### PR TITLE
feat(buildrequest): bridge /call to StreamRequest when Request is unavailable

### DIFF
--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -2178,6 +2178,22 @@ func Generate(selfPkg string) {
 			)
 		}
 
+		// fallbackChainConsumeCond builds the condition guarding the call-side
+		// fallback block. When a StreamRequest bridge exists downstream, the
+		// call block only consumes chains with no call-legacy children; mixed
+		// chains must fall through so the bridge can re-resolve them with
+		// IsProviderSupported and drive call-legacy-but-stream-supported
+		// children through the streaming path rather than legacyCallChildFn.
+		// Without a bridge, the call block is the only BuildRequest landing
+		// spot and accepts any non-empty chain, matching pre-bridge behaviour.
+		fallbackChainConsumeCond := func(hasBridge bool) jen.Code {
+			nonEmpty := jen.Len(jen.Id("__chain")).Op(">").Lit(0)
+			if !hasBridge {
+				return nonEmpty
+			}
+			return nonEmpty.Op("&&").Len(jen.Id("__legacyChildren")).Op("==").Lit(0)
+		}
+
 		// Non-streaming BuildRequest path for /call and /call-with-raw.
 		// Uses Request (not StreamRequest) to build non-streaming HTTP requests.
 		// Checked before the streaming path since it's more efficient for call modes.
@@ -2218,10 +2234,16 @@ func Generate(selfPkg string) {
 						jen.Return(jen.Id("out"), jen.Nil()),
 					),
 					// Fallback chain path: if single-provider check failed,
-					// try resolving a fallback chain. Mixed chains (with
-					// any legacy children) route through the BuildRequest
-					// path — the orchestrator dispatches legacy children
-					// to the generated legacyCallChildFn.
+					// try resolving a fallback chain. When a bridge block
+					// exists (hasBuildRequest), a mixed chain — one with any
+					// call-legacy children — must fall through so the bridge
+					// re-resolves it with IsProviderSupported; a child that is
+					// call-legacy may still be stream-supported, and the
+					// bridge's StreamRequest path drives such children better
+					// than legacyCallChildFn. This block therefore only takes
+					// chains that are fully call-supported. When no bridge
+					// exists (hasBuildRequest=false) mixed chains stay here,
+					// matching the pre-bridge behaviour.
 					jen.List(jen.Id("__chain"), jen.Id("__cprov"), jen.Id("__legacyChildren")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChain").Call(
 						jen.Id("adapter"),
 						jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
@@ -2229,7 +2251,7 @@ func Generate(selfPkg string) {
 						jen.Qual(common.IntrospectedPkg, "ClientProvider"),
 						jen.Qual(common.BuildRequestPkg, "IsCallProviderSupported"),
 					),
-					jen.If(jen.Len(jen.Id("__chain")).Op(">").Lit(0)).Block(
+					jen.If(fallbackChainConsumeCond(hasBuildRequest)).Block(
 						resolveRetryPolicy(),
 						jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildFallbackChainPlan").Call(
 							jen.Id("adapter"),

--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -2203,6 +2203,7 @@ func Generate(selfPkg string) {
 							jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
 							jen.Id("provider"),
 							jen.Id("retryPolicy"),
+							jen.Qual(common.BuildRequestPkg, "BuildRequestAPIRequest"),
 						),
 						jen.Id("err").Op("=").Id(buildCallRequestMethodName).Call(
 							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
@@ -2237,6 +2238,7 @@ func Generate(selfPkg string) {
 							jen.Id("__cprov"),
 							jen.Id("__legacyChildren"),
 							jen.Id("retryPolicy"),
+							jen.Qual(common.BuildRequestPkg, "BuildRequestAPIRequest"),
 						),
 						jen.Id("err").Op("=").Id(buildCallRequestMethodName).Call(
 							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
@@ -2255,8 +2257,9 @@ func Generate(selfPkg string) {
 		}
 
 		// Streaming BuildRequest path for /stream and /stream-with-raw.
-		// Explicitly gated to streaming modes so call modes that decline the
-		// non-streaming branch above fall through to the legacy path, not here.
+		// Explicitly gated to streaming modes; a separate bridge block below
+		// handles /call and /call-with-raw via stream accumulation when the
+		// non-streaming Request API declined.
 		if hasBuildRequest {
 			routerBody = append(routerBody,
 				jen.Comment("Try streaming BuildRequest path for /stream and /stream-with-raw"),
@@ -2279,6 +2282,7 @@ func Generate(selfPkg string) {
 							jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
 							jen.Id("provider"),
 							jen.Id("retryPolicy"),
+							jen.Qual(common.BuildRequestPkg, "BuildRequestAPIStreamRequest"),
 						),
 						jen.Id("err").Op("=").Id(buildRequestMethodName).Call(
 							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
@@ -2312,6 +2316,89 @@ func Generate(selfPkg string) {
 							jen.Id("__cprov"),
 							jen.Id("__legacyChildren"),
 							jen.Id("retryPolicy"),
+							jen.Qual(common.BuildRequestPkg, "BuildRequestAPIStreamRequest"),
+						),
+						jen.Id("err").Op("=").Id(buildRequestMethodName).Call(
+							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
+							jen.Lit(""), jen.Id("retryPolicy"),
+							jen.Id("__chain"), jen.Id("__cprov"),
+							jen.Id("__legacyChildren"),
+							jen.Id("__planned"),
+						),
+						jen.If(jen.Id("err").Op("!=").Nil()).Block(
+							jen.Return(jen.Nil(), jen.Id("err")),
+						),
+						jen.Return(jen.Id("out"), jen.Nil()),
+					),
+				),
+			)
+		}
+
+		// Bridge: /call and /call-with-raw that the non-streaming block
+		// declined fall through to the streaming BuildRequest path, which
+		// accumulates SSE deltas into a unary response. Triggered when the
+		// non-streaming Request API is unavailable (introspected.Request==nil
+		// or the call-side support gate rejected the provider/chain) but the
+		// StreamRequest API can drive it. StreamMode is StreamModeCall or
+		// StreamModeCallWithRaw, so NeedsPartials is false inside the
+		// orchestrator and no partials ever reach the output channel — the
+		// pool sees the same shape as the non-streaming call path.
+		if hasBuildRequest {
+			routerBody = append(routerBody,
+				jen.Comment("Bridge: /call and /call-with-raw via StreamRequest when Request is unavailable"),
+				jen.If(
+					jen.Qual(common.BuildRequestPkg, "UseBuildRequest").Call().
+						Op("&&").Qual(common.IntrospectedPkg, "StreamRequest").Op("!=").Nil().
+						Op("&&").Parens(jen.Id("mode").Op("==").Qual(common.InterfacesPkg, "StreamModeCall").
+						Op("||").Id("mode").Op("==").Qual(common.InterfacesPkg, "StreamModeCallWithRaw")),
+				).Block(
+					// Single-provider path
+					jen.Id("provider").Op(":=").Qual(common.BuildRequestPkg, "ResolveProvider").Call(
+						jen.Id("adapter"),
+						jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
+						jen.Qual(common.IntrospectedPkg, "FunctionProvider").Index(jen.Lit(methodName)),
+					),
+					jen.If(jen.Id("provider").Op("!=").Lit("").Op("&&").Qual(common.BuildRequestPkg, "IsProviderSupported").Call(jen.Id("provider"))).Block(
+						resolveRetryPolicy(),
+						jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildSingleProviderPlan").Call(
+							jen.Id("adapter"),
+							jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
+							jen.Id("provider"),
+							jen.Id("retryPolicy"),
+							jen.Qual(common.BuildRequestPkg, "BuildRequestAPIStreamRequest"),
+						),
+						jen.Id("err").Op("=").Id(buildRequestMethodName).Call(
+							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
+							jen.Id("provider"), jen.Id("retryPolicy"),
+							jen.Nil(), jen.Nil(),
+							jen.Nil(),
+							jen.Id("__planned"),
+						),
+						jen.If(jen.Id("err").Op("!=").Nil()).Block(
+							jen.Return(jen.Nil(), jen.Id("err")),
+						),
+						jen.Return(jen.Id("out"), jen.Nil()),
+					),
+					// Fallback chain path (bridge). Uses IsProviderSupported
+					// (stream side) because the whole point of the bridge is
+					// to accept chains that IsCallProviderSupported rejected.
+					jen.List(jen.Id("__chain"), jen.Id("__cprov"), jen.Id("__legacyChildren")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChain").Call(
+						jen.Id("adapter"),
+						jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
+						jen.Qual(common.IntrospectedPkg, "FallbackChains"),
+						jen.Qual(common.IntrospectedPkg, "ClientProvider"),
+						jen.Qual(common.BuildRequestPkg, "IsProviderSupported"),
+					),
+					jen.If(jen.Len(jen.Id("__chain")).Op(">").Lit(0)).Block(
+						resolveRetryPolicy(),
+						jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildFallbackChainPlan").Call(
+							jen.Id("adapter"),
+							jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
+							jen.Id("__chain"),
+							jen.Id("__cprov"),
+							jen.Id("__legacyChildren"),
+							jen.Id("retryPolicy"),
+							jen.Qual(common.BuildRequestPkg, "BuildRequestAPIStreamRequest"),
 						),
 						jen.Id("err").Op("=").Id(buildRequestMethodName).Call(
 							jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),

--- a/bamlutils/buildrequest/call_support_debug.go
+++ b/bamlutils/buildrequest/call_support_debug.go
@@ -1,0 +1,60 @@
+//go:build debug
+
+// Package buildrequest — call_support_debug.go provides a debug-build-only
+// test hook that lets integration tests force specific providers out of the
+// call-supported set without waiting for callSupportedProviders and
+// supportedProviders to diverge organically. Compiled only when built with
+// `-tags debug` (see cmd/build/build.sh); release builds use the no-op stub
+// in call_support_stub.go.
+package buildrequest
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+// callUnsupportedProvidersOnce caches the parsed set so
+// debugFilterCallSupported stays hot on the request path. Same rationale
+// as useBuildRequestOnce — os.Getenv takes a lock each call.
+var callUnsupportedProvidersOnce sync.Once
+var callUnsupportedProvidersCached map[string]bool
+
+// parseCallUnsupportedProvidersEnv reads BAML_REST_CALL_UNSUPPORTED_PROVIDERS
+// as a comma-separated list and returns the providers marked as
+// call-unsupported. Whitespace around each entry is trimmed; empty entries
+// are ignored. Extracted so the test can verify parsing without the cache.
+func parseCallUnsupportedProvidersEnv() map[string]bool {
+	raw := os.Getenv("BAML_REST_CALL_UNSUPPORTED_PROVIDERS")
+	if raw == "" {
+		return nil
+	}
+	set := make(map[string]bool)
+	for _, p := range strings.Split(raw, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			set[p] = true
+		}
+	}
+	return set
+}
+
+func callUnsupportedProviders() map[string]bool {
+	callUnsupportedProvidersOnce.Do(func() {
+		callUnsupportedProvidersCached = parseCallUnsupportedProvidersEnv()
+	})
+	return callUnsupportedProvidersCached
+}
+
+// debugFilterCallSupported refines the static call-supported answer with the
+// debug override. When a provider is listed in
+// BAML_REST_CALL_UNSUPPORTED_PROVIDERS, it is reported as call-unsupported
+// regardless of the static map — letting tests put that provider into a
+// fallback chain next to a truly call-supported one to exercise the mixed-
+// chain fall-through gate.
+func debugFilterCallSupported(provider string, staticSupported bool) bool {
+	if callUnsupportedProviders()[provider] {
+		return false
+	}
+	return staticSupported
+}

--- a/bamlutils/buildrequest/call_support_debug_test.go
+++ b/bamlutils/buildrequest/call_support_debug_test.go
@@ -1,0 +1,42 @@
+//go:build debug
+
+package buildrequest
+
+import (
+	"testing"
+)
+
+func TestParseCallUnsupportedProvidersEnv(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  map[string]bool
+	}{
+		{"empty", "", nil},
+		{"single", "openai", map[string]bool{"openai": true}},
+		{
+			"multi_comma",
+			"openai,anthropic",
+			map[string]bool{"openai": true, "anthropic": true},
+		},
+		{
+			"whitespace_and_empty",
+			"  openai , , anthropic  ",
+			map[string]bool{"openai": true, "anthropic": true},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BAML_REST_CALL_UNSUPPORTED_PROVIDERS", tc.value)
+			got := parseCallUnsupportedProvidersEnv()
+			if len(got) != len(tc.want) {
+				t.Fatalf("len: got %d, want %d (got=%v)", len(got), len(tc.want), got)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("key %q: got %v, want %v", k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/bamlutils/buildrequest/call_support_stub.go
+++ b/bamlutils/buildrequest/call_support_stub.go
@@ -1,0 +1,11 @@
+//go:build !debug
+
+package buildrequest
+
+// debugFilterCallSupported is a release-build no-op: the debug env override
+// compiles away so IsCallProviderSupported's behaviour on a release binary
+// is driven entirely by callSupportedProviders. See call_support_debug.go
+// for the debug implementation.
+func debugFilterCallSupported(_ string, staticSupported bool) bool {
+	return staticSupported
+}

--- a/bamlutils/buildrequest/metadata_resolve_test.go
+++ b/bamlutils/buildrequest/metadata_resolve_test.go
@@ -7,6 +7,33 @@ import (
 	"github.com/invakid404/baml-rest/bamlutils"
 )
 
+func TestParseDisableCallBuildRequestEnv(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"true", "true", true},
+		{"True", "True", true},
+		{"1", "1", true},
+		{"on", "on", true},
+		{"yes", "yes", true},
+		{"false", "false", false},
+		{"0", "0", false},
+		{"off", "off", false},
+		{"garbage", "garbage", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BAML_REST_DISABLE_CALL_BUILD_REQUEST", tc.value)
+			if got := parseDisableCallBuildRequestEnv(); got != tc.want {
+				t.Errorf("value=%q: got %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestResolveProviderWithReason_BuildRequestSupported(t *testing.T) {
 	adapter := &mockAdapter{Context: context.Background()}
 	res := ResolveProviderWithReason(adapter, "MyClient", "openai", IsProviderSupported)

--- a/bamlutils/buildrequest/metadata_resolve_test.go
+++ b/bamlutils/buildrequest/metadata_resolve_test.go
@@ -111,9 +111,12 @@ func TestResolveFallbackChainWithReason_MixedDrivable(t *testing.T) {
 
 func TestBuildSingleProviderPlan(t *testing.T) {
 	adapter := &mockAdapter{Context: context.Background()}
-	plan := BuildSingleProviderPlan(adapter, "MyClient", "openai", nil)
+	plan := BuildSingleProviderPlan(adapter, "MyClient", "openai", nil, BuildRequestAPIRequest)
 	if plan.Path != "buildrequest" {
 		t.Errorf("path: got %q, want buildrequest", plan.Path)
+	}
+	if plan.BuildRequestAPI != BuildRequestAPIRequest {
+		t.Errorf("BuildRequestAPI: got %q, want %q", plan.BuildRequestAPI, BuildRequestAPIRequest)
 	}
 	if plan.Client != "MyClient" {
 		t.Errorf("client: got %q, want MyClient", plan.Client)
@@ -123,6 +126,27 @@ func TestBuildSingleProviderPlan(t *testing.T) {
 	}
 	if plan.RetryMax != nil {
 		t.Errorf("RetryMax should be nil when policy is nil; got %v", plan.RetryMax)
+	}
+}
+
+func TestBuildSingleProviderPlan_StreamRequestAPI(t *testing.T) {
+	adapter := &mockAdapter{Context: context.Background()}
+	plan := BuildSingleProviderPlan(adapter, "MyClient", "openai", nil, BuildRequestAPIStreamRequest)
+	if plan.BuildRequestAPI != BuildRequestAPIStreamRequest {
+		t.Errorf("BuildRequestAPI: got %q, want %q", plan.BuildRequestAPI, BuildRequestAPIStreamRequest)
+	}
+}
+
+func TestBuildFallbackChainPlan_APIFieldCarriesThrough(t *testing.T) {
+	adapter := &mockAdapter{Context: context.Background()}
+	chain := []string{"A", "B"}
+	providers := map[string]string{"A": "openai", "B": "anthropic"}
+	plan := BuildFallbackChainPlan(adapter, "Strategy", chain, providers, nil, nil, BuildRequestAPIStreamRequest)
+	if plan.BuildRequestAPI != BuildRequestAPIStreamRequest {
+		t.Errorf("BuildRequestAPI: got %q, want %q", plan.BuildRequestAPI, BuildRequestAPIStreamRequest)
+	}
+	if plan.Strategy != "baml-fallback" {
+		t.Errorf("strategy: got %q, want baml-fallback", plan.Strategy)
 	}
 }
 

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -135,6 +135,21 @@ func ResolveProvider(adapter bamlutils.Adapter, defaultClientName string, intros
 	return introspectedProvider
 }
 
+// BuildRequestAPI identifies which BAML API drove a Path=="buildrequest"
+// request. These values populate Metadata.BuildRequestAPI and the
+// X-BAML-Build-Request-API response header.
+const (
+	// BuildRequestAPIRequest means the request used the non-streaming
+	// Request API via RunCallOrchestration (one HTTP call, JSON response).
+	BuildRequestAPIRequest = "request"
+	// BuildRequestAPIStreamRequest means the request used the streaming
+	// StreamRequest API via RunStreamOrchestration. For stream modes this
+	// is the normal path. For call modes this signals the bridge: SSE is
+	// accumulated and returned as a unary response because the non-streaming
+	// Request API was not available for the resolved provider.
+	BuildRequestAPIStreamRequest = "streamrequest"
+)
+
 // PathReason enumerates the classification reasons an orchestrator reports
 // alongside the legacy-path decision. Each value is stable and appears in
 // the X-BAML-Path-Reason response header and in metadata payloads.
@@ -251,22 +266,27 @@ func ResolveProviderWithReason(
 // through the BuildRequest path with a single (non-strategy) client. Called
 // by the generated router once the provider has been resolved and the
 // support gate has been cleared, so Path is always "buildrequest".
+//
+// buildRequestAPI is one of BuildRequestAPIRequest /
+// BuildRequestAPIStreamRequest (see constants above).
 func BuildSingleProviderPlan(
 	adapter bamlutils.Adapter,
 	defaultClientName string,
 	provider string,
 	retryPolicy *retry.Policy,
+	buildRequestAPI string,
 ) *bamlutils.Metadata {
 	clientName := defaultClientName
 	if reg := adapter.OriginalClientRegistry(); reg != nil && reg.Primary != nil && *reg.Primary != "" {
 		clientName = *reg.Primary
 	}
 	plan := &bamlutils.Metadata{
-		Phase:       bamlutils.MetadataPhasePlanned,
-		Path:        "buildrequest",
-		Client:      clientName,
-		Provider:    provider,
-		RetryPolicy: EncodeRetryPolicy(retryPolicy),
+		Phase:           bamlutils.MetadataPhasePlanned,
+		Path:            "buildrequest",
+		BuildRequestAPI: buildRequestAPI,
+		Client:          clientName,
+		Provider:        provider,
+		RetryPolicy:     EncodeRetryPolicy(retryPolicy),
 	}
 	if retryPolicy != nil {
 		m := retryPolicy.MaxRetries
@@ -278,6 +298,9 @@ func BuildSingleProviderPlan(
 // BuildFallbackChainPlan constructs planned metadata for a request routed
 // through the BuildRequest path as a fallback strategy. chain/providers/
 // legacyChildren are the resolved values from ResolveFallbackChain.
+//
+// buildRequestAPI is one of BuildRequestAPIRequest /
+// BuildRequestAPIStreamRequest (see constants above).
 func BuildFallbackChainPlan(
 	adapter bamlutils.Adapter,
 	defaultClientName string,
@@ -285,18 +308,20 @@ func BuildFallbackChainPlan(
 	providers map[string]string,
 	legacyChildren map[string]bool,
 	retryPolicy *retry.Policy,
+	buildRequestAPI string,
 ) *bamlutils.Metadata {
 	clientName := defaultClientName
 	if reg := adapter.OriginalClientRegistry(); reg != nil && reg.Primary != nil && *reg.Primary != "" {
 		clientName = *reg.Primary
 	}
 	plan := &bamlutils.Metadata{
-		Phase:       bamlutils.MetadataPhasePlanned,
-		Path:        "buildrequest",
-		Client:      clientName,
-		Strategy:    "baml-fallback",
-		Chain:       append([]string(nil), chain...),
-		RetryPolicy: EncodeRetryPolicy(retryPolicy),
+		Phase:           bamlutils.MetadataPhasePlanned,
+		Path:            "buildrequest",
+		BuildRequestAPI: buildRequestAPI,
+		Client:          clientName,
+		Strategy:        "baml-fallback",
+		Chain:           append([]string(nil), chain...),
+		RetryPolicy:     EncodeRetryPolicy(retryPolicy),
 	}
 	if retryPolicy != nil {
 		m := retryPolicy.MaxRetries
@@ -1230,14 +1255,22 @@ func RunStreamOrchestration(
 			// Emit a reset signal before trying the next child so the
 			// downstream discards any partial/raw state leaked by the
 			// previous child's failed stream. Not needed before the first
-			// child in the chain.
+			// child in the chain. Only emitted when partials could have
+			// reached the client — for NeedsPartials=false (call modes
+			// bridged through this orchestrator) there is no partial state
+			// downstream, and the reset would falsely flip the pool's
+			// gotFirstByte flag, disabling hung detection for the next
+			// child. The heartbeat reset still runs so the next child
+			// re-arms first-byte detection via its own heartbeat.
 			if i > 0 && lastErr != nil {
-				r := newResult(bamlutils.StreamResultKindStream, nil, nil, "", nil, true)
-				select {
-				case out <- r:
-				case <-ctx.Done():
-					r.Release()
-					return nil, ctx.Err()
+				if config.NeedsPartials {
+					r := newResult(bamlutils.StreamResultKindStream, nil, nil, "", nil, true)
+					select {
+					case out <- r:
+					case <-ctx.Done():
+						r.Release()
+						return nil, ctx.Err()
+					}
 				}
 				heartbeatSent.Store(false)
 			}
@@ -1283,15 +1316,23 @@ func RunStreamOrchestration(
 
 	// Execute with retries
 	_, err := retry.Execute(ctx, config.RetryPolicy, attemptFull, func(attempt int) {
-		// Emit reset signal so downstream discards accumulated partial state
-		r := newResult(bamlutils.StreamResultKindStream, nil, nil, "", nil, true)
-		select {
-		case out <- r:
-		case <-ctx.Done():
-			r.Release()
+		// Emit reset signal so downstream discards accumulated partial state.
+		// Only emitted when partials could have reached the client. For
+		// NeedsPartials=false (call modes bridged through this orchestrator)
+		// there is no partial state downstream, and the reset event would
+		// falsely flip the pool's gotFirstByte flag before the retry's
+		// upstream has produced a byte — disabling hung detection.
+		if config.NeedsPartials {
+			r := newResult(bamlutils.StreamResultKindStream, nil, nil, "", nil, true)
+			select {
+			case out <- r:
+			case <-ctx.Done():
+				r.Release()
+			}
 		}
 
-		// Reset heartbeat for new attempt
+		// Reset heartbeat for new attempt so first-byte detection re-arms
+		// via the next attempt's heartbeat.
 		heartbeatSent.Store(false)
 	})
 

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -144,11 +144,19 @@ var callSupportedProviders = map[string]bool{
 // Returns false for every provider when BAML_REST_DISABLE_CALL_BUILD_REQUEST
 // is set, which routes /call{,-with-raw} through the stream-accumulation
 // bridge (or legacy, if StreamRequest is unavailable).
+//
+// Debug builds (-tags debug) additionally honour
+// BAML_REST_CALL_UNSUPPORTED_PROVIDERS, a comma-separated list that marks
+// specific providers as call-unsupported while keeping them stream-
+// supported. This exists so integration tests can force the mixed-chain
+// fall-through gate to fire without waiting for callSupportedProviders and
+// supportedProviders to diverge organically. See debugFilterCallSupported
+// in call_support_debug.go / call_support_stub.go.
 func IsCallProviderSupported(provider string) bool {
 	if disableCallBuildRequest() {
 		return false
 	}
-	return callSupportedProviders[provider]
+	return debugFilterCallSupported(provider, callSupportedProviders[provider])
 }
 
 // ResolveProvider determines the provider for a function by checking the

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -55,6 +55,43 @@ func UseBuildRequest() bool {
 	return useBuildRequestCached
 }
 
+// parseDisableCallBuildRequestEnv reads BAML_REST_DISABLE_CALL_BUILD_REQUEST
+// and returns its boolean interpretation. Extracted so the test can verify
+// parsing logic independently of the cache.
+func parseDisableCallBuildRequestEnv() bool {
+	v := os.Getenv("BAML_REST_DISABLE_CALL_BUILD_REQUEST")
+	switch strings.ToLower(v) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// disableCallBuildRequestOnce caches the result of the env lookup so
+// IsCallProviderSupported stays hot. Same rationale as useBuildRequestOnce.
+var disableCallBuildRequestOnce sync.Once
+var disableCallBuildRequestCached bool
+
+// disableCallBuildRequest returns true when BAML_REST_DISABLE_CALL_BUILD_REQUEST
+// is set, forcing the non-streaming Request API off for all providers. The
+// call-mode router block then declines and /call{,-with-raw} fall through to
+// the stream-accumulation bridge (when StreamRequest is available) or legacy.
+//
+// Primary uses:
+//
+//   - Exercising the bridge path in integration tests without relying on an
+//     organic divergence between callSupportedProviders and supportedProviders.
+//   - An operational escape hatch if the non-streaming Request API regresses
+//     for a provider; flipping this forces bridging at a latency cost while a
+//     fix ships.
+func disableCallBuildRequest() bool {
+	disableCallBuildRequestOnce.Do(func() {
+		disableCallBuildRequestCached = parseDisableCallBuildRequestEnv()
+	})
+	return disableCallBuildRequestCached
+}
+
 // supportedProviders is the set of providers whose SSE format is handled by
 // ExtractDeltaFromText. This must match the switch cases in that function
 // exactly — any provider not in this set falls back to the legacy path.
@@ -103,7 +140,14 @@ var callSupportedProviders = map[string]bool{
 // response format is handled by ExtractResponseContent and the provider
 // supports BAML's Request API. Unknown providers fall back to the legacy
 // CallStream+OnTick path.
+//
+// Returns false for every provider when BAML_REST_DISABLE_CALL_BUILD_REQUEST
+// is set, which routes /call{,-with-raw} through the stream-accumulation
+// bridge (or legacy, if StreamRequest is unavailable).
 func IsCallProviderSupported(provider string) bool {
+	if disableCallBuildRequest() {
+		return false
+	}
 	return callSupportedProviders[provider]
 }
 

--- a/bamlutils/buildrequest/orchestrator_test.go
+++ b/bamlutils/buildrequest/orchestrator_test.go
@@ -1791,3 +1791,258 @@ func TestRunStreamOrchestration_MixedChain_HTTPBackedEndToEnd(t *testing.T) {
 		t.Errorf("expected raw=%q from legacy child, got %q", legacyRaw, finalRaw)
 	}
 }
+
+// TestRunStreamOrchestration_CallBridge_ShapedLikeUnary simulates the
+// call-mode bridge: NeedsPartials=false, NeedsRaw=true. The orchestrator
+// consumes SSE, never emits a partial, and produces a single final with the
+// accumulated raw. This is the shape pool.Call expects, so the unary handler
+// returns the final as if it came from RunCallOrchestration.
+func TestRunStreamOrchestration_CallBridge_ShapedLikeUnary(t *testing.T) {
+	server := makeOpenAIServer([]string{"Hello", " ", "world"})
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &StreamConfig{
+		Provider:      "openai",
+		NeedsPartials: false, // call-mode bridge
+		NeedsRaw:      true,
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+			return &llmhttp.Request{URL: server.URL, Method: "POST", Body: `{}`}, nil
+		},
+		nil, // parseStream unused with NeedsPartials=false
+		func(ctx context.Context, accumulated string) (any, error) { return accumulated, nil },
+		newTestResult,
+	)
+	close(out)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var partials, finals, heartbeats, errors int
+	var finalVal any
+	var finalRaw string
+	for r := range out {
+		tr := r.(*testResult)
+		switch tr.kind {
+		case bamlutils.StreamResultKindStream:
+			partials++
+		case bamlutils.StreamResultKindFinal:
+			finals++
+			finalVal = tr.final
+			finalRaw = tr.raw
+		case bamlutils.StreamResultKindHeartbeat:
+			heartbeats++
+		case bamlutils.StreamResultKindError:
+			errors++
+		}
+	}
+
+	if partials != 0 {
+		t.Errorf("bridge should emit no partials; got %d", partials)
+	}
+	if finals != 1 {
+		t.Fatalf("expected 1 final, got %d", finals)
+	}
+	if errors != 0 {
+		t.Errorf("expected 0 errors, got %d", errors)
+	}
+	if heartbeats != 1 {
+		t.Errorf("expected 1 heartbeat, got %d", heartbeats)
+	}
+	if finalVal != "Hello world" {
+		t.Errorf("expected final='Hello world', got %v", finalVal)
+	}
+	if finalRaw != "Hello world" {
+		t.Errorf("expected raw='Hello world', got %q", finalRaw)
+	}
+}
+
+// TestRunStreamOrchestration_NoResetWhenNeedsPartialsFalse_Retry verifies
+// that the retry-boundary reset event is suppressed when NeedsPartials=false.
+// Context: call modes (StreamModeCall / StreamModeCallWithRaw) bridged
+// through this orchestrator have no partial audience downstream, so a reset
+// event would falsely flip the pool's gotFirstByte flag before the retry's
+// upstream has produced any byte — disabling hung detection.
+func TestRunStreamOrchestration_NoResetWhenNeedsPartialsFalse_Retry(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n < 2 {
+			w.WriteHeader(500)
+			fmt.Fprint(w, "internal error")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &StreamConfig{
+		Provider:      "openai",
+		NeedsPartials: false, // call-mode bridge
+		NeedsRaw:      true,
+		RetryPolicy: &retry.Policy{
+			MaxRetries: 2,
+			Strategy:   &retry.ConstantDelay{DelayMs: 1},
+		},
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+			return &llmhttp.Request{URL: server.URL, Method: "POST", Body: `{}`}, nil
+		},
+		nil,
+		func(ctx context.Context, accumulated string) (any, error) { return accumulated, nil },
+		newTestResult,
+	)
+	close(out)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts.Load())
+	}
+
+	var resets, finals, heartbeats int
+	for r := range out {
+		tr := r.(*testResult)
+		if tr.reset {
+			resets++
+		}
+		if tr.kind == bamlutils.StreamResultKindFinal {
+			finals++
+		}
+		if tr.kind == bamlutils.StreamResultKindHeartbeat {
+			heartbeats++
+		}
+	}
+
+	if resets != 0 {
+		t.Errorf("expected 0 reset events under NeedsPartials=false; got %d", resets)
+	}
+	if finals != 1 {
+		t.Errorf("expected 1 final, got %d", finals)
+	}
+	// The failing attempt never produces a byte (500 before SSE begins), so
+	// its sendHeartbeat never fires. The retry re-arms heartbeatSent; the
+	// successful attempt then fires one heartbeat on HTTP connect.
+	if heartbeats < 1 {
+		t.Errorf("expected >=1 heartbeat from the successful attempt; got %d", heartbeats)
+	}
+}
+
+// TestRunStreamOrchestration_NoResetWhenNeedsPartialsFalse_FallbackChain
+// verifies the in-chain reset (between failing children) is also suppressed
+// under NeedsPartials=false. Same rationale as the retry variant.
+func TestRunStreamOrchestration_NoResetWhenNeedsPartialsFalse_FallbackChain(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt := int(attempts.Add(1))
+		flusher, _ := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		if attempt == 1 {
+			// Primary: stream content that parseFinal rejects.
+			fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"stale\"}}]}\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			fmt.Fprint(w, "data: [DONE]\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return
+		}
+		// Secondary: stream valid content.
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"good\"}}]}\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &StreamConfig{
+		Provider:      "",
+		RetryPolicy:   &retry.Policy{MaxRetries: 1, Strategy: &retry.ConstantDelay{DelayMs: 1}},
+		NeedsPartials: false, // call-mode bridge
+		FallbackChain: []string{"PrimaryClient", "SecondaryClient"},
+		ClientProviders: map[string]string{
+			"PrimaryClient":   "openai",
+			"SecondaryClient": "openai",
+		},
+	}
+
+	parseFinal := func(_ context.Context, s string) (any, error) {
+		if s == "stale" {
+			return nil, fmt.Errorf("rejected stale content")
+		}
+		return s, nil
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+			return &llmhttp.Request{URL: server.URL, Method: "POST", Body: `{}`}, nil
+		},
+		nil,
+		parseFinal,
+		newTestResult,
+	)
+	close(out)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resets, finals, heartbeats int
+	var finalVal any
+	for r := range out {
+		tr := r.(*testResult)
+		if tr.reset {
+			resets++
+		}
+		if tr.kind == bamlutils.StreamResultKindFinal {
+			finals++
+			finalVal = tr.final
+		}
+		if tr.kind == bamlutils.StreamResultKindHeartbeat {
+			heartbeats++
+		}
+	}
+
+	if resets != 0 {
+		t.Errorf("expected 0 reset events under NeedsPartials=false; got %d", resets)
+	}
+	if finals != 1 {
+		t.Errorf("expected 1 final, got %d", finals)
+	}
+	if finalVal != "good" {
+		t.Errorf("expected final=%q, got %v", "good", finalVal)
+	}
+	// Both children emit a heartbeat on HTTP connect; the in-chain reset
+	// must still clear heartbeatSent.
+	if heartbeats < 2 {
+		t.Errorf("expected >=2 heartbeats (one per child), got %d", heartbeats)
+	}
+}

--- a/bamlutils/embed.go
+++ b/bamlutils/embed.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed adapters.go buildrequest/call_orchestrator.go buildrequest/legacy_log.go buildrequest/orchestrator.go buildrequest/response_extract.go buildrequest/strategy_testhelper.go clientdefaults/clientdefaults.go clientdefaults/handlers.go dynamic.go embed.go go.mod go.sum interfaces.go legacy_outcome.go llmhttp/cache.go llmhttp/fast_backend.go llmhttp/llmhttp.go media.go pool.go retry/retry.go sse/extract.go sseclient/sseclient.go urlrewrite/urlrewrite.go versions.go
+//go:embed adapters.go buildrequest/call_orchestrator.go buildrequest/call_support_debug.go buildrequest/call_support_stub.go buildrequest/legacy_log.go buildrequest/orchestrator.go buildrequest/response_extract.go buildrequest/strategy_testhelper.go clientdefaults/clientdefaults.go clientdefaults/handlers.go dynamic.go embed.go go.mod go.sum interfaces.go legacy_outcome.go llmhttp/cache.go llmhttp/fast_backend.go llmhttp/llmhttp.go media.go pool.go retry/retry.go sse/extract.go sseclient/sseclient.go urlrewrite/urlrewrite.go versions.go
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -59,6 +59,15 @@ type Metadata struct {
 	Path       string        `json:"path"`                  // "buildrequest" or "legacy"
 	PathReason string        `json:"path_reason,omitempty"` // legacy classification enum; empty when Path=="buildrequest"
 
+	// BuildRequestAPI identifies which BAML API drove a Path=="buildrequest"
+	// request. "request" means the non-streaming Request API (unary HTTP,
+	// RunCallOrchestration). "streamrequest" means the streaming StreamRequest
+	// API (SSE accumulation, RunStreamOrchestration); for call modes this
+	// indicates the bridge from /call{,-with-raw} through stream accumulation,
+	// used when the non-streaming API is unavailable for the resolved
+	// provider. Empty on the legacy path.
+	BuildRequestAPI string `json:"build_request_api,omitempty"`
+
 	// Planned fields
 	Client         string   `json:"client,omitempty"`           // resolved runtime client name (strategy or single)
 	Provider       string   `json:"provider,omitempty"`         // provider of resolved single client; empty for strategies

--- a/cmd/build/build.sh
+++ b/cmd/build/build.sh
@@ -526,7 +526,7 @@ if [ -n "${BAML_REST_BASE_URL_REWRITES:-}" ]; then
     echo "Baking in base URL rewrites: ${BAML_REST_BASE_URL_REWRITES}"
     WORKER_LDFLAGS="-X 'github.com/invakid404/baml-rest/bamlutils/urlrewrite.builtinRules=${BAML_REST_BASE_URL_REWRITES}'"
 fi
-go build ${WORKER_LDFLAGS:+-ldflags "${WORKER_LDFLAGS}"} -o cmd/serve/worker cmd/worker/main.go
+go build ${GO_BUILD_TAGS} ${WORKER_LDFLAGS:+-ldflags "${WORKER_LDFLAGS}"} -o cmd/serve/worker cmd/worker/main.go
 
 # Generate OpenAPI schema (this also imports baml)
 echo "Generating OpenAPI schema..."

--- a/cmd/serve/headers.go
+++ b/cmd/serve/headers.go
@@ -16,6 +16,7 @@ import (
 const (
 	HeaderBAMLPath             = "X-BAML-Path"
 	HeaderBAMLPathReason       = "X-BAML-Path-Reason"
+	HeaderBAMLBuildRequestAPI  = "X-BAML-Build-Request-API"
 	HeaderBAMLClient           = "X-BAML-Client"
 	HeaderBAMLWinnerClient     = "X-BAML-Winner-Client"
 	HeaderBAMLWinnerProvider   = "X-BAML-Winner-Provider"
@@ -51,6 +52,9 @@ func setBAMLHeaders(setter headerSetter, planned, outcome *bamlutils.Metadata) {
 		}
 		if planned.PathReason != "" {
 			setter(HeaderBAMLPathReason, planned.PathReason)
+		}
+		if planned.BuildRequestAPI != "" {
+			setter(HeaderBAMLBuildRequestAPI, planned.BuildRequestAPI)
 		}
 		if v := sanitizeTokenHeader(planned.Client); v != "" {
 			setter(HeaderBAMLClient, v)

--- a/cmd/serve/headers_test.go
+++ b/cmd/serve/headers_test.go
@@ -14,7 +14,7 @@ func TestSetBAMLHeaders_OmitsWhenNil(t *testing.T) {
 	setBAMLHeaders(netHTTPHeaderSetter(h), nil, nil)
 
 	for _, name := range []string{
-		HeaderBAMLPath, HeaderBAMLPathReason, HeaderBAMLClient,
+		HeaderBAMLPath, HeaderBAMLPathReason, HeaderBAMLBuildRequestAPI, HeaderBAMLClient,
 		HeaderBAMLWinnerClient, HeaderBAMLWinnerProvider,
 		HeaderBAMLRetryMax, HeaderBAMLRetryCount, HeaderBAMLUpstreamDuration,
 		HeaderBAMLBamlCallCount,
@@ -133,6 +133,50 @@ func TestSetBAMLHeaders_OutcomeWinnerDiffers(t *testing.T) {
 	if got := h.Get(HeaderBAMLWinnerClient); got != "Backup" {
 		t.Errorf("WinnerClient: got %q, want %q", got, "Backup")
 	}
+}
+
+func TestSetBAMLHeaders_BuildRequestAPI(t *testing.T) {
+	t.Parallel()
+
+	t.Run("absent when empty", func(t *testing.T) {
+		t.Parallel()
+		h := http.Header{}
+		planned := &bamlutils.Metadata{Phase: bamlutils.MetadataPhasePlanned, Path: "buildrequest", Client: "MyClient"}
+		setBAMLHeaders(netHTTPHeaderSetter(h), planned, nil)
+		if got := h.Get(HeaderBAMLBuildRequestAPI); got != "" {
+			t.Errorf("header should be absent when BuildRequestAPI is empty; got %q", got)
+		}
+	})
+
+	t.Run("request", func(t *testing.T) {
+		t.Parallel()
+		h := http.Header{}
+		planned := &bamlutils.Metadata{
+			Phase:           bamlutils.MetadataPhasePlanned,
+			Path:            "buildrequest",
+			BuildRequestAPI: "request",
+			Client:          "MyClient",
+		}
+		setBAMLHeaders(netHTTPHeaderSetter(h), planned, nil)
+		if got := h.Get(HeaderBAMLBuildRequestAPI); got != "request" {
+			t.Errorf("header: got %q, want request", got)
+		}
+	})
+
+	t.Run("streamrequest", func(t *testing.T) {
+		t.Parallel()
+		h := http.Header{}
+		planned := &bamlutils.Metadata{
+			Phase:           bamlutils.MetadataPhasePlanned,
+			Path:            "buildrequest",
+			BuildRequestAPI: "streamrequest",
+			Client:          "MyClient",
+		}
+		setBAMLHeaders(netHTTPHeaderSetter(h), planned, nil)
+		if got := h.Get(HeaderBAMLBuildRequestAPI); got != "streamrequest" {
+			t.Errorf("header: got %q, want streamrequest", got)
+		}
+	})
 }
 
 func TestSetBAMLHeaders_DropsControlChars(t *testing.T) {

--- a/integration/bridge_test.go
+++ b/integration/bridge_test.go
@@ -1,0 +1,182 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// TestCallBridge_ForcesStreamRequest end-to-end-verifies the bridge that
+// routes /call{,-with-raw} through StreamRequest + SSE accumulation when the
+// non-streaming Request API is unavailable for the resolved provider.
+//
+// Production divergence between callSupportedProviders and supportedProviders
+// doesn't exist today (both sets are identical), so the test forces the
+// bridge by setting BAML_REST_DISABLE_CALL_BUILD_REQUEST=true in a dedicated
+// container. Under that flag IsCallProviderSupported returns false for every
+// provider — block 1 of the router declines, block 2 (stream modes only) is
+// skipped, and the bridge block takes over for call modes.
+//
+// Checks:
+//   - /call returns the parsed data
+//   - /call-with-raw returns parsed data + non-empty raw
+//   - X-BAML-Build-Request-API == "streamrequest"
+//   - Outcome metadata fields (RetryCount, UpstreamDuration) are present
+//
+// The bridge only makes sense with BuildRequest on, so the test skips on the
+// legacy leg where the flag would no-op.
+func TestCallBridge_ForcesStreamRequest(t *testing.T) {
+	if !ActuallyBuildRequest() {
+		t.Skip("bridge requires BuildRequest path; skipping on legacy or pre-0.219 runtimes")
+	}
+
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer setupCancel()
+
+	adapterVersion, err := testutil.GetAdapterVersionForBAML(BAMLVersion)
+	if err != nil {
+		t.Fatalf("Failed to get adapter version: %v", err)
+	}
+	bamlSrcPath, err := findTestdataPath()
+	if err != nil {
+		t.Fatalf("Failed to find testdata: %v", err)
+	}
+
+	env, err := testutil.Setup(setupCtx, testutil.SetupOptions{
+		BAMLSrcPath:     bamlSrcPath,
+		BAMLVersion:     BAMLVersion,
+		AdapterVersion:  adapterVersion,
+		BAMLSource:      BAMLSourcePath,
+		UseBuildRequest: true,
+		RuntimeEnv: map[string]string{
+			// Forces IsCallProviderSupported to return false for every
+			// provider, routing /call{,-with-raw} through the stream-
+			// accumulation bridge.
+			"BAML_REST_DISABLE_CALL_BUILD_REQUEST": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to setup dedicated env: %v", err)
+	}
+	defer func() {
+		termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer termCancel()
+		if err := env.Terminate(termCtx); err != nil {
+			t.Logf("dedicated env Terminate: %v", err)
+		}
+	}()
+
+	mockClient := mockllm.NewClient(env.MockLLMURL)
+	bamlClient := testutil.NewBAMLRestClient(env.BAMLRestURL)
+
+	registerBridgeScenario := func(t *testing.T, scenarioID, content string) *testutil.BAMLOptions {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		// Bridge drives the upstream as streaming (stream: true) so mock
+		// must respond with SSE chunks, not a single JSON body.
+		scenario := &mockllm.Scenario{
+			ID:             scenarioID,
+			Provider:       "openai",
+			Content:        content,
+			ChunkSize:      20,
+			InitialDelayMs: 10,
+			ChunkDelayMs:   5,
+		}
+		if err := mockClient.RegisterScenario(ctx, scenario); err != nil {
+			t.Fatalf("RegisterScenario: %v", err)
+		}
+		return &testutil.BAMLOptions{
+			ClientRegistry: testutil.CreateTestClient(env.MockLLMInternal, scenarioID),
+		}
+	}
+
+	t.Run("call_returns_data_via_streamrequest", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		opts := registerBridgeScenario(t, "test-bridge-call", "Hello, bridge!")
+
+		resp, err := bamlClient.Call(ctx, testutil.CallRequest{
+			Method:  "GetGreeting",
+			Input:   map[string]any{"name": "Bridge"},
+			Options: opts,
+		})
+		if err != nil {
+			t.Fatalf("Call failed: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		var result string
+		if err := json.Unmarshal(resp.Body, &result); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if result != "Hello, bridge!" {
+			t.Errorf("got %q, want %q", result, "Hello, bridge!")
+		}
+
+		// Routing headers: Path stays "buildrequest" — the bridge is
+		// still the BuildRequest orchestrator. BuildRequestAPI flips to
+		// "streamrequest" so operators can distinguish a bridged /call
+		// from a native Request API one.
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI, "streamrequest")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestClient")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLRetryCount, "0")
+		testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
+	})
+
+	t.Run("call_with_raw_returns_data_and_raw_via_streamrequest", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		content := `{"message": "bridged-raw"}`
+		opts := registerBridgeScenario(t, "test-bridge-call-with-raw", content)
+
+		resp, err := bamlClient.CallWithRaw(ctx, testutil.CallRequest{
+			Method:  "GetSimple",
+			Input:   map[string]any{"input": "test"},
+			Options: opts,
+		})
+		if err != nil {
+			t.Fatalf("CallWithRaw failed: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		// Parsed data is the SimpleOutput struct extracted from the SSE-
+		// accumulated text.
+		var data struct {
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		if data.Message != "bridged-raw" {
+			t.Errorf("data.message: got %q, want %q", data.Message, "bridged-raw")
+		}
+
+		// Raw reconstructed from SSE deltas must match the mock content
+		// byte-for-byte — SSE accumulation preserves the full wire text.
+		if resp.Raw != content {
+			t.Errorf("raw: got %q, want %q", resp.Raw, content)
+		}
+
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI, "streamrequest")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestClient")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLRetryCount, "0")
+		testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
+	})
+}

--- a/integration/bridge_test.go
+++ b/integration/bridge_test.go
@@ -179,4 +179,65 @@ func TestCallBridge_ForcesStreamRequest(t *testing.T) {
 		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLRetryCount, "0")
 		testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
 	})
+
+	// Fallback-chain /call under the disable flag: call-side
+	// ResolveFallbackChain sees every child as legacy-under-call and
+	// returns nil (all-legacy short circuit), so the call block declines;
+	// the bridge block re-resolves with IsProviderSupported, accepts the
+	// chain with all children as BuildRequest-driven, and the stream
+	// orchestrator walks the strategy. Covers the new mixed-chain guard's
+	// fall-through composition: call-side refuses → bridge accepts → chain
+	// succeeds end-to-end.
+	t.Run("fallback_chain_call_bridges_to_streamrequest", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Primary returns 500 immediately; secondary succeeds.
+		if err := mockClient.RegisterScenario(ctx, &mockllm.Scenario{
+			ID:          "fallback-primary",
+			Provider:    "openai",
+			Content:     "should not see this",
+			FailAfter:   1,
+			FailureMode: "500",
+		}); err != nil {
+			t.Fatalf("register primary: %v", err)
+		}
+		if err := mockClient.RegisterScenario(ctx, &mockllm.Scenario{
+			ID:             "fallback-secondary",
+			Provider:       "openai",
+			Content:        "Hello from secondary!",
+			ChunkSize:      20,
+			InitialDelayMs: 10,
+			ChunkDelayMs:   5,
+		}); err != nil {
+			t.Fatalf("register secondary: %v", err)
+		}
+
+		resp, err := bamlClient.Call(ctx, testutil.CallRequest{
+			Method: "GetGreetingFallbackPair",
+			Input:  map[string]any{"name": "Bridge"},
+		})
+		if err != nil {
+			t.Fatalf("Call failed: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		var result string
+		if err := json.Unmarshal(resp.Body, &result); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if result != "Hello from secondary!" {
+			t.Errorf("got %q, want %q", result, "Hello from secondary!")
+		}
+
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI, "streamrequest")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestFallbackPair")
+		// Secondary won; surface it as winner-client to distinguish from
+		// the strategy name in planned.Client.
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackSecondary")
+		testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
+	})
 }

--- a/integration/bridge_test.go
+++ b/integration/bridge_test.go
@@ -241,3 +241,167 @@ func TestCallBridge_ForcesStreamRequest(t *testing.T) {
 		testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
 	})
 }
+
+// TestCallBridge_MixedChainFallsThrough exercises the call block's mixed-
+// chain fall-through gate: when ResolveFallbackChain returns a non-empty
+// chain with some call-legacy children, the call block must decline so the
+// bridge can re-resolve with IsProviderSupported and drive those children
+// through StreamRequest rather than legacyCallChildFn.
+//
+// The previous test used BAML_REST_DISABLE_CALL_BUILD_REQUEST to force every
+// provider call-unsupported, which short-circuits ResolveFallbackChain to
+// a nil chain (all-legacy path). That proves the bridge's fallback branch
+// works, but does not exercise the new gate — the gate fires specifically
+// on mixed chains, i.e. chain != nil with legacyChildren non-empty.
+//
+// This test uses the debug-build BAML_REST_CALL_UNSUPPORTED_PROVIDERS hook
+// to mark a single provider (openai-generic) as call-unsupported while
+// leaving it stream-supported. A runtime client_registry override switches
+// FallbackPrimary to openai-generic; FallbackSecondary stays openai. Under
+// that setup:
+//
+//   - Call-side ResolveFallbackChain(..., IsCallProviderSupported) sees
+//     FallbackPrimary as !callOK, FallbackSecondary as callOK → returns a
+//     non-empty mixed chain with legacyChildren={FallbackPrimary:true}.
+//   - The new gate — len(chain) > 0 && len(legacyChildren) == 0 — fails
+//     on the second clause, so the call block declines.
+//   - The bridge block re-resolves with IsProviderSupported (both
+//     providers stream-supported), accepts the chain with no legacy
+//     children, and RunStreamOrchestration walks primary → secondary.
+//
+// Requires the debug build tag (see cmd/build/build.sh), which the
+// integration testcontainer already enables.
+func TestCallBridge_MixedChainFallsThrough(t *testing.T) {
+	if !ActuallyBuildRequest() {
+		t.Skip("bridge requires BuildRequest path; skipping on legacy or pre-0.219 runtimes")
+	}
+
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer setupCancel()
+
+	adapterVersion, err := testutil.GetAdapterVersionForBAML(BAMLVersion)
+	if err != nil {
+		t.Fatalf("Failed to get adapter version: %v", err)
+	}
+	bamlSrcPath, err := findTestdataPath()
+	if err != nil {
+		t.Fatalf("Failed to find testdata: %v", err)
+	}
+
+	env, err := testutil.Setup(setupCtx, testutil.SetupOptions{
+		BAMLSrcPath:     bamlSrcPath,
+		BAMLVersion:     BAMLVersion,
+		AdapterVersion:  adapterVersion,
+		BAMLSource:      BAMLSourcePath,
+		UseBuildRequest: true,
+		RuntimeEnv: map[string]string{
+			// Mark openai-generic as call-unsupported (but still stream-
+			// supported). Debug-tag only — no effect on release builds.
+			"BAML_REST_CALL_UNSUPPORTED_PROVIDERS": "openai-generic",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to setup dedicated env: %v", err)
+	}
+	defer func() {
+		termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer termCancel()
+		if err := env.Terminate(termCtx); err != nil {
+			t.Logf("dedicated env Terminate: %v", err)
+		}
+	}()
+
+	mockClient := mockllm.NewClient(env.MockLLMURL)
+	bamlClient := testutil.NewBAMLRestClient(env.BAMLRestURL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Primary always fails (500); secondary succeeds. openai-generic and
+	// openai both use OpenAI wire format, so a single /v1/chat/completions
+	// handler on the mock serves both — the 500 fires before any provider-
+	// specific parsing matters.
+	if err := mockClient.RegisterScenario(ctx, &mockllm.Scenario{
+		ID:          "fallback-primary",
+		Provider:    "openai",
+		Content:     "should not see this",
+		FailAfter:   1,
+		FailureMode: "500",
+	}); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if err := mockClient.RegisterScenario(ctx, &mockllm.Scenario{
+		ID:             "fallback-secondary",
+		Provider:       "openai",
+		Content:        "Hello from mixed-chain secondary!",
+		ChunkSize:      20,
+		InitialDelayMs: 10,
+		ChunkDelayMs:   5,
+	}); err != nil {
+		t.Fatalf("register secondary: %v", err)
+	}
+
+	// Runtime client_registry: override FallbackPrimary's provider to
+	// openai-generic (call-unsupported under the debug flag, stream-
+	// supported) and keep FallbackSecondary on openai (call-supported).
+	// Both children hit the mock's OpenAI-format endpoint so the failure
+	// path is deterministic.
+	baseURL := env.MockLLMInternal
+	registry := &testutil.ClientRegistry{
+		Primary: "TestFallbackPair",
+		Clients: []*testutil.ClientProperty{
+			{
+				Name:     "FallbackPrimary",
+				Provider: "openai-generic",
+				Options: map[string]any{
+					"model":    "fallback-primary",
+					"base_url": baseURL,
+					"api_key":  "test-key",
+				},
+			},
+			{
+				Name:     "FallbackSecondary",
+				Provider: "openai",
+				Options: map[string]any{
+					"model":    "fallback-secondary",
+					"base_url": baseURL,
+					"api_key":  "test-key",
+				},
+			},
+		},
+	}
+
+	resp, err := bamlClient.Call(ctx, testutil.CallRequest{
+		Method: "GetGreetingFallbackPair",
+		Input:  map[string]any{"name": "Mixed"},
+		Options: &testutil.BAMLOptions{
+			ClientRegistry: registry,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, resp.Error)
+	}
+
+	var result string
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result != "Hello from mixed-chain secondary!" {
+		t.Errorf("got %q, want %q", result, "Hello from mixed-chain secondary!")
+	}
+
+	// The headers prove routing: BuildRequestAPI=streamrequest means the
+	// bridge block served the request, not the legacy path and not the
+	// call block. A value of "request" (call block) or absence of this
+	// header (legacy path) here would mean the mixed-chain gate did not
+	// fire as expected.
+	testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
+	testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI, "streamrequest")
+	testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestFallbackPair")
+	testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackSecondary")
+	testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+	testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
+}

--- a/integration/call_test.go
+++ b/integration/call_test.go
@@ -51,6 +51,12 @@ func TestCallEndpoint(t *testing.T) {
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestClient")
 			if ActuallyBuildRequest() {
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
+				// Non-streaming /call on a BuildRequest-capable provider
+				// uses the Request API (block 1 wins before the stream-bridge
+				// block). The header distinguishes this from a stream-bridged
+				// /call; its presence alone proves the call went through the
+				// BuildRequest layer rather than legacy.
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI, "request")
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLRetryCount, "0")
 				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
@@ -61,6 +67,8 @@ func TestCallEndpoint(t *testing.T) {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "legacy")
+				// Legacy path does not set BuildRequestAPI.
+				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI)
 				// Single-provider legacy route: WinnerProvider falls back to
 				// the planned Provider via BuildLegacyOutcome's ladder;
 				// WinnerClient is suppressed because it equals planned.Client.
@@ -396,6 +404,9 @@ func TestCallWithRawEndpoint(t *testing.T) {
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestClient")
 			if ActuallyBuildRequest() {
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
+				// /call-with-raw on a BuildRequest-capable provider uses the
+				// Request API; the stream-bridge would report "streamrequest".
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI, "request")
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLRetryCount, "0")
 				testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
@@ -403,6 +414,7 @@ func TestCallWithRawEndpoint(t *testing.T) {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "legacy")
+				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI)
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLWinnerClient)
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -2285,6 +2285,11 @@ func (m *metadataTracker) assertBuildRequestInvariants() {
 		if m.planned.Path != "buildrequest" {
 			m.t.Errorf("planned.Path: got %q, want %q", m.planned.Path, "buildrequest")
 		}
+		// /stream and /stream-with-raw always use the StreamRequest API on
+		// the BuildRequest path — the Request API is call-only.
+		if m.planned.BuildRequestAPI != "streamrequest" {
+			m.t.Errorf("planned.BuildRequestAPI: got %q, want %q", m.planned.BuildRequestAPI, "streamrequest")
+		}
 		if m.planned.Client == "" {
 			m.t.Errorf("planned.Client: expected non-empty on BuildRequest path")
 		}

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -331,18 +331,19 @@ func (e *StreamEvent) IsMetadata() bool {
 // server-side bamlutils package, and a full mirror would drift as unused
 // fields get added. Extend this only when a test needs a new field.
 type StreamMetadata struct {
-	Phase          string   `json:"phase"`
-	Path           string   `json:"path,omitempty"`
-	Client         string   `json:"client,omitempty"`
-	Strategy       string   `json:"strategy,omitempty"`
-	Chain          []string `json:"chain,omitempty"`
-	RetryMax       *int     `json:"retry_max,omitempty"`
-	RetryCount     *int     `json:"retry_count,omitempty"`
-	WinnerClient   string   `json:"winner_client,omitempty"`
-	WinnerProvider string   `json:"winner_provider,omitempty"`
-	WinnerPath     string   `json:"winner_path,omitempty"`
-	UpstreamDurMs  *int64   `json:"upstream_duration_ms,omitempty"`
-	BamlCallCount  *int     `json:"baml_call_count,omitempty"`
+	Phase           string   `json:"phase"`
+	Path            string   `json:"path,omitempty"`
+	BuildRequestAPI string   `json:"build_request_api,omitempty"`
+	Client          string   `json:"client,omitempty"`
+	Strategy        string   `json:"strategy,omitempty"`
+	Chain           []string `json:"chain,omitempty"`
+	RetryMax        *int     `json:"retry_max,omitempty"`
+	RetryCount      *int     `json:"retry_count,omitempty"`
+	WinnerClient    string   `json:"winner_client,omitempty"`
+	WinnerProvider  string   `json:"winner_provider,omitempty"`
+	WinnerPath      string   `json:"winner_path,omitempty"`
+	UpstreamDurMs   *int64   `json:"upstream_duration_ms,omitempty"`
+	BamlCallCount   *int     `json:"baml_call_count,omitempty"`
 }
 
 // ParseMetadata decodes a metadata event's data payload.
@@ -901,6 +902,7 @@ func parseNDJSON(ctx context.Context, r io.Reader, events chan<- StreamEvent) er
 const (
 	HeaderBAMLPath             = "X-BAML-Path"
 	HeaderBAMLPathReason       = "X-BAML-Path-Reason"
+	HeaderBAMLBuildRequestAPI  = "X-BAML-Build-Request-API"
 	HeaderBAMLClient           = "X-BAML-Client"
 	HeaderBAMLWinnerClient     = "X-BAML-Winner-Client"
 	HeaderBAMLWinnerProvider   = "X-BAML-Winner-Provider"


### PR DESCRIPTION
## Summary

- `/call` and `/call-with-raw` now fall through to the streaming BuildRequest path (SSE accumulated into a unary response) when the non-streaming `Request` API is unavailable for the resolved provider/chain — instead of going straight to legacy.
- Reset events emitted on retry boundaries and between failed fallback children are now gated on `NeedsPartials`. Under `NeedsPartials=false` there is no partial audience, and the reset event would falsely flip the pool's `gotFirstByte` flag before the next retry's upstream produces a byte, disabling hung detection. Heartbeat re-arm still runs.
- Adds `BuildRequestAPI` (`"request"` vs `"streamrequest"`) on planned metadata / `X-BAML-Build-Request-API` header so a bridged `/call` is distinguishable from a native non-streaming one.

## Design

Router (per generated method) now has four ordered blocks:

1. Non-streaming BuildRequest (`Request` API, `RunCallOrchestration`) — call modes only
2. Streaming BuildRequest (`StreamRequest` API, `RunStreamOrchestration`) — stream modes only
3. **NEW**: Bridge — streaming BuildRequest for call modes, emitted when `hasBuildRequest`; gates on `IsProviderSupported` (stream side), not `IsCallProviderSupported`
4. Legacy `CallStream + OnTick`

No new accumulation code: `RunStreamOrchestration` with `NeedsPartials=false` + `NeedsRaw=streamMode.NeedsRaw()` already produces the shape `pool.Call` drains — heartbeat → planned metadata → outcome metadata → single `StreamResultKindFinal` with raw populated. The adapter's `StreamMode()` is read per-request into the existing `StreamConfig` wiring, so the generated `{method}_buildRequest` method is reused verbatim.

## Test plan

- [ ] `go test ./bamlutils/...` — includes new reset-suppression tests (`TestRunStreamOrchestration_NoResetWhenNeedsPartialsFalse_{Retry,FallbackChain}`) and the call-bridge shape test (`TestRunStreamOrchestration_CallBridge_ShapedLikeUnary`), plus `BuildRequestAPI` plan-builder tests.
- [ ] `go test -tags unaryserver ./cmd/serve/...` — includes new header tests for `X-BAML-Build-Request-API`.
- [ ] `go test -tags integration ./integration/...` — `/call`, `/call-with-raw`, and `/stream*` now assert the expected `BuildRequestAPI` header/field.
- [ ] Manual verification that a provider where `Request` is unavailable but `StreamRequest` is supported now routes through the bridge (planned metadata shows `BuildRequestAPI=streamrequest`, path still `buildrequest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Requests now record which BuildRequest API handled them (request vs stream) and expose it via the X-BAML-Build-Request-API response header.
  * /call and /call-with-raw can be routed through a streaming bridge when available; an environment toggle can force routing away from non-streaming call handling.
  * Debug toggle to mark specific providers as call-unsupported for testing.

* **Tests**
  * Expanded integration and unit tests covering routing, bridge behavior, headers, retries, fallback chains, and environment parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->