### PR TITLE
fix(serve): drain in-flight unary calls on SIGTERM

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -376,7 +376,11 @@ var serveCmd = &cobra.Command{
 
 			makeCallHandler := func(streamMode bamlutils.StreamMode) fiber.Handler {
 				return func(c fiber.Ctx) error {
-					ctx, cancel := context.WithCancel(c.RequestCtx())
+					// Use c.Context() rather than c.RequestCtx(): fasthttp's
+					// RequestCtx.Done() is server-shutdown-scoped (shared s.done
+					// channel), so deriving from it cancels the worker call the
+					// instant Fiber.Shutdown starts — before the pool can drain.
+					ctx, cancel := context.WithCancel(c.Context())
 					defer cancel()
 
 					result, err := workerPool.Call(ctx, methodName, c.Body(), streamMode)
@@ -418,7 +422,7 @@ var serveCmd = &cobra.Command{
 
 			// Parse endpoint - parses raw LLM output using this method's schema
 			app.Post(fmt.Sprintf("/parse/%s", methodName), func(c fiber.Ctx) error {
-				ctx, cancel := context.WithCancel(c.RequestCtx())
+				ctx, cancel := context.WithCancel(c.Context())
 				defer cancel()
 
 				result, err := workerPool.Parse(ctx, methodName, c.Body())
@@ -441,7 +445,7 @@ var serveCmd = &cobra.Command{
 
 			makeDynamicCallHandler := func(streamMode bamlutils.StreamMode) fiber.Handler {
 				return func(c fiber.Ctx) error {
-					ctx, cancel := context.WithCancel(c.RequestCtx())
+					ctx, cancel := context.WithCancel(c.Context())
 					defer cancel()
 
 					rawBody := c.Body()
@@ -519,7 +523,7 @@ var serveCmd = &cobra.Command{
 
 			// Dynamic parse endpoint
 			app.Post(fmt.Sprintf("/parse/%s", bamlutils.DynamicEndpointName), func(c fiber.Ctx) error {
-				ctx, cancel := context.WithCancel(c.RequestCtx())
+				ctx, cancel := context.WithCancel(c.Context())
 				defer cancel()
 
 				rawBody := c.Body()

--- a/integration/shutdown_test.go
+++ b/integration/shutdown_test.go
@@ -1,0 +1,222 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// TestGracefulShutdownDrainsInFlightCall verifies that a SIGTERM delivered
+// while a /call request is in-flight lets the handler run to completion and
+// return 200 (the pool's graceful shutdown path drains before workers die).
+//
+// Regression: fasthttp's RequestCtx.Done() is tied to a server-wide s.done
+// channel that fasthttp closes as the very first step of Server.Shutdown.
+// When handlers derived the worker-call context from c.RequestCtx(), any
+// in-flight call was canceled before the pool could drain, producing a 500.
+//
+// The test uses a dedicated test environment because it kills the server.
+func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
+	// Matrix across the BAML_REST_USE_BUILD_REQUEST toggle is handled by CI
+	// via env vars; we inherit whatever the outer TestMain decided.
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer setupCancel()
+
+	adapterVersion, err := testutil.GetAdapterVersionForBAML(BAMLVersion)
+	if err != nil {
+		t.Fatalf("Failed to get adapter version: %v", err)
+	}
+	bamlSrcPath, err := findTestdataPath()
+	if err != nil {
+		t.Fatalf("Failed to find testdata: %v", err)
+	}
+
+	env, err := testutil.Setup(setupCtx, testutil.SetupOptions{
+		BAMLSrcPath:     bamlSrcPath,
+		BAMLVersion:     BAMLVersion,
+		AdapterVersion:  adapterVersion,
+		BAMLSource:      BAMLSourcePath,
+		UseBuildRequest: UseBuildRequest,
+	})
+	if err != nil {
+		t.Fatalf("Failed to setup dedicated shutdown env: %v", err)
+	}
+	// Container will be stopped by the test; Terminate on cleanup is still
+	// needed to remove the container and network.
+	defer func() {
+		if err := env.Terminate(context.Background()); err != nil {
+			t.Logf("shutdown env Terminate: %v", err)
+		}
+	}()
+
+	mockClient := mockllm.NewClient(env.MockLLMURL)
+	bamlClient := testutil.NewBAMLRestClient(env.BAMLRestURL)
+
+	// Scenario with a long InitialDelayMs so a /call is reliably in-flight
+	// when we send SIGTERM. The delay needs to dwarf any scheduling jitter
+	// between "fire request" and "stop container".
+	const inFlightDelay = 3 * time.Second
+	scenario := &mockllm.Scenario{
+		ID:             "shutdown-drain",
+		Provider:       "openai",
+		Content:        `{"name": "Shutdown", "age": 1, "tags": ["drain"]}`,
+		ChunkSize:      0,
+		InitialDelayMs: int(inFlightDelay / time.Millisecond),
+	}
+	regCtx, regCancel := context.WithTimeout(setupCtx, 10*time.Second)
+	if err := mockClient.RegisterScenario(regCtx, scenario); err != nil {
+		regCancel()
+		t.Fatalf("RegisterScenario: %v", err)
+	}
+	regCancel()
+
+	// Fire the long-running call on a background goroutine. We want it
+	// in-flight when SIGTERM arrives, and want to capture its final result.
+	type callResult struct {
+		resp *testutil.CallResponse
+		err  error
+	}
+	resultCh := make(chan callResult, 1)
+
+	callCtx, callCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer callCancel()
+
+	var inFlight atomic.Bool
+	go func() {
+		inFlight.Store(true)
+		resp, err := bamlClient.Call(callCtx, testutil.CallRequest{
+			Method: "GetPerson",
+			Input:  map[string]any{"description": "shutdown-drain"},
+			Options: &testutil.BAMLOptions{
+				ClientRegistry: testutil.CreateTestClient(env.MockLLMInternal, scenario.ID),
+			},
+		})
+		inFlight.Store(false)
+		resultCh <- callResult{resp: resp, err: err}
+	}()
+
+	// Give the request time to reach the worker and start waiting on the
+	// mock LLM's InitialDelayMs. A short poll with the /_debug/in-flight
+	// endpoint would be more precise but requires the debug build — a plain
+	// sleep is sufficient for a regression test.
+	time.Sleep(500 * time.Millisecond)
+	if !inFlight.Load() {
+		t.Fatalf("call goroutine should still be in-flight after 500ms")
+	}
+
+	// Send SIGTERM to PID 1 inside the container (Go binary). Timeout is
+	// large so the graceful shutdown has room to drain even if the
+	// in-flight scenario takes its full InitialDelayMs to return.
+	stopTimeout := 2 * time.Minute
+	stopStart := time.Now()
+	if err := env.BAMLRest.Stop(setupCtx, &stopTimeout); err != nil {
+		t.Fatalf("container Stop (SIGTERM): %v", err)
+	}
+	stopDuration := time.Since(stopStart)
+	t.Logf("container stopped after %s (SIGTERM→exit)", stopDuration)
+
+	// Collect the call result.
+	var result callResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("call goroutine did not return within 30s of container stop")
+	}
+
+	if result.err != nil {
+		t.Fatalf("in-flight call errored during graceful shutdown: %v", result.err)
+	}
+	if result.resp.StatusCode != 200 {
+		t.Fatalf("in-flight call returned status %d during graceful shutdown (expected 200): %s",
+			result.resp.StatusCode, result.resp.Error)
+	}
+	var person struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(result.resp.Body, &person); err != nil {
+		t.Fatalf("failed to unmarshal in-flight call response: %v (body=%s)", err, result.resp.Body)
+	}
+	if person.Name == "" {
+		t.Fatalf("response body missing name field: %s", result.resp.Body)
+	}
+
+	// The stop must have taken at least the scenario's InitialDelayMs —
+	// i.e. shutdown waited for the in-flight call rather than bailing out
+	// immediately. Allow a margin for scheduling.
+	if stopDuration < inFlightDelay/2 {
+		t.Fatalf("container stopped in %s, less than half the in-flight delay %s: "+
+			"shutdown did not wait for the drain", stopDuration, inFlightDelay)
+	}
+
+	// Sanity-check container logs: the drain-order markers should be in
+	// the expected sequence, and there should be no "worker call failed"
+	// with "context canceled" in the shutdown window.
+	logs := collectContainerLogs(t, env.BAMLRest)
+	assertShutdownLogOrdering(t, logs)
+}
+
+func collectContainerLogs(t *testing.T, c interface {
+	Logs(context.Context) (io.ReadCloser, error)
+}) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	rc, err := c.Logs(ctx)
+	if err != nil {
+		t.Logf("collectContainerLogs: %v", err)
+		return ""
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Logf("collectContainerLogs read: %v", err)
+		return ""
+	}
+	return string(data)
+}
+
+func assertShutdownLogOrdering(t *testing.T, logs string) {
+	t.Helper()
+
+	// Must have received the shutdown signal and completed the pool drain.
+	signalIdx := strings.Index(logs, "Received signal, initiating graceful shutdown")
+	httpStoppedIdx := strings.Index(logs, "HTTP servers stopped, shutting down worker pool")
+	drainCompleteIdx := strings.Index(logs, "All in-flight requests completed")
+
+	if signalIdx < 0 {
+		t.Errorf("shutdown logs missing 'Received signal' marker\nlogs:\n%s", logs)
+		return
+	}
+	if httpStoppedIdx < 0 {
+		t.Errorf("shutdown logs missing 'HTTP servers stopped' marker\nlogs:\n%s", logs)
+		return
+	}
+	if drainCompleteIdx < 0 {
+		t.Errorf("shutdown logs missing 'All in-flight requests completed' marker\nlogs:\n%s", logs)
+		return
+	}
+	if !(signalIdx < httpStoppedIdx && httpStoppedIdx < drainCompleteIdx) {
+		t.Errorf("shutdown log ordering wrong: signal=%d httpStopped=%d drainComplete=%d",
+			signalIdx, httpStoppedIdx, drainCompleteIdx)
+	}
+
+	// The regression we're guarding against: the in-flight handler
+	// surfacing context.Canceled from its worker call. A plain substring
+	// match is good enough — the handler's error log uses these exact
+	// tokens (see cmd/serve/main.go).
+	shutdownWindow := logs[signalIdx:]
+	if strings.Contains(shutdownWindow, "worker call failed") &&
+		strings.Contains(shutdownWindow, "context canceled") {
+		t.Errorf("in-flight worker call was canceled during shutdown (regression):\n%s",
+			shutdownWindow)
+	}
+}

--- a/integration/shutdown_test.go
+++ b/integration/shutdown_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -21,15 +22,23 @@ import (
 //
 // Regression: fasthttp's RequestCtx.Done() is tied to a server-wide s.done
 // channel that fasthttp closes as the very first step of Server.Shutdown.
-// When handlers derived the worker-call context from c.RequestCtx(), any
-// in-flight call was canceled before the pool could drain, producing a 500.
+// When Fiber handlers derived the worker-call context from c.RequestCtx(),
+// any in-flight call was canceled before the pool could drain, producing a
+// 500. The chi/net-http unary server uses r.Context() (connection-scoped,
+// not server-shutdown-scoped), so it was already correct — but we still
+// cover it here so a future regression on either stack is caught.
 //
 // The test uses a dedicated test environment because it kills the server.
+// It mirrors the outer matrix's unary-server axis: when the shared
+// UnaryClient is configured (UNARY_SERVER=true leg), we enable chi in the
+// dedicated container too and assert the drain property on both stacks.
 func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
-	// Matrix across the BAML_REST_USE_BUILD_REQUEST toggle is handled by CI
-	// via env vars; we inherit whatever the outer TestMain decided.
 	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer setupCancel()
+
+	// Match the outer matrix leg's unary-server setting. UnaryClient is
+	// non-nil iff TestMain enabled the chi server for this run.
+	unaryEnabled := UnaryClient != nil
 
 	adapterVersion, err := testutil.GetAdapterVersionForBAML(BAMLVersion)
 	if err != nil {
@@ -45,6 +54,7 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 		BAMLVersion:     BAMLVersion,
 		AdapterVersion:  adapterVersion,
 		BAMLSource:      BAMLSourcePath,
+		UnaryServer:     unaryEnabled,
 		UseBuildRequest: UseBuildRequest,
 	})
 	if err != nil {
@@ -59,11 +69,23 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 	}()
 
 	mockClient := mockllm.NewClient(env.MockLLMURL)
-	bamlClient := testutil.NewBAMLRestClient(env.BAMLRestURL)
 
-	// Scenario with a long InitialDelayMs so a /call is reliably in-flight
-	// when we send SIGTERM. The delay needs to dwarf any scheduling jitter
-	// between "fire request" and "stop container".
+	// Build the set of clients we'll exercise concurrently. Fiber is
+	// always tested; chi is added only when the matrix enabled it, so
+	// CI legs match the semantics of forEachUnaryClient elsewhere.
+	clients := []namedClient{
+		{Name: "fiber", Client: testutil.NewBAMLRestClient(env.BAMLRestURL)},
+	}
+	if unaryEnabled {
+		clients = append(clients, namedClient{
+			Name:   "chi",
+			Client: testutil.NewBAMLRestClient(env.BAMLRestUnaryURL),
+		})
+	}
+
+	// Scenario with a long InitialDelayMs so the /call is reliably
+	// in-flight when we send SIGTERM. The delay needs to dwarf any
+	// scheduling jitter between "fire request" and "stop container".
 	const inFlightDelay = 3 * time.Second
 	scenario := &mockllm.Scenario{
 		ID:             "shutdown-drain",
@@ -79,38 +101,46 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 	}
 	regCancel()
 
-	// Fire the long-running call on a background goroutine. We want it
-	// in-flight when SIGTERM arrives, and want to capture its final result.
+	// Fire one in-flight call per backend on background goroutines so a
+	// single SIGTERM exercises the drain path on both stacks at once.
 	type callResult struct {
-		resp *testutil.CallResponse
-		err  error
+		backend string
+		resp    *testutil.CallResponse
+		err     error
 	}
-	resultCh := make(chan callResult, 1)
 
 	callCtx, callCancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer callCancel()
 
-	var inFlight atomic.Bool
-	go func() {
-		inFlight.Store(true)
-		resp, err := bamlClient.Call(callCtx, testutil.CallRequest{
-			Method: "GetPerson",
-			Input:  map[string]any{"description": "shutdown-drain"},
-			Options: &testutil.BAMLOptions{
-				ClientRegistry: testutil.CreateTestClient(env.MockLLMInternal, scenario.ID),
-			},
-		})
-		inFlight.Store(false)
-		resultCh <- callResult{resp: resp, err: err}
-	}()
+	opts := &testutil.BAMLOptions{
+		ClientRegistry: testutil.CreateTestClient(env.MockLLMInternal, scenario.ID),
+	}
 
-	// Give the request time to reach the worker and start waiting on the
-	// mock LLM's InitialDelayMs. A short poll with the /_debug/in-flight
-	// endpoint would be more precise but requires the debug build — a plain
-	// sleep is sufficient for a regression test.
+	results := make(chan callResult, len(clients))
+	var inFlight atomic.Int32
+	var wg sync.WaitGroup
+	for _, nc := range clients {
+		wg.Add(1)
+		inFlight.Add(1)
+		go func(nc namedClient) {
+			defer wg.Done()
+			resp, err := nc.Client.Call(callCtx, testutil.CallRequest{
+				Method:  "GetPerson",
+				Input:   map[string]any{"description": "shutdown-drain-" + nc.Name},
+				Options: opts,
+			})
+			inFlight.Add(-1)
+			results <- callResult{backend: nc.Name, resp: resp, err: err}
+		}(nc)
+	}
+
+	// Give the requests time to reach the worker and start waiting on the
+	// mock LLM's InitialDelayMs. A short poll with /_debug/in-flight would
+	// be more precise but requires the debug build — a plain sleep is
+	// sufficient for a regression test.
 	time.Sleep(500 * time.Millisecond)
-	if !inFlight.Load() {
-		t.Fatalf("call goroutine should still be in-flight after 500ms")
+	if got := inFlight.Load(); int(got) != len(clients) {
+		t.Fatalf("expected %d in-flight calls after 500ms, got %d", len(clients), got)
 	}
 
 	// Send SIGTERM to PID 1 inside the container (Go binary). Timeout is
@@ -124,34 +154,40 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 	stopDuration := time.Since(stopStart)
 	t.Logf("container stopped after %s (SIGTERM→exit)", stopDuration)
 
-	// Collect the call result.
-	var result callResult
+	// Collect all results.
+	waitDone := make(chan struct{})
+	go func() { wg.Wait(); close(waitDone) }()
 	select {
-	case result = <-resultCh:
+	case <-waitDone:
 	case <-time.After(30 * time.Second):
-		t.Fatalf("call goroutine did not return within 30s of container stop")
+		t.Fatalf("call goroutines did not return within 30s of container stop")
+	}
+	close(results)
+
+	for r := range results {
+		if r.err != nil {
+			t.Errorf("[%s] in-flight call errored during graceful shutdown: %v", r.backend, r.err)
+			continue
+		}
+		if r.resp.StatusCode != 200 {
+			t.Errorf("[%s] in-flight call returned status %d during graceful shutdown (expected 200): %s",
+				r.backend, r.resp.StatusCode, r.resp.Error)
+			continue
+		}
+		var person struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(r.resp.Body, &person); err != nil {
+			t.Errorf("[%s] failed to unmarshal response: %v (body=%s)", r.backend, err, r.resp.Body)
+			continue
+		}
+		if person.Name == "" {
+			t.Errorf("[%s] response body missing name field: %s", r.backend, r.resp.Body)
+		}
 	}
 
-	if result.err != nil {
-		t.Fatalf("in-flight call errored during graceful shutdown: %v", result.err)
-	}
-	if result.resp.StatusCode != 200 {
-		t.Fatalf("in-flight call returned status %d during graceful shutdown (expected 200): %s",
-			result.resp.StatusCode, result.resp.Error)
-	}
-	var person struct {
-		Name string `json:"name"`
-	}
-	if err := json.Unmarshal(result.resp.Body, &person); err != nil {
-		t.Fatalf("failed to unmarshal in-flight call response: %v (body=%s)", err, result.resp.Body)
-	}
-	if person.Name == "" {
-		t.Fatalf("response body missing name field: %s", result.resp.Body)
-	}
-
-	// The stop must have taken at least the scenario's InitialDelayMs —
-	// i.e. shutdown waited for the in-flight call rather than bailing out
-	// immediately. Allow a margin for scheduling.
+	// The stop must have taken at least half the in-flight delay — i.e.
+	// shutdown waited for the drain rather than bailing immediately.
 	if stopDuration < inFlightDelay/2 {
 		t.Fatalf("container stopped in %s, less than half the in-flight delay %s: "+
 			"shutdown did not wait for the drain", stopDuration, inFlightDelay)
@@ -211,8 +247,10 @@ func assertShutdownLogOrdering(t *testing.T, logs string) {
 
 	// The regression we're guarding against: the in-flight handler
 	// surfacing context.Canceled from its worker call. A plain substring
-	// match is good enough — the handler's error log uses these exact
-	// tokens (see cmd/serve/main.go).
+	// match is good enough — the Fiber handler's error log uses these
+	// exact tokens (see cmd/serve/main.go). The chi handler classifies
+	// cancellation as 408 without this log line, which is fine: the
+	// per-result status-code check above catches chi regressions.
 	shutdownWindow := logs[signalIdx:]
 	if strings.Contains(shutdownWindow, "worker call failed") &&
 		strings.Contains(shutdownWindow, "context canceled") {

--- a/integration/shutdown_test.go
+++ b/integration/shutdown_test.go
@@ -4,10 +4,10 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -61,9 +61,12 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 		t.Fatalf("Failed to setup dedicated shutdown env: %v", err)
 	}
 	// Container will be stopped by the test; Terminate on cleanup is still
-	// needed to remove the container and network.
+	// needed to remove the container and network. Bound teardown so a
+	// hung cleanup doesn't stall the whole integration leg.
 	defer func() {
-		if err := env.Terminate(context.Background()); err != nil {
+		termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer termCancel()
+		if err := env.Terminate(termCtx); err != nil {
 			t.Logf("shutdown env Terminate: %v", err)
 		}
 	}()
@@ -73,8 +76,9 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 	// Build the set of clients we'll exercise concurrently. Fiber is
 	// always tested; chi is added only when the matrix enabled it, so
 	// CI legs match the semantics of forEachUnaryClient elsewhere.
+	fiberClient := testutil.NewBAMLRestClient(env.BAMLRestURL)
 	clients := []namedClient{
-		{Name: "fiber", Client: testutil.NewBAMLRestClient(env.BAMLRestURL)},
+		{Name: "fiber", Client: fiberClient},
 	}
 	if unaryEnabled {
 		clients = append(clients, namedClient{
@@ -85,7 +89,7 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 
 	// Scenario with a long InitialDelayMs so the /call is reliably
 	// in-flight when we send SIGTERM. The delay needs to dwarf any
-	// scheduling jitter between "fire request" and "stop container".
+	// scheduling jitter between "observed in-flight" and "stop container".
 	const inFlightDelay = 3 * time.Second
 	scenario := &mockllm.Scenario{
 		ID:             "shutdown-drain",
@@ -117,11 +121,9 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 	}
 
 	results := make(chan callResult, len(clients))
-	var inFlight atomic.Int32
 	var wg sync.WaitGroup
 	for _, nc := range clients {
 		wg.Add(1)
-		inFlight.Add(1)
 		go func(nc namedClient) {
 			defer wg.Done()
 			resp, err := nc.Client.Call(callCtx, testutil.CallRequest{
@@ -129,19 +131,22 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 				Input:   map[string]any{"description": "shutdown-drain-" + nc.Name},
 				Options: opts,
 			})
-			inFlight.Add(-1)
 			results <- callResult{backend: nc.Name, resp: resp, err: err}
 		}(nc)
 	}
 
-	// Give the requests time to reach the worker and start waiting on the
-	// mock LLM's InitialDelayMs. A short poll with /_debug/in-flight would
-	// be more precise but requires the debug build — a plain sleep is
-	// sufficient for a regression test.
-	time.Sleep(500 * time.Millisecond)
-	if got := inFlight.Load(); int(got) != len(clients) {
-		t.Fatalf("expected %d in-flight calls after 500ms, got %d", len(clients), got)
+	// Gate on a server-observed signal: the pool's in-flight counter
+	// ticks up only once a request has been dispatched to a worker, so
+	// this proves both backends' handlers actually reached the worker
+	// layer (i.e. have live work to drain). Without this, SIGTERM could
+	// race the transport and fire before the regression path is even
+	// exercised.
+	waitCtx, waitCancel := context.WithTimeout(callCtx, 20*time.Second)
+	if err := waitForPoolInFlight(waitCtx, fiberClient, len(clients)); err != nil {
+		waitCancel()
+		t.Fatalf("pool never saw %d in-flight requests: %v", len(clients), err)
 	}
+	waitCancel()
 
 	// Send SIGTERM to PID 1 inside the container (Go binary). Timeout is
 	// large so the graceful shutdown has room to drain even if the
@@ -200,6 +205,31 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 	assertShutdownLogOrdering(t, logs)
 }
 
+// waitForPoolInFlight polls /_debug/in-flight until the pool's in-flight
+// counter across all workers reaches min. Available because the test
+// container is built with debug endpoints (see testutil.Setup).
+func waitForPoolInFlight(ctx context.Context, c *testutil.BAMLRestClient, min int) error {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		status, err := c.GetInFlightStatus(ctx)
+		if err == nil {
+			total := 0
+			for _, w := range status.Workers {
+				total += w.InFlight
+			}
+			if total >= min {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("deadline waiting for >=%d in-flight: %w", min, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
 func collectContainerLogs(t *testing.T, c interface {
 	Logs(context.Context) (io.ReadCloser, error)
 }) string {
@@ -245,16 +275,18 @@ func assertShutdownLogOrdering(t *testing.T, logs string) {
 			signalIdx, httpStoppedIdx, drainCompleteIdx)
 	}
 
-	// The regression we're guarding against: the in-flight handler
-	// surfacing context.Canceled from its worker call. A plain substring
-	// match is good enough — the Fiber handler's error log uses these
-	// exact tokens (see cmd/serve/main.go). The chi handler classifies
-	// cancellation as 408 without this log line, which is fine: the
-	// per-result status-code check above catches chi regressions.
+	// The regression we're guarding against: a single zerolog entry that
+	// is a "worker call failed" error whose error field is "context
+	// canceled". Match per-line so unrelated post-signal entries can't
+	// conspire to false-positive. (The chi handler classifies
+	// cancellation as 408 and doesn't emit this log; the per-backend
+	// status-code check above catches chi regressions directly.)
 	shutdownWindow := logs[signalIdx:]
-	if strings.Contains(shutdownWindow, "worker call failed") &&
-		strings.Contains(shutdownWindow, "context canceled") {
-		t.Errorf("in-flight worker call was canceled during shutdown (regression):\n%s",
-			shutdownWindow)
+	for _, line := range strings.Split(shutdownWindow, "\n") {
+		if strings.Contains(line, "worker call failed") &&
+			strings.Contains(line, "context canceled") {
+			t.Errorf("in-flight worker call was canceled during shutdown (regression): %s", line)
+			return
+		}
 	}
 }


### PR DESCRIPTION
## Symptom

Production log sequence on SIGTERM (sub-millisecond timeline):

```
10:36:05.866533 INFO  signal=terminated 'Received signal, initiating graceful shutdown'
10:36:05.867538 ERROR method=PlanSupplierResponse error='context canceled' 'worker call failed'
10:36:05.867549 ERROR status=500 latency=5.36625527s POST /call/PlanSupplierResponse 'Server error'
10:36:05.868    [BAML WARN] Function PlanSupplierResponse: Operation cancelled
10:36:05.967794 INFO  'HTTP servers stopped, shutting down worker pool'
10:36:05.969112 INFO  'Pool draining, waiting for in-flight requests to complete'
10:36:05.969119 INFO  'All in-flight requests completed'
```

A request 5.4s deep into a BAML call was context-canceled ~1ms after the signal — not after any graceful timeout — and the pool-drain loop fired ~100ms later with nothing left in flight.

## Root cause

Fiber's `c.RequestCtx()` returns `*fasthttp.RequestCtx`, which implements `context.Context`. Its `Done()` is the server-wide `s.done` channel:

```go
// valyala/fasthttp/server.go
// RequestCtx.s.done is only closed when the server is shutting down.
func (ctx *RequestCtx) Done() <-chan struct{} { return ctx.s.done }
```

`fasthttp.Server.ShutdownWithContext` closes `s.done` as the **very first step** after closing listeners, *before* the loop that waits for in-flight connections to finish (server.go:1952-1954). So every in-flight `RequestCtx.Done()` fires the instant `app.ShutdownWithContext` is called.

The four unary handlers (`/call`, `/parse`, and their dynamic variants) derived their worker-call context from `c.RequestCtx()`:

```go
ctx, cancel := context.WithCancel(c.RequestCtx())
// ...
workerPool.Call(ctx, methodName, c.Body(), streamMode)
```

So SIGTERM → `s.done` closed → handler ctx canceled → pool call returns `context.Canceled` → 500 → connection idle → fasthttp drain returns → pool drain finds nothing in flight.

The stream handlers already avoided this trap: `cmd/serve/streamwriter.go:166,387` use `c.Context()` and the code even has a comment explaining the pitfall (`streamwriter.go:212-214`). The unary handlers were simply inconsistent.

## Fix

Switch all four unary handler sites from `c.RequestCtx()` to `c.Context()` as the parent of the worker-call context (matching the stream path). `c.Context()` is `context.Background()` unless a middleware overrides it, so it's independent of fasthttp's server-shutdown channel. The handler's `defer cancel()` still runs on return, and `pool.Shutdown`'s drain loop remains the authoritative bound on shutdown duration.

## Client-disconnect caveat

`c.Context()` is `context.Background()`, so a client hanging up mid-call no longer cancels the worker. This matches what the stream path already does — streams detect disconnects via write errors / keepalives, not context cancellation (see streamwriter.go:212-214). For unary calls this means an orphaned handler continues to completion; the pool's per-call timeouts and pool capacity are the backpressure.

## Regression test

`integration/shutdown_test.go::TestGracefulShutdownDrainsInFlightCall` spins up a dedicated baml-rest + mockllm container pair, registers a scenario with a 3s `InitialDelayMs`, fires a `/call/GetPerson` in a goroutine, waits 500ms for it to be in-flight, then calls `container.Stop` (SIGTERM to PID 1 with a 2m kill timeout). Asserts:

1. The call returns status 200 with a valid response body.
2. The container stop took at least half the `InitialDelayMs` — i.e. shutdown actually waited on the drain rather than bailing immediately.
3. Container logs contain `signal → HTTP servers stopped → All in-flight requests completed` in that order.
4. No `worker call failed` + `context canceled` lines in the shutdown window.

## Test plan

- [ ] CI integration leg (fiber): `TestGracefulShutdownDrainsInFlightCall` passes.
- [ ] CI integration leg (chi unary): pre-existing resilience/leak tests still pass (this PR doesn't touch the chi path).
- [ ] Manual smoke: send SIGTERM to a running server mid-`/call` and confirm the client sees 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown so in-flight requests are awaited during shutdown and not prematurely canceled.

* **Tests**
  * Added an integration test that verifies in-flight requests are drained during shutdown, validates responses, and checks shutdown log ordering and absence of cancellation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->