### PR TITLE
feat: emit outcome metadata on the legacy CallStream+OnTick path

### DIFF
--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -1228,6 +1228,10 @@ func Generate(selfPkg string) {
 						}
 						return jen.Null()
 					}(),
+					// Emit outcome metadata before sending Final, so it lands
+					// between the last partial and the terminal payload —
+					// matching the BuildRequest path's contract.
+					jen.Id("beforeFinal").Call(),
 					jen.Select().Block(
 						jen.Case(jen.Id("out").Op("<-").Id("__r")).Block(),
 						jen.Case(jen.Op("<-").Id("adapter").Dot("Done").Call()).Block(
@@ -1289,15 +1293,15 @@ func Generate(selfPkg string) {
 				jen.Func().Params(jen.Id("__r").Qual(common.InterfacesPkg, "StreamResult")).Block(
 					jen.Id("__r").Dot("Release").Call(),
 				),
-				// newPlannedMetadata: constructs a planned metadata result
-				// from the caller-supplied plan. nil when plan is nil,
-				// which disables the emission.
-				jen.Func().Params().Qual(common.InterfacesPkg, "StreamResult").Block(
-					jen.If(jen.Id("plannedMetadata").Op("==").Nil()).Block(jen.Return(jen.Nil())),
-					jen.Return(jen.Id(metadataConstructorName).Call(jen.Id("plannedMetadata"))),
+				// plannedMetadata: passed straight through; orchestrator
+				// builds both planned and outcome events from this seed.
+				jen.Id("plannedMetadata"),
+				// newMetadataResult: pool-wraps a Metadata payload.
+				jen.Func().Params(jen.Id("md").Op("*").Qual(common.InterfacesPkg, "Metadata")).Qual(common.InterfacesPkg, "StreamResult").Block(
+					jen.Return(jen.Id(metadataConstructorName).Call(jen.Id("md"))),
 				),
-				// body - receives onTick, handles stream creation and iteration
-				jen.Func().Params(jen.Id("onTick").Add(onTickType())).Error().Block(noRawGoroutineBody...),
+				// body - receives beforeFinal + onTick, handles stream creation and iteration
+				jen.Func().Params(jen.Id("beforeFinal").Func().Params(), jen.Id("onTick").Add(onTickType())).Error().Block(noRawGoroutineBody...),
 			)),
 		)
 
@@ -1569,10 +1573,12 @@ func Generate(selfPkg string) {
 				jen.Func().Params(jen.Id("__r").Qual(common.InterfacesPkg, "StreamResult")).Block(
 					jen.Id("__r").Dot("Release").Call(),
 				),
-				// newPlannedMetadata
-				jen.Func().Params().Qual(common.InterfacesPkg, "StreamResult").Block(
-					jen.If(jen.Id("plannedMetadata").Op("==").Nil()).Block(jen.Return(jen.Nil())),
-					jen.Return(jen.Id(metadataConstructorName).Call(jen.Id("plannedMetadata"))),
+				// plannedMetadata: passed straight through; orchestrator
+				// builds both planned and outcome events from this seed.
+				jen.Id("plannedMetadata"),
+				// newMetadataResult: pool-wraps a Metadata payload.
+				jen.Func().Params(jen.Id("md").Op("*").Qual(common.InterfacesPkg, "Metadata")).Qual(common.InterfacesPkg, "StreamResult").Block(
+					jen.Return(jen.Id(metadataConstructorName).Call(jen.Id("md"))),
 				),
 				// processTick
 				jen.Func().Params(
@@ -3554,23 +3560,45 @@ func generateStreamHelpers(out *jen.File) {
 			jen.Id("newHeartbeat").Func().Params().Add(streamResultIface.Clone()),
 			jen.Id("newError").Func().Params(jen.Error()).Add(streamResultIface.Clone()),
 			jen.Id("release").Func().Params(streamResultIface.Clone()),
-			// newPlannedMetadata is invoked inside the first-tick branch of
-			// onTick (after the heartbeat send) to emit the planned metadata
-			// event. Pass nil when metadata emission is not desired (tests,
-			// mixed-mode legacy children whose parent orchestrator already
-			// emitted planned metadata for the chain).
-			jen.Id("newPlannedMetadata").Func().Params().Add(streamResultIface.Clone()),
-			jen.Id("body").Func().Params(jen.Add(onTickType())).Error(),
+			// plannedMetadata: pre-built planned-phase Metadata for this request,
+			// or nil to disable metadata emission entirely (tests, mixed-mode
+			// legacy children whose parent orchestrator already emitted
+			// metadata for the chain). The orchestrator emits a planned event
+			// on the first tick (alongside the heartbeat) and an outcome
+			// event via the body's beforeFinal callback.
+			jen.Id("plannedMetadata").Op("*").Qual(common.InterfacesPkg, "Metadata"),
+			// newMetadataResult: pool-wraps a Metadata payload as a StreamResult.
+			// Required when plannedMetadata is non-nil.
+			jen.Id("newMetadataResult").Func().Params(jen.Op("*").Qual(common.InterfacesPkg, "Metadata")).Add(streamResultIface.Clone()),
+			// body receives a beforeFinal callback that the body MUST invoke
+			// before sending the final StreamResult, and an onTick callback
+			// that body MUST install on the BAML stream. beforeFinal builds
+			// and emits the outcome metadata event so it lands between the
+			// last partial and the final.
+			jen.Id("body").Func().Params(jen.Func().Params(), jen.Add(onTickType())).Error(),
 		).
 		Error().
 		Block(
+			// startTime anchors the UpstreamDurMs measurement on the outcome
+			// metadata event.
+			jen.Id("startTime").Op(":=").Qual("time", "Now").Call(),
 			jen.Var().Id("heartbeatSent").Qual("sync/atomic", "Bool"),
+			// lastFuncLog stores the most recent FunctionLog reference seen
+			// by onTick. Read by beforeFinal to derive winner identity and
+			// BAML's internal call count for the outcome event. nil if no
+			// onTick fired before the stream completed (rare; degrade
+			// gracefully via BuildLegacyOutcome's planned-fallback ladder).
+			jen.Var().Id("lastFuncLog").Qual("sync/atomic", "Value"),
 
 			jen.Id("onTick").Op(":=").Func().Params(
 				jen.Id("_").Qual("context", "Context"),
 				jen.Id("_").Qual(BamlPkg, "TickReason"),
-				jen.Id("_").Qual(BamlPkg, "FunctionLog"),
+				jen.Id("funcLog").Qual(BamlPkg, "FunctionLog"),
 			).Qual(BamlPkg, "FunctionSignal").Block(
+				// Store the latest FunctionLog on every tick (not just the
+				// first) so the outcome event reflects the post-stream
+				// state, not the pre-stream state.
+				jen.Id("lastFuncLog").Dot("Store").Call(jen.Id("funcLog")),
 				jen.If(jen.Id("heartbeatSent").Dot("CompareAndSwap").Call(jen.False(), jen.True())).Block(
 					jen.Select().Block(
 						jen.Case(jen.Op("<-").Id("adapter").Dot("Done").Call()).Block(jen.Return(jen.Nil())),
@@ -3587,8 +3615,10 @@ func generateStreamHelpers(out *jen.File) {
 					// orchestrator invocation (subsequent ticks skip).
 					// Non-blocking: release the result if the output buffer
 					// is full, matching the heartbeat's drop-on-full policy.
-					jen.If(jen.Id("newPlannedMetadata").Op("!=").Nil()).Block(
-						jen.Id("__m").Op(":=").Id("newPlannedMetadata").Call(),
+					jen.If(jen.Id("plannedMetadata").Op("!=").Nil().Op("&&").Id("newMetadataResult").Op("!=").Nil()).Block(
+						jen.Id("__plan").Op(":=").Op("*").Id("plannedMetadata"),
+						jen.Id("__plan").Dot("Phase").Op("=").Qual(common.InterfacesPkg, "MetadataPhasePlanned"),
+						jen.Id("__m").Op(":=").Id("newMetadataResult").Call(jen.Op("&").Id("__plan")),
 						jen.If(jen.Id("__m").Op("!=").Nil()).Block(
 							jen.Select().Block(
 								jen.Case(jen.Id("out").Op("<-").Id("__m")).Block(),
@@ -3598,6 +3628,60 @@ func generateStreamHelpers(out *jen.File) {
 					),
 				),
 				jen.Return(jen.Nil()),
+			),
+
+			// beforeFinal builds the outcome metadata event from lastFuncLog
+			// (if any) and emits it. Body MUST call this exactly once,
+			// immediately before sending the final StreamResult, so the
+			// metadata event lands between the last partial and the final.
+			// Safe to call when plannedMetadata is nil — short-circuits.
+			jen.Id("beforeFinal").Op(":=").Func().Params().Block(
+				jen.If(jen.Id("plannedMetadata").Op("==").Nil().Op("||").Id("newMetadataResult").Op("==").Nil()).Block(
+					jen.Return(),
+				),
+				jen.Var().Id("__winnerClient").String(),
+				jen.Var().Id("__winnerProvider").String(),
+				jen.Var().Id("__bamlCallCount").Op("*").Int(),
+				jen.If(
+					jen.List(jen.Id("fl"), jen.Id("flOk")).Op(":=").Id("lastFuncLog").Dot("Load").Call().Assert(jen.Qual(BamlPkg, "FunctionLog")),
+					jen.Id("flOk"),
+				).Block(
+					jen.If(
+						jen.List(jen.Id("__sel"), jen.Id("__selErr")).Op(":=").Id("fl").Dot("SelectedCall").Call(),
+						jen.Id("__selErr").Op("==").Nil().Op("&&").Id("__sel").Op("!=").Nil(),
+					).Block(
+						jen.If(
+							jen.List(jen.Id("__cn"), jen.Id("__cnErr")).Op(":=").Id("__sel").Dot("ClientName").Call(),
+							jen.Id("__cnErr").Op("==").Nil(),
+						).Block(jen.Id("__winnerClient").Op("=").Id("__cn")),
+						jen.If(
+							jen.List(jen.Id("__pv"), jen.Id("__pvErr")).Op(":=").Id("__sel").Dot("Provider").Call(),
+							jen.Id("__pvErr").Op("==").Nil(),
+						).Block(jen.Id("__winnerProvider").Op("=").Id("__pv")),
+					),
+					jen.If(
+						jen.List(jen.Id("__calls"), jen.Id("__callsErr")).Op(":=").Id("fl").Dot("Calls").Call(),
+						jen.Id("__callsErr").Op("==").Nil(),
+					).Block(
+						jen.Id("__n").Op(":=").Len(jen.Id("__calls")).Op("-").Lit(1),
+						jen.If(jen.Id("__n").Op("<").Lit(0)).Block(jen.Id("__n").Op("=").Lit(0)),
+						jen.Id("__bamlCallCount").Op("=").Op("&").Id("__n"),
+					),
+				),
+				jen.Id("__outcome").Op(":=").Qual(common.InterfacesPkg, "BuildLegacyOutcome").Call(
+					jen.Id("plannedMetadata"),
+					jen.Qual("time", "Since").Call(jen.Id("startTime")).Dot("Milliseconds").Call(),
+					jen.Id("__winnerClient"),
+					jen.Id("__winnerProvider"),
+					jen.Id("__bamlCallCount"),
+				),
+				jen.If(jen.Id("__outcome").Op("==").Nil()).Block(jen.Return()),
+				jen.Id("__om").Op(":=").Id("newMetadataResult").Call(jen.Id("__outcome")),
+				jen.If(jen.Id("__om").Op("==").Nil()).Block(jen.Return()),
+				jen.Select().Block(
+					jen.Case(jen.Id("out").Op("<-").Id("__om")).Block(),
+					jen.Case(jen.Op("<-").Id("adapter").Dot("Done").Call()).Block(jen.Id("release").Call(jen.Id("__om"))),
+				),
 			),
 
 			jen.Go().Func().Params().Block(
@@ -3613,7 +3697,7 @@ func generateStreamHelpers(out *jen.File) {
 						),
 					),
 					jen.Func().Params().Error().Block(
-						jen.Return(jen.Id("body").Call(jen.Id("onTick"))),
+						jen.Return(jen.Id("body").Call(jen.Id("beforeFinal"), jen.Id("onTick"))),
 					),
 				),
 			).Call(),
@@ -3636,8 +3720,15 @@ func generateStreamHelpers(out *jen.File) {
 			jen.Id("newHeartbeat").Func().Params().Add(streamResultIface.Clone()),
 			jen.Id("newError").Func().Params(jen.Error()).Add(streamResultIface.Clone()),
 			jen.Id("release").Func().Params(streamResultIface.Clone()),
-			// newPlannedMetadata: see runNoRawOrchestration for the contract.
-			jen.Id("newPlannedMetadata").Func().Params().Add(streamResultIface.Clone()),
+			// plannedMetadata: pre-built planned-phase Metadata for this request,
+			// or nil to disable metadata emission entirely. The orchestrator
+			// emits a planned event on the first tick (alongside the heartbeat)
+			// and an outcome event just before the final result. Both events
+			// are constructed from this seed via newMetadataResult.
+			jen.Id("plannedMetadata").Op("*").Qual(common.InterfacesPkg, "Metadata"),
+			// newMetadataResult: pool-wraps a Metadata payload as a StreamResult.
+			// Required when plannedMetadata is non-nil.
+			jen.Id("newMetadataResult").Func().Params(jen.Op("*").Qual(common.InterfacesPkg, "Metadata")).Add(streamResultIface.Clone()),
 			// processTick: handle one FunctionLog tick (extract chunks, parse, emit partial).
 			// Receives the shared extractor + mutex.
 			jen.Id("processTick").Func().Params(
@@ -3654,6 +3745,11 @@ func generateStreamHelpers(out *jen.File) {
 		).
 		Error().
 		Block(
+			// startTime anchors the UpstreamDurMs measurement on the outcome
+			// metadata event. Captured at orchestrator entry to match the
+			// BuildRequest path's wall-clock semantics.
+			jen.Id("startTime").Op(":=").Qual("time", "Now").Call(),
+
 			// Queue + context
 			jen.Id("funcLogQueue").Op(":=").Qual(common.GoConcurrentQueuePkg, "NewFIFO").Call(),
 			jen.List(jen.Id("queueCtx"), jen.Id("queueCancel")).Op(":=").Qual("context", "WithCancel").Call(jen.Qual("context", "Background").Call()),
@@ -3755,8 +3851,14 @@ func generateStreamHelpers(out *jen.File) {
 									jen.Case(jen.Id("out").Op("<-").Id("__r")).Block(),
 									jen.Default().Block(jen.Id("release").Call(jen.Id("__r"))),
 								),
-								jen.If(jen.Id("newPlannedMetadata").Op("!=").Nil()).Block(
-									jen.Id("__m").Op(":=").Id("newPlannedMetadata").Call(),
+								jen.If(jen.Id("plannedMetadata").Op("!=").Nil().Op("&&").Id("newMetadataResult").Op("!=").Nil()).Block(
+									// Copy and tag Phase=Planned. Caller-supplied
+									// plannedMetadata may have been built with
+									// Phase already set, but flipping here makes
+									// the contract local and survives reuse.
+									jen.Id("__plan").Op(":=").Op("*").Id("plannedMetadata"),
+									jen.Id("__plan").Dot("Phase").Op("=").Qual(common.InterfacesPkg, "MetadataPhasePlanned"),
+									jen.Id("__m").Op(":=").Id("newMetadataResult").Call(jen.Op("&").Id("__plan")),
 									jen.If(jen.Id("__m").Op("!=").Nil()).Block(
 										jen.Select().Block(
 											jen.Case(jen.Id("out").Op("<-").Id("__m")).Block(),
@@ -3921,6 +4023,60 @@ func generateStreamHelpers(out *jen.File) {
 								jen.Id("finalRaw").Op("=").Id("authRaw"),
 							),
 						),
+
+						// Outcome metadata: build from the winning attempt's
+						// FunctionLog and emit just before the final, so clients
+						// observe the routing outcome attached to (and ordered
+						// before) the terminal payload. Mirrors the BuildRequest
+						// path's contract; no-op when plannedMetadata is nil.
+						jen.If(jen.Id("plannedMetadata").Op("!=").Nil().Op("&&").Id("newMetadataResult").Op("!=").Nil()).Block(
+							jen.Var().Id("__winnerClient").String(),
+							jen.Var().Id("__winnerProvider").String(),
+							jen.Var().Id("__bamlCallCount").Op("*").Int(),
+							jen.If(jen.Id("flOk")).Block(
+								jen.If(
+									jen.List(jen.Id("__sel"), jen.Id("__selErr")).Op(":=").Id("fl").Dot("SelectedCall").Call(),
+									jen.Id("__selErr").Op("==").Nil().Op("&&").Id("__sel").Op("!=").Nil(),
+								).Block(
+									jen.If(
+										jen.List(jen.Id("__cn"), jen.Id("__cnErr")).Op(":=").Id("__sel").Dot("ClientName").Call(),
+										jen.Id("__cnErr").Op("==").Nil(),
+									).Block(jen.Id("__winnerClient").Op("=").Id("__cn")),
+									jen.If(
+										jen.List(jen.Id("__pv"), jen.Id("__pvErr")).Op(":=").Id("__sel").Dot("Provider").Call(),
+										jen.Id("__pvErr").Op("==").Nil(),
+									).Block(jen.Id("__winnerProvider").Op("=").Id("__pv")),
+								),
+								jen.If(
+									jen.List(jen.Id("__calls"), jen.Id("__callsErr")).Op(":=").Id("fl").Dot("Calls").Call(),
+									jen.Id("__callsErr").Op("==").Nil(),
+								).Block(
+									jen.Id("__n").Op(":=").Len(jen.Id("__calls")).Op("-").Lit(1),
+									jen.If(jen.Id("__n").Op("<").Lit(0)).Block(jen.Id("__n").Op("=").Lit(0)),
+									jen.Id("__bamlCallCount").Op("=").Op("&").Id("__n"),
+								),
+							),
+							jen.Id("__outcome").Op(":=").Qual(common.InterfacesPkg, "BuildLegacyOutcome").Call(
+								jen.Id("plannedMetadata"),
+								jen.Qual("time", "Since").Call(jen.Id("startTime")).Dot("Milliseconds").Call(),
+								jen.Id("__winnerClient"),
+								jen.Id("__winnerProvider"),
+								jen.Id("__bamlCallCount"),
+							),
+							jen.If(jen.Id("__outcome").Op("!=").Nil()).Block(
+								jen.Id("__om").Op(":=").Id("newMetadataResult").Call(jen.Id("__outcome")),
+								jen.If(jen.Id("__om").Op("!=").Nil()).Block(
+									jen.Select().Block(
+										jen.Case(jen.Id("out").Op("<-").Id("__om")).Block(),
+										jen.Case(jen.Op("<-").Id("adapter").Dot("Done").Call()).Block(
+											jen.Id("release").Call(jen.Id("__om")),
+											jen.Return(jen.Nil()),
+										),
+									),
+								),
+							),
+						),
+
 						jen.Id("__r").Op(":=").Id("emitFinal").Call(jen.Id("finalResult"), jen.Id("finalRaw")),
 						jen.Select().Block(
 							jen.Case(jen.Id("out").Op("<-").Id("__r")).Block(),

--- a/adapters/common/codegen/stream_helpers_test.go
+++ b/adapters/common/codegen/stream_helpers_test.go
@@ -1,0 +1,70 @@
+package codegen
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/adapters/common"
+)
+
+// TestGenerateStreamHelpers_ParsesAsValidGo emits the orchestration helpers
+// (runNoRawOrchestration / runFullOrchestration / runLegacyChildStream) into
+// a synthetic file and confirms the output parses as valid Go syntax. The
+// adapter package is generated at user build time against a real baml_client,
+// so this is the closest in-repo guard against codegen syntax regressions.
+func TestGenerateStreamHelpers_ParsesAsValidGo(t *testing.T) {
+	t.Parallel()
+
+	out := common.MakeFile()
+	generateStreamHelpers(out)
+
+	rendered := out.GoString()
+	if rendered == "" {
+		t.Fatal("generateStreamHelpers produced empty output")
+	}
+
+	fset := token.NewFileSet()
+	if _, err := parser.ParseFile(fset, "stream_helpers_synth.go", rendered, parser.AllErrors); err != nil {
+		// Print a few lines of context around the failure to make the error
+		// readable; jennifer output can be long.
+		t.Fatalf("generated stream helpers do not parse as valid Go: %v\n--- snippet ---\n%s", err, snippet(rendered, 3000))
+	}
+}
+
+// TestGenerateStreamHelpers_ContainsExpectedSymbols asserts the new
+// orchestration contract's call sites appear in the generated source. This
+// is a low-cost guard against accidentally dropping the outcome-emission
+// changes from runNoRaw / runFull during future refactors.
+func TestGenerateStreamHelpers_ContainsExpectedSymbols(t *testing.T) {
+	t.Parallel()
+
+	out := common.MakeFile()
+	generateStreamHelpers(out)
+	rendered := out.GoString()
+
+	wantSubstrings := []string{
+		"runNoRawOrchestration",
+		"runFullOrchestration",
+		"BuildLegacyOutcome",
+		"plannedMetadata",
+		"newMetadataResult",
+		"beforeFinal",
+		"lastFuncLog",
+		"SelectedCall",
+		"startTime",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("generated source missing expected symbol %q", want)
+		}
+	}
+}
+
+func snippet(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "\n...[truncated]"
+}

--- a/bamlutils/embed.go
+++ b/bamlutils/embed.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed adapters.go buildrequest/call_orchestrator.go buildrequest/legacy_log.go buildrequest/orchestrator.go buildrequest/response_extract.go buildrequest/strategy_testhelper.go clientdefaults/clientdefaults.go clientdefaults/handlers.go dynamic.go embed.go go.mod go.sum interfaces.go llmhttp/llmhttp.go media.go pool.go retry/retry.go sse/extract.go sseclient/sseclient.go urlrewrite/urlrewrite.go versions.go
+//go:embed adapters.go buildrequest/call_orchestrator.go buildrequest/legacy_log.go buildrequest/orchestrator.go buildrequest/response_extract.go buildrequest/strategy_testhelper.go clientdefaults/clientdefaults.go clientdefaults/handlers.go dynamic.go embed.go go.mod go.sum interfaces.go legacy_outcome.go llmhttp/llmhttp.go media.go pool.go retry/retry.go sse/extract.go sseclient/sseclient.go urlrewrite/urlrewrite.go versions.go
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -68,11 +68,19 @@ type Metadata struct {
 	RetryPolicy    string   `json:"retry_policy,omitempty"`     // compact encoding (e.g. "exp:200ms:1.5:10s")
 
 	// Outcome fields — populated only on the outcome event
-	RetryCount     *int   `json:"retry_count,omitempty"`           // outer orchestrator retries consumed; nil=unknown
+	RetryCount     *int   `json:"retry_count,omitempty"`           // outer orchestrator retries consumed; nil=unknown. Always nil on legacy (no outer orchestrator).
 	WinnerClient   string `json:"winner_client,omitempty"`         // chain child that succeeded (same as Client for non-chains)
 	WinnerProvider string `json:"winner_provider,omitempty"`       // provider of the winner
 	WinnerPath     string `json:"winner_path,omitempty"`           // "buildrequest" or "legacy" (legacy-child inside mixed chain)
 	UpstreamDurMs  *int64 `json:"upstream_duration_ms,omitempty"`  // upstream wall time in ms
+	// BamlCallCount is the number of *additional* LLM calls BAML made
+	// beyond the first on the legacy path, i.e. max(len(FunctionLog.Calls())-1, 0).
+	// This collapses BAML-internal retries (per-client retry policy) and
+	// fallback chain walking into one figure — nonzero means BAML did
+	// something beyond a single happy-path call. Always nil on the
+	// BuildRequest path (BuildRequest issues one HTTP per outer attempt;
+	// inner retries are tracked via RetryCount instead).
+	BamlCallCount *int `json:"baml_call_count,omitempty"`
 }
 
 // StreamMode controls how streaming results are processed and what data is collected.

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -50,8 +50,9 @@ const (
 // responses and as in-stream events on streaming responses).
 //
 // Pointer fields distinguish "unknown" (nil) from "zero" (pointer to 0) so
-// absence can be represented faithfully — critical for legacy v1 which
-// cannot populate outcome fields.
+// absence can be represented faithfully. Some outcome fields are populated
+// only on one path (e.g. RetryCount on BuildRequest, BamlCallCount on
+// legacy) — see per-field doc strings for the contract.
 type Metadata struct {
 	Phase      MetadataPhase `json:"phase"`                 // "planned" or "outcome"
 	Attempt    int           `json:"attempt"`               // pool-level attempt number (0-based). Orchestrator emits 0; pool rewrites.
@@ -67,19 +68,24 @@ type Metadata struct {
 	RetryMax       *int     `json:"retry_max,omitempty"`        // configured max retries
 	RetryPolicy    string   `json:"retry_policy,omitempty"`     // compact encoding (e.g. "exp:200ms:1.5:10s")
 
-	// Outcome fields — populated only on the outcome event
-	RetryCount     *int   `json:"retry_count,omitempty"`           // outer orchestrator retries consumed; nil=unknown. Always nil on legacy (no outer orchestrator).
-	WinnerClient   string `json:"winner_client,omitempty"`         // chain child that succeeded (same as Client for non-chains)
-	WinnerProvider string `json:"winner_provider,omitempty"`       // provider of the winner
-	WinnerPath     string `json:"winner_path,omitempty"`           // "buildrequest" or "legacy" (legacy-child inside mixed chain)
-	UpstreamDurMs  *int64 `json:"upstream_duration_ms,omitempty"`  // upstream wall time in ms
-	// BamlCallCount is the number of *additional* LLM calls BAML made
-	// beyond the first on the legacy path, i.e. max(len(FunctionLog.Calls())-1, 0).
-	// This collapses BAML-internal retries (per-client retry policy) and
+	// Outcome fields — populated only on the outcome event.
+	// RetryCount counts retries consumed by the BuildRequest orchestrator
+	// itself (one per attempt of the fallback strategy). Always nil on the
+	// legacy path: the legacy path runs no outer retry orchestrator — BAML's
+	// runtime owns retry behaviour internally and that count is surfaced via
+	// BamlCallCount instead.
+	RetryCount     *int   `json:"retry_count,omitempty"`
+	WinnerClient   string `json:"winner_client,omitempty"`        // actual client that produced the final result; absent for legacy strategy routes when funcLog.SelectedCall yields no data
+	WinnerProvider string `json:"winner_provider,omitempty"`      // provider of the winner
+	WinnerPath     string `json:"winner_path,omitempty"`          // "buildrequest" or "legacy" (latter for pure legacy or a legacy child inside a mixed chain)
+	UpstreamDurMs  *int64 `json:"upstream_duration_ms,omitempty"` // upstream wall time in ms (orchestrator entry to outcome emission)
+	// BamlCallCount is the number of *additional* LLM calls BAML made beyond
+	// the first, computed as max(len(FunctionLog.Calls())-1, 0). It collapses
+	// BAML-internal retries (per-client retry policy) and BAML-internal
 	// fallback chain walking into one figure — nonzero means BAML did
-	// something beyond a single happy-path call. Always nil on the
-	// BuildRequest path (BuildRequest issues one HTTP per outer attempt;
-	// inner retries are tracked via RetryCount instead).
+	// something beyond a single happy-path call. Populated only on the
+	// legacy path (the BuildRequest path issues one HTTP request per outer
+	// attempt and surfaces its retries via RetryCount).
 	BamlCallCount *int `json:"baml_call_count,omitempty"`
 }
 

--- a/bamlutils/legacy_outcome.go
+++ b/bamlutils/legacy_outcome.go
@@ -1,0 +1,83 @@
+package bamlutils
+
+// BuildLegacyOutcome composes a Metadata payload describing the outcome of
+// a request that ran on the legacy CallStream+OnTick path. Called by the
+// per-method orchestrators (runFullOrchestration / runNoRawOrchestration)
+// once the winning attempt has been identified.
+//
+// The helper is intentionally pure: callers extract winner/call-count
+// values from BAML's FunctionLog and pass them in, so this function does
+// not depend on the BAML SDK and is trivial to unit-test.
+//
+// Inputs:
+//   - planned: the planned-phase metadata used to seed the outcome. Returns
+//     nil when planned is nil (callers no-op when no plan is configured).
+//   - upstreamDurMs: wall-clock milliseconds since orchestration started.
+//     The caller computes this (typically time.Since(startTime).Milliseconds())
+//     so the helper stays pure.
+//   - winnerClient, winnerProvider: extracted from
+//     funcLog.SelectedCall().{ClientName,Provider}(). Pass empty strings
+//     when SelectedCall returned an error, was nil, or no FunctionLog was
+//     ever observed.
+//   - bamlCallCount: max(len(funcLog.Calls())-1, 0). Pass nil when
+//     Calls() failed or no FunctionLog was ever observed.
+//
+// Behavior:
+//   - Phase is set to MetadataPhaseOutcome.
+//   - WinnerPath is always "legacy".
+//   - WinnerClient / WinnerProvider follow a fallback ladder:
+//     1. If winnerClient != "", use the provided values.
+//     2. Else if planned.Strategy == "" (single-provider route), fall back
+//        to planned.Client / planned.Provider — they are tautologically the
+//        actual winner on a single-provider route.
+//     3. Else (strategy route, no SelectedCall data), leave both absent.
+//        Reporting the strategy name as the winner would conflate the
+//        planned strategy with the actual chosen child.
+//   - BamlCallCount is echoed as-is (nil-passthrough).
+//   - UpstreamDurMs is set from the caller-provided duration.
+//   - Planned-only fields (RetryMax, RetryPolicy, Chain, LegacyChildren,
+//     Strategy, Provider) are cleared from the outcome to keep the event
+//     compact. Consumers see the planned-phase event separately for those
+//     fields.
+//   - RetryCount is left nil. The legacy path has no outer retry
+//     orchestrator; BAML's internal retries are surfaced via BamlCallCount.
+func BuildLegacyOutcome(
+	planned *Metadata,
+	upstreamDurMs int64,
+	winnerClient, winnerProvider string,
+	bamlCallCount *int,
+) *Metadata {
+	if planned == nil {
+		return nil
+	}
+
+	out := *planned
+	out.Phase = MetadataPhaseOutcome
+	out.Attempt = 0
+	out.RetryMax = nil
+	out.RetryPolicy = ""
+	out.Chain = nil
+	out.LegacyChildren = nil
+	out.Strategy = ""
+	out.Provider = ""
+	out.RetryCount = nil
+
+	out.WinnerPath = "legacy"
+	switch {
+	case winnerClient != "":
+		out.WinnerClient = winnerClient
+		out.WinnerProvider = winnerProvider
+	case planned.Strategy == "":
+		out.WinnerClient = planned.Client
+		out.WinnerProvider = planned.Provider
+	default:
+		out.WinnerClient = ""
+		out.WinnerProvider = ""
+	}
+
+	out.BamlCallCount = bamlCallCount
+	dur := upstreamDurMs
+	out.UpstreamDurMs = &dur
+
+	return &out
+}

--- a/bamlutils/legacy_outcome_test.go
+++ b/bamlutils/legacy_outcome_test.go
@@ -1,0 +1,202 @@
+package bamlutils
+
+import (
+	"testing"
+)
+
+func TestBuildLegacyOutcome_NilPlanned(t *testing.T) {
+	t.Parallel()
+
+	if got := BuildLegacyOutcome(nil, 100, "", "", nil); got != nil {
+		t.Fatalf("nil planned should yield nil outcome; got %+v", got)
+	}
+}
+
+func TestBuildLegacyOutcome_SingleProviderRouteUsesPlanned(t *testing.T) {
+	t.Parallel()
+
+	planned := &Metadata{
+		Phase:    MetadataPhasePlanned,
+		Path:     "legacy",
+		Client:   "MyClient",
+		Provider: "openai",
+	}
+	got := BuildLegacyOutcome(planned, 250, "", "", nil)
+
+	if got == nil {
+		t.Fatal("expected non-nil outcome")
+	}
+	if got.Phase != MetadataPhaseOutcome {
+		t.Errorf("Phase: got %q, want outcome", got.Phase)
+	}
+	if got.WinnerPath != "legacy" {
+		t.Errorf("WinnerPath: got %q, want legacy", got.WinnerPath)
+	}
+	if got.WinnerClient != "MyClient" {
+		t.Errorf("WinnerClient: got %q, want MyClient (fallback to planned)", got.WinnerClient)
+	}
+	if got.WinnerProvider != "openai" {
+		t.Errorf("WinnerProvider: got %q, want openai (fallback to planned)", got.WinnerProvider)
+	}
+	if got.UpstreamDurMs == nil || *got.UpstreamDurMs != 250 {
+		t.Errorf("UpstreamDurMs: got %v, want &250", got.UpstreamDurMs)
+	}
+	if got.BamlCallCount != nil {
+		t.Errorf("BamlCallCount: should be nil when not provided; got %v", *got.BamlCallCount)
+	}
+	if got.RetryCount != nil {
+		t.Errorf("RetryCount: must be nil on legacy; got %v", *got.RetryCount)
+	}
+}
+
+func TestBuildLegacyOutcome_ExplicitWinnerOverridesPlanned(t *testing.T) {
+	t.Parallel()
+
+	planned := &Metadata{
+		Phase:    MetadataPhasePlanned,
+		Path:     "legacy",
+		Client:   "MyClient",
+		Provider: "openai",
+	}
+	five := 5
+	got := BuildLegacyOutcome(planned, 100, "FromSelectedCall", "anthropic", &five)
+
+	if got.WinnerClient != "FromSelectedCall" {
+		t.Errorf("WinnerClient: got %q, want FromSelectedCall", got.WinnerClient)
+	}
+	if got.WinnerProvider != "anthropic" {
+		t.Errorf("WinnerProvider: got %q, want anthropic", got.WinnerProvider)
+	}
+	if got.BamlCallCount == nil || *got.BamlCallCount != 5 {
+		t.Errorf("BamlCallCount: got %v, want &5", got.BamlCallCount)
+	}
+}
+
+func TestBuildLegacyOutcome_StrategyWithoutWinnerLeavesAbsent(t *testing.T) {
+	t.Parallel()
+
+	planned := &Metadata{
+		Phase:    MetadataPhasePlanned,
+		Path:     "legacy",
+		Client:   "Strategy",
+		Strategy: "baml-fallback",
+		Chain:    []string{"A", "B"},
+	}
+	got := BuildLegacyOutcome(planned, 100, "", "", nil)
+
+	if got.WinnerClient != "" {
+		t.Errorf("WinnerClient must be absent on strategy route without SelectedCall data; got %q", got.WinnerClient)
+	}
+	if got.WinnerProvider != "" {
+		t.Errorf("WinnerProvider must be absent on strategy route without SelectedCall data; got %q", got.WinnerProvider)
+	}
+	if got.WinnerPath != "legacy" {
+		t.Errorf("WinnerPath: got %q, want legacy", got.WinnerPath)
+	}
+}
+
+func TestBuildLegacyOutcome_StrategyWithWinnerUsesSelectedCall(t *testing.T) {
+	t.Parallel()
+
+	planned := &Metadata{
+		Phase:    MetadataPhasePlanned,
+		Path:     "legacy",
+		Client:   "Strategy",
+		Strategy: "baml-fallback",
+		Chain:    []string{"Primary", "Backup"},
+	}
+	got := BuildLegacyOutcome(planned, 100, "Backup", "anthropic", nil)
+
+	if got.WinnerClient != "Backup" {
+		t.Errorf("WinnerClient: got %q, want Backup", got.WinnerClient)
+	}
+	if got.WinnerProvider != "anthropic" {
+		t.Errorf("WinnerProvider: got %q, want anthropic", got.WinnerProvider)
+	}
+}
+
+func TestBuildLegacyOutcome_ClearsPlannedOnlyFields(t *testing.T) {
+	t.Parallel()
+
+	five := 5
+	planned := &Metadata{
+		Phase:          MetadataPhasePlanned,
+		Path:           "legacy",
+		Client:         "Strategy",
+		Strategy:       "baml-fallback",
+		Provider:       "openai",
+		Chain:          []string{"A", "B"},
+		LegacyChildren: []string{"B"},
+		RetryMax:       &five,
+		RetryPolicy:    "exp:200ms:1.5:10s",
+	}
+	got := BuildLegacyOutcome(planned, 100, "A", "openai", nil)
+
+	if got.RetryMax != nil {
+		t.Errorf("RetryMax must be cleared from outcome; got %v", *got.RetryMax)
+	}
+	if got.RetryPolicy != "" {
+		t.Errorf("RetryPolicy must be cleared from outcome; got %q", got.RetryPolicy)
+	}
+	if got.Chain != nil {
+		t.Errorf("Chain must be cleared from outcome; got %v", got.Chain)
+	}
+	if got.LegacyChildren != nil {
+		t.Errorf("LegacyChildren must be cleared from outcome; got %v", got.LegacyChildren)
+	}
+	if got.Strategy != "" {
+		t.Errorf("Strategy must be cleared from outcome; got %q", got.Strategy)
+	}
+	if got.Provider != "" {
+		t.Errorf("Provider must be cleared from outcome; got %q", got.Provider)
+	}
+}
+
+func TestBuildLegacyOutcome_PreservesPath(t *testing.T) {
+	t.Parallel()
+
+	planned := &Metadata{
+		Phase:      MetadataPhasePlanned,
+		Path:       "legacy",
+		PathReason: "unsupported-provider",
+		Client:     "MyClient",
+		Provider:   "aws-bedrock",
+	}
+	got := BuildLegacyOutcome(planned, 100, "", "", nil)
+
+	if got.Path != "legacy" {
+		t.Errorf("Path must be preserved; got %q", got.Path)
+	}
+	if got.PathReason != "unsupported-provider" {
+		t.Errorf("PathReason must be preserved; got %q", got.PathReason)
+	}
+}
+
+func TestBuildLegacyOutcome_ZeroDurationStillSetsField(t *testing.T) {
+	t.Parallel()
+
+	planned := &Metadata{Phase: MetadataPhasePlanned, Path: "legacy", Client: "X", Provider: "openai"}
+	got := BuildLegacyOutcome(planned, 0, "", "", nil)
+
+	if got.UpstreamDurMs == nil {
+		t.Fatal("UpstreamDurMs must be set even on zero duration")
+	}
+	if *got.UpstreamDurMs != 0 {
+		t.Errorf("UpstreamDurMs: got %d, want 0", *got.UpstreamDurMs)
+	}
+}
+
+func TestBuildLegacyOutcome_BamlCallCountZeroPropagates(t *testing.T) {
+	t.Parallel()
+
+	planned := &Metadata{Phase: MetadataPhasePlanned, Path: "legacy", Client: "X", Provider: "openai"}
+	zero := 0
+	got := BuildLegacyOutcome(planned, 100, "", "", &zero)
+
+	if got.BamlCallCount == nil {
+		t.Fatal("BamlCallCount=&0 must propagate (distinct from nil)")
+	}
+	if *got.BamlCallCount != 0 {
+		t.Errorf("BamlCallCount: got %d, want 0", *got.BamlCallCount)
+	}
+}

--- a/bamlutils/metadata_test.go
+++ b/bamlutils/metadata_test.go
@@ -62,6 +62,18 @@ func TestMetadata_JSONRoundtrip(t *testing.T) {
 			},
 		},
 		{
+			name: "legacy outcome with baml call count",
+			md: Metadata{
+				Phase:          MetadataPhaseOutcome,
+				Path:           "legacy",
+				WinnerClient:   "MyClient",
+				WinnerProvider: "openai",
+				WinnerPath:     "legacy",
+				UpstreamDurMs:  &dur,
+				BamlCallCount:  &five,
+			},
+		},
+		{
 			name: "legacy planned with reason",
 			md: Metadata{
 				Phase:      MetadataPhasePlanned,
@@ -129,6 +141,9 @@ func TestMetadata_JSONRoundtrip(t *testing.T) {
 			}
 			if !equalPtrInt64(got.UpstreamDurMs, tc.md.UpstreamDurMs) {
 				t.Errorf("UpstreamDurMs: got %v, want %v", got.UpstreamDurMs, tc.md.UpstreamDurMs)
+			}
+			if !equalPtrInt(got.BamlCallCount, tc.md.BamlCallCount) {
+				t.Errorf("BamlCallCount: got %v, want %v", got.BamlCallCount, tc.md.BamlCallCount)
 			}
 		})
 	}

--- a/bamlutils/metadata_test.go
+++ b/bamlutils/metadata_test.go
@@ -120,6 +120,9 @@ func TestMetadata_JSONRoundtrip(t *testing.T) {
 			if got.WinnerProvider != tc.md.WinnerProvider {
 				t.Errorf("WinnerProvider: got %q, want %q", got.WinnerProvider, tc.md.WinnerProvider)
 			}
+			if got.WinnerPath != tc.md.WinnerPath {
+				t.Errorf("WinnerPath: got %q, want %q", got.WinnerPath, tc.md.WinnerPath)
+			}
 			// Pointer fields: nil-ness and value both matter.
 			equalPtrInt := func(a, b *int) bool {
 				if a == nil || b == nil {

--- a/cmd/serve/headers.go
+++ b/cmd/serve/headers.go
@@ -22,6 +22,7 @@ const (
 	HeaderBAMLRetryMax         = "X-BAML-Retry-Max"
 	HeaderBAMLRetryCount       = "X-BAML-Retry-Count"
 	HeaderBAMLUpstreamDuration = "X-BAML-Upstream-Duration-Ms"
+	HeaderBAMLBamlCallCount    = "X-BAML-Baml-Call-Count"
 )
 
 // headerSetter abstracts over net/http.Header.Set and fiber.Ctx.Set so the
@@ -77,6 +78,9 @@ func setBAMLHeaders(setter headerSetter, planned, outcome *bamlutils.Metadata) {
 		}
 		if outcome.UpstreamDurMs != nil {
 			setter(HeaderBAMLUpstreamDuration, strconv.FormatInt(*outcome.UpstreamDurMs, 10))
+		}
+		if outcome.BamlCallCount != nil {
+			setter(HeaderBAMLBamlCallCount, strconv.Itoa(*outcome.BamlCallCount))
 		}
 	}
 }

--- a/cmd/serve/headers_test.go
+++ b/cmd/serve/headers_test.go
@@ -17,6 +17,7 @@ func TestSetBAMLHeaders_OmitsWhenNil(t *testing.T) {
 		HeaderBAMLPath, HeaderBAMLPathReason, HeaderBAMLClient,
 		HeaderBAMLWinnerClient, HeaderBAMLWinnerProvider,
 		HeaderBAMLRetryMax, HeaderBAMLRetryCount, HeaderBAMLUpstreamDuration,
+		HeaderBAMLBamlCallCount,
 	} {
 		if got := h.Get(name); got != "" {
 			t.Errorf("expected %s to be absent when both metadata args are nil; got %q", name, got)
@@ -46,11 +47,49 @@ func TestSetBAMLHeaders_PlannedOnly(t *testing.T) {
 	if got := h.Get(HeaderBAMLRetryMax); got != "3" {
 		t.Errorf("RetryMax: got %q, want %q", got, "3")
 	}
-	for _, outcomeName := range []string{HeaderBAMLWinnerClient, HeaderBAMLWinnerProvider, HeaderBAMLRetryCount, HeaderBAMLUpstreamDuration} {
+	for _, outcomeName := range []string{HeaderBAMLWinnerClient, HeaderBAMLWinnerProvider, HeaderBAMLRetryCount, HeaderBAMLUpstreamDuration, HeaderBAMLBamlCallCount} {
 		if got := h.Get(outcomeName); got != "" {
 			t.Errorf("%s should be absent when outcome is nil; got %q", outcomeName, got)
 		}
 	}
+}
+
+func TestSetBAMLHeaders_BamlCallCount(t *testing.T) {
+	t.Parallel()
+
+	planned := &bamlutils.Metadata{Phase: bamlutils.MetadataPhasePlanned, Path: "legacy", Client: "MyClient"}
+
+	t.Run("nil omitted", func(t *testing.T) {
+		t.Parallel()
+		h := http.Header{}
+		outcome := &bamlutils.Metadata{Phase: bamlutils.MetadataPhaseOutcome, WinnerPath: "legacy"}
+		setBAMLHeaders(netHTTPHeaderSetter(h), planned, outcome)
+		if got := h.Get(HeaderBAMLBamlCallCount); got != "" {
+			t.Errorf("nil BamlCallCount should be omitted; got %q", got)
+		}
+	})
+
+	t.Run("zero present", func(t *testing.T) {
+		t.Parallel()
+		h := http.Header{}
+		zero := 0
+		outcome := &bamlutils.Metadata{Phase: bamlutils.MetadataPhaseOutcome, WinnerPath: "legacy", BamlCallCount: &zero}
+		setBAMLHeaders(netHTTPHeaderSetter(h), planned, outcome)
+		if got := h.Get(HeaderBAMLBamlCallCount); got != "0" {
+			t.Errorf("BamlCallCount=&0 should emit \"0\" (distinct from absent); got %q", got)
+		}
+	})
+
+	t.Run("nonzero present", func(t *testing.T) {
+		t.Parallel()
+		h := http.Header{}
+		three := 3
+		outcome := &bamlutils.Metadata{Phase: bamlutils.MetadataPhaseOutcome, WinnerPath: "legacy", BamlCallCount: &three}
+		setBAMLHeaders(netHTTPHeaderSetter(h), planned, outcome)
+		if got := h.Get(HeaderBAMLBamlCallCount); got != "3" {
+			t.Errorf("BamlCallCount: got %q, want 3", got)
+		}
+	})
 }
 
 func TestSetBAMLHeaders_OutcomeWinnerSameAsClient(t *testing.T) {

--- a/integration/call_test.go
+++ b/integration/call_test.go
@@ -41,10 +41,12 @@ func TestCallEndpoint(t *testing.T) {
 				t.Errorf("Expected 'Hello, World!', got '%s'", result)
 			}
 
-			// Routing metadata headers. Path/Client are always set; outcome
-			// headers (Winner*, Retry-Count, Upstream-Duration) only appear
-			// on the BuildRequest leg because the legacy path does not yet
-			// synthesize an outcome event (absence = unknown, per plan §4f).
+			// Routing metadata headers. Path/Client are always set on both
+			// legs. Both legs now synthesize an outcome event with
+			// UpstreamDuration; legacy additionally exposes BamlCallCount
+			// (BAML-internal call count derived from FunctionLog.Calls).
+			// RetryCount is buildrequest-only — it counts outer orchestrator
+			// retries, which the legacy path does not perform.
 			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLPath)
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestClient")
 			if ActuallyBuildRequest() {
@@ -55,15 +57,19 @@ func TestCallEndpoint(t *testing.T) {
 				// Single-provider route: no fallback chain, so there is no
 				// "winner client" distinct from the planned Client.
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerClient)
+				// BamlCallCount is legacy-only.
+				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "legacy")
-				// Legacy v1 emits no outcome event — all outcome-derived
-				// headers must be absent so callers can distinguish
-				// "unknown" from a concrete value.
+				// Single-provider legacy route: WinnerProvider falls back to
+				// the planned Provider via BuildLegacyOutcome's ladder;
+				// WinnerClient is suppressed because it equals planned.Client.
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerClient)
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerProvider)
+				// RetryCount is outer-orchestrator only; absent on legacy.
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
+				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
+				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			}
 		})
 
@@ -391,12 +397,14 @@ func TestCallWithRawEndpoint(t *testing.T) {
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLRetryCount, "0")
 				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerClient)
+				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "legacy")
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerClient)
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerProvider)
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
+				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
+				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			}
 		})
 

--- a/integration/call_test.go
+++ b/integration/call_test.go
@@ -69,7 +69,10 @@ func TestCallEndpoint(t *testing.T) {
 				// RetryCount is outer-orchestrator only; absent on legacy.
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
 				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
-				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
+				// Single happy-path call: len(funcLog.Calls()) == 1, so
+				// BamlCallCount = max(1-1, 0) = 0. A nonzero value here would
+				// mean BAML retried something internally.
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBamlCallCount, "0")
 			}
 		})
 

--- a/integration/call_test.go
+++ b/integration/call_test.go
@@ -407,7 +407,8 @@ func TestCallWithRawEndpoint(t *testing.T) {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerClient)
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
 				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
-				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
+				// Single happy-path call: BamlCallCount = max(1-1, 0) = 0.
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBamlCallCount, "0")
 			}
 		})
 

--- a/integration/fallback_test.go
+++ b/integration/fallback_test.go
@@ -184,7 +184,10 @@ func TestFallbackCall(t *testing.T) {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
-				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
+				// Two children walked (primary failed, secondary succeeded);
+				// hit-count assertion above pins this at 2 calls total, so
+				// BamlCallCount = max(2-1, 0) = 1.
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBamlCallCount, "1")
 			}
 		})
 
@@ -258,7 +261,10 @@ func TestFallbackCall(t *testing.T) {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
-				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
+				// Three children walked (primary + secondary failed, tertiary
+				// succeeded); hit-count assertion above pins this at 3 calls
+				// total, so BamlCallCount = max(3-1, 0) = 2.
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBamlCallCount, "2")
 			}
 		})
 
@@ -415,7 +421,10 @@ func TestFallbackCallWithRaw(t *testing.T) {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
-				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
+				// Two children walked (primary failed, secondary succeeded);
+				// hit-count assertion above pins this at 2 calls total, so
+				// BamlCallCount = max(2-1, 0) = 1.
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBamlCallCount, "1")
 			}
 		})
 	})
@@ -577,8 +586,12 @@ func TestFallbackStream(t *testing.T) {
 				if tracker.outcome.WinnerProvider != "openai" {
 					t.Errorf("legacy outcome.WinnerProvider: got %q, want openai", tracker.outcome.WinnerProvider)
 				}
+				// Two children walked (primary failed, secondary succeeded);
+				// BamlCallCount = max(2-1, 0) = 1.
 				if tracker.outcome.BamlCallCount == nil {
-					t.Errorf("legacy outcome.BamlCallCount: expected non-nil (FunctionLog.Calls observed via onTick)")
+					t.Errorf("legacy outcome.BamlCallCount: expected non-nil")
+				} else if *tracker.outcome.BamlCallCount != 1 {
+					t.Errorf("legacy outcome.BamlCallCount: got %d, want 1", *tracker.outcome.BamlCallCount)
 				}
 			}
 		}

--- a/integration/fallback_test.go
+++ b/integration/fallback_test.go
@@ -170,19 +170,21 @@ func TestFallbackCall(t *testing.T) {
 
 			// Routing metadata: Client is the strategy name (always set).
 			// Retry-Max comes from the retry policy wired on the fallback
-			// client (FallbackRetry: max_retries 3). Winner-Client /
-			// Winner-Provider only appear on BuildRequest, which synthesizes
-			// outcome metadata from the winning child.
+			// client (FallbackRetry: max_retries 3). Both legs now report a
+			// Winner-Client distinct from the strategy: BuildRequest tracks
+			// it via its own chain walk, legacy via funcLog.SelectedCall.
+			// Legacy additionally reports BamlCallCount; RetryCount stays
+			// buildrequest-only (legacy has no outer orchestrator).
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestFallbackPair")
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLRetryMax, "3")
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackSecondary")
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
 			if ActuallyBuildRequest() {
-				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackSecondary")
-				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerClient)
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerProvider)
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
+				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			}
 		})
 
@@ -244,17 +246,19 @@ func TestFallbackCall(t *testing.T) {
 			assertHitCounts(t, map[string]int{"fallback-primary": 1, "fallback-secondary": 1, "fallback-tertiary": 1})
 
 			// Routing metadata: three-client chain reports the strategy
-			// client name and on BuildRequest the tertiary winner.
+			// client name and the tertiary winner on both legs (legacy
+			// derives it from funcLog.SelectedCall, BuildRequest from its
+			// own chain walk).
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestFallbackChain")
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLRetryMax, "3")
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackTertiary")
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
 			if ActuallyBuildRequest() {
-				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackTertiary")
-				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerClient)
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerProvider)
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
+				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			}
 		})
 
@@ -404,14 +408,14 @@ func TestFallbackCallWithRaw(t *testing.T) {
 			// with /call, so the same fallback assertions apply.
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestFallbackPair")
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLRetryMax, "3")
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackSecondary")
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
 			if ActuallyBuildRequest() {
-				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackSecondary")
-				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerClient)
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerProvider)
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
-				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
+				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			}
 		})
 	})
@@ -538,8 +542,9 @@ func TestFallbackStream(t *testing.T) {
 		assertHitCounts(t, map[string]int{"fallback-primary": 1, "fallback-secondary": 1})
 
 		// Streaming routing metadata events. Planned describes the chain,
-		// outcome carries the winner. Only BuildRequest synthesizes outcome
-		// today (§4f); the legacy path may emit planned but no outcome.
+		// outcome carries the winner. Both legs synthesize outcome since
+		// the legacy-outcome change; legacy derives the winner from
+		// funcLog.SelectedCall and additionally exposes BamlCallCount.
 		if tracker.planned == nil {
 			t.Fatalf("expected planned metadata event")
 		}
@@ -561,6 +566,19 @@ func TestFallbackStream(t *testing.T) {
 				}
 				if tracker.outcome.WinnerProvider != "openai" {
 					t.Errorf("outcome.WinnerProvider: got %q, want openai", tracker.outcome.WinnerProvider)
+				}
+			}
+		} else {
+			tracker.assertLegacyInvariants()
+			if tracker.outcome != nil {
+				if tracker.outcome.WinnerClient != "FallbackSecondary" {
+					t.Errorf("legacy outcome.WinnerClient: got %q, want FallbackSecondary", tracker.outcome.WinnerClient)
+				}
+				if tracker.outcome.WinnerProvider != "openai" {
+					t.Errorf("legacy outcome.WinnerProvider: got %q, want openai", tracker.outcome.WinnerProvider)
+				}
+				if tracker.outcome.BamlCallCount == nil {
+					t.Errorf("legacy outcome.BamlCallCount: expected non-nil (FunctionLog.Calls observed via onTick)")
 				}
 			}
 		}

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -102,6 +102,11 @@ func TestStreamEndpoint(t *testing.T) {
 				}())
 			}
 			tracker.assertBuildRequestInvariants()
+		} else {
+			// Legacy path also synthesizes outcome metadata since the
+			// legacy-outcome change. The first-semantic-event check stays
+			// buildrequest-only because legacy may emit a heartbeat first.
+			tracker.assertLegacyInvariants()
 		}
 	})
 
@@ -935,6 +940,11 @@ func TestStreamNDJSONEndpoint(t *testing.T) {
 				}())
 			}
 			tracker.assertBuildRequestInvariants()
+		} else {
+			// Legacy path also synthesizes outcome metadata since the
+			// legacy-outcome change. The first-semantic-event check stays
+			// buildrequest-only because legacy may emit a heartbeat first.
+			tracker.assertLegacyInvariants()
 		}
 	})
 
@@ -1274,6 +1284,11 @@ func TestStreamWithRawNDJSONEndpoint(t *testing.T) {
 				}())
 			}
 			tracker.assertBuildRequestInvariants()
+		} else {
+			// Legacy path also synthesizes outcome metadata since the
+			// legacy-outcome change. The first-semantic-event check stays
+			// buildrequest-only because legacy may emit a heartbeat first.
+			tracker.assertLegacyInvariants()
 		}
 	})
 
@@ -1679,6 +1694,11 @@ func TestStreamWithRawEndpoint(t *testing.T) {
 				}())
 			}
 			tracker.assertBuildRequestInvariants()
+		} else {
+			// Legacy path also synthesizes outcome metadata since the
+			// legacy-outcome change. The first-semantic-event check stays
+			// buildrequest-only because legacy may emit a heartbeat first.
+			tracker.assertLegacyInvariants()
 		}
 	})
 }
@@ -2295,5 +2315,41 @@ func (m *metadataTracker) assertBuildRequestInvariants() {
 	}
 	if m.outcome != nil && m.outcome.WinnerProvider == "" {
 		m.t.Errorf("outcome.WinnerProvider: expected non-empty on BuildRequest path")
+	}
+}
+
+// assertLegacyInvariants checks the legacy-path emission contract: planned
+// present, outcome present (as of the legacy-outcome change), planned before
+// outcome, outcome before final. Outcome carries WinnerPath="legacy" and
+// UpstreamDurMs; RetryCount stays nil (legacy has no outer retry
+// orchestrator). BamlCallCount derives from FunctionLog.Calls and is
+// expected to be present whenever any onTick fired (the common case).
+func (m *metadataTracker) assertLegacyInvariants() {
+	m.t.Helper()
+	if m.planned == nil {
+		m.t.Errorf("expected planned metadata event on legacy path")
+	}
+	if m.outcome == nil {
+		m.t.Errorf("expected outcome metadata event on legacy path")
+	}
+	if m.planned != nil && m.outcome != nil && m.plannedIdx >= m.outcomeIdx {
+		m.t.Errorf("planned metadata (idx %d) must precede outcome (idx %d)", m.plannedIdx, m.outcomeIdx)
+	}
+	if m.outcome != nil && m.finalSeen && m.outcomeIdx >= m.finalIdx {
+		m.t.Errorf("outcome metadata (idx %d) must precede final (idx %d)", m.outcomeIdx, m.finalIdx)
+	}
+	if m.planned != nil && m.planned.Path != "legacy" {
+		m.t.Errorf("planned.Path: got %q, want %q", m.planned.Path, "legacy")
+	}
+	if m.outcome != nil {
+		if m.outcome.WinnerPath != "legacy" {
+			m.t.Errorf("outcome.WinnerPath: got %q, want %q", m.outcome.WinnerPath, "legacy")
+		}
+		if m.outcome.UpstreamDurMs == nil {
+			m.t.Errorf("outcome.UpstreamDurMs: expected non-nil on legacy outcome")
+		}
+		if m.outcome.RetryCount != nil {
+			m.t.Errorf("outcome.RetryCount: must be nil on legacy (got %v)", *m.outcome.RetryCount)
+		}
 	}
 }

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -87,11 +87,10 @@ func TestStreamEndpoint(t *testing.T) {
 			t.Errorf("Expected John Doe (30), got %s (%d)", person.Name, person.Age)
 		}
 
-		// Routing metadata: on BuildRequest the first semantic event is
-		// planned metadata, and outcome metadata arrives before final.
-		// Legacy path may emit planned (but no outcome) depending on the
-		// version; assert only on BuildRequest to keep the legacy matrix
-		// stable.
+		// Routing metadata: both legs emit planned as the first semantic
+		// event and outcome before final. Per-path invariants (winner
+		// derivation, RetryCount vs BamlCallCount, etc.) are checked by
+		// the appropriate tracker assertion below.
 		if ActuallyBuildRequest() {
 			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
 				t.Errorf("first semantic event should be metadata; got event type %q", func() string {

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -91,29 +91,10 @@ func TestStreamEndpoint(t *testing.T) {
 		// event and outcome before final. Per-path invariants (winner
 		// derivation, RetryCount vs BamlCallCount, etc.) are checked by
 		// the appropriate tracker assertion below.
+		assertFirstSemanticEventIsMetadata(t, firstSemanticEvent)
 		if ActuallyBuildRequest() {
-			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
-				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
-					if firstSemanticEvent == nil {
-						return "<none>"
-					}
-					return firstSemanticEvent.Event
-				}())
-			}
 			tracker.assertBuildRequestInvariants()
 		} else {
-			// Legacy path now synthesizes outcome metadata too. Heartbeats
-			// are filtered by both NDJSON and SSE parsers, so the first
-			// semantic event the test sees is the planned-metadata event
-			// emitted from onTick — same expectation as BuildRequest.
-			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
-				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
-					if firstSemanticEvent == nil {
-						return "<none>"
-					}
-					return firstSemanticEvent.Event
-				}())
-			}
 			tracker.assertLegacyInvariants()
 		}
 	})
@@ -938,29 +919,10 @@ func TestStreamNDJSONEndpoint(t *testing.T) {
 		}
 
 		// NDJSON metadata parity with the SSE path.
+		assertFirstSemanticEventIsMetadata(t, firstSemanticEvent)
 		if ActuallyBuildRequest() {
-			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
-				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
-					if firstSemanticEvent == nil {
-						return "<none>"
-					}
-					return firstSemanticEvent.Event
-				}())
-			}
 			tracker.assertBuildRequestInvariants()
 		} else {
-			// Legacy path now synthesizes outcome metadata too. Heartbeats
-			// are filtered by both NDJSON and SSE parsers, so the first
-			// semantic event the test sees is the planned-metadata event
-			// emitted from onTick — same expectation as BuildRequest.
-			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
-				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
-					if firstSemanticEvent == nil {
-						return "<none>"
-					}
-					return firstSemanticEvent.Event
-				}())
-			}
 			tracker.assertLegacyInvariants()
 		}
 	})
@@ -1291,29 +1253,10 @@ func TestStreamWithRawNDJSONEndpoint(t *testing.T) {
 		// BuildRequest must emit exactly one planned + one outcome event,
 		// with the correct ordering, and planned must arrive BEFORE any
 		// raw/data event so clients see routing info first.
+		assertFirstSemanticEventIsMetadata(t, firstSemanticEvent)
 		if ActuallyBuildRequest() {
-			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
-				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
-					if firstSemanticEvent == nil {
-						return "<none>"
-					}
-					return firstSemanticEvent.Event
-				}())
-			}
 			tracker.assertBuildRequestInvariants()
 		} else {
-			// Legacy path now synthesizes outcome metadata too. Heartbeats
-			// are filtered by both NDJSON and SSE parsers, so the first
-			// semantic event the test sees is the planned-metadata event
-			// emitted from onTick — same expectation as BuildRequest.
-			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
-				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
-					if firstSemanticEvent == nil {
-						return "<none>"
-					}
-					return firstSemanticEvent.Event
-				}())
-			}
 			tracker.assertLegacyInvariants()
 		}
 	})
@@ -1710,29 +1653,10 @@ func TestStreamWithRawEndpoint(t *testing.T) {
 		// BuildRequest must emit exactly one planned + one outcome event,
 		// with the correct ordering, and planned must arrive BEFORE any
 		// raw/data event so clients see routing info first.
+		assertFirstSemanticEventIsMetadata(t, firstSemanticEvent)
 		if ActuallyBuildRequest() {
-			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
-				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
-					if firstSemanticEvent == nil {
-						return "<none>"
-					}
-					return firstSemanticEvent.Event
-				}())
-			}
 			tracker.assertBuildRequestInvariants()
 		} else {
-			// Legacy path now synthesizes outcome metadata too. Heartbeats
-			// are filtered by both NDJSON and SSE parsers, so the first
-			// semantic event the test sees is the planned-metadata event
-			// emitted from onTick — same expectation as BuildRequest.
-			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
-				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
-					if firstSemanticEvent == nil {
-						return "<none>"
-					}
-					return firstSemanticEvent.Event
-				}())
-			}
 			tracker.assertLegacyInvariants()
 		}
 	})
@@ -2258,6 +2182,23 @@ func TestRequestCancellationNDJSON(t *testing.T) {
 			logLeakedStacks(t, finalResult)
 		}
 	})
+}
+
+// assertFirstSemanticEventIsMetadata fails the test if the first event a
+// stream consumer observed after heartbeat filtering was not the planned
+// metadata event. Both paths emit planned as the first post-heartbeat
+// event (BuildRequest from the orchestrator's sendHeartbeat, legacy from
+// the onTick first-tick CAS), so the check is path-independent.
+func assertFirstSemanticEventIsMetadata(t *testing.T, ev *testutil.StreamEvent) {
+	t.Helper()
+	if ev != nil && ev.IsMetadata() {
+		return
+	}
+	got := "<none>"
+	if ev != nil {
+		got = ev.Event
+	}
+	t.Errorf("first semantic event should be metadata; got event type %q", got)
 }
 
 // metadataTracker records routing-metadata events during a stream drain

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -103,9 +103,18 @@ func TestStreamEndpoint(t *testing.T) {
 			}
 			tracker.assertBuildRequestInvariants()
 		} else {
-			// Legacy path also synthesizes outcome metadata since the
-			// legacy-outcome change. The first-semantic-event check stays
-			// buildrequest-only because legacy may emit a heartbeat first.
+			// Legacy path now synthesizes outcome metadata too. Heartbeats
+			// are filtered by both NDJSON and SSE parsers, so the first
+			// semantic event the test sees is the planned-metadata event
+			// emitted from onTick — same expectation as BuildRequest.
+			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
+				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
+					if firstSemanticEvent == nil {
+						return "<none>"
+					}
+					return firstSemanticEvent.Event
+				}())
+			}
 			tracker.assertLegacyInvariants()
 		}
 	})
@@ -941,9 +950,18 @@ func TestStreamNDJSONEndpoint(t *testing.T) {
 			}
 			tracker.assertBuildRequestInvariants()
 		} else {
-			// Legacy path also synthesizes outcome metadata since the
-			// legacy-outcome change. The first-semantic-event check stays
-			// buildrequest-only because legacy may emit a heartbeat first.
+			// Legacy path now synthesizes outcome metadata too. Heartbeats
+			// are filtered by both NDJSON and SSE parsers, so the first
+			// semantic event the test sees is the planned-metadata event
+			// emitted from onTick — same expectation as BuildRequest.
+			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
+				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
+					if firstSemanticEvent == nil {
+						return "<none>"
+					}
+					return firstSemanticEvent.Event
+				}())
+			}
 			tracker.assertLegacyInvariants()
 		}
 	})
@@ -1285,9 +1303,18 @@ func TestStreamWithRawNDJSONEndpoint(t *testing.T) {
 			}
 			tracker.assertBuildRequestInvariants()
 		} else {
-			// Legacy path also synthesizes outcome metadata since the
-			// legacy-outcome change. The first-semantic-event check stays
-			// buildrequest-only because legacy may emit a heartbeat first.
+			// Legacy path now synthesizes outcome metadata too. Heartbeats
+			// are filtered by both NDJSON and SSE parsers, so the first
+			// semantic event the test sees is the planned-metadata event
+			// emitted from onTick — same expectation as BuildRequest.
+			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
+				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
+					if firstSemanticEvent == nil {
+						return "<none>"
+					}
+					return firstSemanticEvent.Event
+				}())
+			}
 			tracker.assertLegacyInvariants()
 		}
 	})
@@ -1695,9 +1722,18 @@ func TestStreamWithRawEndpoint(t *testing.T) {
 			}
 			tracker.assertBuildRequestInvariants()
 		} else {
-			// Legacy path also synthesizes outcome metadata since the
-			// legacy-outcome change. The first-semantic-event check stays
-			// buildrequest-only because legacy may emit a heartbeat first.
+			// Legacy path now synthesizes outcome metadata too. Heartbeats
+			// are filtered by both NDJSON and SSE parsers, so the first
+			// semantic event the test sees is the planned-metadata event
+			// emitted from onTick — same expectation as BuildRequest.
+			if firstSemanticEvent == nil || !firstSemanticEvent.IsMetadata() {
+				t.Errorf("first semantic event should be metadata; got event type %q", func() string {
+					if firstSemanticEvent == nil {
+						return "<none>"
+					}
+					return firstSemanticEvent.Event
+				}())
+			}
 			tracker.assertLegacyInvariants()
 		}
 	})
@@ -2350,6 +2386,22 @@ func (m *metadataTracker) assertLegacyInvariants() {
 		}
 		if m.outcome.RetryCount != nil {
 			m.t.Errorf("outcome.RetryCount: must be nil on legacy (got %v)", *m.outcome.RetryCount)
+		}
+		// WinnerProvider is populated either from funcLog.SelectedCall
+		// (strategy routes) or from the planned Provider fallback
+		// (single-provider routes); both apply here. Strategy routes
+		// without a successful child would fall outside the helper's
+		// happy-path contract.
+		if m.outcome.WinnerProvider == "" {
+			m.t.Errorf("outcome.WinnerProvider: expected non-empty on legacy outcome")
+		}
+		// BamlCallCount is derived from funcLog.Calls(), which the
+		// orchestrator captures on every onTick. Any non-trivial stream
+		// fires onTick at least once, so this is non-nil in the common
+		// case. The graceful-degradation path (no onTick before final)
+		// would leave it nil, but no production stream should hit that.
+		if m.outcome.BamlCallCount == nil {
+			m.t.Errorf("outcome.BamlCallCount: expected non-nil on legacy outcome (onTick should have fired)")
 		}
 	}
 }

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -334,10 +334,15 @@ type StreamMetadata struct {
 	Phase          string   `json:"phase"`
 	Path           string   `json:"path,omitempty"`
 	Client         string   `json:"client,omitempty"`
+	Strategy       string   `json:"strategy,omitempty"`
 	Chain          []string `json:"chain,omitempty"`
 	RetryMax       *int     `json:"retry_max,omitempty"`
+	RetryCount     *int     `json:"retry_count,omitempty"`
 	WinnerClient   string   `json:"winner_client,omitempty"`
 	WinnerProvider string   `json:"winner_provider,omitempty"`
+	WinnerPath     string   `json:"winner_path,omitempty"`
+	UpstreamDurMs  *int64   `json:"upstream_duration_ms,omitempty"`
+	BamlCallCount  *int     `json:"baml_call_count,omitempty"`
 }
 
 // ParseMetadata decodes a metadata event's data payload.
@@ -902,6 +907,7 @@ const (
 	HeaderBAMLRetryMax         = "X-BAML-Retry-Max"
 	HeaderBAMLRetryCount       = "X-BAML-Retry-Count"
 	HeaderBAMLUpstreamDuration = "X-BAML-Upstream-Duration-Ms"
+	HeaderBAMLBamlCallCount    = "X-BAML-Baml-Call-Count"
 )
 
 // AssertHeaderEquals fails the test if the given header is missing or does

--- a/workerplugin/plugin.go
+++ b/workerplugin/plugin.go
@@ -54,10 +54,12 @@ type CallResult struct {
 	Data []byte // JSON-encoded result
 	Raw  string // Raw LLM response
 	// Planned and Outcome carry routing/retry metadata for the request.
-	// Either may be nil: Planned is absent when no metadata plan was wired
-	// (older callers, tests); Outcome is absent on legacy paths that don't
-	// synthesize an outcome event. Both are JSON-encoded bamlutils.Metadata
-	// payloads forwarded verbatim from the worker.
+	// Both BuildRequest and legacy paths now synthesize planned + outcome
+	// events, so the bytes are typically populated for any successful call;
+	// either may still be nil if no metadata plan was wired (e.g. tests
+	// invoking the worker directly without a planner) or if the worker
+	// errored before emitting the relevant event. Both are JSON-encoded
+	// bamlutils.Metadata payloads forwarded verbatim from the worker.
 	Planned []byte
 	Outcome []byte
 }


### PR DESCRIPTION
## Summary

- Wire outcome metadata emission into both legacy orchestration helpers (`runFullOrchestration` + `runNoRawOrchestration`) so all four endpoints carry equivalent observability on either routing path
- Add `BamlCallCount *int` to `bamlutils.Metadata` (legacy-only, derived from `max(len(FunctionLog.Calls())-1, 0)`) and a matching `X-BAML-Baml-Call-Count` header
- Introduce a pure `bamlutils.BuildLegacyOutcome` helper that composes the outcome from caller-extracted winner data, keeping `bamlutils` SDK-free and unit-testable

## Why

PR #185 (per-request routing metadata) shipped outcome metadata for the BuildRequest path but deliberately omitted it on the legacy path. That asymmetry would force operators to special-case dashboards by mode — `/call` and `/stream` (the most-used endpoints) would lose the `Winner*` / `UpstreamDuration` headers anytime BuildRequest declined the request (older BAML, unsupported provider, feature flag off). This PR closes that gap.

## Design notes

- `WinnerClient` / `WinnerProvider` use a fallback ladder: `funcLog.SelectedCall()` if available; planned `Client`/`Provider` for single-provider routes; absent for strategy routes that lack `SelectedCall` data. This keeps the field semantics path-independent — it always means "the actual client used," never the planned strategy name.
- `RetryCount` stays nil on legacy. The field's documented meaning is "outer orchestrator retries"; legacy doesn't run an outer orchestrator (BAML drives retries internally), so emitting `0` would falsely imply "no retries" instead of "not applicable."
- BAML-internal retries + fallback walking collapse into the new `BamlCallCount`. Naming is honest: it counts extra LLM calls beyond the first, regardless of why.
- `runNoRawOrchestration` adds a `lastFuncLog atomic.Value` (stored on every tick) and a `beforeFinal func()` callback the body invokes immediately before sending the final result. The orchestrator owns outcome construction; body just calls the hook.
- `runFullOrchestration` reuses its existing `lastFuncLog` and inserts the outcome emission between the final reconciliation pass and the existing `emitFinal` send.
- Both helpers' `newPlannedMetadata` closure parameter is generalized to a `newMetadataResult(*Metadata) StreamResult` constructor so the orchestrator can construct both planned and outcome events itself.

## Test plan

- [x] Unit tests for `BuildLegacyOutcome` covering the fallback ladder, nil-planned, strategy-without-winner, planned-only field clearing
- [x] Round-trip test for `BamlCallCount` in `bamlutils/metadata_test.go`
- [x] Header emission tests in `cmd/serve/headers_test.go` (nil/zero/nonzero)
- [x] Codegen syntax-check test (`generateStreamHelpers` output parses as valid Go) + symbol presence guard
- [x] Integration `call_test.go` legacy assertions flipped from "outcome absent" to expect `WinnerProvider` + `UpstreamDuration` + `BamlCallCount`
- [x] Integration `fallback_test.go` legacy strategy routes assert `WinnerClient` / `WinnerProvider` from `SelectedCall`
- [x] New `metadataTracker.assertLegacyInvariants` mirrors `assertBuildRequestInvariants` and is wired into all four streaming-mode tests
- [x] `go build ./...` + `go vet ./...` + full unit suite green
- [ ] Integration suite green in CI (Docker not available locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added X-BAML-Baml-Call-Count response header and exported BamlCallCount metadata field.
  * Legacy execution now synthesizes outcome metadata (winner attribution and upstream duration) alongside planned metadata.

* **Bug Fixes**
  * Streaming metadata ordering and emission guarantees: planned is emitted first, outcome emitted before terminal frame, and outcome reflects final winner/BAML call counts.

* **Tests**
  * Expanded unit and integration tests covering streaming helpers, legacy outcome semantics, headers, and JSON roundtrips.

* **Documentation**
  * Clarified metadata field meanings and retry/BamlCallCount semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->