### PR TITLE
chore(integration/testutil): use typed errors.Is for transient-conn detection

### DIFF
--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -9,8 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/goccy/go-json"
@@ -81,10 +83,11 @@ func isTransientConnError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return false
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "connection refused") ||
-		strings.Contains(msg, "connection reset") ||
-		strings.Contains(msg, "EOF")
+	return errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, io.EOF)
 }
 
 // errorResponse represents the JSON error response format from the server.


### PR DESCRIPTION
## Summary

Part of #199 item 7 (sentinel error coverage audit). Swaps the substring-matching transport-flake leg in `integration/testutil/client.go`'s `isTransientConnError` to typed `errors.Is` checks against `syscall.ECONNREFUSED`, `syscall.ECONNRESET`, `syscall.EPIPE`, `net.ErrClosed`, `io.EOF`. Aligns with the production-side `classifyTransportErr` discipline established in #208.

The function already used `errors.Is` for context-cancellation detection — the substring-vs-typed mismatch within the same function was the giveaway that the transport leg should match the same style. Item 3 explicitly deferred this site here ("the integration testutil targets the docker baml-rest container via stdlib `http.Client`, not `llmhttp.Client`, so [`errors.Is(err, llmhttp.ErrTransportFlake)`] doesn't apply directly — defer to issue #199 item 7's broader sentinel audit").

`io.ErrUnexpectedEOF`: **excluded.** Pre-implementation verification: production-side discipline at `bamlutils/llmhttp/errors_test.go:196-200` classifies `io.ErrUnexpectedEOF` as NOT a flake even with `staleConnTeardownAcceptable=true` (unexpected EOF is mid-stream content failure, not transport flake). The integration testutil's `isTransientConnError` fires downstream of `c.http.Do` AND `io.ReadAll(resp.Body)`, both equivalent to the body-read sites where bare-EOF acceptance is gated. `git log -p` on this file shows the substring `"EOF"` needle was introduced with the function in #185 and was never expanded specifically to catch `"unexpected EOF"` — no historical evidence of the integration suite retrying on it. Narrowing to typed `io.EOF` matches the production discipline.

This PR is the only actionable item from item 7's audit. The full audit (5 production sentinels inventoried, all paths checked against logically-equivalent failure sites) found no missing-emit gaps and no stale sentinels. The remaining symmetry observation at the resolver layer (`provider:"baml-fallback"` + missing `options.strategy`) is a flag-not-fix — routing already succeeds via the unsupported-provider gate at `IsCallProviderSupported`/`IsProviderSupported`; adding a resolver-level sentinel would expand `roundrobin.Resolve`'s scope beyond its name. Tracked in the audit doc for future hardening if the support gate ever changes.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go vet -tags integration ./integration/...` — clean
- [x] `go build -tags integration ./integration/...` — clean
- [ ] CI integration-tests workflow — confirm green (load-bearing for the EOF coverage decision)

<!-- webtty-bridge: session=s-yqyd29e14n -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test infrastructure to improve detection and handling of transient connection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->