### PR TITLE
fix(sync): preserve adapter BAML pins; remove common from go.work

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,3 +50,18 @@ jobs:
         # check has been green for ≥N consecutive main-branch runs covering
         # at least one PR touching adapters/ or adapters/common/codegen/.
         run: go run ./cmd/verify-framework-adapter
+
+      - name: scripts/sync.sh fresh-tree gate
+        # Fresh-tree gate for the sync.sh / per-adapter BAML-pin contract.
+        # Running sync.sh on a clean checkout must leave every pinned
+        # module's go.mod / go.sum byte-identical: if `go work sync` ever
+        # lifts a pin (the regression fixed by removing adapters/common
+        # from go.work), this step fails with a diff. The verify step
+        # double-asserts the pin matrix via cmd/verify-adapter-pins so a
+        # diff-free-but-wrong state can't slip through either.
+        run: |
+          git status --porcelain
+          ./scripts/sync.sh
+          git diff --exit-code -- \
+            adapters/common/go.mod adapters/common/go.sum \
+            'adapters/adapter_v0_*/go.mod' 'adapters/adapter_v0_*/go.sum'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,9 +35,23 @@ jobs:
           # Adapter modules run their own tests inside cmd/build/build.sh
           # during the integration test workflow, against the BAML version
           # they're pinned to.
+          #
+          # adapters/common is also outside go.work (it directly requires
+          # github.com/boundaryml/baml v0.204.0; keeping it in the workspace
+          # would make go work sync lift its BAML pin to the workspace MVS
+          # max — see go.work for the full rationale). With go.work active,
+          # `go test ./...` from inside common resolves through the
+          # workspace's main module (root), which doesn't contain
+          # adapters/common packages, and fails setup. GOWORK=off forces
+          # common's own go.mod to be the build list — same envelope
+          # scripts/sync.sh uses for the per-adapter tidies.
           find . -name go.mod -not -path '*/adapters/adapter_*' -exec dirname {} \; | while read dir; do
             echo "=== Testing $dir ==="
-            (cd "$dir" && go test -race -count=100 ./...)
+            if [ "$dir" = "./adapters/common" ]; then
+              (cd "$dir" && GOWORK=off go test -race -count=100 ./...)
+            else
+              (cd "$dir" && go test -race -count=100 ./...)
+            fi
           done
 
       - name: Verify framework adapter codegen-emit

--- a/adapters/common/adapterversions/adapterversions.go
+++ b/adapters/common/adapterversions/adapterversions.go
@@ -1,6 +1,6 @@
 // Package adapterversions is the canonical inventory of pinned BAML
 // adapter versions baml-rest supports, plus the codegen.Options each
-// version requires. Two consumers share this list:
+// version requires. Three consumers share this list:
 //
 //   - cmd/verify-framework-adapter (the PR 4a CI verifier) iterates
 //     FrameworkAdapters to run the structural-equivalence /
@@ -9,6 +9,9 @@
 //   - Each adapters/adapter_v0_<X>_0/cmd/main.go calls
 //     MustOptionsForSelfPkg to fetch its own options without
 //     re-declaring the matrix.
+//   - cmd/verify-adapter-pins iterates PinnedModules to assert each
+//     pinned go.mod still resolves github.com/boundaryml/baml to its
+//     canonical version after `scripts/sync.sh` runs.
 //
 // Keeping the list in one place avoids the (verifier, 3 cmd/main.go)
 // duplication and means new adapter versions or new feature flags get
@@ -30,6 +33,12 @@ type FrameworkAdapter struct {
 	// "adapter_v0_204_0". Consumed by the verifier to build paths
 	// like adapters/<DirName>/adapter/adapter.go.
 	DirName string
+	// BAMLVersion is the canonical github.com/boundaryml/baml pin for
+	// this adapter's go.mod, e.g. "v0.204.0". The pin verifier reads
+	// this to assert that `go list -m github.com/boundaryml/baml`
+	// inside adapters/<DirName> still returns this exact version
+	// after `scripts/sync.sh` runs.
+	BAMLVersion string
 	// Options is the per-version codegen feature matrix the adapter's
 	// cmd/main.go would otherwise inline. Every field codegen.Options
 	// carries today is captured here so consumers don't accidentally
@@ -42,7 +51,8 @@ type FrameworkAdapter struct {
 // per-version flag values are paired with their SelfPkg here.
 var FrameworkAdapters = []FrameworkAdapter{
 	{
-		DirName: "adapter_v0_204_0",
+		DirName:     "adapter_v0_204_0",
+		BAMLVersion: "v0.204.0",
 		Options: codegen.Options{
 			SelfPkg:            "github.com/invakid404/baml-rest/adapters/adapter_v0_204_0",
 			SupportsWithClient: false,
@@ -51,7 +61,8 @@ var FrameworkAdapters = []FrameworkAdapter{
 		},
 	},
 	{
-		DirName: "adapter_v0_215_0",
+		DirName:     "adapter_v0_215_0",
+		BAMLVersion: "v0.215.0",
 		Options: codegen.Options{
 			SelfPkg:            "github.com/invakid404/baml-rest/adapters/adapter_v0_215_0",
 			SupportsWithClient: false,
@@ -60,7 +71,8 @@ var FrameworkAdapters = []FrameworkAdapter{
 		},
 	},
 	{
-		DirName: "adapter_v0_219_0",
+		DirName:     "adapter_v0_219_0",
+		BAMLVersion: "v0.219.0",
 		Options: codegen.Options{
 			SelfPkg:            "github.com/invakid404/baml-rest/adapters/adapter_v0_219_0",
 			SupportsWithClient: true,
@@ -68,6 +80,33 @@ var FrameworkAdapters = []FrameworkAdapter{
 			HasHTTPClient:      true,
 		},
 	},
+}
+
+// PinnedModule is one (DirName, BAMLVersion) pair that the pin
+// verifier asserts against. PinnedModules is the union of
+// adapters/common (which is not a FrameworkAdapter — it has no
+// codegen.Options matrix — but does pin a BAML version that must not
+// drift) and the FrameworkAdapters set.
+type PinnedModule struct {
+	// DirName is the path relative to the repo root, e.g.
+	// "adapters/common" or "adapters/adapter_v0_204_0". The verifier
+	// resolves it under repoRoot to run `go list -m`.
+	DirName string
+	// BAMLVersion is the canonical github.com/boundaryml/baml pin
+	// expected for the module at DirName.
+	BAMLVersion string
+}
+
+// PinnedModules is the canonical pin matrix consumed by
+// cmd/verify-adapter-pins. The common module pins the lowest adapter
+// BAML version (v0.204.0) so that the local `replace ../common`
+// directives in each adapter's go.mod can satisfy v0.204.0,
+// v0.215.0, and v0.219.0 without pulling any adapter forward.
+var PinnedModules = []PinnedModule{
+	{DirName: "adapters/common", BAMLVersion: "v0.204.0"},
+	{DirName: "adapters/adapter_v0_204_0", BAMLVersion: "v0.204.0"},
+	{DirName: "adapters/adapter_v0_215_0", BAMLVersion: "v0.215.0"},
+	{DirName: "adapters/adapter_v0_219_0", BAMLVersion: "v0.219.0"},
 }
 
 // MustOptionsForSelfPkg returns the codegen.Options registered for

--- a/adapters/common/go.sum
+++ b/adapters/common/go.sum
@@ -14,6 +14,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ghetzel/testify v1.4.1 h1:wpJirdM+znAnxWruGDBdIys5aU+wGJHNUTkgEo4PYwk=
+github.com/ghetzel/testify v1.4.1/go.mod h1:FwvFn1OiGEUgzhS3ySCjTBG7/sez0WRvOAxz5uQU8so=
 github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
 github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
@@ -60,6 +62,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/verify-adapter-pins/main.go
+++ b/cmd/verify-adapter-pins/main.go
@@ -1,0 +1,128 @@
+// verify-adapter-pins asserts that every module listed in
+// adapterversions.PinnedModules still resolves
+// github.com/boundaryml/baml to its canonical pin. It is the
+// post-tidy gate scripts/sync.sh runs to catch the workspace-MVS lift
+// regression that motivated this command (see go.work for the full
+// rationale): if `go work sync` ever pulls common's BAML pin forward,
+// the per-adapter `replace ../common` directives propagate the lift
+// into every adapter on the next `go mod tidy`, silently breaking
+// per-adapter version isolation.
+//
+// For each PinnedModule p, the verifier runs
+//
+//	GOWORK=off go list -m github.com/boundaryml/baml
+//
+// inside <repoRoot>/<p.DirName> and compares the second whitespace-
+// separated field to p.BAMLVersion. GOWORK=off is mandatory: with a
+// workspace active, `go list -m` returns the workspace-resolved
+// version, not the per-module pin we want to assert.
+//
+// Exit codes: 0 = every pin matches; 1 = one or more mismatches; 2 =
+// invocation error (wrong cwd, subprocess failure, etc.).
+//
+// Invocation:
+//
+//	cd <repo-root>
+//	go run ./cmd/verify-adapter-pins
+//
+// scripts/sync.sh invokes this as the final step of a normal sync,
+// and `scripts/sync.sh --check-pins-only` runs only this verifier.
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/invakid404/baml-rest/adapters/common/adapterversions"
+)
+
+// goListTimeout caps each `go list -m` subprocess. The command is
+// metadata-only and finishes well under a second on a warm cache; 30s
+// is the same circuit-breaker pattern cmd/verify-framework-adapter
+// uses for gofmt.
+const goListTimeout = 30 * time.Second
+
+const bamlModulePath = "github.com/boundaryml/baml"
+
+func main() {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		fail("getcwd: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repoRoot, "go.work")); err != nil {
+		fail("must be invoked from the repo root (no go.work in %s)", repoRoot)
+	}
+
+	type drift struct {
+		dirName string
+		got     string
+		want    string
+	}
+	var drifts []drift
+
+	for _, p := range adapterversions.PinnedModules {
+		got, err := resolveBAMLVersion(repoRoot, p.DirName)
+		if err != nil {
+			fail("resolve baml version for %s: %v", p.DirName, err)
+		}
+		if got != p.BAMLVersion {
+			drifts = append(drifts, drift{dirName: p.DirName, got: got, want: p.BAMLVersion})
+			fmt.Printf("  %s: got %s, want %s  FAIL\n", p.DirName, got, p.BAMLVersion)
+			continue
+		}
+		fmt.Printf("  %s: %s  ok\n", p.DirName, got)
+	}
+
+	if len(drifts) > 0 {
+		fmt.Fprintf(os.Stderr, "\nadapter pin drift:\n")
+		for _, d := range drifts {
+			fmt.Fprintf(os.Stderr, "  %s: got %s, want %s\n", d.dirName, d.got, d.want)
+		}
+		os.Exit(1)
+	}
+	fmt.Printf("\nAll %d pinned BAML version(s) match.\n", len(adapterversions.PinnedModules))
+}
+
+// resolveBAMLVersion runs `GOWORK=off go list -m
+// github.com/boundaryml/baml` in <repoRoot>/<dirName> and returns the
+// resolved version string (e.g. "v0.204.0"). GOWORK=off is required
+// so the per-module go.mod is the source of truth — under a workspace
+// the command would return the workspace-MVS-selected version
+// instead, which is exactly the value the verifier exists to detect.
+func resolveBAMLVersion(repoRoot, dirName string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), goListTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "list", "-m", bamlModulePath)
+	cmd.Dir = filepath.Join(repoRoot, dirName)
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return "", fmt.Errorf("go list -m timed out after %s in %s: %s", goListTimeout, dirName, errb.String())
+	}
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, errb.String())
+	}
+	// `go list -m <path>` prints "<path> <version>" on a single line.
+	// Anything else is a toolchain shape change worth surfacing
+	// loudly rather than silently parsing the wrong field.
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) < 2 {
+		return "", fmt.Errorf("unexpected `go list -m` output for %s: %q", dirName, out.String())
+	}
+	return fields[1], nil
+}
+
+func fail(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, "verify-adapter-pins: "+format+"\n", a...)
+	os.Exit(2)
+}

--- a/embed.go
+++ b/embed.go
@@ -15,7 +15,7 @@ import (
 	"github.com/invakid404/baml-rest/workerplugin"
 )
 
-//go:embed adapter.go adapters cmd/build cmd/embed cmd/hacks cmd/introspect/main.go cmd/schema cmd/serve/debug.go cmd/serve/debug_stub.go cmd/serve/error.go cmd/serve/headers.go cmd/serve/main.go cmd/serve/openapi.json cmd/serve/streamwriter.go cmd/serve/unary.go cmd/serve/unary_handlers.go cmd/serve/unary_stub.go cmd/serve/worker cmd/verify-framework-adapter/main.go cmd/worker/main.go embed.go go.mod go.sum go.work go.work.sum internal/apierror internal/httplogger internal/memlimit/memlimit.go internal/unsafeutil renovate.json scripts
+//go:embed adapter.go adapters cmd/build cmd/embed cmd/hacks cmd/introspect/main.go cmd/schema cmd/serve/debug.go cmd/serve/debug_stub.go cmd/serve/error.go cmd/serve/headers.go cmd/serve/main.go cmd/serve/openapi.json cmd/serve/streamwriter.go cmd/serve/unary.go cmd/serve/unary_handlers.go cmd/serve/unary_stub.go cmd/serve/worker cmd/verify-adapter-pins cmd/verify-framework-adapter/main.go cmd/worker/main.go embed.go go.mod go.sum go.work go.work.sum internal/apierror internal/httplogger internal/memlimit/memlimit.go internal/unsafeutil renovate.json scripts
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/go.work
+++ b/go.work
@@ -1,12 +1,21 @@
 go 1.26.2
 
-// NOTE: ./adapters/adapter_v* directories are intentionally NOT included in
-// this workspace. Each adapter pins a specific github.com/boundaryml/baml
-// version that represents a different compatibility level, and Go's module
-// system enforces a single resolved version per module path across all
-// workspace modules (via Minimum Version Selection). Adding the adapters
-// here causes `go work sync` to bump every adapter's pinned BAML version to
-// the highest one across the workspace, defeating the per-adapter pinning.
+// NOTE: ./adapters/adapter_v* and ./adapters/common are intentionally NOT
+// included in this workspace. Each adapter pins a specific
+// github.com/boundaryml/baml version that represents a different
+// compatibility level, and Go's module system enforces a single resolved
+// version per module path across all workspace modules (via Minimum Version
+// Selection). Adding the adapters here causes `go work sync` to bump every
+// adapter's pinned BAML version to the highest one across the workspace,
+// defeating the per-adapter pinning.
+//
+// adapters/common is also excluded for the same reason: it directly requires
+// github.com/boundaryml/baml, and each adapter_v* go.mod has a local
+// `replace ../common` that propagates whatever BAML version common pins. If
+// common is a workspace member, `go work sync` lifts it to the workspace-MVS
+// max (currently v0.219.0, because root go.mod requires + replaces all three
+// versioned adapters), and the next `GOWORK=off go mod tidy` in each adapter
+// then propagates that lifted requirement back into the adapter pins.
 //
 // Each adapter is reachable from the root module via the `replace` directives
 // in go.mod, so editor tooling and the build scripts continue to work; for
@@ -17,11 +26,12 @@ go 1.26.2
 //
 // To refresh indirect dependencies in the workspace AND in the per-adapter
 // modules without bumping the pinned BAML versions, run `./scripts/sync.sh`
-// from anywhere in the repo. It runs `go work sync` for the workspace members
-// and then `GOWORK=off go mod tidy` in each adapter directory.
+// from anywhere in the repo. It runs `go work sync` for the workspace
+// members, then `GOWORK=off go mod tidy` in adapters/common and each
+// adapter_v* directory, and finally asserts the BAML pin matrix via
+// cmd/verify-adapter-pins.
 use (
 	.
-	./adapters/common
 	./bamlutils
 	./introspected
 	./pool

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -2,26 +2,38 @@
 set -euo pipefail
 
 # sync.sh — the equivalent of `go work sync` for a repo whose
-# adapter_v* modules sit outside the workspace on purpose.
+# adapter_v* and adapters/common modules sit outside the workspace on
+# purpose.
 #
 # Each adapters/adapter_vX_Y_Z module pins a specific
 # github.com/boundaryml/baml version on purpose; including them in
-# go.work would make MVS bump every adapter to the highest BAML version
-# (see go.work for the full rationale).
+# go.work would make MVS bump every adapter to the highest BAML
+# version (see go.work for the full rationale). adapters/common is
+# excluded for the same reason: it directly requires BAML and each
+# adapter has a local `replace ../common` that propagates whatever
+# version common pins.
 #
 # This script:
 #   1. Runs `go work sync` for the workspace members so their go.mod
 #      files stay reconciled the way they always were.
-#   2. Walks adapters/adapter_v*/go.mod and runs `GOWORK=off go mod
-#      tidy` in each one. Tidying with GOWORK=off forces Go to use that
-#      adapter's own go.mod for the build list, so MVS only ever sees
-#      the single BAML version that adapter pins. Indirect requires get
-#      refreshed without disturbing the BAML pin.
+#   2. Runs `GOWORK=off go mod tidy` in adapters/common. common is no
+#      longer in the workspace, so `go work sync` won't refresh its
+#      indirect requires; tidy it explicitly with the per-module
+#      go.mod as the build list so its BAML pin stays at the
+#      lowest-adapter version.
+#   3. Walks adapters/adapter_v*/go.mod and runs `GOWORK=off go mod
+#      tidy` in each one. Tidying with GOWORK=off forces Go to use
+#      that adapter's own go.mod for the build list, so MVS only ever
+#      sees the single BAML version that adapter pins. Indirect
+#      requires get refreshed without disturbing the BAML pin.
+#   4. Runs cmd/verify-adapter-pins to assert that every pinned
+#      module's go.mod still resolves the canonical BAML version.
 #
 # Usage:
-#   scripts/sync.sh                  # workspace + every adapter
-#   scripts/sync.sh --only-workspace # skip per-adapter tidy
+#   scripts/sync.sh                  # workspace + every adapter + verify
+#   scripts/sync.sh --only-workspace # skip per-adapter tidy + verify
 #   scripts/sync.sh --only-adapters  # skip `go work sync`
+#   scripts/sync.sh --check-pins-only# skip every tidy step; only verify
 #   scripts/sync.sh -h | --help      # print this header
 
 usage() {
@@ -30,18 +42,27 @@ usage() {
 
 only_workspace=false
 only_adapters=false
+check_pins_only=false
 
 for arg in "$@"; do
     case "$arg" in
-        --only-workspace) only_workspace=true ;;
-        --only-adapters)  only_adapters=true ;;
-        -h|--help)        usage; exit 0 ;;
+        --only-workspace)  only_workspace=true ;;
+        --only-adapters)   only_adapters=true ;;
+        --check-pins-only) check_pins_only=true ;;
+        -h|--help)         usage; exit 0 ;;
         *) echo "ERROR: unknown flag: $arg" >&2; usage >&2; exit 2 ;;
     esac
 done
 
-if $only_workspace && $only_adapters; then
-    echo "ERROR: --only-workspace and --only-adapters are mutually exclusive" >&2
+# --check-pins-only is meant to be used by itself; combining it with
+# either --only-* flag would silently override one of them, which is
+# never what the caller wants.
+mode_count=0
+$only_workspace  && mode_count=$((mode_count + 1))
+$only_adapters   && mode_count=$((mode_count + 1))
+$check_pins_only && mode_count=$((mode_count + 1))
+if [ "$mode_count" -gt 1 ]; then
+    echo "ERROR: --only-workspace, --only-adapters, and --check-pins-only are mutually exclusive" >&2
     exit 2
 fi
 
@@ -60,6 +81,26 @@ if [ ! -f "$repo_root/go.work" ]; then
 fi
 cd "$repo_root"
 
+# common_dir and adapter_dirs are populated up-front so the same lists
+# drive the tidy loop and the pin-only path. Using nullglob means a
+# layout change that drops every adapter directory is a clean no-op
+# rather than a failed glob expansion.
+common_dir="adapters/common"
+shopt -s nullglob
+adapter_dirs=(adapters/adapter_v*/)
+shopt -u nullglob
+
+verify_pins() {
+    echo
+    echo "Verifying BAML pin matrix..."
+    go run ./cmd/verify-adapter-pins
+}
+
+if $check_pins_only; then
+    verify_pins
+    exit 0
+fi
+
 if ! $only_adapters; then
     echo "Running \`go work sync\`..."
     go work sync
@@ -70,9 +111,15 @@ if $only_workspace; then
     exit 0
 fi
 
-shopt -s nullglob
-adapter_dirs=(adapters/adapter_v*/)
-shopt -u nullglob
+# adapters/common is no longer a workspace member, so `go work sync`
+# above no longer refreshes it. Tidy it explicitly before the adapter
+# loop so the adapters' `replace ../common` directives see an
+# up-to-date common/go.mod with its BAML pin still at the canonical
+# lowest-adapter version.
+if [ -f "$common_dir/go.mod" ]; then
+    echo "Tidying $common_dir with GOWORK=off..."
+    (cd "$common_dir" && GOWORK=off go mod tidy)
+fi
 
 count=0
 for dir in "${adapter_dirs[@]}"; do
@@ -91,12 +138,17 @@ done
 
 if [ "$count" -eq 0 ]; then
     echo "No adapter version modules to tidy."
+    # Still verify pins — the common module has a pin to assert even
+    # in a layout with zero versioned adapters.
+    verify_pins
     exit 0
 fi
 
+verify_pins
+
 echo
 if $only_adapters; then
-    echo "Done. Synced $count adapter(s)."
+    echo "Done. Synced $count adapter(s) + common."
 else
-    echo "Done. Synced workspace + $count adapter(s)."
+    echo "Done. Synced workspace + common + $count adapter(s)."
 fi


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

`./scripts/sync.sh` on a fresh `gh repo clone` was lifting `adapter_v0_204_0` and `adapter_v0_215_0`'s BAML pins to `v0.219.0`. PR #205 had removed versioned adapters from `go.work` to prevent workspace-MVS lifts, but PR #215 later added `github.com/boundaryml/baml v0.204.0` as a direct requirement of `adapters/common` — and common was still a workspace member. `go work sync` therefore lifted common to the workspace-MVS-selected `v0.219.0`, and each adapter's `replace ../common` propagated the lift through `go mod tidy`.

This PR closes the gap:

- Removes `./adapters/common` from `go.work` so `go work sync` no longer touches it.
- `scripts/sync.sh` now tidies `adapters/common` explicitly with `GOWORK=off` before the adapter loop, then runs `cmd/verify-adapter-pins` as the post-tidy assertion. New `--check-pins-only` flag runs only the verifier.
- `cmd/verify-adapter-pins` iterates `adapterversions.PinnedModules` (common + 3 adapters) and asserts `GOWORK=off go list -m github.com/boundaryml/baml` returns the canonical pin per module. Failure prints a drift summary and exits 1.
- `adapters/common/adapterversions` gains `BAMLVersion` on `FrameworkAdapter` and a sibling `PinnedModules` inventory so the matrix has one source of truth.
- CI gate runs `sync.sh` on a fresh checkout and asserts no diff in any pinned module's `go.mod` / `go.sum`.
- `adapters/common/go.sum` picks up two transitive test sums (`ghetzel/testify`, `gopkg.in/yaml.v2`) that the previous workspace-MVS tidy flow pruned; tidying common standalone with `GOWORK=off` correctly includes them.

## Test plan

- [x] Fresh `gh repo clone` of the branch + `./scripts/sync.sh` produces no diff in `adapters/`.
- [x] All 4 pins match canonical: common = v0.204.0; adapter_v0_204 = v0.204.0; adapter_v0_215 = v0.215.0; adapter_v0_219 = v0.219.0.
- [x] `cmd/verify-framework-adapter` still passes 9/9.
- [ ] CI gate fails when intentionally drifting a pin.
- [x] Per-adapter `GOWORK=off go list -m github.com/boundaryml/baml` resolves canonical version locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an adapter pin verification tool to ensure each adapter is pinned to the expected BAML version.

* **Tests**
  * CI now runs a fresh-tree sync check that fails if adapter pin files diverge, preventing version drift during sync.

* **Chores**
  * Sync workflow and tooling updated to include explicit pin-only verification mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->