### PR TITLE
chore: tighten integration event-count contracts

### DIFF
--- a/integration/dynamic_endpoint_test.go
+++ b/integration/dynamic_endpoint_test.go
@@ -1622,8 +1622,13 @@ func TestDynamicEndpointPromptWhitespace(t *testing.T) {
 			}
 
 			messages := extractLLMMessageTexts(t, captured)
-			if len(messages) < 6 {
-				t.Fatalf("Expected at least 6 messages, got %d", len(messages))
+			// The request sends 6 messages (system + 5 conversation turns)
+			// and BAML's dynamic endpoint forwards the messages array 1:1
+			// to the LLM, so the captured count is structurally exact.
+			// A regression that dropped, duplicated, or synthesized
+			// messages would fail strict but pass a lower-bound check.
+			if len(messages) != 6 {
+				t.Fatalf("Expected exactly 6 messages, got %d", len(messages))
 			}
 
 			for i, m := range messages {

--- a/integration/media_test.go
+++ b/integration/media_test.go
@@ -566,7 +566,8 @@ func TestMediaStreamEndpoint(t *testing.T) {
 		// path-dependent count (Legacy=6, BuildRequest=7) because BAML's
 		// SSE extractor coalesces one partial in the Legacy leg only.
 		// Pinning either value would lock in path-specific BAML internals
-		// rather than a stable contract; deferred for #199 PR-C.
+		// rather than a stable contract, so the lower bound intentionally
+		// remains.
 		if eventCount < 2 {
 			t.Errorf("Expected multiple events, got %d", eventCount)
 		}

--- a/integration/media_test.go
+++ b/integration/media_test.go
@@ -421,8 +421,15 @@ func TestNestedMediaStreamEndpoint(t *testing.T) {
 		}
 	doneNestedStream:
 
-		if eventCount < 2 {
-			t.Errorf("Expected multiple events, got %d", eventCount)
+		// Path-stable shape: 1 planned metadata + 3 partials + 1 outcome
+		// metadata + 1 final = 6. The mock streams the 44-char content in
+		// three 20/20/4-char chunks via setupScenario's ChunkSize=20, BAML's
+		// extractor emits a partial per delta with no observed coalescing
+		// for 3-chunk runs, and both Legacy and BuildRequest legs emit
+		// planned/outcome around the partials. Verified deterministic
+		// across 5 Legacy runs + 1 BuildRequest run locally.
+		if eventCount != 6 {
+			t.Errorf("Expected exactly 6 events (planned + 3 partials + outcome + final), got %d", eventCount)
 		}
 
 		var result string
@@ -555,6 +562,11 @@ func TestMediaStreamEndpoint(t *testing.T) {
 		}
 	done:
 
+		// Lower-bound retained intentionally: 67-char content yields a
+		// path-dependent count (Legacy=6, BuildRequest=7) because BAML's
+		// SSE extractor coalesces one partial in the Legacy leg only.
+		// Pinning either value would lock in path-specific BAML internals
+		// rather than a stable contract; deferred for #199 PR-C.
 		if eventCount < 2 {
 			t.Errorf("Expected multiple events, got %d", eventCount)
 		}
@@ -611,6 +623,10 @@ func TestMediaStreamEndpoint(t *testing.T) {
 		}
 	done2:
 
+		// Lower-bound retained: same path-dependent partial-coalescing
+		// as the SSE counterpart above (Legacy=6, BuildRequest=7) for
+		// 4-chunk content. The companion `finals != 1` check below pins
+		// the part of the contract that is path-stable.
 		if eventCount < 2 {
 			t.Errorf("Expected multiple events, got %d", eventCount)
 		}
@@ -668,6 +684,9 @@ func TestMediaStreamEndpoint(t *testing.T) {
 		}
 	done3:
 
+		// Lower-bound retained: same path-dependent partial-coalescing
+		// (Legacy=6, BuildRequest=7) for 4-chunk content; deferred per
+		// the SSE site rationale above.
 		if eventCount < 2 {
 			t.Errorf("Expected multiple events, got %d", eventCount)
 		}
@@ -720,8 +739,13 @@ func TestMediaStreamEndpoint(t *testing.T) {
 		}
 	done4:
 
-		if eventCount < 2 {
-			t.Errorf("Expected multiple events, got %d", eventCount)
+		// Path-stable shape: 1 planned metadata + 2 partials + 1 outcome
+		// metadata + 1 final = 5. The 37-char content streams in two
+		// 20/17-char chunks (no coalescing observed for 2-chunk runs in
+		// either leg). Verified deterministic across 5 Legacy runs + 1
+		// BuildRequest run locally.
+		if eventCount != 5 {
+			t.Errorf("Expected exactly 5 events (planned + 2 partials + outcome + final), got %d", eventCount)
 		}
 
 		// Final event should have raw content

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -1392,7 +1392,9 @@ func TestStreamWithRawNDJSONEndpoint(t *testing.T) {
 		// timing-sensitive (the `resetCount > 0` log below acknowledges
 		// this branch). The typical-case shape is segments=1 (no
 		// retry) but a tightened pin would flake on the retry branch
-		// without surfacing a real regression. Deferred for #199 PR-C.
+		// without surfacing a real regression; keep the lower bound
+		// until the retry path exposes a path-stable segment-count
+		// contract.
 		if len(segments) == 0 {
 			t.Fatal("Expected at least one segment with raw values")
 		}

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -69,9 +69,15 @@ func TestStreamEndpoint(t *testing.T) {
 		}
 	done:
 
-		// Should have received multiple events (chunked streaming)
-		if eventCount < 2 {
-			t.Errorf("Expected multiple events, got %d", eventCount)
+		// Path-stable: the loop above filters metadata out of eventCount,
+		// so the count is partials + final from the BAML stream alone.
+		// The 43-char content streams in three 20/20/3-char chunks via
+		// setupScenario's ChunkSize=20; both legs emit one partial per
+		// delta with no coalescing for 3-chunk runs. 3 partials + 1
+		// final = 4. Verified deterministic across 5 Legacy + 1
+		// BuildRequest run locally.
+		if eventCount != 4 {
+			t.Errorf("Expected exactly 4 non-metadata events (3 partials + final), got %d", eventCount)
 		}
 
 		// Last event should have the complete data
@@ -499,8 +505,14 @@ func TestWorkerDeathMidStream(t *testing.T) {
 			t.Error("Failed to kill worker - test setup issue")
 		}
 
-		if eventsBeforeKill == 0 {
-			t.Error("Expected to receive at least one event before worker death")
+		// Kill fires on the first non-metadata event (per the loop
+		// above), at which point receivedEvents contains exactly
+		// [planned metadata, first partial]. Both Legacy and BuildRequest
+		// emit planned metadata before any upstream byte, so this count
+		// is path-stable. Verified deterministic across 5 Legacy + 1
+		// BuildRequest run locally.
+		if eventsBeforeKill != 2 {
+			t.Errorf("Expected exactly 2 events before worker death (planned metadata + first partial), got %d", eventsBeforeKill)
 		}
 
 		// VERIFY EXPECTED BEHAVIOR:
@@ -940,9 +952,12 @@ func TestStreamNDJSONEndpoint(t *testing.T) {
 		}
 	done:
 
-		// Should have received multiple events (chunked streaming)
-		if eventCount < 2 {
-			t.Errorf("Expected multiple events, got %d", eventCount)
+		// Path-stable: like the SSE counterpart, the loop above filters
+		// metadata out of eventCount, leaving partials + final. 3
+		// partials + 1 final = 4. Verified deterministic across 5
+		// Legacy + 1 BuildRequest run locally.
+		if eventCount != 4 {
+			t.Errorf("Expected exactly 4 non-metadata events (3 partials + final), got %d", eventCount)
 		}
 
 		// Last non-metadata event should be a data event
@@ -1372,7 +1387,12 @@ func TestStreamWithRawNDJSONEndpoint(t *testing.T) {
 			segments = append(segments, currentSegment)
 		}
 
-		// Should have at least one segment with multiple raw values
+		// Lower-bound retained intentionally: segment count depends on
+		// whether BAML triggers an internal retry mid-stream, which is
+		// timing-sensitive (the `resetCount > 0` log below acknowledges
+		// this branch). The typical-case shape is segments=1 (no
+		// retry) but a tightened pin would flake on the retry branch
+		// without surfacing a real regression. Deferred for #199 PR-C.
 		if len(segments) == 0 {
 			t.Fatal("Expected at least one segment with raw values")
 		}
@@ -1618,8 +1638,12 @@ func TestWorkerDeathMidStreamNDJSON(t *testing.T) {
 			t.Error("Failed to kill worker - test setup issue")
 		}
 
-		if eventsBeforeKill == 0 {
-			t.Error("Expected to receive at least one event before worker death")
+		// Same path-stable shape as the SSE counterpart: kill lands on
+		// the first non-metadata event, after exactly 1 planned metadata
+		// frame. eventsBeforeKill == 2 in both legs; verified across 5
+		// Legacy + 1 BuildRequest run locally.
+		if eventsBeforeKill != 2 {
+			t.Errorf("Expected exactly 2 events before worker death (planned metadata + first partial), got %d", eventsBeforeKill)
 		}
 
 		// VERIFY EXPECTED BEHAVIOR:


### PR DESCRIPTION
## Summary

Part of #199 item 2 (assertion-strictness sweep). PR-C of a 3-PR sequence; PR-A (#206) and PR-B (#207) merged. Unblocked by #199 item 3 (transport-flake sentinels), which landed as #208 — closes the flake mechanism that previously caused mockllm-driven event counts to drift.

This PR tightens lower-bound event-count assertions on integration tests where the mockllm fixture is genuinely deterministic. Sites where the fixture has observable variability are deferred with a documented reason inline.

Sites tightened (~7, all verified deterministic across 5 Legacy + 1 BuildRequest run locally — both paths agreeing on the pinned value):
- `integration/dynamic_endpoint_test.go:1618` — `many_messages_no_accumulated_whitespace`: 6 messages in → 6 forwarded (BAML dynamic endpoint passes the messages array 1:1).
- `integration/media_test.go:424` — `class_with_image_stream`: planned + 3 partials + outcome + final = 6 (3-chunk content, no coalescing in either leg).
- `integration/media_test.go:723` — `stream_with_raw_image`: planned + 2 partials + outcome + final = 5 (2-chunk content).
- `integration/stream_test.go:73, :942` — `multiple_sse_events`, `multiple_ndjson_events`: metadata-filtered loops, partials + final = 4 (path-stable since metadata is excluded from the count).
- `integration/stream_test.go:503, :1620` — `worker_killed_after_first_byte` SSE + NDJSON: `eventsBeforeKill = 2` ([planned metadata, first partial] when the kill fires on the first non-metadata event; both legs emit planned upfront).

Sites deferred (with reason inline next to the original lower-bound):
- `integration/media_test.go:558, :614, :671` — `image_sse_stream`, `image_ndjson_stream`, `image_with_text_param_stream`: 4-chunk content yields a path-dependent count (Legacy=6, BuildRequest=7). The discrepancy reflects BAML's SSE extractor coalescing one partial in the Legacy leg only — pinning either value would lock in path-specific internals rather than a stable contract.
- `integration/stream_test.go:1373` — `raw_grows_incrementally_ndjson` segments: count depends on whether BAML triggers an internal mid-stream retry, which is timing-sensitive (the existing `resetCount > 0` log acknowledges this branch).
- `integration/thinking_test.go:448, :521` — `sawThinkingMarker`: same reasoning as PR-B's deferral; `result.rawSnapshots` is cumulative by orchestrator design (each subsequent snapshot extends prior content), so the boolean "any snapshot contains the marker" shape is the right contract.

Sites NOT in PR-C scope: `integration/resilience_test.go` (fully addressed in PR-B verdicts 1-3); `integration/recursive_types_test.go` and `integration/dynamic_endpoint_test.go:666, :1010` (addressed in PR-B).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go vet -tags integration ./integration/...` — clean
- [x] `gofmt -l` on the touched files — clean
- [x] Targeted integration suite (`TestStreamEndpoint`, `TestNestedMediaStreamEndpoint`, `TestMediaStreamEndpoint`, `TestStreamNDJSONEndpoint`, `TestStreamWithRawNDJSONEndpoint/raw_grows_incrementally_ndjson`, `TestWorkerDeathMidStream*`, `TestDynamicEndpointPromptWhitespace`) ran locally on **both** Legacy and BuildRequest paths — all green with the new exact-count assertions.
- [ ] CI integration-tests workflow — confirm green

<!-- webtty-bridge: session=s-yqyd29e14n -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened streaming endpoint validations to assert exact event counts and deterministic sequencing across dynamic, media, SSE, and NDJSON paths.
  * Added explicit coverage for pre-first-byte, mid-stream failure, retry, and finalization scenarios to improve robustness.
  * Expanded comments and guards in integration tests to document path-stable invariants and expected event patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->