### PR TITLE
feat: mixed-mode fallback chains with legacy child dispatch

### DIFF
--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -1716,7 +1716,11 @@ func Generate(selfPkg string) {
 					jen.Return(jen.Id("r")),
 				),
 
-				// StreamConfig
+				// StreamConfig. LegacyChildren / LegacyStreamChild stay nil
+				// in step 1: the router guard upstream routes any chain
+				// with legacy children to the legacy CallStream path, so
+				// this function is only ever invoked with an all-supported
+				// chain. Step 2 will flip the guard and wire the callback.
 				jen.Id("streamConfig").Op(":=").Op("&").Qual(common.BuildRequestPkg, "StreamConfig").Values(jen.Dict{
 					jen.Id("Provider"):        jen.Id("provider"),
 					jen.Id("RetryPolicy"):     jen.Id("retryPolicy"),
@@ -1724,6 +1728,7 @@ func Generate(selfPkg string) {
 					jen.Id("NeedsRaw"):        jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsRaw").Call(),
 					jen.Id("FallbackChain"):   jen.Id("fallbackChain"),
 					jen.Id("ClientProviders"): jen.Id("clientProviders"),
+					jen.Id("LegacyChildren"):  jen.Id("legacyChildren"),
 				}),
 
 				// Run the orchestration in a goroutine with panic recovery, matching
@@ -1780,6 +1785,7 @@ func Generate(selfPkg string) {
 					jen.Id("retryPolicy").Op("*").Qual(common.RetryPkg, "Policy"),
 					jen.Id("fallbackChain").Index().String(),
 					jen.Id("clientProviders").Map(jen.String()).String(),
+					jen.Id("legacyChildren").Map(jen.String()).Bool(),
 				).
 				Error().
 				Block(buildRequestBody...)
@@ -1894,13 +1900,16 @@ func Generate(selfPkg string) {
 					jen.Return(jen.Id("r")),
 				),
 
-				// CallConfig
+				// CallConfig. LegacyChildren / LegacyCallChild stay nil in
+				// step 1 — the router guard ensures mixed chains don't reach
+				// this helper. Step 2 wires the callback and removes the guard.
 				jen.Id("callConfig").Op(":=").Op("&").Qual(common.BuildRequestPkg, "CallConfig").Values(jen.Dict{
 					jen.Id("Provider"):        jen.Id("provider"),
 					jen.Id("RetryPolicy"):     jen.Id("retryPolicy"),
 					jen.Id("NeedsRaw"):        jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsRaw").Call(),
 					jen.Id("FallbackChain"):   jen.Id("fallbackChain"),
 					jen.Id("ClientProviders"): jen.Id("clientProviders"),
+					jen.Id("LegacyChildren"):  jen.Id("legacyChildren"),
 				}),
 
 				// Resolve HTTP client
@@ -1955,6 +1964,7 @@ func Generate(selfPkg string) {
 					jen.Id("retryPolicy").Op("*").Qual(common.RetryPkg, "Policy"),
 					jen.Id("fallbackChain").Index().String(),
 					jen.Id("clientProviders").Map(jen.String()).String(),
+					jen.Id("legacyChildren").Map(jen.String()).Bool(),
 				).
 				Error().
 				Block(buildCallRequestBody...)
@@ -2008,6 +2018,7 @@ func Generate(selfPkg string) {
 							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
 							jen.Id("provider"), jen.Id("retryPolicy"),
 							jen.Nil(), jen.Nil(),
+							jen.Nil(),
 						),
 						jen.If(jen.Id("err").Op("!=").Nil()).Block(
 							jen.Return(jen.Nil(), jen.Id("err")),
@@ -2015,20 +2026,27 @@ func Generate(selfPkg string) {
 						jen.Return(jen.Id("out"), jen.Nil()),
 					),
 					// Fallback chain path: if single-provider check failed, try resolving
-					// a fallback chain (all children must have supported providers).
-					jen.List(jen.Id("__chain"), jen.Id("__cprov")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChain").Call(
+					// a fallback chain. Mixed-mode chains (with any legacy children)
+					// currently route through the legacy CallStream path — the
+					// per-method legacy callback closures land in step 2, so the
+					// BuildRequest path only accepts all-supported chains today.
+					jen.List(jen.Id("__chain"), jen.Id("__cprov"), jen.Id("__legacyChildren")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChain").Call(
 						jen.Id("adapter"),
 						jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
 						jen.Qual(common.IntrospectedPkg, "FallbackChains"),
 						jen.Qual(common.IntrospectedPkg, "ClientProvider"),
 						jen.Qual(common.BuildRequestPkg, "IsCallProviderSupported"),
 					),
-					jen.If(jen.Len(jen.Id("__chain")).Op(">").Lit(0)).Block(
+					jen.If(
+						jen.Len(jen.Id("__chain")).Op(">").Lit(0).
+							Op("&&").Len(jen.Id("__legacyChildren")).Op("==").Lit(0),
+					).Block(
 						resolveRetryPolicy(),
 						jen.Id("err").Op("=").Id(buildCallRequestMethodName).Call(
 							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
 							jen.Lit(""), jen.Id("retryPolicy"),
 							jen.Id("__chain"), jen.Id("__cprov"),
+							jen.Id("__legacyChildren"),
 						),
 						jen.If(jen.Id("err").Op("!=").Nil()).Block(
 							jen.Return(jen.Nil(), jen.Id("err")),
@@ -2063,26 +2081,35 @@ func Generate(selfPkg string) {
 							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
 							jen.Id("provider"), jen.Id("retryPolicy"),
 							jen.Nil(), jen.Nil(),
+							jen.Nil(),
 						),
 						jen.If(jen.Id("err").Op("!=").Nil()).Block(
 							jen.Return(jen.Nil(), jen.Id("err")),
 						),
 						jen.Return(jen.Id("out"), jen.Nil()),
 					),
-					// Fallback chain path
-					jen.List(jen.Id("__chain"), jen.Id("__cprov")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChain").Call(
+					// Fallback chain path. Mixed-mode chains (with any legacy
+					// children) currently route through the legacy path —
+					// the per-method legacy callback closures land in step 2,
+					// so the BuildRequest path only accepts all-supported
+					// chains today.
+					jen.List(jen.Id("__chain"), jen.Id("__cprov"), jen.Id("__legacyChildren")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChain").Call(
 						jen.Id("adapter"),
 						jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
 						jen.Qual(common.IntrospectedPkg, "FallbackChains"),
 						jen.Qual(common.IntrospectedPkg, "ClientProvider"),
 						jen.Qual(common.BuildRequestPkg, "IsProviderSupported"),
 					),
-					jen.If(jen.Len(jen.Id("__chain")).Op(">").Lit(0)).Block(
+					jen.If(
+						jen.Len(jen.Id("__chain")).Op(">").Lit(0).
+							Op("&&").Len(jen.Id("__legacyChildren")).Op("==").Lit(0),
+					).Block(
 						resolveRetryPolicy(),
 						jen.Id("err").Op("=").Id(buildRequestMethodName).Call(
 							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
 							jen.Lit(""), jen.Id("retryPolicy"),
 							jen.Id("__chain"), jen.Id("__cprov"),
+							jen.Id("__legacyChildren"),
 						),
 						jen.If(jen.Id("err").Op("!=").Nil()).Block(
 							jen.Return(jen.Nil(), jen.Id("err")),

--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -1581,6 +1581,17 @@ func Generate(selfPkg string) {
 			}
 			buildRequestCallParams = append(buildRequestCallParams, jen.Id("callOpts").Op("..."))
 
+			// Call params for the legacy-child Stream.<Method> invocation.
+			// First arg is adapter (its embedded context.Context satisfies
+			// the BAML generated Stream.Method signature); the rest is
+			// method args + opts. Mirrors driveStreamBody at codegen.go:1456.
+			var legacyStreamCallParams []jen.Code
+			legacyStreamCallParams = append(legacyStreamCallParams, jen.Id("adapter"))
+			for _, arg := range args {
+				legacyStreamCallParams = append(legacyStreamCallParams, argCallParam(arg))
+			}
+			legacyStreamCallParams = append(legacyStreamCallParams, jen.Id("opts").Op("..."))
+
 			// The _buildRequest body
 			buildRequestBody := makePreamble()
 
@@ -1716,19 +1727,67 @@ func Generate(selfPkg string) {
 					jen.Return(jen.Id("r")),
 				),
 
-				// StreamConfig. LegacyChildren / LegacyStreamChild stay nil
-				// in step 1: the router guard upstream routes any chain
-				// with legacy children to the legacy CallStream path, so
-				// this function is only ever invoked with an all-supported
-				// chain. Step 2 will flip the guard and wire the callback.
+				// legacyStreamChildFn runs one mixed-mode legacy child via
+				// BAML's Stream API. Delegates the lifecycle (heartbeat
+				// wiring + FunctionLog capture for raw) to the shared
+				// runLegacyChildStream helper; the inner closure supplies
+				// only the per-method Stream.<Method> invocation.
+				jen.Id("legacyStreamChildFn").Op(":=").Func().Params(
+					jen.Id("ctx").Qual("context", "Context"),
+					jen.Id("clientOverride").String(),
+					jen.Id("_").String(),
+					jen.Id("needsRaw").Bool(),
+					jen.Id("sendHeartbeat").Func().Params(),
+				).Params(jen.Any(), jen.String(), jen.Error()).Block(
+					jen.Id("callOpts").Op(":=").Id("options"),
+					jen.If(jen.Id("clientOverride").Op("!=").Lit("")).Block(
+						jen.Id("callOpts").Op("=").Append(
+							jen.Qual("slices", "Clone").Call(jen.Id("options")),
+							jen.Qual(common.GeneratedClientPkg, "WithClient").Call(jen.Id("clientOverride")),
+						),
+					),
+					jen.Return(jen.Id("runLegacyChildStream").Call(
+						jen.Id("ctx"),
+						jen.Id("needsRaw"),
+						jen.Id("sendHeartbeat"),
+						jen.Func().Params(jen.Id("onTick").Add(onTickType())).Params(jen.Any(), jen.Error()).Block(
+							jen.Id("opts").Op(":=").Append(
+								jen.Id("callOpts"),
+								jen.Qual(common.GeneratedClientPkg, "WithOnTick").Call(jen.Id("onTick")),
+							),
+							jen.List(jen.Id("stream"), jen.Id("streamErr")).Op(":=").
+								Qual(common.GeneratedClientPkg, "Stream").Dot(methodName).Call(legacyStreamCallParams...),
+							jen.If(jen.Id("streamErr").Op("!=").Nil()).Block(
+								jen.Return(jen.Nil(), jen.Id("streamErr")),
+							),
+							jen.Var().Id("result").Any(),
+							jen.Var().Id("lastErr").Error(),
+							jen.For(jen.Id("streamVal").Op(":=").Range().Id("stream")).Block(
+								jen.If(jen.Id("streamVal").Dot("IsError")).Block(
+									jen.Id("lastErr").Op("=").Id("streamVal").Dot("Error"),
+									jen.Continue(),
+								),
+								jen.If(jen.Id("streamVal").Dot("IsFinal")).Block(
+									jen.Id("result").Op("=").Id("streamVal").Dot("Final").Call(),
+								),
+							),
+							jen.Return(jen.Id("result"), jen.Id("lastErr")),
+						),
+					)),
+				),
+
+				// StreamConfig. LegacyChildren is populated for mixed chains;
+				// LegacyStreamChild is always wired so the orchestrator's
+				// up-front validation passes even when legacyChildren is nil.
 				jen.Id("streamConfig").Op(":=").Op("&").Qual(common.BuildRequestPkg, "StreamConfig").Values(jen.Dict{
-					jen.Id("Provider"):        jen.Id("provider"),
-					jen.Id("RetryPolicy"):     jen.Id("retryPolicy"),
-					jen.Id("NeedsPartials"):   jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsPartials").Call(),
-					jen.Id("NeedsRaw"):        jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsRaw").Call(),
-					jen.Id("FallbackChain"):   jen.Id("fallbackChain"),
-					jen.Id("ClientProviders"): jen.Id("clientProviders"),
-					jen.Id("LegacyChildren"):  jen.Id("legacyChildren"),
+					jen.Id("Provider"):          jen.Id("provider"),
+					jen.Id("RetryPolicy"):       jen.Id("retryPolicy"),
+					jen.Id("NeedsPartials"):     jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsPartials").Call(),
+					jen.Id("NeedsRaw"):          jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsRaw").Call(),
+					jen.Id("FallbackChain"):     jen.Id("fallbackChain"),
+					jen.Id("ClientProviders"):   jen.Id("clientProviders"),
+					jen.Id("LegacyChildren"):    jen.Id("legacyChildren"),
+					jen.Id("LegacyStreamChild"): jen.Id("legacyStreamChildFn"),
 				}),
 
 				// Run the orchestration in a goroutine with panic recovery, matching
@@ -1810,6 +1869,17 @@ func Generate(selfPkg string) {
 				callRequestCallParams = append(callRequestCallParams, argCallParam(arg))
 			}
 			callRequestCallParams = append(callRequestCallParams, jen.Id("callOpts").Op("..."))
+
+			// Stream.<Method> params for the legacy call-mode child. BAML
+			// exposes streaming as the primitive even for non-streaming use,
+			// so legacy call children reuse runLegacyChildStream just like
+			// streaming children.
+			var legacyCallStreamCallParams []jen.Code
+			legacyCallStreamCallParams = append(legacyCallStreamCallParams, jen.Id("adapter"))
+			for _, arg := range args {
+				legacyCallStreamCallParams = append(legacyCallStreamCallParams, argCallParam(arg))
+			}
+			legacyCallStreamCallParams = append(legacyCallStreamCallParams, jen.Id("opts").Op("..."))
 
 			buildCallRequestBody := makePreamble()
 
@@ -1900,9 +1970,57 @@ func Generate(selfPkg string) {
 					jen.Return(jen.Id("r")),
 				),
 
-				// CallConfig. LegacyChildren / LegacyCallChild stay nil in
-				// step 1 — the router guard ensures mixed chains don't reach
-				// this helper. Step 2 wires the callback and removes the guard.
+				// legacyCallChildFn runs one mixed-mode legacy child for the
+				// non-streaming path. Structurally identical to
+				// legacyStreamChildFn in _buildRequest — see that closure
+				// for the rationale.
+				jen.Id("legacyCallChildFn").Op(":=").Func().Params(
+					jen.Id("ctx").Qual("context", "Context"),
+					jen.Id("clientOverride").String(),
+					jen.Id("_").String(),
+					jen.Id("needsRaw").Bool(),
+					jen.Id("sendHeartbeat").Func().Params(),
+				).Params(jen.Any(), jen.String(), jen.Error()).Block(
+					jen.Id("callOpts").Op(":=").Id("options"),
+					jen.If(jen.Id("clientOverride").Op("!=").Lit("")).Block(
+						jen.Id("callOpts").Op("=").Append(
+							jen.Qual("slices", "Clone").Call(jen.Id("options")),
+							jen.Qual(common.GeneratedClientPkg, "WithClient").Call(jen.Id("clientOverride")),
+						),
+					),
+					jen.Return(jen.Id("runLegacyChildStream").Call(
+						jen.Id("ctx"),
+						jen.Id("needsRaw"),
+						jen.Id("sendHeartbeat"),
+						jen.Func().Params(jen.Id("onTick").Add(onTickType())).Params(jen.Any(), jen.Error()).Block(
+							jen.Id("opts").Op(":=").Append(
+								jen.Id("callOpts"),
+								jen.Qual(common.GeneratedClientPkg, "WithOnTick").Call(jen.Id("onTick")),
+							),
+							jen.List(jen.Id("stream"), jen.Id("streamErr")).Op(":=").
+								Qual(common.GeneratedClientPkg, "Stream").Dot(methodName).Call(legacyCallStreamCallParams...),
+							jen.If(jen.Id("streamErr").Op("!=").Nil()).Block(
+								jen.Return(jen.Nil(), jen.Id("streamErr")),
+							),
+							jen.Var().Id("result").Any(),
+							jen.Var().Id("lastErr").Error(),
+							jen.For(jen.Id("streamVal").Op(":=").Range().Id("stream")).Block(
+								jen.If(jen.Id("streamVal").Dot("IsError")).Block(
+									jen.Id("lastErr").Op("=").Id("streamVal").Dot("Error"),
+									jen.Continue(),
+								),
+								jen.If(jen.Id("streamVal").Dot("IsFinal")).Block(
+									jen.Id("result").Op("=").Id("streamVal").Dot("Final").Call(),
+								),
+							),
+							jen.Return(jen.Id("result"), jen.Id("lastErr")),
+						),
+					)),
+				),
+
+				// CallConfig. LegacyChildren is populated for mixed chains;
+				// LegacyCallChild is always wired so validation passes even
+				// when legacyChildren is nil.
 				jen.Id("callConfig").Op(":=").Op("&").Qual(common.BuildRequestPkg, "CallConfig").Values(jen.Dict{
 					jen.Id("Provider"):        jen.Id("provider"),
 					jen.Id("RetryPolicy"):     jen.Id("retryPolicy"),
@@ -1910,6 +2028,7 @@ func Generate(selfPkg string) {
 					jen.Id("FallbackChain"):   jen.Id("fallbackChain"),
 					jen.Id("ClientProviders"): jen.Id("clientProviders"),
 					jen.Id("LegacyChildren"):  jen.Id("legacyChildren"),
+					jen.Id("LegacyCallChild"): jen.Id("legacyCallChildFn"),
 				}),
 
 				// Resolve HTTP client
@@ -2025,11 +2144,11 @@ func Generate(selfPkg string) {
 						),
 						jen.Return(jen.Id("out"), jen.Nil()),
 					),
-					// Fallback chain path: if single-provider check failed, try resolving
-					// a fallback chain. Mixed-mode chains (with any legacy children)
-					// currently route through the legacy CallStream path — the
-					// per-method legacy callback closures land in step 2, so the
-					// BuildRequest path only accepts all-supported chains today.
+					// Fallback chain path: if single-provider check failed,
+					// try resolving a fallback chain. Mixed chains (with
+					// any legacy children) route through the BuildRequest
+					// path — the orchestrator dispatches legacy children
+					// to the generated legacyCallChildFn.
 					jen.List(jen.Id("__chain"), jen.Id("__cprov"), jen.Id("__legacyChildren")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChain").Call(
 						jen.Id("adapter"),
 						jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
@@ -2037,10 +2156,7 @@ func Generate(selfPkg string) {
 						jen.Qual(common.IntrospectedPkg, "ClientProvider"),
 						jen.Qual(common.BuildRequestPkg, "IsCallProviderSupported"),
 					),
-					jen.If(
-						jen.Len(jen.Id("__chain")).Op(">").Lit(0).
-							Op("&&").Len(jen.Id("__legacyChildren")).Op("==").Lit(0),
-					).Block(
+					jen.If(jen.Len(jen.Id("__chain")).Op(">").Lit(0)).Block(
 						resolveRetryPolicy(),
 						jen.Id("err").Op("=").Id(buildCallRequestMethodName).Call(
 							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
@@ -2088,11 +2204,10 @@ func Generate(selfPkg string) {
 						),
 						jen.Return(jen.Id("out"), jen.Nil()),
 					),
-					// Fallback chain path. Mixed-mode chains (with any legacy
-					// children) currently route through the legacy path —
-					// the per-method legacy callback closures land in step 2,
-					// so the BuildRequest path only accepts all-supported
-					// chains today.
+					// Fallback chain path. Mixed chains (with any legacy
+					// children) route through the BuildRequest path — the
+					// orchestrator dispatches legacy children to the
+					// generated legacyStreamChildFn.
 					jen.List(jen.Id("__chain"), jen.Id("__cprov"), jen.Id("__legacyChildren")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChain").Call(
 						jen.Id("adapter"),
 						jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
@@ -2100,10 +2215,7 @@ func Generate(selfPkg string) {
 						jen.Qual(common.IntrospectedPkg, "ClientProvider"),
 						jen.Qual(common.BuildRequestPkg, "IsProviderSupported"),
 					),
-					jen.If(
-						jen.Len(jen.Id("__chain")).Op(">").Lit(0).
-							Op("&&").Len(jen.Id("__legacyChildren")).Op("==").Lit(0),
-					).Block(
+					jen.If(jen.Len(jen.Id("__chain")).Op(">").Lit(0)).Block(
 						resolveRetryPolicy(),
 						jen.Id("err").Op("=").Id(buildRequestMethodName).Call(
 							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
@@ -3666,5 +3778,72 @@ func generateStreamHelpers(out *jen.File) {
 			).Call(),
 
 			jen.Return(jen.Nil()),
+		)
+
+	// ──────────────────────────────────────────────────────────────────
+	// runLegacyChildStream — shared helper for mixed-mode fallback
+	// ──────────────────────────────────────────────────────────────────
+	out.Comment("runLegacyChildStream drives a single child of a mixed-mode fallback")
+	out.Comment("chain through BAML's Stream API. The per-method closure supplies")
+	out.Comment("driveStream, which appends the WithOnTick option and invokes")
+	out.Comment("Stream.<Method>. This helper wires the onTick callback that fires")
+	out.Comment("sendHeartbeat on the first FunctionLog tick (matching the")
+	out.Comment("BuildRequest path's post-HTTP liveness semantics) and captures the")
+	out.Comment("last FunctionLog so raw can be read via RawLLMResponse.")
+	out.Func().Id("runLegacyChildStream").
+		Params(
+			jen.Id("ctx").Qual("context", "Context"),
+			jen.Id("needsRaw").Bool(),
+			jen.Id("sendHeartbeat").Func().Params(),
+			jen.Id("driveStream").Func().Params(
+				jen.Add(onTickType()),
+			).Params(jen.Any(), jen.Error()),
+		).
+		Params(jen.Any(), jen.String(), jen.Error()).
+		Block(
+			// Track first-tick state so sendHeartbeat fires exactly once when
+			// BAML reports the first FunctionLog tick (i.e. first observed
+			// upstream activity). The orchestrator owns heartbeat
+			// idempotency; this guard just saves the extra closure call.
+			jen.Var().Id("heartbeatFired").Qual("sync/atomic", "Bool"),
+			// lastFuncLog stores the most recent FunctionLog handle so
+			// RawLLMResponse can be read after driveStream returns.
+			jen.Var().Id("lastFuncLog").Qual("sync/atomic", "Value"),
+
+			jen.Id("onTick").Op(":=").Func().Params(
+				jen.Id("_").Qual("context", "Context"),
+				jen.Id("_").Qual(BamlPkg, "TickReason"),
+				jen.Id("funcLog").Qual(BamlPkg, "FunctionLog"),
+			).Qual(BamlPkg, "FunctionSignal").Block(
+				jen.If(jen.Id("heartbeatFired").Dot("CompareAndSwap").Call(jen.False(), jen.True())).Block(
+					jen.Id("sendHeartbeat").Call(),
+				),
+				jen.Id("lastFuncLog").Dot("Store").Call(jen.Id("funcLog")),
+				jen.Return(jen.Nil()),
+			),
+
+			jen.List(jen.Id("finalResult"), jen.Id("err")).Op(":=").Id("driveStream").Call(jen.Id("onTick")),
+			jen.If(jen.Id("err").Op("!=").Nil()).Block(
+				jen.Return(jen.Nil(), jen.Lit(""), jen.Id("err")),
+			),
+
+			// Raw is only computed when requested; callers that don't need
+			// raw skip the BAML call entirely (it's cheap but pointless).
+			jen.Var().Id("raw").String(),
+			jen.If(jen.Id("needsRaw")).Block(
+				jen.If(
+					jen.List(jen.Id("fl"), jen.Id("ok")).Op(":=").Id("lastFuncLog").Dot("Load").Call().Assert(jen.Qual(BamlPkg, "FunctionLog")),
+					jen.Id("ok"),
+				).Block(
+					jen.If(
+						jen.List(jen.Id("r"), jen.Id("rawErr")).Op(":=").Id("fl").Dot("RawLLMResponse").Call(),
+						jen.Id("rawErr").Op("==").Nil(),
+					).Block(
+						jen.Id("raw").Op("=").Id("r"),
+					),
+				),
+			),
+
+			jen.Return(jen.Id("finalResult"), jen.Id("raw"), jen.Nil()),
 		)
 }

--- a/bamlutils/buildrequest/call_orchestrator.go
+++ b/bamlutils/buildrequest/call_orchestrator.go
@@ -141,7 +141,11 @@ func RunCallOrchestration(
 			if config.LegacyChildren[child] {
 				// Legacy children are driven via BAML's Stream API, which
 				// tolerates providers BuildRequest doesn't support; we
-				// only require the legacy callback itself.
+				// only require the legacy callback itself. Skipping the
+				// IsCallProviderSupported check is safe because
+				// ResolveFallbackChain rejects chains with any empty
+				// provider (returns nil,nil,nil), so ClientProviders[child]
+				// is guaranteed non-empty by the time we get here.
 				continue
 			}
 			provider := config.ClientProviders[child]

--- a/bamlutils/buildrequest/call_orchestrator.go
+++ b/bamlutils/buildrequest/call_orchestrator.go
@@ -35,8 +35,41 @@ type CallConfig struct {
 
 	// ClientProviders maps child client names to their provider strings.
 	// Used with FallbackChain to resolve the provider for each attempt.
+	// In mixed-mode chains this map includes both BuildRequest-supported
+	// children and legacy (unsupported-provider) children — it is a pure
+	// lookup table, not a "supported set." Callers must consult
+	// LegacyChildren to decide which path runs a given child.
 	ClientProviders map[string]string
+
+	// LegacyChildren marks the entries in FallbackChain that must be driven
+	// via the legacy BAML Stream API rather than the BuildRequest path.
+	// Mirrors StreamConfig.LegacyChildren — see that field for details.
+	LegacyChildren map[string]bool
+
+	// LegacyCallChild runs a single child via BAML's Stream API for the
+	// non-streaming call path. The orchestrator invokes it for children
+	// marked in LegacyChildren. Contract mirrors
+	// StreamConfig.LegacyStreamChild: callback fires sendHeartbeat on the
+	// first FunctionLog tick (matching the BuildRequest call path's
+	// post-HTTP liveness semantics) and returns (final, raw, err).
+	//
+	// Even though this is the non-streaming path, the BAML runtime exposes
+	// streaming as the primitive, so the legacy helper goes through
+	// Stream.Method + FunctionLog capture identically to the streaming
+	// callback — raw comes from FunctionLog.RawLLMResponse().
+	LegacyCallChild LegacyCallChildFunc
 }
+
+// LegacyCallChildFunc runs one child of a mixed-mode fallback chain via
+// BAML's Stream API for the non-streaming call path. See
+// CallConfig.LegacyCallChild for the full contract.
+type LegacyCallChildFunc func(
+	ctx context.Context,
+	clientOverride string,
+	provider string,
+	needsRaw bool,
+	sendHeartbeat func(),
+) (finalResult any, raw string, err error)
 
 // BuildCallRequestFunc builds an HTTP request for a non-streaming call by
 // calling Request.Method(ctx, args, opts...) and converting the result
@@ -91,15 +124,30 @@ func RunCallOrchestration(
 		httpClient = llmhttp.DefaultClient
 	}
 
-	// Validate that the first provider is supported.
+	// Validate the configured provider(s) up front so invalid fallback
+	// chains fail before any retry attempts are launched. The validation
+	// walks every child — previously only the first child was checked,
+	// which allowed a mixed-shaped chain with a valid first but broken
+	// later child to start retrying before surfacing the error.
 	if len(config.FallbackChain) == 0 {
 		if config.Provider == "" || !IsCallProviderSupported(config.Provider) {
 			return fmt.Errorf("buildrequest: unsupported or empty provider %q for non-streaming call", config.Provider)
 		}
 	} else {
-		first := config.ClientProviders[config.FallbackChain[0]]
-		if first == "" || !IsCallProviderSupported(first) {
-			return fmt.Errorf("buildrequest: unsupported or empty provider %q for non-streaming call", first)
+		if len(config.LegacyChildren) > 0 && config.LegacyCallChild == nil {
+			return fmt.Errorf("buildrequest: LegacyChildren set but LegacyCallChild is nil")
+		}
+		for _, child := range config.FallbackChain {
+			if config.LegacyChildren[child] {
+				// Legacy children are driven via BAML's Stream API, which
+				// tolerates providers BuildRequest doesn't support; we
+				// only require the legacy callback itself.
+				continue
+			}
+			provider := config.ClientProviders[child]
+			if provider == "" || !IsCallProviderSupported(provider) {
+				return fmt.Errorf("buildrequest: unsupported or empty provider %q for child %q", provider, child)
+			}
 		}
 	}
 
@@ -193,6 +241,24 @@ func RunCallOrchestration(
 			case <-ctx.Done():
 				return nil, ctx.Err()
 			default:
+			}
+			if config.LegacyChildren[child] {
+				// Legacy children run via BAML's Stream API. The callback
+				// owns heartbeat timing (fires sendHeartbeat on the first
+				// FunctionLog tick) so pool hung-detection stays correct
+				// for slow upstreams that eventually produce bytes.
+				finalResult, raw, err := config.LegacyCallChild(
+					ctx,
+					child,
+					config.ClientProviders[child],
+					config.NeedsRaw,
+					sendHeartbeat,
+				)
+				if err == nil {
+					return &callAttemptResult{finalResult: finalResult, raw: raw}, nil
+				}
+				lastErr = err
+				continue
 			}
 			provider := config.ClientProviders[child]
 			result, err := tryOneChild(provider, child)

--- a/bamlutils/buildrequest/call_orchestrator_test.go
+++ b/bamlutils/buildrequest/call_orchestrator_test.go
@@ -1275,3 +1275,103 @@ func TestRunCallOrchestration_MixedChain_LegacyNoCallbackErrors(t *testing.T) {
 		t.Fatalf("expected no results on validation failure, got kind %v", r.Kind())
 	}
 }
+
+// TestRunCallOrchestration_MixedChain_HTTPBackedEndToEnd mirrors the
+// stream-side end-to-end test: both children are backed by real httptest
+// servers and the legacy callback routes through llmhttp.Execute so its
+// sendHeartbeat fires on a real 2xx. Covers the call path's mixed-mode
+// dispatch, reset-less retry semantics (call path has no reset events),
+// and raw propagation from a genuinely HTTP-fetched legacy body.
+func TestRunCallOrchestration_MixedChain_HTTPBackedEndToEnd(t *testing.T) {
+	supportedServer := makeJSONServer(500, `{"error":"upstream down"}`)
+	defer supportedServer.Close()
+
+	const legacyFinal = "legacy-call-final"
+	const legacyRaw = "legacy-call-raw-payload"
+	legacyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(10 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(200)
+		fmt.Fprint(w, legacyRaw)
+	}))
+	defer legacyServer.Close()
+
+	httpClient := llmhttp.NewClient(supportedServer.Client())
+
+	legacyCallChild := func(ctx context.Context, clientOverride, provider string, needsRaw bool, sendHeartbeat func()) (any, string, error) {
+		if clientOverride != "LegacyChild" {
+			t.Errorf("legacy callback got clientOverride=%q, want LegacyChild", clientOverride)
+		}
+		req := &llmhttp.Request{URL: legacyServer.URL, Method: "POST", Body: `{}`}
+		resp, err := httpClient.Execute(ctx, req, sendHeartbeat)
+		if err != nil {
+			return nil, "", err
+		}
+		raw := resp.Body
+		if !needsRaw {
+			raw = ""
+		}
+		return legacyFinal, raw, nil
+	}
+
+	out := make(chan bamlutils.StreamResult, 100)
+	config := &CallConfig{
+		RetryPolicy:   &retry.Policy{MaxRetries: 0},
+		NeedsRaw:      true,
+		FallbackChain: []string{"SupportedChild", "LegacyChild"},
+		ClientProviders: map[string]string{
+			"SupportedChild": "openai",
+			"LegacyChild":    "aws-bedrock",
+		},
+		LegacyChildren:  map[string]bool{"LegacyChild": true},
+		LegacyCallChild: legacyCallChild,
+	}
+
+	err := RunCallOrchestration(
+		context.Background(), out, config, httpClient,
+		makeBuildCallRequest(supportedServer.URL),
+		identityParseFinal,
+		ExtractResponseContent,
+		newTestResult,
+	)
+	close(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var (
+		heartbeats int
+		finals     int
+		finalVal   any
+		finalRaw   string
+	)
+	for r := range out {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindHeartbeat:
+			heartbeats++
+		case bamlutils.StreamResultKindFinal:
+			finals++
+			finalVal = r.Final()
+			finalRaw = r.Raw()
+		case bamlutils.StreamResultKindError:
+			t.Fatalf("unexpected error result: %v", r.Error())
+		}
+	}
+
+	// The supported child's HTTP call returns 500 before Execute reaches
+	// the sendHeartbeat step, so only the legacy callback contributes a
+	// heartbeat. This documents the call-path's "heartbeat only on 2xx"
+	// semantics end-to-end.
+	if heartbeats != 1 {
+		t.Errorf("expected exactly 1 heartbeat (from legacy child's 2xx), got %d", heartbeats)
+	}
+	if finals != 1 {
+		t.Fatalf("expected exactly 1 final, got %d", finals)
+	}
+	if finalVal != legacyFinal {
+		t.Errorf("expected final=%q, got %v", legacyFinal, finalVal)
+	}
+	if finalRaw != legacyRaw {
+		t.Errorf("expected raw=%q, got %q", legacyRaw, finalRaw)
+	}
+}

--- a/bamlutils/buildrequest/call_orchestrator_test.go
+++ b/bamlutils/buildrequest/call_orchestrator_test.go
@@ -1070,3 +1070,208 @@ func TestRunCallOrchestration_FallbackChainExtractionFailure(t *testing.T) {
 		t.Errorf("expected exactly 2 attempts (1 extraction failure + 1 success), got %d", got)
 	}
 }
+
+// TestRunCallOrchestration_ValidatesAllChildren closes the previous
+// first-child-only validation gap: a chain whose first child is
+// supported but second child has an unsupported non-legacy provider
+// must fail up-front instead of silently succeeding-then-erroring on
+// the second attempt.
+func TestRunCallOrchestration_ValidatesAllChildren(t *testing.T) {
+	out := make(chan bamlutils.StreamResult, 10)
+	err := RunCallOrchestration(
+		context.Background(), out,
+		&CallConfig{
+			FallbackChain: []string{"GoodClient", "BadClient"},
+			ClientProviders: map[string]string{
+				"GoodClient": "openai",
+				"BadClient":  "aws-bedrock",
+			},
+		},
+		nil,
+		func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+			t.Fatal("buildRequest must not be called when validation fails")
+			return nil, nil
+		},
+		identityParseFinal,
+		ExtractResponseContent,
+		newTestResult,
+	)
+	if err == nil {
+		t.Fatal("expected validation error for unsupported later child")
+	}
+	if !strings.Contains(err.Error(), `for child "BadClient"`) {
+		t.Fatalf("expected error mentioning BadClient, got %v", err)
+	}
+	close(out)
+	for r := range out {
+		t.Fatalf("expected no results on validation failure, got kind %v", r.Kind())
+	}
+}
+
+// TestRunCallOrchestration_MixedChain_LegacySucceedsSecond verifies the
+// typical mixed-mode flow for the non-streaming path: the BuildRequest
+// child fails, then the legacy callback wins. Exactly one final is
+// emitted with the legacy callback's final value; raw propagates when
+// NeedsRaw is true.
+func TestRunCallOrchestration_MixedChain_LegacySucceedsSecond(t *testing.T) {
+	server := makeJSONServer(500, `{"error":"upstream down"}`)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	var legacyCalled atomic.Int32
+	var gotOverride, gotProvider string
+	legacyCallChild := func(ctx context.Context, clientOverride, provider string, needsRaw bool, sendHeartbeat func()) (any, string, error) {
+		legacyCalled.Add(1)
+		gotOverride = clientOverride
+		gotProvider = provider
+		sendHeartbeat()
+		return "legacy call final", "legacy call raw", nil
+	}
+
+	config := &CallConfig{
+		RetryPolicy:   &retry.Policy{MaxRetries: 0},
+		NeedsRaw:      true,
+		FallbackChain: []string{"SupportedChild", "LegacyChild"},
+		ClientProviders: map[string]string{
+			"SupportedChild": "openai",
+			"LegacyChild":    "aws-bedrock",
+		},
+		LegacyChildren:  map[string]bool{"LegacyChild": true},
+		LegacyCallChild: legacyCallChild,
+	}
+
+	err := RunCallOrchestration(
+		context.Background(), out, config, client,
+		makeBuildCallRequest(server.URL),
+		identityParseFinal,
+		ExtractResponseContent,
+		newTestResult,
+	)
+	close(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if legacyCalled.Load() != 1 {
+		t.Fatalf("expected legacy callback invoked once, got %d", legacyCalled.Load())
+	}
+	if gotOverride != "LegacyChild" {
+		t.Errorf("expected clientOverride 'LegacyChild', got %q", gotOverride)
+	}
+	if gotProvider != "aws-bedrock" {
+		t.Errorf("expected provider 'aws-bedrock', got %q", gotProvider)
+	}
+
+	var finals int
+	var finalVal any
+	var finalRaw string
+	for r := range out {
+		if r.Kind() == bamlutils.StreamResultKindFinal {
+			finals++
+			finalVal = r.Final()
+			finalRaw = r.Raw()
+		}
+	}
+	if finals != 1 {
+		t.Fatalf("expected exactly one final, got %d", finals)
+	}
+	if finalVal != "legacy call final" {
+		t.Errorf("expected final='legacy call final', got %v", finalVal)
+	}
+	if finalRaw != "legacy call raw" {
+		t.Errorf("expected raw='legacy call raw', got %q", finalRaw)
+	}
+}
+
+// TestRunCallOrchestration_MixedChain_LegacyFirstFails_SupportedWins
+// ensures that a failing legacy child lets the supported child take
+// over and produce the final via BuildRequest.
+func TestRunCallOrchestration_MixedChain_LegacyFirstFails_SupportedWins(t *testing.T) {
+	server := makeJSONServer(200, `{"choices":[{"message":{"content":"supported ok"}}]}`)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	var legacyCalled atomic.Int32
+	legacyCallChild := func(ctx context.Context, clientOverride, provider string, needsRaw bool, sendHeartbeat func()) (any, string, error) {
+		legacyCalled.Add(1)
+		return nil, "", fmt.Errorf("legacy upstream 500")
+	}
+
+	config := &CallConfig{
+		RetryPolicy:   &retry.Policy{MaxRetries: 0},
+		FallbackChain: []string{"LegacyChild", "SupportedChild"},
+		ClientProviders: map[string]string{
+			"LegacyChild":    "aws-bedrock",
+			"SupportedChild": "openai",
+		},
+		LegacyChildren:  map[string]bool{"LegacyChild": true},
+		LegacyCallChild: legacyCallChild,
+	}
+
+	err := RunCallOrchestration(
+		context.Background(), out, config, client,
+		makeBuildCallRequest(server.URL),
+		identityParseFinal,
+		ExtractResponseContent,
+		newTestResult,
+	)
+	close(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if legacyCalled.Load() != 1 {
+		t.Fatalf("expected legacy callback invoked once, got %d", legacyCalled.Load())
+	}
+
+	var finals int
+	var finalVal any
+	for r := range out {
+		if r.Kind() == bamlutils.StreamResultKindFinal {
+			finals++
+			finalVal = r.Final()
+		}
+	}
+	if finals != 1 {
+		t.Fatalf("expected exactly one final, got %d", finals)
+	}
+	if finalVal != "supported ok" {
+		t.Errorf("expected final='supported ok' from supported child, got %v", finalVal)
+	}
+}
+
+// TestRunCallOrchestration_MixedChain_LegacyNoCallbackErrors verifies
+// up-front validation of LegacyChildren + LegacyCallChild coupling.
+func TestRunCallOrchestration_MixedChain_LegacyNoCallbackErrors(t *testing.T) {
+	out := make(chan bamlutils.StreamResult, 10)
+	err := RunCallOrchestration(
+		context.Background(), out,
+		&CallConfig{
+			FallbackChain: []string{"SupportedChild", "LegacyChild"},
+			ClientProviders: map[string]string{
+				"SupportedChild": "openai",
+				"LegacyChild":    "aws-bedrock",
+			},
+			LegacyChildren: map[string]bool{"LegacyChild": true},
+		},
+		nil,
+		func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+			t.Fatal("buildRequest must not be called when LegacyCallChild is missing")
+			return nil, nil
+		},
+		identityParseFinal,
+		ExtractResponseContent,
+		newTestResult,
+	)
+	if err == nil || !strings.Contains(err.Error(), "LegacyCallChild") {
+		t.Fatalf("expected LegacyCallChild validation error, got %v", err)
+	}
+	close(out)
+	for r := range out {
+		t.Fatalf("expected no results on validation failure, got kind %v", r.Kind())
+	}
+}

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -384,8 +384,14 @@ func ResolveFallbackChain(
 	// helper. Children with an empty (unknown) provider are treated as
 	// fatal — we can't route an unknown provider at all, so fall back to
 	// the existing legacy path for the entire chain.
+	//
+	// legacyPositions counts chain entries that land in legacyChildren. It
+	// differs from len(legacyChildren) when the chain lists the same
+	// unsupported client more than once — the set would undercount and
+	// the all-legacy check below would misclassify such a chain as mixed.
 	providers = make(map[string]string, len(chain))
 	legacyChildren = make(map[string]bool)
+	legacyPositions := 0
 	for _, child := range chain {
 		p := resolveChildProvider(reg, child, clientProviders)
 		if p == "" {
@@ -394,16 +400,17 @@ func ResolveFallbackChain(
 		providers[child] = p
 		if !isProviderSupported(p) {
 			legacyChildren[child] = true
+			legacyPositions++
 		}
 	}
 
-	// If every child is legacy, there is nothing for BuildRequest to do —
-	// the entire chain degenerates to legacy, and the caller is better off
-	// routing the request through the existing CallStream+OnTick path
-	// which can handle the chain wholesale (and preserves any
-	// runtime-specific behaviours like round-robin that BAML exposes for
-	// all-legacy strategies).
-	if len(legacyChildren) == len(chain) {
+	// If every chain position is legacy, there is nothing for BuildRequest
+	// to do — the entire chain degenerates to legacy, and the caller is
+	// better off routing the request through the existing
+	// CallStream+OnTick path which can handle the chain wholesale (and
+	// preserves any runtime-specific behaviours like round-robin that
+	// BAML exposes for all-legacy strategies).
+	if legacyPositions == len(chain) {
 		return nil, nil, nil
 	}
 

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -561,7 +561,11 @@ func RunStreamOrchestration(
 			if config.LegacyChildren[child] {
 				// Legacy children are driven via BAML's Stream API, which
 				// tolerates providers BuildRequest doesn't support; we
-				// only require the legacy callback itself.
+				// only require the legacy callback itself. Skipping the
+				// IsProviderSupported check is safe because
+				// ResolveFallbackChain rejects chains with any empty
+				// provider (returns nil,nil,nil), so ClientProviders[child]
+				// is guaranteed non-empty by the time we get here.
 				continue
 			}
 			provider := config.ClientProviders[child]

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -324,9 +324,20 @@ func resolveFallbackStrategyChain(reg *bamlutils.ClientRegistry, clientName stri
 }
 
 // ResolveFallbackChain determines whether a function's client is a fallback
-// strategy client and, if so, returns the ordered child chain and a map of
-// child client names to their providers. Returns nil, nil if the function
-// does not use a fallback chain or if any child's provider is unsupported.
+// strategy client and, if so, returns the ordered child chain, a map of
+// child client names to their resolved providers, and the set of children
+// whose providers are unsupported by BuildRequest (mixed-mode legacy
+// children). Returns nil, nil, nil if the function does not use a fallback
+// chain, if the chain cannot be resolved, or if every child is legacy (in
+// which case the whole chain should route to the existing CallStream+OnTick
+// legacy path).
+//
+// When the chain mixes supported and unsupported children, the returned
+// chain and providers cover every child; legacyChildren lists the names
+// whose providers require the legacy BAML Stream API. providers still
+// contains entries for legacy children (useful for debugging/logging), but
+// callers must consult legacyChildren before assuming BuildRequest can
+// drive that child.
 //
 // Parameters:
 //   - adapter: the request adapter (for runtime client_registry overrides)
@@ -340,7 +351,7 @@ func ResolveFallbackChain(
 	fallbackChains map[string][]string,
 	clientProviders map[string]string,
 	isProviderSupported func(string) bool,
-) (chain []string, providers map[string]string) {
+) (chain []string, providers map[string]string, legacyChildren map[string]bool) {
 	reg := adapter.OriginalClientRegistry()
 
 	// Determine which client name to look up in fallbackChains.
@@ -358,27 +369,45 @@ func ResolveFallbackChain(
 	// the legacy path where the BAML runtime handles the rotation.
 	parentProvider := resolveChildProvider(reg, clientName, clientProviders)
 	if parentProvider != "baml-fallback" {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	chain = resolveFallbackStrategyChain(reg, clientName, fallbackChains)
 	if len(chain) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Resolve each child's provider, checking runtime client_registry
-	// overrides first (same precedence as ResolveProvider). If any child
-	// is unsupported or has no provider, fall back to the legacy path.
+	// overrides first (same precedence as ResolveProvider). Children with
+	// unsupported providers are recorded in legacyChildren so the
+	// orchestrator can route them through the shared legacy BAML Stream
+	// helper. Children with an empty (unknown) provider are treated as
+	// fatal — we can't route an unknown provider at all, so fall back to
+	// the existing legacy path for the entire chain.
 	providers = make(map[string]string, len(chain))
+	legacyChildren = make(map[string]bool)
 	for _, child := range chain {
 		p := resolveChildProvider(reg, child, clientProviders)
-		if p == "" || !isProviderSupported(p) {
-			return nil, nil
+		if p == "" {
+			return nil, nil, nil
 		}
 		providers[child] = p
+		if !isProviderSupported(p) {
+			legacyChildren[child] = true
+		}
 	}
 
-	return chain, providers
+	// If every child is legacy, there is nothing for BuildRequest to do —
+	// the entire chain degenerates to legacy, and the caller is better off
+	// routing the request through the existing CallStream+OnTick path
+	// which can handle the chain wholesale (and preserves any
+	// runtime-specific behaviours like round-robin that BAML exposes for
+	// all-legacy strategies).
+	if len(legacyChildren) == len(chain) {
+		return nil, nil, nil
+	}
+
+	return chain, providers, legacyChildren
 }
 
 // StreamConfig holds the configuration for a single streaming request.
@@ -410,8 +439,63 @@ type StreamConfig struct {
 
 	// ClientProviders maps child client names to their provider strings.
 	// Used with FallbackChain to resolve the provider for each attempt.
+	// In mixed-mode chains this map includes both BuildRequest-supported
+	// children and legacy (unsupported-provider) children — it is a pure
+	// lookup table, not a "supported set." Callers must consult
+	// LegacyChildren to decide which path runs a given child.
 	ClientProviders map[string]string
+
+	// LegacyChildren marks the entries in FallbackChain that must be driven
+	// via the legacy BAML Stream API (WithClient + WithOnTick) rather than
+	// the BuildRequest path. Populated by ResolveFallbackChain when the
+	// chain mixes supported and unsupported providers. Children absent
+	// from this map use the BuildRequest path (buildRequest closure).
+	// When non-empty, LegacyStreamChild must be non-nil — the orchestrator
+	// fails up-front validation otherwise.
+	LegacyChildren map[string]bool
+
+	// LegacyStreamChild runs a single child via BAML's Stream API. The
+	// orchestrator invokes it for children marked in LegacyChildren.
+	//
+	// Contract:
+	//   - Invoke BAML's Stream.Method with WithClient(clientOverride) and
+	//     wire a WithOnTick callback that invokes sendHeartbeat on the
+	//     first FunctionLog tick (this matches the BuildRequest path's
+	//     post-HTTP heartbeat liveness semantics — don't pre-emit the
+	//     heartbeat before upstream activity, or the pool's hung detector
+	//     is disabled prematurely).
+	//   - Drain the stream to completion; do NOT emit partials on the
+	//     orchestrator's output channel. The orchestrator is responsible
+	//     for the single final emission.
+	//   - Return (final, raw, err). When needsRaw is false the helper may
+	//     return an empty raw string.
+	//
+	// Retry note: this callback goes through BAML's runtime, so any
+	// client-level retry_policy declared statically in the BAML file will
+	// apply on top of the orchestrator's outer retry.Execute loop. Per-
+	// request __baml_options__.retry is NOT forwarded into BAML because
+	// makeOptionsFromAdapter does not translate it — outer retries handle
+	// per-request retries, so only the inner BAML static retry compounds.
+	//
+	// Raw note: legacy raw comes from BAML's FunctionLog.RawLLMResponse(),
+	// which drops Anthropic-family thinking deltas. For providers that
+	// only ever appear as legacy children (e.g. aws-bedrock) this is
+	// lossless; for runtime overrides that push a thinking-capable
+	// provider onto the legacy path, raw will match RawLLMResponse rather
+	// than the full wire text.
+	LegacyStreamChild LegacyStreamChildFunc
 }
+
+// LegacyStreamChildFunc runs one child of a mixed-mode fallback chain via
+// BAML's Stream API. See StreamConfig.LegacyStreamChild for the full
+// contract.
+type LegacyStreamChildFunc func(
+	ctx context.Context,
+	clientOverride string,
+	provider string,
+	needsRaw bool,
+	sendHeartbeat func(),
+) (finalResult any, raw string, err error)
 
 // BuildRequestFunc builds an HTTP request for streaming by calling
 // StreamRequest.Method(ctx, args, opts...) and converting the result
@@ -463,7 +547,16 @@ func RunStreamOrchestration(
 			return fmt.Errorf("buildrequest: unsupported or empty provider %q", config.Provider)
 		}
 	} else {
+		if len(config.LegacyChildren) > 0 && config.LegacyStreamChild == nil {
+			return fmt.Errorf("buildrequest: LegacyChildren set but LegacyStreamChild is nil")
+		}
 		for _, child := range config.FallbackChain {
+			if config.LegacyChildren[child] {
+				// Legacy children are driven via BAML's Stream API, which
+				// tolerates providers BuildRequest doesn't support; we
+				// only require the legacy callback itself.
+				continue
+			}
 			provider := config.ClientProviders[child]
 			if provider == "" || !IsProviderSupported(provider) {
 				return fmt.Errorf("buildrequest: unsupported or empty provider %q for child %q", provider, child)
@@ -485,16 +578,20 @@ func RunStreamOrchestration(
 		}
 	}
 
-	// tryOneStreamChild runs a single child's streaming attempt.
-	tryOneStreamChild := func(provider, clientOverride string) (any, error) {
+	// tryOneStreamChild runs a single child's streaming attempt against the
+	// BuildRequest path. Returns the parsed final plus the accumulated raw
+	// text; the caller (attemptFull) is responsible for emitting the final
+	// result on the output channel so supported and legacy children share a
+	// single emission path.
+	tryOneStreamChild := func(provider, clientOverride string) (any, string, error) {
 		req, err := buildRequest(ctx, clientOverride)
 		if err != nil {
-			return nil, fmt.Errorf("buildrequest: failed to build request: %w", err)
+			return nil, "", fmt.Errorf("buildrequest: failed to build request: %w", err)
 		}
 
 		resp, err := httpClient.ExecuteStream(ctx, req)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		defer resp.Close()
 
@@ -525,7 +622,7 @@ func RunStreamOrchestration(
 			if extractErr != nil {
 				// Extraction error — fail the attempt so retry logic can handle it
 				// rather than silently accumulating incomplete text.
-				return nil, fmt.Errorf("buildrequest: delta extraction failed: %w", extractErr)
+				return nil, "", fmt.Errorf("buildrequest: delta extraction failed: %w", extractErr)
 			}
 			if delta.Raw == "" {
 				continue
@@ -539,7 +636,7 @@ func RunStreamOrchestration(
 			if config.NeedsPartials && delta.Parseable == "" {
 				if config.NeedsRaw {
 					if err := trySendPartial(nil, delta.Raw); err != nil {
-						return nil, err
+						return nil, "", err
 					}
 				}
 				continue
@@ -567,7 +664,7 @@ func RunStreamOrchestration(
 							rawForResult = delta.Raw
 						}
 						if err := trySendPartial(parsed, rawForResult); err != nil {
-							return nil, err
+							return nil, "", err
 						}
 					}
 				}
@@ -579,7 +676,7 @@ func RunStreamOrchestration(
 
 		// Check for stream errors
 		if streamErr := <-resp.Errc; streamErr != nil {
-			return nil, fmt.Errorf("buildrequest: stream error: %w", streamErr)
+			return nil, "", fmt.Errorf("buildrequest: stream error: %w", streamErr)
 		}
 
 		// Parse the final result — let parseFinal decide whether an empty
@@ -588,23 +685,30 @@ func RunStreamOrchestration(
 
 		finalResult, parseErr := parseFinal(ctx, parseableAccumulated.String())
 		if parseErr != nil {
-			return nil, fmt.Errorf("buildrequest: failed to parse final result: %w", parseErr)
+			return nil, "", fmt.Errorf("buildrequest: failed to parse final result: %w", parseErr)
 		}
 
-		// Emit final result
+		return finalResult, fullRaw, nil
+	}
+
+	// emitFinal sends the single StreamResultKindFinal for the winning
+	// attempt, respecting context cancellation. Centralising the emission
+	// here guarantees exactly one final event regardless of whether the
+	// winning child was BuildRequest-driven or routed through the legacy
+	// helper.
+	emitFinal := func(finalResult any, raw string) error {
 		rawForFinal := ""
 		if config.NeedsRaw {
-			rawForFinal = fullRaw
+			rawForFinal = raw
 		}
 		r := newResult(bamlutils.StreamResultKindFinal, nil, finalResult, rawForFinal, nil, false)
 		select {
 		case out <- r:
+			return nil
 		case <-ctx.Done():
 			r.Release()
-			return nil, ctx.Err()
+			return ctx.Err()
 		}
-
-		return finalResult, nil
 	}
 
 	// attemptFull tries the single provider or the entire fallback chain.
@@ -612,7 +716,14 @@ func RunStreamOrchestration(
 	// matching the BAML runtime where retries retry the entire strategy.
 	attemptFull := func(_ int) (any, error) {
 		if len(config.FallbackChain) == 0 {
-			return tryOneStreamChild(config.Provider, "")
+			finalResult, raw, err := tryOneStreamChild(config.Provider, "")
+			if err != nil {
+				return nil, err
+			}
+			if emitErr := emitFinal(finalResult, raw); emitErr != nil {
+				return nil, emitErr
+			}
+			return finalResult, nil
 		}
 		var lastErr error
 		for i, child := range config.FallbackChain {
@@ -635,10 +746,33 @@ func RunStreamOrchestration(
 				}
 				heartbeatSent.Store(false)
 			}
-			provider := config.ClientProviders[child]
-			result, err := tryOneStreamChild(provider, child)
+			var (
+				finalResult any
+				raw         string
+				err         error
+			)
+			if config.LegacyChildren[child] {
+				// Legacy children run via BAML's Stream API. The callback
+				// owns heartbeat timing (fires sendHeartbeat on the first
+				// FunctionLog tick) so pool hung-detection stays correct.
+				// Partials are never emitted by the callback — it reports
+				// only (final, raw, err).
+				finalResult, raw, err = config.LegacyStreamChild(
+					ctx,
+					child,
+					config.ClientProviders[child],
+					config.NeedsRaw,
+					sendHeartbeat,
+				)
+			} else {
+				provider := config.ClientProviders[child]
+				finalResult, raw, err = tryOneStreamChild(provider, child)
+			}
 			if err == nil {
-				return result, nil
+				if emitErr := emitFinal(finalResult, raw); emitErr != nil {
+					return nil, emitErr
+				}
+				return finalResult, nil
 			}
 			lastErr = err
 		}

--- a/bamlutils/buildrequest/orchestrator_test.go
+++ b/bamlutils/buildrequest/orchestrator_test.go
@@ -933,7 +933,7 @@ func TestResolveFallbackChain_RuntimeStrategyOverrideReordersChildren(t *testing
 		},
 	}
 
-	chain, providers, _ := ResolveFallbackChain(
+	chain, providers, legacyChildren := ResolveFallbackChain(
 		adapter, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" || p == "anthropic" },
 	)
@@ -946,6 +946,9 @@ func TestResolveFallbackChain_RuntimeStrategyOverrideReordersChildren(t *testing
 	}
 	if providers["ClientB"] != "anthropic" || providers["ClientA"] != "openai" {
 		t.Errorf("unexpected providers: %v", providers)
+	}
+	if len(legacyChildren) != 0 {
+		t.Errorf("expected no legacy children for all-supported chain, got %v", legacyChildren)
 	}
 }
 
@@ -972,7 +975,7 @@ func TestResolveFallbackChain_RuntimeStrategyOverrideWithoutIntrospectedChain(t 
 		},
 	}
 
-	chain, providers, _ := ResolveFallbackChain(
+	chain, providers, legacyChildren := ResolveFallbackChain(
 		adapter, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" || p == "anthropic" },
 	)
@@ -985,6 +988,9 @@ func TestResolveFallbackChain_RuntimeStrategyOverrideWithoutIntrospectedChain(t 
 	}
 	if providers["ClientB"] != "anthropic" || providers["ClientA"] != "openai" {
 		t.Errorf("unexpected providers: %v", providers)
+	}
+	if len(legacyChildren) != 0 {
+		t.Errorf("expected no legacy children for all-supported chain, got %v", legacyChildren)
 	}
 }
 
@@ -1011,7 +1017,7 @@ func TestResolveFallbackChain_RuntimeQuotedStringStrategyOverride(t *testing.T) 
 		},
 	}
 
-	chain, providers, _ := ResolveFallbackChain(
+	chain, providers, legacyChildren := ResolveFallbackChain(
 		adapter, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" || p == "anthropic" },
 	)
@@ -1024,6 +1030,9 @@ func TestResolveFallbackChain_RuntimeQuotedStringStrategyOverride(t *testing.T) 
 	}
 	if providers["ClientB"] != "anthropic" || providers["ClientA"] != "openai" {
 		t.Errorf("unexpected providers: %v", providers)
+	}
+	if len(legacyChildren) != 0 {
+		t.Errorf("expected no legacy children for all-supported chain, got %v", legacyChildren)
 	}
 }
 

--- a/bamlutils/buildrequest/orchestrator_test.go
+++ b/bamlutils/buildrequest/orchestrator_test.go
@@ -705,7 +705,7 @@ func TestResolveFallbackChain_AllSupported(t *testing.T) {
 	}
 
 	adapter := &mockAdapter{Context: context.Background()}
-	chain, providers := ResolveFallbackChain(
+	chain, providers, legacyChildren := ResolveFallbackChain(
 		adapter, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" || p == "anthropic" },
 	)
@@ -716,26 +716,89 @@ func TestResolveFallbackChain_AllSupported(t *testing.T) {
 	if providers["ClientA"] != "openai" || providers["ClientB"] != "anthropic" {
 		t.Errorf("unexpected providers: %v", providers)
 	}
+	if len(legacyChildren) != 0 {
+		t.Errorf("expected empty legacyChildren for all-supported chain, got %v", legacyChildren)
+	}
 }
 
-func TestResolveFallbackChain_UnsupportedChild(t *testing.T) {
+func TestResolveFallbackChain_MixedSupport(t *testing.T) {
+	// Chain [openai, aws-bedrock, anthropic] with only openai + anthropic
+	// supported by BuildRequest. Expect a 3-element chain back with
+	// legacyChildren marking the aws-bedrock child.
+	fallbackChains := map[string][]string{
+		"MyFallback": {"ClientA", "ClientB", "ClientC"},
+	}
+	clientProviders := map[string]string{
+		"MyFallback": "baml-fallback",
+		"ClientA":    "openai",
+		"ClientB":    "aws-bedrock", // unsupported
+		"ClientC":    "anthropic",
+	}
+
+	adapter := &mockAdapter{Context: context.Background()}
+	chain, providers, legacyChildren := ResolveFallbackChain(
+		adapter, "MyFallback", fallbackChains, clientProviders,
+		func(p string) bool { return p == "openai" || p == "anthropic" },
+	)
+
+	if len(chain) != 3 {
+		t.Fatalf("expected chain length 3 for mixed-mode, got %d", len(chain))
+	}
+	if providers["ClientA"] != "openai" || providers["ClientB"] != "aws-bedrock" || providers["ClientC"] != "anthropic" {
+		t.Errorf("unexpected providers: %v", providers)
+	}
+	if !legacyChildren["ClientB"] {
+		t.Errorf("expected ClientB to be marked legacy, got legacyChildren=%v", legacyChildren)
+	}
+	if legacyChildren["ClientA"] || legacyChildren["ClientC"] {
+		t.Errorf("expected only ClientB to be legacy, got %v", legacyChildren)
+	}
+}
+
+func TestResolveFallbackChain_AllUnsupported(t *testing.T) {
+	// When every child is unsupported, ResolveFallbackChain returns nil so
+	// the caller routes the whole chain through the existing legacy path.
+	fallbackChains := map[string][]string{
+		"MyFallback": {"ClientA", "ClientB"},
+	}
+	clientProviders := map[string]string{
+		"MyFallback": "baml-fallback",
+		"ClientA":    "aws-bedrock",
+		"ClientB":    "aws-bedrock",
+	}
+
+	adapter := &mockAdapter{Context: context.Background()}
+	chain, providers, legacyChildren := ResolveFallbackChain(
+		adapter, "MyFallback", fallbackChains, clientProviders,
+		func(p string) bool { return p == "openai" || p == "anthropic" },
+	)
+
+	if chain != nil || providers != nil || legacyChildren != nil {
+		t.Errorf("expected nil results when every child is unsupported, got chain=%v providers=%v legacy=%v", chain, providers, legacyChildren)
+	}
+}
+
+func TestResolveFallbackChain_EmptyProviderFallsBack(t *testing.T) {
+	// A child with a missing provider is fatal — we can't route an unknown
+	// provider through either BuildRequest or legacy reliably, so the
+	// whole chain should fall back to the legacy path.
 	fallbackChains := map[string][]string{
 		"MyFallback": {"ClientA", "ClientB"},
 	}
 	clientProviders := map[string]string{
 		"MyFallback": "baml-fallback",
 		"ClientA":    "openai",
-		"ClientB":    "aws-bedrock", // unsupported
+		// ClientB intentionally missing
 	}
 
 	adapter := &mockAdapter{Context: context.Background()}
-	chain, providers := ResolveFallbackChain(
+	chain, providers, legacyChildren := ResolveFallbackChain(
 		adapter, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" || p == "anthropic" },
 	)
 
-	if chain != nil || providers != nil {
-		t.Errorf("expected nil chain/providers when child has unsupported provider, got chain=%v providers=%v", chain, providers)
+	if chain != nil || providers != nil || legacyChildren != nil {
+		t.Errorf("expected nil results when a child's provider is empty, got chain=%v providers=%v legacy=%v", chain, providers, legacyChildren)
 	}
 }
 
@@ -759,7 +822,7 @@ func TestResolveFallbackChain_RuntimeOverrideChild(t *testing.T) {
 			},
 		},
 	}
-	chain, providers := ResolveFallbackChain(
+	chain, providers, legacyChildren := ResolveFallbackChain(
 		adapter, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" || p == "anthropic" || p == "google-ai" },
 	)
@@ -773,6 +836,49 @@ func TestResolveFallbackChain_RuntimeOverrideChild(t *testing.T) {
 	}
 	if providers["ClientA"] != "openai" {
 		t.Errorf("expected ClientA provider 'openai' (introspected), got %q", providers["ClientA"])
+	}
+	if len(legacyChildren) != 0 {
+		t.Errorf("expected no legacy children, got %v", legacyChildren)
+	}
+}
+
+func TestResolveFallbackChain_RuntimeOverrideMakesLegacy(t *testing.T) {
+	// All introspected providers are supported; runtime override flips one
+	// child to aws-bedrock, turning this into a mixed-mode chain rather
+	// than falling back entirely to the legacy path.
+	fallbackChains := map[string][]string{
+		"MyFallback": {"ClientA", "ClientB"},
+	}
+	clientProviders := map[string]string{
+		"MyFallback": "baml-fallback",
+		"ClientA":    "openai",
+		"ClientB":    "anthropic",
+	}
+
+	adapter := &mockAdapter{
+		Context: context.Background(),
+		originalRegistry: &bamlutils.ClientRegistry{
+			Clients: []*bamlutils.ClientProperty{
+				{Name: "ClientB", Provider: "aws-bedrock"},
+			},
+		},
+	}
+	chain, providers, legacyChildren := ResolveFallbackChain(
+		adapter, "MyFallback", fallbackChains, clientProviders,
+		func(p string) bool { return p == "openai" || p == "anthropic" },
+	)
+
+	if len(chain) != 2 {
+		t.Fatalf("expected chain length 2 for mixed-mode, got %d", len(chain))
+	}
+	if !legacyChildren["ClientB"] {
+		t.Errorf("expected ClientB to be legacy after runtime override, got %v", legacyChildren)
+	}
+	if legacyChildren["ClientA"] {
+		t.Errorf("expected ClientA to remain BuildRequest-driven, got %v", legacyChildren)
+	}
+	if providers["ClientB"] != "aws-bedrock" {
+		t.Errorf("expected ClientB provider 'aws-bedrock' in providers map, got %q", providers["ClientB"])
 	}
 }
 
@@ -801,7 +907,7 @@ func TestResolveFallbackChain_RuntimeStrategyOverrideReordersChildren(t *testing
 		},
 	}
 
-	chain, providers := ResolveFallbackChain(
+	chain, providers, _ := ResolveFallbackChain(
 		adapter, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" || p == "anthropic" },
 	)
@@ -840,7 +946,7 @@ func TestResolveFallbackChain_RuntimeStrategyOverrideWithoutIntrospectedChain(t 
 		},
 	}
 
-	chain, providers := ResolveFallbackChain(
+	chain, providers, _ := ResolveFallbackChain(
 		adapter, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" || p == "anthropic" },
 	)
@@ -879,7 +985,7 @@ func TestResolveFallbackChain_RuntimeQuotedStringStrategyOverride(t *testing.T) 
 		},
 	}
 
-	chain, providers := ResolveFallbackChain(
+	chain, providers, _ := ResolveFallbackChain(
 		adapter, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" || p == "anthropic" },
 	)
@@ -895,7 +1001,9 @@ func TestResolveFallbackChain_RuntimeQuotedStringStrategyOverride(t *testing.T) 
 	}
 }
 
-func TestResolveFallbackChain_RuntimeOverrideUnsupported(t *testing.T) {
+func TestResolveFallbackChain_RuntimeOverrideMakesAllLegacy(t *testing.T) {
+	// Runtime override flips every child to an unsupported provider →
+	// full legacy fallback (nil results), matching the all-unsupported case.
 	fallbackChains := map[string][]string{
 		"MyFallback": {"ClientA", "ClientB"},
 	}
@@ -905,23 +1013,22 @@ func TestResolveFallbackChain_RuntimeOverrideUnsupported(t *testing.T) {
 		"ClientB":    "anthropic",
 	}
 
-	// Runtime override changes ClientB to an unsupported provider
 	adapter := &mockAdapter{
 		Context: context.Background(),
 		originalRegistry: &bamlutils.ClientRegistry{
 			Clients: []*bamlutils.ClientProperty{
+				{Name: "ClientA", Provider: "aws-bedrock"},
 				{Name: "ClientB", Provider: "aws-bedrock"},
 			},
 		},
 	}
-	chain, providers := ResolveFallbackChain(
+	chain, providers, legacyChildren := ResolveFallbackChain(
 		adapter, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" || p == "anthropic" },
 	)
 
-	// Should fall back to legacy path because runtime override made ClientB unsupported
-	if chain != nil || providers != nil {
-		t.Errorf("expected nil when runtime override makes child unsupported, got chain=%v providers=%v", chain, providers)
+	if chain != nil || providers != nil || legacyChildren != nil {
+		t.Errorf("expected nil when every child is legacy, got chain=%v providers=%v legacy=%v", chain, providers, legacyChildren)
 	}
 }
 
@@ -930,13 +1037,13 @@ func TestResolveFallbackChain_NotFallback(t *testing.T) {
 	clientProviders := map[string]string{"GPT4": "openai"}
 
 	adapter := &mockAdapter{Context: context.Background()}
-	chain, providers := ResolveFallbackChain(
+	chain, providers, legacyChildren := ResolveFallbackChain(
 		adapter, "GPT4", fallbackChains, clientProviders,
 		func(p string) bool { return true },
 	)
 
-	if chain != nil || providers != nil {
-		t.Errorf("expected nil for non-fallback client, got chain=%v providers=%v", chain, providers)
+	if chain != nil || providers != nil || legacyChildren != nil {
+		t.Errorf("expected nil for non-fallback client, got chain=%v providers=%v legacy=%v", chain, providers, legacyChildren)
 	}
 }
 
@@ -953,13 +1060,13 @@ func TestResolveFallbackChain_RoundRobinGated(t *testing.T) {
 	}
 
 	adapter := &mockAdapter{Context: context.Background()}
-	chain, providers := ResolveFallbackChain(
+	chain, providers, legacyChildren := ResolveFallbackChain(
 		adapter, "MyRoundRobin", fallbackChains, clientProviders,
 		func(p string) bool { return true },
 	)
 
-	if chain != nil || providers != nil {
-		t.Errorf("expected nil for baml-roundrobin (should use legacy path), got chain=%v providers=%v", chain, providers)
+	if chain != nil || providers != nil || legacyChildren != nil {
+		t.Errorf("expected nil for baml-roundrobin (should use legacy path), got chain=%v providers=%v legacy=%v", chain, providers, legacyChildren)
 	}
 }
 
@@ -975,7 +1082,7 @@ func TestResolveFallbackChain_FallbackAllowed(t *testing.T) {
 	}
 
 	adapter := &mockAdapter{Context: context.Background()}
-	chain, providers := ResolveFallbackChain(
+	chain, providers, legacyChildren := ResolveFallbackChain(
 		adapter, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" || p == "anthropic" },
 	)
@@ -985,6 +1092,9 @@ func TestResolveFallbackChain_FallbackAllowed(t *testing.T) {
 	}
 	if providers["ClientA"] != "openai" || providers["ClientB"] != "anthropic" {
 		t.Errorf("unexpected providers: %v", providers)
+	}
+	if len(legacyChildren) != 0 {
+		t.Errorf("expected no legacy children for all-supported chain, got %v", legacyChildren)
 	}
 }
 
@@ -1102,4 +1212,384 @@ func TestRunStreamOrchestration_FallbackChainResetBetweenChildren(t *testing.T) 
 	if finalVal != "good data" {
 		t.Errorf("expected final='good data', got %q", finalVal)
 	}
+}
+
+// TestRunStreamOrchestration_MixedChain_LegacySucceedsSecond covers the
+// typical mixed-mode flow: a BuildRequest-driven child fails, then a
+// legacy child wins via the LegacyStreamChild callback. The orchestrator
+// must emit exactly one final (the legacy child's), reset state between
+// children, and not emit any legacy-side partials.
+func TestRunStreamOrchestration_MixedChain_LegacySucceedsSecond(t *testing.T) {
+	// Supported child: streams valid chunks but parseFinal rejects, so the
+	// child fails and the orchestrator advances to the legacy child.
+	server := makeOpenAIServer([]string{"stale"})
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	var legacyCalled atomic.Int32
+	var gotOverride string
+	var gotProvider string
+	var gotNeedsRaw bool
+	legacyStreamChild := func(ctx context.Context, clientOverride, provider string, needsRaw bool, sendHeartbeat func()) (any, string, error) {
+		legacyCalled.Add(1)
+		gotOverride = clientOverride
+		gotProvider = provider
+		gotNeedsRaw = needsRaw
+		sendHeartbeat()
+		return "legacy ok", "legacy raw", nil
+	}
+
+	config := &StreamConfig{
+		RetryPolicy:   &retry.Policy{MaxRetries: 0},
+		NeedsPartials: true,
+		NeedsRaw:      true,
+		FallbackChain: []string{"SupportedChild", "LegacyChild"},
+		ClientProviders: map[string]string{
+			"SupportedChild": "openai",
+			"LegacyChild":    "aws-bedrock",
+		},
+		LegacyChildren:    map[string]bool{"LegacyChild": true},
+		LegacyStreamChild: legacyStreamChild,
+	}
+
+	parseFinal := func(_ context.Context, s string) (any, error) {
+		return nil, fmt.Errorf("supported child rejected")
+	}
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+			return &llmhttp.Request{URL: server.URL, Method: "POST", Body: `{}`}, nil
+		},
+		func(_ context.Context, s string) (any, error) { return s, nil },
+		parseFinal,
+		newTestResult,
+	)
+	close(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if legacyCalled.Load() != 1 {
+		t.Fatalf("expected legacy callback invoked once, got %d", legacyCalled.Load())
+	}
+	if gotOverride != "LegacyChild" {
+		t.Errorf("expected clientOverride 'LegacyChild', got %q", gotOverride)
+	}
+	if gotProvider != "aws-bedrock" {
+		t.Errorf("expected provider 'aws-bedrock', got %q", gotProvider)
+	}
+	if !gotNeedsRaw {
+		t.Errorf("expected needsRaw=true, got false")
+	}
+
+	var resets, finals int
+	var finalVal any
+	var finalRaw string
+	for r := range out {
+		tr := r.(*testResult)
+		if tr.kind == bamlutils.StreamResultKindStream && tr.reset {
+			resets++
+		}
+		if tr.kind == bamlutils.StreamResultKindFinal {
+			finals++
+			finalVal = tr.final
+			finalRaw = tr.raw
+		}
+	}
+	if resets < 1 {
+		t.Errorf("expected at least one reset signal between children, got %d", resets)
+	}
+	if finals != 1 {
+		t.Fatalf("expected exactly one final, got %d", finals)
+	}
+	if finalVal != "legacy ok" {
+		t.Errorf("expected final='legacy ok', got %v", finalVal)
+	}
+	if finalRaw != "legacy raw" {
+		t.Errorf("expected raw='legacy raw', got %q", finalRaw)
+	}
+}
+
+// TestRunStreamOrchestration_MixedChain_LegacyFirstFails_SupportedWins
+// ensures a legacy-first-fails path lets the supported child take over
+// and that the orchestrator emits partials from the supported child only.
+func TestRunStreamOrchestration_MixedChain_LegacyFirstFails_SupportedWins(t *testing.T) {
+	server := makeOpenAIServer([]string{"good"})
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	var legacyCalled atomic.Int32
+	legacyStreamChild := func(ctx context.Context, clientOverride, provider string, needsRaw bool, sendHeartbeat func()) (any, string, error) {
+		legacyCalled.Add(1)
+		return nil, "", fmt.Errorf("legacy upstream 500")
+	}
+
+	config := &StreamConfig{
+		RetryPolicy:   &retry.Policy{MaxRetries: 0},
+		NeedsPartials: true,
+		FallbackChain: []string{"LegacyChild", "SupportedChild"},
+		ClientProviders: map[string]string{
+			"LegacyChild":    "aws-bedrock",
+			"SupportedChild": "openai",
+		},
+		LegacyChildren:    map[string]bool{"LegacyChild": true},
+		LegacyStreamChild: legacyStreamChild,
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+			return &llmhttp.Request{URL: server.URL, Method: "POST", Body: `{}`}, nil
+		},
+		func(_ context.Context, s string) (any, error) { return s, nil },
+		func(_ context.Context, s string) (any, error) { return s, nil },
+		newTestResult,
+	)
+	close(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if legacyCalled.Load() != 1 {
+		t.Fatalf("expected legacy callback invoked once, got %d", legacyCalled.Load())
+	}
+
+	var partials, finals int
+	var finalVal any
+	for r := range out {
+		tr := r.(*testResult)
+		switch tr.kind {
+		case bamlutils.StreamResultKindStream:
+			if !tr.reset {
+				partials++
+			}
+		case bamlutils.StreamResultKindFinal:
+			finals++
+			finalVal = tr.final
+		}
+	}
+	if partials < 1 {
+		t.Errorf("expected at least one partial from the supported child, got %d", partials)
+	}
+	if finals != 1 {
+		t.Fatalf("expected exactly one final, got %d", finals)
+	}
+	if finalVal != "good" {
+		t.Errorf("expected final='good' from supported child, got %v", finalVal)
+	}
+}
+
+// TestRunStreamOrchestration_MixedChain_LegacyNoCallbackErrors verifies
+// up-front validation: if LegacyChildren is non-empty but
+// LegacyStreamChild is nil, the orchestrator returns immediately and
+// never calls buildRequest.
+func TestRunStreamOrchestration_MixedChain_LegacyNoCallbackErrors(t *testing.T) {
+	out := make(chan bamlutils.StreamResult, 10)
+	err := RunStreamOrchestration(
+		context.Background(), out,
+		&StreamConfig{
+			FallbackChain: []string{"SupportedChild", "LegacyChild"},
+			ClientProviders: map[string]string{
+				"SupportedChild": "openai",
+				"LegacyChild":    "aws-bedrock",
+			},
+			LegacyChildren: map[string]bool{"LegacyChild": true},
+		},
+		nil,
+		func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+			t.Fatal("buildRequest must not be called when LegacyStreamChild is missing")
+			return nil, nil
+		},
+		nil, nil,
+		newTestResult,
+	)
+	if err == nil || !strings.Contains(err.Error(), "LegacyStreamChild") {
+		t.Fatalf("expected LegacyStreamChild validation error, got %v", err)
+	}
+	close(out)
+	for r := range out {
+		t.Fatalf("expected no results on validation failure, got kind %v", r.Kind())
+	}
+}
+
+// TestRunStreamOrchestration_MixedChain_LegacyHeartbeat verifies that the
+// orchestrator emits a heartbeat when the legacy callback calls
+// sendHeartbeat, and only emits it once even if the callback calls it
+// multiple times. Also verifies that a legacy callback which never calls
+// sendHeartbeat (simulating a fail-before-first-byte upstream) produces
+// no heartbeat.
+func TestRunStreamOrchestration_MixedChain_LegacyHeartbeat(t *testing.T) {
+	t.Run("callback fires heartbeat", func(t *testing.T) {
+		out := make(chan bamlutils.StreamResult, 100)
+		config := &StreamConfig{
+			FallbackChain: []string{"LegacyChild"},
+			ClientProviders: map[string]string{
+				"LegacyChild": "aws-bedrock",
+			},
+			LegacyChildren: map[string]bool{"LegacyChild": true},
+			LegacyStreamChild: func(ctx context.Context, clientOverride, provider string, needsRaw bool, sendHeartbeat func()) (any, string, error) {
+				// Call sendHeartbeat multiple times to verify idempotency.
+				sendHeartbeat()
+				sendHeartbeat()
+				sendHeartbeat()
+				return "ok", "", nil
+			},
+		}
+		err := RunStreamOrchestration(
+			context.Background(), out, config, nil,
+			func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+				t.Fatal("buildRequest must not be called for legacy-only chain")
+				return nil, nil
+			},
+			nil, nil,
+			newTestResult,
+		)
+		close(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var heartbeats, finals int
+		for r := range out {
+			switch r.Kind() {
+			case bamlutils.StreamResultKindHeartbeat:
+				heartbeats++
+			case bamlutils.StreamResultKindFinal:
+				finals++
+			}
+		}
+		if heartbeats != 1 {
+			t.Errorf("expected exactly 1 heartbeat (idempotent), got %d", heartbeats)
+		}
+		if finals != 1 {
+			t.Errorf("expected 1 final, got %d", finals)
+		}
+	})
+
+	t.Run("callback never fires heartbeat", func(t *testing.T) {
+		out := make(chan bamlutils.StreamResult, 100)
+		config := &StreamConfig{
+			RetryPolicy:   &retry.Policy{MaxRetries: 0},
+			FallbackChain: []string{"LegacyChild"},
+			ClientProviders: map[string]string{
+				"LegacyChild": "aws-bedrock",
+			},
+			LegacyChildren: map[string]bool{"LegacyChild": true},
+			LegacyStreamChild: func(ctx context.Context, clientOverride, provider string, needsRaw bool, sendHeartbeat func()) (any, string, error) {
+				// Simulate failure before any upstream byte — callback
+				// never fires the heartbeat. Pool hung-detection should
+				// still be able to kill this request if it hangs long
+				// enough; here we just assert no heartbeat leaked.
+				return nil, "", fmt.Errorf("upstream 4xx")
+			},
+		}
+		err := RunStreamOrchestration(
+			context.Background(), out, config, nil,
+			func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+				return nil, nil
+			},
+			nil, nil,
+			newTestResult,
+		)
+		close(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var heartbeats int
+		for r := range out {
+			if r.Kind() == bamlutils.StreamResultKindHeartbeat {
+				heartbeats++
+			}
+		}
+		if heartbeats != 0 {
+			t.Errorf("expected 0 heartbeats when callback never calls sendHeartbeat, got %d", heartbeats)
+		}
+	})
+}
+
+// TestRunStreamOrchestration_MixedChain_LegacyRawPropagation verifies
+// that the raw string returned from a winning legacy callback is
+// propagated to the final emission only when NeedsRaw is true.
+func TestRunStreamOrchestration_MixedChain_LegacyRawPropagation(t *testing.T) {
+	legacyChildFn := func(raw string) LegacyStreamChildFunc {
+		return func(ctx context.Context, clientOverride, provider string, needsRaw bool, sendHeartbeat func()) (any, string, error) {
+			sendHeartbeat()
+			return "final", raw, nil
+		}
+	}
+
+	t.Run("NeedsRaw true", func(t *testing.T) {
+		out := make(chan bamlutils.StreamResult, 100)
+		config := &StreamConfig{
+			NeedsRaw:      true,
+			FallbackChain: []string{"LegacyChild"},
+			ClientProviders: map[string]string{
+				"LegacyChild": "aws-bedrock",
+			},
+			LegacyChildren:    map[string]bool{"LegacyChild": true},
+			LegacyStreamChild: legacyChildFn("legacy raw text"),
+		}
+		err := RunStreamOrchestration(
+			context.Background(), out, config, nil,
+			func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+				return nil, nil
+			},
+			nil, nil,
+			newTestResult,
+		)
+		close(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var finalRaw string
+		for r := range out {
+			if r.Kind() == bamlutils.StreamResultKindFinal {
+				finalRaw = r.Raw()
+			}
+		}
+		if finalRaw != "legacy raw text" {
+			t.Errorf("expected raw='legacy raw text', got %q", finalRaw)
+		}
+	})
+
+	t.Run("NeedsRaw false", func(t *testing.T) {
+		out := make(chan bamlutils.StreamResult, 100)
+		config := &StreamConfig{
+			NeedsRaw:      false,
+			FallbackChain: []string{"LegacyChild"},
+			ClientProviders: map[string]string{
+				"LegacyChild": "aws-bedrock",
+			},
+			LegacyChildren:    map[string]bool{"LegacyChild": true},
+			LegacyStreamChild: legacyChildFn("legacy raw text"),
+		}
+		err := RunStreamOrchestration(
+			context.Background(), out, config, nil,
+			func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+				return nil, nil
+			},
+			nil, nil,
+			newTestResult,
+		)
+		close(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var finalRaw string
+		for r := range out {
+			if r.Kind() == bamlutils.StreamResultKindFinal {
+				finalRaw = r.Raw()
+			}
+		}
+		if finalRaw != "" {
+			t.Errorf("expected empty raw when NeedsRaw=false, got %q", finalRaw)
+		}
+	})
 }

--- a/bamlutils/buildrequest/orchestrator_test.go
+++ b/bamlutils/buildrequest/orchestrator_test.go
@@ -778,6 +778,32 @@ func TestResolveFallbackChain_AllUnsupported(t *testing.T) {
 	}
 }
 
+func TestResolveFallbackChain_DuplicateLegacyChildren(t *testing.T) {
+	// A chain listing the same unsupported client twice is still "all
+	// legacy" from a routing standpoint — there is no supported child for
+	// BuildRequest to drive, so the resolver must return nil so the whole
+	// chain routes through the legacy path. The previous implementation
+	// compared len(legacyChildren) (a set, 1) against len(chain)
+	// (positions, 2) and incorrectly reported this as a mixed chain.
+	fallbackChains := map[string][]string{
+		"MyFallback": {"BedrockA", "BedrockA"},
+	}
+	clientProviders := map[string]string{
+		"MyFallback": "baml-fallback",
+		"BedrockA":   "aws-bedrock",
+	}
+
+	adapter := &mockAdapter{Context: context.Background()}
+	chain, providers, legacyChildren := ResolveFallbackChain(
+		adapter, "MyFallback", fallbackChains, clientProviders,
+		func(p string) bool { return p == "openai" || p == "anthropic" },
+	)
+
+	if chain != nil || providers != nil || legacyChildren != nil {
+		t.Errorf("expected nil results when every chain position is legacy (duplicates included), got chain=%v providers=%v legacy=%v", chain, providers, legacyChildren)
+	}
+}
+
 func TestResolveFallbackChain_EmptyProviderFallsBack(t *testing.T) {
 	// A child with a missing provider is fatal — we can't route an unknown
 	// provider through either BuildRequest or legacy reliably, so the

--- a/bamlutils/buildrequest/orchestrator_test.go
+++ b/bamlutils/buildrequest/orchestrator_test.go
@@ -1619,3 +1619,164 @@ func TestRunStreamOrchestration_MixedChain_LegacyRawPropagation(t *testing.T) {
 		}
 	})
 }
+
+// TestRunStreamOrchestration_MixedChain_HTTPBackedEndToEnd is the closest
+// approximation to a "generated-adapter integration test" we can write
+// without adding AWS Bedrock Converse API emulation to the mock LLM (see
+// the PR description for the follow-up needed to exercise a real adapter
+// with a bedrock child). Both children run against real httptest servers:
+//
+//   - Supported child: open an SSE stream from an OpenAI-shaped server;
+//     the orchestrator extracts deltas and parses a final.
+//   - Legacy child: callback mirrors the shape runLegacyChildStream emits
+//     — fires sendHeartbeat on the first upstream byte, drains the body,
+//     and returns (final, raw, err). This exercises the runtime behavior
+//     a real codegen-emitted legacyStreamChildFn would have, including
+//     liveness signalling from a real HTTP round-trip.
+//
+// The test covers the most interesting scenario: supported child fails
+// at parseFinal, the orchestrator emits a reset, dispatches to the
+// legacy callback, and the legacy child's final propagates with its raw
+// text. It checks the observable StreamResult timeline end-to-end.
+func TestRunStreamOrchestration_MixedChain_HTTPBackedEndToEnd(t *testing.T) {
+	// Supported child (openai SSE) — its body parses into "bad" which the
+	// parseFinal closure rejects, so the orchestrator must advance to the
+	// legacy child.
+	supportedServer := makeOpenAIServer([]string{"bad"})
+	defer supportedServer.Close()
+
+	// Legacy child — plain text body, delayed so the heartbeat timing is
+	// observable. This mirrors how a real BAML aws-bedrock response would
+	// look to runLegacyChildStream: drain the body, extract a raw string,
+	// return a final typed value.
+	const legacyFinal = "legacy-final-text"
+	const legacyRaw = "legacy-raw-payload"
+	legacyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Small delay before body to give the test a visible heartbeat
+		// window; runLegacyChildStream in the real generated code fires
+		// its sendHeartbeat on the first FunctionLog tick, which tracks
+		// upstream byte arrival.
+		time.Sleep(10 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(200)
+		fmt.Fprint(w, legacyRaw)
+	}))
+	defer legacyServer.Close()
+
+	httpClient := llmhttp.NewClient(supportedServer.Client())
+
+	// Legacy callback mirrors runLegacyChildStream: make a real HTTP call
+	// via llmhttp, fire sendHeartbeat on first byte (via the Execute
+	// onSuccess callback), read the body as raw, and synthesize a final.
+	legacyStreamChild := func(ctx context.Context, clientOverride, provider string, needsRaw bool, sendHeartbeat func()) (any, string, error) {
+		if clientOverride != "LegacyChild" {
+			t.Errorf("legacy callback got clientOverride=%q, want LegacyChild", clientOverride)
+		}
+		req := &llmhttp.Request{URL: legacyServer.URL, Method: "POST", Body: `{}`}
+		resp, err := httpClient.Execute(ctx, req, sendHeartbeat)
+		if err != nil {
+			return nil, "", err
+		}
+		raw := resp.Body
+		if !needsRaw {
+			raw = ""
+		}
+		return legacyFinal, raw, nil
+	}
+
+	out := make(chan bamlutils.StreamResult, 100)
+	config := &StreamConfig{
+		RetryPolicy:   &retry.Policy{MaxRetries: 0},
+		NeedsPartials: true,
+		NeedsRaw:      true,
+		FallbackChain: []string{"SupportedChild", "LegacyChild"},
+		ClientProviders: map[string]string{
+			"SupportedChild": "openai",
+			"LegacyChild":    "aws-bedrock",
+		},
+		LegacyChildren:    map[string]bool{"LegacyChild": true},
+		LegacyStreamChild: legacyStreamChild,
+	}
+
+	// parseFinal rejects the supported child's content, forcing fall-over
+	// to the legacy child. parseStream is lenient so partials flow
+	// normally until the final reject.
+	parseFinal := func(_ context.Context, s string) (any, error) {
+		if s == "bad" {
+			return nil, fmt.Errorf("parse rejected %q", s)
+		}
+		return s, nil
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, httpClient,
+		func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+			return &llmhttp.Request{URL: supportedServer.URL, Method: "POST", Body: `{}`}, nil
+		},
+		func(_ context.Context, s string) (any, error) { return s, nil },
+		parseFinal,
+		newTestResult,
+	)
+	close(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Walk the full SSE-like timeline and verify ordering/contents.
+	// Expected shape:
+	//   [heartbeat, supported partials..., reset, heartbeat, final(legacy)]
+	// — the supported attempt emits partials and a heartbeat on its HTTP
+	// response; the orchestrator then resets before dispatching to the
+	// legacy callback, which fires its own heartbeat on first-byte and
+	// feeds back a final + raw.
+	var (
+		heartbeats int
+		partials   int
+		resets     int
+		finals     int
+		finalVal   any
+		finalRaw   string
+	)
+	for r := range out {
+		tr := r.(*testResult)
+		switch tr.kind {
+		case bamlutils.StreamResultKindHeartbeat:
+			heartbeats++
+		case bamlutils.StreamResultKindStream:
+			if tr.reset {
+				resets++
+			} else {
+				partials++
+			}
+		case bamlutils.StreamResultKindFinal:
+			finals++
+			finalVal = tr.final
+			finalRaw = tr.raw
+		case bamlutils.StreamResultKindError:
+			t.Fatalf("unexpected error result: %v", tr.err)
+		}
+	}
+
+	if heartbeats < 2 {
+		// Supported child emits one on HTTP connect, legacy callback
+		// emits a second after its reset. Fewer than two indicates the
+		// reset failed to clear heartbeatSent, or the legacy callback
+		// never fired sendHeartbeat.
+		t.Errorf("expected at least 2 heartbeats (one per child attempt), got %d", heartbeats)
+	}
+	if partials < 1 {
+		t.Errorf("expected at least 1 partial from the supported child stream, got %d", partials)
+	}
+	if resets != 1 {
+		t.Errorf("expected exactly 1 reset between children, got %d", resets)
+	}
+	if finals != 1 {
+		t.Fatalf("expected exactly 1 final, got %d", finals)
+	}
+	if finalVal != legacyFinal {
+		t.Errorf("expected final=%q from legacy child, got %v", legacyFinal, finalVal)
+	}
+	if finalRaw != legacyRaw {
+		t.Errorf("expected raw=%q from legacy child, got %q", legacyRaw, finalRaw)
+	}
+}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -2985,3 +2985,196 @@ func TestShutdownZeroValuePool(t *testing.T) {
 		t.Fatalf("Shutdown on zero-value Pool returned error: %v", err)
 	}
 }
+
+// TestCallStreamSlowLegacyHeartbeatPreventsHungKill verifies that a stream
+// which emits a heartbeat before any "real" result — as mixed-mode legacy
+// children do via the orchestrator's sendHeartbeat closure on BAML's first
+// FunctionLog tick — keeps the worker alive even if the overall call takes
+// longer than FirstByteTimeout. This is the positive counterpart to the
+// hung-detection mechanism: anything that looks like upstream activity
+// (heartbeat included) disables hung-kill for the request.
+func TestCallStreamSlowLegacyHeartbeatPreventsHungKill(t *testing.T) {
+	// Heartbeat arrives within FirstByteTimeout (simulating a legacy
+	// child whose first BAML FunctionLog tick lands before the deadline);
+	// the final trails well past the deadline so the hung check has the
+	// opportunity to kill the worker if gotFirstByte isn't being set by
+	// the heartbeat.
+	firstByteTimeout := 40 * time.Millisecond
+	heartbeatDelay := 15 * time.Millisecond
+	finalDelay := 60 * time.Millisecond
+
+	factory := func(id int) (*workerHandle, error) {
+		w := newMockWorker()
+		w.callStreamFn = func(ctx context.Context, _ string, _ []byte, _ bamlutils.StreamMode) (<-chan *workerplugin.StreamResult, error) {
+			ch := make(chan *workerplugin.StreamResult, 2)
+			go func() {
+				defer close(ch)
+				select {
+				case <-time.After(heartbeatDelay):
+				case <-ctx.Done():
+					return
+				}
+				hb := workerplugin.GetStreamResult()
+				hb.Kind = workerplugin.StreamResultKindHeartbeat
+				select {
+				case ch <- hb:
+				case <-ctx.Done():
+					workerplugin.ReleaseStreamResult(hb)
+					return
+				}
+				select {
+				case <-time.After(finalDelay):
+				case <-ctx.Done():
+					return
+				}
+				final := workerplugin.GetStreamResult()
+				final.Kind = workerplugin.StreamResultKindFinal
+				final.Data = []byte(`"mixed-mode-final"`)
+				select {
+				case ch <- final:
+				case <-ctx.Done():
+					workerplugin.ReleaseStreamResult(final)
+				}
+			}()
+			return ch, nil
+		}
+		return newMockHandle(id, w), nil
+	}
+
+	p := newTestPool(t, 1, factory)
+	defer p.Close()
+	p.SetFirstByteTimeout(firstByteTimeout)
+
+	workerClosed := make(chan struct{}, 1)
+	p.workers[0].worker.(*mockWorker).closeFn = func() error {
+		select {
+		case workerClosed <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+
+	results, err := p.CallStream(context.Background(), "Test", []byte(`{}`), bamlutils.StreamModeStream)
+	if err != nil {
+		t.Fatalf("CallStream setup failed: %v", err)
+	}
+
+	// Keep probing hung detection on a fine cadence throughout the stream
+	// so any window where gotFirstByte=false overlapping the timeout
+	// elapses would surface as a kill. Stop once the stream closes.
+	checkerDone := make(chan struct{})
+	go func() {
+		defer close(checkerDone)
+		tick := time.NewTicker(5 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-results:
+				return
+			case <-tick.C:
+				p.checkHungRequests()
+			}
+		}
+	}()
+
+	var gotFinal bool
+	var gotData string
+	for r := range results {
+		if r.Kind == workerplugin.StreamResultKindFinal {
+			gotFinal = true
+			gotData = string(r.Data)
+		}
+		workerplugin.ReleaseStreamResult(r)
+	}
+	<-checkerDone
+
+	if !gotFinal {
+		t.Fatalf("expected a final result, stream terminated without one")
+	}
+	if gotData != `"mixed-mode-final"` {
+		t.Errorf("expected final data %q, got %q", `"mixed-mode-final"`, gotData)
+	}
+
+	select {
+	case <-workerClosed:
+		t.Fatal("worker should not have been killed when heartbeat arrived within FirstByteTimeout")
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+// TestCallStreamSilentLegacyGetsKilled is the negative-path counterpart:
+// a legacy callback that neither fires sendHeartbeat nor produces a final
+// should still be killed by hung detection after FirstByteTimeout. This
+// proves the mixed-mode path hasn't broken the pool's liveness guarantee
+// for genuinely hung upstreams.
+func TestCallStreamSilentLegacyGetsKilled(t *testing.T) {
+	firstByteTimeout := 30 * time.Millisecond
+
+	factory := func(id int) (*workerHandle, error) {
+		w := newMockWorker()
+		w.callStreamFn = func(ctx context.Context, _ string, _ []byte, _ bamlutils.StreamMode) (<-chan *workerplugin.StreamResult, error) {
+			// Worker "hangs" — hold the channel open, send nothing, and
+			// only close on context cancellation so hung-kill cleanly
+			// terminates the goroutine.
+			ch := make(chan *workerplugin.StreamResult)
+			go func() {
+				<-ctx.Done()
+				close(ch)
+			}()
+			return ch, nil
+		}
+		return newMockHandle(id, w), nil
+	}
+
+	p := newTestPool(t, 1, factory)
+	defer p.Close()
+	p.SetFirstByteTimeout(firstByteTimeout)
+
+	workerClosed := make(chan struct{}, 1)
+	p.workers[0].worker.(*mockWorker).closeFn = func() error {
+		select {
+		case workerClosed <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+
+	// Disable retries so the test observes the first-attempt hung kill
+	// directly without the pool silently retrying on a fresh worker.
+	p.config.MaxRetries = 0
+
+	results, err := p.CallStream(context.Background(), "Test", []byte(`{}`), bamlutils.StreamModeStream)
+	if err != nil {
+		t.Fatalf("CallStream setup failed: %v", err)
+	}
+
+	checkerDone := make(chan struct{})
+	go func() {
+		defer close(checkerDone)
+		tick := time.NewTicker(5 * time.Millisecond)
+		defer tick.Stop()
+		timeout := time.After(500 * time.Millisecond)
+		for {
+			select {
+			case <-workerClosed:
+				return
+			case <-timeout:
+				return
+			case <-tick.C:
+				p.checkHungRequests()
+			}
+		}
+	}()
+
+	select {
+	case <-workerClosed:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("worker was not killed when legacy callback produced no heartbeat or final")
+	}
+
+	// Drain the stream so the CallStream goroutine finishes — the pool
+	// restarts the hung worker and propagates the error.
+	for range results {
+	}
+	<-checkerDone
+}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -3045,12 +3045,14 @@ func TestCallStreamSlowLegacyHeartbeatPreventsHungKill(t *testing.T) {
 	defer p.Close()
 	p.SetFirstByteTimeout(firstByteTimeout)
 
-	workerClosed := make(chan struct{}, 1)
+	// workerClosed is closed (not sent-to) so multiple readers all see the
+	// signal. closeFn is guarded by sync.Once because the pool may call
+	// Close more than once over the worker's lifecycle (hung kill + pool
+	// shutdown), and close(workerClosed) would panic on the second call.
+	workerClosed := make(chan struct{})
+	var closeOnce sync.Once
 	p.workers[0].worker.(*mockWorker).closeFn = func() error {
-		select {
-		case workerClosed <- struct{}{}:
-		default:
-		}
+		closeOnce.Do(func() { close(workerClosed) })
 		return nil
 	}
 
@@ -3061,7 +3063,11 @@ func TestCallStreamSlowLegacyHeartbeatPreventsHungKill(t *testing.T) {
 
 	// Keep probing hung detection on a fine cadence throughout the stream
 	// so any window where gotFirstByte=false overlapping the timeout
-	// elapses would surface as a kill. Stop once the stream closes.
+	// elapses would surface as a kill. stopChecker is closed after the
+	// main loop drains `results`, letting the checker exit cleanly —
+	// previously the checker competed with the main loop on `case
+	// <-results:` and could steal a heartbeat or final.
+	stopChecker := make(chan struct{})
 	checkerDone := make(chan struct{})
 	go func() {
 		defer close(checkerDone)
@@ -3069,7 +3075,7 @@ func TestCallStreamSlowLegacyHeartbeatPreventsHungKill(t *testing.T) {
 		defer tick.Stop()
 		for {
 			select {
-			case <-results:
+			case <-stopChecker:
 				return
 			case <-tick.C:
 				p.checkHungRequests()
@@ -3086,6 +3092,7 @@ func TestCallStreamSlowLegacyHeartbeatPreventsHungKill(t *testing.T) {
 		}
 		workerplugin.ReleaseStreamResult(r)
 	}
+	close(stopChecker)
 	<-checkerDone
 
 	if !gotFinal {
@@ -3130,12 +3137,14 @@ func TestCallStreamSilentLegacyGetsKilled(t *testing.T) {
 	defer p.Close()
 	p.SetFirstByteTimeout(firstByteTimeout)
 
-	workerClosed := make(chan struct{}, 1)
+	// workerClosed is closed (not sent-to) so both the checker goroutine
+	// below and the main assertion see the signal. closeFn is guarded by
+	// sync.Once because the pool can call Close more than once (hung kill
+	// + pool shutdown), and close() on an already-closed channel panics.
+	workerClosed := make(chan struct{})
+	var closeOnce sync.Once
 	p.workers[0].worker.(*mockWorker).closeFn = func() error {
-		select {
-		case workerClosed <- struct{}{}:
-		default:
-		}
+		closeOnce.Do(func() { close(workerClosed) })
 		return nil
 	}
 
@@ -3148,17 +3157,18 @@ func TestCallStreamSilentLegacyGetsKilled(t *testing.T) {
 		t.Fatalf("CallStream setup failed: %v", err)
 	}
 
+	// stopChecker lets the main body stop the ticker cleanly after it has
+	// asserted on workerClosed. The checker never reads from workerClosed
+	// itself; closing stopChecker is the sole exit path.
+	stopChecker := make(chan struct{})
 	checkerDone := make(chan struct{})
 	go func() {
 		defer close(checkerDone)
 		tick := time.NewTicker(5 * time.Millisecond)
 		defer tick.Stop()
-		timeout := time.After(500 * time.Millisecond)
 		for {
 			select {
-			case <-workerClosed:
-				return
-			case <-timeout:
+			case <-stopChecker:
 				return
 			case <-tick.C:
 				p.checkHungRequests()
@@ -3169,12 +3179,15 @@ func TestCallStreamSilentLegacyGetsKilled(t *testing.T) {
 	select {
 	case <-workerClosed:
 	case <-time.After(500 * time.Millisecond):
+		close(stopChecker)
+		<-checkerDone
 		t.Fatal("worker was not killed when legacy callback produced no heartbeat or final")
 	}
+	close(stopChecker)
+	<-checkerDone
 
 	// Drain the stream so the CallStream goroutine finishes — the pool
 	// restarts the hung worker and propagates the error.
 	for range results {
 	}
-	<-checkerDone
 }


### PR DESCRIPTION
## Summary
- Fallback chains that mix BuildRequest-supported children with unsupported (legacy-only) providers like `aws-bedrock` now run end-to-end through the BuildRequest orchestrator, dispatching individual legacy children to a shared BAML Stream helper instead of falling back to the legacy path wholesale.
- `ResolveFallbackChain` returns a third value `legacyChildren` marking unsupported entries. `StreamConfig` / `CallConfig` gain `LegacyChildren` + callback fields; the orchestrator dispatches to `LegacyStreamChild` / `LegacyCallChild` for marked children, and the callback owns heartbeat timing via a `sendHeartbeat` closure so pool hung-detection stays correct.
- Codegen emits `runLegacyChildStream` (shared `WithOnTick` + `FunctionLog`-capture helper) plus per-method `legacyStreamChildFn` / `legacyCallChildFn` closures that invoke `Stream.<Method>(adapter, args, WithClient(child), opts...)`.
- Also closes a latent gap in `RunCallOrchestration` that only validated the first chain child up-front.

Fixes #167.

## Review fixes (post-initial-push)
- **Duplicate-child bug in the all-legacy check**: `ResolveFallbackChain` compared `len(legacyChildren)` (a *set*) against `len(chain)` (positions), so a chain like `[BedrockA, BedrockA]` was misclassified as mixed-mode. Now tracks chain positions that land in `legacyChildren` and compares against `len(chain)`. Covered by `TestResolveFallbackChain_DuplicateLegacyChildren`.
- **Pool slow-legacy liveness tests** added per plan §6 test #14: `TestCallStreamSlowLegacyHeartbeatPreventsHungKill` (heartbeat within `FirstByteTimeout` keeps a long-running stream alive) and `TestCallStreamSilentLegacyGetsKilled` (no heartbeat or final → worker still killed).
- **HTTP-backed mixed-mode end-to-end tests** added per plan §6 test #15 (see "Remaining integration gap" below for what's still not covered): `TestRunStreamOrchestration_MixedChain_HTTPBackedEndToEnd` and `TestRunCallOrchestration_MixedChain_HTTPBackedEndToEnd`. Both back supported + legacy children with real httptest servers; the legacy callback routes through `llmhttp.Execute` so `sendHeartbeat` fires on a real 2xx (mirroring `runLegacyChildStream`'s liveness semantics). Covers heartbeat coordination across real HTTP timing, raw propagation through fetched bodies, and reset semantics after a mid-stream parseFinal rejection.

## Remaining integration gap
The plan's original §6 test #15 called for a full generated-adapter integration test with a real BAML aws-bedrock client. BAML's aws-bedrock runtime (AWS Bedrock Runtime Converse API + SigV4 + EventStream binary framing) isn't currently emulated by the mock LLM, and BAML's `endpoint_url` override alone doesn't make that mock work — the mock would need to implement the Converse API and AWS EventStream framing. That's a follow-up engineering task (estimated ~1 day) and is out of scope for this PR. The HTTP-backed orchestrator tests above are the strongest coverage reachable without that work.

## Test plan
- [x] `go build ./...` passes after each commit
- [x] `go test ./bamlutils/buildrequest/...` passes after each commit
- [x] `go test ./pool/...` passes including the new slow-legacy liveness tests
- [x] Orchestrator unit tests cover: `ResolveFallbackChain` mixed/all-unsupported/empty-provider/duplicate-legacy/runtime-override-makes-legacy, stream + call mixed-chain legacy-succeeds-second and legacy-first-fails-supported-wins, callback absence validation, heartbeat idempotency and no-heartbeat-on-fail-before-byte, raw propagation under `NeedsRaw` true/false, all-children call validation
- [x] HTTP-backed mixed-mode end-to-end tests for stream and call paths (httptest servers for both children; legacy callback shapes match `runLegacyChildStream`'s runtime contract)
- [x] Pool slow-legacy liveness: worker emitting a heartbeat within `FirstByteTimeout` isn't killed; worker that never produces heartbeat or final still gets killed after the timeout
- [ ] Generated-adapter integration test against a real aws-bedrock child (blocked on mockllm bedrock support — see "Remaining integration gap" above)

## Notes
- Landed in commits per the implementation plan: step 1 is a behaviour-preserving refactor (router guard keeps mixed chains on the legacy path), step 2 flips the guard and wires the per-method closures, then the Codex-review fix and follow-up test commits.
- `baml-roundrobin` stays gated — the per-request orchestrator has no cross-request rotation state.
- Retry semantics: outer `retry.Execute` wraps the chain as today; for legacy children, BAML's static `retry_policy` (if any) applies on top, so outer × inner retries can compound. Per-request `__baml_options__.retry` is not forwarded into BAML (pre-existing — `makeOptionsFromAdapter` doesn't emit `WithRetry`).
- Raw from legacy children comes from `FunctionLog.RawLLMResponse()`, which drops Anthropic-family thinking deltas. Lossless for `aws-bedrock`; users who runtime-override a thinking-capable provider onto the legacy path will see `RawLLMResponse`-shaped raw rather than full wire text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mixed-mode fallback chains: routes can include both legacy and modern providers with proper raw-response propagation and heartbeat-aware streaming.
  * Configurable legacy callbacks: per-call/stream options now support invoking legacy child callbacks as part of fallbacks.

* **Bug Fixes**
  * Improved validation and fallback routing for mixed chains to prevent invalid runs.
  * Improved hung-request detection and heartbeat handling to avoid premature worker kills.

* **Tests**
  * Extensive new end-to-end and unit tests for mixed-mode, heartbeat, raw propagation, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->