### PR TITLE
chore(verifier): scrub process-tag wording from framework-adapter tests

### DIFF
--- a/cmd/verify-framework-adapter/main_test.go
+++ b/cmd/verify-framework-adapter/main_test.go
@@ -4,10 +4,11 @@ import "testing"
 
 // TestRewriteRelativeReplaceLine pins the contract for the single-line
 // rewriter: only genuinely-relative go.mod replace targets ("./",
-// "../", or exact ".") get rewritten; module-path replaces and
-// absolute-path replaces pass through verbatim. CR verdict-2 flagged
-// the prior `strings.Index(line, "=> ..")` form as too narrow — these
-// cases lock in the broadened detection.
+// "../", exact ".", or exact "..") get rewritten; module-path replaces
+// and absolute-path replaces pass through verbatim. The sub-cases also
+// pin trailing-suffix preservation (versions, comments, tab padding)
+// so a regression that re-narrows the detection or drops a trailing
+// field trips a check.
 func TestRewriteRelativeReplaceLine(t *testing.T) {
 	const origDir = "/repo/adapters/adapter_v0_215_0"
 	cases := []struct {
@@ -26,21 +27,19 @@ func TestRewriteRelativeReplaceLine(t *testing.T) {
 			want: "\tgithub.com/invakid404/baml-rest/bamlutils => /repo/bamlutils",
 		},
 		{
-			name: "same-dir relative replace (./ — previously skipped)",
+			name: "same-dir relative replace (./local)",
 			in:   "\texample.com/local => ./local",
 			want: "\texample.com/local => /repo/adapters/adapter_v0_215_0/local",
 		},
 		{
-			name: "exact dot relative replace (. — previously skipped)",
+			name: "exact same-dir replace (.)",
 			in:   "\texample.com/self => .",
 			want: "\texample.com/self => /repo/adapters/adapter_v0_215_0",
 		},
 		{
-			// Codex sign-off NO-GO blocker on the v2 fix: the new
-			// HasPrefix("../") check missed exact ".." (no trailing
-			// slash). The previous substring matcher caught it by
-			// accident; the predicate has to spell it out.
-			name: "exact double-dot relative replace (.. — verdict-2 v3 gap)",
+			// Exact ".." needs an explicit predicate arm because
+			// strings.HasPrefix("..", "../") is false.
+			name: "exact parent-dir replace (..)",
 			in:   "\texample.com/parent => ..",
 			want: "\texample.com/parent => /repo/adapters",
 		},
@@ -66,8 +65,8 @@ func TestRewriteRelativeReplaceLine(t *testing.T) {
 		},
 		{
 			name: "preserves trailing comment on a relative replace",
-			in:   "\texample.com/x => ../sibling // see #199",
-			want: "\texample.com/x => /repo/adapters/sibling // see #199",
+			in:   "\texample.com/x => ../sibling // local fork",
+			want: "\texample.com/x => /repo/adapters/sibling // local fork",
 		},
 		{
 			name: "single-line replace directive (outside a block)",
@@ -96,7 +95,7 @@ func TestIsRelativeReplacePath(t *testing.T) {
 		want bool
 	}{
 		{".", true},
-		{"..", true}, // verdict-2 v3 gap: exact ".." was missed by HasPrefix("../")
+		{"..", true}, // HasPrefix("..", "../") is false; predicate needs an explicit arm.
 		{"./local", true},
 		{"./", true},
 		{"../common", true},


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Follow-up to #218.

`cmd/verify-framework-adapter/main_test.go` shipped with process-scaffold wording in subtest names and comments. This commit replaces them with durable rationale (where useful) or neutralises them. No functional change — `go test ./cmd/verify-framework-adapter/` still passes all 24 sub-cases and `go run ./cmd/verify-framework-adapter` still reports 9/9.

## What changed

- Subtest renames in `TestRewriteRelativeReplaceLine`:
  - `"same-dir relative replace (./ — previously skipped)"` → `"same-dir relative replace (./local)"`
  - `"exact dot relative replace (. — previously skipped)"` → `"exact same-dir replace (.)"`
  - `"exact double-dot relative replace (.. — verdict-2 v3 gap)"` → `"exact parent-dir replace (..)"`
- Test data placeholder swapped: `// see #199` → `// local fork` in the "preserves trailing comment on a relative replace" fixture.
- Inline comments rewritten to the durable rationale (e.g. exact `..` needs its own predicate arm because `strings.HasPrefix("..", "../")` is false).
- Header doc on `TestRewriteRelativeReplaceLine` widened to mention exact `..` (which the predicate already accepts; the header was still listing only `.`, `./`, `../`).

## Why

Test names and comments tagged to specific review cycles age poorly and clutter `go test -v` output. The file should read self-explanatorily without operator-process context.

## Test plan

- [x] `gofmt -l cmd/verify-framework-adapter/` — clean.
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test -v ./cmd/verify-framework-adapter/` — 24 sub-cases PASS.
- [x] `go run ./cmd/verify-framework-adapter` — 9/9 PASS.
- [x] `go run ./cmd/embed && git diff -- embed.go` — empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for go.mod relative path handling, including same-directory and parent directory references.
  * Improved validation for preservation of version suffixes and comments during path rewriting operations.
  * Added explicit test cases for edge cases in relative path detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->