### PR TITLE
chore: tighten orchestrator/metadata exact-count assertions

### DIFF
--- a/bamlutils/buildrequest/metadata_orchestrator_test.go
+++ b/bamlutils/buildrequest/metadata_orchestrator_test.go
@@ -106,16 +106,23 @@ func TestRunStreamOrchestration_EmitsPlannedFirstThenHeartbeat(t *testing.T) {
 		t.Fatalf("expected outcome metadata to be emitted")
 	}
 
-	// Planned metadata is emitted upfront (first event); heartbeat fires
-	// later from sendHeartbeat when the provider returns 2xx.
-	if len(kinds) < 2 {
-		t.Fatalf("expected at least planned + heartbeat events; got %d", len(kinds))
+	// Success path emits exactly four frames in order: planned metadata
+	// (upfront), heartbeat (sendHeartbeat on 2xx), outcome metadata
+	// (just before final), final.
+	if len(kinds) != 4 {
+		t.Fatalf("expected exactly 4 frames (planned, heartbeat, outcome, final); got %d: %v", len(kinds), kinds)
 	}
 	if kinds[0] != bamlutils.StreamResultKindMetadata {
-		t.Errorf("first event should be planned metadata; got kind %d", kinds[0])
+		t.Errorf("frame 0 should be planned metadata; got kind %d", kinds[0])
 	}
 	if kinds[1] != bamlutils.StreamResultKindHeartbeat {
-		t.Errorf("second event should be heartbeat; got kind %d", kinds[1])
+		t.Errorf("frame 1 should be heartbeat; got kind %d", kinds[1])
+	}
+	if kinds[2] != bamlutils.StreamResultKindMetadata {
+		t.Errorf("frame 2 should be outcome metadata; got kind %d", kinds[2])
+	}
+	if kinds[3] != bamlutils.StreamResultKindFinal {
+		t.Errorf("frame 3 should be final; got kind %d", kinds[3])
 	}
 	// Pin that the FIRST metadata payload was MetadataPhasePlanned,
 	// not just "some metadata kind first". A regression that swapped
@@ -185,17 +192,22 @@ func TestRunCallOrchestration_EmitsPlannedAndOutcome(t *testing.T) {
 		t.Fatalf("expected outcome metadata to be emitted")
 	}
 
-	// Planned metadata is emitted upfront (first event); heartbeat fires
-	// later from sendHeartbeat when the provider returns 2xx. See the
-	// streaming orchestrator's ordering test for rationale.
-	if len(kinds) < 2 {
-		t.Fatalf("expected at least 2 events; got %d", len(kinds))
+	// Success path emits exactly four frames in order: planned, heartbeat,
+	// outcome, final. See the streaming counterpart for rationale.
+	if len(kinds) != 4 {
+		t.Fatalf("expected exactly 4 frames (planned, heartbeat, outcome, final); got %d: %v", len(kinds), kinds)
 	}
 	if kinds[0] != bamlutils.StreamResultKindMetadata {
-		t.Errorf("first event should be planned metadata; got kind %d", kinds[0])
+		t.Errorf("frame 0 should be planned metadata; got kind %d", kinds[0])
 	}
 	if kinds[1] != bamlutils.StreamResultKindHeartbeat {
-		t.Errorf("second event should be heartbeat; got kind %d", kinds[1])
+		t.Errorf("frame 1 should be heartbeat; got kind %d", kinds[1])
+	}
+	if kinds[2] != bamlutils.StreamResultKindMetadata {
+		t.Errorf("frame 2 should be outcome metadata; got kind %d", kinds[2])
+	}
+	if kinds[3] != bamlutils.StreamResultKindFinal {
+		t.Errorf("frame 3 should be final; got kind %d", kinds[3])
 	}
 	// See streaming counterpart for rationale.
 	if len(metadataPhases) == 0 || metadataPhases[0] != bamlutils.MetadataPhasePlanned {

--- a/bamlutils/buildrequest/orchestrator_integration_test.go
+++ b/bamlutils/buildrequest/orchestrator_integration_test.go
@@ -547,13 +547,14 @@ func TestRetry_ExponentialBackoff(t *testing.T) {
 	mu.Lock()
 	ts := timestamps
 	mu.Unlock()
-	if len(ts) >= 3 {
-		delay1 := ts[1].Sub(ts[0])
-		delay2 := ts[2].Sub(ts[1])
-		// Second delay should be roughly 2x the first (with some tolerance)
-		if delay2 < delay1 {
-			t.Errorf("expected increasing delays, got delay1=%v, delay2=%v", delay1, delay2)
-		}
+	if len(ts) != 3 {
+		t.Fatalf("expected exactly 3 server timestamps (one per attempt), got %d", len(ts))
+	}
+	delay1 := ts[1].Sub(ts[0])
+	delay2 := ts[2].Sub(ts[1])
+	// Second delay should be roughly 2x the first (with some tolerance)
+	if delay2 < delay1 {
+		t.Errorf("expected increasing delays, got delay1=%v, delay2=%v", delay1, delay2)
 	}
 }
 
@@ -625,9 +626,11 @@ func TestStreamResultOrder(t *testing.T) {
 		results = append(results, r.(*testResult))
 	}
 
-	// Verify order: heartbeat first, then partials, then final
-	if len(results) < 3 {
-		t.Fatalf("expected at least 3 results (heartbeat + partial + final), got %d", len(results))
+	// Verify order: heartbeat first, then partials, then final.
+	// Server emits two SSE deltas, so the deterministic shape is
+	// [heartbeat, stream, stream, final] = 4 frames.
+	if len(results) != 4 {
+		t.Fatalf("expected exactly 4 results (heartbeat + 2 partials + final), got %d", len(results))
 	}
 
 	if results[0].kind != bamlutils.StreamResultKindHeartbeat {

--- a/bamlutils/buildrequest/orchestrator_test.go
+++ b/bamlutils/buildrequest/orchestrator_test.go
@@ -129,8 +129,8 @@ func TestRunStreamOrchestration_Success(t *testing.T) {
 	if errors != 0 {
 		t.Errorf("expected 0 errors, got %d", errors)
 	}
-	if partials < 1 {
-		t.Errorf("expected at least 1 partial, got %d", partials)
+	if partials != 3 {
+		t.Errorf("expected 3 partials (one per SSE delta), got %d", partials)
 	}
 
 	// The final result should have the full accumulated text
@@ -377,8 +377,8 @@ func TestRunStreamOrchestration_WithRetry(t *testing.T) {
 	// classification, tr.reset is the reset bit, and the comparison is
 	// against bamlutils.StreamResultKindStream (the non-reset partial
 	// shape).
-	if nonResetPartials == 0 {
-		t.Errorf("expected at least one non-reset partial (testResult with kind == bamlutils.StreamResultKindStream and reset == false); got 0")
+	if nonResetPartials != 3 {
+		t.Errorf("expected 3 non-reset partials (one per attempt's delta — 2x 'stale' + 1x 'ok'), got %d", nonResetPartials)
 	}
 }
 
@@ -2150,8 +2150,8 @@ func TestRunStreamOrchestration_MixedChain_LegacySucceedsSecond(t *testing.T) {
 			errors++
 		}
 	}
-	if resets < 1 {
-		t.Errorf("expected at least one reset signal between children, got %d", resets)
+	if resets != 1 {
+		t.Errorf("expected exactly 1 reset signal between children, got %d", resets)
 	}
 	if finals != 1 {
 		t.Fatalf("expected exactly one final, got %d", finals)
@@ -2233,8 +2233,8 @@ func TestRunStreamOrchestration_MixedChain_LegacyFirstFails_SupportedWins(t *tes
 			errors++
 		}
 	}
-	if partials < 1 {
-		t.Errorf("expected at least one partial from the supported child, got %d", partials)
+	if partials != 1 {
+		t.Errorf("expected exactly 1 partial from the supported child, got %d", partials)
 	}
 	if finals != 1 {
 		t.Fatalf("expected exactly one final, got %d", finals)
@@ -2600,15 +2600,16 @@ func TestRunStreamOrchestration_MixedChain_HTTPBackedEndToEnd(t *testing.T) {
 		}
 	}
 
-	if heartbeats < 2 {
+	if heartbeats != 2 {
 		// Supported child emits one on HTTP connect, legacy callback
-		// emits a second after its reset. Fewer than two indicates the
-		// reset failed to clear heartbeatSent, or the legacy callback
-		// never fired sendHeartbeat.
-		t.Errorf("expected at least 2 heartbeats (one per child attempt), got %d", heartbeats)
+		// emits a second after its reset. A different count indicates
+		// the reset failed to clear heartbeatSent, the legacy callback
+		// never fired sendHeartbeat, or a duplicate heartbeat slipped
+		// past.
+		t.Errorf("expected exactly 2 heartbeats (one per child attempt), got %d", heartbeats)
 	}
-	if partials < 1 {
-		t.Errorf("expected at least 1 partial from the supported child stream, got %d", partials)
+	if partials != 1 {
+		t.Errorf("expected exactly 1 partial from the supported child stream, got %d", partials)
 	}
 	if resets != 1 {
 		t.Errorf("expected exactly 1 reset between children, got %d", resets)
@@ -2777,8 +2778,8 @@ func TestRunStreamOrchestration_NoResetWhenNeedsPartialsFalse_Retry(t *testing.T
 	// The failing attempt never produces a byte (500 before SSE begins), so
 	// its sendHeartbeat never fires. The retry re-arms heartbeatSent; the
 	// successful attempt then fires one heartbeat on HTTP connect.
-	if heartbeats < 1 {
-		t.Errorf("expected >=1 heartbeat from the successful attempt; got %d", heartbeats)
+	if heartbeats != 1 {
+		t.Errorf("expected exactly 1 heartbeat from the successful attempt; got %d", heartbeats)
 	}
 	// RunStreamOrchestration emits StreamResultKindError only after
 	// retry.Execute returns an error (whole plan exhausted). A
@@ -2913,8 +2914,8 @@ func TestRunStreamOrchestration_NoResetWhenNeedsPartialsFalse_FallbackChain(t *t
 	}
 	// Both children emit a heartbeat on HTTP connect; the in-chain reset
 	// must still clear heartbeatSent.
-	if heartbeats < 2 {
-		t.Errorf("expected >=2 heartbeats (one per child), got %d", heartbeats)
+	if heartbeats != 2 {
+		t.Errorf("expected exactly 2 heartbeats (one per child), got %d", heartbeats)
 	}
 	// RunStreamOrchestration emits StreamResultKindError only after
 	// retry.Execute returns an error (whole plan exhausted). A


### PR DESCRIPTION
## Summary

Part of #199 item 2 (assertion-strictness sweep). PR-A of a 3-PR sequence.

This PR replaces lower-bound assertions (`x < N`, `x >= N`) with exact-equality checks (`x != K`) in the BuildRequest orchestrator's unit tests where the test fixture is byte-deterministic and the contract is exact. Slipped past regressions where the orchestrator under-counts, duplicate-emits, or merges deltas now fail strict but would have passed loose.

Sites tightened (~12):
- `bamlutils/buildrequest/orchestrator_test.go` (8): partials, resets, heartbeats counters across mocked-OpenAI fixtures
- `bamlutils/buildrequest/metadata_orchestrator_test.go` (2): planned/heartbeat/outcome/final frame ordering
- `bamlutils/buildrequest/orchestrator_integration_test.go` (2): heartbeat/partial/final aggregate count + redundant gate cleanup

Future PRs in the sweep:
- PR-B: existence-flag → count/shape pairings + Category E set/slice equality (~36 sites)
- PR-C: integration-test event-count tightenings (deferred until #199 item 3 stabilizes the integration suite)

Scoping plan: see linked note in PR-comment / issue thread.

## Test plan

- [x] `go test -count=1 ./bamlutils/buildrequest/...` — passes
- [x] `go build ./...` — clean
- [x] `go vet ./bamlutils/buildrequest/...` — clean
- [ ] CI integration-tests workflow — confirm green


<!-- webtty-bridge: session=s-yqyd29e14n -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated orchestration and streaming tests to require exact frame counts and specific event ordering sequences instead of lower-bound assertions, improving test determinism across all orchestration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
