### PR TITLE
chore: drop per-method BuildRequest gate in favor of version-level check

### DIFF
--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -1612,10 +1612,10 @@ func Generate(selfPkg string) {
 		// ====== BUILD REQUEST PATH: methodName_buildRequest ======
 		// This path uses BAML's BuildRequest/StreamRequest API to get the raw HTTP
 		// request, executes it ourselves, and parses SSE events directly.
-		// Only emitted when introspected.StreamRequestMethods contains this method
-		// (BAML >= 0.219.0). For older BAML versions the symbol baml_client.StreamRequest
-		// doesn't exist, so we must not generate code that references it.
-		_, hasBuildRequest := introspected.StreamRequestMethods[methodName]
+		// Only emitted when BAML >= 0.219.0 exposes the StreamRequest singleton —
+		// on older versions the symbol baml_client.StreamRequest doesn't exist,
+		// so we must not generate code that references it.
+		hasBuildRequest := introspected.StreamRequest != nil
 		buildRequestMethodName := strcase.LowerCamelCase(methodName + "_buildRequest")
 
 		if hasBuildRequest {
@@ -1913,8 +1913,8 @@ func Generate(selfPkg string) {
 		// Non-streaming counterpart to _buildRequest. Uses BAML's Request API
 		// (not StreamRequest) to build an HTTP request with "stream": false,
 		// executes it, extracts the LLM text from the JSON response, and parses.
-		// Only emitted when introspected.RequestMethods contains this method.
-		_, hasCallBuildRequest := introspected.RequestMethods[methodName]
+		// Only emitted when BAML >= 0.219.0 exposes the Request singleton.
+		hasCallBuildRequest := introspected.Request != nil
 		buildCallRequestMethodName := strcase.LowerCamelCase(methodName + "_buildCallRequest")
 
 		if hasCallBuildRequest {

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -1039,11 +1039,6 @@ func generateBuildRequestVars(out *jen.File, requestFile, streamRequestFile *par
 		out.Comment("Request is the BAML Request singleton for building non-streaming HTTP requests")
 		out.Var().Id("Request").Op("=").Qual(streamPkg, "Request")
 
-		out.Comment("RequestMethods maps method names to argument names on the Request singleton")
-		out.Var().Id("RequestMethods").Op("=").Map(jen.String()).Index().String().Values(
-			methodsDict(requestMethods)...,
-		)
-
 		out.Comment("RequestFuncs maps Request method names to their function values (for reflection)")
 		entries := make([]jen.Code, 0, len(requestMethods))
 		for _, m := range requestMethods {
@@ -1054,7 +1049,6 @@ func generateBuildRequestVars(out *jen.File, requestFile, streamRequestFile *par
 	} else {
 		out.Comment("Request is nil when BAML version < 0.219.0 (no BuildRequest API)")
 		out.Var().Id("Request").Any()
-		out.Var().Id("RequestMethods").Op("=").Map(jen.String()).Index().String().Values()
 		out.Var().Id("RequestFuncs").Op("=").Map(jen.String()).Any().Values()
 	}
 
@@ -1063,11 +1057,6 @@ func generateBuildRequestVars(out *jen.File, requestFile, streamRequestFile *par
 
 		out.Comment("StreamRequest is the BAML StreamRequest singleton for building streaming HTTP requests")
 		out.Var().Id("StreamRequest").Op("=").Qual(streamPkg, "StreamRequest")
-
-		out.Comment("StreamRequestMethods maps method names to argument names on the StreamRequest singleton")
-		out.Var().Id("StreamRequestMethods").Op("=").Map(jen.String()).Index().String().Values(
-			methodsDict(streamRequestMethods)...,
-		)
 
 		out.Comment("StreamRequestFuncs maps StreamRequest method names to their function values (for reflection)")
 		entries := make([]jen.Code, 0, len(streamRequestMethods))
@@ -1079,7 +1068,6 @@ func generateBuildRequestVars(out *jen.File, requestFile, streamRequestFile *par
 	} else {
 		out.Comment("StreamRequest is nil when BAML version < 0.219.0 (no BuildRequest API)")
 		out.Var().Id("StreamRequest").Any()
-		out.Var().Id("StreamRequestMethods").Op("=").Map(jen.String()).Index().String().Values()
 		out.Var().Id("StreamRequestFuncs").Op("=").Map(jen.String()).Any().Values()
 	}
 }

--- a/introspected/introspected.go
+++ b/introspected/introspected.go
@@ -39,12 +39,10 @@ var MediaParams = map[string]map[string]bamlutils.MediaKind{}
 
 // Request is nil when BAML version < 0.219.0 (no BuildRequest API)
 var Request any
-var RequestMethods = map[string][]string{}
 var RequestFuncs = map[string]any{}
 
 // StreamRequest is nil when BAML version < 0.219.0 (no BuildRequest API)
 var StreamRequest any
-var StreamRequestMethods = map[string][]string{}
 var StreamRequestFuncs = map[string]any{}
 
 // FunctionClient maps BAML function names to their default client name


### PR DESCRIPTION
## Summary

- The codegen router previously looked up each method name in `introspected.StreamRequestMethods` / `introspected.RequestMethods` to decide whether to emit the BuildRequest/StreamRequest path. Upstream BAML (since v0.219.0, `engine/generators/languages/go/src/lib.rs`) iterates `ir.functions` with no per-function filter and emits one `build_request` / `build_request_stream` method for every function — so the key sets of those maps are identical to `SyncMethods` on any BAML >= 0.219.0 and empty on older versions. The per-method check never fires individually; it's a glorified version gate.
- Replace the per-method lookup in `adapters/common/codegen/codegen.go` with `introspected.Request != nil` / `introspected.StreamRequest != nil`, which is the pattern already used elsewhere (e.g. `cmd/serve/main.go:203`) for the same version-level signal.
- Delete the now-unused `RequestMethods` / `StreamRequestMethods` maps from `introspected/introspected.go` and the corresponding emission in `cmd/introspect/main.go`. `RequestFuncs` / `StreamRequestFuncs` stay — they're populated from the same `extractBuildRequestMethods` walk but serve a different purpose.

Net diff: +6 / -20.

## Test plan

- [x] `go build ./...` across all modules (pre-existing failure in `adapters/adapter_v0_204_0` is unrelated — same failure on master).
- [x] `go test ./...` across all modules — passes, including `adapters/common/codegen` and `bamlutils/buildrequest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized code generation for runtime request-building features with improved compatibility detection.
  * Removed internal introspection variables no longer required by the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->