### PR TITLE
fix(dynamic): unwrap typed pointer/map shapes in dynamic helper

### DIFF
--- a/adapters/adapter_v0_204_0/utils/dynamic.go
+++ b/adapters/adapter_v0_204_0/utils/dynamic.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/boundaryml/baml/engine/language_client_go/baml_go/serde"
@@ -67,5 +68,36 @@ func UnwrapDynamicValue(value any) any {
 		return result
 	}
 
+	// Handle typed maps via reflection (e.g. map[string]serde.DynamicClass for
+	// `map<string, ref Class>`). Without this, typed maps fall through and
+	// JSON-marshal the value type's exported fields, leaking the internal
+	// {Name, Fields} / {Name, Value} wrappers.
+	if rv.Kind() == reflect.Map {
+		result := make(map[string]any, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			key := stringifyMapKey(iter.Key())
+			result[key] = UnwrapDynamicValue(iter.Value().Interface())
+		}
+		return result
+	}
+
+	// Dereference a non-nil pointer to recurse on the pointee. This catches
+	// shapes BAML produces for `optional(...)` (e.g. *[]serde.DynamicClass),
+	// where the pointer wraps a typed slice/map whose elements need unwrapping.
+	if rv.Kind() == reflect.Ptr {
+		return UnwrapDynamicValue(rv.Elem().Interface())
+	}
+
 	return value
+}
+
+// stringifyMapKey converts a reflected map key to its string form. Dynamic
+// outputs are string-keyed in practice; the %v fallback covers typed string
+// aliases and any non-string comparable keys without panicking.
+func stringifyMapKey(k reflect.Value) string {
+	if k.Kind() == reflect.String {
+		return k.String()
+	}
+	return fmt.Sprintf("%v", k.Interface())
 }

--- a/adapters/adapter_v0_204_0/utils/dynamic.go
+++ b/adapters/adapter_v0_204_0/utils/dynamic.go
@@ -44,6 +44,9 @@ func UnwrapDynamicValue(value any) any {
 	}
 
 	if anyMap, ok := value.(map[string]any); ok {
+		if anyMap == nil {
+			return value
+		}
 		result := make(map[string]any, len(anyMap))
 		for k, v := range anyMap {
 			result[k] = UnwrapDynamicValue(v)
@@ -52,6 +55,9 @@ func UnwrapDynamicValue(value any) any {
 	}
 
 	if anySlice, ok := value.([]any); ok {
+		if anySlice == nil {
+			return value
+		}
 		result := make([]any, len(anySlice))
 		for i, v := range anySlice {
 			result[i] = UnwrapDynamicValue(v)
@@ -61,6 +67,9 @@ func UnwrapDynamicValue(value any) any {
 
 	// Handle other slice types via reflection (BAML may return typed slices)
 	if rv.Kind() == reflect.Slice {
+		if rv.IsNil() {
+			return value
+		}
 		result := make([]any, rv.Len())
 		for i := 0; i < rv.Len(); i++ {
 			result[i] = UnwrapDynamicValue(rv.Index(i).Interface())
@@ -73,6 +82,9 @@ func UnwrapDynamicValue(value any) any {
 	// JSON-marshal the value type's exported fields, leaking the internal
 	// {Name, Fields} / {Name, Value} wrappers.
 	if rv.Kind() == reflect.Map {
+		if rv.IsNil() {
+			return value
+		}
 		result := make(map[string]any, rv.Len())
 		iter := rv.MapRange()
 		for iter.Next() {

--- a/adapters/adapter_v0_204_0/utils/dynamic_test.go
+++ b/adapters/adapter_v0_204_0/utils/dynamic_test.go
@@ -99,6 +99,106 @@ func TestUnwrapDynamicValue_MapStringRefEnum(t *testing.T) {
 	}
 }
 
+func TestUnwrapDynamicValue_OptionalMapStringRefClass(t *testing.T) {
+	inner := map[string]serde.DynamicClass{
+		"i1": {
+			Name: "Issue",
+			Fields: map[string]any{
+				"description": "from optional map",
+				"type": serde.DynamicEnum{
+					Name:  "IssueType",
+					Value: "Payment_Required",
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(&inner)
+
+	want := map[string]any{
+		"i1": map[string]any{
+			"description": "from optional map",
+			"type":        "Payment_Required",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("optional(map<string, ref Class>) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_ListMapStringRefEnum(t *testing.T) {
+	in := []map[string]serde.DynamicEnum{
+		{
+			"a": {Name: "Status", Value: "ACTIVE"},
+			"b": {Name: "Status", Value: "PENDING"},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := []any{
+		map[string]any{"a": "ACTIVE", "b": "PENDING"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("list(map<string, ref Enum>) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_MapStringListRefClass(t *testing.T) {
+	in := map[string][]serde.DynamicClass{
+		"open": {
+			{
+				Name: "Issue",
+				Fields: map[string]any{
+					"description": "nested list",
+					"type": serde.DynamicEnum{
+						Name:  "IssueType",
+						Value: "Payment_Required",
+					},
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{
+		"open": []any{
+			map[string]any{
+				"description": "nested list",
+				"type":        "Payment_Required",
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("map<string, list(ref Class)> unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_DynamicUnionMapStringRefEnum(t *testing.T) {
+	in := serde.DynamicUnion{
+		Value: map[string]serde.DynamicEnum{
+			"a": {Name: "Status", Value: "ACTIVE"},
+			"b": {Name: "Status", Value: "PENDING"},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{"a": "ACTIVE", "b": "PENDING"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("union(map<string, ref Enum>) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_NonStringMapKeyFallback(t *testing.T) {
+	in := map[int]serde.DynamicEnum{
+		7: {Name: "Status", Value: "ACTIVE"},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{"7": "ACTIVE"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("non-string map key fallback mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
 // TestUnwrapDynamicValue_NilPointer ensures the pre-existing nil-pointer
 // short-circuit still wins over the new pointer-deref branch.
 func TestUnwrapDynamicValue_NilPointer(t *testing.T) {

--- a/adapters/adapter_v0_204_0/utils/dynamic_test.go
+++ b/adapters/adapter_v0_204_0/utils/dynamic_test.go
@@ -107,3 +107,32 @@ func TestUnwrapDynamicValue_NilPointer(t *testing.T) {
 		t.Fatalf("nil *[]DynamicClass should unwrap to nil, got %#v", got)
 	}
 }
+
+func TestUnwrapDynamicValue_PointerToTypedNilSlicePreservesNil(t *testing.T) {
+	var inner []serde.DynamicClass
+	got := UnwrapDynamicValue(&inner)
+	if !isNilLike(got) {
+		t.Fatalf("pointer to typed nil slice should preserve nil semantics, got %#v", got)
+	}
+}
+
+func TestUnwrapDynamicValue_TypedNilMapPreservesNil(t *testing.T) {
+	var in map[string]serde.DynamicClass
+	got := UnwrapDynamicValue(in)
+	if !isNilLike(got) {
+		t.Fatalf("typed nil map should preserve nil semantics, got %#v", got)
+	}
+}
+
+func isNilLike(value any) bool {
+	if value == nil {
+		return true
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}

--- a/adapters/adapter_v0_204_0/utils/dynamic_test.go
+++ b/adapters/adapter_v0_204_0/utils/dynamic_test.go
@@ -1,0 +1,109 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/serde"
+)
+
+// TestUnwrapDynamicValue_OptionalListRefClass covers the shape BAML returns
+// for `optional(list(ref Class))`: a non-nil *[]serde.DynamicClass pointing at
+// a typed slice of dynamic classes (with a nested DynamicEnum field). Without
+// the pointer-deref + typed-slice handling, the pointer falls through and
+// JSON-marshals the wrappers, leaking {Name, Fields} / {Name, Value}.
+func TestUnwrapDynamicValue_OptionalListRefClass(t *testing.T) {
+	inner := []serde.DynamicClass{
+		{
+			Name: "BlockingIssueDetails",
+			Fields: map[string]any{
+				"description": "payment required",
+				"type": serde.DynamicEnum{
+					Name:  "BlockingIssueType",
+					Value: "Payment_Required",
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(&inner)
+
+	want := []any{
+		map[string]any{
+			"description": "payment required",
+			"type":        "Payment_Required",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("optional(list(ref Class)) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_OptionalListRefEnum covers `optional(list(ref Enum))`:
+// a non-nil *[]serde.DynamicEnum. Each element must unwrap to its plain string
+// value, not leak the {Name, Value} wrapper.
+func TestUnwrapDynamicValue_OptionalListRefEnum(t *testing.T) {
+	inner := []serde.DynamicEnum{
+		{Name: "Status", Value: "ACTIVE"},
+		{Name: "Status", Value: "PENDING"},
+	}
+	got := UnwrapDynamicValue(&inner)
+
+	want := []any{"ACTIVE", "PENDING"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("optional(list(ref Enum)) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_MapStringRefClass covers `map<string, ref Class>`:
+// a typed map whose values are serde.DynamicClass. The reflective Map handler
+// must recurse into each value and unwrap to plain map[string]any.
+func TestUnwrapDynamicValue_MapStringRefClass(t *testing.T) {
+	in := map[string]serde.DynamicClass{
+		"i1": {
+			Name: "Issue",
+			Fields: map[string]any{
+				"description": "first",
+				"type": serde.DynamicEnum{
+					Name:  "IssueType",
+					Value: "Payment_Required",
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{
+		"i1": map[string]any{
+			"description": "first",
+			"type":        "Payment_Required",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("map<string, ref Class> unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_MapStringRefEnum covers `map<string, ref Enum>`:
+// a typed map whose values are serde.DynamicEnum. Each value must unwrap to a
+// plain string.
+func TestUnwrapDynamicValue_MapStringRefEnum(t *testing.T) {
+	in := map[string]serde.DynamicEnum{
+		"a": {Name: "Status", Value: "ACTIVE"},
+		"b": {Name: "Status", Value: "PENDING"},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{"a": "ACTIVE", "b": "PENDING"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("map<string, ref Enum> unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_NilPointer ensures the pre-existing nil-pointer
+// short-circuit still wins over the new pointer-deref branch.
+func TestUnwrapDynamicValue_NilPointer(t *testing.T) {
+	var p *[]serde.DynamicClass
+	if got := UnwrapDynamicValue(p); got != nil {
+		t.Fatalf("nil *[]DynamicClass should unwrap to nil, got %#v", got)
+	}
+}

--- a/adapters/adapter_v0_215_0/utils/dynamic.go
+++ b/adapters/adapter_v0_215_0/utils/dynamic.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/boundaryml/baml/engine/language_client_go/baml_go/serde"
@@ -67,5 +68,36 @@ func UnwrapDynamicValue(value any) any {
 		return result
 	}
 
+	// Handle typed maps via reflection (e.g. map[string]serde.DynamicClass for
+	// `map<string, ref Class>`). Without this, typed maps fall through and
+	// JSON-marshal the value type's exported fields, leaking the internal
+	// {Name, Fields} / {Name, Value} wrappers.
+	if rv.Kind() == reflect.Map {
+		result := make(map[string]any, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			key := stringifyMapKey(iter.Key())
+			result[key] = UnwrapDynamicValue(iter.Value().Interface())
+		}
+		return result
+	}
+
+	// Dereference a non-nil pointer to recurse on the pointee. This catches
+	// shapes BAML produces for `optional(...)` (e.g. *[]serde.DynamicClass),
+	// where the pointer wraps a typed slice/map whose elements need unwrapping.
+	if rv.Kind() == reflect.Ptr {
+		return UnwrapDynamicValue(rv.Elem().Interface())
+	}
+
 	return value
+}
+
+// stringifyMapKey converts a reflected map key to its string form. Dynamic
+// outputs are string-keyed in practice; the %v fallback covers typed string
+// aliases and any non-string comparable keys without panicking.
+func stringifyMapKey(k reflect.Value) string {
+	if k.Kind() == reflect.String {
+		return k.String()
+	}
+	return fmt.Sprintf("%v", k.Interface())
 }

--- a/adapters/adapter_v0_215_0/utils/dynamic.go
+++ b/adapters/adapter_v0_215_0/utils/dynamic.go
@@ -44,6 +44,9 @@ func UnwrapDynamicValue(value any) any {
 	}
 
 	if anyMap, ok := value.(map[string]any); ok {
+		if anyMap == nil {
+			return value
+		}
 		result := make(map[string]any, len(anyMap))
 		for k, v := range anyMap {
 			result[k] = UnwrapDynamicValue(v)
@@ -52,6 +55,9 @@ func UnwrapDynamicValue(value any) any {
 	}
 
 	if anySlice, ok := value.([]any); ok {
+		if anySlice == nil {
+			return value
+		}
 		result := make([]any, len(anySlice))
 		for i, v := range anySlice {
 			result[i] = UnwrapDynamicValue(v)
@@ -61,6 +67,9 @@ func UnwrapDynamicValue(value any) any {
 
 	// Handle other slice types via reflection (BAML may return typed slices)
 	if rv.Kind() == reflect.Slice {
+		if rv.IsNil() {
+			return value
+		}
 		result := make([]any, rv.Len())
 		for i := 0; i < rv.Len(); i++ {
 			result[i] = UnwrapDynamicValue(rv.Index(i).Interface())
@@ -73,6 +82,9 @@ func UnwrapDynamicValue(value any) any {
 	// JSON-marshal the value type's exported fields, leaking the internal
 	// {Name, Fields} / {Name, Value} wrappers.
 	if rv.Kind() == reflect.Map {
+		if rv.IsNil() {
+			return value
+		}
 		result := make(map[string]any, rv.Len())
 		iter := rv.MapRange()
 		for iter.Next() {

--- a/adapters/adapter_v0_215_0/utils/dynamic_test.go
+++ b/adapters/adapter_v0_215_0/utils/dynamic_test.go
@@ -99,6 +99,106 @@ func TestUnwrapDynamicValue_MapStringRefEnum(t *testing.T) {
 	}
 }
 
+func TestUnwrapDynamicValue_OptionalMapStringRefClass(t *testing.T) {
+	inner := map[string]serde.DynamicClass{
+		"i1": {
+			Name: "Issue",
+			Fields: map[string]any{
+				"description": "from optional map",
+				"type": serde.DynamicEnum{
+					Name:  "IssueType",
+					Value: "Payment_Required",
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(&inner)
+
+	want := map[string]any{
+		"i1": map[string]any{
+			"description": "from optional map",
+			"type":        "Payment_Required",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("optional(map<string, ref Class>) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_ListMapStringRefEnum(t *testing.T) {
+	in := []map[string]serde.DynamicEnum{
+		{
+			"a": {Name: "Status", Value: "ACTIVE"},
+			"b": {Name: "Status", Value: "PENDING"},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := []any{
+		map[string]any{"a": "ACTIVE", "b": "PENDING"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("list(map<string, ref Enum>) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_MapStringListRefClass(t *testing.T) {
+	in := map[string][]serde.DynamicClass{
+		"open": {
+			{
+				Name: "Issue",
+				Fields: map[string]any{
+					"description": "nested list",
+					"type": serde.DynamicEnum{
+						Name:  "IssueType",
+						Value: "Payment_Required",
+					},
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{
+		"open": []any{
+			map[string]any{
+				"description": "nested list",
+				"type":        "Payment_Required",
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("map<string, list(ref Class)> unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_DynamicUnionMapStringRefEnum(t *testing.T) {
+	in := serde.DynamicUnion{
+		Value: map[string]serde.DynamicEnum{
+			"a": {Name: "Status", Value: "ACTIVE"},
+			"b": {Name: "Status", Value: "PENDING"},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{"a": "ACTIVE", "b": "PENDING"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("union(map<string, ref Enum>) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_NonStringMapKeyFallback(t *testing.T) {
+	in := map[int]serde.DynamicEnum{
+		7: {Name: "Status", Value: "ACTIVE"},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{"7": "ACTIVE"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("non-string map key fallback mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
 // TestUnwrapDynamicValue_NilPointer ensures the pre-existing nil-pointer
 // short-circuit still wins over the new pointer-deref branch.
 func TestUnwrapDynamicValue_NilPointer(t *testing.T) {

--- a/adapters/adapter_v0_215_0/utils/dynamic_test.go
+++ b/adapters/adapter_v0_215_0/utils/dynamic_test.go
@@ -107,3 +107,32 @@ func TestUnwrapDynamicValue_NilPointer(t *testing.T) {
 		t.Fatalf("nil *[]DynamicClass should unwrap to nil, got %#v", got)
 	}
 }
+
+func TestUnwrapDynamicValue_PointerToTypedNilSlicePreservesNil(t *testing.T) {
+	var inner []serde.DynamicClass
+	got := UnwrapDynamicValue(&inner)
+	if !isNilLike(got) {
+		t.Fatalf("pointer to typed nil slice should preserve nil semantics, got %#v", got)
+	}
+}
+
+func TestUnwrapDynamicValue_TypedNilMapPreservesNil(t *testing.T) {
+	var in map[string]serde.DynamicClass
+	got := UnwrapDynamicValue(in)
+	if !isNilLike(got) {
+		t.Fatalf("typed nil map should preserve nil semantics, got %#v", got)
+	}
+}
+
+func isNilLike(value any) bool {
+	if value == nil {
+		return true
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}

--- a/adapters/adapter_v0_215_0/utils/dynamic_test.go
+++ b/adapters/adapter_v0_215_0/utils/dynamic_test.go
@@ -1,0 +1,109 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/serde"
+)
+
+// TestUnwrapDynamicValue_OptionalListRefClass covers the shape BAML returns
+// for `optional(list(ref Class))`: a non-nil *[]serde.DynamicClass pointing at
+// a typed slice of dynamic classes (with a nested DynamicEnum field). Without
+// the pointer-deref + typed-slice handling, the pointer falls through and
+// JSON-marshals the wrappers, leaking {Name, Fields} / {Name, Value}.
+func TestUnwrapDynamicValue_OptionalListRefClass(t *testing.T) {
+	inner := []serde.DynamicClass{
+		{
+			Name: "BlockingIssueDetails",
+			Fields: map[string]any{
+				"description": "payment required",
+				"type": serde.DynamicEnum{
+					Name:  "BlockingIssueType",
+					Value: "Payment_Required",
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(&inner)
+
+	want := []any{
+		map[string]any{
+			"description": "payment required",
+			"type":        "Payment_Required",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("optional(list(ref Class)) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_OptionalListRefEnum covers `optional(list(ref Enum))`:
+// a non-nil *[]serde.DynamicEnum. Each element must unwrap to its plain string
+// value, not leak the {Name, Value} wrapper.
+func TestUnwrapDynamicValue_OptionalListRefEnum(t *testing.T) {
+	inner := []serde.DynamicEnum{
+		{Name: "Status", Value: "ACTIVE"},
+		{Name: "Status", Value: "PENDING"},
+	}
+	got := UnwrapDynamicValue(&inner)
+
+	want := []any{"ACTIVE", "PENDING"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("optional(list(ref Enum)) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_MapStringRefClass covers `map<string, ref Class>`:
+// a typed map whose values are serde.DynamicClass. The reflective Map handler
+// must recurse into each value and unwrap to plain map[string]any.
+func TestUnwrapDynamicValue_MapStringRefClass(t *testing.T) {
+	in := map[string]serde.DynamicClass{
+		"i1": {
+			Name: "Issue",
+			Fields: map[string]any{
+				"description": "first",
+				"type": serde.DynamicEnum{
+					Name:  "IssueType",
+					Value: "Payment_Required",
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{
+		"i1": map[string]any{
+			"description": "first",
+			"type":        "Payment_Required",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("map<string, ref Class> unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_MapStringRefEnum covers `map<string, ref Enum>`:
+// a typed map whose values are serde.DynamicEnum. Each value must unwrap to a
+// plain string.
+func TestUnwrapDynamicValue_MapStringRefEnum(t *testing.T) {
+	in := map[string]serde.DynamicEnum{
+		"a": {Name: "Status", Value: "ACTIVE"},
+		"b": {Name: "Status", Value: "PENDING"},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{"a": "ACTIVE", "b": "PENDING"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("map<string, ref Enum> unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_NilPointer ensures the pre-existing nil-pointer
+// short-circuit still wins over the new pointer-deref branch.
+func TestUnwrapDynamicValue_NilPointer(t *testing.T) {
+	var p *[]serde.DynamicClass
+	if got := UnwrapDynamicValue(p); got != nil {
+		t.Fatalf("nil *[]DynamicClass should unwrap to nil, got %#v", got)
+	}
+}

--- a/adapters/adapter_v0_219_0/utils/dynamic.go
+++ b/adapters/adapter_v0_219_0/utils/dynamic.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/boundaryml/baml/engine/language_client_go/baml_go/serde"
@@ -76,5 +77,39 @@ func UnwrapDynamicValue(value any) any {
 		return result
 	}
 
+	// Handle typed maps via reflection (e.g. map[string]serde.DynamicClass for
+	// `map<string, ref Class>`). Without this, typed maps fall through and
+	// JSON-marshal the value type's exported fields, leaking the internal
+	// {Name, Fields} / {Name, Value} wrappers.
+	if rv.Kind() == reflect.Map {
+		if rv.IsNil() {
+			return value
+		}
+		result := make(map[string]any, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			key := stringifyMapKey(iter.Key())
+			result[key] = UnwrapDynamicValue(iter.Value().Interface())
+		}
+		return result
+	}
+
+	// Dereference a non-nil pointer to recurse on the pointee. This catches
+	// shapes BAML produces for `optional(...)` (e.g. *[]serde.DynamicClass),
+	// where the pointer wraps a typed slice/map whose elements need unwrapping.
+	if rv.Kind() == reflect.Ptr {
+		return UnwrapDynamicValue(rv.Elem().Interface())
+	}
+
 	return value
+}
+
+// stringifyMapKey converts a reflected map key to its string form. Dynamic
+// outputs are string-keyed in practice; the %v fallback covers typed string
+// aliases and any non-string comparable keys without panicking.
+func stringifyMapKey(k reflect.Value) string {
+	if k.Kind() == reflect.String {
+		return k.String()
+	}
+	return fmt.Sprintf("%v", k.Interface())
 }

--- a/adapters/adapter_v0_219_0/utils/dynamic_test.go
+++ b/adapters/adapter_v0_219_0/utils/dynamic_test.go
@@ -99,6 +99,106 @@ func TestUnwrapDynamicValue_MapStringRefEnum(t *testing.T) {
 	}
 }
 
+func TestUnwrapDynamicValue_OptionalMapStringRefClass(t *testing.T) {
+	inner := map[string]serde.DynamicClass{
+		"i1": {
+			Name: "Issue",
+			Fields: map[string]any{
+				"description": "from optional map",
+				"type": serde.DynamicEnum{
+					Name:  "IssueType",
+					Value: "Payment_Required",
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(&inner)
+
+	want := map[string]any{
+		"i1": map[string]any{
+			"description": "from optional map",
+			"type":        "Payment_Required",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("optional(map<string, ref Class>) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_ListMapStringRefEnum(t *testing.T) {
+	in := []map[string]serde.DynamicEnum{
+		{
+			"a": {Name: "Status", Value: "ACTIVE"},
+			"b": {Name: "Status", Value: "PENDING"},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := []any{
+		map[string]any{"a": "ACTIVE", "b": "PENDING"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("list(map<string, ref Enum>) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_MapStringListRefClass(t *testing.T) {
+	in := map[string][]serde.DynamicClass{
+		"open": {
+			{
+				Name: "Issue",
+				Fields: map[string]any{
+					"description": "nested list",
+					"type": serde.DynamicEnum{
+						Name:  "IssueType",
+						Value: "Payment_Required",
+					},
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{
+		"open": []any{
+			map[string]any{
+				"description": "nested list",
+				"type":        "Payment_Required",
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("map<string, list(ref Class)> unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_DynamicUnionMapStringRefEnum(t *testing.T) {
+	in := serde.DynamicUnion{
+		Value: map[string]serde.DynamicEnum{
+			"a": {Name: "Status", Value: "ACTIVE"},
+			"b": {Name: "Status", Value: "PENDING"},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{"a": "ACTIVE", "b": "PENDING"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("union(map<string, ref Enum>) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestUnwrapDynamicValue_NonStringMapKeyFallback(t *testing.T) {
+	in := map[int]serde.DynamicEnum{
+		7: {Name: "Status", Value: "ACTIVE"},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{"7": "ACTIVE"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("non-string map key fallback mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
 // TestUnwrapDynamicValue_NilPointer ensures the pre-existing nil-pointer
 // short-circuit still wins over the new pointer-deref branch.
 func TestUnwrapDynamicValue_NilPointer(t *testing.T) {

--- a/adapters/adapter_v0_219_0/utils/dynamic_test.go
+++ b/adapters/adapter_v0_219_0/utils/dynamic_test.go
@@ -107,3 +107,32 @@ func TestUnwrapDynamicValue_NilPointer(t *testing.T) {
 		t.Fatalf("nil *[]DynamicClass should unwrap to nil, got %#v", got)
 	}
 }
+
+func TestUnwrapDynamicValue_PointerToTypedNilSlicePreservesNil(t *testing.T) {
+	var inner []serde.DynamicClass
+	got := UnwrapDynamicValue(&inner)
+	if !isNilLike(got) {
+		t.Fatalf("pointer to typed nil slice should preserve nil semantics, got %#v", got)
+	}
+}
+
+func TestUnwrapDynamicValue_TypedNilMapPreservesNil(t *testing.T) {
+	var in map[string]serde.DynamicClass
+	got := UnwrapDynamicValue(in)
+	if !isNilLike(got) {
+		t.Fatalf("typed nil map should preserve nil semantics, got %#v", got)
+	}
+}
+
+func isNilLike(value any) bool {
+	if value == nil {
+		return true
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}

--- a/adapters/adapter_v0_219_0/utils/dynamic_test.go
+++ b/adapters/adapter_v0_219_0/utils/dynamic_test.go
@@ -1,0 +1,109 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/serde"
+)
+
+// TestUnwrapDynamicValue_OptionalListRefClass covers the shape BAML returns
+// for `optional(list(ref Class))`: a non-nil *[]serde.DynamicClass pointing at
+// a typed slice of dynamic classes (with a nested DynamicEnum field). Without
+// the pointer-deref + typed-slice handling, the pointer falls through and
+// JSON-marshals the wrappers, leaking {Name, Fields} / {Name, Value}.
+func TestUnwrapDynamicValue_OptionalListRefClass(t *testing.T) {
+	inner := []serde.DynamicClass{
+		{
+			Name: "BlockingIssueDetails",
+			Fields: map[string]any{
+				"description": "payment required",
+				"type": serde.DynamicEnum{
+					Name:  "BlockingIssueType",
+					Value: "Payment_Required",
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(&inner)
+
+	want := []any{
+		map[string]any{
+			"description": "payment required",
+			"type":        "Payment_Required",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("optional(list(ref Class)) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_OptionalListRefEnum covers `optional(list(ref Enum))`:
+// a non-nil *[]serde.DynamicEnum. Each element must unwrap to its plain string
+// value, not leak the {Name, Value} wrapper.
+func TestUnwrapDynamicValue_OptionalListRefEnum(t *testing.T) {
+	inner := []serde.DynamicEnum{
+		{Name: "Status", Value: "ACTIVE"},
+		{Name: "Status", Value: "PENDING"},
+	}
+	got := UnwrapDynamicValue(&inner)
+
+	want := []any{"ACTIVE", "PENDING"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("optional(list(ref Enum)) unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_MapStringRefClass covers `map<string, ref Class>`:
+// a typed map whose values are serde.DynamicClass. The reflective Map handler
+// must recurse into each value and unwrap to plain map[string]any.
+func TestUnwrapDynamicValue_MapStringRefClass(t *testing.T) {
+	in := map[string]serde.DynamicClass{
+		"i1": {
+			Name: "Issue",
+			Fields: map[string]any{
+				"description": "first",
+				"type": serde.DynamicEnum{
+					Name:  "IssueType",
+					Value: "Payment_Required",
+				},
+			},
+		},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{
+		"i1": map[string]any{
+			"description": "first",
+			"type":        "Payment_Required",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("map<string, ref Class> unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_MapStringRefEnum covers `map<string, ref Enum>`:
+// a typed map whose values are serde.DynamicEnum. Each value must unwrap to a
+// plain string.
+func TestUnwrapDynamicValue_MapStringRefEnum(t *testing.T) {
+	in := map[string]serde.DynamicEnum{
+		"a": {Name: "Status", Value: "ACTIVE"},
+		"b": {Name: "Status", Value: "PENDING"},
+	}
+	got := UnwrapDynamicValue(in)
+
+	want := map[string]any{"a": "ACTIVE", "b": "PENDING"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("map<string, ref Enum> unwrap mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestUnwrapDynamicValue_NilPointer ensures the pre-existing nil-pointer
+// short-circuit still wins over the new pointer-deref branch.
+func TestUnwrapDynamicValue_NilPointer(t *testing.T) {
+	var p *[]serde.DynamicClass
+	if got := UnwrapDynamicValue(p); got != nil {
+		t.Fatalf("nil *[]DynamicClass should unwrap to nil, got %#v", got)
+	}
+}

--- a/integration/dynamic_endpoint_test.go
+++ b/integration/dynamic_endpoint_test.go
@@ -694,6 +694,71 @@ func TestDynamicEndpoint(t *testing.T) {
 		}
 	})
 
+	t.Run("call_repro_map_string_ref_enum_unwrapped", func(t *testing.T) {
+		if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+			t.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		opts := setupNonStreamingScenario(t, "test-dynamic-call-map-string-ref-enum", `{"status_by_id": {"a": "ACTIVE", "b": "PENDING"}}`)
+
+		resp, err := BAMLClient.DynamicCall(ctx, testutil.DynamicRequest{
+			Messages: []testutil.DynamicMessage{
+				{Role: "user", Content: "Return statuses by id."},
+			},
+			ClientRegistry: opts.ClientRegistry,
+			OutputSchema: &testutil.DynamicOutputSchema{
+				Enums: map[string]*testutil.DynamicEnum{
+					"DynCallMapEnumStatus": {
+						Values: []*testutil.DynamicEnumValue{
+							{Name: "ACTIVE"},
+							{Name: "PENDING"},
+							{Name: "INACTIVE"},
+						},
+					},
+				},
+				Properties: map[string]*testutil.DynamicProperty{
+					"status_by_id": {
+						Type:   "map",
+						Keys:   &testutil.DynamicTypeSpec{Type: "string"},
+						Values: &testutil.DynamicTypeSpec{Ref: "DynCallMapEnumStatus"},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("DynamicCall failed: %v", err)
+		}
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(resp.Body, &result); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+
+		byID, ok := result["status_by_id"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected status_by_id to be an object, got %T: %v", result["status_by_id"], result["status_by_id"])
+		}
+
+		want := map[string]string{"a": "ACTIVE", "b": "PENDING"}
+		for k, w := range want {
+			got := byID[k]
+			if leaked, isMap := got.(map[string]any); isMap {
+				t.Errorf("/call/_dynamic map<string, ref Enum>[%q] leaked DynamicEnum {Name, Value} wrapper, got: %v", k, leaked)
+				continue
+			}
+			if got != w {
+				t.Errorf("Expected status_by_id[%q] = %q (string), got %v (type: %T)", k, w, got, got)
+			}
+		}
+	})
+
 	// Parse validation tests
 	t.Run("validation_missing_raw", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/integration/dynamic_endpoint_test.go
+++ b/integration/dynamic_endpoint_test.go
@@ -419,6 +419,281 @@ func TestDynamicEndpoint(t *testing.T) {
 		}
 	})
 
+	// Repro for reported leak: dynamic refs inside certain container shapes
+	// (optional(list(...)) and map<string, ...>) leak BAML's internal
+	// {Name, Fields} (DynamicClass) and {Name, Value} (DynamicEnum) wrappers
+	// instead of being unwrapped like the existing list(ref Class) case is.
+	//
+	// These four subtests exercise the four leaking shapes called out in the
+	// report. They assert the EXPECTED unwrapped JSON; on master they should
+	// fail with output that demonstrates the wrapper leak.
+	t.Run("repro_optional_list_ref_class_unwrapped", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		resp, err := BAMLClient.DynamicParse(ctx, testutil.DynamicParseRequest{
+			Raw: `{"blocking_issues": [{"type": "Payment_Required", "description": "payment required before production"}]}`,
+			OutputSchema: &testutil.DynamicOutputSchema{
+				Enums: map[string]*testutil.DynamicEnum{
+					"DynBlockingIssueType": {
+						Values: []*testutil.DynamicEnumValue{
+							{Name: "Payment_Required"},
+							{Name: "Other"},
+						},
+					},
+				},
+				Classes: map[string]*testutil.DynamicClass{
+					"DynBlockingIssueDetails": {
+						Properties: map[string]*testutil.DynamicProperty{
+							"type":        {Ref: "DynBlockingIssueType"},
+							"description": {Type: "string"},
+						},
+					},
+				},
+				Properties: map[string]*testutil.DynamicProperty{
+					"blocking_issues": {
+						Type: "optional",
+						Inner: &testutil.DynamicTypeSpec{
+							Type:  "list",
+							Items: &testutil.DynamicTypeSpec{Ref: "DynBlockingIssueDetails"},
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("DynamicParse failed: %v", err)
+		}
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		t.Logf("Response data: %s", string(resp.Data))
+
+		var result map[string]any
+		if err := json.Unmarshal(resp.Data, &result); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+
+		issues, ok := result["blocking_issues"].([]any)
+		if !ok {
+			t.Fatalf("Expected blocking_issues to be an array, got %T: %v", result["blocking_issues"], result["blocking_issues"])
+		}
+		if len(issues) != 1 {
+			t.Fatalf("Expected 1 blocking issue, got %d", len(issues))
+		}
+
+		issue, ok := issues[0].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected blocking_issues[0] to be an object, got %T", issues[0])
+		}
+
+		// The class wrapper must not leak.
+		if issue["Name"] != nil || issue["Fields"] != nil {
+			t.Errorf("optional(list(ref Class)) leaked DynamicClass {Name, Fields} wrapper, got: %v", issue)
+		}
+
+		if issue["description"] != "payment required before production" {
+			t.Errorf("Expected blocking_issues[0].description 'payment required before production', got %v", issue["description"])
+		}
+
+		// The nested enum wrapper must not leak either; expect plain string.
+		if issue["type"] != "Payment_Required" {
+			t.Errorf("Expected blocking_issues[0].type 'Payment_Required' (string), got %v (type: %T)", issue["type"], issue["type"])
+		}
+	})
+
+	t.Run("repro_optional_list_ref_enum_unwrapped", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		resp, err := BAMLClient.DynamicParse(ctx, testutil.DynamicParseRequest{
+			Raw: `{"statuses": ["ACTIVE", "PENDING"]}`,
+			OutputSchema: &testutil.DynamicOutputSchema{
+				Enums: map[string]*testutil.DynamicEnum{
+					"DynLeakStatus": {
+						Values: []*testutil.DynamicEnumValue{
+							{Name: "ACTIVE"},
+							{Name: "PENDING"},
+							{Name: "INACTIVE"},
+						},
+					},
+				},
+				Properties: map[string]*testutil.DynamicProperty{
+					"statuses": {
+						Type: "optional",
+						Inner: &testutil.DynamicTypeSpec{
+							Type:  "list",
+							Items: &testutil.DynamicTypeSpec{Ref: "DynLeakStatus"},
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("DynamicParse failed: %v", err)
+		}
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		t.Logf("Response data: %s", string(resp.Data))
+
+		var result map[string]any
+		if err := json.Unmarshal(resp.Data, &result); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+
+		statuses, ok := result["statuses"].([]any)
+		if !ok {
+			t.Fatalf("Expected statuses to be an array, got %T: %v", result["statuses"], result["statuses"])
+		}
+		if len(statuses) != 2 {
+			t.Fatalf("Expected 2 statuses, got %d", len(statuses))
+		}
+
+		want := []string{"ACTIVE", "PENDING"}
+		for i, w := range want {
+			if leaked, isMap := statuses[i].(map[string]any); isMap {
+				t.Errorf("optional(list(ref Enum))[%d] leaked DynamicEnum {Name, Value} wrapper, got: %v", i, leaked)
+				continue
+			}
+			if statuses[i] != w {
+				t.Errorf("Expected statuses[%d] = %q (string), got %v (type: %T)", i, w, statuses[i], statuses[i])
+			}
+		}
+	})
+
+	t.Run("repro_map_string_ref_class_unwrapped", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		resp, err := BAMLClient.DynamicParse(ctx, testutil.DynamicParseRequest{
+			Raw: `{"issues_by_id": {"i1": {"type": "Payment_Required", "description": "first issue"}}}`,
+			OutputSchema: &testutil.DynamicOutputSchema{
+				Enums: map[string]*testutil.DynamicEnum{
+					"DynMapIssueType": {
+						Values: []*testutil.DynamicEnumValue{
+							{Name: "Payment_Required"},
+							{Name: "Other"},
+						},
+					},
+				},
+				Classes: map[string]*testutil.DynamicClass{
+					"DynMapIssue": {
+						Properties: map[string]*testutil.DynamicProperty{
+							"type":        {Ref: "DynMapIssueType"},
+							"description": {Type: "string"},
+						},
+					},
+				},
+				Properties: map[string]*testutil.DynamicProperty{
+					"issues_by_id": {
+						Type:   "map",
+						Keys:   &testutil.DynamicTypeSpec{Type: "string"},
+						Values: &testutil.DynamicTypeSpec{Ref: "DynMapIssue"},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("DynamicParse failed: %v", err)
+		}
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		t.Logf("Response data: %s", string(resp.Data))
+
+		var result map[string]any
+		if err := json.Unmarshal(resp.Data, &result); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+
+		byID, ok := result["issues_by_id"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected issues_by_id to be an object, got %T: %v", result["issues_by_id"], result["issues_by_id"])
+		}
+
+		issue, ok := byID["i1"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected issues_by_id[i1] to be an object, got %T: %v", byID["i1"], byID["i1"])
+		}
+
+		if issue["Name"] != nil || issue["Fields"] != nil {
+			t.Errorf("map<string, ref Class> leaked DynamicClass {Name, Fields} wrapper, got: %v", issue)
+		}
+
+		if issue["description"] != "first issue" {
+			t.Errorf("Expected issues_by_id[i1].description 'first issue', got %v", issue["description"])
+		}
+
+		if issue["type"] != "Payment_Required" {
+			t.Errorf("Expected issues_by_id[i1].type 'Payment_Required' (string), got %v (type: %T)", issue["type"], issue["type"])
+		}
+	})
+
+	t.Run("repro_map_string_ref_enum_unwrapped", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		resp, err := BAMLClient.DynamicParse(ctx, testutil.DynamicParseRequest{
+			Raw: `{"status_by_id": {"a": "ACTIVE", "b": "PENDING"}}`,
+			OutputSchema: &testutil.DynamicOutputSchema{
+				Enums: map[string]*testutil.DynamicEnum{
+					"DynMapEnumStatus": {
+						Values: []*testutil.DynamicEnumValue{
+							{Name: "ACTIVE"},
+							{Name: "PENDING"},
+							{Name: "INACTIVE"},
+						},
+					},
+				},
+				Properties: map[string]*testutil.DynamicProperty{
+					"status_by_id": {
+						Type:   "map",
+						Keys:   &testutil.DynamicTypeSpec{Type: "string"},
+						Values: &testutil.DynamicTypeSpec{Ref: "DynMapEnumStatus"},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("DynamicParse failed: %v", err)
+		}
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, resp.Error)
+		}
+
+		t.Logf("Response data: %s", string(resp.Data))
+
+		var result map[string]any
+		if err := json.Unmarshal(resp.Data, &result); err != nil {
+			t.Fatalf("Failed to unmarshal response: %v", err)
+		}
+
+		byID, ok := result["status_by_id"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected status_by_id to be an object, got %T: %v", result["status_by_id"], result["status_by_id"])
+		}
+
+		want := map[string]string{"a": "ACTIVE", "b": "PENDING"}
+		for k, w := range want {
+			got := byID[k]
+			if leaked, isMap := got.(map[string]any); isMap {
+				t.Errorf("map<string, ref Enum>[%q] leaked DynamicEnum {Name, Value} wrapper, got: %v", k, leaked)
+				continue
+			}
+			if got != w {
+				t.Errorf("Expected status_by_id[%q] = %q (string), got %v (type: %T)", k, w, got, got)
+			}
+		}
+	})
+
 	// Parse validation tests
 	t.Run("validation_missing_raw", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
## Summary

- `/parse/_dynamic` (and the call/stream paths) returned BAML's internal `{Name, Fields}` (`DynamicClass`) and `{Name, Value}` (`DynamicEnum`) wrappers whenever a dynamic ref was nested inside `optional(list(...))` or `map<string, ...>`. `list(ref Class)` and `optional(ref Class)` already unwrapped correctly — the leak was specific to the typed Go shapes BAML uses for those four containers.
- Root cause is in each adapter's `utils/UnwrapDynamicValue`: it handled typed `serde.DynamicClass` / `DynamicEnum` / `DynamicUnion` (value and pointer) plus `map[string]any` / `[]any` / generic `reflect.Slice`, but had no branch for non-nil `reflect.Ptr` (e.g. `*[]serde.DynamicClass` from `optional(list(...))`) and no `reflect.Map` branch (e.g. `map[string]serde.DynamicClass`). Those fell through and `json.Marshal` then emitted the typed structs by their exported field names, leaking the wrappers.

## Leaking shapes now covered + fixed

- [x] `optional(list(ref Class))`
- [x] `optional(list(ref Enum))`
- [x] `map<string, ref Class>`
- [x] `map<string, ref Enum>`

## Commits

This branch has two commits, intentionally separated so reviewers can verify the regression at the parent:

1. `test(integration): repro dynamic ref wrapper leak in optional/map shapes` — adds four `repro_*` subtests under `TestDynamicEndpoint` that drive `/parse/_dynamic` with each leaking shape and assert the expected unwrapped JSON. **These FAIL at this commit on master, demonstrating the leak.**
2. `fix(dynamic): unwrap typed pointer/map shapes in adapter dynamic helper` — extends the recursive walker in each of `adapters/adapter_v0_204_0`, `adapter_v0_215_0`, and `adapter_v0_219_0` (each is its own go module pinning a different BAML version, so the helper cannot live in one shared file) with two new branches: `reflect.Map` (build a plain `map[string]any` recursively, stringifying keys) and a non-nil `reflect.Ptr` fall-through (dereference and recurse). Adds unit tests in each adapter exercising the typed shapes.

The pure-repro branch is also pushed at `test/dynamic-ref-wrapper-leak-repro` for reference.

## Test plan

- [x] `GOWORK=off go test -count=1 -race ./utils/...` in each of the three adapter directories — passes on the new typed `*[]DynamicClass`, `*[]DynamicEnum`, `map[string]DynamicClass`, `map[string]DynamicEnum`, and nil-pointer cases.
- [x] `go test -tags=integration -v -count=1 -p 1 -timeout 30m ./integration/` — full integration suite green (56 PASS, 21 SKIP, 0 FAIL). All four `TestDynamicEndpoint/repro_*` subtests pass; the existing `TestDynamicEndpoint` cases (including `regression_nested_dynamic_types_unwrapped`, `parse_with_list_property`, `parse_nested_class`, `parse_with_enum`) all remain green.
- [x] `go test ./bamlutils/... ./cmd/... ./pool/... ./workerplugin/... ./introspected/...` — all green.
- [x] `go vet ./... && go vet -tags=integration ./integration/...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented internal dynamic wrappers from appearing in responses; maps, lists and nested pointers now unwrap to plain JSON/Go values, preserve nil semantics, and handle typed maps/enums for consistent output.

* **Tests**
  * Added extensive unit and integration tests covering nested dynamic shapes, maps/lists, nil cases, and regression scenarios across multiple adapter versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->