### PR TITLE
chore(adapters): share reflection snapshot helpers via adapters/common/testhelpers

### DIFF
--- a/adapters/adapter_v0_204_0/adapter/adapter_helpers_test.go
+++ b/adapters/adapter_v0_204_0/adapter/adapter_helpers_test.go
@@ -1,10 +1,9 @@
 package adapter
 
 import (
-	"reflect"
-	"unsafe"
-
 	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+
+	"github.com/invakid404/baml-rest/adapters/common/testhelpers"
 )
 
 // upstreamClientNamesSnapshot returns a defensive copy of the names
@@ -23,72 +22,11 @@ func legacyUpstreamClientNamesSnapshot(b *BamlAdapter) []string {
 	return append([]string(nil), b.legacyUpstreamClientNames...)
 }
 
-// clientEntrySnapshot reads the (provider, options) tuple BAML stored
-// under name in the supplied ClientRegistry's internal map. BAML's
-// ClientRegistry exposes only AddLlmClient / SetPrimaryClient —
-// `clients` is unexported. This helper uses reflection +
-// unsafe.Pointer to peek at the field shape pinned in
-// language_client_go's rawobjects_client_registry.go
-// (`clients clientRegistryMap = map[string]clientProperty`, where
-// clientProperty has `provider string` and `options map[string]any`).
-//
-// Returns ok=false when the registry is nil, the key is absent, or
-// the BAML registry shape drifts. Every reflect.Value is verified
-// for kind/type before unsafe.Pointer access, so a future BAML rev
-// that renamed a field or changed `clients` to a non-string-keyed
-// map surfaces loudly as ok=false rather than panicking on
-// UnsafeAddr against an unexpected type.
+// clientEntrySnapshot delegates to the shared reflection helper. The
+// shared package operates on `any` because each adapter's
+// *baml.ClientRegistry is a distinct per-version type identity.
 func clientEntrySnapshot(reg *baml.ClientRegistry, name string) (provider string, options map[string]any, ok bool) {
-	if reg == nil {
-		return "", nil, false
-	}
-	regVal := reflect.ValueOf(reg).Elem()
-	clientsField := regVal.FieldByName("clients")
-	// Shape guards: confirm the field exists, is a map, and has
-	// string keys before any reflection trickery.
-	if !clientsField.IsValid() || clientsField.Kind() != reflect.Map {
-		return "", nil, false
-	}
-	if clientsField.Type().Key().Kind() != reflect.String {
-		return "", nil, false
-	}
-	clientsField = reflect.NewAt(clientsField.Type(), unsafe.Pointer(clientsField.UnsafeAddr())).Elem()
-	entry := clientsField.MapIndex(reflect.ValueOf(name))
-	if !entry.IsValid() {
-		return "", nil, false
-	}
-	if entry.Kind() != reflect.Struct {
-		return "", nil, false
-	}
-	// Map values are returned as unaddressable Values (the map's
-	// internal hashing means there's no stable address). Copy into an
-	// addressable temporary so unsafe.Pointer + UnsafeAddr can read
-	// the unexported provider/options fields.
-	addr := reflect.New(entry.Type()).Elem()
-	addr.Set(entry)
-	providerField := addr.FieldByName("provider")
-	optionsField := addr.FieldByName("options")
-	if !providerField.IsValid() || !optionsField.IsValid() {
-		return "", nil, false
-	}
-	if providerField.Kind() != reflect.String {
-		return "", nil, false
-	}
-	if optionsField.Kind() != reflect.Map || optionsField.Type().Key().Kind() != reflect.String {
-		return "", nil, false
-	}
-	providerField = reflect.NewAt(providerField.Type(), unsafe.Pointer(providerField.UnsafeAddr())).Elem()
-	optionsField = reflect.NewAt(optionsField.Type(), unsafe.Pointer(optionsField.UnsafeAddr())).Elem()
-	provider = providerField.String()
-	if optionsField.IsNil() {
-		options = nil
-	} else {
-		options = make(map[string]any, optionsField.Len())
-		for _, k := range optionsField.MapKeys() {
-			options[k.String()] = optionsField.MapIndex(k).Interface()
-		}
-	}
-	return provider, options, true
+	return testhelpers.ClientEntrySnapshot(reg, name)
 }
 
 // legacyClientEntrySnapshot is the legacy-view wrapper around
@@ -105,28 +43,8 @@ func buildRequestClientEntrySnapshot(b *BamlAdapter, name string) (provider stri
 	return clientEntrySnapshot(b.ClientRegistry, name)
 }
 
-// clientRegistryPrimarySnapshot reads BAML's unexported `primary *string`
-// field from the supplied *baml.ClientRegistry. Returns nil when primary
-// is unset (BAML's representation of "no primary forwarded"), or when the
-// field shape drifts from the pinned `primary *string` type. Otherwise
-// returns a copy of the dereferenced string. Same reflect+unsafe pattern
-// as clientEntrySnapshot.
+// clientRegistryPrimarySnapshot delegates to the shared reflection
+// helper — see clientEntrySnapshot's comment for rationale.
 func clientRegistryPrimarySnapshot(reg *baml.ClientRegistry) *string {
-	if reg == nil {
-		return nil
-	}
-	regVal := reflect.ValueOf(reg).Elem()
-	primaryField := regVal.FieldByName("primary")
-	if !primaryField.IsValid() || primaryField.Kind() != reflect.Ptr {
-		return nil
-	}
-	if primaryField.Type().Elem().Kind() != reflect.String {
-		return nil
-	}
-	primaryField = reflect.NewAt(primaryField.Type(), unsafe.Pointer(primaryField.UnsafeAddr())).Elem()
-	if primaryField.IsNil() {
-		return nil
-	}
-	s := primaryField.Elem().String()
-	return &s
+	return testhelpers.ClientRegistryPrimarySnapshot(reg)
 }

--- a/adapters/adapter_v0_215_0/adapter/adapter_helpers_test.go
+++ b/adapters/adapter_v0_215_0/adapter/adapter_helpers_test.go
@@ -1,10 +1,9 @@
 package adapter
 
 import (
-	"reflect"
-	"unsafe"
-
 	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+
+	"github.com/invakid404/baml-rest/adapters/common/testhelpers"
 )
 
 // upstreamClientNamesSnapshot returns a defensive copy of the names
@@ -23,55 +22,11 @@ func legacyUpstreamClientNamesSnapshot(b *BamlAdapter) []string {
 	return append([]string(nil), b.legacyUpstreamClientNames...)
 }
 
-// clientEntrySnapshot reads the (provider, options) tuple BAML stored
-// under name in the supplied ClientRegistry's internal map — see the
-// v0.204 adapter helper for the full rationale and the kind/type
-// guards that protect against BAML registry shape drift.
+// clientEntrySnapshot delegates to the shared reflection helper. The
+// shared package operates on `any` because each adapter's
+// *baml.ClientRegistry is a distinct per-version type identity.
 func clientEntrySnapshot(reg *baml.ClientRegistry, name string) (provider string, options map[string]any, ok bool) {
-	if reg == nil {
-		return "", nil, false
-	}
-	regVal := reflect.ValueOf(reg).Elem()
-	clientsField := regVal.FieldByName("clients")
-	if !clientsField.IsValid() || clientsField.Kind() != reflect.Map {
-		return "", nil, false
-	}
-	if clientsField.Type().Key().Kind() != reflect.String {
-		return "", nil, false
-	}
-	clientsField = reflect.NewAt(clientsField.Type(), unsafe.Pointer(clientsField.UnsafeAddr())).Elem()
-	entry := clientsField.MapIndex(reflect.ValueOf(name))
-	if !entry.IsValid() {
-		return "", nil, false
-	}
-	if entry.Kind() != reflect.Struct {
-		return "", nil, false
-	}
-	addr := reflect.New(entry.Type()).Elem()
-	addr.Set(entry)
-	providerField := addr.FieldByName("provider")
-	optionsField := addr.FieldByName("options")
-	if !providerField.IsValid() || !optionsField.IsValid() {
-		return "", nil, false
-	}
-	if providerField.Kind() != reflect.String {
-		return "", nil, false
-	}
-	if optionsField.Kind() != reflect.Map || optionsField.Type().Key().Kind() != reflect.String {
-		return "", nil, false
-	}
-	providerField = reflect.NewAt(providerField.Type(), unsafe.Pointer(providerField.UnsafeAddr())).Elem()
-	optionsField = reflect.NewAt(optionsField.Type(), unsafe.Pointer(optionsField.UnsafeAddr())).Elem()
-	provider = providerField.String()
-	if optionsField.IsNil() {
-		options = nil
-	} else {
-		options = make(map[string]any, optionsField.Len())
-		for _, k := range optionsField.MapKeys() {
-			options[k.String()] = optionsField.MapIndex(k).Interface()
-		}
-	}
-	return provider, options, true
+	return testhelpers.ClientEntrySnapshot(reg, name)
 }
 
 func legacyClientEntrySnapshot(b *BamlAdapter, name string) (provider string, options map[string]any, ok bool) {
@@ -82,28 +37,8 @@ func buildRequestClientEntrySnapshot(b *BamlAdapter, name string) (provider stri
 	return clientEntrySnapshot(b.ClientRegistry, name)
 }
 
-// clientRegistryPrimarySnapshot reads BAML's unexported `primary *string`
-// field from the supplied *baml.ClientRegistry. Returns nil when primary
-// is unset (BAML's representation of "no primary forwarded"), or when the
-// field shape drifts from the pinned `primary *string` type. Otherwise
-// returns a copy of the dereferenced string. Same reflect+unsafe pattern
-// as clientEntrySnapshot.
+// clientRegistryPrimarySnapshot delegates to the shared reflection
+// helper — see clientEntrySnapshot's comment for rationale.
 func clientRegistryPrimarySnapshot(reg *baml.ClientRegistry) *string {
-	if reg == nil {
-		return nil
-	}
-	regVal := reflect.ValueOf(reg).Elem()
-	primaryField := regVal.FieldByName("primary")
-	if !primaryField.IsValid() || primaryField.Kind() != reflect.Ptr {
-		return nil
-	}
-	if primaryField.Type().Elem().Kind() != reflect.String {
-		return nil
-	}
-	primaryField = reflect.NewAt(primaryField.Type(), unsafe.Pointer(primaryField.UnsafeAddr())).Elem()
-	if primaryField.IsNil() {
-		return nil
-	}
-	s := primaryField.Elem().String()
-	return &s
+	return testhelpers.ClientRegistryPrimarySnapshot(reg)
 }

--- a/adapters/adapter_v0_219_0/adapter/adapter_helpers_test.go
+++ b/adapters/adapter_v0_219_0/adapter/adapter_helpers_test.go
@@ -1,10 +1,9 @@
 package adapter
 
 import (
-	"reflect"
-	"unsafe"
-
 	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+
+	"github.com/invakid404/baml-rest/adapters/common/testhelpers"
 )
 
 // upstreamClientNamesSnapshot returns a defensive copy of the names
@@ -23,55 +22,11 @@ func legacyUpstreamClientNamesSnapshot(b *BamlAdapter) []string {
 	return append([]string(nil), b.legacyUpstreamClientNames...)
 }
 
-// clientEntrySnapshot reads the (provider, options) tuple BAML stored
-// under name in the supplied ClientRegistry's internal map — see the
-// v0.204 adapter helper for the full rationale and the kind/type
-// guards that protect against BAML registry shape drift.
+// clientEntrySnapshot delegates to the shared reflection helper. The
+// shared package operates on `any` because each adapter's
+// *baml.ClientRegistry is a distinct per-version type identity.
 func clientEntrySnapshot(reg *baml.ClientRegistry, name string) (provider string, options map[string]any, ok bool) {
-	if reg == nil {
-		return "", nil, false
-	}
-	regVal := reflect.ValueOf(reg).Elem()
-	clientsField := regVal.FieldByName("clients")
-	if !clientsField.IsValid() || clientsField.Kind() != reflect.Map {
-		return "", nil, false
-	}
-	if clientsField.Type().Key().Kind() != reflect.String {
-		return "", nil, false
-	}
-	clientsField = reflect.NewAt(clientsField.Type(), unsafe.Pointer(clientsField.UnsafeAddr())).Elem()
-	entry := clientsField.MapIndex(reflect.ValueOf(name))
-	if !entry.IsValid() {
-		return "", nil, false
-	}
-	if entry.Kind() != reflect.Struct {
-		return "", nil, false
-	}
-	addr := reflect.New(entry.Type()).Elem()
-	addr.Set(entry)
-	providerField := addr.FieldByName("provider")
-	optionsField := addr.FieldByName("options")
-	if !providerField.IsValid() || !optionsField.IsValid() {
-		return "", nil, false
-	}
-	if providerField.Kind() != reflect.String {
-		return "", nil, false
-	}
-	if optionsField.Kind() != reflect.Map || optionsField.Type().Key().Kind() != reflect.String {
-		return "", nil, false
-	}
-	providerField = reflect.NewAt(providerField.Type(), unsafe.Pointer(providerField.UnsafeAddr())).Elem()
-	optionsField = reflect.NewAt(optionsField.Type(), unsafe.Pointer(optionsField.UnsafeAddr())).Elem()
-	provider = providerField.String()
-	if optionsField.IsNil() {
-		options = nil
-	} else {
-		options = make(map[string]any, optionsField.Len())
-		for _, k := range optionsField.MapKeys() {
-			options[k.String()] = optionsField.MapIndex(k).Interface()
-		}
-	}
-	return provider, options, true
+	return testhelpers.ClientEntrySnapshot(reg, name)
 }
 
 func legacyClientEntrySnapshot(b *BamlAdapter, name string) (provider string, options map[string]any, ok bool) {
@@ -82,28 +37,8 @@ func buildRequestClientEntrySnapshot(b *BamlAdapter, name string) (provider stri
 	return clientEntrySnapshot(b.ClientRegistry, name)
 }
 
-// clientRegistryPrimarySnapshot reads BAML's unexported `primary *string`
-// field from the supplied *baml.ClientRegistry. Returns nil when primary
-// is unset (BAML's representation of "no primary forwarded"), or when the
-// field shape drifts from the pinned `primary *string` type. Otherwise
-// returns a copy of the dereferenced string. Same reflect+unsafe pattern
-// as clientEntrySnapshot.
+// clientRegistryPrimarySnapshot delegates to the shared reflection
+// helper — see clientEntrySnapshot's comment for rationale.
 func clientRegistryPrimarySnapshot(reg *baml.ClientRegistry) *string {
-	if reg == nil {
-		return nil
-	}
-	regVal := reflect.ValueOf(reg).Elem()
-	primaryField := regVal.FieldByName("primary")
-	if !primaryField.IsValid() || primaryField.Kind() != reflect.Ptr {
-		return nil
-	}
-	if primaryField.Type().Elem().Kind() != reflect.String {
-		return nil
-	}
-	primaryField = reflect.NewAt(primaryField.Type(), unsafe.Pointer(primaryField.UnsafeAddr())).Elem()
-	if primaryField.IsNil() {
-		return nil
-	}
-	s := primaryField.Elem().String()
-	return &s
+	return testhelpers.ClientRegistryPrimarySnapshot(reg)
 }

--- a/adapters/common/embed.go
+++ b/adapters/common/embed.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed codegen/codegen.go embed.go go.mod go.sum helpers.go utils/dynamic.go
+//go:embed codegen/codegen.go embed.go go.mod go.sum helpers.go testhelpers/snapshot.go utils/dynamic.go
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/adapters/common/testhelpers/snapshot.go
+++ b/adapters/common/testhelpers/snapshot.go
@@ -1,0 +1,125 @@
+// Package testhelpers provides version-agnostic reflection-based snapshot
+// helpers that read the unexported fields of BAML's ClientRegistry struct.
+//
+// Each per-adapter module pins its own BAML version and therefore exposes a
+// distinct *baml.ClientRegistry type identity, which cannot be named in a
+// shared package. The helpers here accept the registry pointer as `any` and
+// rely on reflection to read the unexported `clients` map and `primary`
+// pointer. Every reflect.Value is verified for kind/type before any
+// unsafe.Pointer access, so a future BAML rev that renames a field or
+// changes the registry shape surfaces loudly via ok=false (or a nil result)
+// rather than panicking on UnsafeAddr against an unexpected type.
+//
+// These helpers underpin the per-adapter `clientEntrySnapshot` and
+// `clientRegistryPrimarySnapshot` test wrappers; production code must not
+// consume them.
+package testhelpers
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// ClientEntrySnapshot reads the (provider, options) tuple BAML stored under
+// name in the supplied ClientRegistry's internal map. BAML's ClientRegistry
+// exposes only AddLlmClient / SetPrimaryClient — `clients` is unexported.
+// This helper uses reflection + unsafe.Pointer to peek at the field shape
+// pinned in language_client_go's rawobjects_client_registry.go
+// (`clients clientRegistryMap = map[string]clientProperty`, where
+// clientProperty has `provider string` and `options map[string]any`).
+//
+// The reg parameter is typed as `any` so a single implementation works
+// across all per-adapter *baml.ClientRegistry type identities. Callers are
+// expected to pass a non-nil *baml.ClientRegistry; any other shape (or a
+// nil pointer, or a registry whose internal layout has drifted) returns
+// ok=false.
+func ClientEntrySnapshot(reg any, name string) (provider string, options map[string]any, ok bool) {
+	if reg == nil {
+		return "", nil, false
+	}
+	regVal := reflect.ValueOf(reg)
+	if regVal.Kind() != reflect.Ptr || regVal.IsNil() {
+		return "", nil, false
+	}
+	regVal = regVal.Elem()
+	if regVal.Kind() != reflect.Struct {
+		return "", nil, false
+	}
+	clientsField := regVal.FieldByName("clients")
+	if !clientsField.IsValid() || clientsField.Kind() != reflect.Map {
+		return "", nil, false
+	}
+	if clientsField.Type().Key().Kind() != reflect.String {
+		return "", nil, false
+	}
+	clientsField = reflect.NewAt(clientsField.Type(), unsafe.Pointer(clientsField.UnsafeAddr())).Elem()
+	entry := clientsField.MapIndex(reflect.ValueOf(name))
+	if !entry.IsValid() {
+		return "", nil, false
+	}
+	if entry.Kind() != reflect.Struct {
+		return "", nil, false
+	}
+	// Map values are returned as unaddressable Values (the map's internal
+	// hashing means there's no stable address). Copy into an addressable
+	// temporary so unsafe.Pointer + UnsafeAddr can read the unexported
+	// provider/options fields.
+	addr := reflect.New(entry.Type()).Elem()
+	addr.Set(entry)
+	providerField := addr.FieldByName("provider")
+	optionsField := addr.FieldByName("options")
+	if !providerField.IsValid() || !optionsField.IsValid() {
+		return "", nil, false
+	}
+	if providerField.Kind() != reflect.String {
+		return "", nil, false
+	}
+	if optionsField.Kind() != reflect.Map || optionsField.Type().Key().Kind() != reflect.String {
+		return "", nil, false
+	}
+	providerField = reflect.NewAt(providerField.Type(), unsafe.Pointer(providerField.UnsafeAddr())).Elem()
+	optionsField = reflect.NewAt(optionsField.Type(), unsafe.Pointer(optionsField.UnsafeAddr())).Elem()
+	provider = providerField.String()
+	if optionsField.IsNil() {
+		options = nil
+	} else {
+		options = make(map[string]any, optionsField.Len())
+		for _, k := range optionsField.MapKeys() {
+			options[k.String()] = optionsField.MapIndex(k).Interface()
+		}
+	}
+	return provider, options, true
+}
+
+// ClientRegistryPrimarySnapshot reads BAML's unexported `primary *string`
+// field from the supplied *baml.ClientRegistry. Returns nil when primary is
+// unset (BAML's representation of "no primary forwarded"), or when the
+// field shape drifts from the pinned `primary *string` type. Otherwise
+// returns a copy of the dereferenced string. Same reflect+unsafe pattern
+// as ClientEntrySnapshot, and the same `any` boundary for the same reason.
+func ClientRegistryPrimarySnapshot(reg any) *string {
+	if reg == nil {
+		return nil
+	}
+	regVal := reflect.ValueOf(reg)
+	if regVal.Kind() != reflect.Ptr || regVal.IsNil() {
+		return nil
+	}
+	regVal = regVal.Elem()
+	if regVal.Kind() != reflect.Struct {
+		return nil
+	}
+	primaryField := regVal.FieldByName("primary")
+	if !primaryField.IsValid() || primaryField.Kind() != reflect.Ptr {
+		return nil
+	}
+	if primaryField.Type().Elem().Kind() != reflect.String {
+		return nil
+	}
+	primaryField = reflect.NewAt(primaryField.Type(), unsafe.Pointer(primaryField.UnsafeAddr())).Elem()
+	if primaryField.IsNil() {
+		return nil
+	}
+	s := primaryField.Elem().String()
+	return &s
+}

--- a/adapters/common/testhelpers/snapshot.go
+++ b/adapters/common/testhelpers/snapshot.go
@@ -10,6 +10,16 @@
 // changes the registry shape surfaces loudly via ok=false (or a nil result)
 // rather than panicking on UnsafeAddr against an unexpected type.
 //
+// Type guards use exact-type comparison (e.g. `reflect.TypeOf("")` rather
+// than `Kind() == reflect.String`) on every code path that subsequently
+// constructs a typed reflect.Value to interact with the field — most
+// notably `MapIndex` against the `clients` map, which would panic on a
+// defined-string-alias key that passes a Kind-only check. Kind-only checks
+// would suffice while the helpers took a typed `*baml.ClientRegistry`
+// parameter (BAML's pinned shape made the alias case unreachable), but the
+// shared `any` boundary makes arbitrary synthetic shapes reachable, so the
+// guards are tightened accordingly.
+//
 // These helpers underpin the per-adapter `clientEntrySnapshot` and
 // `clientRegistryPrimarySnapshot` test wrappers; production code must not
 // consume them.
@@ -18,6 +28,12 @@ package testhelpers
 import (
 	"reflect"
 	"unsafe"
+)
+
+var (
+	stringType       = reflect.TypeOf("")
+	stringPtrType    = reflect.TypeOf((*string)(nil))
+	stringAnyMapType = reflect.TypeOf(map[string]any(nil))
 )
 
 // ClientEntrySnapshot reads the (provider, options) tuple BAML stored under
@@ -49,7 +65,10 @@ func ClientEntrySnapshot(reg any, name string) (provider string, options map[str
 	if !clientsField.IsValid() || clientsField.Kind() != reflect.Map {
 		return "", nil, false
 	}
-	if clientsField.Type().Key().Kind() != reflect.String {
+	// Exact-type guard on the map key: a defined-string alias
+	// (`type myString string`) would pass a Kind-only check and then
+	// panic at MapIndex below when keyed with a plain `string`.
+	if clientsField.Type().Key() != stringType {
 		return "", nil, false
 	}
 	clientsField = reflect.NewAt(clientsField.Type(), unsafe.Pointer(clientsField.UnsafeAddr())).Elem()
@@ -71,10 +90,15 @@ func ClientEntrySnapshot(reg any, name string) (provider string, options map[str
 	if !providerField.IsValid() || !optionsField.IsValid() {
 		return "", nil, false
 	}
-	if providerField.Kind() != reflect.String {
+	// Exact-type guards: `provider` must be `string` and `options` must be
+	// `map[string]any`. Kind-only checks would let a defined-type alias
+	// through; the read paths below would silently coerce or — for the
+	// options-key case — be one MapIndex(plainString) away from panicking
+	// if the iteration strategy ever changes.
+	if providerField.Type() != stringType {
 		return "", nil, false
 	}
-	if optionsField.Kind() != reflect.Map || optionsField.Type().Key().Kind() != reflect.String {
+	if optionsField.Type() != stringAnyMapType {
 		return "", nil, false
 	}
 	providerField = reflect.NewAt(providerField.Type(), unsafe.Pointer(providerField.UnsafeAddr())).Elem()
@@ -110,10 +134,13 @@ func ClientRegistryPrimarySnapshot(reg any) *string {
 		return nil
 	}
 	primaryField := regVal.FieldByName("primary")
-	if !primaryField.IsValid() || primaryField.Kind() != reflect.Ptr {
+	if !primaryField.IsValid() {
 		return nil
 	}
-	if primaryField.Type().Elem().Kind() != reflect.String {
+	// Exact-type guard: `primary` must be `*string`. A `*StringAlias`
+	// would pass Kind=Ptr + Elem().Kind()=String but break callers that
+	// expect the value to round-trip as a Go string.
+	if primaryField.Type() != stringPtrType {
 		return nil
 	}
 	primaryField = reflect.NewAt(primaryField.Type(), unsafe.Pointer(primaryField.UnsafeAddr())).Elem()

--- a/adapters/common/testhelpers/snapshot_test.go
+++ b/adapters/common/testhelpers/snapshot_test.go
@@ -1,0 +1,174 @@
+package testhelpers_test
+
+import (
+	"reflect"
+	"testing"
+
+	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+
+	"github.com/invakid404/baml-rest/adapters/common/testhelpers"
+)
+
+func TestClientEntrySnapshot_HappyPath(t *testing.T) {
+	reg := &baml.ClientRegistry{}
+	opts := map[string]any{"model": "gpt-4o", "temperature": 0.7}
+	reg.AddLlmClient("MyClient", "openai", opts)
+
+	provider, options, ok := testhelpers.ClientEntrySnapshot(reg, "MyClient")
+	if !ok {
+		t.Fatalf("ClientEntrySnapshot: ok=false for present entry")
+	}
+	if provider != "openai" {
+		t.Errorf("provider: got %q, want %q", provider, "openai")
+	}
+	if !reflect.DeepEqual(options, opts) {
+		t.Errorf("options: got %v, want %v", options, opts)
+	}
+}
+
+func TestClientEntrySnapshot_NilOptions(t *testing.T) {
+	reg := &baml.ClientRegistry{}
+	reg.AddLlmClient("NoOpts", "openai", nil)
+
+	provider, options, ok := testhelpers.ClientEntrySnapshot(reg, "NoOpts")
+	if !ok {
+		t.Fatalf("ClientEntrySnapshot: ok=false for present entry with nil options")
+	}
+	if provider != "openai" {
+		t.Errorf("provider: got %q, want %q", provider, "openai")
+	}
+	if options != nil {
+		t.Errorf("options: got %v, want nil", options)
+	}
+}
+
+func TestClientEntrySnapshot_MissingEntry(t *testing.T) {
+	reg := &baml.ClientRegistry{}
+	reg.AddLlmClient("Other", "openai", nil)
+
+	if _, _, ok := testhelpers.ClientEntrySnapshot(reg, "Missing"); ok {
+		t.Errorf("ClientEntrySnapshot: ok=true for missing entry")
+	}
+}
+
+func TestClientEntrySnapshot_NilRegistry(t *testing.T) {
+	if _, _, ok := testhelpers.ClientEntrySnapshot((*baml.ClientRegistry)(nil), "x"); ok {
+		t.Errorf("typed nil pointer: ok=true, want false")
+	}
+	if _, _, ok := testhelpers.ClientEntrySnapshot(nil, "x"); ok {
+		t.Errorf("untyped nil: ok=true, want false")
+	}
+}
+
+func TestClientEntrySnapshot_EmptyRegistry(t *testing.T) {
+	if _, _, ok := testhelpers.ClientEntrySnapshot(&baml.ClientRegistry{}, "x"); ok {
+		t.Errorf("ClientEntrySnapshot on empty registry: ok=true, want false")
+	}
+}
+
+// driftRegistryNoClientsField mimics a future BAML revision that renamed
+// `clients`. The kind/type guards in ClientEntrySnapshot must surface this
+// as ok=false rather than panicking.
+type driftRegistryNoClientsField struct {
+	primary *string
+	other   map[string]any
+}
+
+// driftRegistryWrongKeyKind has a `clients` field whose key is not a
+// string. ClientEntrySnapshot must return ok=false.
+type driftRegistryWrongKeyKind struct {
+	clients map[int]struct {
+		provider string
+		options  map[string]any
+	}
+}
+
+func TestClientEntrySnapshot_ShapeDrift(t *testing.T) {
+	cases := []struct {
+		name string
+		reg  any
+	}{
+		{"non-pointer", baml.ClientRegistry{}},
+		{"pointer-to-non-struct", func() any { s := "x"; return &s }()},
+		{"missing-clients-field", &driftRegistryNoClientsField{}},
+		{"wrong-key-kind", &driftRegistryWrongKeyKind{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, ok := testhelpers.ClientEntrySnapshot(tc.reg, "x"); ok {
+				t.Errorf("ok=true on shape drift, want false")
+			}
+		})
+	}
+}
+
+func TestClientRegistryPrimarySnapshot_HappyPath(t *testing.T) {
+	reg := &baml.ClientRegistry{}
+	reg.SetPrimaryClient("Primary")
+
+	got := testhelpers.ClientRegistryPrimarySnapshot(reg)
+	if got == nil {
+		t.Fatalf("ClientRegistryPrimarySnapshot: nil for set primary")
+	}
+	if *got != "Primary" {
+		t.Errorf("primary: got %q, want %q", *got, "Primary")
+	}
+}
+
+func TestClientRegistryPrimarySnapshot_Unset(t *testing.T) {
+	reg := &baml.ClientRegistry{}
+	if got := testhelpers.ClientRegistryPrimarySnapshot(reg); got != nil {
+		t.Errorf("ClientRegistryPrimarySnapshot on unset registry: got %q, want nil", *got)
+	}
+}
+
+func TestClientRegistryPrimarySnapshot_Nil(t *testing.T) {
+	if got := testhelpers.ClientRegistryPrimarySnapshot((*baml.ClientRegistry)(nil)); got != nil {
+		t.Errorf("typed nil: got %q, want nil", *got)
+	}
+	if got := testhelpers.ClientRegistryPrimarySnapshot(nil); got != nil {
+		t.Errorf("untyped nil: got %q, want nil", *got)
+	}
+}
+
+// driftRegistryNoPrimaryField mimics a future BAML revision that renamed
+// `primary`. ClientRegistryPrimarySnapshot must return nil rather than
+// panicking.
+type driftRegistryNoPrimaryField struct {
+	clients map[string]any
+}
+
+// driftRegistryPrimaryWrongElem has a `primary` field that's a pointer to
+// something other than string. ClientRegistryPrimarySnapshot must return
+// nil.
+type driftRegistryPrimaryWrongElem struct {
+	primary *int
+	clients map[string]any
+}
+
+// driftRegistryPrimaryNotPointer has a `primary` field that isn't a
+// pointer. ClientRegistryPrimarySnapshot must return nil.
+type driftRegistryPrimaryNotPointer struct {
+	primary string
+	clients map[string]any
+}
+
+func TestClientRegistryPrimarySnapshot_ShapeDrift(t *testing.T) {
+	cases := []struct {
+		name string
+		reg  any
+	}{
+		{"non-pointer", baml.ClientRegistry{}},
+		{"pointer-to-non-struct", func() any { s := "x"; return &s }()},
+		{"missing-primary-field", &driftRegistryNoPrimaryField{}},
+		{"primary-wrong-elem", &driftRegistryPrimaryWrongElem{}},
+		{"primary-not-pointer", &driftRegistryPrimaryNotPointer{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := testhelpers.ClientRegistryPrimarySnapshot(tc.reg); got != nil {
+				t.Errorf("got %q, want nil on shape drift", *got)
+			}
+		})
+	}
+}

--- a/adapters/common/testhelpers/snapshot_test.go
+++ b/adapters/common/testhelpers/snapshot_test.go
@@ -226,10 +226,10 @@ func TestClientEntrySnapshot_ShapeDrift(t *testing.T) {
 				}{"x": {provider: "openai", options: nil}},
 			}),
 		},
-		// Entry-level drift cases (verdict-1 F1): exercise the guards
-		// that fire after a present entry is fetched from the `clients`
-		// map. Each case populates "x" so MapIndex returns a valid
-		// Value, then the per-field guard rejects.
+		// Entry-level drift cases: exercise the guards that fire after
+		// a present entry is fetched from the `clients` map. Each case
+		// populates "x" so MapIndex returns a valid Value, then the
+		// per-field guard rejects.
 		{
 			name: "entry-not-struct",
 			reg: &driftRegistryEntryNotStruct{

--- a/adapters/common/testhelpers/snapshot_test.go
+++ b/adapters/common/testhelpers/snapshot_test.go
@@ -83,7 +83,57 @@ type driftRegistryWrongKeyKind struct {
 	}
 }
 
+// definedStringKey is the regression case for the exact-type guard on the
+// `clients` map key: a defined-string alias passes a Kind-only check and
+// then panics at MapIndex when keyed with a plain `string`. The exact-type
+// guard must reject this with ok=false.
+type definedStringKey string
+
+type driftRegistryDefinedStringKey struct {
+	primary *string
+	clients map[definedStringKey]struct {
+		provider string
+		options  map[string]any
+	}
+}
+
+// driftRegistryProviderDefinedString has the right `clients` shape but
+// the entry's `provider` field is a defined-string alias rather than a
+// plain `string`. The exact-type guard on `provider` must reject this.
+type driftRegistryProviderDefinedString struct {
+	primary *string
+	clients map[string]struct {
+		provider definedStringKey
+		options  map[string]any
+	}
+}
+
+// driftRegistryOptionsDefinedKey has the right `clients` shape but the
+// entry's `options` map key is a defined-string alias rather than a plain
+// `string`. The exact-type guard on `options` must reject this.
+type driftRegistryOptionsDefinedKey struct {
+	primary *string
+	clients map[string]struct {
+		provider string
+		options  map[definedStringKey]any
+	}
+}
+
+// driftRegistryOptionsWrongValue has the right `clients` shape but the
+// entry's `options` map value is `string` instead of `any`. The
+// exact-type guard on `options` must reject this — silently iterating
+// such a map and copying values would coerce them to `any` and surprise
+// downstream callers.
+type driftRegistryOptionsWrongValue struct {
+	primary *string
+	clients map[string]struct {
+		provider string
+		options  map[string]string
+	}
+}
+
 func TestClientEntrySnapshot_ShapeDrift(t *testing.T) {
+	withEntry := func(reg any) any { return reg }
 	cases := []struct {
 		name string
 		reg  any
@@ -92,9 +142,55 @@ func TestClientEntrySnapshot_ShapeDrift(t *testing.T) {
 		{"pointer-to-non-struct", func() any { s := "x"; return &s }()},
 		{"missing-clients-field", &driftRegistryNoClientsField{}},
 		{"wrong-key-kind", &driftRegistryWrongKeyKind{}},
+		// Regression cases for the exact-type guards added per Codex's
+		// NO-GO finding on PR 2: each previously-Kind-only guard would
+		// have either panicked (clients-key) or silently misbehaved
+		// (provider/options) when crossed by a synthetic input via the
+		// `any` boundary that wasn't reachable through *baml.ClientRegistry.
+		{
+			name: "clients-defined-string-key",
+			reg: withEntry(&driftRegistryDefinedStringKey{
+				clients: map[definedStringKey]struct {
+					provider string
+					options  map[string]any
+				}{"x": {provider: "openai", options: nil}},
+			}),
+		},
+		{
+			name: "provider-defined-string",
+			reg: withEntry(&driftRegistryProviderDefinedString{
+				clients: map[string]struct {
+					provider definedStringKey
+					options  map[string]any
+				}{"x": {provider: "openai", options: nil}},
+			}),
+		},
+		{
+			name: "options-defined-string-key",
+			reg: withEntry(&driftRegistryOptionsDefinedKey{
+				clients: map[string]struct {
+					provider string
+					options  map[definedStringKey]any
+				}{"x": {provider: "openai", options: nil}},
+			}),
+		},
+		{
+			name: "options-wrong-value-type",
+			reg: withEntry(&driftRegistryOptionsWrongValue{
+				clients: map[string]struct {
+					provider string
+					options  map[string]string
+				}{"x": {provider: "openai", options: nil}},
+			}),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("ClientEntrySnapshot panicked on shape drift: %v", r)
+				}
+			}()
 			if _, _, ok := testhelpers.ClientEntrySnapshot(tc.reg, "x"); ok {
 				t.Errorf("ok=true on shape drift, want false")
 			}
@@ -153,7 +249,16 @@ type driftRegistryPrimaryNotPointer struct {
 	clients map[string]any
 }
 
+// driftRegistryPrimaryDefinedStringPtr is the regression case for the
+// exact-`*string` guard: `*StringAlias` would pass Kind=Ptr +
+// Elem().Kind()=String but break the round-trip-as-Go-string contract.
+type driftRegistryPrimaryDefinedStringPtr struct {
+	primary *definedStringKey
+	clients map[string]any
+}
+
 func TestClientRegistryPrimarySnapshot_ShapeDrift(t *testing.T) {
+	aliasVal := definedStringKey("Primary")
 	cases := []struct {
 		name string
 		reg  any
@@ -163,9 +268,15 @@ func TestClientRegistryPrimarySnapshot_ShapeDrift(t *testing.T) {
 		{"missing-primary-field", &driftRegistryNoPrimaryField{}},
 		{"primary-wrong-elem", &driftRegistryPrimaryWrongElem{}},
 		{"primary-not-pointer", &driftRegistryPrimaryNotPointer{}},
+		{"primary-defined-string-ptr", &driftRegistryPrimaryDefinedStringPtr{primary: &aliasVal}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("ClientRegistryPrimarySnapshot panicked on shape drift: %v", r)
+				}
+			}()
 			if got := testhelpers.ClientRegistryPrimarySnapshot(tc.reg); got != nil {
 				t.Errorf("got %q, want nil on shape drift", *got)
 			}

--- a/adapters/common/testhelpers/snapshot_test.go
+++ b/adapters/common/testhelpers/snapshot_test.go
@@ -132,6 +132,49 @@ type driftRegistryOptionsWrongValue struct {
 	}
 }
 
+// driftRegistryEntryNotStruct has the right `clients` map key (string)
+// but its value is a string rather than the clientProperty struct. The
+// `entry.Kind() != reflect.Struct` guard must reject this with ok=false.
+type driftRegistryEntryNotStruct struct {
+	primary *string
+	clients map[string]string
+}
+
+// driftRegistryEntryMissingFields has the right key/value-struct shape
+// but the value struct lacks the `provider` and `options` fields. The
+// `providerField.IsValid()` / `optionsField.IsValid()` guards must
+// reject this with ok=false.
+type driftRegistryEntryMissingFields struct {
+	primary *string
+	clients map[string]struct {
+		other int
+	}
+}
+
+// driftRegistryEntryProviderWrongKind has a `provider` field whose kind
+// is not String at all (the existing `provider-defined-string` case
+// covers the alias path; this is the kind-mismatch path). The exact-type
+// guard on `provider` must reject this with ok=false.
+type driftRegistryEntryProviderWrongKind struct {
+	primary *string
+	clients map[string]struct {
+		provider int
+		options  map[string]any
+	}
+}
+
+// driftRegistryEntryOptionsWrongElem has an `options` field that isn't
+// a map at all (the existing `options-*` cases cover map-key/value
+// drift; this is the not-a-map path). The exact-type guard on `options`
+// must reject this with ok=false.
+type driftRegistryEntryOptionsWrongElem struct {
+	primary *string
+	clients map[string]struct {
+		provider string
+		options  []string
+	}
+}
+
 func TestClientEntrySnapshot_ShapeDrift(t *testing.T) {
 	withEntry := func(reg any) any { return reg }
 	cases := []struct {
@@ -180,6 +223,40 @@ func TestClientEntrySnapshot_ShapeDrift(t *testing.T) {
 				clients: map[string]struct {
 					provider string
 					options  map[string]string
+				}{"x": {provider: "openai", options: nil}},
+			}),
+		},
+		// Entry-level drift cases (verdict-1 F1): exercise the guards
+		// that fire after a present entry is fetched from the `clients`
+		// map. Each case populates "x" so MapIndex returns a valid
+		// Value, then the per-field guard rejects.
+		{
+			name: "entry-not-struct",
+			reg: &driftRegistryEntryNotStruct{
+				clients: map[string]string{"x": "openai"},
+			},
+		},
+		{
+			name: "entry-missing-provider-options",
+			reg: withEntry(&driftRegistryEntryMissingFields{
+				clients: map[string]struct{ other int }{"x": {other: 1}},
+			}),
+		},
+		{
+			name: "entry-provider-wrong-kind",
+			reg: withEntry(&driftRegistryEntryProviderWrongKind{
+				clients: map[string]struct {
+					provider int
+					options  map[string]any
+				}{"x": {provider: 7, options: nil}},
+			}),
+		},
+		{
+			name: "entry-options-wrong-elem",
+			reg: withEntry(&driftRegistryEntryOptionsWrongElem{
+				clients: map[string]struct {
+					provider string
+					options  []string
 				}{"x": {provider: "openai", options: nil}},
 			}),
 		},

--- a/adapters/common/testhelpers/snapshot_test.go
+++ b/adapters/common/testhelpers/snapshot_test.go
@@ -142,11 +142,11 @@ func TestClientEntrySnapshot_ShapeDrift(t *testing.T) {
 		{"pointer-to-non-struct", func() any { s := "x"; return &s }()},
 		{"missing-clients-field", &driftRegistryNoClientsField{}},
 		{"wrong-key-kind", &driftRegistryWrongKeyKind{}},
-		// Regression cases for the exact-type guards added per Codex's
-		// NO-GO finding on PR 2: each previously-Kind-only guard would
-		// have either panicked (clients-key) or silently misbehaved
-		// (provider/options) when crossed by a synthetic input via the
-		// `any` boundary that wasn't reachable through *baml.ClientRegistry.
+		// Regression cases for the exact-type guards: each previously
+		// Kind-only guard would have either panicked (clients-key) or
+		// silently misbehaved (provider/options) when crossed by a
+		// synthetic input via the `any` boundary that isn't reachable
+		// through the typed *baml.ClientRegistry parameter.
 		{
 			name: "clients-defined-string-key",
 			reg: withEntry(&driftRegistryDefinedStringKey{

--- a/adapters/common/testhelpers/snapshot_test.go
+++ b/adapters/common/testhelpers/snapshot_test.go
@@ -176,7 +176,6 @@ type driftRegistryEntryOptionsWrongElem struct {
 }
 
 func TestClientEntrySnapshot_ShapeDrift(t *testing.T) {
-	withEntry := func(reg any) any { return reg }
 	cases := []struct {
 		name string
 		reg  any
@@ -192,39 +191,39 @@ func TestClientEntrySnapshot_ShapeDrift(t *testing.T) {
 		// through the typed *baml.ClientRegistry parameter.
 		{
 			name: "clients-defined-string-key",
-			reg: withEntry(&driftRegistryDefinedStringKey{
+			reg: &driftRegistryDefinedStringKey{
 				clients: map[definedStringKey]struct {
 					provider string
 					options  map[string]any
 				}{"x": {provider: "openai", options: nil}},
-			}),
+			},
 		},
 		{
 			name: "provider-defined-string",
-			reg: withEntry(&driftRegistryProviderDefinedString{
+			reg: &driftRegistryProviderDefinedString{
 				clients: map[string]struct {
 					provider definedStringKey
 					options  map[string]any
 				}{"x": {provider: "openai", options: nil}},
-			}),
+			},
 		},
 		{
 			name: "options-defined-string-key",
-			reg: withEntry(&driftRegistryOptionsDefinedKey{
+			reg: &driftRegistryOptionsDefinedKey{
 				clients: map[string]struct {
 					provider string
 					options  map[definedStringKey]any
 				}{"x": {provider: "openai", options: nil}},
-			}),
+			},
 		},
 		{
 			name: "options-wrong-value-type",
-			reg: withEntry(&driftRegistryOptionsWrongValue{
+			reg: &driftRegistryOptionsWrongValue{
 				clients: map[string]struct {
 					provider string
 					options  map[string]string
 				}{"x": {provider: "openai", options: nil}},
-			}),
+			},
 		},
 		// Entry-level drift cases: exercise the guards that fire after
 		// a present entry is fetched from the `clients` map. Each case
@@ -238,27 +237,27 @@ func TestClientEntrySnapshot_ShapeDrift(t *testing.T) {
 		},
 		{
 			name: "entry-missing-provider-options",
-			reg: withEntry(&driftRegistryEntryMissingFields{
+			reg: &driftRegistryEntryMissingFields{
 				clients: map[string]struct{ other int }{"x": {other: 1}},
-			}),
+			},
 		},
 		{
 			name: "entry-provider-wrong-kind",
-			reg: withEntry(&driftRegistryEntryProviderWrongKind{
+			reg: &driftRegistryEntryProviderWrongKind{
 				clients: map[string]struct {
 					provider int
 					options  map[string]any
 				}{"x": {provider: 7, options: nil}},
-			}),
+			},
 		},
 		{
 			name: "entry-options-wrong-elem",
-			reg: withEntry(&driftRegistryEntryOptionsWrongElem{
+			reg: &driftRegistryEntryOptionsWrongElem{
 				clients: map[string]struct {
 					provider string
 					options  []string
 				}{"x": {provider: "openai", options: nil}},
-			}),
+			},
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

PR 2 of 4 implementing #199 item 1 — per-adapter divergence audit. Test-only; zero production risk.

Moves the two version-agnostic reflection-based snapshot helpers (`clientEntrySnapshot`, `clientRegistryPrimarySnapshot`) from per-adapter `adapter_helpers_test.go` files into a new shared `adapters/common/testhelpers/` package. The helpers take `any` at the package boundary because each adapter's `*baml.ClientRegistry` is a distinct per-version type identity; the reflection bodies inside `testhelpers` then operate uniformly across all three adapters' `clients clientRegistryMap` shape (verified version-stable across v0.204 → v0.215 → v0.219; verdict-39 F1-F3's kind/type guards make any future shape drift fail loudly via `ok=false` instead of panic).

The 4 `*BamlAdapter`-taking wrappers (`legacyClientEntrySnapshot`, `buildRequestClientEntrySnapshot`, `upstreamClientNamesSnapshot`, `legacyUpstreamClientNamesSnapshot`) stay per-adapter because they reach into per-version struct fields, but their bodies shrink to 1-2 lines delegating into the now-shared helpers.

**Folds in #199 item 5** (reflection in adapter test helpers — previously listed as blocked on BAML upstream). The fold-in is safe because:
- BAML's unexported `clients clientRegistryMap` and `primary *string` shapes have held across v0.204 → v0.215 → v0.219 (verified at master against the BAML module cache for each pinned version).
- Verdict-39 F1-F3's reflection-hardening (`Kind()` / `Type()` guards) makes shape drift surface as `ok=false`, not panic. The shared helpers inherit this hardening and broaden it (additional guards reject non-pointer / pointer-to-non-struct inputs at the `any` boundary).
- Item 5 closes as folded-in once this PR lands.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `cd adapters/common && go test ./...` — passes (including new `testhelpers` package tests)
- [x] for each adapter `v0_204_0` / `v0_215_0` / `v0_219_0`: `GOWORK=off go test ./adapter/` — passes
- [x] MVS spot-check unchanged from PR 1 (each adapter still resolves to its pinned BAML version)
- [x] `adapters/common/embed.go` regenerated via `go run ./cmd/embed` (single-line addition for `testhelpers/snapshot.go`)
- [ ] CI integration-tests workflow — confirm green

## Sequence context

- PR 1 (#215): utils consolidation + nil-factory parity — merged.
- PR 2 (this one): shared reflection testhelpers, folds in item 5.
- PR 3: shared test driver, expands v0.204/v0.215 coverage to match v0.219.
- PR 4: codegen-emit framework `adapter.go` (4a/4b verifier-then-cleanup split).

<!-- webtty-bridge: session=s-yqyd29e14n -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adapter tests now delegate registry inspection to a centralized shared helper, removing duplicated low-level inspection logic.

* **New Features**
  * Added shared snapshot helpers to consistently read client registry entries and primary selection across adapter versions; embedded resources updated to include these utilities.

* **Tests**
  * Added extensive tests for normal, nil/missing, and malformed inputs to ensure safe, non‑panicking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->