### PR TITLE
fix: extend context hack to cover build_request receivers (v0.219.0)

### DIFF
--- a/integration/testdata/baml_src/functions.baml
+++ b/integration/testdata/baml_src/functions.baml
@@ -140,6 +140,19 @@ function DescribeCaptionList(inputs: ImageWithCaption[]) -> string {
     prompt #"Describe captioned images: {{ inputs }}"#
 }
 
+// Regression test: parameter named "context" that shadows Go's context package.
+// BAML preserves user parameter names verbatim in generated Go code. When a parameter
+// is named "context", it shadows the "context" standard library import, causing
+// compilation errors in functions_build_request.go / functions_build_request_stream.go
+// (and previously in functions_parse.go / functions_parse_stream.go).
+// The context_fix hack (cmd/hacks/hacks/context_fix.go) works around this by rewriting
+// the generated code. If this function causes a build failure, the hack needs updating.
+// See: https://github.com/BoundaryML/baml/issues/2393
+function GetContextInput(context: string) -> string {
+    client TestClient
+    prompt #"Process context: {{ context }}"#
+}
+
 // Self-referential types: recursive tree without media
 function ParseTree(input: string) -> TreeNode {
     client TestClient


### PR DESCRIPTION
## Summary

- Extends `context_fix` hack to also rewrite `build_request` and `build_request_stream` methods introduced in BAML v0.219.0. These use `context.Background()` in the same goroutine-leaking pattern as `parse`/`parse_stream` (`BuildRequest` spawns a goroutine waiting on `ctx.Done()` that never fires with `context.Background()`).
- Adds a regression canary (`GetContextInput(context: string)`) to the integration test BAML source so the build fails if the hack ever falls out of date.

## Context

BAML v0.219.0 introduced `functions_build_request.go` / `functions_build_request_stream.go` with methods on `*build_request` / `*build_request_stream` receivers. These call `context.Background()` and pass it to `bamlRuntime.BuildRequest()`, which has the same goroutine leak pattern as `CallFunctionParse`. When a user's BAML function has a parameter named `context`, it shadows the Go `context` package and causes a compilation error.

Upstream issue: https://github.com/BoundaryML/baml/issues/2393