### PR TITLE
fix(llmhttp): classify streaming transport read errors

### DIFF
--- a/bamlutils/llmhttp/errors.go
+++ b/bamlutils/llmhttp/errors.go
@@ -2,6 +2,7 @@ package llmhttp
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -152,4 +153,32 @@ func classifyTransportErr(err error, prefix string, staleConnTeardownAcceptable 
 	}
 
 	return nil
+}
+
+// classifyStreamErrc consumes the single terminal value sseclient.Stream
+// (and the fast-path stream reader) emits and re-emits it on a buffered(1)
+// channel after running non-nil values through classifyTransportErr with
+// body-read semantics — same as Execute and readFastBodyLimitedCtx, where
+// any bytes already delivered upstream rule out the gated stale-conn-
+// teardown family. A typed mid-stream transport drop (ECONNRESET / EPIPE /
+// ECONNREFUSED / net.ErrClosed) therefore carries the ErrTransportFlake
+// umbrella sentinel out of the streaming path; io.ErrUnexpectedEOF
+// (chunked truncation) falls through to the generic wrap so its
+// content-integrity meaning is preserved.
+func classifyStreamErrc(src <-chan error) <-chan error {
+	out := make(chan error, 1)
+	go func() {
+		defer close(out)
+		err := <-src
+		if err == nil {
+			out <- nil
+			return
+		}
+		if te := classifyTransportErr(err, "llmhttp: failed to read response body", false); te != nil {
+			out <- te
+			return
+		}
+		out <- fmt.Errorf("llmhttp: failed to read response body: %w", err)
+	}()
+	return out
 }

--- a/bamlutils/llmhttp/errors_test.go
+++ b/bamlutils/llmhttp/errors_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -325,4 +326,103 @@ func containsTransportFlakeText(s string) bool {
 		}
 	}
 	return false
+}
+
+func TestClassifyStreamErrc(t *testing.T) {
+	t.Parallel()
+
+	transportReset := &net.OpError{Op: "read", Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET}}
+
+	cases := []struct {
+		name           string
+		in             error
+		wantNil        bool
+		wantFlake      bool
+		wantUnderlying error
+	}{
+		{
+			name:    "nil terminal passes through",
+			in:      nil,
+			wantNil: true,
+		},
+		{
+			name:           "ECONNRESET classifies and exposes ErrTransportFlake + underlying",
+			in:             transportReset,
+			wantFlake:      true,
+			wantUnderlying: syscall.ECONNRESET,
+		},
+		{
+			name:           "EPIPE classifies",
+			in:             &net.OpError{Op: "write", Err: &os.SyscallError{Syscall: "write", Err: syscall.EPIPE}},
+			wantFlake:      true,
+			wantUnderlying: syscall.EPIPE,
+		},
+		{
+			name:           "io.ErrUnexpectedEOF stays content-integrity (no flake, chain preserved)",
+			in:             io.ErrUnexpectedEOF,
+			wantFlake:      false,
+			wantUnderlying: io.ErrUnexpectedEOF,
+		},
+		{
+			name:           "bare io.EOF is not a flake at body-read sites (gate=false)",
+			in:             io.EOF,
+			wantFlake:      false,
+			wantUnderlying: io.EOF,
+		},
+		{
+			name:           "context.DeadlineExceeded is not a flake but chain is preserved",
+			in:             context.DeadlineExceeded,
+			wantFlake:      false,
+			wantUnderlying: context.DeadlineExceeded,
+		},
+		{
+			name:      "unrelated err wraps but does not match ErrTransportFlake",
+			in:        errors.New("nope"),
+			wantFlake: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			src := make(chan error, 1)
+			src <- tc.in
+			close(src)
+
+			out := classifyStreamErrc(src)
+
+			got, ok := <-out
+			if !ok {
+				t.Fatal("out channel closed without emitting a value")
+			}
+			// classifyStreamErrc must emit exactly one terminal value
+			// then close, mirroring sseclient.Stream's errc contract.
+			if extra, stillOpen := <-out; stillOpen {
+				t.Fatalf("out channel still open after one value, got extra: %v", extra)
+			}
+
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil terminal, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil error for input %v, got nil", tc.in)
+			}
+			if errors.Is(got, ErrTransportFlake) != tc.wantFlake {
+				t.Errorf("errors.Is(err, ErrTransportFlake) = %v; want %v; err = %v", !tc.wantFlake, tc.wantFlake, got)
+			}
+			if tc.wantUnderlying != nil && !errors.Is(got, tc.wantUnderlying) {
+				t.Errorf("errors.Is(err, underlying) = false; want true; err = %v", got)
+			}
+			// Non-flake errors are wrapped with the body-read prefix
+			// — match the rendering of the non-streaming sites.
+			if !tc.wantFlake {
+				if !strings.Contains(got.Error(), "llmhttp: failed to read response body") {
+					t.Errorf("non-flake err should carry the body-read prefix; got: %q", got.Error())
+				}
+			}
+		})
+	}
 }

--- a/bamlutils/llmhttp/fast_backend.go
+++ b/bamlutils/llmhttp/fast_backend.go
@@ -243,13 +243,16 @@ func (c *Client) executeStreamFast(ctx context.Context, req *Request, rewrittenU
 
 	rc := newFastStreamReader(ctx, fReq, fResp, bodyStream, slot, hc)
 
+	// Same classification wrapper as the stdlib path in ExecuteStream:
+	// surface typed mid-stream transport drops as ErrTransportFlake while
+	// leaving io.ErrUnexpectedEOF (chunked truncation) intact.
 	events, errc := sseclient.Stream(ctx, rc)
 
 	return &StreamResponse{
 		StatusCode: status,
 		Headers:    headers,
 		Events:     events,
-		Errc:       errc,
+		Errc:       classifyStreamErrc(errc),
 		body:       rc,
 	}, nil
 }

--- a/bamlutils/llmhttp/llmhttp.go
+++ b/bamlutils/llmhttp/llmhttp.go
@@ -270,14 +270,18 @@ func (c *Client) ExecuteStream(ctx context.Context, req *Request) (*StreamRespon
 		return nil, fmt.Errorf("llmhttp: unexpected Content-Type %q (expected text/event-stream): %s", ct, string(body))
 	}
 
-	// Start SSE parsing on the response body
+	// Start SSE parsing on the response body. The terminal value sseclient
+	// emits on errc is run through classifyStreamErrc so a mid-stream typed
+	// transport drop (ECONNRESET / EPIPE / ECONNREFUSED / net.ErrClosed)
+	// carries ErrTransportFlake out of the streaming path — matching the
+	// non-streaming body-read site at Execute below.
 	events, errc := sseclient.Stream(ctx, resp.Body)
 
 	return &StreamResponse{
 		StatusCode: resp.StatusCode,
 		Headers:    resp.Header,
 		Events:     events,
-		Errc:       errc,
+		Errc:       classifyStreamErrc(errc),
 		body:       resp.Body,
 	}, nil
 }

--- a/bamlutils/llmhttp/llmhttp_test.go
+++ b/bamlutils/llmhttp/llmhttp_test.go
@@ -2,11 +2,15 @@ package llmhttp
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -921,5 +925,137 @@ func TestExecuteOnSuccessNotFiredOnError(t *testing.T) {
 	}
 	if called {
 		t.Fatal("onSuccess callback should not fire on non-2xx response")
+	}
+}
+
+// roundTripperFunc lets a test return a synthetic *http.Response with a
+// body of its choosing — useful for driving ExecuteStream over a body
+// reader that emits valid SSE bytes and then a typed transport error.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// scriptedReader emits a fixed prefix on its first Read calls and then
+// returns finalErr once the prefix has been drained. Used to simulate a
+// streaming body that delivers a complete SSE event before the transport
+// connection drops mid-stream.
+type scriptedReader struct {
+	prefix []byte
+	pos    int
+	err    error
+	closed bool
+}
+
+func (s *scriptedReader) Read(p []byte) (int, error) {
+	if s.pos < len(s.prefix) {
+		n := copy(p, s.prefix[s.pos:])
+		s.pos += n
+		return n, nil
+	}
+	return 0, s.err
+}
+
+func (s *scriptedReader) Close() error {
+	s.closed = true
+	return nil
+}
+
+func TestExecuteStream_MidStreamTransportFlakeClassified(t *testing.T) {
+	// Force the net/http dispatch path so the custom RoundTripper is the
+	// only thing that observes the request — the cache's ALPN probe must
+	// not run against a fake URL.
+	t.Setenv(EnvVarClientMode, "nethttp")
+
+	transportErr := &net.OpError{Op: "read", Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET}}
+
+	rt := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		body := &scriptedReader{
+			prefix: []byte("data: first\n\ndata: [DONE]\n\n"),
+			err:    transportErr,
+		}
+		return &http.Response{
+			Status:     "200 OK",
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       body,
+			Request:    r,
+		}, nil
+	})
+
+	client := NewClient(&http.Client{Transport: rt})
+	resp, err := client.ExecuteStream(context.Background(), &Request{
+		URL:    "http://example.invalid/",
+		Method: "POST",
+		Body:   `{}`,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream: %v", err)
+	}
+	defer resp.Close()
+
+	var events []sseclient.Event
+	for ev := range resp.Events {
+		events = append(events, ev)
+	}
+	if len(events) < 1 {
+		t.Fatal("expected at least one event before the transport drop")
+	}
+
+	streamErr := <-resp.Errc
+	if streamErr == nil {
+		t.Fatal("expected non-nil terminal error after a mid-stream ECONNRESET")
+	}
+	if !errors.Is(streamErr, ErrTransportFlake) {
+		t.Errorf("errors.Is(err, ErrTransportFlake) = false; want true; err = %v", streamErr)
+	}
+	if !errors.Is(streamErr, syscall.ECONNRESET) {
+		t.Errorf("errors.Is(err, syscall.ECONNRESET) = false; want true; err = %v", streamErr)
+	}
+}
+
+func TestExecuteStream_TruncationStaysContentIntegrity(t *testing.T) {
+	// io.ErrUnexpectedEOF (chunked truncation) must NOT be reclassified
+	// as ErrTransportFlake — the body-read site uses
+	// staleConnTeardownAcceptable=false, and the wrapper must mirror
+	// that. Truncation is a content-integrity failure, not a transport
+	// flake.
+	t.Setenv(EnvVarClientMode, "nethttp")
+
+	rt := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		body := &scriptedReader{
+			prefix: []byte("data: partial\n\n"),
+			err:    io.ErrUnexpectedEOF,
+		}
+		return &http.Response{
+			Status:     "200 OK",
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       body,
+			Request:    r,
+		}, nil
+	})
+
+	client := NewClient(&http.Client{Transport: rt})
+	resp, err := client.ExecuteStream(context.Background(), &Request{
+		URL:    "http://example.invalid/",
+		Method: "POST",
+		Body:   `{}`,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream: %v", err)
+	}
+	defer resp.Close()
+
+	for range resp.Events {
+	}
+	streamErr := <-resp.Errc
+	if streamErr == nil {
+		t.Fatal("expected non-nil terminal error for truncated body")
+	}
+	if errors.Is(streamErr, ErrTransportFlake) {
+		t.Errorf("io.ErrUnexpectedEOF must not match ErrTransportFlake; err = %v", streamErr)
+	}
+	if !errors.Is(streamErr, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(err, io.ErrUnexpectedEOF) = false; want true; err = %v", streamErr)
 	}
 }


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes one item from the #199 sentinel-error coverage audit (item 7).

The non-streaming HTTP body-read path classifies typed transport errors (`ECONNRESET`, `EPIPE`, `ECONNREFUSED`, `net.ErrClosed`, gated stale-connection teardown shapes, HTTP/2 GOAWAY, gated bare `io.EOF`) through `classifyTransportErr`, exposing `ErrTransportFlake` identity for downstream `errors.Is` checks. The streaming paths (`ExecuteStream` stdlib + `executeStreamFast`) forwarded `errc` raw, so mid-stream typed transport drops bypassed the sentinel after `orchestrator.go` wrapping.

This adds a small helper that classifies non-nil values from a stream `errc` channel and uses it at both call sites. `io.ErrUnexpectedEOF` content-integrity behavior is preserved.

## Test plan

- [ ] `ExecuteStream` unit test: SSE body emits ≥1 event then a typed `ECONNRESET`; `errors.Is(err, ErrTransportFlake)` and `errors.Is(err, syscall.ECONNRESET)` both match.
- [ ] Fast-path or helper-level test for the same shape.
- [ ] Truncation behavior (`io.ErrUnexpectedEOF`) unchanged — existing `fast_backend_test.go` truncation tests still pass.
- [ ] `go test ./bamlutils/...` clean.
- [ ] `go test ./adapters/...` clean (transport-flake gate at `call_orchestrator_test.go:1097` continues to consume `ErrTransportFlake`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling for streaming responses by enhancing error classification logic to better distinguish temporary network failures (connection resets, broken pipes, closed connections) from genuine content integrity issues, providing more accurate error diagnostics and improved reliability for streaming operations.

## Tests
* Added comprehensive test coverage validating streaming error classification behavior, including handling of network failures and content-related errors under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->