### PR TITLE
fix(dynamic): handle self-referential classes in /call/_dynamic

### DIFF
--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -2,6 +2,9 @@ package bamlutils
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/goccy/go-json"
 	"github.com/tidwall/gjson"
@@ -361,14 +364,9 @@ func (d *DynamicInput) Validate() error {
 
 // ToWorkerInput converts to the internal format for worker processing
 func (d *DynamicInput) ToWorkerInput() ([]byte, error) {
-	// Build classes map: start with user-defined classes, then add the output class
-	classes := make(map[string]*DynamicClass)
-	for name, class := range d.OutputSchema.Classes {
-		classes[name] = class
-	}
-	// Add the output class with the top-level properties
-	classes["Baml_Rest_DynamicOutput"] = &DynamicClass{
-		Properties: d.OutputSchema.Properties,
+	tb, err := buildDynamicTypeBuilder(d.OutputSchema)
+	if err != nil {
+		return nil, err
 	}
 
 	// Convert messages to internal format
@@ -381,12 +379,7 @@ func (d *DynamicInput) ToWorkerInput() ([]byte, error) {
 		"messages": internalMessages,
 		"__baml_options__": &BamlOptions{
 			ClientRegistry: d.ClientRegistry,
-			TypeBuilder: &TypeBuilder{
-				DynamicTypes: &DynamicTypes{
-					Classes: classes,
-					Enums:   d.OutputSchema.Enums,
-				},
-			},
+			TypeBuilder:    tb,
 		},
 	}
 	return json.Marshal(internal)
@@ -411,28 +404,299 @@ func (d *DynamicParseInput) Validate() error {
 
 // ToWorkerInput converts to the internal format for worker processing
 func (d *DynamicParseInput) ToWorkerInput() ([]byte, error) {
-	// Build classes map: start with user-defined classes, then add the output class
-	classes := make(map[string]*DynamicClass)
-	for name, class := range d.OutputSchema.Classes {
-		classes[name] = class
-	}
-	// Add the output class with the top-level properties
-	classes["Baml_Rest_DynamicOutput"] = &DynamicClass{
-		Properties: d.OutputSchema.Properties,
+	tb, err := buildDynamicTypeBuilder(d.OutputSchema)
+	if err != nil {
+		return nil, err
 	}
 
 	internal := map[string]any{
 		"raw": d.Raw,
 		"__baml_options__": &BamlOptions{
-			TypeBuilder: &TypeBuilder{
-				DynamicTypes: &DynamicTypes{
-					Classes: classes,
-					Enums:   d.OutputSchema.Enums,
-				},
-			},
+			TypeBuilder: tb,
 		},
 	}
 	return json.Marshal(internal)
+}
+
+// buildDynamicTypeBuilder converts a DynamicOutputSchema into a TypeBuilder for
+// the worker. When the user's classes contain a self-referential cycle, the
+// classes (and the dynamic output entry point) are emitted as BAML source via
+// BamlSnippets instead of the imperative DynamicTypes API. This works around a
+// BAML runtime segfault that occurs when ctx.output_format renders a dynamic
+// class with cycles built through the imperative TypeBuilder. Statically
+// defined recursive classes — and the same shape declared through tb.AddBaml —
+// render correctly, so we feed the cyclic case through that path. Enums always
+// stay in DynamicTypes; they're applied first by the codegen so snippets can
+// reference them by name.
+func buildDynamicTypeBuilder(schema *DynamicOutputSchema) (*TypeBuilder, error) {
+	if hasClassCycles(schema.Classes) {
+		snippet, err := dynamicSchemaToBamlSource(schema)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert recursive dynamic schema to BAML source: %w", err)
+		}
+		return &TypeBuilder{
+			BamlSnippets: []string{snippet},
+			DynamicTypes: &DynamicTypes{
+				Enums: schema.Enums,
+			},
+		}, nil
+	}
+
+	classes := make(map[string]*DynamicClass, len(schema.Classes)+1)
+	for name, class := range schema.Classes {
+		classes[name] = class
+	}
+	classes["Baml_Rest_DynamicOutput"] = &DynamicClass{
+		Properties: schema.Properties,
+	}
+	return &TypeBuilder{
+		DynamicTypes: &DynamicTypes{
+			Classes: classes,
+			Enums:   schema.Enums,
+		},
+	}, nil
+}
+
+// hasClassCycles returns true if any user-defined dynamic class transitively
+// references itself through its property types.
+func hasClassCycles(classes map[string]*DynamicClass) bool {
+	for start, cls := range classes {
+		if cls == nil {
+			continue
+		}
+		toVisit := classDirectRefs(cls)
+		visited := make(map[string]bool, len(classes))
+		for len(toVisit) > 0 {
+			cur := toVisit[len(toVisit)-1]
+			toVisit = toVisit[:len(toVisit)-1]
+			if cur == start {
+				return true
+			}
+			if visited[cur] {
+				continue
+			}
+			visited[cur] = true
+			if c, ok := classes[cur]; ok {
+				toVisit = append(toVisit, classDirectRefs(c)...)
+			}
+		}
+	}
+	return false
+}
+
+func classDirectRefs(cls *DynamicClass) []string {
+	if cls == nil {
+		return nil
+	}
+	var refs []string
+	for _, prop := range cls.Properties {
+		if prop == nil {
+			continue
+		}
+		if prop.Ref != "" {
+			refs = append(refs, prop.Ref)
+		}
+		refs = appendTypeSpecRefs(refs, prop.Items)
+		refs = appendTypeSpecRefs(refs, prop.Inner)
+		refs = appendTypeSpecRefs(refs, prop.Keys)
+		refs = appendTypeSpecRefs(refs, prop.Values)
+		for _, t := range prop.OneOf {
+			refs = appendTypeSpecRefs(refs, t)
+		}
+	}
+	return refs
+}
+
+func appendTypeSpecRefs(refs []string, t *DynamicTypeSpec) []string {
+	if t == nil {
+		return refs
+	}
+	if t.Ref != "" {
+		refs = append(refs, t.Ref)
+	}
+	refs = appendTypeSpecRefs(refs, t.Items)
+	refs = appendTypeSpecRefs(refs, t.Inner)
+	refs = appendTypeSpecRefs(refs, t.Keys)
+	refs = appendTypeSpecRefs(refs, t.Values)
+	for _, sub := range t.OneOf {
+		refs = appendTypeSpecRefs(refs, sub)
+	}
+	return refs
+}
+
+// dynamicSchemaToBamlSource emits a BAML source snippet that defines all
+// user-supplied classes plus a `dynamic class Baml_Rest_DynamicOutput { ... }`
+// block adding the schema's top-level properties.
+func dynamicSchemaToBamlSource(schema *DynamicOutputSchema) (string, error) {
+	var sb strings.Builder
+
+	classNames := make([]string, 0, len(schema.Classes))
+	for name := range schema.Classes {
+		classNames = append(classNames, name)
+	}
+	sort.Strings(classNames)
+	for _, name := range classNames {
+		cls := schema.Classes[name]
+		if cls == nil {
+			continue
+		}
+		if err := writeBamlClass(&sb, "class "+name, cls.Properties); err != nil {
+			return "", fmt.Errorf("class %q: %w", name, err)
+		}
+	}
+
+	if err := writeBamlClass(&sb, "dynamic class Baml_Rest_DynamicOutput", schema.Properties); err != nil {
+		return "", fmt.Errorf("dynamic output: %w", err)
+	}
+
+	return sb.String(), nil
+}
+
+func writeBamlClass(sb *strings.Builder, header string, props map[string]*DynamicProperty) error {
+	sb.WriteString(header)
+	sb.WriteString(" {\n")
+	propNames := make([]string, 0, len(props))
+	for n := range props {
+		propNames = append(propNames, n)
+	}
+	sort.Strings(propNames)
+	for _, n := range propNames {
+		prop := props[n]
+		if prop == nil {
+			continue
+		}
+		typStr, err := propertyToBamlType(prop)
+		if err != nil {
+			return fmt.Errorf("property %q: %w", n, err)
+		}
+		sb.WriteString("  ")
+		sb.WriteString(n)
+		sb.WriteString(" ")
+		sb.WriteString(typStr)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("}\n\n")
+	return nil
+}
+
+func propertyToBamlType(prop *DynamicProperty) (string, error) {
+	if prop.Ref != "" {
+		return prop.Ref, nil
+	}
+	return typeSpecToBamlType(&DynamicTypeSpec{
+		Type:   prop.Type,
+		Items:  prop.Items,
+		Inner:  prop.Inner,
+		OneOf:  prop.OneOf,
+		Keys:   prop.Keys,
+		Values: prop.Values,
+		Value:  prop.Value,
+	})
+}
+
+func typeSpecToBamlType(t *DynamicTypeSpec) (string, error) {
+	if t == nil {
+		return "", fmt.Errorf("nil type spec")
+	}
+	if t.Ref != "" {
+		return t.Ref, nil
+	}
+	switch t.Type {
+	case "string", "int", "float", "bool", "null":
+		return t.Type, nil
+	case "list":
+		if t.Items == nil {
+			return "", fmt.Errorf("list requires 'items'")
+		}
+		inner, err := typeSpecToBamlType(t.Items)
+		if err != nil {
+			return "", fmt.Errorf("list items: %w", err)
+		}
+		if needsParens(t.Items) {
+			inner = "(" + inner + ")"
+		}
+		return inner + "[]", nil
+	case "optional":
+		if t.Inner == nil {
+			return "", fmt.Errorf("optional requires 'inner'")
+		}
+		inner, err := typeSpecToBamlType(t.Inner)
+		if err != nil {
+			return "", fmt.Errorf("optional inner: %w", err)
+		}
+		if needsParens(t.Inner) {
+			inner = "(" + inner + ")"
+		}
+		return inner + "?", nil
+	case "map":
+		if t.Keys == nil || t.Values == nil {
+			return "", fmt.Errorf("map requires 'keys' and 'values'")
+		}
+		k, err := typeSpecToBamlType(t.Keys)
+		if err != nil {
+			return "", fmt.Errorf("map keys: %w", err)
+		}
+		v, err := typeSpecToBamlType(t.Values)
+		if err != nil {
+			return "", fmt.Errorf("map values: %w", err)
+		}
+		return "map<" + k + ", " + v + ">", nil
+	case "union":
+		if len(t.OneOf) == 0 {
+			return "", fmt.Errorf("union requires 'oneOf' with at least one type")
+		}
+		parts := make([]string, len(t.OneOf))
+		for i, v := range t.OneOf {
+			s, err := typeSpecToBamlType(v)
+			if err != nil {
+				return "", fmt.Errorf("union[%d]: %w", i, err)
+			}
+			parts[i] = s
+		}
+		return strings.Join(parts, " | "), nil
+	case "literal_string":
+		s, ok := t.Value.(string)
+		if !ok {
+			return "", fmt.Errorf("literal_string value must be a string, got %T", t.Value)
+		}
+		return strconv.Quote(s), nil
+	case "literal_int":
+		switch v := t.Value.(type) {
+		case float64:
+			return strconv.FormatInt(int64(v), 10), nil
+		case int:
+			return strconv.Itoa(v), nil
+		case int64:
+			return strconv.FormatInt(v, 10), nil
+		default:
+			return "", fmt.Errorf("literal_int value must be a number, got %T", v)
+		}
+	case "literal_bool":
+		b, ok := t.Value.(bool)
+		if !ok {
+			return "", fmt.Errorf("literal_bool value must be a bool, got %T", t.Value)
+		}
+		if b {
+			return "true", nil
+		}
+		return "false", nil
+	default:
+		return "", fmt.Errorf("unknown type %q", t.Type)
+	}
+}
+
+// needsParens reports whether a sub-type must be parenthesized when used as
+// the inner of a list or optional, to disambiguate against BAML's parse rules
+// (e.g. `string | int[]` would otherwise mean `string | (int[])`).
+func needsParens(t *DynamicTypeSpec) bool {
+	if t == nil {
+		return false
+	}
+	switch t.Type {
+	case "union", "optional":
+		return true
+	}
+	return false
 }
 
 // FlattenDynamicOutput extracts the DynamicProperties field from a dynamic endpoint response.

--- a/integration/dynamic_endpoint_test.go
+++ b/integration/dynamic_endpoint_test.go
@@ -725,6 +725,151 @@ func TestDynamicEndpoint(t *testing.T) {
 	})
 }
 
+// TestDynamicEndpointRecursiveSchema reproduces a crash where /call/_dynamic
+// segfaults when output_schema contains a self-referential class (a class with
+// a list-of-self property). The same recursion shape works fine as a static
+// BAML function (see TestRecursiveTypes), so the bug is specific to the
+// dynamic schema path.
+func TestDynamicEndpointRecursiveSchema(t *testing.T) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		t.Skip("Skipping: dynamic endpoints require BAML >= 0.215.0")
+	}
+	if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+		t.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
+	}
+
+	t.Run("self_referential_class_parse", func(t *testing.T) {
+		// /parse/_dynamic exercises schema construction without prompt rendering,
+		// so the same recursive shape going through this path narrows the original
+		// segfault to the output_format renderer (which only runs on the call/stream
+		// path) rather than the TypeBuilder.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		resp, err := BAMLClient.DynamicParse(ctx, testutil.DynamicParseRequest{
+			Raw: `{"items": [{"name": "PO-123", "children": [{"name": "ALU-789", "children": []}]}]}`,
+			OutputSchema: &testutil.DynamicOutputSchema{
+				Classes: map[string]*testutil.DynamicClass{
+					"Item": {
+						Properties: map[string]*testutil.DynamicProperty{
+							"name": {Type: "string"},
+							"children": {
+								Type:  "list",
+								Items: &testutil.DynamicTypeSpec{Ref: "Item"},
+							},
+						},
+					},
+				},
+				Properties: map[string]*testutil.DynamicProperty{
+					"items": {
+						Type:  "list",
+						Items: &testutil.DynamicTypeSpec{Ref: "Item"},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("DynamicParse failed: %v", err)
+		}
+		t.Logf("Parse status: %d", resp.StatusCode)
+		if resp.Error != "" {
+			t.Logf("Parse error: %s", resp.Error)
+		}
+		if resp.Data != nil {
+			t.Logf("Parse data: %s", string(resp.Data))
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("Parse expected 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+	})
+
+	t.Run("self_referential_class", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Mock LLM returns a valid recursive Item structure
+		content := `{"items": [{"name": "PO-123", "children": [{"name": "ALU-789", "children": []}]}]}`
+		opts := setupNonStreamingScenario(t, "test-dynamic-recursive", content)
+
+		resp, err := BAMLClient.DynamicCall(ctx, testutil.DynamicRequest{
+			Messages: []testutil.DynamicMessage{
+				{
+					Role: "user",
+					Content: []testutil.DynamicContentPart{
+						{Type: "text", Text: strPtr("PO-123 has material ALU-789")},
+						{Type: "output_format"},
+					},
+				},
+			},
+			ClientRegistry: opts.ClientRegistry,
+			OutputSchema: &testutil.DynamicOutputSchema{
+				Classes: map[string]*testutil.DynamicClass{
+					"Item": {
+						Properties: map[string]*testutil.DynamicProperty{
+							"name": {Type: "string"},
+							"children": {
+								Type:  "list",
+								Items: &testutil.DynamicTypeSpec{Ref: "Item"},
+							},
+						},
+					},
+				},
+				Properties: map[string]*testutil.DynamicProperty{
+					"items": {
+						Type:  "list",
+						Items: &testutil.DynamicTypeSpec{Ref: "Item"},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("DynamicCall failed: %v", err)
+		}
+
+		t.Logf("Response status: %d", resp.StatusCode)
+		if resp.Error != "" {
+			t.Logf("Response error: %s", resp.Error)
+		}
+		if resp.Body != nil {
+			t.Logf("Response body: %s", string(resp.Body))
+		}
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(resp.Body, &result); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+
+		items, ok := result["items"].([]any)
+		if !ok {
+			t.Fatalf("Expected items to be an array, got %T", result["items"])
+		}
+		if len(items) != 1 {
+			t.Fatalf("Expected 1 top-level item, got %d", len(items))
+		}
+
+		item, ok := items[0].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected item to be an object, got %T", items[0])
+		}
+		if item["name"] != "PO-123" {
+			t.Errorf("Expected item.name 'PO-123', got %v", item["name"])
+		}
+
+		children, ok := item["children"].([]any)
+		if !ok || len(children) != 1 {
+			t.Fatalf("Expected 1 child, got %v", item["children"])
+		}
+		child, _ := children[0].(map[string]any)
+		if child["name"] != "ALU-789" {
+			t.Errorf("Expected child.name 'ALU-789', got %v", child["name"])
+		}
+	})
+}
+
 // TestDynamicEndpointMultiPartContent tests multi-part content support in dynamic endpoints.
 func TestDynamicEndpointMultiPartContent(t *testing.T) {
 	// Dynamic endpoints require BAML >= 0.215.0


### PR DESCRIPTION
## Summary

`POST /call/_dynamic` reliably segfaults the worker plugin when `output_schema` contains a self-referential class. The same recursion shape works fine when declared statically in `baml_src` (see `TestRecursiveTypes` / `TreeNode`), so the bug is specific to the dynamic-schema path.

### Minimal reproducer

```bash
curl -X POST http://<server>/call/_dynamic -H 'Content-Type: application/json' -d '{
  "client_registry": {
    "clients": [{"name": "p", "provider": "openai", "options": {"model": "...", "api_key": "...", "base_url": "..."}}],
    "primary": "p"
  },
  "messages": [{"role": "user", "content": [{"type": "text", "text": "PO-123 has material ALU-789"}, {"type": "output_format"}]}],
  "output_schema": {
    "classes": {
      "Item": {
        "properties": {
          "name": {"type": "string"},
          "children": {"type": "list", "items": {"ref": "Item"}}
        }
      }
    },
    "properties": {"items": {"type": "list", "items": {"ref": "Item"}}}
  }
}'
```

Server logs on crash:
```
{level:error, worker:N, error:'signal: segmentation fault', message:'plugin process exited'}
{level:error, error:'all stream retries exhausted', message:'dynamic worker call failed'}
```

Replacing `children` with a scalar field returns a normal 200.

## Root cause

The bug is upstream in BAML's TypeBuilder, not in baml-rest. The imperative API (`add_class` + `add_property`) only appends to `self.classes` — it never populates `recursive_classes`. Only the BAML-source path (`tb.add_baml(...)`) runs the validation pipeline that detects cycles and feeds them into `recursive_classes` / `recursive_aliases`. See `engine/baml-runtime/src/type_builder/mod.rs` ~699-720 in [BoundaryML/baml](https://github.com/BoundaryML/baml).

The output-format renderer at `engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs` ~440-470 then asks the IR which classes participate in a cycle so it can emit a name reference instead of expanding the type inline:

```rust
for cycle in ir.finite_recursive_cycles() {
    if cycle.contains(cls) { recursive_classes.extend(...); }
}
for cycle in &ctx.recursive_class_overrides {
    if cycle.contains(cls) { recursive_classes.extend(...); }
}
```

For an imperatively-built recursive class, neither collection lists it, the renderer recurses without bound, and the resulting native stack overflow surfaces across the go-plugin gRPC boundary as `signal: segmentation fault`. The crash is deterministic and survives plugin restarts (`/call/_dynamic` retries hit other workers and segfault those too).

This also matches the existing skipped `TestRecursiveTypesWithMedia` ("Rust panic on recursive types with media fields"), which is the same family of bug — the static path's cycle detection is the only thing keeping recursive output rendering safe.

## Fix

`bamlutils/dynamic.go` now detects cycles in the user-supplied class graph (DFS from each class through its property refs) and, when present, round-trips those classes through BAML source via `BamlSnippets`:

```baml
class Item {
  children Item[]
  name string
}

dynamic class Baml_Rest_DynamicOutput {
  items Item[]
}
```

The snippet path runs the same validation pipeline as static recursive classes, so `recursive_classes` gets populated and the renderer terminates. Enums stay in `DynamicTypes` (codegen applies them before snippets, so snippet code can still reference them by name). Non-cyclic schemas are untouched and continue to use the imperative path.

## Test coverage

- New `TestDynamicEndpointRecursiveSchema` in `integration/dynamic_endpoint_test.go`:
  - `self_referential_class_parse` — `/parse/_dynamic` with the recursive `Item` schema (narrows the bug to prompt rendering: parse exercises schema construction without prompt rendering and was already returning 200 in ~5ms before the fix)
  - `self_referential_class` — `/call/_dynamic` with the minimal reproducer shape
- Full regression sweep across `TestDynamicEndpoint*` (40 subtests covering parse, call, stream, multi-part, whitespace, OpenAPI, validation), `TestRecursiveTypes` (5 subtests, static recursion), and `TestRecursiveJsonType` (3 subtests) — **49/49 pass**, no regressions.

Run the new test alone:
```bash
go test -tags=integration -v -count=1 -p 1 -timeout 30m \
  -run '^TestDynamicEndpointRecursiveSchema$' ./integration/...
```

## Note: this is a workaround

The proper fix belongs upstream — BAML's `TypeBuilder::to_overrides()` should compute `recursive_class_overrides` from the imperatively added classes the same way `add_baml` does it. Worth filing an issue against BoundaryML/baml so this can eventually move out of baml-rest.

## Test plan

- [x] `TestDynamicEndpointRecursiveSchema/self_referential_class` passes (was crashing the worker on master)
- [x] `TestDynamicEndpointRecursiveSchema/self_referential_class_parse` passes
- [x] Full regression sweep: `TestDynamicEndpoint*`, `TestRecursiveTypes`, `TestRecursiveJsonType` — 49/49 pass
- [x] `bamlutils` unit tests pass
- [x] `go vet ./...` clean (with and without `-tags=integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dynamic endpoints to support recursive and self-referential schema definitions, enabling parsing of complex nested data structures.

* **Tests**
  * Added integration test coverage for dynamic endpoints with recursive schema structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->