### PR TITLE
feat: introduce IncludeThinkingInRaw opt-in (Anthropic; phase 1 of #195)

### DIFF
--- a/adapters/adapter_v0_204_0/adapter/adapter.go
+++ b/adapters/adapter_v0_204_0/adapter/adapter.go
@@ -36,6 +36,13 @@ type BamlAdapter struct {
 	// retryConfig holds per-request retry overrides from __baml_options__.retry.
 	retryConfig *bamlutils.RetryConfig
 
+	// includeThinkingInRaw is the per-request opt-in for surfacing
+	// provider-specific reasoning/thinking content in /with-raw's raw
+	// field. Mirrors __baml_options__.include_thinking_in_raw and is
+	// honored by the SSE/non-streaming extractors. Never affects the
+	// parseable text passed to Parse/ParseStream.
+	includeThinkingInRaw bool
+
 	// clientRegistryProvider is the provider of the primary client from
 	// the runtime ClientRegistry override. Empty if no override.
 	clientRegistryProvider string
@@ -50,6 +57,14 @@ func (b *BamlAdapter) SetRetryConfig(config *bamlutils.RetryConfig) {
 
 func (b *BamlAdapter) RetryConfig() *bamlutils.RetryConfig {
 	return b.retryConfig
+}
+
+func (b *BamlAdapter) SetIncludeThinkingInRaw(includeThinking bool) {
+	b.includeThinkingInRaw = includeThinking
+}
+
+func (b *BamlAdapter) IncludeThinkingInRaw() bool {
+	return b.includeThinkingInRaw
 }
 
 func (b *BamlAdapter) SetClientRegistry(clientRegistry *bamlutils.ClientRegistry) error {

--- a/adapters/adapter_v0_215_0/adapter/adapter.go
+++ b/adapters/adapter_v0_215_0/adapter/adapter.go
@@ -36,6 +36,13 @@ type BamlAdapter struct {
 	// retryConfig holds per-request retry overrides from __baml_options__.retry.
 	retryConfig *bamlutils.RetryConfig
 
+	// includeThinkingInRaw is the per-request opt-in for surfacing
+	// provider-specific reasoning/thinking content in /with-raw's raw
+	// field. Mirrors __baml_options__.include_thinking_in_raw and is
+	// honored by the SSE/non-streaming extractors. Never affects the
+	// parseable text passed to Parse/ParseStream.
+	includeThinkingInRaw bool
+
 	// clientRegistryProvider is the provider of the primary client from
 	// the runtime ClientRegistry override. Empty if no override.
 	clientRegistryProvider string
@@ -50,6 +57,14 @@ func (b *BamlAdapter) SetRetryConfig(config *bamlutils.RetryConfig) {
 
 func (b *BamlAdapter) RetryConfig() *bamlutils.RetryConfig {
 	return b.retryConfig
+}
+
+func (b *BamlAdapter) SetIncludeThinkingInRaw(includeThinking bool) {
+	b.includeThinkingInRaw = includeThinking
+}
+
+func (b *BamlAdapter) IncludeThinkingInRaw() bool {
+	return b.includeThinkingInRaw
 }
 
 func (b *BamlAdapter) SetClientRegistry(clientRegistry *bamlutils.ClientRegistry) error {

--- a/adapters/adapter_v0_219_0/adapter/adapter.go
+++ b/adapters/adapter_v0_219_0/adapter/adapter.go
@@ -37,6 +37,13 @@ type BamlAdapter struct {
 	// retryConfig holds per-request retry overrides from __baml_options__.retry.
 	retryConfig *bamlutils.RetryConfig
 
+	// includeThinkingInRaw is the per-request opt-in for surfacing
+	// provider-specific reasoning/thinking content in /with-raw's raw
+	// field. Mirrors __baml_options__.include_thinking_in_raw and is
+	// honored by the SSE/non-streaming extractors. Never affects the
+	// parseable text passed to Parse/ParseStream.
+	includeThinkingInRaw bool
+
 	// clientRegistryProvider is the provider of the primary client from
 	// the runtime ClientRegistry override. Empty if no override.
 	clientRegistryProvider string
@@ -57,6 +64,14 @@ func (b *BamlAdapter) SetRetryConfig(config *bamlutils.RetryConfig) {
 
 func (b *BamlAdapter) RetryConfig() *bamlutils.RetryConfig {
 	return b.retryConfig
+}
+
+func (b *BamlAdapter) SetIncludeThinkingInRaw(includeThinking bool) {
+	b.includeThinkingInRaw = includeThinking
+}
+
+func (b *BamlAdapter) IncludeThinkingInRaw() bool {
+	return b.includeThinkingInRaw
 }
 
 func (b *BamlAdapter) SetClientRegistry(clientRegistry *bamlutils.ClientRegistry) error {

--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -1831,15 +1831,16 @@ func Generate(selfPkg string) {
 				// routing metadata through to the orchestrator's planned +
 				// outcome emissions.
 				jen.Id("streamConfig").Op(":=").Op("&").Qual(common.BuildRequestPkg, "StreamConfig").Values(jen.Dict{
-					jen.Id("Provider"):          jen.Id("provider"),
-					jen.Id("RetryPolicy"):       jen.Id("retryPolicy"),
-					jen.Id("NeedsPartials"):     jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsPartials").Call(),
-					jen.Id("NeedsRaw"):          jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsRaw").Call(),
-					jen.Id("FallbackChain"):     jen.Id("fallbackChain"),
-					jen.Id("ClientProviders"):   jen.Id("clientProviders"),
-					jen.Id("LegacyChildren"):    jen.Id("legacyChildren"),
-					jen.Id("LegacyStreamChild"): jen.Id("legacyStreamChildFn"),
-					jen.Id("MetadataPlan"):      jen.Id("plannedMetadata"),
+					jen.Id("Provider"):             jen.Id("provider"),
+					jen.Id("RetryPolicy"):          jen.Id("retryPolicy"),
+					jen.Id("NeedsPartials"):        jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsPartials").Call(),
+					jen.Id("NeedsRaw"):             jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsRaw").Call(),
+					jen.Id("IncludeThinkingInRaw"): jen.Id("adapter").Dot("IncludeThinkingInRaw").Call(),
+					jen.Id("FallbackChain"):        jen.Id("fallbackChain"),
+					jen.Id("ClientProviders"):      jen.Id("clientProviders"),
+					jen.Id("LegacyChildren"):       jen.Id("legacyChildren"),
+					jen.Id("LegacyStreamChild"):    jen.Id("legacyStreamChildFn"),
+					jen.Id("MetadataPlan"):         jen.Id("plannedMetadata"),
 					jen.Id("NewMetadataResult"): jen.Func().Params(
 						jen.Id("md").Op("*").Qual(common.InterfacesPkg, "Metadata"),
 					).Qual(common.InterfacesPkg, "StreamResult").Block(
@@ -2080,14 +2081,15 @@ func Generate(selfPkg string) {
 				// LegacyCallChild is always wired so validation passes even
 				// when legacyChildren is nil.
 				jen.Id("callConfig").Op(":=").Op("&").Qual(common.BuildRequestPkg, "CallConfig").Values(jen.Dict{
-					jen.Id("Provider"):          jen.Id("provider"),
-					jen.Id("RetryPolicy"):       jen.Id("retryPolicy"),
-					jen.Id("NeedsRaw"):          jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsRaw").Call(),
-					jen.Id("FallbackChain"):     jen.Id("fallbackChain"),
-					jen.Id("ClientProviders"):   jen.Id("clientProviders"),
-					jen.Id("LegacyChildren"):    jen.Id("legacyChildren"),
-					jen.Id("LegacyCallChild"):   jen.Id("legacyCallChildFn"),
-					jen.Id("MetadataPlan"):      jen.Id("plannedMetadata"),
+					jen.Id("Provider"):             jen.Id("provider"),
+					jen.Id("RetryPolicy"):          jen.Id("retryPolicy"),
+					jen.Id("NeedsRaw"):             jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsRaw").Call(),
+					jen.Id("IncludeThinkingInRaw"): jen.Id("adapter").Dot("IncludeThinkingInRaw").Call(),
+					jen.Id("FallbackChain"):        jen.Id("fallbackChain"),
+					jen.Id("ClientProviders"):      jen.Id("clientProviders"),
+					jen.Id("LegacyChildren"):       jen.Id("legacyChildren"),
+					jen.Id("LegacyCallChild"):      jen.Id("legacyCallChildFn"),
+					jen.Id("MetadataPlan"):         jen.Id("plannedMetadata"),
 					jen.Id("NewMetadataResult"): jen.Func().Params(
 						jen.Id("md").Op("*").Qual(common.InterfacesPkg, "Metadata"),
 					).Qual(common.InterfacesPkg, "StreamResult").Block(
@@ -3879,8 +3881,17 @@ func generateStreamHelpers(out *jen.File) {
 			jen.Var().Id("fatalMu").Qual("sync", "Mutex"),
 			jen.Var().Id("fatalErr").Error(),
 
-			// Extractor
-			jen.Id("extractor").Op(":=").Qual(common.SSEPkg, "NewIncrementalExtractor").Call(),
+			// Extractor. The boolean argument captures the per-request
+			// IncludeThinkingInRaw opt-in: when true, Anthropic
+			// thinking_delta events are accumulated into the extractor's
+			// raw buffer alongside text deltas; when false (default), the
+			// extractor matches BAML's RawLLMResponse() text-only
+			// semantics. Parseable text seen by Parse/ParseStream is never
+			// affected by this flag — the extractor only feeds the raw
+			// channel.
+			jen.Id("extractor").Op(":=").Qual(common.SSEPkg, "NewIncrementalExtractor").Call(
+				jen.Id("adapter").Dot("IncludeThinkingInRaw").Call(),
+			),
 			jen.Var().Id("extractorMu").Qual("sync", "Mutex"),
 			// lastFuncLog stores the most recent FunctionLog reference seen by
 			// onTick. FunctionLog is a live handle into the BAML runtime, so
@@ -4103,24 +4114,28 @@ func generateStreamHelpers(out *jen.File) {
 							jen.Id("_").Op("=").Id("processTick").Call(jen.Id("fl"), jen.Id("extractor"), jen.Op("&").Id("extractorMu")),
 						),
 
-						// Emit final. The /with-raw contract for this codebase is
-						// that raw includes provider-specific raw-only content
-						// (e.g. Anthropic thinking deltas) that parseable excludes.
-						// The extractor accumulates delta.Raw, which preserves that
-						// semantic; FunctionLog.RawLLMResponse() is built from
-						// text_delta only and drops thinking_delta.
+						// Emit final. Reconciling extractor.Full() with
+						// RawLLMResponse() handles two distinct concerns:
 						//
-						// Under normal conditions extractor.Full() is authoritative.
-						// But in rare CI-only races where lastFuncLog's SSEChunks
-						// view is stale (onTick didn't cover the final SSE event),
-						// the extractor can end up truncated or empty while
-						// RawLLMResponse is complete. Prefer whichever is longer:
-						//   - Anthropic with thinking: extractor > RawLLMResponse
-						//     (extractor wins, thinking preserved).
-						//   - Other providers / anthropic w/o thinking: equal, or
-						//     extractor shorter on timing loss (RawLLMResponse
-						//     wins, matches parseable which is the full content
-						//     for those providers anyway).
+						//   - Stale-SSE-view race (always-on): in rare CI-only
+						//     races where lastFuncLog's SSEChunks view is stale
+						//     (onTick didn't cover the final SSE event), the
+						//     extractor can end up truncated or empty while
+						//     RawLLMResponse is complete. RawLLMResponse wins.
+						//
+						//   - IncludeThinkingInRaw opt-in (per-request): when
+						//     enabled, the extractor accumulates Anthropic
+						//     thinking_delta into raw while BAML's runtime never
+						//     surfaces thinking. The extractor's view is then
+						//     longer; extractor wins so opted-in clients see the
+						//     reasoning content.
+						//
+						// Picking the longer of the two satisfies both goals:
+						// the extractor wins under flag=true (thinking content
+						// preserved) and RawLLMResponse wins under stale-SSE
+						// races (truncation absorbed). Under happy-path
+						// flag=false, both are equal text-only and the choice
+						// is immaterial.
 						jen.Id("extractorMu").Dot("Lock").Call(),
 						jen.Id("finalRaw").Op(":=").Id("extractor").Dot("Full").Call(),
 						jen.Id("extractorMu").Dot("Unlock").Call(),

--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -1403,11 +1403,38 @@ func Generate(selfPkg string) {
 				jen.Id("extractor"), jen.Id("callCount"), jen.Id("provider"), jen.Id("chunks"),
 			),
 			jen.If(jen.Id("skipIntermediateParsing")).Block(jen.Return(jen.Nil())),
-			jen.If(jen.Id("extractResult").Dot("Delta").Op("==").Lit("").Op("&&").Op("!").Id("extractResult").Dot("Reset")).Block(jen.Return(jen.Nil())),
-			jen.Id("raw").Op(":=").Id("extractResult").Dot("Full"),
-			jen.Id("rawDelta").Op(":=").Id("extractResult").Dot("Delta"),
-			// Short-circuit: empty delta/raw → emit reset-only result
-			jen.If(jen.Id("rawDelta").Op("==").Lit("").Op("||").Id("raw").Op("==").Lit("")).Block(
+			// Skip if absolutely nothing new arrived this tick (no delta on
+			// either buffer) and no reset occurred.
+			jen.If(
+				jen.Id("extractResult").Dot("ParseableDelta").Op("==").Lit("").
+					Op("&&").Id("extractResult").Dot("RawDelta").Op("==").Lit("").
+					Op("&&").Op("!").Id("extractResult").Dot("Reset"),
+			).Block(jen.Return(jen.Nil())),
+			// parseable is the cumulative text-only buffer fed to ParseStream.
+			// Reasoning content (e.g. Anthropic thinking_delta under
+			// IncludeThinkingInRaw=true) is excluded by construction in
+			// IncrementalExtractor, so the BAML parser sees only the textual
+			// response stream regardless of the opt-in flag.
+			jen.Id("parseable").Op(":=").Id("extractResult").Dot("ParseableFull"),
+			jen.Id("parseableDelta").Op(":=").Id("extractResult").Dot("ParseableDelta"),
+			// rawDelta is the per-tick wire-output content. Mirrors
+			// parseableDelta when the opt-in is off; additionally carries
+			// thinking_delta content under opt-in.
+			jen.Id("rawDelta").Op(":=").Id("extractResult").Dot("RawDelta"),
+			// Raw-only / reset-only path. Triggered when:
+			//   - No parseable content has accumulated yet (e.g., the only
+			//     events seen so far are thinking_delta under opt-in).
+			//   - No new parseable content this tick (e.g., a thinking-only
+			//     event under opt-in advanced raw but not parseable).
+			//   - A reset boundary occurred but parseable is empty.
+			//
+			// In all three cases we cannot meaningfully call ParseStream, but
+			// we still emit a partial so the wire's raw buffer accumulates and
+			// any reset boundary reaches the client.
+			jen.If(
+				jen.Id("parseable").Op("==").Lit("").
+					Op("||").Id("parseableDelta").Op("==").Lit(""),
+			).Block(
 				jen.Select().Block(
 					jen.Case(jen.Op("<-").Id("adapter").Dot("Done").Call()).Block(jen.Return(jen.Nil())),
 					jen.Default().Block(),
@@ -1432,10 +1459,10 @@ func Generate(selfPkg string) {
 				),
 				jen.Return(jen.Nil()),
 			),
-			// Call ParseStream
+			// Call ParseStream on the cumulative parseable buffer.
 			jen.List(jen.Id("parsed"), jen.Id("parseErr")).Op(":=").
 				Qual(common.GeneratedClientPkg, "ParseStream").Dot(methodName).Call(
-				jen.Id("adapter"), jen.Id("raw"), jen.Id("options").Op("..."),
+				jen.Id("adapter"), jen.Id("parseable"), jen.Id("options").Op("..."),
 			),
 			jen.If(jen.Id("parseErr").Op("==").Nil()).Block(
 				jen.Select().Block(
@@ -4114,7 +4141,7 @@ func generateStreamHelpers(out *jen.File) {
 							jen.Id("_").Op("=").Id("processTick").Call(jen.Id("fl"), jen.Id("extractor"), jen.Op("&").Id("extractorMu")),
 						),
 
-						// Emit final. Reconciling extractor.Full() with
+						// Emit final. Reconciling extractor.RawFull() with
 						// RawLLMResponse() handles two distinct concerns:
 						//
 						//   - Stale-SSE-view race (always-on): in rare CI-only
@@ -4137,7 +4164,7 @@ func generateStreamHelpers(out *jen.File) {
 						// flag=false, both are equal text-only and the choice
 						// is immaterial.
 						jen.Id("extractorMu").Dot("Lock").Call(),
-						jen.Id("finalRaw").Op(":=").Id("extractor").Dot("Full").Call(),
+						jen.Id("finalRaw").Op(":=").Id("extractor").Dot("RawFull").Call(),
 						jen.Id("extractorMu").Dot("Unlock").Call(),
 						jen.If(jen.Id("flOk")).Block(
 							jen.If(

--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -4148,30 +4148,51 @@ func generateStreamHelpers(out *jen.File) {
 						//     races where lastFuncLog's SSEChunks view is stale
 						//     (onTick didn't cover the final SSE event), the
 						//     extractor can end up truncated or empty while
-						//     RawLLMResponse is complete. RawLLMResponse wins.
+						//     RawLLMResponse is complete. We splice in only the
+						//     missing text suffix from RawLLMResponse so any
+						//     late text the extractor missed is recovered.
 						//
 						//   - IncludeThinkingInRaw opt-in (per-request): when
 						//     enabled, the extractor accumulates Anthropic
 						//     thinking_delta into raw while BAML's runtime never
-						//     surfaces thinking. The extractor's view is then
-						//     longer; extractor wins so opted-in clients see the
-						//     reasoning content.
+						//     surfaces thinking. The splice approach preserves
+						//     thinking content (which lives only in
+						//     extractor.RawFull) alongside any recovered text.
 						//
-						// Picking the longer of the two satisfies both goals:
-						// the extractor wins under flag=true (thinking content
-						// preserved) and RawLLMResponse wins under stale-SSE
-						// races (truncation absorbed). Under happy-path
-						// flag=false, both are equal text-only and the choice
-						// is immaterial.
+						// Reconciliation logic:
+						//   1. If RawLLMResponse extends extractor.ParseableFull
+						//      as a prefix and is longer, splice in the missing
+						//      text suffix. This is the common case under both
+						//      stale-race and happy-path-with-opt-in.
+						//   2. Else if RawLLMResponse is longer than
+						//      extractor.RawFull (the prefix invariant is
+						//      violated — should not happen under Anthropic's
+						//      thinking-then-text ordering, but defend anyway),
+						//      defer to RawLLMResponse for correctness. This
+						//      loses thinking under opt-in but ensures the
+						//      authoritative text wins.
+						//   3. Else keep extractor.RawFull (happy path:
+						//      extractor's view is at least as complete).
 						jen.Id("extractorMu").Dot("Lock").Call(),
 						jen.Id("finalRaw").Op(":=").Id("extractor").Dot("RawFull").Call(),
+						jen.Id("parseableFull").Op(":=").Id("extractor").Dot("ParseableFull").Call(),
 						jen.Id("extractorMu").Dot("Unlock").Call(),
 						jen.If(jen.Id("flOk")).Block(
 							jen.If(
 								jen.List(jen.Id("authRaw"), jen.Id("rawErr")).Op(":=").Id("fl").Dot("RawLLMResponse").Call(),
-								jen.Id("rawErr").Op("==").Nil().Op("&&").Len(jen.Id("authRaw")).Op(">").Len(jen.Id("finalRaw")),
+								jen.Id("rawErr").Op("==").Nil(),
 							).Block(
-								jen.Id("finalRaw").Op("=").Id("authRaw"),
+								jen.If(
+									jen.Len(jen.Id("authRaw")).Op(">").Len(jen.Id("parseableFull")).
+										Op("&&").
+										Qual("strings", "HasPrefix").Call(jen.Id("authRaw"), jen.Id("parseableFull")),
+								).Block(
+									jen.Id("finalRaw").Op("=").Id("finalRaw").Op("+").Id("authRaw").Index(jen.Len(jen.Id("parseableFull")), jen.Empty()),
+								).Else().If(
+									jen.Len(jen.Id("authRaw")).Op(">").Len(jen.Id("finalRaw")),
+								).Block(
+									jen.Id("finalRaw").Op("=").Id("authRaw"),
+								),
 							),
 						),
 

--- a/bamlutils/buildrequest/call_orchestrator.go
+++ b/bamlutils/buildrequest/call_orchestrator.go
@@ -29,6 +29,14 @@ type CallConfig struct {
 	// (for /call-with-raw endpoint).
 	NeedsRaw bool
 
+	// IncludeThinkingInRaw is the per-request opt-in for surfacing
+	// provider-specific reasoning/thinking content in raw. When true,
+	// the response extractor accumulates Anthropic thinking blocks
+	// into raw alongside text blocks. When false (default), raw
+	// matches BAML's RawLLMResponse() text-only semantics. The flag
+	// never affects the parseable text passed to Parse.
+	IncludeThinkingInRaw bool
+
 	// FallbackChain is the ordered list of child client names for fallback
 	// strategies. When non-empty, each retry attempt walks the entire chain
 	// in order; if any child succeeds, the attempt returns immediately.
@@ -91,17 +99,21 @@ type BuildCallRequestFunc func(ctx context.Context, clientOverride string) (*llm
 
 // ExtractResponseFunc extracts the LLM output text from a non-streaming
 // JSON response body. Returns two strings: parseable (for Parse.Method)
-// and raw (for /call-with-raw's Raw()). For most providers these are
-// identical; for Anthropic with extended thinking, raw includes thinking
-// blocks while parseable does not.
-type ExtractResponseFunc func(provider string, responseBody string) (parseable, raw string, err error)
+// and raw (for /call-with-raw's Raw()).
+//
+// Parseable is always text-only — reasoning/thinking content is never
+// accumulated into it, so the BAML parser cannot be influenced by
+// reasoning text. Raw matches parseable by default; when includeThinking
+// is true the function may additionally surface provider-specific
+// reasoning (e.g. Anthropic thinking blocks) in raw for telemetry.
+type ExtractResponseFunc func(provider string, responseBody string, includeThinking bool) (parseable, raw string, err error)
 
 // RunCallOrchestration executes the non-streaming BuildRequest path.
 //
 // Flow — single retry loop covering HTTP, extraction, and parsing:
 //  1. buildRequest(ctx, clientOverride) → llmhttp.Request
 //  2. httpClient.Execute(ctx, req, onSuccess) → llmhttp.Response
-//  3. extractResponse(provider, body) → parseable + raw text
+//  3. extractResponse(provider, body, includeThinking) → parseable + raw text
 //  4. parseFinal(ctx, parseable) → typed result
 //  5. emit StreamResultKindFinal on channel
 //
@@ -258,7 +270,7 @@ func RunCallOrchestration(
 			return nil, httpErr
 		}
 
-		parseable, raw, extractErr := extractResponse(provider, resp.Body)
+		parseable, raw, extractErr := extractResponse(provider, resp.Body, config.IncludeThinkingInRaw)
 		if extractErr != nil {
 			return nil, fmt.Errorf("buildrequest: failed to extract response content: %w", extractErr)
 		}

--- a/bamlutils/buildrequest/call_orchestrator_test.go
+++ b/bamlutils/buildrequest/call_orchestrator_test.go
@@ -526,11 +526,9 @@ func TestRunCallOrchestration_Anthropic(t *testing.T) {
 	}
 }
 
-func TestRunCallOrchestration_AnthropicThinkingSplit(t *testing.T) {
-	// End-to-end test proving the parseable/raw split is wired correctly
-	// through RunCallOrchestration. The mock server returns a response with
-	// both thinking and text blocks. parseFinal should receive ONLY the
-	// text content, while Raw() should contain thinking + text.
+func TestRunCallOrchestration_AnthropicThinkingSplit_Default(t *testing.T) {
+	// Default (IncludeThinkingInRaw=false, BAML-aligned): both parseable and
+	// raw exclude thinking. parseFinal receives text only; Raw() returns text.
 	body := `{"content":[{"type":"thinking","thinking":"Step 1: reason..."},{"type":"text","text":"The answer is 42"}],"stop_reason":"end_turn"}`
 	server := makeJSONServer(200, body)
 	defer server.Close()
@@ -539,11 +537,11 @@ func TestRunCallOrchestration_AnthropicThinkingSplit(t *testing.T) {
 	out := make(chan bamlutils.StreamResult, 100)
 
 	config := &CallConfig{
-		Provider: "anthropic",
-		NeedsRaw: true,
+		Provider:             "anthropic",
+		NeedsRaw:             true,
+		IncludeThinkingInRaw: false,
 	}
 
-	// Track what parseFinal actually received
 	var parseFinalInput string
 	captureParseFinal := func(_ context.Context, text string) (any, error) {
 		parseFinalInput = text
@@ -563,12 +561,73 @@ func TestRunCallOrchestration_AnthropicThinkingSplit(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify parseFinal received only the text content (no thinking)
 	if parseFinalInput != "The answer is 42" {
 		t.Errorf("parseFinal received %q, expected only 'The answer is 42' (no thinking)", parseFinalInput)
 	}
 
-	// Verify the final result's Raw() contains both thinking + text
+	var results []bamlutils.StreamResult
+	for r := range out {
+		results = append(results, r)
+	}
+
+	hasFinal := false
+	for _, r := range results {
+		if r.Kind() == bamlutils.StreamResultKindFinal {
+			hasFinal = true
+			expectedRaw := "The answer is 42"
+			if r.Raw() != expectedRaw {
+				t.Errorf("Raw() = %q, expected %q (thinking should be dropped under default flag)", r.Raw(), expectedRaw)
+			}
+			if r.Final() != "The answer is 42" {
+				t.Errorf("Final() = %v, expected 'The answer is 42'", r.Final())
+			}
+		}
+	}
+	if !hasFinal {
+		t.Fatal("no final result found")
+	}
+}
+
+func TestRunCallOrchestration_AnthropicThinkingSplit_OptIn(t *testing.T) {
+	// Opt-in (IncludeThinkingInRaw=true): parseable still excludes thinking
+	// (the BAML parser must never see it), Raw() includes thinking + text.
+	body := `{"content":[{"type":"thinking","thinking":"Step 1: reason..."},{"type":"text","text":"The answer is 42"}],"stop_reason":"end_turn"}`
+	server := makeJSONServer(200, body)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &CallConfig{
+		Provider:             "anthropic",
+		NeedsRaw:             true,
+		IncludeThinkingInRaw: true,
+	}
+
+	var parseFinalInput string
+	captureParseFinal := func(_ context.Context, text string) (any, error) {
+		parseFinalInput = text
+		return text, nil
+	}
+
+	err := RunCallOrchestration(
+		context.Background(), out, config, client,
+		makeBuildCallRequest(server.URL),
+		captureParseFinal,
+		ExtractResponseContent,
+		newTestResult,
+	)
+	close(out)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Parseable invariant: parseFinal must see text-only regardless of flag.
+	if parseFinalInput != "The answer is 42" {
+		t.Errorf("parseFinal received %q, expected only 'The answer is 42' (parseable invariant)", parseFinalInput)
+	}
+
 	var results []bamlutils.StreamResult
 	for r := range out {
 		results = append(results, r)

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -889,6 +889,14 @@ type StreamConfig struct {
 	// NeedsRaw is true if the caller wants raw LLM response text.
 	NeedsRaw bool
 
+	// IncludeThinkingInRaw is the per-request opt-in for surfacing
+	// provider-specific reasoning/thinking content in raw. When true,
+	// the streaming extractor accumulates Anthropic thinking_delta
+	// events into raw alongside text deltas. When false (default),
+	// raw matches BAML's RawLLMResponse() text-only semantics. The
+	// flag never affects the parseable text passed to ParseStream.
+	IncludeThinkingInRaw bool
+
 	// ParseThrottleInterval is the minimum time between ParseStream calls.
 	// Zero means parse on every SSE event (no throttling).
 	ParseThrottleInterval time.Duration
@@ -955,11 +963,15 @@ type StreamConfig struct {
 	// per-request retries, so only the inner BAML static retry compounds.
 	//
 	// Raw note: legacy raw comes from BAML's FunctionLog.RawLLMResponse(),
-	// which drops Anthropic-family thinking deltas. For providers that
-	// only ever appear as legacy children (e.g. aws-bedrock) this is
-	// lossless; for runtime overrides that push a thinking-capable
-	// provider onto the legacy path, raw will match RawLLMResponse rather
-	// than the full wire text.
+	// which is text-only across providers (BAML's runtime drops Anthropic-
+	// thinking_delta and equivalents). Under the default
+	// IncludeThinkingInRaw=false this exactly matches the BuildRequest
+	// path's behavior. Under IncludeThinkingInRaw=true, this niche path's
+	// raw stays text-only — the flag has no effect here because BAML's
+	// runtime never surfaces thinking content for this codepath to
+	// accumulate. Documented as a known limitation in the
+	// include-thinking-in-raw tracking issue; revisit only if reported in
+	// a real workflow.
 	LegacyStreamChild LegacyStreamChildFunc
 }
 
@@ -1134,8 +1146,11 @@ func RunStreamOrchestration(
 
 		for ev := range resp.Events {
 			// Extract parseable/raw delta content from the SSE event using this
-			// attempt's provider. Anthropic thinking deltas contribute only to raw.
-			delta, extractErr := sse.ExtractDeltaPartsFromText(provider, ev.Data)
+			// attempt's provider. When IncludeThinkingInRaw is true, Anthropic
+			// thinking_delta events contribute to Raw only; Parseable always
+			// excludes thinking so the BAML parser cannot be influenced by
+			// reasoning text regardless of the flag.
+			delta, extractErr := sse.ExtractDeltaPartsFromText(provider, ev.Data, config.IncludeThinkingInRaw)
 			if extractErr != nil {
 				// Extraction error — fail the attempt so retry logic can handle it
 				// rather than silently accumulating incomplete text.

--- a/bamlutils/buildrequest/orchestrator_integration_test.go
+++ b/bamlutils/buildrequest/orchestrator_integration_test.go
@@ -728,7 +728,7 @@ func TestProvider_WhitelistMatchesExtractor(t *testing.T) {
 		"vertex-ai":        `{"candidates":[{"content":{"parts":[{"text":"test"}]}}]}`,
 	}
 	for provider, chunk := range sampleChunks {
-		delta, err := sse.ExtractDeltaFromText(provider, chunk)
+		delta, err := sse.ExtractDeltaFromText(provider, chunk, false)
 		if err != nil {
 			t.Errorf("ExtractDeltaFromText(%q) returned error: %v", provider, err)
 		}

--- a/bamlutils/buildrequest/orchestrator_test.go
+++ b/bamlutils/buildrequest/orchestrator_test.go
@@ -532,7 +532,11 @@ func TestRunStreamOrchestration_AnthropicThinkingUsesAnswerOnlyParsing(t *testin
 	}
 }
 
-func TestRunStreamOrchestration_AnthropicThinkingPreservesRawStream(t *testing.T) {
+func TestRunStreamOrchestration_AnthropicThinkingDropsThinkingFromRaw_Default(t *testing.T) {
+	// Default (IncludeThinkingInRaw=false, BAML-aligned): thinking_delta
+	// events are dropped from the extractor entirely. They produce no Stream
+	// kind result (delta.Raw is empty), so partials count is 2 (text deltas
+	// only), and final raw equals parseable.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(200)
@@ -549,9 +553,97 @@ func TestRunStreamOrchestration_AnthropicThinkingPreservesRawStream(t *testing.T
 	out := make(chan bamlutils.StreamResult, 100)
 
 	config := &StreamConfig{
-		Provider:      "anthropic",
-		NeedsPartials: true,
-		NeedsRaw:      true,
+		Provider:             "anthropic",
+		NeedsPartials:        true,
+		NeedsRaw:             true,
+		IncludeThinkingInRaw: false,
+	}
+
+	var parseStreamInputs []string
+	var parseFinalInput string
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		func(ctx context.Context, clientOverride string) (*llmhttp.Request, error) {
+			return &llmhttp.Request{URL: server.URL, Method: "POST", Body: `{}`}, nil
+		},
+		func(ctx context.Context, accumulated string) (any, error) {
+			parseStreamInputs = append(parseStreamInputs, accumulated)
+			return accumulated, nil
+		},
+		func(ctx context.Context, accumulated string) (any, error) {
+			parseFinalInput = accumulated
+			return accumulated, nil
+		},
+		newTestResult,
+	)
+	close(out)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := parseStreamInputs, []string{"The answer", "The answer is 42"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("parseStream inputs = %v, want %v", got, want)
+	}
+	if parseFinalInput != "The answer is 42" {
+		t.Fatalf("parseFinal input = %q, want %q", parseFinalInput, "The answer is 42")
+	}
+
+	var partialRaws []string
+	var partialStreams []any
+	var finalResult *testResult
+	for r := range out {
+		tr := r.(*testResult)
+		if tr.kind == bamlutils.StreamResultKindStream {
+			partialRaws = append(partialRaws, tr.raw)
+			partialStreams = append(partialStreams, tr.stream)
+		}
+		if tr.kind == bamlutils.StreamResultKindFinal {
+			finalResult = tr
+		}
+	}
+
+	if want := []string{"The answer", " is 42"}; len(partialRaws) != len(want) || partialRaws[0] != want[0] || partialRaws[1] != want[1] {
+		t.Fatalf("partial raws = %v, want %v", partialRaws, want)
+	}
+	if partialStreams[0] != "The answer" || partialStreams[1] != "The answer is 42" {
+		t.Fatalf("text partial streams = %v", partialStreams)
+	}
+	if finalResult == nil {
+		t.Fatal("expected a final result")
+	}
+	if finalResult.final != "The answer is 42" {
+		t.Fatalf("final = %v, want %q", finalResult.final, "The answer is 42")
+	}
+	if finalResult.raw != "The answer is 42" {
+		t.Fatalf("final raw = %q (thinking should be dropped under default flag)", finalResult.raw)
+	}
+}
+
+func TestRunStreamOrchestration_AnthropicThinkingPreservesRawStream_OptIn(t *testing.T) {
+	// Opt-in (IncludeThinkingInRaw=true): thinking_delta events accumulate
+	// into the raw stream alongside text deltas. Parseable still excludes
+	// thinking content (the BAML parser must never see it).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		fmt.Fprint(w, "event: message_start\ndata: {\"type\":\"message_start\"}\n\n")
+		fmt.Fprint(w, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Step 1: reason...\"}}\n\n")
+		fmt.Fprint(w, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"The answer\"}}\n\n")
+		fmt.Fprint(w, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\" Step 2: refine...\"}}\n\n")
+		fmt.Fprint(w, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\" is 42\"}}\n\n")
+		fmt.Fprint(w, "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+	}))
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &StreamConfig{
+		Provider:             "anthropic",
+		NeedsPartials:        true,
+		NeedsRaw:             true,
+		IncludeThinkingInRaw: true,
 	}
 
 	var parseStreamInputs []string

--- a/bamlutils/buildrequest/resolve_test.go
+++ b/bamlutils/buildrequest/resolve_test.go
@@ -13,6 +13,7 @@ import (
 type mockAdapter struct {
 	context.Context
 	retryConfig            *bamlutils.RetryConfig
+	includeThinkingInRaw   bool
 	clientRegistryProvider string
 	originalRegistry       *bamlutils.ClientRegistry
 }
@@ -31,6 +32,8 @@ func (m *mockAdapter) NewMediaFromBase64(_ bamlutils.MediaKind, _ string, _ *str
 }
 func (m *mockAdapter) SetRetryConfig(rc *bamlutils.RetryConfig) { m.retryConfig = rc }
 func (m *mockAdapter) RetryConfig() *bamlutils.RetryConfig      { return m.retryConfig }
+func (m *mockAdapter) SetIncludeThinkingInRaw(v bool)           { m.includeThinkingInRaw = v }
+func (m *mockAdapter) IncludeThinkingInRaw() bool               { return m.includeThinkingInRaw }
 func (m *mockAdapter) ClientRegistryProvider() string           { return m.clientRegistryProvider }
 func (m *mockAdapter) HTTPClient() *llmhttp.Client              { return nil }
 func (m *mockAdapter) OriginalClientRegistry() *bamlutils.ClientRegistry {

--- a/bamlutils/buildrequest/response_extract.go
+++ b/bamlutils/buildrequest/response_extract.go
@@ -18,16 +18,18 @@ import (
 // non-streaming completions.
 //
 // Returns two strings:
-//   - parseable: the text that should be passed to Parse.Method(). For most
-//     providers this is the full text content. For Anthropic with extended
-//     thinking, this excludes thinking blocks (only text blocks).
-//   - raw: the full text including thinking/reasoning content, used for
-//     /call-with-raw's Raw() field. For providers without thinking support,
-//     raw == parseable.
+//   - parseable: the text that should be passed to Parse.Method(). For
+//     all providers this is text-only — reasoning/thinking content is
+//     never accumulated into parseable so the BAML parser cannot be
+//     influenced by reasoning text.
+//   - raw: the text used for /call-with-raw's Raw() field. By default
+//     equals parseable (matches BAML's RawLLMResponse() text-only
+//     contract). When includeThinking is true, raw additionally carries
+//     provider-specific reasoning content (Anthropic thinking blocks).
 //
 // Returns an error for unsupported providers, empty bodies, invalid JSON,
 // and when a non-empty response body does not contain the expected structure.
-func ExtractResponseContent(provider string, responseBody string) (parseable, raw string, err error) {
+func ExtractResponseContent(provider string, responseBody string, includeThinking bool) (parseable, raw string, err error) {
 	// An LLM provider should never return a valid 200 with an empty body.
 	if strings.TrimSpace(responseBody) == "" {
 		return "", "", fmt.Errorf("provider %s: empty response body", provider)
@@ -46,7 +48,7 @@ func ExtractResponseContent(provider string, responseBody string) (parseable, ra
 		return text, text, extractErr
 
 	case "anthropic":
-		return extractAnthropicContent(provider, responseBody)
+		return extractAnthropicContent(provider, responseBody, includeThinking)
 
 	case "openai-responses":
 		text, extractErr := extractOpenAIResponsesContent(provider, responseBody)
@@ -155,12 +157,17 @@ func extractOpenAIContent(provider string, responseBody string) (string, error) 
 // non-streaming response.
 //
 // Returns two strings:
-//   - parseable: only "text" blocks (the final answer), suitable for Parse.Method
-//   - raw: "text" + "thinking" blocks, suitable for /call-with-raw's Raw()
+//   - parseable: only "text" blocks (the final answer), suitable for
+//     Parse.Method. Thinking blocks are never accumulated here — by
+//     construction — so the BAML parser cannot be influenced by
+//     reasoning text regardless of the includeThinking flag.
+//   - raw: "text" blocks always; "thinking" blocks only when
+//     includeThinking is true (the per-request opt-in for surfacing
+//     reasoning content via /call-with-raw's Raw()).
 //
-// The BuildRequest streaming path uses the same split: raw accumulates both
-// text_delta and thinking_delta, while Parse/ParseStream see only answer text.
-func extractAnthropicContent(provider string, responseBody string) (parseable, raw string, err error) {
+// The default (includeThinking=false) matches BAML's RawLLMResponse()
+// text-only contract.
+func extractAnthropicContent(provider string, responseBody string, includeThinking bool) (parseable, raw string, err error) {
 	contentArray := gjson.Get(responseBody, "content")
 
 	if contentArray.IsArray() {
@@ -194,8 +201,11 @@ func extractAnthropicContent(provider string, responseBody string) (parseable, r
 					iterErr = fmt.Errorf("%s: unexpected type for thinking block (got %s)", provider, thinkField.Type)
 					return false
 				}
-				// Thinking goes to raw only, not parseable
-				rawSB.WriteString(thinkField.String())
+				// Thinking goes to raw only when the caller has opted in;
+				// parseable never receives thinking content.
+				if includeThinking {
+					rawSB.WriteString(thinkField.String())
+				}
 			}
 			return true
 		})

--- a/bamlutils/buildrequest/response_extract_test.go
+++ b/bamlutils/buildrequest/response_extract_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestExtractResponseContent_OpenAI(t *testing.T) {
 	body := `{"id":"chatcmpl-abc","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello world"},"finish_reason":"stop"}]}`
-	text, _, err := ExtractResponseContent("openai", body)
+	text, _, err := ExtractResponseContent("openai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -21,7 +21,7 @@ func TestExtractResponseContent_OpenAICompatible(t *testing.T) {
 
 	for _, provider := range []string{"openai", "openai-generic", "azure-openai", "ollama", "openrouter"} {
 		t.Run(provider, func(t *testing.T) {
-			text, _, err := ExtractResponseContent(provider, body)
+			text, _, err := ExtractResponseContent(provider, body, false)
 			if err != nil {
 				t.Fatalf("unexpected error for %s: %v", provider, err)
 			}
@@ -34,7 +34,7 @@ func TestExtractResponseContent_OpenAICompatible(t *testing.T) {
 
 func TestExtractResponseContent_OpenAIEmptyContent(t *testing.T) {
 	body := `{"choices":[{"message":{"content":""}}]}`
-	text, _, err := ExtractResponseContent("openai", body)
+	text, _, err := ExtractResponseContent("openai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestExtractResponseContent_OpenAIEmptyContent(t *testing.T) {
 func TestExtractResponseContent_OpenAINullContent(t *testing.T) {
 	// Some providers return null content for function calls
 	body := `{"choices":[{"message":{"content":null,"function_call":{"name":"foo"}}}]}`
-	text, _, err := ExtractResponseContent("openai", body)
+	text, _, err := ExtractResponseContent("openai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestExtractResponseContent_OpenAINullContent(t *testing.T) {
 func TestExtractResponseContent_OpenAINumericContent(t *testing.T) {
 	// content is a number — unexpected type, should error
 	body := `{"choices":[{"message":{"content":123}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for numeric content")
 	}
@@ -67,7 +67,7 @@ func TestExtractResponseContent_OpenAINumericContent(t *testing.T) {
 func TestExtractResponseContent_OpenAIObjectContent(t *testing.T) {
 	// content is an object (not array) — unexpected type, should error
 	body := `{"choices":[{"message":{"content":{"foo":"bar"}}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for object content")
 	}
@@ -75,7 +75,7 @@ func TestExtractResponseContent_OpenAIObjectContent(t *testing.T) {
 
 func TestExtractResponseContent_OpenAIBoolContent(t *testing.T) {
 	body := `{"choices":[{"message":{"content":true}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for boolean content")
 	}
@@ -84,7 +84,7 @@ func TestExtractResponseContent_OpenAIBoolContent(t *testing.T) {
 func TestExtractResponseContent_OpenAIRefusal(t *testing.T) {
 	// message.refusal field present → error surfacing the refusal text
 	body := `{"choices":[{"message":{"role":"assistant","refusal":"I cannot help with that","content":null}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for refusal response")
 	}
@@ -96,7 +96,7 @@ func TestExtractResponseContent_OpenAIRefusal(t *testing.T) {
 func TestExtractResponseContent_OpenAIRefusalEmptyTopLevel(t *testing.T) {
 	// message.refusal is an empty string with null content — still a refusal
 	body := `{"choices":[{"message":{"refusal":"","content":null}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for empty top-level refusal")
 	}
@@ -108,7 +108,7 @@ func TestExtractResponseContent_OpenAIRefusalEmptyTopLevel(t *testing.T) {
 func TestExtractResponseContent_OpenAIRefusalNullFallsThrough(t *testing.T) {
 	// Explicit null refusal with valid content — not a refusal, normal extraction
 	body := `{"choices":[{"message":{"refusal":null,"content":"Hello world"}}]}`
-	text, _, err := ExtractResponseContent("openai", body)
+	text, _, err := ExtractResponseContent("openai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestExtractResponseContent_OpenAIRefusalNullFallsThrough(t *testing.T) {
 func TestExtractResponseContent_OpenAIRefusalNonString(t *testing.T) {
 	// message.refusal is a non-string type — still a refusal
 	body := `{"choices":[{"message":{"refusal":true,"content":null}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for non-string top-level refusal")
 	}
@@ -132,7 +132,7 @@ func TestExtractResponseContent_OpenAIRefusalNonString(t *testing.T) {
 func TestExtractResponseContent_OpenAIRefusalInContentArray(t *testing.T) {
 	// {"type":"refusal"} part in content array → error
 	body := `{"choices":[{"message":{"content":[{"type":"refusal","refusal":"Not allowed"}]}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for refusal content part")
 	}
@@ -144,7 +144,7 @@ func TestExtractResponseContent_OpenAIRefusalInContentArray(t *testing.T) {
 func TestExtractResponseContent_OpenAIRefusalEmptyText(t *testing.T) {
 	// type=="refusal" with empty refusal field — still an error
 	body := `{"choices":[{"message":{"content":[{"type":"refusal","refusal":""}]}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for refusal part with empty text")
 	}
@@ -156,7 +156,7 @@ func TestExtractResponseContent_OpenAIRefusalEmptyText(t *testing.T) {
 func TestExtractResponseContent_OpenAIRefusalMissingField(t *testing.T) {
 	// type=="refusal" with no refusal field at all — still an error
 	body := `{"choices":[{"message":{"content":[{"type":"refusal"}]}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for refusal part with missing field")
 	}
@@ -168,7 +168,7 @@ func TestExtractResponseContent_OpenAIRefusalMissingField(t *testing.T) {
 func TestExtractResponseContent_OpenAIArrayNonObjectElement(t *testing.T) {
 	// content array with a non-object element → error
 	body := `{"choices":[{"message":{"content":[123]}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for non-object element in content array")
 	}
@@ -176,7 +176,7 @@ func TestExtractResponseContent_OpenAIArrayNonObjectElement(t *testing.T) {
 
 func TestExtractResponseContent_AnthropicNonObjectElement(t *testing.T) {
 	body := `{"content":["not an object"]}`
-	_, _, err := ExtractResponseContent("anthropic", body)
+	_, _, err := ExtractResponseContent("anthropic", body, false)
 	if err == nil {
 		t.Fatal("expected error for non-object element in Anthropic content array")
 	}
@@ -184,7 +184,7 @@ func TestExtractResponseContent_AnthropicNonObjectElement(t *testing.T) {
 
 func TestExtractResponseContent_GeminiNonObjectElement(t *testing.T) {
 	body := `{"candidates":[{"content":{"parts":["not an object"]}}]}`
-	_, _, err := ExtractResponseContent("google-ai", body)
+	_, _, err := ExtractResponseContent("google-ai", body, false)
 	if err == nil {
 		t.Fatal("expected error for non-object element in Gemini parts array")
 	}
@@ -194,7 +194,7 @@ func TestExtractResponseContent_GeminiNonObjectElement(t *testing.T) {
 
 func TestExtractResponseContent_OpenAIResponses(t *testing.T) {
 	body := `{"output":[{"type":"message","status":"completed","content":[{"type":"output_text","text":"Hello from Responses API"}],"role":"assistant"}]}`
-	text, _, err := ExtractResponseContent("openai-responses", body)
+	text, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestExtractResponseContent_OpenAIResponsesMultiPart(t *testing.T) {
 		{"type":"output_text","text":"Part one. "},
 		{"type":"output_text","text":"Part two."}
 	],"role":"assistant"}]}`
-	text, _, err := ExtractResponseContent("openai-responses", body)
+	text, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestExtractResponseContent_OpenAIResponsesWithReasoning(t *testing.T) {
 			{"type":"output_text","text":"The answer is 42"}
 		],"role":"assistant"}
 	]}`
-	text, _, err := ExtractResponseContent("openai-responses", body)
+	text, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestExtractResponseContent_OpenAIResponsesMultipleMessageItems(t *testing.T
 		{"type":"reasoning","content":[],"summary":[]},
 		{"type":"message","content":[{"type":"output_text","text":"Second."}],"role":"assistant"}
 	]}`
-	text, _, err := ExtractResponseContent("openai-responses", body)
+	text, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestExtractResponseContent_OpenAIResponsesMultipleMessageItemsMultiPart(t *
 			{"type":"output_text","text":"D"}
 		],"role":"assistant"}
 	]}`
-	text, _, err := ExtractResponseContent("openai-responses", body)
+	text, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestExtractResponseContent_OpenAIResponsesMultipleMessageItemsMultiPart(t *
 func TestExtractResponseContent_OpenAIResponsesNoMessageItem(t *testing.T) {
 	// No message item in output → error
 	body := `{"output":[{"type":"reasoning","content":[],"summary":[]}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for missing message item")
 	}
@@ -281,7 +281,7 @@ func TestExtractResponseContent_OpenAIResponsesNoMessageItem(t *testing.T) {
 func TestExtractResponseContent_OpenAIResponsesEmptyContent(t *testing.T) {
 	// Message item with empty content array → empty string (valid)
 	body := `{"output":[{"type":"message","content":[],"role":"assistant"}]}`
-	text, _, err := ExtractResponseContent("openai-responses", body)
+	text, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestExtractResponseContent_OpenAIResponsesEmptyContent(t *testing.T) {
 func TestExtractResponseContent_OpenAIResponsesNonObjectOutputElement(t *testing.T) {
 	// Non-object element in output array → error (not silently skipped)
 	body := `{"output":[123,{"type":"message","content":[{"type":"output_text","text":"ok"}],"role":"assistant"}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for non-object element in output array")
 	}
@@ -302,7 +302,7 @@ func TestExtractResponseContent_OpenAIResponsesNonObjectOutputElement(t *testing
 func TestExtractResponseContent_OpenAIResponsesOutputMissingType(t *testing.T) {
 	// Output item with no type field before valid message → error
 	body := `{"output":[{"foo":"bar"},{"type":"message","content":[{"type":"output_text","text":"ok"}],"role":"assistant"}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for output item missing type field")
 	}
@@ -311,7 +311,7 @@ func TestExtractResponseContent_OpenAIResponsesOutputMissingType(t *testing.T) {
 func TestExtractResponseContent_OpenAIResponsesOutputNonStringType(t *testing.T) {
 	// Output item with non-string type before valid message → error
 	body := `{"output":[{"type":true},{"type":"message","content":[{"type":"output_text","text":"ok"}],"role":"assistant"}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for output item with non-string type field")
 	}
@@ -320,7 +320,7 @@ func TestExtractResponseContent_OpenAIResponsesOutputNonStringType(t *testing.T)
 func TestExtractResponseContent_OpenAIResponsesTrailingNonObjectOutputElement(t *testing.T) {
 	// Non-object element AFTER a valid message item → still an error
 	body := `{"output":[{"type":"message","content":[{"type":"output_text","text":"ok"}],"role":"assistant"},123]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for trailing non-object element in output array")
 	}
@@ -328,7 +328,7 @@ func TestExtractResponseContent_OpenAIResponsesTrailingNonObjectOutputElement(t 
 
 func TestExtractResponseContent_OpenAIResponsesMissingOutput(t *testing.T) {
 	body := `{"id":"resp_01"}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for missing output array")
 	}
@@ -337,7 +337,7 @@ func TestExtractResponseContent_OpenAIResponsesMissingOutput(t *testing.T) {
 func TestExtractResponseContent_OpenAIResponsesMalformedTextField(t *testing.T) {
 	// output_text with non-string text → error
 	body := `{"output":[{"type":"message","content":[{"type":"output_text","text":123}],"role":"assistant"}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for non-string text field")
 	}
@@ -346,7 +346,7 @@ func TestExtractResponseContent_OpenAIResponsesMalformedTextField(t *testing.T) 
 func TestExtractResponseContent_OpenAIResponsesNonObjectContent(t *testing.T) {
 	// Non-object element in content array → error
 	body := `{"output":[{"type":"message","content":["not an object"],"role":"assistant"}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for non-object content element")
 	}
@@ -355,7 +355,7 @@ func TestExtractResponseContent_OpenAIResponsesNonObjectContent(t *testing.T) {
 func TestExtractResponseContent_OpenAIResponsesMissingContentArray(t *testing.T) {
 	// Message item with no content field → error
 	body := `{"output":[{"type":"message","role":"assistant"}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for missing content array in message item")
 	}
@@ -364,7 +364,7 @@ func TestExtractResponseContent_OpenAIResponsesMissingContentArray(t *testing.T)
 func TestExtractResponseContent_OpenAIResponsesRefusal(t *testing.T) {
 	// Refusal-only response → error with refusal text
 	body := `{"output":[{"type":"message","content":[{"type":"refusal","refusal":"I cannot help with that"}],"role":"assistant"}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for refusal content part")
 	}
@@ -382,7 +382,7 @@ func TestExtractResponseContent_OpenAIResponsesRefusalBeforeText(t *testing.T) {
 		{"type":"refusal","refusal":"Not allowed"},
 		{"type":"output_text","text":"Should not reach this"}
 	],"role":"assistant"}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for refusal part even with output_text present")
 	}
@@ -394,7 +394,7 @@ func TestExtractResponseContent_OpenAIResponsesRefusalBeforeText(t *testing.T) {
 func TestExtractResponseContent_OpenAIResponsesRefusalEmptyText(t *testing.T) {
 	// Refusal part with empty refusal field — still an error
 	body := `{"output":[{"type":"message","content":[{"type":"refusal","refusal":""}],"role":"assistant"}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for refusal part with empty text")
 	}
@@ -406,7 +406,7 @@ func TestExtractResponseContent_OpenAIResponsesRefusalEmptyText(t *testing.T) {
 func TestExtractResponseContent_OpenAIResponsesRefusalMissingField(t *testing.T) {
 	// Refusal part with no refusal field — still an error
 	body := `{"output":[{"type":"message","content":[{"type":"refusal"}],"role":"assistant"}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for refusal part with missing field")
 	}
@@ -423,7 +423,7 @@ func TestExtractResponseContent_OpenAIArrayContent(t *testing.T) {
 		{"type":"text","text":"Hello"},
 		{"type":"text","text":" world"}
 	]}}]}`
-	text, _, err := ExtractResponseContent("openai", body)
+	text, _, err := ExtractResponseContent("openai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -439,7 +439,7 @@ func TestExtractResponseContent_OpenAIArrayContentMixed(t *testing.T) {
 		{"type":"image_url","image_url":{"url":"https://example.com/img.png"}},
 		{"type":"text","text":"After image."}
 	]}}]}`
-	text, _, err := ExtractResponseContent("openai", body)
+	text, _, err := ExtractResponseContent("openai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -451,7 +451,7 @@ func TestExtractResponseContent_OpenAIArrayContentMixed(t *testing.T) {
 func TestExtractResponseContent_OpenAIArrayContentMalformedTextField(t *testing.T) {
 	// text field is a number instead of string — should error
 	body := `{"choices":[{"message":{"content":[{"type":"text","text":123}]}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for numeric text field in content part")
 	}
@@ -459,7 +459,7 @@ func TestExtractResponseContent_OpenAIArrayContentMalformedTextField(t *testing.
 
 func TestExtractResponseContent_OpenAIArrayContentSingleText(t *testing.T) {
 	body := `{"choices":[{"message":{"content":[{"type":"text","text":"only text"}]}}]}`
-	text, _, err := ExtractResponseContent("openai", body)
+	text, _, err := ExtractResponseContent("openai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -471,7 +471,7 @@ func TestExtractResponseContent_OpenAIArrayContentSingleText(t *testing.T) {
 func TestExtractResponseContent_OpenAIArrayContentMissingType(t *testing.T) {
 	// Content part with no type field → error (not silently skipped)
 	body := `{"choices":[{"message":{"content":[{"text":"ok"}]}}]}`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for content part missing type field")
 	}
@@ -479,7 +479,7 @@ func TestExtractResponseContent_OpenAIArrayContentMissingType(t *testing.T) {
 
 func TestExtractResponseContent_AnthropicMissingBlockType(t *testing.T) {
 	body := `{"content":[{"text":"ok"}]}`
-	_, _, err := ExtractResponseContent("anthropic", body)
+	_, _, err := ExtractResponseContent("anthropic", body, false)
 	if err == nil {
 		t.Fatal("expected error for Anthropic content block missing type field")
 	}
@@ -487,7 +487,7 @@ func TestExtractResponseContent_AnthropicMissingBlockType(t *testing.T) {
 
 func TestExtractResponseContent_OpenAIResponsesMissingContentType(t *testing.T) {
 	body := `{"output":[{"type":"message","content":[{"text":"ok"}],"role":"assistant"}]}`
-	_, _, err := ExtractResponseContent("openai-responses", body)
+	_, _, err := ExtractResponseContent("openai-responses", body, false)
 	if err == nil {
 		t.Fatal("expected error for Responses API content entry missing type field")
 	}
@@ -495,7 +495,7 @@ func TestExtractResponseContent_OpenAIResponsesMissingContentType(t *testing.T) 
 
 func TestExtractResponseContent_OpenAIArrayContentEmpty(t *testing.T) {
 	body := `{"choices":[{"message":{"content":[]}}]}`
-	text, _, err := ExtractResponseContent("openai", body)
+	text, _, err := ExtractResponseContent("openai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -514,7 +514,7 @@ func TestExtractResponseContent_Anthropic(t *testing.T) {
 		],
 		"stop_reason": "end_turn"
 	}`
-	text, _, err := ExtractResponseContent("anthropic", body)
+	text, _, err := ExtractResponseContent("anthropic", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -530,7 +530,7 @@ func TestExtractResponseContent_AnthropicMultipleTextBlocks(t *testing.T) {
 			{"type": "text", "text": "Second part."}
 		]
 	}`
-	text, _, err := ExtractResponseContent("anthropic", body)
+	text, _, err := ExtractResponseContent("anthropic", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -539,16 +539,37 @@ func TestExtractResponseContent_AnthropicMultipleTextBlocks(t *testing.T) {
 	}
 }
 
-func TestExtractResponseContent_AnthropicWithThinking(t *testing.T) {
-	// Parseable should contain only text blocks (the final answer).
-	// Raw should contain thinking + text (matching the streaming path).
+func TestExtractResponseContent_AnthropicWithThinking_Default(t *testing.T) {
+	// Default (includeThinking=false, BAML-aligned): parseable AND raw
+	// contain only the text block. Thinking blocks are dropped from raw.
 	body := `{
 		"content": [
 			{"type": "thinking", "thinking": "Let me think about this..."},
 			{"type": "text", "text": "The answer is 42"}
 		]
 	}`
-	parseable, raw, err := ExtractResponseContent("anthropic", body)
+	parseable, raw, err := ExtractResponseContent("anthropic", body, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parseable != "The answer is 42" {
+		t.Errorf("expected parseable 'The answer is 42', got %q", parseable)
+	}
+	if raw != "The answer is 42" {
+		t.Errorf("expected raw 'The answer is 42' (thinking dropped), got %q", raw)
+	}
+}
+
+func TestExtractResponseContent_AnthropicWithThinking_OptIn(t *testing.T) {
+	// Opt-in (includeThinking=true): parseable contains only text (the BAML
+	// parser must never see thinking content), raw contains thinking + text.
+	body := `{
+		"content": [
+			{"type": "thinking", "thinking": "Let me think about this..."},
+			{"type": "text", "text": "The answer is 42"}
+		]
+	}`
+	parseable, raw, err := ExtractResponseContent("anthropic", body, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -560,14 +581,59 @@ func TestExtractResponseContent_AnthropicWithThinking(t *testing.T) {
 	}
 }
 
-func TestExtractResponseContent_AnthropicThinkingOnly(t *testing.T) {
-	// With only thinking blocks: parseable is empty, raw has the thinking
+func TestExtractResponseContent_AnthropicWithThinking_ParseableInvariant(t *testing.T) {
+	// Parseable must never include thinking content, regardless of the
+	// includeThinking flag value. Codifies the structural guarantee.
+	body := `{
+		"content": [
+			{"type": "thinking", "thinking": "Let me think about this..."},
+			{"type": "text", "text": "The answer is 42"}
+		]
+	}`
+	parseableOff, _, err := ExtractResponseContent("anthropic", body, false)
+	if err != nil {
+		t.Fatalf("flag=false extraction failed: %v", err)
+	}
+	parseableOn, _, err := ExtractResponseContent("anthropic", body, true)
+	if err != nil {
+		t.Fatalf("flag=true extraction failed: %v", err)
+	}
+	if parseableOff != parseableOn {
+		t.Errorf("parseable diverged across flag values: off=%q on=%q",
+			parseableOff, parseableOn)
+	}
+	if parseableOff != "The answer is 42" {
+		t.Errorf("expected parseable 'The answer is 42', got %q", parseableOff)
+	}
+}
+
+func TestExtractResponseContent_AnthropicThinkingOnly_Default(t *testing.T) {
+	// Default: thinking-only response is empty in both parseable and raw.
 	body := `{
 		"content": [
 			{"type": "thinking", "thinking": "Reasoning without output"}
 		]
 	}`
-	parseable, raw, err := ExtractResponseContent("anthropic", body)
+	parseable, raw, err := ExtractResponseContent("anthropic", body, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parseable != "" {
+		t.Errorf("expected empty parseable, got %q", parseable)
+	}
+	if raw != "" {
+		t.Errorf("expected empty raw under default flag, got %q", raw)
+	}
+}
+
+func TestExtractResponseContent_AnthropicThinkingOnly_OptIn(t *testing.T) {
+	// Opt-in: thinking-only response has empty parseable and the thinking in raw.
+	body := `{
+		"content": [
+			{"type": "thinking", "thinking": "Reasoning without output"}
+		]
+	}`
+	parseable, raw, err := ExtractResponseContent("anthropic", body, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -575,13 +641,13 @@ func TestExtractResponseContent_AnthropicThinkingOnly(t *testing.T) {
 		t.Errorf("expected empty parseable, got %q", parseable)
 	}
 	if raw != "Reasoning without output" {
-		t.Errorf("expected raw thinking content, got %q", raw)
+		t.Errorf("expected raw thinking content under opt-in, got %q", raw)
 	}
 }
 
 func TestExtractResponseContent_AnthropicMalformedTextField(t *testing.T) {
 	body := `{"content":[{"type":"text","text":123}]}`
-	_, _, err := ExtractResponseContent("anthropic", body)
+	_, _, err := ExtractResponseContent("anthropic", body, false)
 	if err == nil {
 		t.Fatal("expected error for numeric text field in Anthropic block")
 	}
@@ -589,7 +655,7 @@ func TestExtractResponseContent_AnthropicMalformedTextField(t *testing.T) {
 
 func TestExtractResponseContent_AnthropicMalformedThinkingField(t *testing.T) {
 	body := `{"content":[{"type":"thinking","thinking":true}]}`
-	_, _, err := ExtractResponseContent("anthropic", body)
+	_, _, err := ExtractResponseContent("anthropic", body, false)
 	if err == nil {
 		t.Fatal("expected error for boolean thinking field in Anthropic block")
 	}
@@ -597,7 +663,7 @@ func TestExtractResponseContent_AnthropicMalformedThinkingField(t *testing.T) {
 
 func TestExtractResponseContent_AnthropicEmptyContent(t *testing.T) {
 	body := `{"content": []}`
-	text, _, err := ExtractResponseContent("anthropic", body)
+	text, _, err := ExtractResponseContent("anthropic", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -609,7 +675,7 @@ func TestExtractResponseContent_AnthropicEmptyContent(t *testing.T) {
 func TestExtractResponseContent_AnthropicMissingContent(t *testing.T) {
 	// Non-empty body but no content array → error (malformed Anthropic response)
 	body := `{"id": "msg_01"}`
-	_, _, err := ExtractResponseContent("anthropic", body)
+	_, _, err := ExtractResponseContent("anthropic", body, false)
 	if err == nil {
 		t.Fatal("expected error for missing content array in non-empty body")
 	}
@@ -627,7 +693,7 @@ func TestExtractResponseContent_GoogleAI(t *testing.T) {
 			}
 		]
 	}`
-	text, _, err := ExtractResponseContent("google-ai", body)
+	text, _, err := ExtractResponseContent("google-ai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -638,7 +704,7 @@ func TestExtractResponseContent_GoogleAI(t *testing.T) {
 
 func TestExtractResponseContent_VertexAI(t *testing.T) {
 	body := `{"candidates":[{"content":{"parts":[{"text":"Vertex response"}],"role":"model"}}]}`
-	text, _, err := ExtractResponseContent("vertex-ai", body)
+	text, _, err := ExtractResponseContent("vertex-ai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -653,7 +719,7 @@ func TestExtractResponseContent_GeminiMultipleParts(t *testing.T) {
 		{"text":"First paragraph. "},
 		{"text":"Second paragraph."}
 	],"role":"model"}}]}`
-	text, _, err := ExtractResponseContent("google-ai", body)
+	text, _, err := ExtractResponseContent("google-ai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -669,7 +735,7 @@ func TestExtractResponseContent_GeminiMixedParts(t *testing.T) {
 		{"functionCall":{"name":"get_weather","args":{"city":"NYC"}}},
 		{"text":"Done."}
 	],"role":"model"}}]}`
-	text, _, err := ExtractResponseContent("google-ai", body)
+	text, _, err := ExtractResponseContent("google-ai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -680,7 +746,7 @@ func TestExtractResponseContent_GeminiMixedParts(t *testing.T) {
 
 func TestExtractResponseContent_GeminiMalformedTextField(t *testing.T) {
 	body := `{"candidates":[{"content":{"parts":[{"text":123}]}}]}`
-	_, _, err := ExtractResponseContent("google-ai", body)
+	_, _, err := ExtractResponseContent("google-ai", body, false)
 	if err == nil {
 		t.Fatal("expected error for numeric text field in Gemini part")
 	}
@@ -688,7 +754,7 @@ func TestExtractResponseContent_GeminiMalformedTextField(t *testing.T) {
 
 func TestExtractResponseContent_GeminiObjectTextField(t *testing.T) {
 	body := `{"candidates":[{"content":{"parts":[{"text":{"a":1}}]}}]}`
-	_, _, err := ExtractResponseContent("google-ai", body)
+	_, _, err := ExtractResponseContent("google-ai", body, false)
 	if err == nil {
 		t.Fatal("expected error for object text field in Gemini part")
 	}
@@ -696,7 +762,7 @@ func TestExtractResponseContent_GeminiObjectTextField(t *testing.T) {
 
 func TestExtractResponseContent_GeminiEmptyParts(t *testing.T) {
 	body := `{"candidates":[{"content":{"parts":[],"role":"model"}}]}`
-	text, _, err := ExtractResponseContent("google-ai", body)
+	text, _, err := ExtractResponseContent("google-ai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -708,7 +774,7 @@ func TestExtractResponseContent_GeminiEmptyParts(t *testing.T) {
 func TestExtractResponseContent_GeminiMissingParts(t *testing.T) {
 	// Non-empty body but parts array is missing → error
 	body := `{"candidates":[{"content":{"role":"model"}}]}`
-	_, _, err := ExtractResponseContent("google-ai", body)
+	_, _, err := ExtractResponseContent("google-ai", body, false)
 	if err == nil {
 		t.Fatal("expected error for missing parts in non-empty body")
 	}
@@ -719,7 +785,7 @@ func TestExtractResponseContent_VertexMultipleParts(t *testing.T) {
 		{"text":"Part A"},
 		{"text":"Part B"}
 	],"role":"model"}}]}`
-	text, _, err := ExtractResponseContent("vertex-ai", body)
+	text, _, err := ExtractResponseContent("vertex-ai", body, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -729,14 +795,14 @@ func TestExtractResponseContent_VertexMultipleParts(t *testing.T) {
 }
 
 func TestExtractResponseContent_UnsupportedProvider(t *testing.T) {
-	_, _, err := ExtractResponseContent("aws-bedrock", `{}`)
+	_, _, err := ExtractResponseContent("aws-bedrock", `{}`, false)
 	if err == nil {
 		t.Fatal("expected error for unsupported provider")
 	}
 }
 
 func TestExtractResponseContent_UnknownProvider(t *testing.T) {
-	_, _, err := ExtractResponseContent("some-unknown-provider", `{}`)
+	_, _, err := ExtractResponseContent("some-unknown-provider", `{}`, false)
 	if err == nil {
 		t.Fatal("expected error for unknown provider")
 	}
@@ -746,7 +812,7 @@ func TestExtractResponseContent_MalformedJSON(t *testing.T) {
 	// Non-empty body that isn't valid JSON → error (can't extract content)
 	for _, provider := range []string{"openai", "anthropic", "google-ai"} {
 		t.Run(provider, func(t *testing.T) {
-			_, _, err := ExtractResponseContent(provider, `{invalid json}`)
+			_, _, err := ExtractResponseContent(provider, `{invalid json}`, false)
 			if err == nil {
 				t.Fatalf("expected error for malformed JSON with provider %s", provider)
 			}
@@ -758,7 +824,7 @@ func TestExtractResponseContent_TrailingGarbage(t *testing.T) {
 	// Valid JSON followed by trailing garbage — gjson would accept this
 	// but gjson.Valid rejects it. Should error, not false-success.
 	body := `{"choices":[{"message":{"content":"ok"}}]} garbage`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for JSON with trailing garbage")
 	}
@@ -767,7 +833,7 @@ func TestExtractResponseContent_TrailingGarbage(t *testing.T) {
 func TestExtractResponseContent_TruncatedJSON(t *testing.T) {
 	// Truncated JSON that gjson can still partially query — should error.
 	body := `{"choices":[{"message":{"content":"partial`
-	_, _, err := ExtractResponseContent("openai", body)
+	_, _, err := ExtractResponseContent("openai", body, false)
 	if err == nil {
 		t.Fatal("expected error for truncated JSON")
 	}
@@ -785,7 +851,7 @@ func TestExtractResponseContent_MissingExpectedFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.provider, func(t *testing.T) {
-			_, _, err := ExtractResponseContent(tt.provider, tt.body)
+			_, _, err := ExtractResponseContent(tt.provider, tt.body, false)
 			if err == nil {
 				t.Fatalf("expected error for %s with missing fields", tt.provider)
 			}
@@ -797,7 +863,7 @@ func TestExtractResponseContent_EmptyBody(t *testing.T) {
 	// An LLM provider should never return a valid 200 with an empty body.
 	for _, provider := range []string{"openai", "anthropic", "google-ai"} {
 		t.Run(provider, func(t *testing.T) {
-			_, _, err := ExtractResponseContent(provider, "")
+			_, _, err := ExtractResponseContent(provider, "", false)
 			if err == nil {
 				t.Fatalf("expected error for empty body with provider %s", provider)
 			}
@@ -806,7 +872,7 @@ func TestExtractResponseContent_EmptyBody(t *testing.T) {
 }
 
 func TestExtractResponseContent_WhitespaceOnlyBody(t *testing.T) {
-	_, _, err := ExtractResponseContent("openai", "   \n\t  ")
+	_, _, err := ExtractResponseContent("openai", "   \n\t  ", false)
 	if err == nil {
 		t.Fatal("expected error for whitespace-only body")
 	}
@@ -835,7 +901,7 @@ func TestCallProviderWhitelistMatchesExtractor(t *testing.T) {
 			if !ok {
 				t.Fatalf("provider %q in callSupportedProviders but no test body defined", provider)
 			}
-			parseable, _, err := ExtractResponseContent(provider, body)
+			parseable, _, err := ExtractResponseContent(provider, body, false)
 			if err != nil {
 				t.Fatalf("ExtractResponseContent(%q) returned error: %v", provider, err)
 			}

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -509,6 +509,14 @@ type Adapter interface {
 	SetRetryConfig(config *RetryConfig)
 	// RetryConfig returns the per-request retry config, or nil if not set.
 	RetryConfig() *RetryConfig
+	// SetIncludeThinkingInRaw enables provider-specific reasoning/thinking
+	// content in the /with-raw `raw` field for this request. Default false
+	// matches upstream BAML's RawLLMResponse() semantics (text-only). The
+	// flag never affects the parseable text seen by Parse/ParseStream.
+	SetIncludeThinkingInRaw(includeThinking bool)
+	// IncludeThinkingInRaw returns the per-request opt-in flag. Defaults to
+	// false when no override has been applied.
+	IncludeThinkingInRaw() bool
 	// ClientRegistryProvider returns the provider string of the primary client
 	// from the runtime ClientRegistry override, or empty string if no override.
 	// Used by the BuildRequest router to select the correct SSE delta extractor.
@@ -528,6 +536,16 @@ type BamlOptions struct {
 	ClientRegistry *ClientRegistry `json:"client_registry"`
 	TypeBuilder    *TypeBuilder    `json:"type_builder"`
 	Retry          *RetryConfig    `json:"retry,omitempty"`
+	// IncludeThinkingInRaw opts the request into having provider-specific
+	// reasoning/thinking content surfaced in /with-raw's `raw` field.
+	//
+	// Default false aligns baml-rest with upstream BAML's RawLLMResponse()
+	// semantics (text-only). Set true to additionally accumulate Anthropic
+	// thinking_delta / thinking blocks (and, in later phases, other providers'
+	// reasoning surfaces) into raw for telemetry. The flag never affects the
+	// parseable text passed to Parse/ParseStream — that stays text-only by
+	// construction so reasoning content cannot influence parsing.
+	IncludeThinkingInRaw bool `json:"include_thinking_in_raw,omitempty"`
 }
 
 // RetryConfig provides explicit retry configuration for the BuildRequest path.

--- a/bamlutils/sse/extract.go
+++ b/bamlutils/sse/extract.go
@@ -9,8 +9,12 @@ import (
 )
 
 // DeltaParts contains the parseable/raw split for a single SSE event.
-// For most providers Parseable == Raw. Anthropic extended-thinking events use
-// Parseable for answer text only and Raw for answer + thinking deltas.
+// Parseable is always text-only — reasoning/thinking content never enters
+// it, so the BAML parser cannot be influenced by reasoning text. Raw
+// matches Parseable for providers without a reasoning surface; for
+// Anthropic, raw additionally carries thinking_delta content when the
+// caller opts in via IncludeThinkingInRaw on the IncrementalExtractor or
+// the includeThinking parameter on ExtractDeltaPartsFromText.
 type DeltaParts struct {
 	Parseable string
 	Raw       string
@@ -36,7 +40,12 @@ type StreamingData struct {
 // GetCurrentContent returns the accumulated content so far from streaming
 // by extracting deltas from SSE chunks of the last call only.
 // Earlier calls are ignored since they represent failed retry attempts.
-func GetCurrentContent(data *StreamingData) (string, error) {
+//
+// includeThinking is the per-request opt-in flag for surfacing provider-
+// specific reasoning content. False (default) yields BAML-aligned text-only
+// content; true additionally accumulates Anthropic thinking_delta into the
+// returned string.
+func GetCurrentContent(data *StreamingData, includeThinking bool) (string, error) {
 	if len(data.Calls) == 0 {
 		return "", nil
 	}
@@ -46,7 +55,7 @@ func GetCurrentContent(data *StreamingData) (string, error) {
 
 	var sb strings.Builder
 	for _, chunk := range call.Chunks {
-		delta, err := ExtractDeltaContent(call.Provider, chunk)
+		delta, err := ExtractDeltaContent(call.Provider, chunk, includeThinking)
 		if err == nil && delta != "" {
 			sb.WriteString(delta)
 		}
@@ -56,18 +65,26 @@ func GetCurrentContent(data *StreamingData) (string, error) {
 }
 
 // ExtractDeltaContent extracts the text delta from an SSE chunk based on provider.
-func ExtractDeltaContent(provider string, chunk SSEChunk) (string, error) {
+// See ExtractDeltaPartsFromText for the includeThinking semantics.
+func ExtractDeltaContent(provider string, chunk SSEChunk, includeThinking bool) (string, error) {
 	rawText, err := chunk.Text()
 	if err != nil {
 		return "", fmt.Errorf("failed to get chunk text: %w", err)
 	}
-	return ExtractDeltaFromText(provider, rawText)
+	return ExtractDeltaFromText(provider, rawText, includeThinking)
 }
 
 // ExtractDeltaPartsFromText contains the provider-specific delta extraction
 // logic, operating on the raw text string. It returns both the parseable delta
 // (used for Parse/ParseStream) and the raw delta (used for /with-raw output).
-func ExtractDeltaPartsFromText(provider string, rawText string) (DeltaParts, error) {
+//
+// includeThinking is the per-request opt-in flag for surfacing provider-
+// specific reasoning content in Raw. When false (default), Parseable == Raw
+// and Anthropic thinking_delta events are dropped — matching BAML's
+// RawLLMResponse() text-only contract. When true, Anthropic thinking_delta
+// events contribute to Raw only; Parseable is unaffected by construction so
+// the BAML parser cannot be influenced by reasoning text.
+func ExtractDeltaPartsFromText(provider string, rawText string, includeThinking bool) (DeltaParts, error) {
 	switch provider {
 	// OpenAI-compatible providers (Chat Completions API format)
 	// Path: choices[0].delta.content
@@ -85,7 +102,10 @@ func ExtractDeltaPartsFromText(provider string, rawText string) (DeltaParts, err
 		return DeltaParts{}, nil
 
 	// Anthropic
-	// Path: delta.text or delta.thinking (when type == "content_block_delta")
+	// Path: delta.text (text_delta) or delta.thinking (thinking_delta)
+	// when type == "content_block_delta". Thinking deltas contribute to
+	// Raw only when includeThinking is true; Parseable always excludes
+	// thinking so the BAML parser sees text-only input.
 	case "anthropic":
 		if gjson.Get(rawText, "type").String() == "content_block_delta" {
 			switch gjson.Get(rawText, "delta.type").String() {
@@ -93,6 +113,9 @@ func ExtractDeltaPartsFromText(provider string, rawText string) (DeltaParts, err
 				delta := gjson.Get(rawText, "delta.text").String()
 				return DeltaParts{Parseable: delta, Raw: delta}, nil
 			case "thinking_delta":
+				if !includeThinking {
+					return DeltaParts{}, nil
+				}
 				return DeltaParts{Raw: gjson.Get(rawText, "delta.thinking").String()}, nil
 			}
 		}
@@ -122,12 +145,15 @@ func ExtractDeltaPartsFromText(provider string, rawText string) (DeltaParts, err
 // operating on the raw text string. It takes a provider name and the raw JSON
 // text of a single SSE event, and returns the raw textual delta content.
 //
+// includeThinking is the per-request opt-in flag for surfacing provider-
+// specific reasoning content. See ExtractDeltaPartsFromText for semantics.
+//
 // This function is used by both:
 //   - The existing OnTick/IncrementalExtractor path (via ExtractFrom)
 //   - Callers that want the raw textual contribution of an SSE event without
 //     the parseable/raw split from ExtractDeltaPartsFromText
-func ExtractDeltaFromText(provider string, rawText string) (string, error) {
-	delta, err := ExtractDeltaPartsFromText(provider, rawText)
+func ExtractDeltaFromText(provider string, rawText string, includeThinking bool) (string, error) {
+	delta, err := ExtractDeltaPartsFromText(provider, rawText, includeThinking)
 	if err != nil {
 		return "", err
 	}
@@ -185,6 +211,10 @@ func IsDeltaProviderSupported(provider string) bool {
 
 // IncrementalExtractor extracts SSE content incrementally, tracking which chunks
 // have already been processed to avoid re-parsing on each tick.
+//
+// includeThinkingInRaw is captured at construction time and applied uniformly
+// to every chunk processed by this extractor; see ExtractDeltaPartsFromText
+// for the per-provider semantics.
 type IncrementalExtractor struct {
 	// callCount tracks the number of calls seen (to detect retries)
 	callCount int
@@ -192,11 +222,19 @@ type IncrementalExtractor struct {
 	cursor int
 	// accumulated content from processed chunks
 	accumulated strings.Builder
+	// includeThinkingInRaw mirrors the per-request opt-in for surfacing
+	// provider-specific reasoning content. False (default) yields BAML-
+	// aligned text-only output; true additionally accumulates Anthropic
+	// thinking_delta into the running buffer.
+	includeThinkingInRaw bool
 }
 
-// NewIncrementalExtractor creates a new incremental extractor.
-func NewIncrementalExtractor() *IncrementalExtractor {
-	return &IncrementalExtractor{}
+// NewIncrementalExtractor creates a new incremental extractor. Pass
+// includeThinking=true to opt the extractor into accumulating Anthropic
+// thinking_delta content alongside text deltas; pass false (default) for
+// BAML-aligned text-only output.
+func NewIncrementalExtractor(includeThinking bool) *IncrementalExtractor {
+	return &IncrementalExtractor{includeThinkingInRaw: includeThinking}
 }
 
 // ExtractResult contains the result of an incremental extraction.
@@ -261,7 +299,7 @@ func ExtractFrom[T SSEChunk](e *IncrementalExtractor, callCount int, provider st
 			if err != nil {
 				continue
 			}
-			delta, err := ExtractDeltaFromText(provider, rawText)
+			delta, err := ExtractDeltaFromText(provider, rawText, e.includeThinkingInRaw)
 			if err == nil && delta != "" {
 				e.accumulated.WriteString(delta)
 			}
@@ -282,7 +320,7 @@ func ExtractFrom[T SSEChunk](e *IncrementalExtractor, callCount int, provider st
 		if err != nil {
 			continue
 		}
-		delta, err := ExtractDeltaFromText(provider, rawText)
+		delta, err := ExtractDeltaFromText(provider, rawText, e.includeThinkingInRaw)
 		if err == nil && delta != "" {
 			deltaBuf.WriteString(delta)
 			e.accumulated.WriteString(delta)

--- a/bamlutils/sse/extract.go
+++ b/bamlutils/sse/extract.go
@@ -212,43 +212,86 @@ func IsDeltaProviderSupported(provider string) bool {
 // IncrementalExtractor extracts SSE content incrementally, tracking which chunks
 // have already been processed to avoid re-parsing on each tick.
 //
-// includeThinkingInRaw is captured at construction time and applied uniformly
-// to every chunk processed by this extractor; see ExtractDeltaPartsFromText
-// for the per-provider semantics.
+// Two buffers are maintained side-by-side so the parseable invariant holds
+// uniformly across all consumers:
+//
+//   - parseable accumulates text-only deltas (from DeltaParts.Parseable).
+//     This is what BAML's parser sees via ParseStream — reasoning/thinking
+//     content never enters this buffer regardless of includeThinkingInRaw,
+//     so a malformed JSON-ish thinking fragment cannot influence parsing.
+//   - raw accumulates wire-output deltas (from DeltaParts.Raw). When
+//     includeThinkingInRaw is true, this additionally carries Anthropic
+//     thinking_delta content; otherwise it equals the parseable buffer
+//     byte-for-byte.
+//
+// Under the default flag-off configuration the two buffers always hold
+// identical content. Under opt-in they diverge whenever a non-text content
+// surface (e.g., thinking_delta) is observed: parseable stays text-only,
+// raw absorbs the additional content.
 type IncrementalExtractor struct {
 	// callCount tracks the number of calls seen (to detect retries)
 	callCount int
 	// cursor tracks chunks processed in the current (last) call
 	cursor int
-	// accumulated content from processed chunks
-	accumulated strings.Builder
+	// parseable accumulates text-only deltas; fed to ParseStream so the
+	// BAML parser cannot be influenced by reasoning content even under
+	// IncludeThinkingInRaw=true.
+	parseable strings.Builder
+	// raw accumulates the wire-output deltas; mirrors parseable when
+	// includeThinkingInRaw is false, and additionally carries provider-
+	// specific reasoning content when true.
+	raw strings.Builder
 	// includeThinkingInRaw mirrors the per-request opt-in for surfacing
 	// provider-specific reasoning content. False (default) yields BAML-
-	// aligned text-only output; true additionally accumulates Anthropic
-	// thinking_delta into the running buffer.
+	// aligned text-only output across both buffers; true additionally
+	// accumulates Anthropic thinking_delta into raw only.
 	includeThinkingInRaw bool
 }
 
 // NewIncrementalExtractor creates a new incremental extractor. Pass
 // includeThinking=true to opt the extractor into accumulating Anthropic
-// thinking_delta content alongside text deltas; pass false (default) for
-// BAML-aligned text-only output.
+// thinking_delta content alongside text deltas in the raw buffer; pass
+// false (default) for BAML-aligned text-only output across both the
+// parseable and raw buffers. The parseable buffer is text-only regardless
+// of this flag — the gate only affects the raw buffer.
 func NewIncrementalExtractor(includeThinking bool) *IncrementalExtractor {
 	return &IncrementalExtractor{includeThinkingInRaw: includeThinking}
 }
 
-// ExtractResult contains the result of an incremental extraction.
+// ExtractResult contains the result of an incremental extraction. Two
+// parallel pairs of (Delta, Full) values are returned, one for each
+// internal buffer:
+//
+//   - ParseableDelta / ParseableFull: text-only content. Use these to feed
+//     ParseStream so reasoning/thinking content cannot influence the
+//     BAML parser.
+//   - RawDelta / RawFull: wire-output content. Mirrors the parseable
+//     values under default (flag-off) configuration; additionally carries
+//     reasoning content when IncludeThinkingInRaw is enabled.
+//
+// Reset signals that the consumer should discard accumulated state — this
+// is set when a retry rebuild has occurred (chunks decreased or callCount
+// changed).
 type ExtractResult struct {
-	// Delta is the new content extracted from this tick (empty if no new content)
-	Delta string
-	// Full is the complete accumulated content
-	Full string
-	// Reset is true if the client should discard accumulated state (retry occurred).
-	// This is NOT set on first extraction - only when a retry causes a rebuild.
+	// ParseableDelta is the new parseable (text-only) content this tick.
+	ParseableDelta string
+	// ParseableFull is the cumulative parseable (text-only) content.
+	ParseableFull string
+	// RawDelta is the new raw content this tick (text + thinking when
+	// IncludeThinkingInRaw=true; same as ParseableDelta otherwise).
+	RawDelta string
+	// RawFull is the cumulative raw content (text + thinking when
+	// IncludeThinkingInRaw=true; same as ParseableFull otherwise).
+	RawFull string
+	// Reset is true if the client should discard accumulated state (retry
+	// occurred). This is NOT set on first extraction — only when a retry
+	// causes a rebuild.
 	Reset bool
 }
 
-// Extract processes new SSE chunks incrementally, returning only the delta.
+// Extract processes new SSE chunks incrementally, returning the parseable
+// and raw deltas plus their cumulative buffers.
+//
 // Parameters:
 //   - callCount: total number of calls in the FunctionLog (used to detect retries)
 //   - provider: the LLM provider for the current (last) call
@@ -268,7 +311,8 @@ func (e *IncrementalExtractor) Extract(callCount int, provider string, chunks []
 func (e *IncrementalExtractor) Clear() {
 	e.callCount = 0
 	e.cursor = 0
-	e.accumulated.Reset()
+	e.parseable.Reset()
+	e.raw.Reset()
 }
 
 // ExtractFrom is like Extract but accepts a concrete slice type via generics,
@@ -277,7 +321,8 @@ func (e *IncrementalExtractor) Clear() {
 // without first copying it into []SSEChunk.
 //
 // Internally it calls chunk.Text() on the concrete type and passes the raw
-// string to extractDeltaFromText, so no per-element interface boxing occurs.
+// string to ExtractDeltaPartsFromText so the parseable/raw split is preserved
+// per-event, then accumulates each part into its own buffer on the extractor.
 func ExtractFrom[T SSEChunk](e *IncrementalExtractor, callCount int, provider string, chunks []T) ExtractResult {
 	if callCount == 0 {
 		return ExtractResult{}
@@ -292,50 +337,79 @@ func ExtractFrom[T SSEChunk](e *IncrementalExtractor, callCount int, provider st
 	if needsRebuild {
 		e.callCount = callCount
 		e.cursor = 0
-		e.accumulated.Reset()
+		e.parseable.Reset()
+		e.raw.Reset()
 
 		for _, chunk := range chunks {
 			rawText, err := chunk.Text()
 			if err != nil {
 				continue
 			}
-			delta, err := ExtractDeltaFromText(provider, rawText, e.includeThinkingInRaw)
-			if err == nil && delta != "" {
-				e.accumulated.WriteString(delta)
+			parts, err := ExtractDeltaPartsFromText(provider, rawText, e.includeThinkingInRaw)
+			if err != nil {
+				continue
+			}
+			if parts.Parseable != "" {
+				e.parseable.WriteString(parts.Parseable)
+			}
+			if parts.Raw != "" {
+				e.raw.WriteString(parts.Raw)
 			}
 		}
 		e.cursor = len(chunks)
 
 		return ExtractResult{
-			Delta: e.accumulated.String(),
-			Full:  e.accumulated.String(),
-			Reset: isRetry || chunksDecreased,
+			ParseableDelta: e.parseable.String(),
+			ParseableFull:  e.parseable.String(),
+			RawDelta:       e.raw.String(),
+			RawFull:        e.raw.String(),
+			Reset:          isRetry || chunksDecreased,
 		}
 	}
 
 	// Incremental: only process new chunks
-	var deltaBuf strings.Builder
+	var parseableDeltaBuf strings.Builder
+	var rawDeltaBuf strings.Builder
 	for i := e.cursor; i < len(chunks); i++ {
 		rawText, err := chunks[i].Text()
 		if err != nil {
 			continue
 		}
-		delta, err := ExtractDeltaFromText(provider, rawText, e.includeThinkingInRaw)
-		if err == nil && delta != "" {
-			deltaBuf.WriteString(delta)
-			e.accumulated.WriteString(delta)
+		parts, err := ExtractDeltaPartsFromText(provider, rawText, e.includeThinkingInRaw)
+		if err != nil {
+			continue
+		}
+		if parts.Parseable != "" {
+			parseableDeltaBuf.WriteString(parts.Parseable)
+			e.parseable.WriteString(parts.Parseable)
+		}
+		if parts.Raw != "" {
+			rawDeltaBuf.WriteString(parts.Raw)
+			e.raw.WriteString(parts.Raw)
 		}
 	}
 	e.cursor = len(chunks)
 
 	return ExtractResult{
-		Delta: deltaBuf.String(),
-		Full:  e.accumulated.String(),
-		Reset: false,
+		ParseableDelta: parseableDeltaBuf.String(),
+		ParseableFull:  e.parseable.String(),
+		RawDelta:       rawDeltaBuf.String(),
+		RawFull:        e.raw.String(),
+		Reset:          false,
 	}
 }
 
-// Full returns the complete accumulated content without processing new data.
-func (e *IncrementalExtractor) Full() string {
-	return e.accumulated.String()
+// RawFull returns the complete accumulated raw content without processing
+// new data. Under IncludeThinkingInRaw=true this includes thinking_delta
+// content for Anthropic; otherwise it matches ParseableFull byte-for-byte.
+func (e *IncrementalExtractor) RawFull() string {
+	return e.raw.String()
+}
+
+// ParseableFull returns the complete accumulated parseable (text-only)
+// content without processing new data. Use this to feed ParseStream — the
+// returned content never includes reasoning/thinking text regardless of
+// the IncludeThinkingInRaw flag.
+func (e *IncrementalExtractor) ParseableFull() string {
+	return e.parseable.String()
 }

--- a/bamlutils/sse/extract_test.go
+++ b/bamlutils/sse/extract_test.go
@@ -23,11 +23,17 @@ func TestIncrementalExtractor_HappyPath(t *testing.T) {
 	}
 
 	result1 := extractor.Extract(1, "openai", chunks1)
-	if result1.Delta != "Hello world" {
-		t.Errorf("expected delta 'Hello world', got %q", result1.Delta)
+	if result1.RawDelta != "Hello world" {
+		t.Errorf("expected raw delta 'Hello world', got %q", result1.RawDelta)
 	}
-	if result1.Full != "Hello world" {
-		t.Errorf("expected full 'Hello world', got %q", result1.Full)
+	if result1.RawFull != "Hello world" {
+		t.Errorf("expected raw full 'Hello world', got %q", result1.RawFull)
+	}
+	if result1.ParseableDelta != "Hello world" {
+		t.Errorf("expected parseable delta 'Hello world', got %q", result1.ParseableDelta)
+	}
+	if result1.ParseableFull != "Hello world" {
+		t.Errorf("expected parseable full 'Hello world', got %q", result1.ParseableFull)
 	}
 	if result1.Reset {
 		t.Error("expected Reset=false for first extraction (nothing to reset)")
@@ -41,11 +47,11 @@ func TestIncrementalExtractor_HappyPath(t *testing.T) {
 	}
 
 	result2 := extractor.Extract(1, "openai", chunks2)
-	if result2.Delta != "!" {
-		t.Errorf("expected delta '!', got %q", result2.Delta)
+	if result2.RawDelta != "!" {
+		t.Errorf("expected raw delta '!', got %q", result2.RawDelta)
 	}
-	if result2.Full != "Hello world!" {
-		t.Errorf("expected full 'Hello world!', got %q", result2.Full)
+	if result2.RawFull != "Hello world!" {
+		t.Errorf("expected raw full 'Hello world!', got %q", result2.RawFull)
 	}
 	if result2.Reset {
 		t.Error("expected Reset=false for incremental extraction")
@@ -53,11 +59,11 @@ func TestIncrementalExtractor_HappyPath(t *testing.T) {
 
 	// Third tick: no new chunks
 	result3 := extractor.Extract(1, "openai", chunks2)
-	if result3.Delta != "" {
-		t.Errorf("expected empty delta, got %q", result3.Delta)
+	if result3.RawDelta != "" {
+		t.Errorf("expected empty raw delta, got %q", result3.RawDelta)
 	}
-	if result3.Full != "Hello world!" {
-		t.Errorf("expected full 'Hello world!', got %q", result3.Full)
+	if result3.RawFull != "Hello world!" {
+		t.Errorf("expected raw full 'Hello world!', got %q", result3.RawFull)
 	}
 	if result3.Reset {
 		t.Error("expected Reset=false when no new chunks")
@@ -76,8 +82,8 @@ func TestIncrementalExtractor_ResetOnRetry(t *testing.T) {
 	if result1.Reset {
 		t.Error("expected Reset=false for first extraction")
 	}
-	if result1.Full != "First attempt partial" {
-		t.Errorf("expected full 'First attempt partial', got %q", result1.Full)
+	if result1.RawFull != "First attempt partial" {
+		t.Errorf("expected raw full 'First attempt partial', got %q", result1.RawFull)
 	}
 
 	// Second tick: call count increased (retry) - pass NEW call's chunks
@@ -91,8 +97,8 @@ func TestIncrementalExtractor_ResetOnRetry(t *testing.T) {
 		t.Error("expected Reset=true when retry occurred (call count changed)")
 	}
 	// Should only contain content from the retry call
-	if result2.Full != "Retry success" {
-		t.Errorf("expected full 'Retry success', got %q", result2.Full)
+	if result2.RawFull != "Retry success" {
+		t.Errorf("expected raw full 'Retry success', got %q", result2.RawFull)
 	}
 
 	// Third tick: more chunks on retry call - incremental, no reset
@@ -105,30 +111,36 @@ func TestIncrementalExtractor_ResetOnRetry(t *testing.T) {
 	if result3.Reset {
 		t.Error("expected Reset=false for incremental extraction after retry")
 	}
-	if result3.Delta != "!" {
-		t.Errorf("expected delta '!', got %q", result3.Delta)
+	if result3.RawDelta != "!" {
+		t.Errorf("expected raw delta '!', got %q", result3.RawDelta)
 	}
-	if result3.Full != "Retry success!" {
-		t.Errorf("expected full 'Retry success!', got %q", result3.Full)
+	if result3.RawFull != "Retry success!" {
+		t.Errorf("expected raw full 'Retry success!', got %q", result3.RawFull)
 	}
 }
 
-func TestIncrementalExtractor_Full(t *testing.T) {
+func TestIncrementalExtractor_RawAndParseableFull(t *testing.T) {
 	extractor := NewIncrementalExtractor(false)
 
-	// Before any extraction
-	if got := extractor.Full(); got != "" {
-		t.Errorf("expected empty Full() before extraction, got %q", got)
+	// Before any extraction both accessors are empty.
+	if got := extractor.RawFull(); got != "" {
+		t.Errorf("expected empty RawFull() before extraction, got %q", got)
+	}
+	if got := extractor.ParseableFull(); got != "" {
+		t.Errorf("expected empty ParseableFull() before extraction, got %q", got)
 	}
 
-	// After extraction
+	// After extraction (text-only provider) both accessors return identical content.
 	chunks := []SSEChunk{
 		mockChunk{`{"choices":[{"delta":{"content":"test"}}]}`},
 	}
 
 	extractor.Extract(1, "openai", chunks)
-	if got := extractor.Full(); got != "test" {
-		t.Errorf("expected Full() 'test', got %q", got)
+	if got := extractor.RawFull(); got != "test" {
+		t.Errorf("expected RawFull() 'test', got %q", got)
+	}
+	if got := extractor.ParseableFull(); got != "test" {
+		t.Errorf("expected ParseableFull() 'test', got %q", got)
 	}
 }
 
@@ -141,8 +153,8 @@ func TestIncrementalExtractor_ResetWithEmptyDelta(t *testing.T) {
 	}
 
 	result1 := extractor.Extract(1, "openai", chunks1)
-	if result1.Full != "Hello" {
-		t.Errorf("expected full 'Hello', got %q", result1.Full)
+	if result1.RawFull != "Hello" {
+		t.Errorf("expected raw full 'Hello', got %q", result1.RawFull)
 	}
 
 	// Second tick: retry occurred (callCount=2) but new call has 0 chunks yet
@@ -153,11 +165,11 @@ func TestIncrementalExtractor_ResetWithEmptyDelta(t *testing.T) {
 	if !result2.Reset {
 		t.Error("expected Reset=true when retry occurred, even with empty delta")
 	}
-	if result2.Delta != "" {
-		t.Errorf("expected empty delta, got %q", result2.Delta)
+	if result2.RawDelta != "" {
+		t.Errorf("expected empty raw delta, got %q", result2.RawDelta)
 	}
-	if result2.Full != "" {
-		t.Errorf("expected empty full (new call has no content yet), got %q", result2.Full)
+	if result2.RawFull != "" {
+		t.Errorf("expected empty raw full (new call has no content yet), got %q", result2.RawFull)
 	}
 
 	// Third tick: new call gets content - Reset should now be false
@@ -169,11 +181,11 @@ func TestIncrementalExtractor_ResetWithEmptyDelta(t *testing.T) {
 	if result3.Reset {
 		t.Error("expected Reset=false for incremental update after retry")
 	}
-	if result3.Delta != "World" {
-		t.Errorf("expected delta 'World', got %q", result3.Delta)
+	if result3.RawDelta != "World" {
+		t.Errorf("expected raw delta 'World', got %q", result3.RawDelta)
 	}
-	if result3.Full != "World" {
-		t.Errorf("expected full 'World', got %q", result3.Full)
+	if result3.RawFull != "World" {
+		t.Errorf("expected raw full 'World', got %q", result3.RawFull)
 	}
 }
 
@@ -186,8 +198,8 @@ func TestIncrementalExtractor_DifferentProviders(t *testing.T) {
 	}
 
 	result1 := extractor.Extract(1, "openai", chunks1)
-	if result1.Full != "OpenAI" {
-		t.Errorf("expected full 'OpenAI', got %q", result1.Full)
+	if result1.RawFull != "OpenAI" {
+		t.Errorf("expected raw full 'OpenAI', got %q", result1.RawFull)
 	}
 
 	// Retry with Anthropic (different provider)
@@ -199,8 +211,8 @@ func TestIncrementalExtractor_DifferentProviders(t *testing.T) {
 	if !result2.Reset {
 		t.Error("expected Reset=true on retry")
 	}
-	if result2.Full != "Anthropic" {
-		t.Errorf("expected full 'Anthropic', got %q", result2.Full)
+	if result2.RawFull != "Anthropic" {
+		t.Errorf("expected raw full 'Anthropic', got %q", result2.RawFull)
 	}
 }
 
@@ -273,6 +285,52 @@ func TestExtractDeltaPartsFromText_AnthropicThinking_ParseableInvariant(t *testi
 	}
 }
 
+// TestIncrementalExtractor_AnthropicThinking_ParseableInvariant exercises the
+// extractor end-to-end with a thinking-then-text Anthropic stream and asserts
+// the structural guarantee at the buffer level: regardless of the
+// IncludeThinkingInRaw flag, the parseable buffer is text-only. Under opt-in
+// the raw buffer additionally carries thinking content; under default both
+// buffers are equal.
+//
+// This test is the architectural counterpart to the per-event parseable
+// invariant test above — it verifies the guarantee survives accumulation,
+// which is what the legacy stream path relies on when feeding ParseStream.
+func TestIncrementalExtractor_AnthropicThinking_ParseableInvariant(t *testing.T) {
+	chunks := []SSEChunk{
+		mockChunk{`{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"Let me reason..."}}`},
+		mockChunk{`{"type":"content_block_delta","delta":{"type":"text_delta","text":"The answer "}}`},
+		mockChunk{`{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":" still thinking"}}`},
+		mockChunk{`{"type":"content_block_delta","delta":{"type":"text_delta","text":"is 42"}}`},
+	}
+
+	// Default flag: both buffers carry text only.
+	extOff := NewIncrementalExtractor(false)
+	rOff := extOff.Extract(1, "anthropic", chunks)
+	if rOff.ParseableFull != "The answer is 42" {
+		t.Errorf("default: ParseableFull = %q, want %q", rOff.ParseableFull, "The answer is 42")
+	}
+	if rOff.RawFull != "The answer is 42" {
+		t.Errorf("default: RawFull = %q, want %q (text-only)", rOff.RawFull, "The answer is 42")
+	}
+
+	// Opt-in: parseable still text-only, raw carries thinking + text.
+	extOn := NewIncrementalExtractor(true)
+	rOn := extOn.Extract(1, "anthropic", chunks)
+	if rOn.ParseableFull != "The answer is 42" {
+		t.Errorf("opt-in: ParseableFull = %q, want %q (parseable invariant violated!)", rOn.ParseableFull, "The answer is 42")
+	}
+	expectedRaw := "Let me reason...The answer  still thinkingis 42"
+	if rOn.RawFull != expectedRaw {
+		t.Errorf("opt-in: RawFull = %q, want %q", rOn.RawFull, expectedRaw)
+	}
+
+	// Cross-flag invariant: parseable is byte-identical regardless of flag.
+	if rOff.ParseableFull != rOn.ParseableFull {
+		t.Errorf("Parseable diverged across flag values: off=%q on=%q",
+			rOff.ParseableFull, rOn.ParseableFull)
+	}
+}
+
 func TestGetCurrentContent_OnlyUsesLastCall(t *testing.T) {
 	// GetCurrentContent should also only use the last call
 	data := &StreamingData{
@@ -306,7 +364,7 @@ func TestIncrementalExtractor_ZeroCallCount(t *testing.T) {
 
 	// callCount=0 should return empty result
 	result := extractor.Extract(0, "openai", nil)
-	if result.Delta != "" || result.Full != "" || result.Reset {
+	if result.RawDelta != "" || result.RawFull != "" || result.ParseableDelta != "" || result.ParseableFull != "" || result.Reset {
 		t.Error("expected empty result for callCount=0")
 	}
 }
@@ -339,11 +397,11 @@ func TestExtractFrom_MatchesExtract(t *testing.T) {
 	r1 := ext1.Extract(1, "openai", ifaceChunks)
 	r2 := ExtractFrom(ext2, 1, "openai", concreteChunks)
 
-	if r1.Delta != r2.Delta {
-		t.Errorf("Delta mismatch: Extract=%q, ExtractFrom=%q", r1.Delta, r2.Delta)
+	if r1.RawDelta != r2.RawDelta {
+		t.Errorf("RawDelta mismatch: Extract=%q, ExtractFrom=%q", r1.RawDelta, r2.RawDelta)
 	}
-	if r1.Full != r2.Full {
-		t.Errorf("Full mismatch: Extract=%q, ExtractFrom=%q", r1.Full, r2.Full)
+	if r1.RawFull != r2.RawFull {
+		t.Errorf("RawFull mismatch: Extract=%q, ExtractFrom=%q", r1.RawFull, r2.RawFull)
 	}
 	if r1.Reset != r2.Reset {
 		t.Errorf("Reset mismatch: Extract=%v, ExtractFrom=%v", r1.Reset, r2.Reset)
@@ -356,11 +414,11 @@ func TestExtractFrom_MatchesExtract(t *testing.T) {
 	r1 = ext1.Extract(1, "openai", ifaceChunks)
 	r2 = ExtractFrom(ext2, 1, "openai", concreteChunks)
 
-	if r1.Delta != r2.Delta {
-		t.Errorf("Delta mismatch (tick 2): Extract=%q, ExtractFrom=%q", r1.Delta, r2.Delta)
+	if r1.RawDelta != r2.RawDelta {
+		t.Errorf("RawDelta mismatch (tick 2): Extract=%q, ExtractFrom=%q", r1.RawDelta, r2.RawDelta)
 	}
-	if r1.Full != r2.Full {
-		t.Errorf("Full mismatch (tick 2): Extract=%q, ExtractFrom=%q", r1.Full, r2.Full)
+	if r1.RawFull != r2.RawFull {
+		t.Errorf("RawFull mismatch (tick 2): Extract=%q, ExtractFrom=%q", r1.RawFull, r2.RawFull)
 	}
 	if r1.Reset != r2.Reset {
 		t.Errorf("Reset mismatch (tick 2): Extract=%v, ExtractFrom=%v", r1.Reset, r2.Reset)
@@ -386,8 +444,8 @@ func TestExtractFrom_RetryReset(t *testing.T) {
 	if !r2.Reset {
 		t.Error("expected Reset=true on retry")
 	}
-	if r2.Full != "Retry" {
-		t.Errorf("expected Full 'Retry', got %q", r2.Full)
+	if r2.RawFull != "Retry" {
+		t.Errorf("expected RawFull 'Retry', got %q", r2.RawFull)
 	}
 }
 
@@ -395,7 +453,7 @@ func TestExtractFrom_ZeroCallCount(t *testing.T) {
 	ext := NewIncrementalExtractor(false)
 
 	result := ExtractFrom(ext, 0, "openai", []concreteChunk(nil))
-	if result.Delta != "" || result.Full != "" || result.Reset {
+	if result.RawDelta != "" || result.RawFull != "" || result.ParseableDelta != "" || result.ParseableFull != "" || result.Reset {
 		t.Error("expected empty result for callCount=0")
 	}
 }
@@ -409,18 +467,24 @@ func TestIncrementalExtractor_Clear(t *testing.T) {
 		mockChunk{`{"choices":[{"delta":{"content":" world"}}]}`},
 	}
 	r := ext.Extract(1, "openai", chunks)
-	if r.Full != "Hello world" {
-		t.Fatalf("setup: expected 'Hello world', got %q", r.Full)
+	if r.RawFull != "Hello world" {
+		t.Fatalf("setup: expected 'Hello world', got %q", r.RawFull)
 	}
-	if ext.Full() != "Hello world" {
-		t.Fatalf("setup: Full() should return accumulated content")
+	if ext.RawFull() != "Hello world" {
+		t.Fatalf("setup: RawFull() should return accumulated content")
+	}
+	if ext.ParseableFull() != "Hello world" {
+		t.Fatalf("setup: ParseableFull() should return accumulated content")
 	}
 
 	// Clear resets all internal state
 	ext.Clear()
 
-	if ext.Full() != "" {
-		t.Errorf("after Clear: Full() should be empty, got %q", ext.Full())
+	if ext.RawFull() != "" {
+		t.Errorf("after Clear: RawFull() should be empty, got %q", ext.RawFull())
+	}
+	if ext.ParseableFull() != "" {
+		t.Errorf("after Clear: ParseableFull() should be empty, got %q", ext.ParseableFull())
 	}
 
 	// Next extraction should behave like a first extraction (Reset == false)
@@ -431,11 +495,11 @@ func TestIncrementalExtractor_Clear(t *testing.T) {
 	if r2.Reset {
 		t.Error("after Clear: first extraction should have Reset=false")
 	}
-	if r2.Full != "New" {
-		t.Errorf("after Clear: expected Full='New', got %q", r2.Full)
+	if r2.RawFull != "New" {
+		t.Errorf("after Clear: expected RawFull='New', got %q", r2.RawFull)
 	}
-	if r2.Delta != "New" {
-		t.Errorf("after Clear: expected Delta='New', got %q", r2.Delta)
+	if r2.RawDelta != "New" {
+		t.Errorf("after Clear: expected RawDelta='New', got %q", r2.RawDelta)
 	}
 }
 
@@ -450,8 +514,8 @@ func TestIncrementalExtractor_ResetOnChunksDecreased(t *testing.T) {
 	}
 
 	result1 := extractor.Extract(1, "openai", chunks1)
-	if result1.Full != "ABC" {
-		t.Errorf("expected full 'ABC', got %q", result1.Full)
+	if result1.RawFull != "ABC" {
+		t.Errorf("expected raw full 'ABC', got %q", result1.RawFull)
 	}
 	if result1.Reset {
 		t.Error("expected Reset=false for first extraction")
@@ -468,12 +532,12 @@ func TestIncrementalExtractor_ResetOnChunksDecreased(t *testing.T) {
 	if !result2.Reset {
 		t.Error("expected Reset=true when chunks decreased (client state is invalid)")
 	}
-	if result2.Full != "XY" {
-		t.Errorf("expected full 'XY', got %q", result2.Full)
+	if result2.RawFull != "XY" {
+		t.Errorf("expected raw full 'XY', got %q", result2.RawFull)
 	}
 	// Delta should be the full content since we rebuilt
-	if result2.Delta != "XY" {
-		t.Errorf("expected delta 'XY' (full rebuild), got %q", result2.Delta)
+	if result2.RawDelta != "XY" {
+		t.Errorf("expected raw delta 'XY' (full rebuild), got %q", result2.RawDelta)
 	}
 }
 

--- a/bamlutils/sse/extract_test.go
+++ b/bamlutils/sse/extract_test.go
@@ -14,7 +14,7 @@ func (m mockChunk) Text() (string, error) { return m.text, nil }
 func (m mockChunk) JSON() (any, error)    { return nil, nil }
 
 func TestIncrementalExtractor_HappyPath(t *testing.T) {
-	extractor := NewIncrementalExtractor()
+	extractor := NewIncrementalExtractor(false)
 
 	// First tick: 2 chunks
 	chunks1 := []SSEChunk{
@@ -65,7 +65,7 @@ func TestIncrementalExtractor_HappyPath(t *testing.T) {
 }
 
 func TestIncrementalExtractor_ResetOnRetry(t *testing.T) {
-	extractor := NewIncrementalExtractor()
+	extractor := NewIncrementalExtractor(false)
 
 	// First tick: 1 call with content
 	chunks1 := []SSEChunk{
@@ -114,7 +114,7 @@ func TestIncrementalExtractor_ResetOnRetry(t *testing.T) {
 }
 
 func TestIncrementalExtractor_Full(t *testing.T) {
-	extractor := NewIncrementalExtractor()
+	extractor := NewIncrementalExtractor(false)
 
 	// Before any extraction
 	if got := extractor.Full(); got != "" {
@@ -133,7 +133,7 @@ func TestIncrementalExtractor_Full(t *testing.T) {
 }
 
 func TestIncrementalExtractor_ResetWithEmptyDelta(t *testing.T) {
-	extractor := NewIncrementalExtractor()
+	extractor := NewIncrementalExtractor(false)
 
 	// First tick: 1 call with content
 	chunks1 := []SSEChunk{
@@ -178,7 +178,7 @@ func TestIncrementalExtractor_ResetWithEmptyDelta(t *testing.T) {
 }
 
 func TestIncrementalExtractor_DifferentProviders(t *testing.T) {
-	extractor := NewIncrementalExtractor()
+	extractor := NewIncrementalExtractor(false)
 
 	// First call with OpenAI
 	chunks1 := []SSEChunk{
@@ -204,8 +204,12 @@ func TestIncrementalExtractor_DifferentProviders(t *testing.T) {
 	}
 }
 
-func TestExtractDeltaPartsFromText_AnthropicThinking(t *testing.T) {
-	textDelta, err := ExtractDeltaPartsFromText("anthropic", `{"type":"content_block_delta","delta":{"type":"text_delta","text":"Answer"}}`)
+// TestExtractDeltaPartsFromText_AnthropicThinking_Default verifies that with
+// includeThinking=false (the default, BAML-aligned behavior), Anthropic
+// thinking_delta events contribute nothing to either Parseable or Raw, while
+// text_delta events behave normally.
+func TestExtractDeltaPartsFromText_AnthropicThinking_Default(t *testing.T) {
+	textDelta, err := ExtractDeltaPartsFromText("anthropic", `{"type":"content_block_delta","delta":{"type":"text_delta","text":"Answer"}}`, false)
 	if err != nil {
 		t.Fatalf("text delta extraction failed: %v", err)
 	}
@@ -213,12 +217,59 @@ func TestExtractDeltaPartsFromText_AnthropicThinking(t *testing.T) {
 		t.Fatalf("unexpected text delta: %+v", textDelta)
 	}
 
-	thinkingDelta, err := ExtractDeltaPartsFromText("anthropic", `{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"Reasoning"}}`)
+	thinkingDelta, err := ExtractDeltaPartsFromText("anthropic", `{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"Reasoning"}}`, false)
+	if err != nil {
+		t.Fatalf("thinking delta extraction failed: %v", err)
+	}
+	if thinkingDelta.Parseable != "" || thinkingDelta.Raw != "" {
+		t.Fatalf("expected thinking delta to be dropped under default flag, got: %+v", thinkingDelta)
+	}
+}
+
+// TestExtractDeltaPartsFromText_AnthropicThinking_OptIn verifies that with
+// includeThinking=true, Anthropic thinking_delta events accumulate into Raw
+// while Parseable stays empty (so the BAML parser is never fed thinking
+// content). text_delta behavior is unchanged.
+func TestExtractDeltaPartsFromText_AnthropicThinking_OptIn(t *testing.T) {
+	textDelta, err := ExtractDeltaPartsFromText("anthropic", `{"type":"content_block_delta","delta":{"type":"text_delta","text":"Answer"}}`, true)
+	if err != nil {
+		t.Fatalf("text delta extraction failed: %v", err)
+	}
+	if textDelta.Parseable != "Answer" || textDelta.Raw != "Answer" {
+		t.Fatalf("unexpected text delta: %+v", textDelta)
+	}
+
+	thinkingDelta, err := ExtractDeltaPartsFromText("anthropic", `{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"Reasoning"}}`, true)
 	if err != nil {
 		t.Fatalf("thinking delta extraction failed: %v", err)
 	}
 	if thinkingDelta.Parseable != "" || thinkingDelta.Raw != "Reasoning" {
-		t.Fatalf("unexpected thinking delta: %+v", thinkingDelta)
+		t.Fatalf("unexpected thinking delta under opt-in: %+v", thinkingDelta)
+	}
+}
+
+// TestExtractDeltaPartsFromText_AnthropicThinking_ParseableInvariant codifies
+// the structural guarantee that Parseable never includes thinking content,
+// regardless of the includeThinking flag value. Any future refactor that
+// breaks this invariant will fail this test.
+func TestExtractDeltaPartsFromText_AnthropicThinking_ParseableInvariant(t *testing.T) {
+	chunks := []string{
+		`{"type":"content_block_delta","delta":{"type":"text_delta","text":"Answer"}}`,
+		`{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"Reasoning"}}`,
+	}
+	for _, chunk := range chunks {
+		off, err := ExtractDeltaPartsFromText("anthropic", chunk, false)
+		if err != nil {
+			t.Fatalf("flag=false extraction failed: %v", err)
+		}
+		on, err := ExtractDeltaPartsFromText("anthropic", chunk, true)
+		if err != nil {
+			t.Fatalf("flag=true extraction failed: %v", err)
+		}
+		if off.Parseable != on.Parseable {
+			t.Errorf("Parseable diverged across flag values for chunk %q: off=%q on=%q",
+				chunk, off.Parseable, on.Parseable)
+		}
 	}
 }
 
@@ -241,7 +292,7 @@ func TestGetCurrentContent_OnlyUsesLastCall(t *testing.T) {
 		},
 	}
 
-	content, err := GetCurrentContent(data)
+	content, err := GetCurrentContent(data, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -251,7 +302,7 @@ func TestGetCurrentContent_OnlyUsesLastCall(t *testing.T) {
 }
 
 func TestIncrementalExtractor_ZeroCallCount(t *testing.T) {
-	extractor := NewIncrementalExtractor()
+	extractor := NewIncrementalExtractor(false)
 
 	// callCount=0 should return empty result
 	result := extractor.Extract(0, "openai", nil)
@@ -273,8 +324,8 @@ func TestExtractFrom_MatchesExtract(t *testing.T) {
 	// Run the same sequence through both Extract (interface slice) and
 	// ExtractFrom (concrete slice) and verify identical results.
 
-	ext1 := NewIncrementalExtractor()
-	ext2 := NewIncrementalExtractor()
+	ext1 := NewIncrementalExtractor(false)
+	ext2 := NewIncrementalExtractor(false)
 
 	ifaceChunks := []SSEChunk{
 		mockChunk{`{"choices":[{"delta":{"content":"Hello"}}]}`},
@@ -317,7 +368,7 @@ func TestExtractFrom_MatchesExtract(t *testing.T) {
 }
 
 func TestExtractFrom_RetryReset(t *testing.T) {
-	ext := NewIncrementalExtractor()
+	ext := NewIncrementalExtractor(false)
 
 	chunks1 := []concreteChunk{
 		{`{"choices":[{"delta":{"content":"First"}}]}`},
@@ -341,7 +392,7 @@ func TestExtractFrom_RetryReset(t *testing.T) {
 }
 
 func TestExtractFrom_ZeroCallCount(t *testing.T) {
-	ext := NewIncrementalExtractor()
+	ext := NewIncrementalExtractor(false)
 
 	result := ExtractFrom(ext, 0, "openai", []concreteChunk(nil))
 	if result.Delta != "" || result.Full != "" || result.Reset {
@@ -350,7 +401,7 @@ func TestExtractFrom_ZeroCallCount(t *testing.T) {
 }
 
 func TestIncrementalExtractor_Clear(t *testing.T) {
-	ext := NewIncrementalExtractor()
+	ext := NewIncrementalExtractor(false)
 
 	// Populate state with two ticks
 	chunks := []SSEChunk{
@@ -389,7 +440,7 @@ func TestIncrementalExtractor_Clear(t *testing.T) {
 }
 
 func TestIncrementalExtractor_ResetOnChunksDecreased(t *testing.T) {
-	extractor := NewIncrementalExtractor()
+	extractor := NewIncrementalExtractor(false)
 
 	// First tick: 3 chunks
 	chunks1 := []SSEChunk{
@@ -463,7 +514,7 @@ func TestDeltaProviderSupportMatchesExtractor(t *testing.T) {
 			t.Errorf("IsDeltaProviderSupported(%q) = false; provider has a sample chunk and must be supported", provider)
 			continue
 		}
-		parts, err := ExtractDeltaPartsFromText(provider, chunk)
+		parts, err := ExtractDeltaPartsFromText(provider, chunk, false)
 		if err != nil {
 			t.Errorf("ExtractDeltaPartsFromText(%q) returned error: %v", provider, err)
 			continue
@@ -479,7 +530,7 @@ func TestDeltaProviderSupportMatchesExtractor(t *testing.T) {
 		if IsDeltaProviderSupported(provider) {
 			t.Errorf("IsDeltaProviderSupported(%q) = true, want false", provider)
 		}
-		if _, err := ExtractDeltaPartsFromText(provider, "{}"); err == nil {
+		if _, err := ExtractDeltaPartsFromText(provider, "{}", false); err == nil {
 			t.Errorf("ExtractDeltaPartsFromText(%q, \"{}\") returned nil error; expected unsupported provider", provider)
 		} else if !strings.Contains(err.Error(), "unsupported provider") {
 			t.Errorf("ExtractDeltaPartsFromText(%q) error = %v, want to contain %q", provider, err, "unsupported provider")

--- a/bamlutils/sse/generated_hotpath_bench_test.go
+++ b/bamlutils/sse/generated_hotpath_bench_test.go
@@ -40,7 +40,7 @@ func BenchmarkGeneratedChunkInterfaceCopyAndExtract(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		extractor := NewIncrementalExtractor()
+		extractor := NewIncrementalExtractor(false)
 		sseChunks := make([]SSEChunk, len(chunks))
 		for j, chunk := range chunks {
 			sseChunks[j] = chunk
@@ -60,7 +60,7 @@ func BenchmarkExtractPreboxedChunks(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		extractor := NewIncrementalExtractor()
+		extractor := NewIncrementalExtractor(false)
 		benchExtractResultSink = extractor.Extract(1, "openai", sseChunks)
 	}
 }
@@ -74,7 +74,7 @@ func BenchmarkExtractFromConcreteChunks(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		extractor := NewIncrementalExtractor()
+		extractor := NewIncrementalExtractor(false)
 		benchExtractResultSink = ExtractFrom(extractor, 1, "openai", chunks)
 	}
 }
@@ -91,7 +91,7 @@ func BenchmarkExtractFromSteadyState(b *testing.B) {
 	allChunks := makeBenchChunks(totalChunks)
 
 	// Pre-warm: advance the extractor to a mid-stream position.
-	extractor := NewIncrementalExtractor()
+	extractor := NewIncrementalExtractor(false)
 	for end := chunksPerTick; end <= warmupChunks; end += chunksPerTick {
 		ExtractFrom(extractor, 1, "openai", allChunks[:end])
 	}
@@ -105,7 +105,7 @@ func BenchmarkExtractFromSteadyState(b *testing.B) {
 		if next > totalChunks {
 			// Wrap around: reset extractor and re-warm so we stay in steady state
 			b.StopTimer()
-			extractor = NewIncrementalExtractor()
+			extractor = NewIncrementalExtractor(false)
 			for end := chunksPerTick; end <= warmupChunks; end += chunksPerTick {
 				ExtractFrom(extractor, 1, "openai", allChunks[:end])
 			}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -187,6 +187,11 @@ func (o *workerBamlOptions) apply(adapter bamlutils.Adapter) error {
 		adapter.SetRetryConfig(o.Options.Retry)
 	}
 
+	// Always pass IncludeThinkingInRaw through (even when false) so the
+	// adapter reflects an explicit per-request choice. Default value
+	// matches BAML's RawLLMResponse() text-only contract.
+	adapter.SetIncludeThinkingInRaw(o.Options.IncludeThinkingInRaw)
+
 	return nil
 }
 

--- a/integration/mockllm/providers.go
+++ b/integration/mockllm/providers.go
@@ -195,9 +195,17 @@ func (p *AnthropicProvider) ContentType(streaming bool) string {
 // Anthropic streaming response. Used by streamAnthropicWithThinking which
 // decouples the message prologue from FormatChunk so a thinking content
 // block can be emitted before the text content block.
+//
+// The "usage" object is required by AnthropicMessageResponse in BAML's
+// types.rs (input_tokens and output_tokens are non-optional u64 fields);
+// omitting it causes MessageChunk::deserialize to fail on pre-0.218 BAML
+// runtimes where stream.rs enforces a "stream ended cleanly" check. On
+// 0.218+ a missing usage just produces a single LLMFailure event in the
+// middle of the stream, which is harmless because subsequent text-block
+// events still drive the accumulator forward.
 func (p *AnthropicProvider) AnthropicMessageStart() string {
 	return `event: message_start` + "\n" +
-		`data: {"type":"message_start","message":{"id":"msg-test","type":"message","role":"assistant","content":[],"model":"test-model"}}` + "\n\n"
+		`data: {"type":"message_start","message":{"id":"msg-test","type":"message","role":"assistant","content":[],"model":"test-model","usage":{"input_tokens":10,"output_tokens":0}}}` + "\n\n"
 }
 
 // AnthropicBlockStart emits a content_block_start event for the given block
@@ -249,8 +257,15 @@ func (p *AnthropicProvider) AnthropicBlockStop(blockIndex int) string {
 // that closes an Anthropic streaming response. Equivalent to the existing
 // FormatDone() output but exposed as a named primitive so the
 // thinking-aware stream path can reuse it.
+//
+// AnthropicUsage requires both input_tokens and output_tokens (non-optional
+// u64); omitting input_tokens makes MessageDelta deserialization fail on
+// pre-0.218 BAML runtimes, which prevents baml_is_complete from being set
+// to true and causes stream.rs to report a "Stream ended prematurely"
+// timeout. The same shape is used in FormatDone for symmetry across the
+// thinking-aware and non-thinking streaming paths.
 func (p *AnthropicProvider) AnthropicMessageStop() string {
-	return "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":10}}\n\n" +
+	return "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":10}}\n\n" +
 		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
 }
 

--- a/integration/mockllm/providers.go
+++ b/integration/mockllm/providers.go
@@ -112,8 +112,10 @@ func (p *AnthropicProvider) FormatChunk(content string, index int) string {
 		// First chunk: send message_start + content_block_start + first delta.
 		// The prologue is emitted unconditionally even when content is empty —
 		// the delta simply carries an empty "text" field in that case.
+		// usage is required by AnthropicMessageResponse on every BAML version;
+		// see the comment on AnthropicMessageStart for the per-version impact.
 		start := `event: message_start` + "\n" +
-			`data: {"type":"message_start","message":{"id":"msg-test","type":"message","role":"assistant","content":[],"model":"test-model"}}` + "\n\n"
+			`data: {"type":"message_start","message":{"id":"msg-test","type":"message","role":"assistant","content":[],"model":"test-model","usage":{"input_tokens":10,"output_tokens":0}}}` + "\n\n"
 		blockStart := `event: content_block_start` + "\n" +
 			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n"
 		delta := map[string]any{
@@ -143,8 +145,13 @@ func (p *AnthropicProvider) FormatFinalChunk(index int) string {
 	return "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n"
 }
 
+// FormatDone matches the usage shape on AnthropicMessageStop: AnthropicUsage
+// requires both input_tokens and output_tokens (non-optional u64), so omitting
+// either makes message_delta deserialization fail on pre-0.218 BAML runtimes
+// and surfaces as a "Stream ended prematurely" timeout. See AnthropicMessageStop
+// for the full per-version analysis.
 func (p *AnthropicProvider) FormatDone() string {
-	return "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":10}}\n\n" +
+	return "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":10}}\n\n" +
 		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
 }
 

--- a/integration/mockllm/providers.go
+++ b/integration/mockllm/providers.go
@@ -149,21 +149,36 @@ func (p *AnthropicProvider) FormatDone() string {
 }
 
 func (p *AnthropicProvider) FormatNonStreaming(content string) ([]byte, error) {
+	return p.FormatNonStreamingWithThinking(content, "")
+}
+
+// FormatNonStreamingWithThinking emits the Anthropic non-streaming response
+// shape with an optional leading "thinking" content block before the "text"
+// block. When thinking is empty, the response is identical to
+// FormatNonStreaming(content).
+func (p *AnthropicProvider) FormatNonStreamingWithThinking(content, thinking string) ([]byte, error) {
+	contentBlocks := make([]map[string]any, 0, 2)
+	if thinking != "" {
+		contentBlocks = append(contentBlocks, map[string]any{
+			"type":     "thinking",
+			"thinking": thinking,
+		})
+	}
+	contentBlocks = append(contentBlocks, map[string]any{
+		"type": "text",
+		"text": content,
+	})
+
 	response := map[string]any{
-		"id":    "msg-test",
-		"type":  "message",
-		"role":  "assistant",
-		"model": "test-model",
-		"content": []map[string]any{
-			{
-				"type": "text",
-				"text": content,
-			},
-		},
+		"id":          "msg-test",
+		"type":        "message",
+		"role":        "assistant",
+		"model":       "test-model",
+		"content":     contentBlocks,
 		"stop_reason": "end_turn",
 		"usage": map[string]any{
 			"input_tokens":  10,
-			"output_tokens": len(content) / 4,
+			"output_tokens": (len(content) + len(thinking)) / 4,
 		},
 	}
 	return json.Marshal(response)
@@ -174,6 +189,69 @@ func (p *AnthropicProvider) ContentType(streaming bool) string {
 		return "text/event-stream"
 	}
 	return "application/json"
+}
+
+// AnthropicMessageStart returns the message_start SSE event that opens an
+// Anthropic streaming response. Used by streamAnthropicWithThinking which
+// decouples the message prologue from FormatChunk so a thinking content
+// block can be emitted before the text content block.
+func (p *AnthropicProvider) AnthropicMessageStart() string {
+	return `event: message_start` + "\n" +
+		`data: {"type":"message_start","message":{"id":"msg-test","type":"message","role":"assistant","content":[],"model":"test-model"}}` + "\n\n"
+}
+
+// AnthropicBlockStart emits a content_block_start event for the given block
+// type and content_block index. blockType is "text" or "thinking".
+func (p *AnthropicProvider) AnthropicBlockStart(blockType string, blockIndex int) string {
+	var emptyField string
+	switch blockType {
+	case "thinking":
+		emptyField = `"thinking":""`
+	default:
+		emptyField = `"text":""`
+	}
+	return fmt.Sprintf(
+		"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":%d,\"content_block\":{\"type\":%q,%s}}\n\n",
+		blockIndex, blockType, emptyField,
+	)
+}
+
+// AnthropicBlockDelta emits a content_block_delta event for the given delta
+// type and content_block index. deltaType is "text_delta" or "thinking_delta",
+// content is the delta payload (placed in the .text or .thinking field
+// respectively).
+func (p *AnthropicProvider) AnthropicBlockDelta(deltaType, content string, blockIndex int) string {
+	var deltaPayload map[string]any
+	switch deltaType {
+	case "thinking_delta":
+		deltaPayload = map[string]any{"type": "thinking_delta", "thinking": content}
+	default:
+		deltaPayload = map[string]any{"type": "text_delta", "text": content}
+	}
+	event := map[string]any{
+		"type":  "content_block_delta",
+		"index": blockIndex,
+		"delta": deltaPayload,
+	}
+	data, _ := json.Marshal(event)
+	return fmt.Sprintf("event: content_block_delta\ndata: %s\n\n", data)
+}
+
+// AnthropicBlockStop emits a content_block_stop event for the given index.
+func (p *AnthropicProvider) AnthropicBlockStop(blockIndex int) string {
+	return fmt.Sprintf(
+		"event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":%d}\n\n",
+		blockIndex,
+	)
+}
+
+// AnthropicMessageStop returns the message_delta + message_stop terminator
+// that closes an Anthropic streaming response. Equivalent to the existing
+// FormatDone() output but exposed as a named primitive so the
+// thinking-aware stream path can reuse it.
+func (p *AnthropicProvider) AnthropicMessageStop() string {
+	return "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":10}}\n\n" +
+		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
 }
 
 // GoogleAIProvider implements the Google AI (Gemini) streaming format.

--- a/integration/mockllm/scenario.go
+++ b/integration/mockllm/scenario.go
@@ -19,6 +19,16 @@ type Scenario struct {
 	// Content is the actual LLM response content to return
 	Content string `json:"content"`
 
+	// Thinking is provider-specific reasoning/thinking content emitted as
+	// a separate content block (Anthropic) ahead of Content. Empty by
+	// default, in which case the response carries only Content. Currently
+	// honoured by AnthropicProvider:
+	//   - non-streaming: emits a "thinking" block before the "text" block
+	//   - streaming: emits content_block_start/delta/stop for thinking at
+	//     content_block index 0, then the text block at index 1
+	// Other providers ignore this field.
+	Thinking string `json:"thinking,omitempty"`
+
 	// ChunkSize is the number of characters per SSE chunk (0 = single non-streaming response)
 	ChunkSize int `json:"chunk_size"`
 

--- a/integration/mockllm/server.go
+++ b/integration/mockllm/server.go
@@ -51,6 +51,11 @@ func NewServer(addr string) *Server {
 	app.Post("/v1/chat/completions", s.handleChatCompletions)
 	app.Post("/chat/completions", s.handleChatCompletions)
 
+	// Anthropic Messages API endpoint. The Anthropic provider in BAML appends
+	// "/v1/messages" to the configured base_url, so client base_url should be
+	// the bare scheme://host of the mock server (e.g. http://mockllm:8080).
+	app.Post("/v1/messages", s.handleAnthropicMessages)
+
 	s.app = app
 
 	return s
@@ -224,15 +229,44 @@ func (s *Server) handleChatCompletions(c fiber.Ctx) error {
 
 	s.log("chat completions request: model=%s, stream=%v", req.Model, req.Stream)
 
+	return s.dispatchScenario(c, body, req.Model, req.Stream)
+}
+
+// anthropicMessagesRequest is the minimal Anthropic Messages API request
+// shape needed for scenario routing. We only use Model (for scenario lookup)
+// and Stream; everything else is consumed by the response shape provided by
+// AnthropicProvider so we don't deserialize it here.
+type anthropicMessagesRequest struct {
+	Model  string `json:"model"`
+	Stream bool   `json:"stream"`
+}
+
+func (s *Server) handleAnthropicMessages(c fiber.Ctx) error {
+	body := append([]byte(nil), c.Body()...)
+
+	var req anthropicMessagesRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.Status(fiber.StatusBadRequest).SendString(fmt.Sprintf("invalid JSON: %v", err))
+	}
+
+	s.log("anthropic messages request: model=%s, stream=%v", req.Model, req.Stream)
+
+	return s.dispatchScenario(c, body, req.Model, req.Stream)
+}
+
+// dispatchScenario is the shared scenario lookup + provider dispatch path
+// used by both the OpenAI and Anthropic endpoints. The endpoint-specific
+// handlers stay narrow (just request decoding) and delegate the rest here.
+func (s *Server) dispatchScenario(c fiber.Ctx, body []byte, model string, stream bool) error {
 	// Look up scenario by model name and get effective delay for this request
-	scenario, effectiveDelay, ok := s.store.GetAndAdvance(req.Model)
+	scenario, effectiveDelay, ok := s.store.GetAndAdvance(model)
 	if !ok {
-		s.log("scenario not found for model: %s", req.Model)
-		return c.Status(fiber.StatusNotFound).SendString(fmt.Sprintf("no scenario registered for model: %s", req.Model))
+		s.log("scenario not found for model: %s", model)
+		return c.Status(fiber.StatusNotFound).SendString(fmt.Sprintf("no scenario registered for model: %s", model))
 	}
 
 	// Capture request body for test inspection
-	s.store.CaptureRequest(req.Model, body)
+	s.store.CaptureRequest(model, body)
 
 	s.log("effective initial delay for this request: %dms", effectiveDelay)
 
@@ -262,7 +296,7 @@ func (s *Server) handleChatCompletions(c fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).SendString("Internal Server Error")
 	}
 
-	if req.Stream {
+	if stream {
 		return s.handleStreamingResponse(c, scenario, provider, effectiveDelay)
 	}
 
@@ -337,7 +371,18 @@ func (s *Server) handleNonStreamingResponse(c fiber.Ctx, scenario *Scenario, pro
 		}
 	}
 
-	data, err := provider.FormatNonStreaming(scenario.Content)
+	// Anthropic with scenario.Thinking emits a leading thinking content block
+	// before the text block. The base Provider interface stays text-only; the
+	// thinking-aware shape is reached through the concrete Anthropic type.
+	var (
+		data []byte
+		err  error
+	)
+	if anthropic, ok := provider.(*AnthropicProvider); ok && scenario.Thinking != "" {
+		data, err = anthropic.FormatNonStreamingWithThinking(scenario.Content, scenario.Thinking)
+	} else {
+		data, err = provider.FormatNonStreaming(scenario.Content)
+	}
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString(fmt.Sprintf("failed to format response: %v", err))
 	}

--- a/integration/mockllm/streaming.go
+++ b/integration/mockllm/streaming.go
@@ -53,8 +53,6 @@ func (sw *StreamWriter) WriteDone() error {
 // StreamResponse streams the scenario content with configured timing.
 // The effectiveDelay parameter overrides scenario.InitialDelayMs when specified (>= 0).
 func StreamResponse(ctx context.Context, w *bufio.Writer, scenario *Scenario, provider Provider, effectiveDelay int) error {
-	sw := NewStreamWriter(w, provider)
-
 	// Initial delay - use the effective delay passed from the caller
 	if effectiveDelay > 0 {
 		select {
@@ -64,6 +62,15 @@ func StreamResponse(ctx context.Context, w *bufio.Writer, scenario *Scenario, pr
 		}
 	}
 
+	// Anthropic with scenario.Thinking takes a dedicated path that emits a
+	// thinking content block (index 0) before the text content block (index 1).
+	// The existing FormatChunk-based path doesn't handle multi-block streams,
+	// so we keep it for the default text-only case and branch here when needed.
+	if anthropic, ok := provider.(*AnthropicProvider); ok && scenario.Thinking != "" {
+		return streamAnthropicWithThinking(ctx, w, scenario, anthropic)
+	}
+
+	sw := NewStreamWriter(w, provider)
 	content := scenario.Content
 	chunkSize := scenario.ChunkSize
 	if chunkSize <= 0 {
@@ -110,6 +117,115 @@ func StreamResponse(ctx context.Context, w *bufio.Writer, scenario *Scenario, pr
 	}
 
 	return sw.WriteDone()
+}
+
+// streamAnthropicWithThinking emits an Anthropic streaming response with a
+// thinking content block followed by a text content block. Both blocks honor
+// scenario.ChunkSize / ChunkDelayMs / ChunkJitterMs for delta pacing, and
+// failure injection is honored across the full event sequence (counted from
+// the first delta of either block, matching the existing semantics).
+func streamAnthropicWithThinking(ctx context.Context, w *bufio.Writer, scenario *Scenario, provider *AnthropicProvider) error {
+	deltaIndex := 0
+
+	// message_start
+	if _, err := w.WriteString(provider.AnthropicMessageStart()); err != nil {
+		return err
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	// Thinking content block (index 0)
+	if err := streamAnthropicBlock(ctx, w, provider, "thinking", "thinking_delta", scenario.Thinking, 0, scenario, &deltaIndex); err != nil {
+		return err
+	}
+
+	// Text content block (index 1)
+	if err := streamAnthropicBlock(ctx, w, provider, "text", "text_delta", scenario.Content, 1, scenario, &deltaIndex); err != nil {
+		return err
+	}
+
+	// message_delta + message_stop
+	if _, err := w.WriteString(provider.AnthropicMessageStop()); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+// streamAnthropicBlock streams a single Anthropic content_block (start, one
+// or more deltas honoring scenario chunking, stop). deltaIndex is the
+// running cross-block delta count used by the FailAfter check so it matches
+// the chunk counting semantics of the default StreamResponse path.
+func streamAnthropicBlock(
+	ctx context.Context,
+	w *bufio.Writer,
+	provider *AnthropicProvider,
+	blockType, deltaType, content string,
+	blockIndex int,
+	scenario *Scenario,
+	deltaIndex *int,
+) error {
+	if _, err := w.WriteString(provider.AnthropicBlockStart(blockType, blockIndex)); err != nil {
+		return err
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	chunkSize := scenario.ChunkSize
+	if chunkSize <= 0 {
+		chunkSize = len(content)
+	}
+	if chunkSize <= 0 {
+		// Empty content — emit one empty delta so the block has a delta event,
+		// matching the shape of FormatChunk for an empty content scenario.
+		if _, err := w.WriteString(provider.AnthropicBlockDelta(deltaType, "", blockIndex)); err != nil {
+			return err
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+		*deltaIndex++
+	} else {
+		for i := 0; i < len(content); i += chunkSize {
+			end := i + chunkSize
+			if end > len(content) {
+				end = len(content)
+			}
+			chunk := content[i:end]
+
+			if scenario.FailAfter > 0 && *deltaIndex >= scenario.FailAfter {
+				return handleFailure(ctx, scenario)
+			}
+
+			if _, err := w.WriteString(provider.AnthropicBlockDelta(deltaType, chunk, blockIndex)); err != nil {
+				return err
+			}
+			if err := w.Flush(); err != nil {
+				return err
+			}
+			*deltaIndex++
+
+			if end < len(content) {
+				delay := scenario.ChunkDelayMs
+				if scenario.ChunkJitterMs > 0 {
+					delay += rand.Intn(scenario.ChunkJitterMs)
+				}
+				if delay > 0 {
+					select {
+					case <-time.After(time.Duration(delay) * time.Millisecond):
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+			}
+		}
+	}
+
+	if _, err := w.WriteString(provider.AnthropicBlockStop(blockIndex)); err != nil {
+		return err
+	}
+	return w.Flush()
 }
 
 func handleFailure(ctx context.Context, scenario *Scenario) error {

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -968,6 +968,29 @@ func CreateTestClient(mockLLMURL string, scenarioID string) *ClientRegistry {
 	}
 }
 
+// CreateAnthropicTestClient creates a client registry that points to the mock
+// LLM server using the Anthropic provider. The mock server's "/v1/messages"
+// route handles Anthropic-shaped requests; BAML's Anthropic client appends
+// "/v1/messages" to base_url so mockLLMURL should be the bare scheme://host
+// (e.g. "http://mockllm:8080"), without a "/v1" suffix.
+func CreateAnthropicTestClient(mockLLMURL string, scenarioID string) *ClientRegistry {
+	return &ClientRegistry{
+		Primary: "TestClient",
+		Clients: []*ClientProperty{
+			{
+				Name:     "TestClient",
+				Provider: "anthropic",
+				Options: map[string]any{
+					"model":      scenarioID,
+					"base_url":   mockLLMURL,
+					"api_key":    "test-key",
+					"max_tokens": 1024,
+				},
+			},
+		},
+	}
+}
+
 // DynamicContentPart represents a single part within a multi-part message content.
 type DynamicContentPart struct {
 	Type  string      `json:"type"`

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -137,6 +137,11 @@ type CallRequest struct {
 type BAMLOptions struct {
 	ClientRegistry *ClientRegistry `json:"client_registry,omitempty"`
 	TypeBuilder    *TypeBuilder    `json:"type_builder,omitempty"`
+	// IncludeThinkingInRaw mirrors bamlutils.BamlOptions.IncludeThinkingInRaw.
+	// Default false matches BAML's RawLLMResponse() text-only contract; set
+	// true to opt the request into surfacing provider-specific reasoning
+	// content (e.g. Anthropic thinking blocks) in /with-raw's `raw` field.
+	IncludeThinkingInRaw bool `json:"include_thinking_in_raw,omitempty"`
 }
 
 // ClientRegistry allows overriding client configuration.

--- a/integration/thinking_test.go
+++ b/integration/thinking_test.go
@@ -340,7 +340,15 @@ func runStreamWithRaw(t *testing.T, ctx context.Context, opts *testutil.BAMLOpti
 			if len(event.Data) > 0 && string(event.Data) != "null" {
 				result.dataEvents = append(result.dataEvents, event.Data)
 			}
-		case err := <-errs:
+		case err, ok := <-errs:
+			if !ok {
+				// errs closed by the streaming goroutine; nil out the
+				// channel so this select arm blocks forever and we
+				// continue draining events without spinning. The events
+				// arm's !ok check below is what terminates the loop.
+				errs = nil
+				continue
+			}
 			if err != nil {
 				t.Fatalf("Stream error: %v", err)
 			}

--- a/integration/thinking_test.go
+++ b/integration/thinking_test.go
@@ -9,14 +9,20 @@ package integration
 // StreamConfig/CallConfig → extractors → HTTP envelope — that the unit
 // tests below the orchestrator boundary can't cover end-to-end.
 //
-// Each public scenario is exercised in three flag states:
+// Each public scenario is exercised in two flag states:
 //
 //   - "default" (omitted from the request body) — expected: thinking absent
 //     from raw, matching upstream BAML's RawLLMResponse() text-only contract.
-//   - "explicit_false" — expected: identical to default. Codifies that
-//     setting the field to false must not differ from omitting it.
 //   - "opt_in" (true) — expected: thinking text included in raw, parseable
 //     unchanged.
+//
+// Note on a third state: BamlOptions.IncludeThinkingInRaw is a plain
+// `bool` with `json:"include_thinking_in_raw,omitempty"` on both the
+// testutil and bamlutils sides, so an explicit `false` serializes
+// identically to "field omitted" (Go's omitempty drops zero values).
+// On the worker side, a missing field decodes to the same zero value,
+// so "explicit false" and "default" are not integration-observable as
+// distinct cases — they're treated as the same scenario.
 //
 // A dedicated parseable-invariant test runs the same input through both the
 // default and opt-in flag values and asserts the parsed Data is byte-identical
@@ -93,8 +99,13 @@ func setupAnthropicThinkingScenario(t *testing.T, scenarioID, content, thinking 
 	return opts
 }
 
-// boolPtr returns a pointer to v. Used to disambiguate a missing flag (nil)
-// from an explicitly-set flag (&true / &false) when constructing BamlOptions.
+// boolPtr returns a pointer to v. Used by setupAnthropicThinkingScenario
+// so callers can pass nil to skip the assignment entirely or pass a
+// pointer to opt in. In practice the only meaningful non-nil value is
+// boolPtr(true): boolPtr(false) is observationally equivalent to nil at
+// the JSON wire (omitempty drops false) and at the worker (a missing
+// field decodes to the zero value), so all current callers use either
+// nil or boolPtr(true).
 func boolPtr(v bool) *bool { return &v }
 
 // assertParsedMessage decodes resp.Data and asserts the parsed message matches

--- a/integration/thinking_test.go
+++ b/integration/thinking_test.go
@@ -26,6 +26,7 @@ package integration
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -528,15 +529,17 @@ func TestStreamWithRaw_AnthropicThinking_ParseableInvariant_PerEvent(t *testing.
 }
 
 // containsAny returns true if s contains any of the given substrings. Tiny
-// helper to keep the leak-detection assertions readable.
+// helper to keep the leak-detection assertions readable. Empty subs are
+// skipped (rather than matching every string per strings.Contains' semantics)
+// so callers can pass conditionally-empty markers without changing the test's
+// outcome.
 func containsAny(s string, subs ...string) bool {
 	for _, sub := range subs {
-		if len(sub) > 0 && len(s) >= len(sub) {
-			for i := 0; i+len(sub) <= len(s); i++ {
-				if s[i:i+len(sub)] == sub {
-					return true
-				}
-			}
+		if sub == "" {
+			continue
+		}
+		if strings.Contains(s, sub) {
+			return true
 		}
 	}
 	return false

--- a/integration/thinking_test.go
+++ b/integration/thinking_test.go
@@ -1,0 +1,469 @@
+//go:build integration
+
+package integration
+
+// Integration tests for the IncludeThinkingInRaw opt-in covering the
+// /call-with-raw and /stream-with-raw endpoints against the mock Anthropic
+// provider. These exercise the full plumbing chain — JSON →
+// BamlOptions.IncludeThinkingInRaw → Adapter.SetIncludeThinkingInRaw →
+// StreamConfig/CallConfig → extractors → HTTP envelope — that the unit
+// tests below the orchestrator boundary can't cover end-to-end.
+//
+// Each public scenario is exercised in three flag states:
+//
+//   - "default" (omitted from the request body) — expected: thinking absent
+//     from raw, matching upstream BAML's RawLLMResponse() text-only contract.
+//   - "explicit_false" — expected: identical to default. Codifies that
+//     setting the field to false must not differ from omitting it.
+//   - "opt_in" (true) — expected: thinking text included in raw, parseable
+//     unchanged.
+//
+// A dedicated parseable-invariant test runs the same input through both the
+// default and opt-in flag values and asserts the parsed Data is byte-identical
+// across both. This codifies the structural guarantee that flipping the flag
+// can never leak thinking into the parser; the gate is on the rawSB / Raw
+// writes only, never on parseableSB / Parseable.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+const (
+	// thinkingTestContent is the text content the mock returns. Kept as a
+	// well-formed JSON object so GetSimple can parse it; the parser only sees
+	// this content (never the thinking) regardless of the flag value, by
+	// construction.
+	thinkingTestContent = `{"message": "hello"}`
+
+	// thinkingTestThinking is the thinking-block content the mock emits
+	// before the text content. Deliberately chosen to look JSON-ish so a
+	// regression that accidentally fed it into the parser would corrupt
+	// resp.Data with `"answer"` instead of `"hello"` — making any leak
+	// loud and trivially detectable.
+	thinkingTestThinking = `Let me think about this. The answer should be: {"message": "answer"}`
+)
+
+// setupAnthropicThinkingScenario registers an Anthropic-provider scenario
+// with both text content and thinking content, returning BAMLOptions ready
+// for use against /call-with-raw or /stream-with-raw.
+//
+// includeThinkingInRaw maps to BamlOptions.IncludeThinkingInRaw verbatim;
+// callers pass *bool so a nil value omits the field from the JSON entirely
+// (matching the "default" flag-absent shape).
+func setupAnthropicThinkingScenario(t *testing.T, scenarioID, content, thinking string, streaming bool, includeThinkingInRaw *bool) *testutil.BAMLOptions {
+	t.Helper()
+
+	waitForHealthy(t, 30*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	scenario := &mockllm.Scenario{
+		ID:             scenarioID,
+		Provider:       "anthropic",
+		Content:        content,
+		Thinking:       thinking,
+		InitialDelayMs: 50,
+	}
+	if streaming {
+		// Small chunks so the stream emits multiple deltas per block; this
+		// also exercises the IncrementalExtractor's accumulation path the
+		// per-event raw assertions depend on.
+		scenario.ChunkSize = 8
+		scenario.ChunkDelayMs = 5
+	}
+
+	if err := MockClient.RegisterScenario(ctx, scenario); err != nil {
+		t.Fatalf("Failed to register scenario: %v", err)
+	}
+
+	opts := &testutil.BAMLOptions{
+		ClientRegistry: testutil.CreateAnthropicTestClient(TestEnv.MockLLMInternal, scenarioID),
+	}
+	if includeThinkingInRaw != nil {
+		opts.IncludeThinkingInRaw = *includeThinkingInRaw
+	}
+	return opts
+}
+
+// boolPtr returns a pointer to v. Used to disambiguate a missing flag (nil)
+// from an explicitly-set flag (&true / &false) when constructing BamlOptions.
+func boolPtr(v bool) *bool { return &v }
+
+// assertParsedMessage decodes resp.Data and asserts the parsed message matches
+// the expected text — never the thinking. Centralized because every
+// /call-with-raw test in this file makes the same assertion (the parseable
+// guarantee is the whole point of the opt-in design).
+func assertParsedMessage(t *testing.T, data json.RawMessage, want string) {
+	t.Helper()
+	var parsed struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal parsed data: %v (raw bytes: %s)", err, string(data))
+	}
+	if parsed.Message != want {
+		t.Errorf("Parsed message: got %q, want %q (full data: %s)", parsed.Message, want, string(data))
+	}
+}
+
+// TestCallWithRaw_AnthropicThinking_DefaultExcludes verifies the default
+// (flag-absent) /call-with-raw behavior: raw contains the text only,
+// matching upstream BAML's RawLLMResponse() contract. Thinking is dropped
+// across the JSON → adapter → orchestrator → extractor chain.
+func TestCallWithRaw_AnthropicThinking_DefaultExcludes(t *testing.T) {
+	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		opts := setupAnthropicThinkingScenario(
+			t,
+			"test-anthropic-think-call-default",
+			thinkingTestContent,
+			thinkingTestThinking,
+			false, /*streaming*/
+			nil,   /*flag absent*/
+		)
+
+		resp, err := client.CallWithRaw(ctx, testutil.CallRequest{
+			Method:  "GetSimple",
+			Input:   map[string]any{"input": "anything"},
+			Options: opts,
+		})
+		if err != nil {
+			t.Fatalf("CallWithRaw failed: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		if resp.Raw != thinkingTestContent {
+			t.Errorf("default flag: raw got %q, want %q (thinking should be excluded)", resp.Raw, thinkingTestContent)
+		}
+		assertParsedMessage(t, resp.Data, "hello")
+	})
+}
+
+// TestCallWithRaw_AnthropicThinking_ExplicitFalse verifies that setting
+// IncludeThinkingInRaw=false explicitly yields the same behavior as omitting
+// it entirely. Codifies that the worker apply step always passes the value
+// through (rather than skipping the setter when false), so a per-request
+// false doesn't accidentally inherit a sticky true from a prior request on
+// the same adapter.
+func TestCallWithRaw_AnthropicThinking_ExplicitFalse(t *testing.T) {
+	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		opts := setupAnthropicThinkingScenario(
+			t,
+			"test-anthropic-think-call-explicit-false",
+			thinkingTestContent,
+			thinkingTestThinking,
+			false, /*streaming*/
+			boolPtr(false),
+		)
+
+		resp, err := client.CallWithRaw(ctx, testutil.CallRequest{
+			Method:  "GetSimple",
+			Input:   map[string]any{"input": "anything"},
+			Options: opts,
+		})
+		if err != nil {
+			t.Fatalf("CallWithRaw failed: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		if resp.Raw != thinkingTestContent {
+			t.Errorf("explicit false: raw got %q, want %q", resp.Raw, thinkingTestContent)
+		}
+		assertParsedMessage(t, resp.Data, "hello")
+	})
+}
+
+// TestCallWithRaw_AnthropicThinking_OptInIncludes verifies the opt-in
+// (flag=true) /call-with-raw behavior: raw includes both the thinking and
+// text content, with thinking emitted before text (matching the wire order
+// of the Anthropic content blocks).
+func TestCallWithRaw_AnthropicThinking_OptInIncludes(t *testing.T) {
+	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		opts := setupAnthropicThinkingScenario(
+			t,
+			"test-anthropic-think-call-optin",
+			thinkingTestContent,
+			thinkingTestThinking,
+			false, /*streaming*/
+			boolPtr(true),
+		)
+
+		resp, err := client.CallWithRaw(ctx, testutil.CallRequest{
+			Method:  "GetSimple",
+			Input:   map[string]any{"input": "anything"},
+			Options: opts,
+		})
+		if err != nil {
+			t.Fatalf("CallWithRaw failed: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		want := thinkingTestThinking + thinkingTestContent
+		if resp.Raw != want {
+			t.Errorf("opt-in: raw got %q, want %q", resp.Raw, want)
+		}
+		// Parseable invariant — thinking, even though it contains a JSON-ish
+		// fragment that mentions a different message value, must NOT confuse
+		// the parser.
+		assertParsedMessage(t, resp.Data, "hello")
+	})
+}
+
+// TestCallWithRaw_AnthropicThinking_ParseableInvariant runs the same
+// scenario through both the default and opt-in flag values and asserts the
+// parsed Data is byte-identical. This codifies the structural guarantee that
+// IncludeThinkingInRaw can never affect what the BAML parser sees — the gate
+// is on raw writes only, not parseable.
+func TestCallWithRaw_AnthropicThinking_ParseableInvariant(t *testing.T) {
+	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Use distinct scenario IDs so the request-count counter doesn't
+		// interfere across invocations; the underlying mock content is
+		// identical.
+		optsDefault := setupAnthropicThinkingScenario(
+			t,
+			"test-anthropic-think-invariant-default",
+			thinkingTestContent,
+			thinkingTestThinking,
+			false,
+			nil,
+		)
+		optsOptIn := setupAnthropicThinkingScenario(
+			t,
+			"test-anthropic-think-invariant-optin",
+			thinkingTestContent,
+			thinkingTestThinking,
+			false,
+			boolPtr(true),
+		)
+
+		respDefault, err := client.CallWithRaw(ctx, testutil.CallRequest{
+			Method:  "GetSimple",
+			Input:   map[string]any{"input": "anything"},
+			Options: optsDefault,
+		})
+		if err != nil {
+			t.Fatalf("default CallWithRaw failed: %v", err)
+		}
+		if respDefault.StatusCode != 200 {
+			t.Fatalf("default: expected status 200, got %d: %s", respDefault.StatusCode, respDefault.Error)
+		}
+
+		respOptIn, err := client.CallWithRaw(ctx, testutil.CallRequest{
+			Method:  "GetSimple",
+			Input:   map[string]any{"input": "anything"},
+			Options: optsOptIn,
+		})
+		if err != nil {
+			t.Fatalf("opt-in CallWithRaw failed: %v", err)
+		}
+		if respOptIn.StatusCode != 200 {
+			t.Fatalf("opt-in: expected status 200, got %d: %s", respOptIn.StatusCode, respOptIn.Error)
+		}
+
+		// Sanity checks the raw values diverge as expected — confirms the
+		// flag actually had an effect, so the Data equality below is a
+		// meaningful invariant check rather than a tautology.
+		if string(respDefault.Raw) == string(respOptIn.Raw) {
+			t.Fatalf("raw values unexpectedly identical between flag states: %q", respDefault.Raw)
+		}
+
+		if string(respDefault.Data) != string(respOptIn.Data) {
+			t.Errorf("parseable invariant violated:\n  default Data: %s\n  opt-in  Data: %s", respDefault.Data, respOptIn.Data)
+		}
+	})
+}
+
+// streamWithRawResult is the accumulated outcome of a /stream-with-raw run,
+// used by both the default and opt-in stream tests to share the same event
+// loop while keeping per-test assertions narrow.
+type streamWithRawResult struct {
+	lastRaw      string         // last non-empty Raw observed; cumulative by orchestrator design
+	finalEvent   *testutil.StreamEvent // the "final" event (if seen), carries fully validated Data
+	rawSnapshots []string       // every non-empty Raw observed, in order
+}
+
+// runStreamWithRaw drives a /stream-with-raw call to completion, returning
+// the accumulated raw snapshots and the final event for caller assertions.
+func runStreamWithRaw(t *testing.T, ctx context.Context, opts *testutil.BAMLOptions) streamWithRawResult {
+	t.Helper()
+
+	events, errs := BAMLClient.StreamWithRaw(ctx, testutil.CallRequest{
+		Method:  "GetSimple",
+		Input:   map[string]any{"input": "anything"},
+		Options: opts,
+	})
+
+	var result streamWithRawResult
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return result
+			}
+			if event.IsMetadata() {
+				continue
+			}
+			if event.IsFinal() {
+				ev := event
+				result.finalEvent = &ev
+			}
+			if event.Raw != "" {
+				result.lastRaw = event.Raw
+				result.rawSnapshots = append(result.rawSnapshots, event.Raw)
+			}
+		case err := <-errs:
+			if err != nil {
+				t.Fatalf("Stream error: %v", err)
+			}
+		case <-ctx.Done():
+			t.Fatal("Context cancelled")
+		}
+	}
+}
+
+// TestStreamWithRaw_AnthropicThinking_DefaultExcludes verifies the default
+// (flag-absent) /stream-with-raw behavior: per-event raw values exclude
+// thinking deltas, and the cumulative raw at end-of-stream equals the text
+// content. Thinking SSE events emit no per-event raw at all, since the
+// orchestrator skips StreamResultKindStream when delta.Raw == "".
+func TestStreamWithRaw_AnthropicThinking_DefaultExcludes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	opts := setupAnthropicThinkingScenario(
+		t,
+		"test-anthropic-think-stream-default",
+		thinkingTestContent,
+		thinkingTestThinking,
+		true, /*streaming*/
+		nil,
+	)
+
+	result := runStreamWithRaw(t, ctx, opts)
+
+	if result.lastRaw != thinkingTestContent {
+		t.Errorf("default stream: final cumulative raw got %q, want %q", result.lastRaw, thinkingTestContent)
+	}
+
+	// No per-event raw snapshot should ever contain the thinking text — even
+	// on intermediate snapshots that show partial accumulations. Any leak is
+	// a regression in the gating logic.
+	for i, snap := range result.rawSnapshots {
+		// A leaked thinking delta would manifest as a raw snapshot that
+		// either starts with a thinking byte (snap[0] is the first byte of
+		// thinking content) or contains a substring of the thinking text
+		// that isn't also in the text content.
+		if containsAny(snap, "answer", "Let me think") {
+			t.Errorf("default stream: raw snapshot %d leaked thinking content: %q", i, snap)
+		}
+	}
+
+	if result.finalEvent != nil {
+		assertParsedMessage(t, result.finalEvent.Data, "hello")
+	}
+}
+
+// TestStreamWithRaw_AnthropicThinking_OptInIncludes verifies the opt-in
+// (flag=true) /stream-with-raw behavior: the final cumulative raw equals
+// thinking + text concatenated, and at least one observable raw event
+// surfaces thinking content alongside text content.
+//
+// The path-specific timing of when thinking content first appears in
+// per-event raw differs between the BuildRequest and legacy paths:
+//
+//   - BuildRequest emits per-event raw deltas as the orchestrator parses
+//     each SSE frame, so intermediate snapshots can be a strict prefix of
+//     thinking text before any text deltas arrive.
+//   - Legacy uses the IncrementalExtractor + ParseStream loop. Early
+//     thinking-only ticks are accumulated by the extractor but ParseStream
+//     fails on the not-yet-JSON content and no partial is emitted; the
+//     thinking content surfaces in the final event via the codegen's
+//     max(extractor.Full(), RawLLMResponse()) reconciliation at
+//     adapters/common/codegen/codegen.go:4124-4138.
+//
+// Both paths converge to the same final cumulative raw, which is what the
+// /with-raw contract guarantees. The test asserts that, plus a uniqueness
+// check on a thinking-only substring to confirm the flag actually had an
+// effect on observable raw output (rather than the final assertion
+// accidentally matching for some other reason).
+func TestStreamWithRaw_AnthropicThinking_OptInIncludes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	opts := setupAnthropicThinkingScenario(
+		t,
+		"test-anthropic-think-stream-optin",
+		thinkingTestContent,
+		thinkingTestThinking,
+		true,
+		boolPtr(true),
+	)
+
+	result := runStreamWithRaw(t, ctx, opts)
+
+	want := thinkingTestThinking + thinkingTestContent
+	if result.lastRaw != want {
+		t.Errorf("opt-in stream: final cumulative raw got %q, want %q", result.lastRaw, want)
+	}
+
+	// thinkingOnlyMarker is a substring that appears in the thinking text
+	// but never in the text content, so observing it in raw confirms the
+	// opt-in flag took effect end-to-end. "answer" is in thinking
+	// ('{"message": "answer"}') but not in content ('{"message": "hello"}').
+	const thinkingOnlyMarker = "answer"
+	sawThinkingMarker := false
+	for _, snap := range result.rawSnapshots {
+		if containsAny(snap, thinkingOnlyMarker) {
+			sawThinkingMarker = true
+			break
+		}
+	}
+	if !sawThinkingMarker {
+		t.Errorf("opt-in stream: expected raw to contain %q somewhere; got snapshots: %v", thinkingOnlyMarker, result.rawSnapshots)
+	}
+
+	if result.finalEvent != nil {
+		// Parseable invariant — even when raw includes thinking, the parsed
+		// data must reflect text only.
+		assertParsedMessage(t, result.finalEvent.Data, "hello")
+	}
+}
+
+// containsAny returns true if s contains any of the given substrings. Tiny
+// helper to keep the leak-detection assertions readable.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if len(sub) > 0 && len(s) >= len(sub) {
+			for i := 0; i+len(sub) <= len(s); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/integration/thinking_test.go
+++ b/integration/thinking_test.go
@@ -416,9 +416,14 @@ func TestStreamWithRaw_AnthropicThinking_DefaultExcludes(t *testing.T) {
 //     (text + thinking under opt-in) buffers. ParseStream is fed the
 //     parseable buffer, so early thinking-only ticks emit a raw-only
 //     partial without parsed Data. The thinking content reaches the wire
-//     incrementally as those raw-only partials, and is also reconciled at
-//     the final via max(extractor.RawFull(), RawLLMResponse()) at
-//     adapters/common/codegen/codegen.go:4144-4168.
+//     incrementally as those raw-only partials. At end-of-stream a
+//     suffix-splice reconciliation at
+//     adapters/common/codegen/codegen.go:4144-4197 compares
+//     extractor.ParseableFull (text-only the extractor saw) against
+//     fl.RawLLMResponse() (BAML's authoritative text-only): if the
+//     latter extends the former as a prefix, the missing text suffix
+//     is appended to extractor.RawFull, recovering any text lost to a
+//     stale-SSE-view race while preserving accumulated thinking.
 //
 // Both paths converge to the same final cumulative raw, which is what the
 // /with-raw contract guarantees. The test asserts that, plus a uniqueness

--- a/integration/thinking_test.go
+++ b/integration/thinking_test.go
@@ -151,45 +151,6 @@ func TestCallWithRaw_AnthropicThinking_DefaultExcludes(t *testing.T) {
 	})
 }
 
-// TestCallWithRaw_AnthropicThinking_ExplicitFalse verifies that setting
-// IncludeThinkingInRaw=false explicitly yields the same behavior as omitting
-// it entirely. Codifies that the worker apply step always passes the value
-// through (rather than skipping the setter when false), so a per-request
-// false doesn't accidentally inherit a sticky true from a prior request on
-// the same adapter.
-func TestCallWithRaw_AnthropicThinking_ExplicitFalse(t *testing.T) {
-	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		opts := setupAnthropicThinkingScenario(
-			t,
-			"test-anthropic-think-call-explicit-false",
-			thinkingTestContent,
-			thinkingTestThinking,
-			false, /*streaming*/
-			boolPtr(false),
-		)
-
-		resp, err := client.CallWithRaw(ctx, testutil.CallRequest{
-			Method:  "GetSimple",
-			Input:   map[string]any{"input": "anything"},
-			Options: opts,
-		})
-		if err != nil {
-			t.Fatalf("CallWithRaw failed: %v", err)
-		}
-		if resp.StatusCode != 200 {
-			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, resp.Error)
-		}
-
-		if resp.Raw != thinkingTestContent {
-			t.Errorf("explicit false: raw got %q, want %q", resp.Raw, thinkingTestContent)
-		}
-		assertParsedMessage(t, resp.Data, "hello")
-	})
-}
-
 // TestCallWithRaw_AnthropicThinking_OptInIncludes verifies the opt-in
 // (flag=true) /call-with-raw behavior: raw includes both the thinking and
 // text content, with thinking emitted before text (matching the wire order

--- a/integration/thinking_test.go
+++ b/integration/thinking_test.go
@@ -301,9 +301,10 @@ func TestCallWithRaw_AnthropicThinking_ParseableInvariant(t *testing.T) {
 // used by both the default and opt-in stream tests to share the same event
 // loop while keeping per-test assertions narrow.
 type streamWithRawResult struct {
-	lastRaw      string         // last non-empty Raw observed; cumulative by orchestrator design
+	lastRaw      string                // last non-empty Raw observed; cumulative by orchestrator design
 	finalEvent   *testutil.StreamEvent // the "final" event (if seen), carries fully validated Data
-	rawSnapshots []string       // every non-empty Raw observed, in order
+	rawSnapshots []string              // every non-empty Raw observed, in order
+	dataEvents   []json.RawMessage     // every Data observed (intermediate + final), in order
 }
 
 // runStreamWithRaw drives a /stream-with-raw call to completion, returning
@@ -334,6 +335,9 @@ func runStreamWithRaw(t *testing.T, ctx context.Context, opts *testutil.BAMLOpti
 			if event.Raw != "" {
 				result.lastRaw = event.Raw
 				result.rawSnapshots = append(result.rawSnapshots, event.Raw)
+			}
+			if len(event.Data) > 0 && string(event.Data) != "null" {
+				result.dataEvents = append(result.dataEvents, event.Data)
 			}
 		case err := <-errs:
 			if err != nil {
@@ -398,12 +402,14 @@ func TestStreamWithRaw_AnthropicThinking_DefaultExcludes(t *testing.T) {
 //   - BuildRequest emits per-event raw deltas as the orchestrator parses
 //     each SSE frame, so intermediate snapshots can be a strict prefix of
 //     thinking text before any text deltas arrive.
-//   - Legacy uses the IncrementalExtractor + ParseStream loop. Early
-//     thinking-only ticks are accumulated by the extractor but ParseStream
-//     fails on the not-yet-JSON content and no partial is emitted; the
-//     thinking content surfaces in the final event via the codegen's
-//     max(extractor.Full(), RawLLMResponse()) reconciliation at
-//     adapters/common/codegen/codegen.go:4124-4138.
+//   - Legacy uses the IncrementalExtractor + ParseStream loop. The
+//     extractor maintains separate parseable (text-only) and raw
+//     (text + thinking under opt-in) buffers. ParseStream is fed the
+//     parseable buffer, so early thinking-only ticks emit a raw-only
+//     partial without parsed Data. The thinking content reaches the wire
+//     incrementally as those raw-only partials, and is also reconciled at
+//     the final via max(extractor.RawFull(), RawLLMResponse()) at
+//     adapters/common/codegen/codegen.go:4144-4168.
 //
 // Both paths converge to the same final cumulative raw, which is what the
 // /with-raw contract guarantees. The test asserts that, plus a uniqueness
@@ -450,6 +456,74 @@ func TestStreamWithRaw_AnthropicThinking_OptInIncludes(t *testing.T) {
 		// Parseable invariant — even when raw includes thinking, the parsed
 		// data must reflect text only.
 		assertParsedMessage(t, result.finalEvent.Data, "hello")
+	}
+}
+
+// TestStreamWithRaw_AnthropicThinking_ParseableInvariant_PerEvent codifies the
+// strongest version of the parseable invariant: under opt-in
+// (IncludeThinkingInRaw=true), thinking content reaches the wire's raw
+// buffer, BUT no per-event Data value (intermediate or final) ever reflects
+// thinking-derived JSON.
+//
+// This is the regression test for the legacy-path bug: prior to the
+// IncrementalExtractor parseable/raw split, the legacy code fed
+// extractor.Full() (which under opt-in contained text + thinking) directly
+// to ParseStream. The thinking text used here contains a complete
+// `{"message": "answer"}` JSON object — if it were fed to the parser, an
+// intermediate Data event would unmarshal to message="answer" instead of
+// "hello". The test exercises the BAML parser end-to-end against thinking
+// content that would unambiguously corrupt parsing, so any regression
+// reintroducing the leak fails loudly.
+//
+// The assertion runs over every Data event the stream emits, not just the
+// final, because the failure mode primarily manifests in intermediate
+// partials.
+func TestStreamWithRaw_AnthropicThinking_ParseableInvariant_PerEvent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	opts := setupAnthropicThinkingScenario(
+		t,
+		"test-anthropic-think-stream-parseable-invariant",
+		thinkingTestContent,
+		thinkingTestThinking,
+		true,
+		boolPtr(true),
+	)
+
+	result := runStreamWithRaw(t, ctx, opts)
+
+	if len(result.dataEvents) == 0 {
+		t.Fatal("opt-in stream parseable invariant: no Data events observed; cannot verify per-event invariant")
+	}
+
+	for i, data := range result.dataEvents {
+		var parsed struct {
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			// Intermediate partials may not be fully-formed; the parser
+			// emits whatever shape it can. A partial that doesn't have a
+			// message field at all is fine — that's not a leak. Skip.
+			continue
+		}
+		if parsed.Message == "answer" {
+			t.Errorf("opt-in stream Data event %d leaked thinking-derived value: parsed message %q (raw data: %s)", i, parsed.Message, string(data))
+		}
+	}
+
+	// Confirm raw still carries thinking (i.e. the flag actually had an
+	// effect; otherwise the per-event invariant above is a tautology).
+	const thinkingOnlyMarker = "answer"
+	sawThinkingMarker := false
+	for _, snap := range result.rawSnapshots {
+		if containsAny(snap, thinkingOnlyMarker) {
+			sawThinkingMarker = true
+			break
+		}
+	}
+	if !sawThinkingMarker {
+		t.Fatalf("opt-in stream parseable invariant: expected raw to contain %q somewhere; got snapshots: %v (sanity check failed — flag not honored)", thinkingOnlyMarker, result.rawSnapshots)
 	}
 }
 

--- a/integration/thinking_test.go
+++ b/integration/thinking_test.go
@@ -282,6 +282,14 @@ type streamWithRawResult struct {
 
 // runStreamWithRaw drives a /stream-with-raw call to completion, returning
 // the accumulated raw snapshots and the final event for caller assertions.
+//
+// The helper enforces that a terminal SSE event (event.IsFinal() == true)
+// was observed before the events channel closed. A missing final is
+// treated as a test failure rather than a silently-truncated stream,
+// since all current callers' assertions assume the stream ran to
+// completion. Without this check, a regression that caused the pipeline
+// to drop the final event would silently skip downstream parseable
+// invariant assertions that gate on result.finalEvent != nil.
 func runStreamWithRaw(t *testing.T, ctx context.Context, opts *testutil.BAMLOptions) streamWithRawResult {
 	t.Helper()
 
@@ -296,6 +304,9 @@ func runStreamWithRaw(t *testing.T, ctx context.Context, opts *testutil.BAMLOpti
 		select {
 		case event, ok := <-events:
 			if !ok {
+				if result.finalEvent == nil {
+					t.Fatalf("stream closed without a terminal SSE event (IsFinal()==true never observed); raw snapshots: %d, data events: %d", len(result.rawSnapshots), len(result.dataEvents))
+				}
 				return result
 			}
 			if event.IsMetadata() {
@@ -367,9 +378,9 @@ func TestStreamWithRaw_AnthropicThinking_DefaultExcludes(t *testing.T) {
 		}
 	}
 
-	if result.finalEvent != nil {
-		assertParsedMessage(t, result.finalEvent.Data, "hello")
-	}
+	// runStreamWithRaw guarantees finalEvent is non-nil (fails the test
+	// otherwise), so this is unconditional.
+	assertParsedMessage(t, result.finalEvent.Data, "hello")
 }
 
 // TestStreamWithRaw_AnthropicThinking_OptInIncludes verifies the opt-in
@@ -438,11 +449,10 @@ func TestStreamWithRaw_AnthropicThinking_OptInIncludes(t *testing.T) {
 		t.Errorf("opt-in stream: expected raw to contain %q somewhere; got snapshots: %v", thinkingOnlyMarker, result.rawSnapshots)
 	}
 
-	if result.finalEvent != nil {
-		// Parseable invariant — even when raw includes thinking, the parsed
-		// data must reflect text only.
-		assertParsedMessage(t, result.finalEvent.Data, "hello")
-	}
+	// Parseable invariant — even when raw includes thinking, the parsed
+	// data must reflect text only. runStreamWithRaw guarantees finalEvent
+	// is non-nil.
+	assertParsedMessage(t, result.finalEvent.Data, "hello")
 }
 
 // TestStreamWithRaw_AnthropicThinking_ParseableInvariant_PerEvent codifies the


### PR DESCRIPTION
## Summary

- Adds a per-request opt-in (`__baml_options__.include_thinking_in_raw`) for surfacing provider-specific reasoning/thinking content in `/with-raw`'s `raw` field. Default `false` aligns baml-rest with upstream BAML's `RawLLMResponse()` text-only contract.
- Phase 1 of #195: only Anthropic gating. Subsequent phases will add Gemini (incl. parseable-safety bug fix), OpenAI Chat Completions `reasoning_content`, OpenAI Responses reasoning summaries.
- `Parseable` (the text passed to `Parse`/`ParseStream`) is **never** affected by the flag — it stays text-only by construction (via `DeltaParts.Parseable` and `parseableSB`), so reasoning content cannot influence parser behavior regardless of the opt-in choice.

## Design

Plumbing mirrors the existing `RetryConfig` pattern:

- `bamlutils.BamlOptions.IncludeThinkingInRaw bool` (`json:"include_thinking_in_raw,omitempty"`)
- `bamlutils.Adapter`: `SetIncludeThinkingInRaw(bool)` / `IncludeThinkingInRaw() bool`
- `cmd/worker/main.go::workerBamlOptions.apply` — always passes through, so the adapter reflects an explicit per-request choice (even when `false`).
- `buildrequest.{StreamConfig,CallConfig}.IncludeThinkingInRaw bool`

Extraction signatures take an `includeThinking bool`:

- `sse.ExtractDeltaPartsFromText`, `sse.ExtractDeltaFromText`, `sse.ExtractDeltaContent`, `sse.GetCurrentContent`, `sse.NewIncrementalExtractor`
- `buildrequest.ExtractResponseContent`, `buildrequest.extractAnthropicContent`

The Anthropic switch arms drop `thinking_delta` (streaming) and `thinking` blocks (non-streaming) from `Raw` when `includeThinking==false`; never touch `Parseable`/`parseableSB` either way.

Codegen wires `adapter.IncludeThinkingInRaw()` into both `*Config` literals and `NewIncrementalExtractor()`. The post-stream `max(extractor.Full(), RawLLMResponse())` reconciliation now serves a dual purpose:

- **flag=false (default)**: extractor and `RawLLMResponse` both text-only — choice is immaterial, race safety preserved.
- **flag=true**: extractor accumulated thinking; BAML's runtime never did → extractor wins, opt-in content is preserved.

## Known limitation

Under flag=true, the mixed-mode legacy fallback child path (`StreamConfig.LegacyStreamChild`) stays text-only because BAML's runtime doesn't surface thinking content for that codepath to accumulate. Documented inline in `bamlutils/buildrequest/orchestrator.go:965-974`. Most thinking-capable providers go through BuildRequest by default; this only affects obscure runtime-overridden chains. Will revisit only if reported in a real workflow.

## Test plan

- [x] `go test ./bamlutils/...` — includes paired `Default`/`OptIn` test variants for every previously-existing thinking test plus a parseable-invariant case.
- [x] `go test ./adapters/common/...` — codegen package builds clean.
- [x] `go test ./adapters/adapter_v0_215_0/... ./adapters/adapter_v0_219_0/...` — both build clean.
- [x] `go vet ./...` — clean across all touched modules.
- [ ] `go test ./adapters/adapter_v0_204_0/...` — pre-existing build failure on master (CFFI bindings need Docker codegen; unrelated to this change).
- [ ] Manual verification: Anthropic call with `include_thinking_in_raw: true` → `raw` includes thinking; with the field absent or `false` → `raw` is text-only.

## Refs

Tracking issue: #195
Originally surfaced in: #167 (Anthropic divergence bullet)

## Test changes (paired)

- `sse.TestExtractDeltaPartsFromText_AnthropicThinking{Default,OptIn}` — parseable invariant explicitly asserted in both.
- `response_extract.TestExtractResponseContent_AnthropicWithThinking{Default,OptIn}` and `…_AnthropicThinkingOnly{Default,OptIn}` — same pairing; new `…_ParseableInvariant` test running both flag values on the same input.
- `orchestrator.TestRunStreamOrchestration_AnthropicThinking{DefaultDropsThinking,OptInPreservesThinking}` — partial counts adjust per flag (thinking events skipped under `delta.Raw==""`).
- `call_orchestrator.TestRunCallOrchestration_AnthropicThinking{DefaultDropsThinking,OptInIncludesThinking}` — `Final()` invariant asserted in both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request opt-in flag to include provider "thinking" content in raw outputs for unary and streaming endpoints; propagated through request options and extraction/streaming paths while parseable output remains text-only.

* **Tests**
  * Expanded unit, integration, and benchmark coverage validating default vs opt-in behavior, streaming deltas, parseable invariants, and end-to-end Anthropic-thinking scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->