### PR TITLE
feat: deployment-wide ClientRegistry defaults via BAML_REST_CLIENT_DEFAULTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+## Runtime configuration
+
+baml-rest reads the following environment variables at startup:
+
+- `BAML_REST_USE_BUILD_REQUEST` — toggle the BuildRequest/StreamRequest code
+  path. `1`/`true`/`yes`/`on` enables it; any other value (including empty)
+  falls back to the legacy CallStream+OnTick path.
+- `BAML_REST_BASE_URL_REWRITES` — semicolon-separated URL rewrite rules
+  applied to LLM provider base URLs, both at build time and at runtime.
+  Format: `from1=to1;from2=to2`. See
+  [bamlutils/urlrewrite](bamlutils/urlrewrite/urlrewrite.go) for the full
+  semantics.
+- `BAML_REST_CLIENT_DEFAULTS` — JSON object pinning deployment-wide defaults
+  for BAML `ClientRegistry` option values. Each key in `options` is merged
+  into every caller's `client_registry.clients[].options` map unless the
+  caller already set it. Example:
+
+  ```json
+  {
+    "client_defaults": {
+      "options": {
+        "allowed_role_metadata": ["cache_control"]
+      }
+    }
+  }
+  ```
+
+  v1 recognizes `allowed_role_metadata` only. See
+  [bamlutils/clientdefaults](bamlutils/clientdefaults/clientdefaults.go) for
+  the merge contract, supported opt-outs, and BuildRequest caveat.
+- `BAML_LOG` — BAML internal log level (`debug`, `info`, `warn`, `error`).
+
 ## Known bugs/limitations
 
 ### Upstream

--- a/bamlutils/clientdefaults/clientdefaults.go
+++ b/bamlutils/clientdefaults/clientdefaults.go
@@ -55,6 +55,7 @@ package clientdefaults
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 
@@ -114,7 +115,8 @@ func parse(raw string) (*Config, error) {
 	if err := dec.Decode(&env); err != nil {
 		return nil, fmt.Errorf("%s: %w", EnvVar, err)
 	}
-	if dec.More() {
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
 		return nil, fmt.Errorf("%s: unexpected trailing data", EnvVar)
 	}
 

--- a/bamlutils/clientdefaults/clientdefaults.go
+++ b/bamlutils/clientdefaults/clientdefaults.go
@@ -1,0 +1,207 @@
+// Package clientdefaults provides deployment-wide defaults for BAML
+// ClientRegistry option values. Defaults are parsed once at worker startup
+// and merged into every caller's client Options map before the registry is
+// handed to the BAML SDK.
+//
+// Configuration is loaded from the BAML_REST_CLIENT_DEFAULTS environment
+// variable. The value is a JSON object:
+//
+//	{
+//	  "client_defaults": {
+//	    "options": {
+//	      "allowed_role_metadata": ["cache_control"]
+//	    }
+//	  }
+//	}
+//
+// v1 recognizes exactly one option, allowed_role_metadata. The envelope is
+// designed to accept additional options additively in future versions.
+//
+// # Merge contract
+//
+// For each handler and each client in the registry:
+//
+//   - If the caller did not set the handler's key in client.Options, the
+//     deployment default is injected (a freshly-allocated clone, so
+//     concurrent requests don't alias shared state).
+//   - If the caller set the key with any value, including null, [], "",
+//     or "none", the caller wins and the default is not applied.
+//
+// # Advertised opt-outs for allowed_role_metadata
+//
+// To opt out of the deployment default for a particular request, callers
+// should set one of:
+//
+//   - "allowed_role_metadata": []     — BAML parses as empty Only([])
+//   - "allowed_role_metadata": "none" — BAML parses as AllowedRoleMetadata::None
+//
+// Both produce "no metadata allowed" end-to-end and are BAML-valid.
+//
+// # Anti-pattern: null
+//
+// "allowed_role_metadata": null is respected by this package's merge rule
+// (caller wins, default not applied), but BAML's ensure_allowed_metadata
+// rejects non-array/non-string values at LLM-client construction time, so
+// the request fails. Do not advertise null as an opt-out.
+//
+// # BuildRequest caveat
+//
+// When BAML_REST_USE_BUILD_REQUEST=true, message-level metadata (including
+// cache_control) is dropped by BAML's BuildRequest serializer regardless of
+// the allowed_role_metadata default configured here. The worker emits a
+// startup warning when both conditions hold.
+package clientdefaults
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// EnvVar is the environment variable name read by Load.
+const EnvVar = "BAML_REST_CLIENT_DEFAULTS"
+
+// Config is the parsed, validated deployment config. Immutable after Load.
+type Config struct {
+	// parsed holds one entry per handler whose key appeared in the config.
+	// The value is the output of Handler.Parse. Entries preserve the
+	// registry's handler order for deterministic Apply iteration.
+	parsed []parsedEntry
+}
+
+type parsedEntry struct {
+	handler *Handler
+	value   any
+}
+
+// envelope is the top-level shape of BAML_REST_CLIENT_DEFAULTS. Fields are
+// decoded with DisallowUnknownFields so typos in envelope-level keys are
+// rejected loudly.
+type envelope struct {
+	ClientDefaults *clientDefaultsBody `json:"client_defaults"`
+}
+
+type clientDefaultsBody struct {
+	Options map[string]json.RawMessage `json:"options"`
+}
+
+// Load reads BAML_REST_CLIENT_DEFAULTS and returns a non-nil *Config. An
+// empty or unset env var returns a Config whose Apply is a no-op.
+//
+// Errors are returned for:
+//   - malformed JSON
+//   - unknown envelope keys (caught by DisallowUnknownFields)
+//   - unknown option keys (no handler registered for the key)
+//   - handler-specific Parse errors (wrong value shape)
+func Load() (*Config, error) {
+	raw := os.Getenv(EnvVar)
+	return parse(raw)
+}
+
+func parse(raw string) (*Config, error) {
+	cfg := &Config{}
+	if raw == "" {
+		return cfg, nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	var env envelope
+	if err := dec.Decode(&env); err != nil {
+		return nil, fmt.Errorf("%s: %w", EnvVar, err)
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("%s: unexpected trailing data", EnvVar)
+	}
+
+	if env.ClientDefaults == nil {
+		return cfg, nil
+	}
+
+	// Validate option keys against the handler registry. Preserve handler
+	// order for deterministic Apply iteration; sort unknown-key errors for
+	// stable error messages regardless of Go map iteration order.
+	unknown := make([]string, 0)
+	for key := range env.ClientDefaults.Options {
+		if handlerByKey(key) == nil {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return nil, fmt.Errorf(
+			"%s: unknown option key(s): %v (known keys: %v)",
+			EnvVar, unknown, knownKeys())
+	}
+
+	for i := range registry {
+		h := &registry[i]
+		raw, ok := env.ClientDefaults.Options[h.Key]
+		if !ok {
+			continue
+		}
+		value, err := h.Parse(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", EnvVar, err)
+		}
+		cfg.parsed = append(cfg.parsed, parsedEntry{handler: h, value: value})
+	}
+
+	return cfg, nil
+}
+
+func knownKeys() []string {
+	out := make([]string, 0, len(registry))
+	for i := range registry {
+		out = append(out, registry[i].Key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// HasKey reports whether the given option key was configured. Used by the
+// worker to emit narrow warnings (e.g. the BuildRequest caveat).
+func (c *Config) HasKey(key string) bool {
+	if c == nil {
+		return false
+	}
+	for _, e := range c.parsed {
+		if e.handler.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// Apply merges deployment defaults into each client's Options map in the
+// registry. For each handler, calls the handler's Apply function with the
+// caller's existing value (if any) to decide what to set.
+//
+// Apply is safe to call concurrently from multiple goroutines on the same
+// Config: handlers produce freshly-allocated values for every client, so no
+// state is shared across calls.
+func (c *Config) Apply(registry *bamlutils.ClientRegistry) {
+	if c == nil || len(c.parsed) == 0 || registry == nil {
+		return
+	}
+	for _, client := range registry.Clients {
+		if client == nil {
+			continue
+		}
+		for _, entry := range c.parsed {
+			existing, present := client.Options[entry.handler.Key]
+			result, set := entry.handler.Apply(entry.value, existing, present)
+			if !set {
+				continue
+			}
+			if client.Options == nil {
+				client.Options = map[string]any{}
+			}
+			client.Options[entry.handler.Key] = result
+		}
+	}
+}

--- a/bamlutils/clientdefaults/clientdefaults.go
+++ b/bamlutils/clientdefaults/clientdefaults.go
@@ -54,11 +54,11 @@ package clientdefaults
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
 
+	"github.com/goccy/go-json"
 	"github.com/invakid404/baml-rest/bamlutils"
 )
 

--- a/bamlutils/clientdefaults/clientdefaults_test.go
+++ b/bamlutils/clientdefaults/clientdefaults_test.go
@@ -199,6 +199,9 @@ func TestLoad_UnknownEnvelopeKey(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for unknown envelope key")
 	}
+	if !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("expected unknown-field error, got %v", err)
+	}
 }
 
 func TestLoad_TrailingData(t *testing.T) {

--- a/bamlutils/clientdefaults/clientdefaults_test.go
+++ b/bamlutils/clientdefaults/clientdefaults_test.go
@@ -201,6 +201,24 @@ func TestLoad_UnknownEnvelopeKey(t *testing.T) {
 	}
 }
 
+func TestLoad_TrailingData(t *testing.T) {
+	cases := []string{
+		`{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}} trailing`,
+		`{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}} }`,
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			_, err := loadFromString(t, raw)
+			if err == nil {
+				t.Fatalf("expected error for trailing data")
+			}
+			if !strings.Contains(err.Error(), "unexpected trailing data") {
+				t.Fatalf("expected trailing-data error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestLoad_CloningGuarantee(t *testing.T) {
 	// Two clients with no caller value should receive independent copies of
 	// the default. Mutating one must not affect the other — and must not

--- a/bamlutils/clientdefaults/clientdefaults_test.go
+++ b/bamlutils/clientdefaults/clientdefaults_test.go
@@ -231,14 +231,16 @@ func TestLoad_CloningGuarantee(t *testing.T) {
 	slice0 := client0.Options["allowed_role_metadata"].([]any)
 	slice1 := client1.Options["allowed_role_metadata"].([]any)
 
-	slice0 = append(slice0, "tenant_id")
 	slice0[0] = "hijacked"
+	if len(slice1) != 1 || slice1[0] != "cache_control" {
+		t.Fatalf("client1 aliased client0's slice: %v", slice1)
+	}
+	slice0 = append(slice0, "tenant_id")
 	client0.Options["allowed_role_metadata"] = slice0
 
 	if got := client1.Options["allowed_role_metadata"].([]any); len(got) != 1 || got[0] != "cache_control" {
 		t.Fatalf("client1 aliased client0's slice: %v", got)
 	}
-	_ = slice1
 
 	// A fresh Apply on a third client must still emit the pristine default.
 	client2 := &bamlutils.ClientProperty{Name: "C"}

--- a/bamlutils/clientdefaults/clientdefaults_test.go
+++ b/bamlutils/clientdefaults/clientdefaults_test.go
@@ -1,0 +1,259 @@
+package clientdefaults
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// loadFromString is the test entry point. We avoid mutating the real env var
+// so tests are safe under t.Parallel() and don't leak across packages.
+func loadFromString(t *testing.T, raw string) (*Config, error) {
+	t.Helper()
+	return parse(raw)
+}
+
+func mustLoad(t *testing.T, raw string) *Config {
+	t.Helper()
+	c, err := loadFromString(t, raw)
+	if err != nil {
+		t.Fatalf("parse(%q) unexpected error: %v", raw, err)
+	}
+	if c == nil {
+		t.Fatalf("parse(%q) returned nil config", raw)
+	}
+	return c
+}
+
+func newRegistry(clients ...*bamlutils.ClientProperty) *bamlutils.ClientRegistry {
+	return &bamlutils.ClientRegistry{Clients: clients}
+}
+
+func TestLoad_EmptyEnv(t *testing.T) {
+	cfg := mustLoad(t, "")
+	reg := newRegistry(&bamlutils.ClientProperty{
+		Name:     "A",
+		Provider: "openai-generic",
+		Options:  map[string]any{"model": "gpt-4"},
+	})
+	cfg.Apply(reg)
+	if got := reg.Clients[0].Options["allowed_role_metadata"]; got != nil {
+		t.Fatalf("expected no injection on empty config, got %v", got)
+	}
+	if len(reg.Clients[0].Options) != 1 {
+		t.Fatalf("expected Options untouched, got %v", reg.Clients[0].Options)
+	}
+}
+
+func TestLoad_InjectsDefaultWhenKeyAbsent(t *testing.T) {
+	cfg := mustLoad(t, `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`)
+	client := &bamlutils.ClientProperty{
+		Name:     "A",
+		Provider: "openai-generic",
+		Options:  map[string]any{"model": "gpt-4"},
+	}
+	cfg.Apply(newRegistry(client))
+
+	got, ok := client.Options["allowed_role_metadata"].([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T: %v", client.Options["allowed_role_metadata"], client.Options["allowed_role_metadata"])
+	}
+	if len(got) != 1 || got[0] != "cache_control" {
+		t.Fatalf("expected [cache_control], got %v", got)
+	}
+}
+
+func TestLoad_CallerValueWins(t *testing.T) {
+	cfg := mustLoad(t, `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`)
+	client := &bamlutils.ClientProperty{
+		Options: map[string]any{
+			"allowed_role_metadata": []any{"tenant_id"},
+		},
+	}
+	cfg.Apply(newRegistry(client))
+
+	got := client.Options["allowed_role_metadata"].([]any)
+	if len(got) != 1 || got[0] != "tenant_id" {
+		t.Fatalf("expected caller value [tenant_id] preserved, got %v", got)
+	}
+}
+
+func TestLoad_CallerEmptyListOptOutWins(t *testing.T) {
+	cfg := mustLoad(t, `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`)
+	client := &bamlutils.ClientProperty{
+		Options: map[string]any{
+			"allowed_role_metadata": []any{},
+		},
+	}
+	cfg.Apply(newRegistry(client))
+
+	got, ok := client.Options["allowed_role_metadata"].([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", client.Options["allowed_role_metadata"])
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected caller opt-out [] preserved, got %v", got)
+	}
+}
+
+func TestLoad_CallerNoneOptOutWins(t *testing.T) {
+	cfg := mustLoad(t, `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`)
+	client := &bamlutils.ClientProperty{
+		Options: map[string]any{
+			"allowed_role_metadata": "none",
+		},
+	}
+	cfg.Apply(newRegistry(client))
+
+	if got := client.Options["allowed_role_metadata"]; got != "none" {
+		t.Fatalf("expected \"none\" preserved, got %v", got)
+	}
+}
+
+func TestLoad_CallerNullWins(t *testing.T) {
+	// Explicit null: caller wins at the merge layer. (BAML will reject this
+	// downstream at LLM-client construction, per the package doc comment.)
+	cfg := mustLoad(t, `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`)
+	client := &bamlutils.ClientProperty{
+		Options: map[string]any{
+			"allowed_role_metadata": nil,
+		},
+	}
+	cfg.Apply(newRegistry(client))
+
+	got, present := client.Options["allowed_role_metadata"]
+	if !present {
+		t.Fatalf("expected key to remain present with nil value")
+	}
+	if got != nil {
+		t.Fatalf("expected nil preserved, got %v", got)
+	}
+}
+
+func TestLoad_MultiClientInjection(t *testing.T) {
+	cfg := mustLoad(t, `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`)
+	clients := []*bamlutils.ClientProperty{
+		{Name: "A", Options: map[string]any{"model": "a"}},
+		{Name: "B", Options: map[string]any{"model": "b"}},
+		{Name: "C", Options: map[string]any{"model": "c"}},
+	}
+	cfg.Apply(&bamlutils.ClientRegistry{Clients: clients})
+
+	for _, c := range clients {
+		got, ok := c.Options["allowed_role_metadata"].([]any)
+		if !ok || len(got) != 1 || got[0] != "cache_control" {
+			t.Fatalf("client %s: expected [cache_control], got %v (type %T)",
+				c.Name, c.Options["allowed_role_metadata"], c.Options["allowed_role_metadata"])
+		}
+	}
+}
+
+func TestLoad_NilOptionsMapGetsAllocated(t *testing.T) {
+	cfg := mustLoad(t, `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`)
+	client := &bamlutils.ClientProperty{Name: "A"}
+	if client.Options != nil {
+		t.Fatalf("precondition: expected nil Options")
+	}
+	cfg.Apply(newRegistry(client))
+	if client.Options == nil {
+		t.Fatalf("expected Options to be lazily allocated")
+	}
+	if _, ok := client.Options["allowed_role_metadata"]; !ok {
+		t.Fatalf("expected allowed_role_metadata to be set")
+	}
+}
+
+func TestLoad_MalformedJSON(t *testing.T) {
+	_, err := loadFromString(t, `{bad`)
+	if err == nil {
+		t.Fatalf("expected error for malformed JSON")
+	}
+	if !strings.Contains(err.Error(), "BAML_REST_CLIENT_DEFAULTS") {
+		t.Fatalf("expected error to mention env var name, got %v", err)
+	}
+}
+
+func TestLoad_UnknownOptionKey(t *testing.T) {
+	_, err := loadFromString(t, `{"client_defaults":{"options":{"foo_bar":1}}}`)
+	if err == nil {
+		t.Fatalf("expected error for unknown option key")
+	}
+	if !strings.Contains(err.Error(), "foo_bar") {
+		t.Fatalf("expected error to name unknown key foo_bar, got %v", err)
+	}
+}
+
+func TestLoad_WrongValueType(t *testing.T) {
+	_, err := loadFromString(t, `{"client_defaults":{"options":{"allowed_role_metadata":42}}}`)
+	if err == nil {
+		t.Fatalf("expected error for wrong value type")
+	}
+	if !strings.Contains(err.Error(), "allowed_role_metadata") {
+		t.Fatalf("expected error to mention allowed_role_metadata, got %v", err)
+	}
+}
+
+func TestLoad_UnknownEnvelopeKey(t *testing.T) {
+	_, err := loadFromString(t, `{"client_default":{"options":{"allowed_role_metadata":["cache_control"]}}}`)
+	if err == nil {
+		t.Fatalf("expected error for unknown envelope key")
+	}
+}
+
+func TestLoad_CloningGuarantee(t *testing.T) {
+	// Two clients with no caller value should receive independent copies of
+	// the default. Mutating one must not affect the other — and must not
+	// affect the Config's internal parsed state.
+	cfg := mustLoad(t, `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`)
+	client0 := &bamlutils.ClientProperty{Name: "A"}
+	client1 := &bamlutils.ClientProperty{Name: "B"}
+	cfg.Apply(&bamlutils.ClientRegistry{Clients: []*bamlutils.ClientProperty{client0, client1}})
+
+	slice0 := client0.Options["allowed_role_metadata"].([]any)
+	slice1 := client1.Options["allowed_role_metadata"].([]any)
+
+	slice0 = append(slice0, "tenant_id")
+	slice0[0] = "hijacked"
+	client0.Options["allowed_role_metadata"] = slice0
+
+	if got := client1.Options["allowed_role_metadata"].([]any); len(got) != 1 || got[0] != "cache_control" {
+		t.Fatalf("client1 aliased client0's slice: %v", got)
+	}
+	_ = slice1
+
+	// A fresh Apply on a third client must still emit the pristine default.
+	client2 := &bamlutils.ClientProperty{Name: "C"}
+	cfg.Apply(newRegistry(client2))
+	if got := client2.Options["allowed_role_metadata"].([]any); len(got) != 1 || got[0] != "cache_control" {
+		t.Fatalf("Config's parsed state was mutated: %v", got)
+	}
+}
+
+func TestHasKey(t *testing.T) {
+	cfg := mustLoad(t, `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`)
+	if !cfg.HasKey("allowed_role_metadata") {
+		t.Fatalf("expected HasKey(allowed_role_metadata) = true")
+	}
+	if cfg.HasKey("headers") {
+		t.Fatalf("expected HasKey(headers) = false")
+	}
+
+	empty := mustLoad(t, "")
+	if empty.HasKey("allowed_role_metadata") {
+		t.Fatalf("expected HasKey on empty config = false")
+	}
+
+	var nilCfg *Config
+	if nilCfg.HasKey("anything") {
+		t.Fatalf("HasKey on nil config must not panic and must return false")
+	}
+}
+
+func TestApply_NilSafe(t *testing.T) {
+	var nilCfg *Config
+	nilCfg.Apply(newRegistry(&bamlutils.ClientProperty{}))
+
+	cfg := mustLoad(t, `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`)
+	cfg.Apply(nil)
+}

--- a/bamlutils/clientdefaults/handlers.go
+++ b/bamlutils/clientdefaults/handlers.go
@@ -64,6 +64,16 @@ var allowedRoleMetadataHandler = Handler{
 		}
 		switch typed := v.(type) {
 		case string:
+			// BAML's parser only accepts the literal strings "all" and "none"
+			// for the non-list form (see engine/baml-lib/llm-client/src/
+			// clientspec.rs:461). Reject other strings at startup so a typo
+			// like "cache_control" fails loudly in the worker instead of
+			// silently passing through and exploding at LLM-client
+			// construction time on the first request.
+			if typed != "all" && typed != "none" {
+				return nil, fmt.Errorf(
+					"allowed_role_metadata string must be \"all\" or \"none\", got %q", typed)
+			}
 			return typed, nil
 		case []any:
 			for i, elem := range typed {
@@ -75,7 +85,7 @@ var allowedRoleMetadataHandler = Handler{
 			return typed, nil
 		default:
 			return nil, fmt.Errorf(
-				"allowed_role_metadata must be a string or array of strings, got %T", v)
+				"allowed_role_metadata must be \"all\", \"none\", or an array of strings, got %T", v)
 		}
 	},
 	Apply: func(parsed, _ any, present bool) (any, bool) {

--- a/bamlutils/clientdefaults/handlers.go
+++ b/bamlutils/clientdefaults/handlers.go
@@ -1,8 +1,9 @@
 package clientdefaults
 
 import (
-	"encoding/json"
 	"fmt"
+
+	"github.com/goccy/go-json"
 )
 
 // Handler describes how one ClientRegistry option key is parsed from the

--- a/bamlutils/clientdefaults/handlers.go
+++ b/bamlutils/clientdefaults/handlers.go
@@ -1,0 +1,123 @@
+package clientdefaults
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Handler describes how one ClientRegistry option key is parsed from the
+// deployment config and merged into each caller's client Options map.
+//
+// Adding a new deployment-wide default is a new Handler struct literal
+// appended to registry plus a handler test case. No changes to Load, Apply,
+// or Config are required.
+type Handler struct {
+	// Key is the BAML client option this handler manages. It corresponds to
+	// a key inside `client_registry.clients[].options`.
+	Key string
+
+	// Parse validates and converts the JSON value from the config into
+	// whatever opaque Go form Apply expects. Called once per Load.
+	Parse func(raw json.RawMessage) (any, error)
+
+	// Apply is called per client per Apply() invocation. Arguments:
+	//   parsed   — the value returned by Parse.
+	//   existing — the caller's current value for this key in their Options
+	//              map, or nil if the key wasn't present.
+	//   present  — true if the caller set the key in their Options map
+	//              (including explicit null, empty list, etc.).
+	// Returns (out, true) to set client.Options[Key] = out, or (nil, false)
+	// to leave the caller's value unchanged.
+	//
+	// Implementers MUST return a freshly-allocated value (no shared
+	// references to `parsed`) so multiple clients within the same request
+	// and multiple concurrent requests don't alias the same slice/map.
+	// Use cloneAsJSONValue for the common case.
+	Apply func(parsed, existing any, present bool) (any, bool)
+}
+
+// registry is the set of handlers recognized by Load and Apply. The order
+// does not matter: each handler manages its own key and operates
+// independently of the others.
+var registry = []Handler{
+	allowedRoleMetadataHandler,
+}
+
+// allowedRoleMetadataHandler manages the `allowed_role_metadata` option.
+//
+// BAML's runtime uses this option to decide which message-level metadata keys
+// survive the message→request-body conversion. When the option is absent, BAML
+// defaults to AllowedRoleMetadata::None, which silently strips every key —
+// including `cache_control` for Anthropic prompt caching. This handler lets
+// operators pin a deployment-wide default so callers don't have to remember
+// to set it on every client.
+//
+// Accepts the same value shapes BAML accepts: "all", "none", or a list of
+// strings. Any caller-provided value (including null, "") wins over the
+// deployment default — see the package doc comment for the merge contract.
+var allowedRoleMetadataHandler = Handler{
+	Key: "allowed_role_metadata",
+	Parse: func(raw json.RawMessage) (any, error) {
+		var v any
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return nil, fmt.Errorf("allowed_role_metadata: invalid JSON: %w", err)
+		}
+		switch typed := v.(type) {
+		case string:
+			return typed, nil
+		case []any:
+			for i, elem := range typed {
+				if _, ok := elem.(string); !ok {
+					return nil, fmt.Errorf(
+						"allowed_role_metadata[%d] must be a string, got %T", i, elem)
+				}
+			}
+			return typed, nil
+		default:
+			return nil, fmt.Errorf(
+				"allowed_role_metadata must be a string or array of strings, got %T", v)
+		}
+	},
+	Apply: func(parsed, _ any, present bool) (any, bool) {
+		if present {
+			return nil, false
+		}
+		return cloneAsJSONValue(parsed), true
+	},
+}
+
+// cloneAsJSONValue deep-copies a value in the shapes produced by
+// json.Unmarshal into map[string]any: []any, map[string]any, and primitive
+// scalars. Returns the input unchanged for types that aren't part of that
+// shape space.
+//
+// Handlers use this to satisfy the fresh-allocation contract of Handler.Apply.
+func cloneAsJSONValue(v any) any {
+	switch typed := v.(type) {
+	case []any:
+		out := make([]any, len(typed))
+		for i, elem := range typed {
+			out[i] = cloneAsJSONValue(elem)
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, elem := range typed {
+			out[k] = cloneAsJSONValue(elem)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// handlerByKey returns the registered handler for the given option key, or
+// nil if no handler is registered. Used by Load for unknown-key rejection.
+func handlerByKey(key string) *Handler {
+	for i := range registry {
+		if registry[i].Key == key {
+			return &registry[i]
+		}
+	}
+	return nil
+}

--- a/bamlutils/clientdefaults/handlers_test.go
+++ b/bamlutils/clientdefaults/handlers_test.go
@@ -29,6 +29,12 @@ func TestAllowedRoleMetadataHandler_ParseRejects(t *testing.T) {
 		`{"foo":"bar"}`,
 		`[1,2,3]`,
 		`[null]`,
+		// Arbitrary strings: BAML only accepts "all" / "none" for the
+		// string form, so anything else must fail at startup rather than
+		// survive into BAML and blow up on the first request.
+		`"cache_control"`,
+		`"ALL"`,
+		`""`,
 	}
 	for _, c := range cases {
 		t.Run(c, func(t *testing.T) {

--- a/bamlutils/clientdefaults/handlers_test.go
+++ b/bamlutils/clientdefaults/handlers_test.go
@@ -1,0 +1,110 @@
+package clientdefaults
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAllowedRoleMetadataHandler_ParseAccepts(t *testing.T) {
+	cases := []string{
+		`"all"`,
+		`"none"`,
+		`[]`,
+		`["cache_control"]`,
+		`["cache_control","tenant_id"]`,
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			if _, err := allowedRoleMetadataHandler.Parse(json.RawMessage(c)); err != nil {
+				t.Fatalf("expected Parse(%s) to succeed, got %v", c, err)
+			}
+		})
+	}
+}
+
+func TestAllowedRoleMetadataHandler_ParseRejects(t *testing.T) {
+	cases := []string{
+		`42`,
+		`true`,
+		`{"foo":"bar"}`,
+		`[1,2,3]`,
+		`[null]`,
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			if _, err := allowedRoleMetadataHandler.Parse(json.RawMessage(c)); err == nil {
+				t.Fatalf("expected Parse(%s) to fail", c)
+			}
+		})
+	}
+}
+
+func TestAllowedRoleMetadataHandler_ApplyPresentFalse(t *testing.T) {
+	parsed := []any{"cache_control"}
+	out, set := allowedRoleMetadataHandler.Apply(parsed, nil, false)
+	if !set {
+		t.Fatalf("expected set=true when key absent")
+	}
+	outSlice := out.([]any)
+	if len(outSlice) != 1 || outSlice[0] != "cache_control" {
+		t.Fatalf("expected cloned [cache_control], got %v", outSlice)
+	}
+
+	// Mutating the parsed value after Apply must not affect what was returned.
+	parsed[0] = "hijacked"
+	if outSlice[0] != "cache_control" {
+		t.Fatalf("Apply aliased parsed slice: %v", outSlice)
+	}
+}
+
+func TestAllowedRoleMetadataHandler_ApplyPresentTrue(t *testing.T) {
+	parsed := []any{"cache_control"}
+	cases := []any{
+		[]any{"tenant_id"},
+		[]any{},
+		"none",
+		"all",
+		nil,
+	}
+	for i, existing := range cases {
+		out, set := allowedRoleMetadataHandler.Apply(parsed, existing, true)
+		if set {
+			t.Fatalf("case %d: expected set=false when caller value present", i)
+		}
+		if out != nil {
+			t.Fatalf("case %d: expected out=nil when set=false, got %v", i, out)
+		}
+	}
+}
+
+func TestCloneAsJSONValue(t *testing.T) {
+	original := map[string]any{
+		"scalar": "s",
+		"list":   []any{"a", "b"},
+		"nested": map[string]any{"inner": []any{"x"}},
+		"num":    float64(1.5),
+		"bool":   true,
+		"null":   nil,
+	}
+	clone := cloneAsJSONValue(original).(map[string]any)
+
+	clone["scalar"] = "hijacked"
+	if original["scalar"] != "s" {
+		t.Fatalf("cloneAsJSONValue did not clone top-level map")
+	}
+
+	clone["list"].([]any)[0] = "hijacked"
+	if original["list"].([]any)[0] != "a" {
+		t.Fatalf("cloneAsJSONValue did not clone list")
+	}
+
+	clone["nested"].(map[string]any)["inner"].([]any)[0] = "hijacked"
+	if original["nested"].(map[string]any)["inner"].([]any)[0] != "x" {
+		t.Fatalf("cloneAsJSONValue did not clone nested list")
+	}
+
+	// Primitive scalars are returned unchanged — they're immutable in Go.
+	if cloneAsJSONValue("s").(string) != "s" {
+		t.Fatalf("scalar clone changed value")
+	}
+}

--- a/bamlutils/clientdefaults/handlers_test.go
+++ b/bamlutils/clientdefaults/handlers_test.go
@@ -1,8 +1,9 @@
 package clientdefaults
 
 import (
-	"encoding/json"
 	"testing"
+
+	"github.com/goccy/go-json"
 )
 
 func TestAllowedRoleMetadataHandler_ParseAccepts(t *testing.T) {

--- a/bamlutils/embed.go
+++ b/bamlutils/embed.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed adapters.go buildrequest/call_orchestrator.go buildrequest/orchestrator.go buildrequest/response_extract.go dynamic.go embed.go go.mod go.sum interfaces.go llmhttp/llmhttp.go media.go pool.go retry/retry.go sse/extract.go sseclient/sseclient.go urlrewrite/urlrewrite.go versions.go
+//go:embed adapters.go buildrequest/call_orchestrator.go buildrequest/orchestrator.go buildrequest/response_extract.go buildrequest/strategy_testhelper.go clientdefaults/clientdefaults.go clientdefaults/handlers.go dynamic.go embed.go go.mod go.sum interfaces.go llmhttp/llmhttp.go media.go pool.go retry/retry.go sse/extract.go sseclient/sseclient.go urlrewrite/urlrewrite.go versions.go
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/cmd/build/dynamic.baml
+++ b/cmd/build/dynamic.baml
@@ -34,7 +34,9 @@ class Baml_Rest_DynamicOutput {
 }
 
 // Placeholder client - callers MUST provide client_registry.primary
-// For cache_control to work, include allowed_role_metadata in client options
+// For cache_control to work, either include allowed_role_metadata in
+// client_registry.clients[].options, or set it deployment-wide via the
+// BAML_REST_CLIENT_DEFAULTS env var. See the server README.
 client<llm> Baml_Rest_DynamicClient {
   provider "openai"
   options {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -17,6 +17,8 @@ import (
 	goplugin "github.com/hashicorp/go-plugin"
 	baml_rest "github.com/invakid404/baml-rest"
 	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/buildrequest"
+	"github.com/invakid404/baml-rest/bamlutils/clientdefaults"
 	"github.com/invakid404/baml-rest/bamlutils/urlrewrite"
 	"github.com/invakid404/baml-rest/internal/memlimit"
 	"github.com/invakid404/baml-rest/workerplugin"
@@ -37,6 +39,30 @@ func main() {
 		Output:     os.Stderr,
 		JSONFormat: true,
 	})
+
+	// Load deployment-wide ClientRegistry defaults. A parse failure here is
+	// fatal by design: the worker exits non-zero, go-plugin's handshake
+	// fails, and pool.New surfaces the error to serve's startup. This keeps
+	// misconfiguration loud instead of silently ignoring the env var.
+	//
+	// logger.Error (hclog-structured JSON on stderr) is the only channel
+	// go-plugin preserves; fmt.Fprintln / log.Fatal output would be demoted
+	// to debug or dropped entirely by the plugin host.
+	var err error
+	workerClientDefaults, err = clientdefaults.Load()
+	if err != nil {
+		logger.Error("invalid BAML_REST_CLIENT_DEFAULTS", "err", err.Error())
+		os.Exit(1)
+	}
+	if workerClientDefaults.HasKey("allowed_role_metadata") && buildrequest.UseBuildRequest() {
+		logger.Warn(
+			"BAML_REST_CLIENT_DEFAULTS sets allowed_role_metadata but " +
+				"BAML_REST_USE_BUILD_REQUEST=true; message-level metadata " +
+				"(e.g. cache_control) is dropped by the BuildRequest serializer " +
+				"until the upstream TODOs are resolved: " +
+				"baml_language/crates/sys_llm/src/build_request/openai.rs:100 and " +
+				"baml_language/crates/sys_llm/src/build_request/anthropic.rs:91")
+	}
 
 	// Start RSS monitor to trigger GC when native memory pressure is high.
 	// BAML's native (Rust) memory isn't visible to Go's GC, so we monitor RSS
@@ -116,6 +142,11 @@ func ActiveDrainGoroutines() int64 {
 	return activeDrainGoroutines.Load()
 }
 
+// workerClientDefaults holds deployment-wide ClientRegistry option defaults
+// parsed from BAML_REST_CLIENT_DEFAULTS at worker startup. Always non-nil
+// after main() runs; Apply is a no-op when no options were configured.
+var workerClientDefaults *clientdefaults.Config
+
 // workerImpl implements the workerplugin.Worker interface
 type workerImpl struct {
 	metricsReg *prometheus.Registry
@@ -137,6 +168,10 @@ func (o *workerBamlOptions) apply(adapter bamlutils.Adapter) error {
 		if rules := urlrewrite.GlobalRules(); len(rules) > 0 {
 			rewriteClientBaseURLs(o.Options.ClientRegistry, rules)
 		}
+		// Merge deployment-wide defaults *after* URL rewrites (so injected
+		// values aren't accidentally URL-rewritten) and *before*
+		// SetClientRegistry (so BAML sees the merged options).
+		workerClientDefaults.Apply(o.Options.ClientRegistry)
 		if err := adapter.SetClientRegistry(o.Options.ClientRegistry); err != nil {
 			return fmt.Errorf("failed to set client registry: %w", err)
 		}

--- a/go.work.sum
+++ b/go.work.sum
@@ -1203,6 +1203,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
 golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1214,7 +1216,6 @@ golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
@@ -1232,7 +1233,6 @@ golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7
 golang.org/x/term v0.33.0/go.mod h1:s18+ql9tYWp1IfpV9DmCtQDDSRBUjKaw9M1eAv5UeF0=
 golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=
 golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=
-golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1203,8 +1203,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
 golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1216,6 +1214,7 @@ golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
@@ -1233,6 +1232,7 @@ golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7
 golang.org/x/term v0.33.0/go.mod h1:s18+ql9tYWp1IfpV9DmCtQDDSRBUjKaw9M1eAv5UeF0=
 golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=
 golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=
+golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=

--- a/integration/client_defaults_test.go
+++ b/integration/client_defaults_test.go
@@ -1,0 +1,213 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// TestClientDefaults_AllowedRoleMetadata exercises the
+// BAML_REST_CLIENT_DEFAULTS feature end-to-end. Two sub-tests:
+//
+//  1. positive: a dedicated container with the env var set. The caller's
+//     ClientRegistry deliberately omits allowed_role_metadata; we verify the
+//     deployment default lets cache_control survive into the outbound body.
+//     Skipped on the BuildRequest leg — see the skip message for rationale.
+//
+//  2. negative: reuses the shared TestEnv (no BAML_REST_CLIENT_DEFAULTS).
+//     Same request shape; asserts cache_control is dropped. Reproduces the
+//     bug this feature is fixing.
+func TestClientDefaults_AllowedRoleMetadata(t *testing.T) {
+	// Dynamic endpoints are the carrier for message-level metadata.
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		t.Skip("Skipping: dynamic endpoints require BAML >= 0.215.0")
+	}
+
+	t.Run("positive_default_preserves_cache_control", func(t *testing.T) {
+		if UseBuildRequest {
+			t.Skip("cache_control survives BAML's allowed_role_metadata filter on " +
+				"the classic runtime path but is dropped by the BuildRequest " +
+				"serializer. Upstream TODOs: " +
+				"baml_language/crates/sys_llm/src/build_request/openai.rs:100 and " +
+				"baml_language/crates/sys_llm/src/build_request/anthropic.rs:91. " +
+				"Remove this skip when those TODOs are resolved.")
+		}
+
+		setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		defer setupCancel()
+
+		adapterVersion, err := testutil.GetAdapterVersionForBAML(BAMLVersion)
+		if err != nil {
+			t.Fatalf("Failed to get adapter version: %v", err)
+		}
+		bamlSrcPath, err := findTestdataPath()
+		if err != nil {
+			t.Fatalf("Failed to find testdata: %v", err)
+		}
+
+		env, err := testutil.Setup(setupCtx, testutil.SetupOptions{
+			BAMLSrcPath:     bamlSrcPath,
+			BAMLVersion:     BAMLVersion,
+			AdapterVersion:  adapterVersion,
+			BAMLSource:      BAMLSourcePath,
+			UseBuildRequest: UseBuildRequest,
+			RuntimeEnv: map[string]string{
+				"BAML_REST_CLIENT_DEFAULTS": `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Failed to setup dedicated env: %v", err)
+		}
+		defer func() {
+			termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer termCancel()
+			if err := env.Terminate(termCtx); err != nil {
+				t.Logf("dedicated env Terminate: %v", err)
+			}
+		}()
+
+		mockClient := mockllm.NewClient(env.MockLLMURL)
+		bamlClient := testutil.NewBAMLRestClient(env.BAMLRestURL)
+
+		scenarioID := "test-client-defaults-positive"
+		registerCacheScenario(t, mockClient, scenarioID)
+
+		// Deliberately omit allowed_role_metadata from the caller's options;
+		// the deployment default must inject it at the worker.
+		registry := &testutil.ClientRegistry{
+			Primary: "TestClient",
+			Clients: []*testutil.ClientProperty{
+				{
+					Name:     "TestClient",
+					Provider: "openai-generic",
+					Options: map[string]any{
+						"model":    scenarioID,
+						"base_url": env.MockLLMInternal,
+						"api_key":  "test-key",
+					},
+				},
+			},
+		}
+
+		callCtx, callCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer callCancel()
+
+		resp, err := bamlClient.DynamicCall(callCtx, testutil.DynamicRequest{
+			Messages: []testutil.DynamicMessage{
+				{
+					Role:    "user",
+					Content: "Does cache_control survive?",
+					Metadata: &testutil.DynamicMessageMetadata{
+						CacheControl: &testutil.DynamicCacheControl{Type: "ephemeral"},
+					},
+				},
+			},
+			ClientRegistry: registry,
+			OutputSchema: &testutil.DynamicOutputSchema{
+				Properties: map[string]*testutil.DynamicProperty{
+					"answer": {Type: "string"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("DynamicCall failed: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		inspectCtx, inspectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer inspectCancel()
+		body, err := mockClient.GetLastRequest(inspectCtx, scenarioID)
+		if err != nil {
+			t.Fatalf("GetLastRequest failed: %v", err)
+		}
+		if !strings.Contains(string(body), `"cache_control"`) {
+			t.Fatalf("expected cache_control in outbound body, got:\n%s", body)
+		}
+	})
+
+	t.Run("negative_no_default_drops_cache_control", func(t *testing.T) {
+		// Shared TestEnv has no BAML_REST_CLIENT_DEFAULTS, so this reproduces
+		// the pre-fix behavior: BAML defaults allowed_role_metadata to None
+		// and silently strips cache_control before serialization.
+		scenarioID := "test-client-defaults-negative"
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		registerCacheScenario(t, MockClient, scenarioID)
+
+		registry := &testutil.ClientRegistry{
+			Primary: "TestClient",
+			Clients: []*testutil.ClientProperty{
+				{
+					Name:     "TestClient",
+					Provider: "openai-generic",
+					Options: map[string]any{
+						"model":    scenarioID,
+						"base_url": TestEnv.MockLLMInternal,
+						"api_key":  "test-key",
+					},
+				},
+			},
+		}
+
+		resp, err := BAMLClient.DynamicCall(ctx, testutil.DynamicRequest{
+			Messages: []testutil.DynamicMessage{
+				{
+					Role:    "user",
+					Content: "Does cache_control survive?",
+					Metadata: &testutil.DynamicMessageMetadata{
+						CacheControl: &testutil.DynamicCacheControl{Type: "ephemeral"},
+					},
+				},
+			},
+			ClientRegistry: registry,
+			OutputSchema: &testutil.DynamicOutputSchema{
+				Properties: map[string]*testutil.DynamicProperty{
+					"answer": {Type: "string"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("DynamicCall failed: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		body, err := MockClient.GetLastRequest(ctx, scenarioID)
+		if err != nil {
+			t.Fatalf("GetLastRequest failed: %v", err)
+		}
+		if strings.Contains(string(body), `"cache_control"`) {
+			t.Fatalf("expected cache_control absent from outbound body, got:\n%s", body)
+		}
+	})
+}
+
+// registerCacheScenario registers a minimal openai-shaped scenario whose
+// response body matches the dynamic output schema used by the test.
+func registerCacheScenario(t *testing.T, client *mockllm.Client, scenarioID string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := client.RegisterScenario(ctx, &mockllm.Scenario{
+		ID:        scenarioID,
+		Provider:  "openai",
+		Content:   `{"answer": "yes"}`,
+		ChunkSize: 0,
+	})
+	if err != nil {
+		t.Fatalf("RegisterScenario: %v", err)
+	}
+}
+

--- a/integration/client_defaults_test.go
+++ b/integration/client_defaults_test.go
@@ -184,7 +184,9 @@ func TestClientDefaults_AllowedRoleMetadata(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, resp.Error)
 		}
 
-		body, err := MockClient.GetLastRequest(ctx, scenarioID)
+		inspectCtx, inspectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer inspectCancel()
+		body, err := MockClient.GetLastRequest(inspectCtx, scenarioID)
 		if err != nil {
 			t.Fatalf("GetLastRequest failed: %v", err)
 		}
@@ -210,4 +212,3 @@ func registerCacheScenario(t *testing.T, client *mockllm.Client, scenarioID stri
 		t.Fatalf("RegisterScenario: %v", err)
 	}
 }
-

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -106,6 +106,12 @@ type SetupOptions struct {
 	// CallStream+OnTick path. This must be forwarded from the host env
 	// so that the CI matrix leg actually toggles the code path under test.
 	UseBuildRequest bool
+
+	// RuntimeEnv adds arbitrary environment variables to the baml-rest
+	// container. Used by tests that need to configure runtime-only features
+	// (e.g. BAML_REST_CLIENT_DEFAULTS) that the shared test env does not set.
+	// Keys collide in favor of RuntimeEnv, so tests can override defaults.
+	RuntimeEnv map[string]string
 }
 
 // Setup creates the test environment with mock LLM server and baml-rest container.
@@ -264,10 +270,7 @@ func startBAMLRestContainer(ctx context.Context, networkName string, opts SetupO
 		NetworkAliases: map[string][]string{
 			networkName: {BAMLRestContainerName},
 		},
-		Env: map[string]string{
-			"BAML_LOG":                    "debug",
-			"BAML_REST_USE_BUILD_REQUEST": strconv.FormatBool(opts.UseBuildRequest),
-		},
+		Env: buildContainerEnv(opts),
 		HostConfigModifier: func(hc *container.HostConfig) {
 			if hc.Sysctls == nil {
 				hc.Sysctls = make(map[string]string)
@@ -285,6 +288,20 @@ func startBAMLRestContainer(ctx context.Context, networkName string, opts SetupO
 		ContainerRequest: req,
 		Started:          true,
 	})
+}
+
+// buildContainerEnv returns the env map passed to the baml-rest container.
+// Entries in opts.RuntimeEnv take precedence over the shared defaults, so a
+// test can override BAML_LOG or BAML_REST_USE_BUILD_REQUEST if it needs to.
+func buildContainerEnv(opts SetupOptions) map[string]string {
+	env := map[string]string{
+		"BAML_LOG":                    "debug",
+		"BAML_REST_USE_BUILD_REQUEST": strconv.FormatBool(opts.UseBuildRequest),
+	}
+	for k, v := range opts.RuntimeEnv {
+		env[k] = v
+	}
+	return env
 }
 
 // dockerfileTemplateData maps SetupOptions to the template fields used by cmd/build/Dockerfile.tmpl


### PR DESCRIPTION
## Summary

Fix a silent-data-loss bug where Anthropic `cache_control` markers (and any other message-level metadata) were being dropped before reaching the LLM. BAML's runtime filters message metadata through the caller's `allowed_role_metadata` client option; when that option is absent, BAML defaults it to `None` and silently strips every metadata key. The `cmd/build/dynamic.baml` comment warned callers about this, but baml-rest itself never injected the option, so every caller had to remember it on every client. When they didn't, prompt caching appeared wired up end-to-end but produced zero cache hits.

This PR adds a deployment-wide mechanism for operators to pin BAML `ClientRegistry` option defaults.

- New env var: `BAML_REST_CLIENT_DEFAULTS` — JSON object parsed once at worker startup.
- Merge contract: for each configured option, inject the default into every client's `Options` map unless the caller already set the key (caller wins, in all forms including `null`/`[]`/`"none"`).
- v1 recognizes one option, `allowed_role_metadata`. The `Handler{Key, Parse, Apply}` registry is designed to accept future options (`headers`, `request_timeout_ms`, …) as a new struct literal plus a test case — no changes to `Load`/`Apply`.
- Strict validation: `DisallowUnknownFields()` on the envelope, per-handler value validation on the inside. `allowed_role_metadata` is tightened to BAML's own grammar — `"all"`, `"none"`, or an array of strings; typos like `"cache_control"` fail loudly at worker boot instead of surviving into BAML.

Example config:

```json
{
  "client_defaults": {
    "options": {
      "allowed_role_metadata": ["cache_control"]
    }
  }
}
```

Worker startup parses the env var eagerly. Parse failure → `logger.Error` + `os.Exit(1)` → go-plugin handshake fails → `pool.New` surfaces the error to serve startup, so misconfiguration is loud.

## Known limitation: BuildRequest path

When `BAML_REST_USE_BUILD_REQUEST=true`, BAML's Rust BuildRequest serializer drops message-level metadata during prompt→body conversion (upstream TODOs at `baml_language/crates/sys_llm/src/build_request/openai.rs:100` and `.../anthropic.rs:91`). In that mode, `allowed_role_metadata` is still logically consumed by BAML but the metadata on messages is dropped at the subsequent serialization step, so `cache_control` never reaches the outbound body.

This is surfaced three ways:

1. A narrow hclog warning at worker startup when both conditions hold (`BAML_REST_CLIENT_DEFAULTS` configures `allowed_role_metadata` AND `BAML_REST_USE_BUILD_REQUEST=true`).
2. A `t.Skip` on the positive integration test's BuildRequest leg, with a message pointing at the upstream TODOs.
3. A note in the package doc comment and the README.

When the upstream TODOs are resolved, the fix is to remove all three of those references and verify the integration test passes on both matrix legs.

## Test plan

- [x] Unit tests (`bamlutils/clientdefaults/`): 25 cases covering merge semantics (caller-absent / caller-value / `[]` opt-out / `"none"` opt-out / explicit null), multi-client injection, lazy Options allocation, cloning guarantees (mutating one client's injected slice can't affect another's or future `Apply` calls), malformed JSON / unknown envelope key / unknown option key / wrong-type / non-`all`-or-`none` string rejection, and `HasKey` / nil-safety.
- [x] Integration tests (`integration/client_defaults_test.go`, under `//go:build integration`): positive test spins up a dedicated container with the env var set and asserts `cache_control` survives into mockllm's raw-body capture; negative test against the shared `TestEnv` (no env var) asserts `cache_control` is dropped. Both use `openai-generic` against mockllm's `/v1/chat/completions` to exercise the provider-agnostic filter on the path real deployments take (`baml-rest → BAML(openai-generic) → LiteLLM`). Positive test skips on the `BAML_REST_USE_BUILD_REQUEST=true` matrix leg per the known-limitation above.
- [x] Ran `go test -tags=integration -run=TestClientDefaults_AllowedRoleMetadata ./integration/` locally on the classic leg: both subtests pass in ~45s wall-clock (including docker build).
- [x] `go build ./...`, `go vet ./...`, and `go vet -tags=integration ./integration/...` all clean.

## Notable files

- `bamlutils/clientdefaults/` — new package: `Config`, `Load`, `Apply`, `Handler` registry, `cloneAsJSONValue`.
- `cmd/worker/main.go` — eager `Load` at startup, BuildRequest warning, `Apply` between URL rewrites and `SetClientRegistry`.
- `integration/testutil/container.go` — `SetupOptions.RuntimeEnv` lets tests forward arbitrary env vars into the baml-rest container; reusable seam beyond this feature.
- `bamlutils/embed.go` — regenerated via `cmd/embed/` so the new package ships inside the embedded source FS that container builds unpack.
- `cmd/build/dynamic.baml`, `README.md` — doc updates pointing callers at both per-client and deployment-wide configuration.

## Design plan

The consolidated multi-round design plan lives at `/tmp/baml-rest-client-defaults-plan.md` (local to the working machine). Key decisions baked into this PR:

- **Env-var-only, JSON-shaped config**: matches existing `BAML_REST_BASE_URL_REWRITES` / `BAML_REST_USE_BUILD_REQUEST` convention; JSON accommodates nested values a `from=to;from=to` scheme can't.
- **Generic `Handler{Key, Parse, Apply}` over switch statement or reflection**: merge semantics live next to the key they manage; adding `headers` or `request_timeout_ms` later is a struct literal plus a test case.
- **Caller-present-wins in all forms including `null`**: respects caller intent; `null` is documented as an anti-pattern because BAML's `ensure_allowed_metadata` rejects non-array/non-string values downstream.
- **Worker-only parse site**: fail-fast via go-plugin handshake → `pool.New`; no preflight in `cmd/serve`.
- **`Apply` after URL rewrites, before `SetClientRegistry`**: URL rewrite is pure mutation, defaults is inject-when-absent; folding them into one framework would distort one or the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Runtime configuration” section documenting BAML_REST_CLIENT_DEFAULTS, BAML_REST_USE_BUILD_REQUEST, BAML_REST_BASE_URL_REWRITES, and BAML_LOG.

* **New Features**
  * Deployment-wide client defaults via BAML_REST_CLIENT_DEFAULTS.
  * Global default for allowed_role_metadata that applies to all clients.

* **Behavior Changes**
  * Startup validates client-defaults (fatal on malformed) and warns when message-level metadata may be dropped.
  * Test harness can inject runtime env vars for containerized tests.

* **Tests**
  * Added unit and integration tests for parsing, merging, and application of client defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->