### PR TITLE
chore: pair existence flags with count/shape and pin registry set-equality

### DIFF
--- a/adapters/common/codegen/codegen_test.go
+++ b/adapters/common/codegen/codegen_test.go
@@ -151,6 +151,9 @@ func TestStructContainsMediaVisited_SharedVisitedAcrossFields(t *testing.T) {
 	if !visited[reflect.TypeOf(mutualB{})] {
 		t.Error("mutualB should be in visited set after scanning mutualA")
 	}
+	if got := len(visited); got != 2 {
+		t.Errorf("visited set: got len=%d (%v), want exactly 2 — only mutualA + mutualB should be recorded; any extra would indicate the walker descended past the cycle pair", got, visited)
+	}
 }
 
 // TestEmitMakeLegacyStreamOptionsFromAdapter_PinsPrimaryToClientOverride

--- a/bamlutils/buildrequest/call_orchestrator_test.go
+++ b/bamlutils/buildrequest/call_orchestrator_test.go
@@ -212,17 +212,17 @@ func TestRunCallOrchestration_WithRetry(t *testing.T) {
 	}
 
 	// Should succeed on 3rd attempt: heartbeat + final
-	hasFinal := false
+	finals := 0
 	for _, r := range results {
 		if r.Kind() == bamlutils.StreamResultKindFinal {
-			hasFinal = true
+			finals++
 			if r.Final() != "retry success" {
 				t.Errorf("expected 'retry success', got %v", r.Final())
 			}
 		}
 	}
-	if !hasFinal {
-		t.Fatal("expected a final result after retry")
+	if finals != 1 {
+		t.Fatalf("expected exactly 1 final result after retry, got %d", finals)
 	}
 
 	if attempts.Load() != 3 {
@@ -264,14 +264,14 @@ func TestRunCallOrchestration_RetryExhausted(t *testing.T) {
 	}
 
 	// Should get an error after exhausting retries
-	hasError := false
+	errs := 0
 	for r := range out {
 		if r.Kind() == bamlutils.StreamResultKindError {
-			hasError = true
+			errs++
 		}
 	}
-	if !hasError {
-		t.Fatal("expected error result after exhausting retries")
+	if errs != 1 {
+		t.Fatalf("expected exactly 1 error result after exhausting retries, got %d", errs)
 	}
 }
 
@@ -531,17 +531,17 @@ func TestRunCallOrchestration_ParseFinalError(t *testing.T) {
 		results = append(results, r)
 	}
 
-	hasError := false
+	errs := 0
 	for _, r := range results {
 		if r.Kind() == bamlutils.StreamResultKindError {
-			hasError = true
+			errs++
 			if !strings.Contains(r.Error().Error(), "parse failed") {
 				t.Errorf("unexpected error: %v", r.Error())
 			}
 		}
 	}
-	if !hasError {
-		t.Fatal("expected parse error result")
+	if errs != 1 {
+		t.Fatalf("expected exactly 1 parse error result, got %d", errs)
 	}
 }
 
@@ -576,10 +576,10 @@ func TestRunCallOrchestration_Anthropic(t *testing.T) {
 		results = append(results, r)
 	}
 
-	hasFinal := false
+	finals := 0
 	for _, r := range results {
 		if r.Kind() == bamlutils.StreamResultKindFinal {
-			hasFinal = true
+			finals++
 			if r.Final() != "Anthropic response" {
 				t.Errorf("expected 'Anthropic response', got %v", r.Final())
 			}
@@ -588,8 +588,8 @@ func TestRunCallOrchestration_Anthropic(t *testing.T) {
 			}
 		}
 	}
-	if !hasFinal {
-		t.Fatal("expected final result")
+	if finals != 1 {
+		t.Fatalf("expected exactly 1 final result, got %d", finals)
 	}
 }
 
@@ -637,10 +637,10 @@ func TestRunCallOrchestration_AnthropicThinkingSplit_Default(t *testing.T) {
 		results = append(results, r)
 	}
 
-	hasFinal := false
+	finals := 0
 	for _, r := range results {
 		if r.Kind() == bamlutils.StreamResultKindFinal {
-			hasFinal = true
+			finals++
 			expectedRaw := "The answer is 42"
 			if r.Raw() != expectedRaw {
 				t.Errorf("Raw() = %q, expected %q (thinking should be dropped under default flag)", r.Raw(), expectedRaw)
@@ -650,8 +650,8 @@ func TestRunCallOrchestration_AnthropicThinkingSplit_Default(t *testing.T) {
 			}
 		}
 	}
-	if !hasFinal {
-		t.Fatal("no final result found")
+	if finals != 1 {
+		t.Fatalf("expected exactly 1 final result, got %d", finals)
 	}
 }
 
@@ -700,10 +700,10 @@ func TestRunCallOrchestration_AnthropicThinkingSplit_OptIn(t *testing.T) {
 		results = append(results, r)
 	}
 
-	hasFinal := false
+	finals := 0
 	for _, r := range results {
 		if r.Kind() == bamlutils.StreamResultKindFinal {
-			hasFinal = true
+			finals++
 			expectedRaw := "Step 1: reason...The answer is 42"
 			if r.Raw() != expectedRaw {
 				t.Errorf("Raw() = %q, expected %q (thinking + text)", r.Raw(), expectedRaw)
@@ -713,8 +713,8 @@ func TestRunCallOrchestration_AnthropicThinkingSplit_OptIn(t *testing.T) {
 			}
 		}
 	}
-	if !hasFinal {
-		t.Fatal("no final result found")
+	if finals != 1 {
+		t.Fatalf("expected exactly 1 final result, got %d", finals)
 	}
 }
 
@@ -832,18 +832,18 @@ func TestRunCallOrchestration_RetryDoesNotEmitRetryHeartbeats(t *testing.T) {
 
 	// Exactly 1 heartbeat: onSuccess after the 2xx response on the 3rd attempt.
 	heartbeats := 0
-	hasFinal := false
+	finals := 0
 	for _, r := range results {
 		switch r.Kind() {
 		case bamlutils.StreamResultKindHeartbeat:
 			heartbeats++
 		case bamlutils.StreamResultKindFinal:
-			hasFinal = true
+			finals++
 		}
 	}
 
-	if !hasFinal {
-		t.Fatal("expected a final result")
+	if finals != 1 {
+		t.Fatalf("expected exactly 1 final result, got %d", finals)
 	}
 	if heartbeats != 1 {
 		t.Errorf("expected exactly 1 heartbeat (onSuccess only), got %d", heartbeats)
@@ -918,17 +918,17 @@ func TestRunCallOrchestration_RetryRebuildsRequest(t *testing.T) {
 	}
 
 	// The first attempt hits server1 (500), retry rebuilds and hits server2 (200).
-	hasFinal := false
+	finals := 0
 	for r := range out {
 		if r.Kind() == bamlutils.StreamResultKindFinal {
-			hasFinal = true
+			finals++
 			if r.Final() != "server2 ok" {
 				t.Errorf("expected 'server2 ok', got %v", r.Final())
 			}
 		}
 	}
-	if !hasFinal {
-		t.Fatal("expected a final result from server2 after retry rotation")
+	if finals != 1 {
+		t.Fatalf("expected exactly 1 final result from server2 after retry rotation, got %d", finals)
 	}
 }
 
@@ -1134,17 +1134,17 @@ func TestRunCallOrchestration_FallbackChain(t *testing.T) {
 	}
 
 	// Verify the result was extracted with the anthropic provider
-	hasFinal := false
+	finals := 0
 	for r := range out {
 		if r.Kind() == bamlutils.StreamResultKindFinal {
-			hasFinal = true
+			finals++
 			if r.Final() != "anthropic ok" {
 				t.Errorf("expected 'anthropic ok', got %v", r.Final())
 			}
 		}
 	}
-	if !hasFinal {
-		t.Fatal("expected a final result from anthropic fallback")
+	if finals != 1 {
+		t.Fatalf("expected exactly 1 final result from anthropic fallback, got %d", finals)
 	}
 }
 
@@ -1202,10 +1202,10 @@ func TestRunCallOrchestration_FallbackChainWithRaw(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var hasFinal bool
+	finals := 0
 	for r := range out {
 		if r.Kind() == bamlutils.StreamResultKindFinal {
-			hasFinal = true
+			finals++
 			if r.Final() != "fallback ok" {
 				t.Errorf("expected 'fallback ok', got %v", r.Final())
 			}
@@ -1214,8 +1214,8 @@ func TestRunCallOrchestration_FallbackChainWithRaw(t *testing.T) {
 			}
 		}
 	}
-	if !hasFinal {
-		t.Fatal("expected a final result from fallback")
+	if finals != 1 {
+		t.Fatalf("expected exactly 1 final result from fallback, got %d", finals)
 	}
 }
 
@@ -1269,17 +1269,17 @@ func TestRunCallOrchestration_FallbackChainExtractionFailure(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	hasFinal := false
+	finals := 0
 	for r := range out {
 		if r.Kind() == bamlutils.StreamResultKindFinal {
-			hasFinal = true
+			finals++
 			if r.Final() != "recovered" {
 				t.Errorf("expected 'recovered', got %v", r.Final())
 			}
 		}
 	}
-	if !hasFinal {
-		t.Fatal("expected final result after extraction failure retry")
+	if finals != 1 {
+		t.Fatalf("expected exactly 1 final result after extraction failure retry, got %d", finals)
 	}
 	if got := int(attempts.Load()); got != 2 {
 		t.Errorf("expected exactly 2 attempts (1 extraction failure + 1 success), got %d", got)

--- a/bamlutils/buildrequest/call_orchestrator_test.go
+++ b/bamlutils/buildrequest/call_orchestrator_test.go
@@ -269,13 +269,17 @@ func TestRunCallOrchestration_RetryExhausted(t *testing.T) {
 
 	// Should get an error after exhausting retries
 	errs := 0
+	finals := 0
 	for r := range out {
-		if r.Kind() == bamlutils.StreamResultKindError {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindError:
 			errs++
+		case bamlutils.StreamResultKindFinal:
+			finals++
 		}
 	}
-	if errs != 1 {
-		t.Fatalf("expected exactly 1 error result after exhausting retries, got %d", errs)
+	if errs != 1 || finals != 0 {
+		t.Fatalf("expected exactly 1 error and 0 finals after exhausting retries, got errs=%d finals=%d", errs, finals)
 	}
 }
 
@@ -536,16 +540,20 @@ func TestRunCallOrchestration_ParseFinalError(t *testing.T) {
 	}
 
 	errs := 0
+	finals := 0
 	for _, r := range results {
-		if r.Kind() == bamlutils.StreamResultKindError {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindError:
 			errs++
 			if !strings.Contains(r.Error().Error(), "parse failed") {
 				t.Errorf("unexpected error: %v", r.Error())
 			}
+		case bamlutils.StreamResultKindFinal:
+			finals++
 		}
 	}
-	if errs != 1 {
-		t.Fatalf("expected exactly 1 parse error result, got %d", errs)
+	if errs != 1 || finals != 0 {
+		t.Fatalf("expected exactly 1 parse error and 0 finals, got errs=%d finals=%d", errs, finals)
 	}
 }
 

--- a/bamlutils/buildrequest/call_orchestrator_test.go
+++ b/bamlutils/buildrequest/call_orchestrator_test.go
@@ -213,16 +213,20 @@ func TestRunCallOrchestration_WithRetry(t *testing.T) {
 
 	// Should succeed on 3rd attempt: heartbeat + final
 	finals := 0
+	errors := 0
 	for _, r := range results {
-		if r.Kind() == bamlutils.StreamResultKindFinal {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindFinal:
 			finals++
 			if r.Final() != "retry success" {
 				t.Errorf("expected 'retry success', got %v", r.Final())
 			}
+		case bamlutils.StreamResultKindError:
+			errors++
 		}
 	}
-	if finals != 1 {
-		t.Fatalf("expected exactly 1 final result after retry, got %d", finals)
+	if finals != 1 || errors != 0 {
+		t.Fatalf("expected exactly 1 final and 0 errors after retry, got finals=%d errors=%d", finals, errors)
 	}
 
 	if attempts.Load() != 3 {
@@ -577,8 +581,10 @@ func TestRunCallOrchestration_Anthropic(t *testing.T) {
 	}
 
 	finals := 0
+	errors := 0
 	for _, r := range results {
-		if r.Kind() == bamlutils.StreamResultKindFinal {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindFinal:
 			finals++
 			if r.Final() != "Anthropic response" {
 				t.Errorf("expected 'Anthropic response', got %v", r.Final())
@@ -586,10 +592,12 @@ func TestRunCallOrchestration_Anthropic(t *testing.T) {
 			if r.Raw() != "Anthropic response" {
 				t.Errorf("expected raw 'Anthropic response', got %q", r.Raw())
 			}
+		case bamlutils.StreamResultKindError:
+			errors++
 		}
 	}
-	if finals != 1 {
-		t.Fatalf("expected exactly 1 final result, got %d", finals)
+	if finals != 1 || errors != 0 {
+		t.Fatalf("expected exactly 1 final and 0 errors, got finals=%d errors=%d", finals, errors)
 	}
 }
 
@@ -638,8 +646,10 @@ func TestRunCallOrchestration_AnthropicThinkingSplit_Default(t *testing.T) {
 	}
 
 	finals := 0
+	errors := 0
 	for _, r := range results {
-		if r.Kind() == bamlutils.StreamResultKindFinal {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindFinal:
 			finals++
 			expectedRaw := "The answer is 42"
 			if r.Raw() != expectedRaw {
@@ -648,10 +658,12 @@ func TestRunCallOrchestration_AnthropicThinkingSplit_Default(t *testing.T) {
 			if r.Final() != "The answer is 42" {
 				t.Errorf("Final() = %v, expected 'The answer is 42'", r.Final())
 			}
+		case bamlutils.StreamResultKindError:
+			errors++
 		}
 	}
-	if finals != 1 {
-		t.Fatalf("expected exactly 1 final result, got %d", finals)
+	if finals != 1 || errors != 0 {
+		t.Fatalf("expected exactly 1 final and 0 errors, got finals=%d errors=%d", finals, errors)
 	}
 }
 
@@ -701,8 +713,10 @@ func TestRunCallOrchestration_AnthropicThinkingSplit_OptIn(t *testing.T) {
 	}
 
 	finals := 0
+	errors := 0
 	for _, r := range results {
-		if r.Kind() == bamlutils.StreamResultKindFinal {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindFinal:
 			finals++
 			expectedRaw := "Step 1: reason...The answer is 42"
 			if r.Raw() != expectedRaw {
@@ -711,10 +725,12 @@ func TestRunCallOrchestration_AnthropicThinkingSplit_OptIn(t *testing.T) {
 			if r.Final() != "The answer is 42" {
 				t.Errorf("Final() = %v, expected 'The answer is 42'", r.Final())
 			}
+		case bamlutils.StreamResultKindError:
+			errors++
 		}
 	}
-	if finals != 1 {
-		t.Fatalf("expected exactly 1 final result, got %d", finals)
+	if finals != 1 || errors != 0 {
+		t.Fatalf("expected exactly 1 final and 0 errors, got finals=%d errors=%d", finals, errors)
 	}
 }
 
@@ -833,17 +849,20 @@ func TestRunCallOrchestration_RetryDoesNotEmitRetryHeartbeats(t *testing.T) {
 	// Exactly 1 heartbeat: onSuccess after the 2xx response on the 3rd attempt.
 	heartbeats := 0
 	finals := 0
+	errors := 0
 	for _, r := range results {
 		switch r.Kind() {
 		case bamlutils.StreamResultKindHeartbeat:
 			heartbeats++
 		case bamlutils.StreamResultKindFinal:
 			finals++
+		case bamlutils.StreamResultKindError:
+			errors++
 		}
 	}
 
-	if finals != 1 {
-		t.Fatalf("expected exactly 1 final result, got %d", finals)
+	if finals != 1 || errors != 0 {
+		t.Fatalf("expected exactly 1 final and 0 errors, got finals=%d errors=%d", finals, errors)
 	}
 	if heartbeats != 1 {
 		t.Errorf("expected exactly 1 heartbeat (onSuccess only), got %d", heartbeats)
@@ -919,16 +938,20 @@ func TestRunCallOrchestration_RetryRebuildsRequest(t *testing.T) {
 
 	// The first attempt hits server1 (500), retry rebuilds and hits server2 (200).
 	finals := 0
+	errors := 0
 	for r := range out {
-		if r.Kind() == bamlutils.StreamResultKindFinal {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindFinal:
 			finals++
 			if r.Final() != "server2 ok" {
 				t.Errorf("expected 'server2 ok', got %v", r.Final())
 			}
+		case bamlutils.StreamResultKindError:
+			errors++
 		}
 	}
-	if finals != 1 {
-		t.Fatalf("expected exactly 1 final result from server2 after retry rotation, got %d", finals)
+	if finals != 1 || errors != 0 {
+		t.Fatalf("expected exactly 1 final and 0 errors from server2 after retry rotation, got finals=%d errors=%d", finals, errors)
 	}
 }
 
@@ -1135,16 +1158,20 @@ func TestRunCallOrchestration_FallbackChain(t *testing.T) {
 
 	// Verify the result was extracted with the anthropic provider
 	finals := 0
+	errors := 0
 	for r := range out {
-		if r.Kind() == bamlutils.StreamResultKindFinal {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindFinal:
 			finals++
 			if r.Final() != "anthropic ok" {
 				t.Errorf("expected 'anthropic ok', got %v", r.Final())
 			}
+		case bamlutils.StreamResultKindError:
+			errors++
 		}
 	}
-	if finals != 1 {
-		t.Fatalf("expected exactly 1 final result from anthropic fallback, got %d", finals)
+	if finals != 1 || errors != 0 {
+		t.Fatalf("expected exactly 1 final and 0 errors from anthropic fallback, got finals=%d errors=%d", finals, errors)
 	}
 }
 
@@ -1203,8 +1230,10 @@ func TestRunCallOrchestration_FallbackChainWithRaw(t *testing.T) {
 	}
 
 	finals := 0
+	errors := 0
 	for r := range out {
-		if r.Kind() == bamlutils.StreamResultKindFinal {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindFinal:
 			finals++
 			if r.Final() != "fallback ok" {
 				t.Errorf("expected 'fallback ok', got %v", r.Final())
@@ -1212,10 +1241,12 @@ func TestRunCallOrchestration_FallbackChainWithRaw(t *testing.T) {
 			if r.Raw() != "fallback ok" {
 				t.Errorf("expected Raw()='fallback ok', got %q", r.Raw())
 			}
+		case bamlutils.StreamResultKindError:
+			errors++
 		}
 	}
-	if finals != 1 {
-		t.Fatalf("expected exactly 1 final result from fallback, got %d", finals)
+	if finals != 1 || errors != 0 {
+		t.Fatalf("expected exactly 1 final and 0 errors from fallback, got finals=%d errors=%d", finals, errors)
 	}
 }
 
@@ -1270,16 +1301,20 @@ func TestRunCallOrchestration_FallbackChainExtractionFailure(t *testing.T) {
 	}
 
 	finals := 0
+	errors := 0
 	for r := range out {
-		if r.Kind() == bamlutils.StreamResultKindFinal {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindFinal:
 			finals++
 			if r.Final() != "recovered" {
 				t.Errorf("expected 'recovered', got %v", r.Final())
 			}
+		case bamlutils.StreamResultKindError:
+			errors++
 		}
 	}
-	if finals != 1 {
-		t.Fatalf("expected exactly 1 final result after extraction failure retry, got %d", finals)
+	if finals != 1 || errors != 0 {
+		t.Fatalf("expected exactly 1 final and 0 errors after extraction failure retry, got finals=%d errors=%d", finals, errors)
 	}
 	if got := int(attempts.Load()); got != 2 {
 		t.Errorf("expected exactly 2 attempts (1 extraction failure + 1 success), got %d", got)

--- a/bamlutils/buildrequest/legacy_child_registry_test.go
+++ b/bamlutils/buildrequest/legacy_child_registry_test.go
@@ -32,15 +32,13 @@ func TestBuildLegacyChildRegistryEntries_IncludesNonStrategyLeaves(t *testing.T)
 
 	entries := BuildLegacyChildRegistryEntries(reg, "InnerRR", introspectedProviders, introspectedChains)
 
-	got := make(map[string]bool, len(entries))
-	for _, e := range entries {
-		got[e.Name] = true
+	gotNames := make([]string, len(entries))
+	for i, e := range entries {
+		gotNames[i] = e.Name
 	}
-	if !got["TenantLeaf"] {
-		t.Errorf("expected TenantLeaf in scoped registry; entries=%+v", entries)
-	}
-	if !got["InnerRR"] {
-		t.Errorf("expected InnerRR in scoped registry (target strategy parent); entries=%+v", entries)
+	want := []string{"TenantLeaf", "InnerRR"}
+	if !reflect.DeepEqual(gotNames, want) {
+		t.Errorf("scoped registry names: got %v, want %v (entries=%+v); the static introspected chain leaves StaticBlue/StaticGreen must NOT leak in alongside the runtime override", gotNames, want, entries)
 	}
 }
 
@@ -67,10 +65,17 @@ func TestBuildLegacyChildRegistryEntries_DropsUnreachableStrategyParents(t *test
 
 	entries := BuildLegacyChildRegistryEntries(reg, "InnerRR", introspectedProviders, nil)
 
-	for _, e := range entries {
-		if e.Name == "OtherFallback" {
-			t.Errorf("OtherFallback (unreachable) leaked into scoped registry: entries=%+v", entries)
-		}
+	gotNames := make([]string, len(entries))
+	for i, e := range entries {
+		gotNames[i] = e.Name
+	}
+	// LeafA isn't in reg.Clients (only in InnerRR.strategy), so it's not
+	// emitted as an entry even though it's reachable. Only InnerRR (the
+	// target) survives reg.Clients iteration; OtherFallback is unreachable
+	// and dropped.
+	want := []string{"InnerRR"}
+	if !reflect.DeepEqual(gotNames, want) {
+		t.Errorf("scoped registry names: got %v, want %v (entries=%+v); OtherFallback must drop, only the target InnerRR survives", gotNames, want, entries)
 	}
 }
 
@@ -97,18 +102,13 @@ func TestBuildLegacyChildRegistryEntries_TransitiveReachability(t *testing.T) {
 
 	entries := BuildLegacyChildRegistryEntries(reg, "InnerFallback", introspectedProviders, nil)
 
-	got := make(map[string]bool, len(entries))
-	for _, e := range entries {
-		got[e.Name] = true
+	gotNames := make([]string, len(entries))
+	for i, e := range entries {
+		gotNames[i] = e.Name
 	}
-	if !got["InnerFallback"] {
-		t.Errorf("expected InnerFallback in scoped registry; entries=%+v", entries)
-	}
-	if !got["DeeperRR"] {
-		t.Errorf("expected DeeperRR (transitively reachable) in scoped registry; entries=%+v", entries)
-	}
-	if !got["TenantLeaf"] {
-		t.Errorf("expected TenantLeaf (leaf) in scoped registry; entries=%+v", entries)
+	want := []string{"InnerFallback", "DeeperRR", "TenantLeaf"}
+	if !reflect.DeepEqual(gotNames, want) {
+		t.Errorf("scoped registry names: got %v, want %v (entries=%+v); transitive walk must include all three", gotNames, want, entries)
 	}
 }
 
@@ -157,15 +157,13 @@ func TestBuildLegacyChildRegistryEntries_DynamicOnlyParent(t *testing.T) {
 
 	entries := BuildLegacyChildRegistryEntries(reg, "DynamicFallback", nil, nil)
 
-	got := make(map[string]bool, len(entries))
-	for _, e := range entries {
-		got[e.Name] = true
+	gotNames := make([]string, len(entries))
+	for i, e := range entries {
+		gotNames[i] = e.Name
 	}
-	if !got["DynamicFallback"] {
-		t.Errorf("expected DynamicFallback (dynamic-only nested parent) in scoped registry; entries=%+v", entries)
-	}
-	if !got["TenantLeaf"] {
-		t.Errorf("expected TenantLeaf (dynamic leaf under DynamicFallback) in scoped registry; entries=%+v", entries)
+	want := []string{"DynamicFallback", "TenantLeaf"}
+	if !reflect.DeepEqual(gotNames, want) {
+		t.Errorf("scoped registry names: got %v, want %v (entries=%+v); dynamic-only nested parent and its leaf must both reach the registry", gotNames, want, entries)
 	}
 }
 
@@ -287,18 +285,15 @@ func TestBuildLegacyChildRegistryEntries_DropsUnreachableLeaf(t *testing.T) {
 
 	entries := BuildLegacyChildRegistryEntries(reg, "InnerRR", nil, nil)
 
-	got := make(map[string]bool, len(entries))
-	for _, e := range entries {
-		got[e.Name] = true
+	gotNames := make([]string, len(entries))
+	for i, e := range entries {
+		gotNames[i] = e.Name
 	}
-	if !got["ReachableLeaf"] {
-		t.Errorf("ReachableLeaf must survive — it is in InnerRR.strategy; entries=%+v", entries)
-	}
-	if got["UnrelatedLeaf"] {
-		t.Errorf("UnrelatedLeaf (unreachable) leaked into scoped registry; entries=%+v", entries)
-	}
-	if !got["InnerRR"] {
-		t.Errorf("InnerRR (target) must survive; entries=%+v", entries)
+	// reg.Clients order: ReachableLeaf, UnrelatedLeaf, InnerRR. UnrelatedLeaf
+	// is dropped via the reachability gate; the others survive in source order.
+	want := []string{"ReachableLeaf", "InnerRR"}
+	if !reflect.DeepEqual(gotNames, want) {
+		t.Errorf("scoped registry names: got %v, want %v (entries=%+v); UnrelatedLeaf must drop, ReachableLeaf and target InnerRR survive in reg.Clients order", gotNames, want, entries)
 	}
 }
 
@@ -388,18 +383,16 @@ func TestBuildLegacyChildRegistryEntries_InvalidStrategyOverrideStopsWalk(t *tes
 
 	entries := BuildLegacyChildRegistryEntries(reg, "InnerFallback", introspectedProviders, introspectedChains)
 
-	got := make(map[string]bool, len(entries))
-	for _, e := range entries {
-		got[e.Name] = true
+	gotNames := make([]string, len(entries))
+	for i, e := range entries {
+		gotNames[i] = e.Name
 	}
-	if !got["InnerFallback"] {
-		t.Errorf("InnerFallback (target with present-invalid override) must still be in the scoped registry; entries=%+v", entries)
-	}
-	if got["StaticDeeperRR"] {
-		t.Errorf("StaticDeeperRR leaked through fall-through to introspected chain — invalid runtime override should stop the walk, not silently use the static graph; entries=%+v", entries)
-	}
-	if got["OtherStaticRR"] {
-		t.Errorf("OtherStaticRR leaked through fall-through to introspected chain — invalid runtime override should stop the walk; entries=%+v", entries)
+	// Only the target survives — the present-invalid override must stop
+	// the walk so neither static descendant (StaticDeeperRR/OtherStaticRR)
+	// leaks via fall-through to the introspected chain.
+	want := []string{"InnerFallback"}
+	if !reflect.DeepEqual(gotNames, want) {
+		t.Errorf("scoped registry names: got %v, want %v (entries=%+v); invalid runtime override must stop the walk, not silently descend the static graph", gotNames, want, entries)
 	}
 }
 

--- a/bamlutils/buildrequest/orchestrator_integration_test.go
+++ b/bamlutils/buildrequest/orchestrator_integration_test.go
@@ -340,11 +340,11 @@ func TestEmptyCompletion_LetParseFinalDecide(t *testing.T) {
 	close(out)
 
 	// Should have a final result, NOT an error
-	var gotFinal bool
+	finals := 0
 	for r := range out {
 		tr := r.(*testResult)
 		if tr.kind == bamlutils.StreamResultKindFinal {
-			gotFinal = true
+			finals++
 			if tr.final != "parsed:" {
 				t.Errorf("expected final='parsed:', got %q", tr.final)
 			}
@@ -353,8 +353,8 @@ func TestEmptyCompletion_LetParseFinalDecide(t *testing.T) {
 			t.Errorf("should not get error for empty completion, got: %v", tr.err)
 		}
 	}
-	if !gotFinal {
-		t.Error("expected a final result for empty completion")
+	if finals != 1 {
+		t.Errorf("expected exactly 1 final result for empty completion, got %d", finals)
 	}
 }
 

--- a/bamlutils/buildrequest/orchestrator_test.go
+++ b/bamlutils/buildrequest/orchestrator_test.go
@@ -1628,6 +1628,9 @@ func TestResolveFallbackChain_NestedValidOverrideStillResolves(t *testing.T) {
 	if !legacy["InnerRR"] {
 		t.Errorf("InnerRR must remain on the mixed-mode legacy child list (BAML runtime handles RR rotation), legacyChildren=%v", legacy)
 	}
+	if legacy["FastLeaf"] {
+		t.Errorf("FastLeaf is a supported leaf; it must NOT be misclassified as legacy, legacyChildren=%v", legacy)
+	}
 }
 
 // TestResolveFallbackChain_TransitiveInvalidStartOverride pins the
@@ -1821,6 +1824,9 @@ func TestResolveFallbackChain_TransitiveCycleSafe(t *testing.T) {
 	}
 	if !legacy["InnerFallback"] {
 		t.Errorf("InnerFallback must be on the mixed-mode legacy child list (strategy parent), legacyChildren=%v", legacy)
+	}
+	if legacy["FastLeaf"] {
+		t.Errorf("FastLeaf is a supported leaf; it must NOT be misclassified as legacy, legacyChildren=%v", legacy)
 	}
 }
 

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -297,6 +297,15 @@ func TestBridgeStreamResultsForwardsStreamResult(t *testing.T) {
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("timed out waiting for bridged stream result")
 	}
+
+	select {
+	case _, ok := <-out:
+		if ok {
+			t.Fatal("expected bridged output channel to close after upstream closes (no leakage past the single forwarded frame)")
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for bridged output channel to close")
+	}
 }
 
 func TestBridgeStreamResultsResetOnlyStreamHasNoPayload(t *testing.T) {
@@ -333,6 +342,15 @@ func TestBridgeStreamResultsResetOnlyStreamHasNoPayload(t *testing.T) {
 		}
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("timed out waiting for bridged reset-only stream result")
+	}
+
+	select {
+	case _, ok := <-out:
+		if ok {
+			t.Fatal("expected bridged output channel to close after upstream closes (no leakage past the reset-only frame)")
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for bridged output channel to close")
 	}
 }
 

--- a/integration/dynamic_endpoint_test.go
+++ b/integration/dynamic_endpoint_test.go
@@ -647,10 +647,10 @@ func TestDynamicEndpoint(t *testing.T) {
 			},
 		})
 
-		var gotFinal bool
+		finals := 0
 		for event := range events {
 			if event.IsFinal() {
-				gotFinal = true
+				finals++
 			}
 		}
 
@@ -663,8 +663,8 @@ func TestDynamicEndpoint(t *testing.T) {
 		default:
 		}
 
-		if !gotFinal {
-			t.Error("Expected to receive final event")
+		if finals != 1 {
+			t.Errorf("Expected exactly 1 final event, got %d", finals)
 		}
 	})
 
@@ -1008,6 +1008,13 @@ func TestDynamicEndpointMultiPartContent(t *testing.T) {
 
 		if lastEvent == nil {
 			t.Fatal("Expected at least one stream event")
+		}
+		var dyn map[string]any
+		if err := json.Unmarshal(lastEvent.Data, &dyn); err != nil {
+			t.Fatalf("Failed to unmarshal last event Data: %v (data=%s)", err, string(lastEvent.Data))
+		}
+		if dyn["description"] != "An image" {
+			t.Errorf("Expected last event description='An image', got %v (data=%s)", dyn["description"], string(lastEvent.Data))
 		}
 	})
 }

--- a/integration/fallback_test.go
+++ b/integration/fallback_test.go
@@ -619,10 +619,10 @@ func TestFallbackStream(t *testing.T) {
 			Input:  map[string]any{"name": "World"},
 		})
 
-		var gotError bool
+		errCount := 0
 		for ev := range partials {
 			if ev.IsError() {
-				gotError = true
+				errCount++
 			}
 		}
 		// Drain the error channel
@@ -630,8 +630,8 @@ func TestFallbackStream(t *testing.T) {
 			t.Logf("Stream error channel: %v", streamErr)
 		}
 
-		if !gotError {
-			t.Error("Expected an error event when all fallback clients fail")
+		if errCount != 1 {
+			t.Errorf("Expected exactly 1 terminal error event when all fallback clients fail, got %d", errCount)
 		}
 
 		if bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {

--- a/integration/media_test.go
+++ b/integration/media_test.go
@@ -588,7 +588,7 @@ func TestMediaStreamEndpoint(t *testing.T) {
 
 		var eventCount int
 		var lastEvent testutil.StreamEvent
-		var sawFinal bool
+		var finals int
 
 		for {
 			select {
@@ -599,7 +599,7 @@ func TestMediaStreamEndpoint(t *testing.T) {
 				eventCount++
 				lastEvent = event
 				if event.IsFinal() {
-					sawFinal = true
+					finals++
 				}
 			case err := <-errs:
 				if err != nil {
@@ -615,8 +615,8 @@ func TestMediaStreamEndpoint(t *testing.T) {
 			t.Errorf("Expected multiple events, got %d", eventCount)
 		}
 
-		if !sawFinal {
-			t.Error("Expected a final event")
+		if finals != 1 {
+			t.Errorf("Expected exactly 1 final event, got %d", finals)
 		}
 
 		var result string

--- a/integration/recursive_types_test.go
+++ b/integration/recursive_types_test.go
@@ -187,6 +187,13 @@ func TestRecursiveTypes(t *testing.T) {
 		if lastEvent == nil {
 			t.Fatal("Expected at least one stream event")
 		}
+		var tree map[string]any
+		if err := json.Unmarshal(lastEvent.Data, &tree); err != nil {
+			t.Fatalf("Failed to unmarshal last event Data: %v (data=%s)", err, string(lastEvent.Data))
+		}
+		if tree["value"] != "root" {
+			t.Errorf("Expected last event tree value='root', got %v (data=%s)", tree["value"], string(lastEvent.Data))
+		}
 	})
 
 	t.Run("tree_node_parse", func(t *testing.T) {
@@ -343,6 +350,13 @@ func TestRecursiveTypesWithMedia(t *testing.T) {
 		}
 		if lastEvent == nil {
 			t.Fatal("Expected at least one stream event")
+		}
+		var tree map[string]any
+		if err := json.Unmarshal(lastEvent.Data, &tree); err != nil {
+			t.Fatalf("Failed to unmarshal last event Data: %v (data=%s)", err, string(lastEvent.Data))
+		}
+		if tree["label"] != "root" {
+			t.Errorf("Expected last event tree label='root', got %v (data=%s)", tree["label"], string(lastEvent.Data))
 		}
 	})
 }

--- a/integration/resilience_test.go
+++ b/integration/resilience_test.go
@@ -143,8 +143,8 @@ func TestConcurrentStreamsDuringWorkerDeath(t *testing.T) {
 				Options: opts,
 			})
 
-			var gotFinal bool
-			var gotError bool
+			finals := 0
+			errCount := 0
 			for {
 				select {
 				case event, ok := <-events:
@@ -155,16 +155,16 @@ func TestConcurrentStreamsDuringWorkerDeath(t *testing.T) {
 						resets.Add(1)
 					}
 					if event.IsFinal() {
-						gotFinal = true
+						finals++
 					}
 					if event.IsError() {
-						gotError = true
+						errCount++
 						t.Logf("Request %d got error event: %s", idx, event.Data)
 					}
 				case err := <-errs:
 					if err != nil {
 						t.Logf("Request %d stream error: %v", idx, err)
-						gotError = true
+						errCount++
 					}
 				case <-ctx.Done():
 					goto done
@@ -172,8 +172,8 @@ func TestConcurrentStreamsDuringWorkerDeath(t *testing.T) {
 			}
 		done:
 
-			if !gotFinal || gotError {
-				t.Logf("Request %d: final=%v error=%v", idx, gotFinal, gotError)
+			if finals != 1 || errCount != 0 {
+				t.Logf("Request %d: finals=%d errors=%d", idx, finals, errCount)
 				failures.Add(1)
 			}
 		}(i)
@@ -261,7 +261,7 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 		}
 
 		// Drain remaining events — expect recovery (reset + final).
-		var gotFinal bool
+		finals := 0
 		for {
 			select {
 			case event, ok := <-events:
@@ -269,7 +269,7 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 					goto roundDone
 				}
 				if event.IsFinal() {
-					gotFinal = true
+					finals++
 				}
 			case err := <-errs:
 				if err != nil {
@@ -281,8 +281,8 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 		}
 	roundDone:
 
-		if !gotFinal {
-			t.Errorf("Round %d: never got final result after worker death", round)
+		if finals != 1 {
+			t.Errorf("Round %d: expected exactly 1 final result after worker death, got %d", round, finals)
 		}
 
 		// Verify a simple call works after recovery.
@@ -457,7 +457,8 @@ func TestMixedRequestsDuringWorkerDeath(t *testing.T) {
 				Input:   map[string]any{"description": fmt.Sprintf("streamer_%d", idx)},
 				Options: streamOpts,
 			})
-			var gotFinal, gotError bool
+			finals := 0
+			errCount := 0
 			for {
 				select {
 				case event, ok := <-events:
@@ -465,21 +466,21 @@ func TestMixedRequestsDuringWorkerDeath(t *testing.T) {
 						goto done
 					}
 					if event.IsFinal() {
-						gotFinal = true
+						finals++
 					}
 					if event.IsError() {
-						gotError = true
+						errCount++
 					}
 				case err := <-errs:
 					if err != nil {
-						gotError = true
+						errCount++
 					}
 				case <-ctx.Done():
 					goto done
 				}
 			}
 		done:
-			if !gotFinal || gotError {
+			if finals != 1 || errCount != 0 {
 				streamFailures.Add(1)
 			}
 		}(i)

--- a/integration/resilience_test.go
+++ b/integration/resilience_test.go
@@ -161,7 +161,14 @@ func TestConcurrentStreamsDuringWorkerDeath(t *testing.T) {
 						errCount++
 						t.Logf("Request %d got error event: %s", idx, event.Data)
 					}
-				case err := <-errs:
+				case err, ok := <-errs:
+					if !ok {
+						// errs producer closed (testutil.streamRequest defers close);
+						// disable this select arm so it doesn't busy-spin yielding nil
+						// while the events channel is still draining.
+						errs = nil
+						continue
+					}
 					if err != nil {
 						t.Logf("Request %d stream error: %v", idx, err)
 						errCount++
@@ -271,7 +278,13 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 				if event.IsFinal() {
 					finals++
 				}
-			case err := <-errs:
+			case err, ok := <-errs:
+				if !ok {
+					// errs producer closed; disable this arm so it doesn't
+					// busy-spin yielding nil while events drains.
+					errs = nil
+					continue
+				}
 				if err != nil {
 					t.Logf("Round %d: stream error during drain: %v", round, err)
 				}
@@ -471,7 +484,13 @@ func TestMixedRequestsDuringWorkerDeath(t *testing.T) {
 					if event.IsError() {
 						errCount++
 					}
-				case err := <-errs:
+				case err, ok := <-errs:
+					if !ok {
+						// errs producer closed; disable this arm so it
+						// doesn't busy-spin yielding nil.
+						errs = nil
+						continue
+					}
 					if err != nil {
 						errCount++
 					}

--- a/integration/resilience_test.go
+++ b/integration/resilience_test.go
@@ -244,6 +244,12 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 			Options: opts,
 		})
 
+		// Declared before the first-event wait so an error event observed
+		// as the first event (or a non-nil errs receive at any point) is
+		// counted toward the round's exclusivity check below.
+		finals := 0
+		errCount := 0
+
 		// Wait for first event.
 		select {
 		case event, ok := <-events:
@@ -251,6 +257,12 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 				t.Fatalf("Round %d: stream closed before first event", round)
 			}
 			t.Logf("Round %d: got first event: type=%s", round, event.Event)
+			if event.IsError() {
+				errCount++
+			}
+			if event.IsFinal() {
+				finals++
+			}
 		case err := <-errs:
 			t.Fatalf("Round %d: stream error before first event: %v", round, err)
 		case <-time.After(30 * time.Second):
@@ -268,7 +280,6 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 		}
 
 		// Drain remaining events — expect recovery (reset + final).
-		finals := 0
 		for {
 			select {
 			case event, ok := <-events:
@@ -277,6 +288,9 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 				}
 				if event.IsFinal() {
 					finals++
+				}
+				if event.IsError() {
+					errCount++
 				}
 			case err, ok := <-errs:
 				if !ok {
@@ -287,6 +301,7 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 				}
 				if err != nil {
 					t.Logf("Round %d: stream error during drain: %v", round, err)
+					errCount++
 				}
 			case <-time.After(30 * time.Second):
 				t.Fatalf("Round %d: timeout draining stream", round)
@@ -294,8 +309,8 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 		}
 	roundDone:
 
-		if finals != 1 {
-			t.Errorf("Round %d: expected exactly 1 final result after worker death, got %d", round, finals)
+		if finals != 1 || errCount != 0 {
+			t.Errorf("Round %d: expected exactly 1 final and 0 errors after worker death, got finals=%d errCount=%d", round, finals, errCount)
 		}
 
 		// Verify a simple call works after recovery.

--- a/integration/resilience_test.go
+++ b/integration/resilience_test.go
@@ -259,7 +259,6 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 		// `stream error before first event: <nil>` fatal — disable the arm
 		// on close and keep waiting on events / timeout.
 		firstEventBudget := time.NewTimer(30 * time.Second)
-		defer firstEventBudget.Stop()
 	waitFirst:
 		for {
 			select {
@@ -285,6 +284,7 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 				t.Fatalf("Round %d: timeout waiting for first event", round)
 			}
 		}
+		firstEventBudget.Stop()
 
 		// Kill a worker.
 		killCtx, killCancel := context.WithTimeout(ctx, 5*time.Second)

--- a/integration/resilience_test.go
+++ b/integration/resilience_test.go
@@ -145,11 +145,18 @@ func TestConcurrentStreamsDuringWorkerDeath(t *testing.T) {
 
 			finals := 0
 			errCount := 0
-			for {
+			// Drain BOTH channels until each producer closes its half.
+			// streamRequest defers close on errs and events; on events-close-
+			// first races the buffered errs value would otherwise be left
+			// unread, hiding a non-nil parse/scanner error behind
+			// `finals == 1 && errCount == 0`. Disable each arm on close
+			// (set chan to nil) and exit only when both are nil.
+			for events != nil || errs != nil {
 				select {
 				case event, ok := <-events:
 					if !ok {
-						goto done
+						events = nil
+						continue
 					}
 					if event.IsReset() {
 						resets.Add(1)
@@ -163,9 +170,6 @@ func TestConcurrentStreamsDuringWorkerDeath(t *testing.T) {
 					}
 				case err, ok := <-errs:
 					if !ok {
-						// errs producer closed (testutil.streamRequest defers close);
-						// disable this select arm so it doesn't busy-spin yielding nil
-						// while the events channel is still draining.
 						errs = nil
 						continue
 					}
@@ -250,23 +254,36 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 		finals := 0
 		errCount := 0
 
-		// Wait for first event.
-		select {
-		case event, ok := <-events:
-			if !ok {
-				t.Fatalf("Round %d: stream closed before first event", round)
+		// Wait for first event. Two-value receive on errs so a closed-but-
+		// empty errs channel does not surface as a spurious
+		// `stream error before first event: <nil>` fatal — disable the arm
+		// on close and keep waiting on events / timeout.
+		firstEventBudget := time.NewTimer(30 * time.Second)
+		defer firstEventBudget.Stop()
+	waitFirst:
+		for {
+			select {
+			case event, ok := <-events:
+				if !ok {
+					t.Fatalf("Round %d: stream closed before first event", round)
+				}
+				t.Logf("Round %d: got first event: type=%s", round, event.Event)
+				if event.IsError() {
+					errCount++
+				}
+				if event.IsFinal() {
+					finals++
+				}
+				break waitFirst
+			case err, ok := <-errs:
+				if !ok {
+					errs = nil
+					continue
+				}
+				t.Fatalf("Round %d: stream error before first event: %v", round, err)
+			case <-firstEventBudget.C:
+				t.Fatalf("Round %d: timeout waiting for first event", round)
 			}
-			t.Logf("Round %d: got first event: type=%s", round, event.Event)
-			if event.IsError() {
-				errCount++
-			}
-			if event.IsFinal() {
-				finals++
-			}
-		case err := <-errs:
-			t.Fatalf("Round %d: stream error before first event: %v", round, err)
-		case <-time.After(30 * time.Second):
-			t.Fatalf("Round %d: timeout waiting for first event", round)
 		}
 
 		// Kill a worker.
@@ -279,12 +296,16 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 			t.Logf("Round %d: killed worker %d", round, result.WorkerID)
 		}
 
-		// Drain remaining events — expect recovery (reset + final).
-		for {
+		// Drain remaining events — expect recovery (reset + final). Drain
+		// BOTH channels until each producer closes its half so an
+		// events-close-first race doesn't strand a buffered errs value
+		// behind a `finals == 1 && errCount == 0` false pass.
+		for events != nil || errs != nil {
 			select {
 			case event, ok := <-events:
 				if !ok {
-					goto roundDone
+					events = nil
+					continue
 				}
 				if event.IsFinal() {
 					finals++
@@ -294,8 +315,6 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 				}
 			case err, ok := <-errs:
 				if !ok {
-					// errs producer closed; disable this arm so it doesn't
-					// busy-spin yielding nil while events drains.
 					errs = nil
 					continue
 				}
@@ -307,7 +326,6 @@ func TestSequentialWorkerDeaths(t *testing.T) {
 				t.Fatalf("Round %d: timeout draining stream", round)
 			}
 		}
-	roundDone:
 
 		if finals != 1 || errCount != 0 {
 			t.Errorf("Round %d: expected exactly 1 final and 0 errors after worker death, got finals=%d errCount=%d", round, finals, errCount)
@@ -487,11 +505,14 @@ func TestMixedRequestsDuringWorkerDeath(t *testing.T) {
 			})
 			finals := 0
 			errCount := 0
-			for {
+			// Drain BOTH channels until each producer closes its half so an
+			// events-close-first race doesn't strand a buffered errs value.
+			for events != nil || errs != nil {
 				select {
 				case event, ok := <-events:
 					if !ok {
-						goto done
+						events = nil
+						continue
 					}
 					if event.IsFinal() {
 						finals++
@@ -501,8 +522,6 @@ func TestMixedRequestsDuringWorkerDeath(t *testing.T) {
 					}
 				case err, ok := <-errs:
 					if !ok {
-						// errs producer closed; disable this arm so it
-						// doesn't busy-spin yielding nil.
 						errs = nil
 						continue
 					}

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -386,7 +386,7 @@ func TestWorkerDeathMidStream(t *testing.T) {
 
 		var receivedEvents []testutil.StreamEvent
 		var streamErr error
-		var sawResetEvent bool
+		var resetEventCount int
 		var sawErrorEvent bool
 		var killedWorker bool
 		var eventsBeforeKill int
@@ -413,7 +413,7 @@ func TestWorkerDeathMidStream(t *testing.T) {
 				t.Logf("Received event %d: type=%s, data_len=%d", len(receivedEvents), event.Event, len(event.Data))
 
 				if event.Event == "reset" {
-					sawResetEvent = true
+					resetEventCount++
 					t.Log(">>> SAW RESET EVENT - retry with reset working!")
 				}
 				if event.Event == "error" {
@@ -468,8 +468,8 @@ func TestWorkerDeathMidStream(t *testing.T) {
 					t.Logf("Received stream error: %v", err)
 				}
 			case <-postKillC:
-				t.Errorf("post-kill drain exceeded 30s — retry handoff appears wedged. events=%d, sawReset=%v, sawError=%v, streamErr=%v",
-					len(receivedEvents), sawResetEvent, sawErrorEvent, streamErr)
+				t.Errorf("post-kill drain exceeded 30s — retry handoff appears wedged. events=%d, resets=%d, sawError=%v, streamErr=%v",
+					len(receivedEvents), resetEventCount, sawErrorEvent, streamErr)
 				goto done
 			case <-ctx.Done():
 				t.Logf("Context cancelled")
@@ -487,7 +487,7 @@ func TestWorkerDeathMidStream(t *testing.T) {
 		t.Logf("Events before kill: %d", eventsBeforeKill)
 		t.Logf("Stream error: %v", streamErr)
 		t.Logf("Worker killed: %v", killedWorker)
-		t.Logf("Saw reset event: %v", sawResetEvent)
+		t.Logf("Reset events: %d", resetEventCount)
 		t.Logf("Saw error event: %v", sawErrorEvent)
 
 		for i, event := range receivedEvents {
@@ -505,9 +505,11 @@ func TestWorkerDeathMidStream(t *testing.T) {
 
 		// VERIFY EXPECTED BEHAVIOR:
 
-		// 1. Should have seen a reset event (indicating retry happened)
-		if !sawResetEvent {
-			t.Error("Expected reset event after worker death - mid-stream retry should inject reset")
+		// 1. Should have seen exactly one reset event (one worker kill → one
+		//    reset injection on retry handoff). A duplicate reset would
+		//    indicate a producer-side regression.
+		if resetEventCount != 1 {
+			t.Errorf("Expected exactly 1 reset event after worker death, got %d - mid-stream retry should inject reset once per kill", resetEventCount)
 		}
 
 		// 2. Should have completed successfully (no error event, stream closed gracefully)
@@ -1520,7 +1522,7 @@ func TestWorkerDeathMidStreamNDJSON(t *testing.T) {
 
 		var receivedEvents []testutil.StreamEvent
 		var streamErr error
-		var sawResetEvent bool
+		var resetEventCount int
 		var sawErrorEvent bool
 		var killedWorker bool
 		var eventsBeforeKill int
@@ -1545,7 +1547,7 @@ func TestWorkerDeathMidStreamNDJSON(t *testing.T) {
 				t.Logf("Received event %d: type=%s, data_len=%d", len(receivedEvents), event.Event, len(event.Data))
 
 				if event.IsReset() {
-					sawResetEvent = true
+					resetEventCount++
 					t.Log(">>> SAW RESET EVENT - retry with reset working in NDJSON!")
 				}
 				if event.IsError() {
@@ -1589,8 +1591,8 @@ func TestWorkerDeathMidStreamNDJSON(t *testing.T) {
 					t.Logf("Received stream error: %v", err)
 				}
 			case <-postKillC:
-				t.Errorf("post-kill drain exceeded 30s — retry handoff appears wedged. events=%d, eventsBeforeKill=%d, sawReset=%v, sawError=%v, streamErr=%v",
-					len(receivedEvents), eventsBeforeKill, sawResetEvent, sawErrorEvent, streamErr)
+				t.Errorf("post-kill drain exceeded 30s — retry handoff appears wedged. events=%d, eventsBeforeKill=%d, resets=%d, sawError=%v, streamErr=%v",
+					len(receivedEvents), eventsBeforeKill, resetEventCount, sawErrorEvent, streamErr)
 				goto done
 			case <-ctx.Done():
 				t.Logf("Context cancelled")
@@ -1608,7 +1610,7 @@ func TestWorkerDeathMidStreamNDJSON(t *testing.T) {
 		t.Logf("Events before kill: %d", eventsBeforeKill)
 		t.Logf("Stream error: %v", streamErr)
 		t.Logf("Worker killed: %v", killedWorker)
-		t.Logf("Saw reset event: %v", sawResetEvent)
+		t.Logf("Reset events: %d", resetEventCount)
 		t.Logf("Saw error event: %v", sawErrorEvent)
 
 		// Verify test setup worked
@@ -1622,9 +1624,11 @@ func TestWorkerDeathMidStreamNDJSON(t *testing.T) {
 
 		// VERIFY EXPECTED BEHAVIOR:
 
-		// 1. Should have seen a reset event (indicating retry happened)
-		if !sawResetEvent {
-			t.Error("Expected reset event after worker death - mid-stream retry should inject reset")
+		// 1. Should have seen exactly one reset event (one worker kill → one
+		//    reset injection on retry handoff). A duplicate reset would
+		//    indicate a producer-side regression.
+		if resetEventCount != 1 {
+			t.Errorf("Expected exactly 1 reset event after worker death, got %d - mid-stream retry should inject reset once per kill", resetEventCount)
 		}
 
 		// 2. Should have completed successfully (no error event, stream closed gracefully)

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1196,26 +1196,26 @@ func TestCallStreamMidStreamRetry(t *testing.T) {
 
 	// Wrapped in requireCompleteWithin so a future regression where the
 	// producer/wrapper fails to close the channel surfaces as a test
-	// timeout rather than hanging the test binary. atomic.Bool because
+	// timeout rather than hanging the test binary. atomic.Int32 because
 	// the helper runs the closure in a goroutine.
-	var gotReset, gotFinal atomic.Bool
+	var resets, finals atomic.Int32
 	requireCompleteWithin(t, 2*time.Second, func() {
 		for r := range results {
 			if r.Reset {
-				gotReset.Store(true)
+				resets.Add(1)
 			}
 			if r.Kind == workerplugin.StreamResultKindFinal {
-				gotFinal.Store(true)
+				finals.Add(1)
 			}
 			workerplugin.ReleaseStreamResult(r)
 		}
 	})
 
-	if !gotReset.Load() {
-		t.Error("expected reset event after mid-stream retry")
+	if got := resets.Load(); got != 1 {
+		t.Errorf("expected exactly 1 reset event after mid-stream retry, got %d", got)
 	}
-	if !gotFinal.Load() {
-		t.Error("expected final result after retry")
+	if got := finals.Load(); got != 1 {
+		t.Errorf("expected exactly 1 final result after retry, got %d", got)
 	}
 }
 
@@ -1898,18 +1898,18 @@ func TestCallStreamUnexpectedEOF(t *testing.T) {
 		t.Fatalf("CallStream setup failed: %v", err)
 	}
 
-	var gotFinal bool
+	var finals atomic.Int32
 	requireCompleteWithin(t, 5*time.Second, func() {
 		for r := range results {
 			if r.Kind == workerplugin.StreamResultKindFinal {
-				gotFinal = true
+				finals.Add(1)
 			}
 			workerplugin.ReleaseStreamResult(r)
 		}
 	})
 
-	if !gotFinal {
-		t.Error("expected final result after unexpected EOF retry")
+	if got := finals.Load(); got != 1 {
+		t.Errorf("expected exactly 1 final result after unexpected EOF retry, got %d", got)
 	}
 }
 
@@ -1932,18 +1932,18 @@ func TestCallStreamExhaustsRetries(t *testing.T) {
 		t.Fatalf("CallStream setup should succeed: %v", err)
 	}
 
-	var gotError bool
+	var errs atomic.Int32
 	requireCompleteWithin(t, 10*time.Second, func() {
 		for r := range results {
 			if r.Kind == workerplugin.StreamResultKindError {
-				gotError = true
+				errs.Add(1)
 			}
 			workerplugin.ReleaseStreamResult(r)
 		}
 	})
 
-	if !gotError {
-		t.Error("expected error after exhausting all retries")
+	if got := errs.Load(); got != 1 {
+		t.Errorf("expected exactly 1 error after exhausting all retries, got %d", got)
 	}
 }
 
@@ -1968,18 +1968,18 @@ func TestCallStreamNonRetryableError(t *testing.T) {
 		t.Fatalf("CallStream setup should succeed: %v", err)
 	}
 
-	var gotError bool
+	var errs atomic.Int32
 	requireCompleteWithin(t, 5*time.Second, func() {
 		for r := range results {
 			if r.Kind == workerplugin.StreamResultKindError {
-				gotError = true
+				errs.Add(1)
 			}
 			workerplugin.ReleaseStreamResult(r)
 		}
 	})
 
-	if !gotError {
-		t.Error("expected non-retryable error forwarded to consumer")
+	if got := errs.Load(); got != 1 {
+		t.Errorf("expected exactly 1 non-retryable error forwarded to consumer, got %d", got)
 	}
 	if c := callCounts.Load(); c != 1 {
 		t.Errorf("expected 1 call (no retry for non-retryable), got %d", c)
@@ -3356,15 +3356,15 @@ func TestCallStreamSlowLegacyHeartbeatPreventsHungKill(t *testing.T) {
 
 	// Wrapped in requireCompleteWithin so a future regression where the
 	// producer/wrapper fails to close the channel surfaces as a test
-	// timeout rather than hanging the test binary. atomic.Bool +
+	// timeout rather than hanging the test binary. atomic.Int32 +
 	// atomic.Pointer[string] for the cross-goroutine reads after the
 	// helper returns.
-	var gotFinal atomic.Bool
+	var finals atomic.Int32
 	var gotData atomic.Pointer[string]
 	requireCompleteWithin(t, 2*time.Second, func() {
 		for r := range results {
 			if r.Kind == workerplugin.StreamResultKindFinal {
-				gotFinal.Store(true)
+				finals.Add(1)
 				data := string(r.Data)
 				gotData.Store(&data)
 			}
@@ -3377,8 +3377,8 @@ func TestCallStreamSlowLegacyHeartbeatPreventsHungKill(t *testing.T) {
 	if !heartbeatSent.Load() {
 		t.Fatal("heartbeat was never delivered into the worker result channel — the test premise (heartbeat disables hung-kill) cannot be evaluated; the worker-not-killed assertion below would pass for a trivial reason")
 	}
-	if !gotFinal.Load() {
-		t.Fatalf("expected a final result, stream terminated without one")
+	if got := finals.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 final result, got %d", got)
 	}
 	if got := gotData.Load(); got == nil || *got != `"mixed-mode-final"` {
 		var gotStr string
@@ -3591,18 +3591,20 @@ func TestCallStreamPlannedMetadataDoesNotDisableHungDetection(t *testing.T) {
 	// producer/wrapper fails to close the channel surfaces as a test-
 	// process timeout rather than hanging the whole test binary. The
 	// happy path closes via `defer close(ch)` in the mock factory.
-	var seenPlanned atomic.Bool
+	var planned atomic.Int32
 	requireCompleteWithin(t, 2*time.Second, func() {
 		for r := range results {
 			if r.Kind == workerplugin.StreamResultKindMetadata &&
 				metadataPhase(r.Data) == string(bamlutils.MetadataPhasePlanned) {
-				seenPlanned.Store(true)
+				planned.Add(1)
 			}
 			workerplugin.ReleaseStreamResult(r)
 		}
 	})
-	if !seenPlanned.Load() {
-		t.Error("expected planned metadata frame to reach the consumer; none observed (the test's premise is invalid if the frame was lost upstream)")
+	// Planned metadata is upfront-emit-once per request; a duplicate would
+	// indicate a producer-side regression.
+	if got := planned.Load(); got != 1 {
+		t.Errorf("expected exactly 1 planned metadata frame to reach the consumer, got %d (the test's premise is invalid if the frame was lost upstream)", got)
 	}
 }
 
@@ -3848,23 +3850,24 @@ func TestCallStreamPlannedMetadataDoesNotTriggerResetOnRetry(t *testing.T) {
 
 	// Wrapped in requireCompleteWithin so a future regression where the
 	// producer/wrapper fails to close the channel surfaces as a test
-	// timeout rather than hanging the test binary. atomic.Bool because
+	// timeout rather than hanging the test binary. atomic.Int32 because
 	// the helper runs the closure in a goroutine.
-	var sawReset, sawFinal atomic.Bool
+	var sawReset atomic.Bool
+	var finals atomic.Int32
 	requireCompleteWithin(t, 2*time.Second, func() {
 		for r := range results {
 			if r.Reset {
 				sawReset.Store(true)
 			}
 			if r.Kind == workerplugin.StreamResultKindFinal {
-				sawFinal.Store(true)
+				finals.Add(1)
 			}
 			workerplugin.ReleaseStreamResult(r)
 		}
 	})
 
-	if !sawFinal.Load() {
-		t.Fatal("expected a Final result after retry")
+	if got := finals.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 Final result after retry, got %d", got)
 	}
 	if sawReset.Load() {
 		t.Error("Reset must NOT be injected when only planned metadata was forwarded pre-retry")


### PR DESCRIPTION
## Summary

Part of #199 item 2 (assertion-strictness sweep). PR-B of a 3-PR sequence; PR-A merged as #206.

Two commits:
1. **Category B** (~26 sites): converts existence-only `if !sawX` flags to counters where the contract is exactly-one, and adds "no leakage" companions where appropriate. Closes the regression gap where a duplicate-emit or extra-frame regression would still pass the bool assertion. Files: `bamlutils/buildrequest/call_orchestrator_test.go`, `bamlutils/buildrequest/orchestrator_integration_test.go`, `pool/pool_test.go`, `cmd/worker/main_test.go`, plus deterministic bool-paired sites in `integration/{media,fallback,resilience,stream,recursive_types,dynamic_endpoint}_test.go`.
2. **Category E** (~10 sites): converts `map[string]bool` set-presence probes on `BuildLegacyChildRegistryEntries` outputs to exact `[]string` slice equality (per `TestBuildLegacyChildRegistryEntries_PreservesOrder` template). Captures both set membership and ordering, plus rejects duplicates implicitly. Plus 2 resolver-test sites in `bamlutils/buildrequest/orchestrator_test.go` and 1 marginal codegen site in `adapters/common/codegen/codegen_test.go`.

PR-C (event-count tightenings on integration mockllm fixtures) deferred until #199 item 3 (transport-flake sentinels) lands.

## Test plan

- [x] `go test -count=1 ./bamlutils/buildrequest/...` — passes
- [x] `go test -count=1 ./pool/...` — passes
- [x] `go test -count=1 ./cmd/worker/...` — passes
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [ ] CI integration-tests workflow — confirm green

<!-- webtty-bridge: session=s-yqyd29e14n -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced boolean presence checks with exact-event counters (finals, errors, resets) and assert exact expected counts.
  * Added stricter terminal-frame and streamed-payload validations (content and expected raw payloads).
  * Enforced ordered registry expectations and extra fallback/resolution guards.
  * Strengthened channel/stream closure and resilience checks to detect leaks, duplicate or missing frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->