### PR TITLE
feat: add client base URL rewrite support

### DIFF
--- a/bamlutils/embed.go
+++ b/bamlutils/embed.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed adapters.go buildrequest/call_orchestrator.go buildrequest/orchestrator.go buildrequest/response_extract.go dynamic.go embed.go go.mod go.sum interfaces.go llmhttp/llmhttp.go media.go pool.go retry/retry.go sse/extract.go sseclient/sseclient.go versions.go
+//go:embed adapters.go buildrequest/call_orchestrator.go buildrequest/orchestrator.go buildrequest/response_extract.go dynamic.go embed.go go.mod go.sum interfaces.go llmhttp/llmhttp.go media.go pool.go retry/retry.go sse/extract.go sseclient/sseclient.go urlrewrite/urlrewrite.go versions.go
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/bamlutils/llmhttp/llmhttp.go
+++ b/bamlutils/llmhttp/llmhttp.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/invakid404/baml-rest/bamlutils/sseclient"
+	"github.com/invakid404/baml-rest/bamlutils/urlrewrite"
 )
 
 // Request describes an HTTP request to send to an LLM provider.
@@ -311,9 +312,17 @@ func (e *HTTPError) Error() string {
 }
 
 // buildHTTPRequest converts a Request into a standard *http.Request.
+// If URL rewrite rules are configured (via BAML_REST_BASE_URL_REWRITES),
+// the request URL is rewritten before the HTTP request is created.
 func buildHTTPRequest(ctx context.Context, req *Request) (*http.Request, error) {
 	if req == nil {
 		return nil, fmt.Errorf("llmhttp: nil request")
+	}
+
+	// Apply URL rewrite rules (catch-all for BuildRequest path)
+	url := req.URL
+	if rules := urlrewrite.GlobalRules(); len(rules) > 0 {
+		url = urlrewrite.ApplyToURL(url, rules)
 	}
 
 	var body io.Reader
@@ -321,7 +330,7 @@ func buildHTTPRequest(ctx context.Context, req *Request) (*http.Request, error) 
 		body = strings.NewReader(req.Body)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, req.Method, req.URL, body)
+	httpReq, err := http.NewRequestWithContext(ctx, req.Method, url, body)
 	if err != nil {
 		return nil, err
 	}

--- a/bamlutils/urlrewrite/urlrewrite.go
+++ b/bamlutils/urlrewrite/urlrewrite.go
@@ -1,0 +1,106 @@
+// Package urlrewrite provides URL rewrite rules for remapping LLM provider
+// base URLs. This is used both at build time (search-and-replace in .baml
+// files) and at runtime (rewriting base_url in custom client options and
+// outgoing HTTP requests).
+//
+// Rules are configured via the BAML_REST_BASE_URL_REWRITES environment
+// variable or the --base-url-rewrite flag. Format:
+//
+//	BAML_REST_BASE_URL_REWRITES="https://llm.mandel.ai=http://litellm:4000;https://other.ai=http://local:8000"
+package urlrewrite
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+// Rule represents a URL rewrite rule: occurrences of From are replaced with To.
+type Rule struct {
+	From string
+	To   string
+}
+
+// ParseRules parses URL rewrite rules from a semicolon-separated string.
+// Each rule is in the format "from=to". Whitespace around separators is trimmed.
+func ParseRules(s string) []Rule {
+	if s == "" {
+		return nil
+	}
+	var rules []Rule
+	for _, part := range strings.Split(s, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		// Split on first '=' only (URLs may contain '=' in query params,
+		// but base URLs typically don't)
+		idx := strings.Index(part, "=")
+		if idx <= 0 {
+			continue
+		}
+		from := strings.TrimSpace(part[:idx])
+		to := strings.TrimSpace(part[idx+1:])
+		if from != "" && to != "" {
+			rules = append(rules, Rule{From: from, To: to})
+		}
+	}
+	return rules
+}
+
+// Apply performs a dumb search-and-replace of all rules on the input string.
+// Used for build-time .baml file rewriting.
+func Apply(s string, rules []Rule) string {
+	for _, r := range rules {
+		s = strings.ReplaceAll(s, r.From, r.To)
+	}
+	return s
+}
+
+// ApplyToURL rewrites a URL by replacing a matching prefix. Only the first
+// matching rule is applied. Used for runtime URL rewriting of base_url values
+// and outgoing HTTP request URLs.
+func ApplyToURL(url string, rules []Rule) string {
+	for _, r := range rules {
+		if strings.HasPrefix(url, r.From) {
+			return r.To + url[len(r.From):]
+			// Only apply first match
+		}
+	}
+	return url
+}
+
+// builtinRules is set at compile time via -ldflags:
+//
+//	-X github.com/invakid404/baml-rest/bamlutils/urlrewrite.builtinRules=from1=to1;from2=to2
+//
+// These are the default rewrite rules baked into the binary at build time.
+// They can be overridden at runtime by setting BAML_REST_BASE_URL_REWRITES.
+var builtinRules string
+
+var (
+	globalRulesOnce sync.Once
+	globalRules     []Rule
+)
+
+// GlobalRules returns the active URL rewrite rules. Resolution order:
+//  1. BAML_REST_BASE_URL_REWRITES env var (if set, fully overrides builtin rules)
+//  2. Builtin rules baked in at compile time via -ldflags
+//
+// Parsed once and cached for the process lifetime.
+func GlobalRules() []Rule {
+	globalRulesOnce.Do(func() {
+		if envVal := os.Getenv("BAML_REST_BASE_URL_REWRITES"); envVal != "" {
+			globalRules = ParseRules(envVal)
+		} else {
+			globalRules = ParseRules(builtinRules)
+		}
+	})
+	return globalRules
+}
+
+// ResetGlobalRules clears the cached global rules. Only for testing.
+func ResetGlobalRules() {
+	globalRulesOnce = sync.Once{}
+	globalRules = nil
+}

--- a/bamlutils/urlrewrite/urlrewrite_test.go
+++ b/bamlutils/urlrewrite/urlrewrite_test.go
@@ -1,0 +1,93 @@
+package urlrewrite
+
+import (
+	"testing"
+)
+
+func TestParseRules(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []Rule
+	}{
+		{"empty", "", nil},
+		{"single rule", "https://llm.mandel.ai=http://litellm:4000", []Rule{{From: "https://llm.mandel.ai", To: "http://litellm:4000"}}},
+		{"multiple rules", "https://a.com=http://b:1;https://c.com=http://d:2", []Rule{
+			{From: "https://a.com", To: "http://b:1"},
+			{From: "https://c.com", To: "http://d:2"},
+		}},
+		{"whitespace", " https://a.com = http://b:1 ; https://c.com = http://d:2 ", []Rule{
+			{From: "https://a.com", To: "http://b:1"},
+			{From: "https://c.com", To: "http://d:2"},
+		}},
+		{"trailing semicolon", "https://a.com=http://b:1;", []Rule{{From: "https://a.com", To: "http://b:1"}}},
+		{"no equals", "invalid", nil},
+		{"empty from", "=http://b:1", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseRules(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseRules(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ParseRules(%q)[%d] = %v, want %v", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestApply(t *testing.T) {
+	rules := []Rule{
+		{From: "https://llm.mandel.ai", To: "http://litellm:4000"},
+	}
+
+	input := `client<llm> Claude45Sonnet {
+  provider openai
+  options {
+    base_url "https://llm.mandel.ai"
+    model "bedrock-claude-4.5-sonnet"
+  }
+}`
+
+	want := `client<llm> Claude45Sonnet {
+  provider openai
+  options {
+    base_url "http://litellm:4000"
+    model "bedrock-claude-4.5-sonnet"
+  }
+}`
+
+	got := Apply(input, rules)
+	if got != want {
+		t.Errorf("Apply() =\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestApplyToURL(t *testing.T) {
+	rules := []Rule{
+		{From: "https://llm.mandel.ai", To: "http://litellm:4000"},
+	}
+
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://llm.mandel.ai", "http://litellm:4000"},
+		{"https://llm.mandel.ai/v1/chat/completions", "http://litellm:4000/v1/chat/completions"},
+		{"https://api.openai.com/v1/chat/completions", "https://api.openai.com/v1/chat/completions"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			got := ApplyToURL(tt.url, rules)
+			if got != tt.want {
+				t.Errorf("ApplyToURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/build/Dockerfile.tmpl
+++ b/cmd/build/Dockerfile.tmpl
@@ -109,6 +109,9 @@ ENV DEBUG_BUILD="true"
 {{- if .unaryServer }}
 ENV UNARY_SERVER="true"
 {{- end }}
+{{- if .baseURLRewrites }}
+ENV BAML_REST_BASE_URL_REWRITES="{{ .baseURLRewrites }}"
+{{- end }}
 
 # Run build
 {{- if .noCacheMount }}

--- a/cmd/build/build.sh
+++ b/cmd/build/build.sh
@@ -514,7 +514,12 @@ go run "${ADAPTER_VERSION}/cmd/main.go"
 
 # Build worker binary first (this imports baml and loads the shared library)
 echo "Building worker binary..."
-go build -o cmd/serve/worker cmd/worker/main.go
+WORKER_LDFLAGS=""
+if [ -n "${BAML_REST_BASE_URL_REWRITES:-}" ]; then
+    echo "Baking in base URL rewrites: ${BAML_REST_BASE_URL_REWRITES}"
+    WORKER_LDFLAGS="-X 'github.com/invakid404/baml-rest/bamlutils/urlrewrite.builtinRules=${BAML_REST_BASE_URL_REWRITES}'"
+fi
+go build ${WORKER_LDFLAGS:+-ldflags "${WORKER_LDFLAGS}"} -o cmd/serve/worker cmd/worker/main.go
 
 # Generate OpenAPI schema (this also imports baml)
 echo "Generating OpenAPI schema..."

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -31,6 +31,7 @@ import (
 
 	bamlrest "github.com/invakid404/baml-rest"
 	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/urlrewrite"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/registry"
@@ -166,6 +167,7 @@ var (
 	debugBuild      bool
 	unaryServer     bool
 	prettyLogs      bool
+	baseURLRewrites []string
 )
 
 func init() {
@@ -201,6 +203,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&unaryServer, "unary-server", false, "Enable the chi-based unary HTTP server for client-disconnect cancellation")
 	rootCmd.Flags().StringVar(&bamlSource, "baml-source", "", "Path to local BAML source repository for building from unreleased versions")
 	rootCmd.Flags().BoolVar(&prettyLogs, "pretty", false, "Use pretty console logging instead of structured JSON")
+	rootCmd.Flags().StringArrayVar(&baseURLRewrites, "base-url-rewrite", nil, "Rewrite base URLs in .baml files (format: from=to, repeatable). Also reads BAML_REST_BASE_URL_REWRITES env var (semicolon-separated)")
 
 	_ = viper.BindPFlag("mode", rootCmd.Flags().Lookup("mode"))
 	_ = viper.BindPFlag("target-image", rootCmd.Flags().Lookup("target-image"))
@@ -448,16 +451,25 @@ var rootCmd = &cobra.Command{
 			customBamlGoLib = bamlSource
 		}
 
+		// Parse URL rewrite rules from flag and env var
+		rewriteRules := parseBaseURLRewriteRules(baseURLRewrites)
+		if len(rewriteRules) > 0 {
+			fmt.Printf("Base URL rewrites:\n")
+			for _, r := range rewriteRules {
+				fmt.Printf("  %s -> %s\n", r.From, r.To)
+			}
+		}
+
 		// Dispatch to appropriate build function
 		if buildMode == "docker" {
-			return buildDocker(bamlSrcPath, detectedVersion, adapterInfo.Path, keepSource, parsedPlatform, customBamlLib, customBamlGoLib, debugBuild, unaryServer, bamlSource)
+			return buildDocker(bamlSrcPath, detectedVersion, adapterInfo.Path, keepSource, parsedPlatform, customBamlLib, customBamlGoLib, debugBuild, unaryServer, bamlSource, rewriteRules)
 		} else {
-			return buildNative(bamlSrcPath, detectedVersion, adapterInfo.Path, keepSource, customBamlLib, customBamlGoLib, debugBuild, unaryServer, bamlLibraryPath, bamlCliPath)
+			return buildNative(bamlSrcPath, detectedVersion, adapterInfo.Path, keepSource, customBamlLib, customBamlGoLib, debugBuild, unaryServer, bamlLibraryPath, bamlCliPath, rewriteRules)
 		}
 	},
 }
 
-func buildDocker(bamlSrcPath, bamlVersion, adapterVersion string, keepSource string, platform *ocispec.Platform, customBamlLib string, customBamlGoLib string, debugBuild bool, unaryServer bool, bamlSource string) error {
+func buildDocker(bamlSrcPath, bamlVersion, adapterVersion string, keepSource string, platform *ocispec.Platform, customBamlLib string, customBamlGoLib string, debugBuild bool, unaryServer bool, bamlSource string, rewriteRules []urlrewrite.Rule) error {
 	fmt.Printf("\n=== Docker Build Mode ===\n\n")
 
 	if platform != nil {
@@ -484,12 +496,13 @@ func buildDocker(bamlSrcPath, bamlVersion, adapterVersion string, keepSource str
 	var dockerfileOut bytes.Buffer
 
 	dockerfileTemplateArgs := map[string]interface{}{
-		"bamlVersion":    bamlVersion,
-		"adapterVersion": adapterVersion,
-		"keepSource":     keepSource,
-		"debugBuild":     debugBuild,
-		"unaryServer":    unaryServer,
-		"bamlSource":     bamlSource != "",
+		"bamlVersion":     bamlVersion,
+		"adapterVersion":  adapterVersion,
+		"keepSource":      keepSource,
+		"debugBuild":      debugBuild,
+		"unaryServer":     unaryServer,
+		"bamlSource":      bamlSource != "",
+		"baseURLRewrites": formatRewriteRulesForEnv(rewriteRules),
 	}
 	if bamlSource != "" {
 		protocGenGoVersion, err := detectProtocGenGoVersion(bamlSource)
@@ -548,16 +561,7 @@ func buildDocker(bamlSrcPath, bamlVersion, adapterVersion string, keepSource str
 		}
 	}
 
-	err = copyDirToTar(bamlSrcPath, tarWriter, func(path string, _ fs.DirEntry, fileInfo fs.FileInfo) *string {
-		baseName := fileInfo.Name()
-		if !strings.HasSuffix(baseName, bamlFileExt) {
-			return nil
-		}
-
-		result := fmt.Sprintf("baml_src/%s", path)
-		return &result
-	})
-	if err != nil {
+	if err := copyBamlDirToTar(bamlSrcPath, tarWriter, rewriteRules); err != nil {
 		return fmt.Errorf("failed to copy target directory to build context: %w", err)
 	}
 
@@ -799,7 +803,7 @@ func buildDocker(bamlSrcPath, bamlVersion, adapterVersion string, keepSource str
 	return nil
 }
 
-func buildNative(bamlSrcPath, bamlVersion, adapterVersion string, keepSource string, customBamlLib string, customBamlGoLib string, debugBuild bool, unaryServer bool, bamlLibraryPath string, bamlCliPath string) error {
+func buildNative(bamlSrcPath, bamlVersion, adapterVersion string, keepSource string, customBamlLib string, customBamlGoLib string, debugBuild bool, unaryServer bool, bamlLibraryPath string, bamlCliPath string, rewriteRules []urlrewrite.Rule) error {
 	fmt.Printf("\n=== Native Build Mode ===\n\n")
 
 	// Check prerequisites
@@ -861,16 +865,9 @@ func buildNative(bamlSrcPath, bamlVersion, adapterVersion string, keepSource str
 		}
 	}
 
-	// Copy user's baml_src to build context
+	// Copy user's baml_src to build context (with URL rewrites applied)
 	fmt.Printf("Copying baml_src to build context...\n")
-	if err := copyDirToDisk(bamlSrcPath, buildContextDir, func(path string, _ fs.DirEntry, fileInfo fs.FileInfo) *string {
-		baseName := fileInfo.Name()
-		if !strings.HasSuffix(baseName, bamlFileExt) {
-			return nil
-		}
-		result := filepath.Join(bamlSrcDir, path)
-		return &result
-	}); err != nil {
+	if err := copyBamlDirToDisk(bamlSrcPath, buildContextDir, rewriteRules); err != nil {
 		return fmt.Errorf("failed to copy baml_src to build context: %w", err)
 	}
 
@@ -945,6 +942,9 @@ func buildNative(bamlSrcPath, bamlVersion, adapterVersion string, keepSource str
 	}
 	if bamlCliPath != "" {
 		env = append(env, fmt.Sprintf("BAML_CLI_PATH=%s", bamlCliPath))
+	}
+	if rewriteEnv := formatRewriteRulesForEnv(rewriteRules); rewriteEnv != "" {
+		env = append(env, fmt.Sprintf("BAML_REST_BASE_URL_REWRITES=%s", rewriteEnv))
 	}
 
 	// Execute build.sh
@@ -1551,5 +1551,116 @@ func copyDirToTarExclude(path string, target *tar.Writer, mapper copyFSMapper, e
 		}(file)
 
 		return tw.WriteFile(*name, file, fileInfo.Size(), int64(fileInfo.Mode()))
+	})
+}
+
+// parseBaseURLRewriteRules merges rewrite rules from the --base-url-rewrite
+// flags and the BAML_REST_BASE_URL_REWRITES env var into a single slice.
+func parseBaseURLRewriteRules(flagValues []string) []urlrewrite.Rule {
+	var rules []urlrewrite.Rule
+
+	// Parse from env var first
+	rules = append(rules, urlrewrite.ParseRules(os.Getenv("BAML_REST_BASE_URL_REWRITES"))...)
+
+	// Parse from flags (same format as individual env var entries: "from=to")
+	for _, val := range flagValues {
+		parsed := urlrewrite.ParseRules(val)
+		rules = append(rules, parsed...)
+	}
+
+	return rules
+}
+
+// formatRewriteRulesForEnv formats rewrite rules as a semicolon-separated
+// string suitable for the BAML_REST_BASE_URL_REWRITES env var.
+func formatRewriteRulesForEnv(rules []urlrewrite.Rule) string {
+	if len(rules) == 0 {
+		return ""
+	}
+	parts := make([]string, len(rules))
+	for i, r := range rules {
+		parts[i] = r.From + "=" + r.To
+	}
+	return strings.Join(parts, ";")
+}
+
+// copyBamlDirToDisk copies .baml files from srcPath to targetDir under
+// "baml_src/", applying URL rewrite rules to file contents if any are provided.
+func copyBamlDirToDisk(srcPath string, targetDir string, rules []urlrewrite.Rule) error {
+	return filepath.Walk(srcPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(info.Name(), bamlFileExt) {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(srcPath, path)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path for %s: %w", path, err)
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", path, err)
+		}
+
+		// Apply URL rewrite rules
+		if len(rules) > 0 {
+			content = []byte(urlrewrite.Apply(string(content), rules))
+		}
+
+		destPath := filepath.Join(targetDir, bamlSrcDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			return fmt.Errorf("failed to create directory for %s: %w", destPath, err)
+		}
+		return os.WriteFile(destPath, content, info.Mode())
+	})
+}
+
+// copyBamlDirToTar copies .baml files from srcPath into the tar writer under
+// "baml_src/", applying URL rewrite rules to file contents if any are provided.
+func copyBamlDirToTar(srcPath string, tw *tar.Writer, rules []urlrewrite.Rule) error {
+	return filepath.Walk(srcPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(info.Name(), bamlFileExt) {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(srcPath, path)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path for %s: %w", path, err)
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", path, err)
+		}
+
+		// Apply URL rewrite rules
+		if len(rules) > 0 {
+			content = []byte(urlrewrite.Apply(string(content), rules))
+		}
+
+		header := &tar.Header{
+			Name: fmt.Sprintf("baml_src/%s", relPath),
+			Mode: int64(info.Mode()),
+			Size: int64(len(content)),
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return fmt.Errorf("failed to write tar header for %s: %w", relPath, err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			return fmt.Errorf("failed to write tar content for %s: %w", relPath, err)
+		}
+		return nil
 	})
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -17,6 +17,7 @@ import (
 	goplugin "github.com/hashicorp/go-plugin"
 	baml_rest "github.com/invakid404/baml-rest"
 	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/urlrewrite"
 	"github.com/invakid404/baml-rest/internal/memlimit"
 	"github.com/invakid404/baml-rest/workerplugin"
 	"github.com/prometheus/client_golang/prometheus"
@@ -132,6 +133,10 @@ func (o *workerBamlOptions) apply(adapter bamlutils.Adapter) error {
 	}
 
 	if o.Options.ClientRegistry != nil {
+		// Apply URL rewrite rules to custom client base_url options
+		if rules := urlrewrite.GlobalRules(); len(rules) > 0 {
+			rewriteClientBaseURLs(o.Options.ClientRegistry, rules)
+		}
 		if err := adapter.SetClientRegistry(o.Options.ClientRegistry); err != nil {
 			return fmt.Errorf("failed to set client registry: %w", err)
 		}
@@ -148,6 +153,30 @@ func (o *workerBamlOptions) apply(adapter bamlutils.Adapter) error {
 	}
 
 	return nil
+}
+
+// rewriteClientBaseURLs applies URL rewrite rules to the base_url option
+// of each client in the registry. This allows remapping external URLs
+// (e.g., https://llm.mandel.ai) to internal URLs (e.g., http://litellm:4000)
+// for custom clients passed via __baml_options__.
+func rewriteClientBaseURLs(registry *bamlutils.ClientRegistry, rules []urlrewrite.Rule) {
+	for _, client := range registry.Clients {
+		if client == nil || client.Options == nil {
+			continue
+		}
+		baseURL, ok := client.Options["base_url"]
+		if !ok {
+			continue
+		}
+		urlStr, ok := baseURL.(string)
+		if !ok || urlStr == "" {
+			continue
+		}
+		rewritten := urlrewrite.ApplyToURL(urlStr, rules)
+		if rewritten != urlStr {
+			client.Options["base_url"] = rewritten
+		}
+	}
 }
 
 func (w *workerImpl) CallStream(ctx context.Context, methodName string, inputJSON []byte, streamMode bamlutils.StreamMode) (<-chan *workerplugin.StreamResult, error) {

--- a/go.work.sum
+++ b/go.work.sum
@@ -562,7 +562,6 @@ github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
 github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
@@ -1237,6 +1236,7 @@ golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZ
 golang.org/x/term v0.33.0/go.mod h1:s18+ql9tYWp1IfpV9DmCtQDDSRBUjKaw9M1eAv5UeF0=
 golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=
 golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=
+golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=


### PR DESCRIPTION
## Summary
- Add `--base-url-rewrite from=to` flag to the build command for search-and-replace in `.baml` files at build time
- Bake rewrite rules into the worker binary via `-ldflags -X` so they persist at runtime
- Runtime env var `BAML_REST_BASE_URL_REWRITES` overrides baked-in rules if set
- Rewrites apply to custom client `base_url` options (via `__baml_options__`) and as a catch-all in the HTTP request layer for the BuildRequest path

## Usage

**Build time** (rewrites `.baml` files + bakes rules into binary):
```bash
baml-rest --base-url-rewrite "https://llm.mandel.ai=http://litellm:4000" ./my-project
```

**Runtime override** (env var replaces baked-in rules):
```bash
BAML_REST_BASE_URL_REWRITES="https://llm.mandel.ai=http://litellm:4000" ./baml-rest serve
```

Multiple rules use semicolons: `from1=to1;from2=to2`

## Test plan
- [x] Unit tests for `urlrewrite` package (parse, apply, prefix matching)
- [ ] Build with `--base-url-rewrite` and verify `.baml` files are rewritten in build context
- [ ] Verify baked-in rules apply at runtime without env var
- [ ] Verify `BAML_REST_BASE_URL_REWRITES` env var overrides baked-in rules
- [ ] Test custom client `base_url` rewriting via `__baml_options__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable base URL rewriting via a repeatable CLI flag and environment variable
  * Automatic application of configured rewrite rules to outgoing HTTP requests and client registry base URLs
  * Build tooling can bake rewrite rules into Docker images and native builds

* **Tests**
  * Added unit tests covering rule parsing and rewrite behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->