### PR TITLE
chore(serve): warn at startup when BAML < 0.219.0 lacks BuildRequest API

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ baml-rest reads the following environment variables at startup:
 
 ## Known broken versions
 
-Recommended version: **v0.220.0**
+Recommended version: **v0.221.0**
 
 The BuildRequest code path (`BAML_REST_USE_BUILD_REQUEST=true`) requires
 BAML **v0.219.0** or newer. Older BAML versions remain functional via the

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ baml-rest reads the following environment variables at startup:
 
 Recommended version: **v0.220.0**
 
+The BuildRequest code path (`BAML_REST_USE_BUILD_REQUEST=true`) requires
+BAML **v0.219.0** or newer. Older BAML versions remain functional via the
+CallStream+OnTick path, but baml-rest logs a warning at startup when no
+BuildRequest API is detected in the generated client.
+
 - **v0.215.0**: Type builder is fully broken and panics the entire application
   when used ([issue](https://github.com/BoundaryML/baml/issues/2862))
 - **≥v0.216.0 <0.218.0**: Various issues in dynamic field handling (e.g.,

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -201,7 +201,7 @@ var serveCmd = &cobra.Command{
 		logger := zerolog.New(output).With().Timestamp().Logger()
 
 		if introspected.Request == nil {
-			logger.Warn().Msg("BAML < 0.219.0 detected: BuildRequest API is unavailable, all requests will use the CallStream+OnTick path. Upgrade to BAML >= 0.219.0 to enable the BuildRequest code path (recommended: 0.220.0).")
+			logger.Warn().Msg("BAML < 0.219.0 detected: BuildRequest API is unavailable, all requests will use the CallStream+OnTick path. Upgrade to BAML >= 0.219.0 to enable the BuildRequest code path.")
 		}
 
 		// Configure memory limits

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gregwebs/go-recovery"
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/internal/memlimit"
+	"github.com/invakid404/baml-rest/introspected"
 	"github.com/invakid404/baml-rest/pool"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -198,6 +199,10 @@ var serveCmd = &cobra.Command{
 			output = zerolog.ConsoleWriter{Out: os.Stdout}
 		}
 		logger := zerolog.New(output).With().Timestamp().Logger()
+
+		if introspected.Request == nil {
+			logger.Warn().Msg("BAML < 0.219.0 detected: BuildRequest API is unavailable, all requests will use the CallStream+OnTick path. Upgrade to BAML >= 0.219.0 to enable the BuildRequest code path (recommended: 0.220.0).")
+		}
 
 		// Configure memory limits
 		totalMem := memLimit


### PR DESCRIPTION
## Summary

- Logs a warning at serve startup when `introspected.Request == nil`, i.e. the generated BAML client lacks the modular BuildRequest API (BAML < 0.219.0). Without this, users on older BAML versions silently get routed through the CallStream+OnTick path regardless of `BAML_REST_USE_BUILD_REQUEST`.
- Documents v0.219.0 as the minimum version required for the BuildRequest code path in the README, next to the existing recommended-version note.

Refs #167.

## Test plan

- [ ] Build against a BAML version < 0.219.0 (e.g. v0.218.x) and confirm the warning appears at `serve` startup.
- [ ] Build against BAML >= 0.219.0 and confirm no warning appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated BAML version compatibility information; v0.221.0 now recommended.
  * Added BuildRequest functionality requirements and compatibility notes.

* **Chores**
  * Added startup notification when using BAML versions prior to 0.219.0; fallback support remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->