### PR TITLE
fix(embed): derive package name from source, not directory basename

### DIFF
--- a/cmd/embed/main.go
+++ b/cmd/embed/main.go
@@ -158,6 +158,13 @@ func packageFromGoFiles(root string) string {
 	if err != nil {
 		return ""
 	}
+	// Count occurrences of each package declaration rather than returning
+	// the first hit. A directory may contain more than one package — e.g.
+	// a sibling `foo_test` package alongside `foo`, or (rarely) an
+	// auxiliary build-tagged package — and the one with the most files is
+	// the one whose name the generated embed.go should use. Ties are
+	// broken alphabetically for determinism.
+	counts := make(map[string]int)
 	fset := token.NewFileSet()
 	for _, entry := range entries {
 		name := entry.Name()
@@ -176,10 +183,21 @@ func packageFromGoFiles(root string) string {
 			continue
 		}
 		if f.Name != nil && f.Name.Name != "" {
-			return f.Name.Name
+			counts[f.Name.Name]++
 		}
 	}
-	return ""
+	if len(counts) == 0 {
+		return ""
+	}
+	var best string
+	var bestCount int
+	for pkg, count := range counts {
+		if count > bestCount || (count == bestCount && pkg < best) {
+			best = pkg
+			bestCount = count
+		}
+	}
+	return best
 }
 
 func packageFromGoMod(root string) string {

--- a/cmd/embed/main.go
+++ b/cmd/embed/main.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	_ "embed"
+	"go/parser"
+	"go/token"
 	"io"
 	"os"
 	"path/filepath"
@@ -112,7 +114,7 @@ func main() {
 
 		embedTemplate := template.Must(template.New("embed.go").Parse(embedTemplateInput))
 		input := map[string]any{
-			"Package": strings.ReplaceAll(strcase.SnakeCase(filepath.Base(root)), ".", "_"),
+			"Package": detectPackageName(root),
 			"Dirs":    strings.Join(paths, " "),
 			"Imports": imports,
 		}
@@ -126,6 +128,70 @@ func main() {
 			panic(err)
 		}
 	}
+}
+
+// detectPackageName resolves the Go package name for the embed file at root.
+// The previous approach derived it from filepath.Base(root), which broke for
+// any working directory whose basename didn't match the source's package
+// declaration (a checkout under a non-canonical directory name, for
+// example). The package declaration in existing .go files is the canonical
+// source of truth.
+//
+// Resolution order:
+//  1. Parse one of the existing .go files (skipping _test.go and the
+//     output file itself) and use its package name.
+//  2. Fall back to the go.mod module-path basename, snake-cased.
+//  3. Last resort: the directory basename, snake-cased — preserves the
+//     prior behaviour for empty packages so we don't regress.
+func detectPackageName(root string) string {
+	if name := packageFromGoFiles(root); name != "" {
+		return name
+	}
+	if name := packageFromGoMod(root); name != "" {
+		return name
+	}
+	return strings.ReplaceAll(strcase.SnakeCase(filepath.Base(root)), ".", "_")
+}
+
+func packageFromGoFiles(root string) string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return ""
+	}
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") || name == outputName {
+			continue
+		}
+		path := filepath.Join(root, name)
+		f, err := parser.ParseFile(fset, path, nil, parser.PackageClauseOnly)
+		if err != nil {
+			continue
+		}
+		if f.Name != nil && f.Name.Name != "" {
+			return f.Name.Name
+		}
+	}
+	return ""
+}
+
+func packageFromGoMod(root string) string {
+	data, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		return ""
+	}
+	parsed, err := modfile.Parse("go.mod", data, nil)
+	if err != nil || parsed.Module == nil {
+		return ""
+	}
+	return strings.ReplaceAll(strcase.SnakeCase(filepath.Base(parsed.Module.Mod.Path)), ".", "_")
 }
 
 func buildPathTree(paths []string) map[string][]string {

--- a/go.work.sum
+++ b/go.work.sum
@@ -1203,8 +1203,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
 golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1216,6 +1214,7 @@ golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
@@ -1233,6 +1232,7 @@ golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7
 golang.org/x/term v0.33.0/go.mod h1:s18+ql9tYWp1IfpV9DmCtQDDSRBUjKaw9M1eAv5UeF0=
 golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=
 golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=
+golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=


### PR DESCRIPTION
## Summary

Independent fix split out from #185.

`cmd/embed` previously inferred the generated `embed.go` package name from `filepath.Base(root)`. That works as long as the working directory's basename matches the canonical package declaration, but breaks the moment a checkout is cloned under a different directory name — regenerating the embed file emits the wrong `package` clause and quietly breaks downstream builds.

Now the package name is taken from the package clause of an existing `.go` file in the directory (the canonical source of truth), with `go.mod`'s module-path basename as a fallback for empty packages and the original directory-basename behaviour as a last resort.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes
- [ ] Manually `rm` an embed.go and run `go run ./cmd/embed/` from a checkout cloned under a non-canonical directory name, confirm the regenerated file has the correct package declaration
- [ ] Compare regenerated embed.go against the canonical version in master, confirm only the directory-basename behaviour change has effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package name detection when generating embed files: the tool now prioritizes existing Go source, falls back to module information, and lastly uses the directory name if needed.
  * No changes to exported/public APIs — behavior is internal to embed file generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->