### PR TITLE
feat(apierror): forward worker errors and add classification codes

### DIFF
--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -475,6 +475,43 @@ func generateOpenAPISchema() *openapi3.T {
 		},
 	}
 
+	// Enum of stable error classification codes. Kept in sync by hand
+	// with the apierror.Code constants in internal/apierror/error.go;
+	// add new codes in both places. Clients (humans and LLM agents)
+	// should branch on `code` rather than parsing `error`.
+	errorCodeEnum := []any{
+		"invalid_json",
+		"invalid_request",
+		"request_too_large",
+		"body_read_error",
+		"not_acceptable",
+		"request_canceled",
+		"worker_unavailable",
+		"worker_error",
+		"parse_error",
+		"internal_error",
+	}
+	errorCodeSchema := func() *openapi3.SchemaRef {
+		return &openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				Type:        &openapi3.Types{openapi3.TypeString},
+				Description: "Stable, machine-readable error class. Branch on this rather than parsing the message.",
+				Enum:        errorCodeEnum,
+			},
+		}
+	}
+	errorDetailsSchema := func() *openapi3.SchemaRef {
+		return &openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				Type:        &openapi3.Types{openapi3.TypeObject},
+				Description: "Optional structured context. May carry {\"stacktrace\": \"...\"} on worker panics, or worker-supplied diagnostic fields when available. Absent when no structured details exist.",
+				AdditionalProperties: openapi3.AdditionalProperties{
+					Has: boolPtr(true),
+				},
+			},
+		}
+	}
+
 	streamErrorEventSchemaName := "__StreamErrorEvent__"
 	schemas[streamErrorEventSchemaName] = &openapi3.SchemaRef{
 		Value: &openapi3.Schema{
@@ -493,6 +530,8 @@ func generateOpenAPISchema() *openapi3.T {
 						Description: "Error message describing what went wrong",
 					},
 				},
+				"code":    errorCodeSchema(),
+				"details": errorDetailsSchema(),
 			},
 			Required: []string{"type", "error"},
 		},
@@ -511,6 +550,8 @@ func generateOpenAPISchema() *openapi3.T {
 						Description: "Error message describing what went wrong",
 					},
 				},
+				"code":    errorCodeSchema(),
+				"details": errorDetailsSchema(),
 				"request_id": &openapi3.SchemaRef{
 					Value: &openapi3.Schema{
 						Type:        &openapi3.Types{openapi3.TypeString},

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/goccy/go-json"
 	baml_rest "github.com/invakid404/baml-rest"
 	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/apierror"
 )
 
 func main() {
@@ -475,21 +476,14 @@ func generateOpenAPISchema() *openapi3.T {
 		},
 	}
 
-	// Enum of stable error classification codes. Kept in sync by hand
-	// with the apierror.Code constants in internal/apierror/error.go;
-	// add new codes in both places. Clients (humans and LLM agents)
-	// should branch on `code` rather than parsing `error`.
-	errorCodeEnum := []any{
-		"invalid_json",
-		"invalid_request",
-		"request_too_large",
-		"body_read_error",
-		"not_acceptable",
-		"request_canceled",
-		"worker_unavailable",
-		"worker_error",
-		"parse_error",
-		"internal_error",
+	// Enum of stable error classification codes, sourced directly
+	// from internal/apierror so the OpenAPI schema can never drift
+	// from the runtime contract. Add new codes there; this slice
+	// updates automatically.
+	apiCodes := apierror.AllCodes()
+	errorCodeEnum := make([]any, len(apiCodes))
+	for i, c := range apiCodes {
+		errorCodeEnum[i] = string(c)
 	}
 	errorCodeSchema := func() *openapi3.SchemaRef {
 		return &openapi3.SchemaRef{

--- a/cmd/serve/error.go
+++ b/cmd/serve/error.go
@@ -21,12 +21,15 @@ func writeFiberJSONError(c fiber.Ctx, message string, statusCode int) error {
 
 // writeFiberJSONErrorWithCode writes a JSON error response carrying a
 // machine-readable code and optional structured details. Pass code=""
-// and details=nil to omit those fields.
+// and details=nil to omit those fields. details is validated through
+// apierror.ValidDetails so an invalid json.RawMessage cannot corrupt
+// the encoded body — same defense-in-depth as apierror.WriteJSONWithCode
+// applies on the chi side.
 func writeFiberJSONErrorWithCode(c fiber.Ctx, message string, code apierror.Code, details json.RawMessage, statusCode int) error {
 	return c.Status(statusCode).JSON(apierror.Response{
 		Error:     message,
 		Code:      code,
-		Details:   details,
+		Details:   apierror.ValidDetails(details),
 		RequestID: fiberrequestid.FromContext(c),
 	})
 }

--- a/cmd/serve/error.go
+++ b/cmd/serve/error.go
@@ -40,6 +40,14 @@ func writeFiberJSONErrorWithCode(c fiber.Ctx, message string, code apierror.Code
 // 408 (so client-driven aborts don't inflate 5xx metrics) and everything
 // else to 500 with the classified code/details.
 //
+// Even on the 408 cancellation tail the original err.Error() is forwarded
+// (rather than a fixed "request canceled" string), so the response
+// distinguishes context.Canceled vs context.DeadlineExceeded vs deeper
+// pool diagnostic wraps like "could not acquire worker: context deadline
+// exceeded (pool error: ...)". The 408 status + request_canceled code
+// convey the semantic class; the body keeps the discriminating message
+// so LLM-agent consumers and human debuggers can act on it.
+//
 // Stacktraces from worker panics, when present, are forwarded as
 // details.stacktrace so an LLM agent receiving the error as feedback has
 // the full picture. The full error is also logged via httplogger.SetError
@@ -47,7 +55,7 @@ func writeFiberJSONErrorWithCode(c fiber.Ctx, message string, code apierror.Code
 func writeFiberWorkerError(c fiber.Ctx, err error) error {
 	code, details := classifyWorkerError(err)
 	if code == apierror.CodeRequestCanceled {
-		return writeFiberJSONErrorWithCode(c, "request canceled", code, details, fiber.StatusRequestTimeout)
+		return writeFiberJSONErrorWithCode(c, err.Error(), code, details, fiber.StatusRequestTimeout)
 	}
 	httplogger.SetError(c.Context(), err)
 	return writeFiberJSONErrorWithCode(c, err.Error(), code, details, fiber.StatusInternalServerError)
@@ -60,7 +68,7 @@ func writeFiberWorkerError(c fiber.Ctx, err error) error {
 func writeFiberParseWorkerError(c fiber.Ctx, err error) error {
 	code, details := classifyWorkerError(err)
 	if code == apierror.CodeRequestCanceled {
-		return writeFiberJSONErrorWithCode(c, "request canceled", code, details, fiber.StatusRequestTimeout)
+		return writeFiberJSONErrorWithCode(c, err.Error(), code, details, fiber.StatusRequestTimeout)
 	}
 	httplogger.SetError(c.Context(), err)
 	if code == apierror.CodeWorkerError {
@@ -205,7 +213,7 @@ func writeChiJSONErrorWithCode(w http.ResponseWriter, r *http.Request, message s
 func writeChiWorkerErrorClassified(w http.ResponseWriter, r *http.Request, err error) {
 	code, details := classifyWorkerError(err)
 	if code == apierror.CodeRequestCanceled {
-		writeChiJSONErrorWithCode(w, r, "request canceled", code, details, http.StatusRequestTimeout)
+		writeChiJSONErrorWithCode(w, r, err.Error(), code, details, http.StatusRequestTimeout)
 		return
 	}
 	httplogger.SetError(r.Context(), err)
@@ -215,7 +223,7 @@ func writeChiWorkerErrorClassified(w http.ResponseWriter, r *http.Request, err e
 func writeChiParseWorkerError(w http.ResponseWriter, r *http.Request, err error) {
 	code, details := classifyWorkerError(err)
 	if code == apierror.CodeRequestCanceled {
-		writeChiJSONErrorWithCode(w, r, "request canceled", code, details, http.StatusRequestTimeout)
+		writeChiJSONErrorWithCode(w, r, err.Error(), code, details, http.StatusRequestTimeout)
 		return
 	}
 	httplogger.SetError(r.Context(), err)

--- a/cmd/serve/error.go
+++ b/cmd/serve/error.go
@@ -89,6 +89,37 @@ func writeFiberInternalError(c fiber.Ctx, err error) error {
 	return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInternalError, nil, fiber.StatusInternalServerError)
 }
 
+// fiberErrorHandler is the app-wide ErrorHandler. It catches
+// framework-emitted errors (BodyLimit/413, route 404/405, malformed
+// transport-level requests) plus any error a handler returned
+// without writing a response itself, and converts them into the
+// apierror JSON envelope so the wire shape is identical to what the
+// chi path emits. Without this, Fiber's default ErrorHandler returns
+// text/plain and strips the apierror.Code field — clients (and LLM
+// agents) consuming errors then can't branch on the code at all for
+// framework-level failures.
+//
+// Mapping:
+//   - *fiber.Error 413 → CodeRequestTooLarge (parity with chi's
+//     writeChiBodyReadError handling of MaxBytesReader exhaustion).
+//   - Other *fiber.Error → JSON envelope with the framework-supplied
+//     status and message; no apierror.Code is set because the host
+//     has nothing meaningful to add (the fiber.Error message already
+//     names the class — "Method Not Allowed", "Not Found", etc.).
+//   - Anything else (a handler returning a non-fiber.Error without
+//     writing a response): 500 internal_error.
+func fiberErrorHandler(c fiber.Ctx, err error) error {
+	var fiberErr *fiber.Error
+	if errors.As(err, &fiberErr) {
+		var code apierror.Code
+		if fiberErr.Code == fiber.StatusRequestEntityTooLarge {
+			code = apierror.CodeRequestTooLarge
+		}
+		return writeFiberJSONErrorWithCode(c, fiberErr.Message, code, nil, fiberErr.Code)
+	}
+	return writeFiberInternalError(c, err)
+}
+
 // classifyWorkerError inspects err and returns the apierror.Code that
 // best describes the failure plus any structured details that should
 // reach the client envelope. Precedence:

--- a/cmd/serve/error.go
+++ b/cmd/serve/error.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"net/http"
 
@@ -106,19 +107,21 @@ func writeFiberInternalError(c fiber.Ctx, err error) error {
 // Stacktraces are also independently logged via httplogger.SetError —
 // the response copy is the explicit, agent-facing channel.
 func classifyWorkerError(err error) (apierror.Code, json.RawMessage) {
+	var workerCode apierror.Code
 	var details json.RawMessage
 
 	var stackErr *workerplugin.ErrorWithStack
 	if errors.As(err, &stackErr) {
-		if d := stackErr.GetDetails(); len(d) > 0 && json.Valid(d) {
-			details = json.RawMessage(d)
-		} else if st := stackErr.GetStacktrace(); st != "" {
-			details = stacktraceDetailsJSON(st)
+		workerCode, details = normalizeWorkerMetadata(stackErr.GetCode(), stackErr.GetDetails())
+		if details == nil {
+			if st := stackErr.GetStacktrace(); st != "" {
+				details = stacktraceDetailsJSON(st)
+			}
 		}
 	}
 
-	if stackErr != nil && stackErr.GetCode() != "" {
-		return apierror.Code(stackErr.GetCode()), details
+	if workerCode != "" {
+		return workerCode, details
 	}
 
 	if errors.Is(err, pool.ErrPoolRetriesExhausted) {
@@ -133,6 +136,43 @@ func classifyWorkerError(err error) (apierror.Code, json.RawMessage) {
 		return apierror.CodeWorkerUnavailable, details
 	}
 	return apierror.CodeWorkerError, details
+}
+
+// normalizeWorkerMetadata accepts the raw worker-supplied code +
+// details bytes and returns the contract-compliant pair to put on the
+// response envelope. The host treats both fields as untrusted because
+// they're authored worker-side and there's no shared schema enforcing
+// them, so off-contract values are dropped rather than forwarded:
+//
+//   - code is preserved only if it's one of the documented apierror.Code
+//     constants (apierror.Code.IsKnown). Unknown codes return ""
+//     (empty), which makes classifyWorkerError fall through to host-
+//     side classification — the public OpenAPI enum stays authoritative.
+//   - details is preserved only if it parses as a JSON OBJECT; scalars,
+//     arrays, and null are dropped. The OpenAPI schema declares
+//     details as an object (additionalProperties), so anything else
+//     would lie about the contract and confuse generated clients.
+func normalizeWorkerMetadata(rawCode string, rawDetails []byte) (apierror.Code, json.RawMessage) {
+	var code apierror.Code
+	if c := apierror.Code(rawCode); c.IsKnown() {
+		code = c
+	}
+	var details json.RawMessage
+	if isJSONObject(rawDetails) {
+		details = json.RawMessage(rawDetails)
+	}
+	return code, details
+}
+
+// isJSONObject reports whether b is a syntactically valid JSON
+// document AND its top-level value is an object (`{...}`). Used to
+// gate worker-supplied details against the OpenAPI contract.
+func isJSONObject(b []byte) bool {
+	trimmed := bytes.TrimLeft(b, " \t\n\r")
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return false
+	}
+	return json.Valid(trimmed)
 }
 
 // stacktraceDetailsJSON marshals st into the canonical

--- a/cmd/serve/error.go
+++ b/cmd/serve/error.go
@@ -82,29 +82,47 @@ func writeFiberInternalError(c fiber.Ctx, err error) error {
 // reach the client envelope. Precedence:
 //  1. Worker-supplied code (carried by *workerplugin.ErrorWithStack)
 //     wins — when the worker classified the error, we trust it.
-//  2. Caller cancellation (context.Canceled / DeadlineExceeded or
+//  2. pool.ErrPoolRetriesExhausted → worker_unavailable. Checked BEFORE
+//     caller-cancellation because the pool's retry loop wraps the last
+//     retryable err under the sentinel, and that last err is often a
+//     hung-detection-driven gRPC Canceled / DeadlineExceeded — which
+//     IsCallerCancellationError would otherwise misread as a client-
+//     driven abort. Pool retry exhaustion is by definition infra, not
+//     a client cancellation.
+//  3. Caller cancellation (context.Canceled / DeadlineExceeded or
 //     gRPC Canceled / DeadlineExceeded) maps to request_canceled.
 //     Checked BEFORE pool.IsRetryableWorkerError because the latter
 //     treats those gRPC codes as retryable infrastructure too — without
 //     this short-circuit, a client-driven abort surfaces as
 //     worker_unavailable on streaming and unary paths alike.
-//  3. pool.IsRetryableWorkerError → worker_unavailable (transient infra
+//  4. pool.IsRetryableWorkerError → worker_unavailable (transient infra
 //     failure, retries exhausted by the pool).
-//  4. Default → worker_error (BAML / LLM application error).
+//  5. Default → worker_error (BAML / LLM application error).
+//
+// Details precedence: a worker-supplied JSON Details payload wins; if
+// none is present, a worker-supplied stacktrace is wrapped as
+// {"stacktrace": "..."} so an LLM agent receiving the error as feedback
+// (or a human debugging) sees the panic trace alongside the message.
+// Stacktraces are also independently logged via httplogger.SetError —
+// the response copy is the explicit, agent-facing channel.
 func classifyWorkerError(err error) (apierror.Code, json.RawMessage) {
 	var details json.RawMessage
 
-	// Worker-supplied details (BAML diagnostic JSON, parse failure
-	// fields) — forward verbatim if they form a valid JSON value.
 	var stackErr *workerplugin.ErrorWithStack
 	if errors.As(err, &stackErr) {
 		if d := stackErr.GetDetails(); len(d) > 0 && json.Valid(d) {
 			details = json.RawMessage(d)
+		} else if st := stackErr.GetStacktrace(); st != "" {
+			details = stacktraceDetailsJSON(st)
 		}
 	}
 
 	if stackErr != nil && stackErr.GetCode() != "" {
 		return apierror.Code(stackErr.GetCode()), details
+	}
+
+	if errors.Is(err, pool.ErrPoolRetriesExhausted) {
+		return apierror.CodeWorkerUnavailable, details
 	}
 
 	if pool.IsCallerCancellationError(err) {
@@ -115,6 +133,20 @@ func classifyWorkerError(err error) (apierror.Code, json.RawMessage) {
 		return apierror.CodeWorkerUnavailable, details
 	}
 	return apierror.CodeWorkerError, details
+}
+
+// stacktraceDetailsJSON marshals st into the canonical
+// {"stacktrace": "..."} envelope used by the response Details field.
+// Falls back to nil on the (effectively impossible) marshal failure so
+// callers don't ship a half-formed payload.
+func stacktraceDetailsJSON(st string) json.RawMessage {
+	payload, err := json.Marshal(struct {
+		Stacktrace string `json:"stacktrace"`
+	}{Stacktrace: st})
+	if err != nil {
+		return nil
+	}
+	return payload
 }
 
 // netHTTPHeaderApiError is the chi/net-http analogue of

--- a/cmd/serve/error.go
+++ b/cmd/serve/error.go
@@ -91,11 +91,16 @@ func writeFiberInternalError(c fiber.Ctx, err error) error {
 //     driven abort. Pool retry exhaustion is by definition infra, not
 //     a client cancellation.
 //  3. Caller cancellation (context.Canceled / DeadlineExceeded or
-//     gRPC Canceled / DeadlineExceeded) maps to request_canceled.
-//     Checked BEFORE pool.IsRetryableWorkerError because the latter
-//     treats those gRPC codes as retryable infrastructure too — without
-//     this short-circuit, a client-driven abort surfaces as
-//     worker_unavailable on streaming and unary paths alike.
+//     gRPC Canceled / DeadlineExceeded) maps to request_canceled. Uses
+//     pool.IsTypedCancellationError (NOT IsCallerCancellationError) so
+//     a plain worker error string like "openai: provider timeout:
+//     context deadline exceeded" does NOT trigger this branch — only
+//     typed signals (errors.Is, gRPC status, serialized "rpc error:
+//     code = Canceled" prefix) qualify. Checked BEFORE
+//     pool.IsRetryableWorkerError because the latter treats those gRPC
+//     codes as retryable infrastructure too — without this short-circuit,
+//     a client-driven abort surfaces as worker_unavailable on streaming
+//     and unary paths alike.
 //  4. pool.IsRetryableWorkerError → worker_unavailable (transient infra
 //     failure, retries exhausted by the pool).
 //  5. Default → worker_error (BAML / LLM application error).
@@ -128,7 +133,7 @@ func classifyWorkerError(err error) (apierror.Code, json.RawMessage) {
 		return apierror.CodeWorkerUnavailable, details
 	}
 
-	if pool.IsCallerCancellationError(err) {
+	if pool.IsTypedCancellationError(err) {
 		return apierror.CodeRequestCanceled, details
 	}
 

--- a/cmd/serve/error.go
+++ b/cmd/serve/error.go
@@ -1,15 +1,148 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/goccy/go-json"
 	"github.com/gofiber/fiber/v3"
 	fiberrequestid "github.com/gofiber/fiber/v3/middleware/requestid"
 	"github.com/invakid404/baml-rest/internal/apierror"
+	"github.com/invakid404/baml-rest/internal/httplogger"
+	"github.com/invakid404/baml-rest/pool"
+	"github.com/invakid404/baml-rest/workerplugin"
 )
 
 // writeFiberJSONError writes a JSON-formatted error response for native Fiber handlers.
 func writeFiberJSONError(c fiber.Ctx, message string, statusCode int) error {
+	return writeFiberJSONErrorWithCode(c, message, "", nil, statusCode)
+}
+
+// writeFiberJSONErrorWithCode writes a JSON error response carrying a
+// machine-readable code and optional structured details. Pass code=""
+// and details=nil to omit those fields.
+func writeFiberJSONErrorWithCode(c fiber.Ctx, message string, code apierror.Code, details json.RawMessage, statusCode int) error {
 	return c.Status(statusCode).JSON(apierror.Response{
 		Error:     message,
+		Code:      code,
+		Details:   details,
 		RequestID: fiberrequestid.FromContext(c),
 	})
+}
+
+// writeFiberWorkerError classifies and writes a worker-originated error.
+//
+// The actual error message is forwarded to the client verbatim — this is a
+// developer-facing API where opaque "failed to process request" responses
+// strand both human users and LLM-agent consumers. The classification logic:
+//
+//   - context.Canceled / DeadlineExceeded → 408 request_canceled
+//   - retryable infrastructure failure that exhausted pool retries
+//     (worker crash, gRPC Unavailable, transport reset) → 500 worker_unavailable
+//   - everything else (BAML validation, LLM provider error, parse failure
+//     bubbled from the worker) → 500 worker_error
+//
+// Stacktraces from worker panics, when present, are forwarded as
+// details.stacktrace so an LLM agent receiving the error as feedback has
+// the full picture. The full error is also logged via httplogger.SetError.
+func writeFiberWorkerError(c fiber.Ctx, err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return writeFiberJSONErrorWithCode(c, "request canceled", apierror.CodeRequestCanceled, nil, fiber.StatusRequestTimeout)
+	}
+	httplogger.SetError(c.Context(), err)
+	code, details := classifyWorkerError(err)
+	return writeFiberJSONErrorWithCode(c, err.Error(), code, details, fiber.StatusInternalServerError)
+}
+
+// writeFiberParseWorkerError is the /parse-endpoint variant of
+// writeFiberWorkerError: a non-retryable failure here is a parse error
+// (BAML couldn't validate raw LLM output against the method schema)
+// rather than an LLM call failure.
+func writeFiberParseWorkerError(c fiber.Ctx, err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return writeFiberJSONErrorWithCode(c, "request canceled", apierror.CodeRequestCanceled, nil, fiber.StatusRequestTimeout)
+	}
+	httplogger.SetError(c.Context(), err)
+	code, details := classifyWorkerError(err)
+	if code == apierror.CodeWorkerError {
+		code = apierror.CodeParseError
+	}
+	return writeFiberJSONErrorWithCode(c, err.Error(), code, details, fiber.StatusInternalServerError)
+}
+
+// writeFiberInternalError surfaces a Go-side internal processing error
+// (input conversion, output flattening) as 500 internal_error. The
+// original message is forwarded — these errors reflect bugs in this
+// server, not in BAML or the LLM, so opaqueness helps no one.
+func writeFiberInternalError(c fiber.Ctx, err error) error {
+	httplogger.SetError(c.Context(), err)
+	return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInternalError, nil, fiber.StatusInternalServerError)
+}
+
+// classifyWorkerError inspects err and returns the apierror.Code that
+// best describes the failure plus any structured details that should
+// reach the client envelope. Worker-supplied codes (carried by
+// *workerplugin.ErrorWithStack) take precedence; otherwise the
+// classification falls back to pool.IsRetryableWorkerError to distinguish
+// transient infrastructure failure from a real BAML/LLM error.
+func classifyWorkerError(err error) (apierror.Code, json.RawMessage) {
+	var details json.RawMessage
+
+	// Worker-supplied details (BAML diagnostic JSON, parse failure
+	// fields) — forward verbatim if they form a valid JSON value.
+	var stackErr *workerplugin.ErrorWithStack
+	if errors.As(err, &stackErr) {
+		if d := stackErr.GetDetails(); len(d) > 0 && json.Valid(d) {
+			details = json.RawMessage(d)
+		}
+	}
+
+	// Worker-supplied code wins over heuristic classification — when
+	// the worker has typed knowledge of the failure (e.g. "this is a
+	// parse_error against the BAML schema"), we trust it.
+	if stackErr != nil && stackErr.GetCode() != "" {
+		return apierror.Code(stackErr.GetCode()), details
+	}
+
+	if pool.IsRetryableWorkerError(err) {
+		return apierror.CodeWorkerUnavailable, details
+	}
+	return apierror.CodeWorkerError, details
+}
+
+// netHTTPHeaderApiError is the chi/net-http analogue of
+// writeFiberJSONErrorWithCode. Lives in this file rather than
+// unary_handlers.go so the chi handlers and the Fiber handlers share
+// one definition of the error envelope and the worker-error classifier.
+func writeChiJSONErrorWithCode(w http.ResponseWriter, r *http.Request, message string, code apierror.Code, details json.RawMessage, statusCode int) {
+	apierror.WriteJSONWithCode(w, message, code, details, statusCode, unaryRequestID(r.Context()))
+}
+
+func writeChiWorkerErrorClassified(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		writeChiJSONErrorWithCode(w, r, "request canceled", apierror.CodeRequestCanceled, nil, http.StatusRequestTimeout)
+		return
+	}
+	httplogger.SetError(r.Context(), err)
+	code, details := classifyWorkerError(err)
+	writeChiJSONErrorWithCode(w, r, err.Error(), code, details, http.StatusInternalServerError)
+}
+
+func writeChiParseWorkerError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		writeChiJSONErrorWithCode(w, r, "request canceled", apierror.CodeRequestCanceled, nil, http.StatusRequestTimeout)
+		return
+	}
+	httplogger.SetError(r.Context(), err)
+	code, details := classifyWorkerError(err)
+	if code == apierror.CodeWorkerError {
+		code = apierror.CodeParseError
+	}
+	writeChiJSONErrorWithCode(w, r, err.Error(), code, details, http.StatusInternalServerError)
+}
+
+func writeChiInternalError(w http.ResponseWriter, r *http.Request, err error) {
+	httplogger.SetError(r.Context(), err)
+	writeChiJSONErrorWithCode(w, r, err.Error(), apierror.CodeInternalError, nil, http.StatusInternalServerError)
 }

--- a/cmd/serve/error.go
+++ b/cmd/serve/error.go
@@ -157,17 +157,23 @@ func classifyWorkerError(err error) (apierror.Code, json.RawMessage) {
 // they're authored worker-side and there's no shared schema enforcing
 // them, so off-contract values are dropped rather than forwarded:
 //
-//   - code is preserved only if it's one of the documented apierror.Code
-//     constants (apierror.Code.IsKnown). Unknown codes return ""
-//     (empty), which makes classifyWorkerError fall through to host-
-//     side classification — the public OpenAPI enum stays authoritative.
+//   - code is preserved only if it's worker-facing
+//     (apierror.Code.IsWorkerFacing): worker_error, parse_error, or
+//     internal_error. Request-layer codes (invalid_json,
+//     request_canceled, etc.) and pool-admission codes
+//     (worker_unavailable) are owned by the host — honoring a worker
+//     that claimed e.g. request_canceled would let worker-side text
+//     force the host's 408 classifier branch and dictate HTTP status
+//     semantics. Non-worker-facing codes fall through to host-side
+//     classification, which is the authoritative source for those
+//     classes.
 //   - details is preserved only if it parses as a JSON OBJECT; scalars,
 //     arrays, and null are dropped. The OpenAPI schema declares
 //     details as an object (additionalProperties), so anything else
 //     would lie about the contract and confuse generated clients.
 func normalizeWorkerMetadata(rawCode string, rawDetails []byte) (apierror.Code, json.RawMessage) {
 	var code apierror.Code
-	if c := apierror.Code(rawCode); c.IsKnown() {
+	if c := apierror.Code(rawCode); c.IsWorkerFacing() {
 		code = c
 	}
 	var details json.RawMessage

--- a/cmd/serve/error.go
+++ b/cmd/serve/error.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"net/http"
 
@@ -35,23 +34,21 @@ func writeFiberJSONErrorWithCode(c fiber.Ctx, message string, code apierror.Code
 //
 // The actual error message is forwarded to the client verbatim — this is a
 // developer-facing API where opaque "failed to process request" responses
-// strand both human users and LLM-agent consumers. The classification logic:
-//
-//   - context.Canceled / DeadlineExceeded → 408 request_canceled
-//   - retryable infrastructure failure that exhausted pool retries
-//     (worker crash, gRPC Unavailable, transport reset) → 500 worker_unavailable
-//   - everything else (BAML validation, LLM provider error, parse failure
-//     bubbled from the worker) → 500 worker_error
+// strand both human users and LLM-agent consumers. classifyWorkerError owns
+// the code/status mapping; this helper routes a request_canceled outcome to
+// 408 (so client-driven aborts don't inflate 5xx metrics) and everything
+// else to 500 with the classified code/details.
 //
 // Stacktraces from worker panics, when present, are forwarded as
 // details.stacktrace so an LLM agent receiving the error as feedback has
-// the full picture. The full error is also logged via httplogger.SetError.
+// the full picture. The full error is also logged via httplogger.SetError
+// for non-cancellation paths.
 func writeFiberWorkerError(c fiber.Ctx, err error) error {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return writeFiberJSONErrorWithCode(c, "request canceled", apierror.CodeRequestCanceled, nil, fiber.StatusRequestTimeout)
+	code, details := classifyWorkerError(err)
+	if code == apierror.CodeRequestCanceled {
+		return writeFiberJSONErrorWithCode(c, "request canceled", code, details, fiber.StatusRequestTimeout)
 	}
 	httplogger.SetError(c.Context(), err)
-	code, details := classifyWorkerError(err)
 	return writeFiberJSONErrorWithCode(c, err.Error(), code, details, fiber.StatusInternalServerError)
 }
 
@@ -60,11 +57,11 @@ func writeFiberWorkerError(c fiber.Ctx, err error) error {
 // (BAML couldn't validate raw LLM output against the method schema)
 // rather than an LLM call failure.
 func writeFiberParseWorkerError(c fiber.Ctx, err error) error {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return writeFiberJSONErrorWithCode(c, "request canceled", apierror.CodeRequestCanceled, nil, fiber.StatusRequestTimeout)
+	code, details := classifyWorkerError(err)
+	if code == apierror.CodeRequestCanceled {
+		return writeFiberJSONErrorWithCode(c, "request canceled", code, details, fiber.StatusRequestTimeout)
 	}
 	httplogger.SetError(c.Context(), err)
-	code, details := classifyWorkerError(err)
 	if code == apierror.CodeWorkerError {
 		code = apierror.CodeParseError
 	}
@@ -82,10 +79,18 @@ func writeFiberInternalError(c fiber.Ctx, err error) error {
 
 // classifyWorkerError inspects err and returns the apierror.Code that
 // best describes the failure plus any structured details that should
-// reach the client envelope. Worker-supplied codes (carried by
-// *workerplugin.ErrorWithStack) take precedence; otherwise the
-// classification falls back to pool.IsRetryableWorkerError to distinguish
-// transient infrastructure failure from a real BAML/LLM error.
+// reach the client envelope. Precedence:
+//  1. Worker-supplied code (carried by *workerplugin.ErrorWithStack)
+//     wins — when the worker classified the error, we trust it.
+//  2. Caller cancellation (context.Canceled / DeadlineExceeded or
+//     gRPC Canceled / DeadlineExceeded) maps to request_canceled.
+//     Checked BEFORE pool.IsRetryableWorkerError because the latter
+//     treats those gRPC codes as retryable infrastructure too — without
+//     this short-circuit, a client-driven abort surfaces as
+//     worker_unavailable on streaming and unary paths alike.
+//  3. pool.IsRetryableWorkerError → worker_unavailable (transient infra
+//     failure, retries exhausted by the pool).
+//  4. Default → worker_error (BAML / LLM application error).
 func classifyWorkerError(err error) (apierror.Code, json.RawMessage) {
 	var details json.RawMessage
 
@@ -98,11 +103,12 @@ func classifyWorkerError(err error) (apierror.Code, json.RawMessage) {
 		}
 	}
 
-	// Worker-supplied code wins over heuristic classification — when
-	// the worker has typed knowledge of the failure (e.g. "this is a
-	// parse_error against the BAML schema"), we trust it.
 	if stackErr != nil && stackErr.GetCode() != "" {
 		return apierror.Code(stackErr.GetCode()), details
+	}
+
+	if pool.IsCallerCancellationError(err) {
+		return apierror.CodeRequestCanceled, details
 	}
 
 	if pool.IsRetryableWorkerError(err) {
@@ -120,22 +126,22 @@ func writeChiJSONErrorWithCode(w http.ResponseWriter, r *http.Request, message s
 }
 
 func writeChiWorkerErrorClassified(w http.ResponseWriter, r *http.Request, err error) {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		writeChiJSONErrorWithCode(w, r, "request canceled", apierror.CodeRequestCanceled, nil, http.StatusRequestTimeout)
+	code, details := classifyWorkerError(err)
+	if code == apierror.CodeRequestCanceled {
+		writeChiJSONErrorWithCode(w, r, "request canceled", code, details, http.StatusRequestTimeout)
 		return
 	}
 	httplogger.SetError(r.Context(), err)
-	code, details := classifyWorkerError(err)
 	writeChiJSONErrorWithCode(w, r, err.Error(), code, details, http.StatusInternalServerError)
 }
 
 func writeChiParseWorkerError(w http.ResponseWriter, r *http.Request, err error) {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		writeChiJSONErrorWithCode(w, r, "request canceled", apierror.CodeRequestCanceled, nil, http.StatusRequestTimeout)
+	code, details := classifyWorkerError(err)
+	if code == apierror.CodeRequestCanceled {
+		writeChiJSONErrorWithCode(w, r, "request canceled", code, details, http.StatusRequestTimeout)
 		return
 	}
 	httplogger.SetError(r.Context(), err)
-	code, details := classifyWorkerError(err)
 	if code == apierror.CodeWorkerError {
 		code = apierror.CodeParseError
 	}

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -153,6 +153,31 @@ func TestClassifyWorkerError_NoFalsePositiveOnContextCanceledText(t *testing.T) 
 			errors.New("context canceled by upstream"),
 			apierror.CodeWorkerError,
 		},
+		// Embedded serialized-gRPC text in worker / provider errors
+		// must NOT classify as cancellation (408). parseSerializedGRPCCode
+		// itself uses substring search (the retry classifier wants
+		// that lenience), so IsTypedCancellationError requires the
+		// "rpc error: code = " header at offset 0. Without the
+		// prefix-only guard, a wrapped provider error like
+		// "provider failed: rpc error: code = Canceled ..." would
+		// surface as 408 — exactly the false-positive class this
+		// helper exists to avoid.
+		//
+		// These cases land on worker_unavailable (not worker_error)
+		// because IsRetryableWorkerError still substring-matches
+		// embedded gRPC codes. That's a related-but-separate concern
+		// outside this fix's scope; the point pinned here is that
+		// the cancellation precedence rung does not fire.
+		{
+			"embedded serialized gRPC Canceled in worker text",
+			errors.New("provider failed: rpc error: code = Canceled desc = upstream gone"),
+			apierror.CodeWorkerUnavailable,
+		},
+		{
+			"embedded serialized gRPC DeadlineExceeded in worker text",
+			errors.New("upstream call: rpc error: code = DeadlineExceeded desc = upstream timeout"),
+			apierror.CodeWorkerUnavailable,
+		},
 		// Sanity: typed forms still classify correctly.
 		{
 			"typed context.Canceled still classifies as canceled",

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -154,29 +154,31 @@ func TestClassifyWorkerError_NoFalsePositiveOnContextCanceledText(t *testing.T) 
 			apierror.CodeWorkerError,
 		},
 		// Embedded serialized-gRPC text in worker / provider errors
-		// must NOT classify as cancellation (408). parseSerializedGRPCCode
-		// itself uses substring search (the retry classifier wants
-		// that lenience), so IsTypedCancellationError requires the
-		// "rpc error: code = " header at offset 0. Without the
-		// prefix-only guard, a wrapped provider error like
-		// "provider failed: rpc error: code = Canceled ..." would
-		// surface as 408 — exactly the false-positive class this
-		// helper exists to avoid.
-		//
-		// These cases land on worker_unavailable (not worker_error)
-		// because IsRetryableWorkerError still substring-matches
-		// embedded gRPC codes. That's a related-but-separate concern
-		// outside this fix's scope; the point pinned here is that
-		// the cancellation precedence rung does not fire.
+		// must NOT classify as cancellation (408) OR as transient
+		// infrastructure (worker_unavailable). Both IsTypedCancellationError
+		// and isRetryableWorkerError now require the
+		// "rpc error: code = " header at offset 0 before consulting
+		// parseSerializedGRPCCode (which itself uses substring search
+		// — the strictness lives at the call site). Without the
+		// prefix guard, a wrapped provider error like "provider
+		// failed: rpc error: code = Canceled ..." would surface as
+		// 408 (cancellation rung) or worker_unavailable (retryable
+		// rung). After the guards, both rungs skip and classification
+		// falls through to worker_error.
 		{
 			"embedded serialized gRPC Canceled in worker text",
 			errors.New("provider failed: rpc error: code = Canceled desc = upstream gone"),
-			apierror.CodeWorkerUnavailable,
+			apierror.CodeWorkerError,
 		},
 		{
 			"embedded serialized gRPC DeadlineExceeded in worker text",
 			errors.New("upstream call: rpc error: code = DeadlineExceeded desc = upstream timeout"),
-			apierror.CodeWorkerUnavailable,
+			apierror.CodeWorkerError,
+		},
+		{
+			"embedded serialized gRPC Unavailable in worker text",
+			errors.New("provider returned: rpc error: code = Unavailable desc = downstream"),
+			apierror.CodeWorkerError,
 		},
 		// Sanity: typed forms still classify correctly.
 		{
@@ -481,6 +483,49 @@ func TestClassifyWorkerError_UnknownWorkerCodeFallsThrough(t *testing.T) {
 	got, _ := classifyWorkerError(err)
 	if got != apierror.CodeWorkerUnavailable {
 		t.Errorf("classifyWorkerError = %q, want %q (host-side reclassification of inner Unavailable)", got, apierror.CodeWorkerUnavailable)
+	}
+}
+
+// TestClassifyWorkerError_NonWorkerFacingCodeRejected pins the
+// IsWorkerFacing whitelist: even when the worker emits a known
+// apierror.Code, the host honors it only for worker-facing classes
+// (worker_error / parse_error / internal_error). Request-layer codes
+// (request_canceled, invalid_json, ...) and pool-admission codes
+// (worker_unavailable) are owned by the host — honoring a worker
+// that claimed e.g. request_canceled would let worker text force
+// the 408 branch in writeFiberWorkerError and dictate HTTP status
+// semantics. The wrapped err here has gRPC code Internal (which
+// would normally classify as worker_error via the fall-through), so
+// rejection of the worker code surfaces worker_error, not the
+// claimed request_canceled.
+func TestClassifyWorkerError_NonWorkerFacingCodeRejected(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawCode  string
+		wantCode apierror.Code
+	}{
+		{"worker claims request_canceled", string(apierror.CodeRequestCanceled), apierror.CodeWorkerError},
+		{"worker claims invalid_json", string(apierror.CodeInvalidJSON), apierror.CodeWorkerError},
+		{"worker claims request_too_large", string(apierror.CodeRequestTooLarge), apierror.CodeWorkerError},
+		{"worker claims worker_unavailable", string(apierror.CodeWorkerUnavailable), apierror.CodeWorkerError},
+		// Worker-facing codes still pass through.
+		{"worker claims worker_error", string(apierror.CodeWorkerError), apierror.CodeWorkerError},
+		{"worker claims parse_error", string(apierror.CodeParseError), apierror.CodeParseError},
+		{"worker claims internal_error", string(apierror.CodeInternalError), apierror.CodeInternalError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := workerplugin.NewErrorWithMetadata(
+				status.Error(codes.Internal, "boom"),
+				"",
+				tt.rawCode,
+				nil,
+			)
+			got, _ := classifyWorkerError(err)
+			if got != tt.wantCode {
+				t.Errorf("classifyWorkerError = %q, want %q", got, tt.wantCode)
+			}
+		})
 	}
 }
 

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -101,8 +101,18 @@ func TestClassifyWorkerError_PrecedenceOrder(t *testing.T) {
 			apierror.CodeRequestCanceled,
 		},
 		{
+			"context.DeadlineExceeded → request_canceled",
+			context.DeadlineExceeded,
+			apierror.CodeRequestCanceled,
+		},
+		{
 			"gRPC Canceled status → request_canceled",
 			status.Error(codes.Canceled, "client gone"),
+			apierror.CodeRequestCanceled,
+		},
+		{
+			"gRPC DeadlineExceeded status → request_canceled",
+			status.Error(codes.DeadlineExceeded, "request timed out"),
 			apierror.CodeRequestCanceled,
 		},
 		{

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -181,6 +181,40 @@ func TestClassifyWorkerError_StructuredDetailsBeatStacktrace(t *testing.T) {
 	}
 }
 
+// TestClassifyStreamResultError_StructuredDetailsOverride is the
+// streaming-side counterpart to TestClassifyWorkerError_StructuredDetailsBeatStacktrace:
+// when a worker emits both ErrorDetails (a valid JSON object) and a
+// Stacktrace, the structured payload wins and the stacktrace stays
+// out of the response (it's still logged via httplogger.SetError on
+// the calling path). Pins the precedence so a future refactor of
+// classifyStreamResultError can't silently regress to clobbering
+// worker-supplied structured details with the stacktrace fallback.
+func TestClassifyStreamResultError_StructuredDetailsOverride(t *testing.T) {
+	wantDetails := []byte(`{"foo":"bar","field":"sentiment"}`)
+	result := &workerplugin.StreamResult{
+		Kind:         workerplugin.StreamResultKindError,
+		Error:        errors.New("BAML parse error"),
+		ErrorDetails: wantDetails,
+		Stacktrace:   "goroutine 9 [running]:\nshould.not.appear(...)",
+	}
+
+	_, details := classifyStreamResultError(result)
+	if string(details) != string(wantDetails) {
+		t.Errorf("details = %s, want %s", details, wantDetails)
+	}
+	if strings.Contains(string(details), "stacktrace") {
+		t.Errorf("details should not include stacktrace when structured details supplied; got %s", details)
+	}
+
+	var parsed map[string]string
+	if err := json.Unmarshal(details, &parsed); err != nil {
+		t.Fatalf("details did not unmarshal as object: %v (raw: %s)", err, details)
+	}
+	if parsed["foo"] != "bar" || parsed["field"] != "sentiment" {
+		t.Errorf("unmarshaled details = %v, want foo=bar field=sentiment", parsed)
+	}
+}
+
 // TestClassifyStreamResultError_StacktraceDetails covers the streaming
 // counterpart: StreamResult.Stacktrace surfaces as
 // {"stacktrace": "..."} when ErrorDetails is empty. Mirrors the unary

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -45,6 +45,25 @@ func TestClassifyWorkerError_RetriesExhaustedBeatsCancellation(t *testing.T) {
 			"exhausted with no inner error",
 			fmt.Errorf("%w (no terminal stream frame)", pool.ErrPoolRetriesExhausted),
 		},
+		// No-workers retry tail: getWorkerForRetry can't supply a
+		// replacement worker after a retryable failure, and the pool
+		// wraps with the sentinel so the HTTP layer classifies as
+		// worker_unavailable rather than falling through to
+		// worker_error on the plain "no healthy workers available"
+		// string. Caller-cancellation paths bypass the wrap (verified
+		// separately via the precedence test below).
+		{
+			"exhausted wrapping no healthy workers",
+			fmt.Errorf("%w: %w", pool.ErrPoolRetriesExhausted, errors.New("no healthy workers available")),
+		},
+		{
+			"exhausted wrapping pool closed",
+			fmt.Errorf("%w: %w", pool.ErrPoolRetriesExhausted, errors.New("pool is closed")),
+		},
+		{
+			"exhausted wrapping no-workers with previous",
+			fmt.Errorf("%w: retry failed, no workers available: %w (previous: worker died)", pool.ErrPoolRetriesExhausted, errors.New("no healthy workers available")),
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -103,12 +103,73 @@ func TestClassifyWorkerError_CancelBranchWrapsCtxErr(t *testing.T) {
 			"with previous lastErr in message",
 			fmt.Errorf("retry failed, no workers available: %w (pool error: %v, previous: %v)", context.Canceled, errors.New("no healthy workers available"), errors.New("worker died")),
 		},
+		// CallStream pre-loop cancel shape: caller cancelled before
+		// the goroutine even started, getWorkerForRetry surfaced a
+		// non-cancel error in the race window. The pre-loop wrap
+		// (pool.go:1421) emits this exact format.
+		{
+			"CallStream pre-loop cancel wrap",
+			fmt.Errorf("could not acquire worker: %w (pool error: %v)", context.Canceled, errors.New("pool is draining")),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, _ := classifyWorkerError(tt.err)
 			if got != apierror.CodeRequestCanceled {
 				t.Errorf("classifyWorkerError = %q, want %q", got, apierror.CodeRequestCanceled)
+			}
+		})
+	}
+}
+
+// TestClassifyWorkerError_NoFalsePositiveOnContextCanceledText pins
+// the typed-cancellation contract: a plain worker error string that
+// happens to contain "context canceled" or "context deadline
+// exceeded" verbatim (e.g. an upstream LLM provider error message)
+// must NOT be classified as request_canceled. Previously
+// classifyWorkerError used pool.IsCallerCancellationError, whose
+// trailing string-match fallback would fire on these substrings —
+// turning a real worker_error into a misleading 408. Switched to
+// pool.IsTypedCancellationError which uses only typed signals
+// (errors.Is, *status.Status, "rpc error: code = Canceled" prefix).
+func TestClassifyWorkerError_NoFalsePositiveOnContextCanceledText(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want apierror.Code
+	}{
+		{
+			"upstream LLM timeout containing canceled text",
+			errors.New("openai: provider error: context deadline exceeded"),
+			apierror.CodeWorkerError,
+		},
+		{
+			"BAML parse failure containing canceled text",
+			errors.New("BAML parse error: validation failed; context canceled at line 12"),
+			apierror.CodeWorkerError,
+		},
+		{
+			"plain canceled-shaped error stays worker_error",
+			errors.New("context canceled by upstream"),
+			apierror.CodeWorkerError,
+		},
+		// Sanity: typed forms still classify correctly.
+		{
+			"typed context.Canceled still classifies as canceled",
+			context.Canceled,
+			apierror.CodeRequestCanceled,
+		},
+		{
+			"serialized gRPC Canceled still classifies as canceled",
+			errors.New("rpc error: code = Canceled desc = client gone"),
+			apierror.CodeRequestCanceled,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := classifyWorkerError(tt.err)
+			if got != tt.want {
+				t.Errorf("classifyWorkerError(%q) = %q, want %q", tt.err, got, tt.want)
 			}
 		})
 	}
@@ -131,6 +192,10 @@ func TestClassifyWorkerError_PoolUnavailable(t *testing.T) {
 		{"no healthy workers", fmt.Errorf("%w: no healthy workers available", pool.ErrPoolUnavailable)},
 		{"bare sentinel", pool.ErrPoolUnavailable},
 		{"sentinel through outer wrap", fmt.Errorf("call failed: %w", fmt.Errorf("%w: pool is closed", pool.ErrPoolUnavailable))},
+		// CallStream pre-loop wrap shape: getWorkerForRetry returned
+		// a non-cancel error and the caller didn't cancel. The
+		// pre-loop wrap (pool.go:1421) emits this exact format.
+		{"CallStream pre-loop wrap", fmt.Errorf("%w: %w", pool.ErrPoolUnavailable, errors.New("pool is draining"))},
 	}
 
 	for _, tt := range tests {

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/invakid404/baml-rest/internal/apierror"
+	"github.com/invakid404/baml-rest/pool"
+	"github.com/invakid404/baml-rest/workerplugin"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestClassifyWorkerError_RetriesExhaustedBeatsCancellation pins the
+// precedence rule that the pool's retry-exhaustion sentinel takes
+// priority over caller-cancellation detection. The pool's last
+// retryable error is often a hung-detection-driven gRPC Canceled
+// (worker side aborted the request after first-byte timeout) — without
+// this ordering, IsCallerCancellationError would walk the wrap chain
+// via status.FromError, find the inner Canceled, and misreport a
+// retry-exhaustion as a client-driven abort. Regression guard for the
+// P1 ordering bug Codex flagged after the initial sentinel landed.
+func TestClassifyWorkerError_RetriesExhaustedBeatsCancellation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			"exhausted wrapping gRPC Canceled",
+			fmt.Errorf("%w: %w", pool.ErrPoolRetriesExhausted, status.Error(codes.Canceled, "hung-detected")),
+		},
+		{
+			"exhausted wrapping gRPC DeadlineExceeded",
+			fmt.Errorf("%w: %w", pool.ErrPoolRetriesExhausted, status.Error(codes.DeadlineExceeded, "first-byte timeout")),
+		},
+		{
+			"exhausted wrapping gRPC Unavailable",
+			fmt.Errorf("%w: %w", pool.ErrPoolRetriesExhausted, status.Error(codes.Unavailable, "worker died")),
+		},
+		{
+			"exhausted with no inner error",
+			fmt.Errorf("%w (no terminal stream frame)", pool.ErrPoolRetriesExhausted),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, _ := classifyWorkerError(tt.err)
+			if code != apierror.CodeWorkerUnavailable {
+				t.Errorf("classifyWorkerError(%v) code = %q, want %q", tt.err, code, apierror.CodeWorkerUnavailable)
+			}
+		})
+	}
+}
+
+// TestClassifyWorkerError_PrecedenceOrder spot-checks the full
+// classification ladder so future reorderings can't silently break a
+// rung. Each case exercises exactly one rung.
+func TestClassifyWorkerError_PrecedenceOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want apierror.Code
+	}{
+		{
+			"worker-supplied code wins over everything",
+			workerplugin.NewErrorWithMetadata(
+				status.Error(codes.Canceled, "client gone"),
+				"",
+				string(apierror.CodeParseError),
+				nil,
+			),
+			apierror.CodeParseError,
+		},
+		{
+			"context.Canceled → request_canceled",
+			context.Canceled,
+			apierror.CodeRequestCanceled,
+		},
+		{
+			"gRPC Canceled status → request_canceled",
+			status.Error(codes.Canceled, "client gone"),
+			apierror.CodeRequestCanceled,
+		},
+		{
+			"gRPC Unavailable → worker_unavailable",
+			status.Error(codes.Unavailable, "worker dead"),
+			apierror.CodeWorkerUnavailable,
+		},
+		{
+			"plain BAML-shaped error → worker_error",
+			errors.New("BAML validation failed: field 'x' required"),
+			apierror.CodeWorkerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := classifyWorkerError(tt.err)
+			if got != tt.want {
+				t.Errorf("classifyWorkerError(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClassifyWorkerError_StacktraceDetails pins the contract that a
+// worker-supplied stacktrace surfaces in the response Details field
+// as {"stacktrace": "..."} when no structured Details were provided.
+// Previously the stacktrace was logged server-side only and never
+// reached the client envelope despite the PR comment promising it
+// would — Codex caught the gap and this test locks the fix.
+func TestClassifyWorkerError_StacktraceDetails(t *testing.T) {
+	const trace = "goroutine 42 [running]:\nmain.boom(...)\n\tfile.go:10"
+	err := workerplugin.NewErrorWithMetadata(
+		errors.New("worker panic"),
+		trace,
+		"",
+		nil,
+	)
+
+	_, details := classifyWorkerError(err)
+	if details == nil {
+		t.Fatalf("expected non-nil details carrying stacktrace, got nil")
+	}
+
+	var parsed struct {
+		Stacktrace string `json:"stacktrace"`
+	}
+	if err := json.Unmarshal(details, &parsed); err != nil {
+		t.Fatalf("details did not unmarshal as {stacktrace}: %v (raw: %s)", err, string(details))
+	}
+	if parsed.Stacktrace != trace {
+		t.Errorf("details.stacktrace = %q, want %q", parsed.Stacktrace, trace)
+	}
+}
+
+// TestClassifyWorkerError_StructuredDetailsBeatStacktrace verifies
+// that worker-supplied structured details take priority over the
+// stacktrace fallback — when both are present the structured payload
+// is what reaches the client (the stacktrace is still logged via
+// httplogger.SetError on the calling path).
+func TestClassifyWorkerError_StructuredDetailsBeatStacktrace(t *testing.T) {
+	wantDetails := []byte(`{"field":"sentiment","expected":"positive|negative"}`)
+	err := workerplugin.NewErrorWithMetadata(
+		errors.New("BAML parse error"),
+		"goroutine 42 [running]:\n...",
+		"",
+		wantDetails,
+	)
+
+	_, details := classifyWorkerError(err)
+	if string(details) != string(wantDetails) {
+		t.Errorf("details = %s, want %s", string(details), string(wantDetails))
+	}
+	if strings.Contains(string(details), "stacktrace") {
+		t.Errorf("details should not include stacktrace when structured details supplied; got %s", string(details))
+	}
+}
+
+// TestClassifyStreamResultError_StacktraceDetails covers the streaming
+// counterpart: StreamResult.Stacktrace surfaces as
+// {"stacktrace": "..."} when ErrorDetails is empty. Mirrors the unary
+// path so streaming consumers get the same agent-facing context.
+func TestClassifyStreamResultError_StacktraceDetails(t *testing.T) {
+	const trace = "goroutine 7 [running]:\nworker.run(...)"
+	result := &workerplugin.StreamResult{
+		Kind:       workerplugin.StreamResultKindError,
+		Error:      errors.New("worker panic"),
+		Stacktrace: trace,
+	}
+
+	_, details := classifyStreamResultError(result)
+	if details == nil {
+		t.Fatalf("expected non-nil details, got nil")
+	}
+	var parsed struct {
+		Stacktrace string `json:"stacktrace"`
+	}
+	if err := json.Unmarshal(details, &parsed); err != nil {
+		t.Fatalf("details did not unmarshal: %v (raw: %s)", err, string(details))
+	}
+	if parsed.Stacktrace != trace {
+		t.Errorf("details.stacktrace = %q, want %q", parsed.Stacktrace, trace)
+	}
+}

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -76,6 +76,44 @@ func TestClassifyWorkerError_RetriesExhaustedBeatsCancellation(t *testing.T) {
 	}
 }
 
+// TestClassifyWorkerError_CancelBranchWrapsCtxErr pins the
+// race-window contract for Pool.Parse / Pool.CallStream's caller-
+// cancel branch: when ctx is cancelled but getWorkerForRetry
+// returns a non-cancel error (e.g. "no healthy workers available"
+// from a transient race), wrapping ctx.Err() — not the pool err —
+// is what lets classifyWorkerError detect the cancellation and
+// surface request_canceled. Wrapping the pool err alone would
+// leave context.Canceled out of the chain entirely and the
+// retry-exhaustion sentinel branch would otherwise capture the
+// shape as worker_unavailable.
+func TestClassifyWorkerError_CancelBranchWrapsCtxErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			"context.Canceled wrapped, pool err as %v",
+			fmt.Errorf("retry failed, no workers available: %w (pool error: %v)", context.Canceled, errors.New("no healthy workers available")),
+		},
+		{
+			"context.DeadlineExceeded wrapped, pool err as %v",
+			fmt.Errorf("retry failed, no workers available: %w (pool error: %v)", context.DeadlineExceeded, errors.New("pool is closed")),
+		},
+		{
+			"with previous lastErr in message",
+			fmt.Errorf("retry failed, no workers available: %w (pool error: %v, previous: %v)", context.Canceled, errors.New("no healthy workers available"), errors.New("worker died")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := classifyWorkerError(tt.err)
+			if got != apierror.CodeRequestCanceled {
+				t.Errorf("classifyWorkerError = %q, want %q", got, apierror.CodeRequestCanceled)
+			}
+		})
+	}
+}
+
 // TestClassifyWorkerError_PoolUnavailable pins the admission-side
 // sentinel: pre-retry pool-availability failures (pool closed,
 // draining, no healthy workers) classify as worker_unavailable rather

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/goccy/go-json"
+	"github.com/gofiber/fiber/v3"
 	"github.com/invakid404/baml-rest/internal/apierror"
 	"github.com/invakid404/baml-rest/pool"
 	"github.com/invakid404/baml-rest/workerplugin"
@@ -595,4 +597,130 @@ func TestClassifyStreamResultError_NormalizesWorkerFields(t *testing.T) {
 			t.Errorf("details.stacktrace = %q, want %q", parsed.Stacktrace, trace)
 		}
 	})
+}
+
+// TestFiberErrorHandler_413MapsToRequestTooLarge pins the app-wide
+// ErrorHandler contract: a *fiber.Error with status 413 (BodyLimit
+// being the production source) maps to CodeRequestTooLarge in the
+// JSON envelope, mirroring chi's writeChiBodyReadError 413 path.
+// Without this handler, Fiber's default ErrorHandler emits
+// text/plain "Request Entity Too Large" with no apierror.Code —
+// clients (and LLM agents) lose the ability to branch on the code.
+//
+// Tested through a route that returns the framework error directly
+// rather than through the BodyLimit middleware: app.Test rejects
+// over-limit requests at the test transport layer before reaching
+// the ErrorHandler chain, so the BodyLimit↔ErrorHandler integration
+// is a Fiber framework concern. What we own is the *fiber.Error→
+// apierror.Code mapping; that's what this asserts.
+func TestFiberErrorHandler_413MapsToRequestTooLarge(t *testing.T) {
+	app := fiber.New(fiber.Config{
+		JSONEncoder:  json.Marshal,
+		JSONDecoder:  json.Unmarshal,
+		ErrorHandler: fiberErrorHandler,
+	})
+	app.Post("/oversize", func(c fiber.Ctx) error {
+		return fiber.NewError(fiber.StatusRequestEntityTooLarge, "body size exceeds the given limit")
+	})
+
+	req, _ := http.NewRequest(http.MethodPost, "http://example.com/oversize", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", resp.StatusCode)
+	}
+	if ct := resp.Header.Get(fiber.HeaderContentType); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json (Fiber default would emit text/plain)", ct)
+	}
+	var parsed apierror.Response
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if parsed.Code != apierror.CodeRequestTooLarge {
+		t.Errorf("Code = %q, want %q", parsed.Code, apierror.CodeRequestTooLarge)
+	}
+	if parsed.Error != "body size exceeds the given limit" {
+		t.Errorf("Error = %q, want it to forward the framework-supplied message", parsed.Error)
+	}
+}
+
+// TestFiberErrorHandler_GenericFiberErrorEmitsJSON pins the
+// fall-through for non-413 *fiber.Error values: they still get the
+// JSON envelope with the framework status, just without a specific
+// code. The fiber.Error message is forwarded so the body still
+// names the class — clients consuming the envelope shape don't
+// need a special case for "this came from Fiber, not our handlers."
+func TestFiberErrorHandler_GenericFiberErrorEmitsJSON(t *testing.T) {
+	app := fiber.New(fiber.Config{
+		JSONEncoder:  json.Marshal,
+		JSONDecoder:  json.Unmarshal,
+		ErrorHandler: fiberErrorHandler,
+	})
+	app.Get("/needs-method", func(c fiber.Ctx) error {
+		return fiber.ErrMethodNotAllowed
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/needs-method", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+	if ct := resp.Header.Get(fiber.HeaderContentType); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	var parsed apierror.Response
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if parsed.Code != "" {
+		t.Errorf("Code = %q, want empty (no apierror.Code is meaningful for generic fiber.Error)", parsed.Code)
+	}
+	if parsed.Error == "" {
+		t.Errorf("Error must carry the fiber.Error message; got empty")
+	}
+}
+
+// TestFiberErrorHandler_PlainErrorMapsToInternal pins the safety net
+// for non-fiber.Error errors: a handler returning a bare error
+// (without writing a response itself) gets surfaced as 500
+// internal_error rather than Fiber's default text/plain handling.
+func TestFiberErrorHandler_PlainErrorMapsToInternal(t *testing.T) {
+	app := fiber.New(fiber.Config{
+		JSONEncoder:  json.Marshal,
+		JSONDecoder:  json.Unmarshal,
+		ErrorHandler: fiberErrorHandler,
+	})
+	app.Get("/bug", func(c fiber.Ctx) error {
+		return errors.New("upstream blew up")
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/bug", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", resp.StatusCode)
+	}
+	var parsed apierror.Response
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if parsed.Code != apierror.CodeInternalError {
+		t.Errorf("Code = %q, want %q", parsed.Code, apierror.CodeInternalError)
+	}
+	if !strings.Contains(parsed.Error, "upstream blew up") {
+		t.Errorf("Error = %q, want it to forward the original message", parsed.Error)
+	}
 }

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -76,6 +76,35 @@ func TestClassifyWorkerError_RetriesExhaustedBeatsCancellation(t *testing.T) {
 	}
 }
 
+// TestClassifyWorkerError_PoolUnavailable pins the admission-side
+// sentinel: pre-retry pool-availability failures (pool closed,
+// draining, no healthy workers) classify as worker_unavailable rather
+// than falling through to worker_error on plain string matching.
+// Without ErrPoolUnavailable wrapping, "pool is closed" or "no healthy
+// workers available" would surface as worker_error and clients
+// wouldn't know to retry against transient infra unavailability.
+func TestClassifyWorkerError_PoolUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"pool closed", fmt.Errorf("%w: pool is closed", pool.ErrPoolUnavailable)},
+		{"pool draining", fmt.Errorf("%w: pool is draining, not accepting new requests", pool.ErrPoolUnavailable)},
+		{"no healthy workers", fmt.Errorf("%w: no healthy workers available", pool.ErrPoolUnavailable)},
+		{"bare sentinel", pool.ErrPoolUnavailable},
+		{"sentinel through outer wrap", fmt.Errorf("call failed: %w", fmt.Errorf("%w: pool is closed", pool.ErrPoolUnavailable))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, _ := classifyWorkerError(tt.err)
+			if code != apierror.CodeWorkerUnavailable {
+				t.Errorf("classifyWorkerError(%v) code = %q, want %q", tt.err, code, apierror.CodeWorkerUnavailable)
+			}
+		})
+	}
+}
+
 // TestClassifyWorkerError_PrecedenceOrder spot-checks the full
 // classification ladder so future reorderings can't silently break a
 // rung. Each case exercises exactly one rung.
@@ -380,8 +409,17 @@ func TestClassifyStreamResultError_NormalizesWorkerFields(t *testing.T) {
 			Stacktrace:   trace,
 		}
 		_, details := classifyStreamResultError(result)
-		if !strings.Contains(string(details), "stacktrace") {
-			t.Errorf("expected stacktrace fallback, got details = %s", details)
+		if details == nil {
+			t.Fatalf("expected stacktrace fallback, got nil details")
+		}
+		var parsed struct {
+			Stacktrace string `json:"stacktrace"`
+		}
+		if err := json.Unmarshal(details, &parsed); err != nil {
+			t.Fatalf("details did not unmarshal as {stacktrace}: %v (raw: %s)", err, details)
+		}
+		if parsed.Stacktrace != trace {
+			t.Errorf("details.stacktrace = %q, want %q", parsed.Stacktrace, trace)
 		}
 	})
 }

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -207,3 +207,137 @@ func TestClassifyStreamResultError_StacktraceDetails(t *testing.T) {
 		t.Errorf("details.stacktrace = %q, want %q", parsed.Stacktrace, trace)
 	}
 }
+
+// TestNormalizeWorkerMetadata pins the contract: worker-supplied codes
+// are validated against the public apierror.Code enum, and details are
+// validated as JSON objects. Anything off-contract is dropped — the
+// host-side classifier then takes over for code, and a stacktrace
+// fallback (handled by the caller) replaces malformed details.
+func TestNormalizeWorkerMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		rawCode     string
+		rawDetails  []byte
+		wantCode    apierror.Code
+		wantDetails string // empty means details should be nil
+	}{
+		// Code validation
+		{"known code preserved", string(apierror.CodeParseError), nil, apierror.CodeParseError, ""},
+		{"known worker_error preserved", string(apierror.CodeWorkerError), nil, apierror.CodeWorkerError, ""},
+		{"unknown code dropped", "made_up_code", nil, "", ""},
+		{"empty code stays empty", "", nil, "", ""},
+		{"case-mismatch unknown dropped", "Worker_Error", nil, "", ""},
+
+		// Details validation
+		{"valid object preserved", "", []byte(`{"field":"x"}`), "", `{"field":"x"}`},
+		{"empty object preserved", "", []byte(`{}`), "", `{}`},
+		{"object with leading whitespace preserved", "", []byte(" \n{\"x\":1}"), "", " \n{\"x\":1}"},
+		{"json null dropped", "", []byte(`null`), "", ""},
+		{"json scalar dropped", "", []byte(`42`), "", ""},
+		{"json string dropped", "", []byte(`"oops"`), "", ""},
+		{"json bool dropped", "", []byte(`true`), "", ""},
+		{"json array dropped", "", []byte(`[1,2,3]`), "", ""},
+		{"invalid json dropped", "", []byte(`{not json}`), "", ""},
+		{"empty bytes stays nil", "", []byte{}, "", ""},
+		{"nil bytes stays nil", "", nil, "", ""},
+
+		// Combined
+		{"valid code + valid object both preserved", string(apierror.CodeParseError), []byte(`{"a":1}`), apierror.CodeParseError, `{"a":1}`},
+		{"valid code + invalid details: code kept, details dropped", string(apierror.CodeParseError), []byte(`null`), apierror.CodeParseError, ""},
+		{"invalid code + valid details: code dropped, details kept", "bogus", []byte(`{"a":1}`), "", `{"a":1}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCode, gotDetails := normalizeWorkerMetadata(tt.rawCode, tt.rawDetails)
+			if gotCode != tt.wantCode {
+				t.Errorf("code = %q, want %q", gotCode, tt.wantCode)
+			}
+			if tt.wantDetails == "" {
+				if gotDetails != nil {
+					t.Errorf("details = %s, want nil", gotDetails)
+				}
+			} else {
+				if string(gotDetails) != tt.wantDetails {
+					t.Errorf("details = %s, want %s", gotDetails, tt.wantDetails)
+				}
+			}
+		})
+	}
+}
+
+// TestClassifyWorkerError_UnknownWorkerCodeFallsThrough verifies that
+// a worker emitting an off-contract code falls through to host-side
+// classification rather than introducing the unknown code into the
+// response envelope. Locks the public OpenAPI enum as authoritative.
+func TestClassifyWorkerError_UnknownWorkerCodeFallsThrough(t *testing.T) {
+	err := workerplugin.NewErrorWithMetadata(
+		status.Error(codes.Unavailable, "worker died"),
+		"",
+		"made_up_code",
+		nil,
+	)
+	got, _ := classifyWorkerError(err)
+	if got != apierror.CodeWorkerUnavailable {
+		t.Errorf("classifyWorkerError = %q, want %q (host-side reclassification of inner Unavailable)", got, apierror.CodeWorkerUnavailable)
+	}
+}
+
+// TestClassifyWorkerError_ScalarDetailsFallsBackToStacktrace verifies
+// that worker-supplied non-object details get dropped, and when a
+// stacktrace is available it's used to synthesize the response
+// details instead. Without normalization the schema-violating scalar
+// would have been forwarded.
+func TestClassifyWorkerError_ScalarDetailsFallsBackToStacktrace(t *testing.T) {
+	const trace = "goroutine 1 [running]:\npanic..."
+	err := workerplugin.NewErrorWithMetadata(
+		errors.New("worker panic"),
+		trace,
+		"",
+		[]byte(`null`), // schema-violating
+	)
+	_, details := classifyWorkerError(err)
+	if details == nil {
+		t.Fatal("expected stacktrace fallback, got nil details")
+	}
+	var parsed struct {
+		Stacktrace string `json:"stacktrace"`
+	}
+	if err := json.Unmarshal(details, &parsed); err != nil {
+		t.Fatalf("details did not unmarshal as {stacktrace}: %v (raw: %s)", err, details)
+	}
+	if parsed.Stacktrace != trace {
+		t.Errorf("details.stacktrace = %q, want %q", parsed.Stacktrace, trace)
+	}
+}
+
+// TestClassifyStreamResultError_NormalizesWorkerFields mirrors the
+// unary normalization tests for the streaming path: worker-supplied
+// fields on a StreamResult go through the same gate.
+func TestClassifyStreamResultError_NormalizesWorkerFields(t *testing.T) {
+	t.Run("unknown code falls through", func(t *testing.T) {
+		result := &workerplugin.StreamResult{
+			Kind:      workerplugin.StreamResultKindError,
+			Error:     status.Error(codes.Unavailable, "worker died"),
+			ErrorCode: "fictional_code",
+		}
+		got, _ := classifyStreamResultError(result)
+		if got != apierror.CodeWorkerUnavailable {
+			t.Errorf("code = %q, want %q", got, apierror.CodeWorkerUnavailable)
+		}
+	})
+
+	t.Run("scalar details dropped, stacktrace replaces", func(t *testing.T) {
+		const trace = "goroutine 7..."
+		result := &workerplugin.StreamResult{
+			Kind:         workerplugin.StreamResultKindError,
+			Error:        errors.New("worker panic"),
+			ErrorDetails: []byte(`42`),
+			Stacktrace:   trace,
+		}
+		_, details := classifyStreamResultError(result)
+		if !strings.Contains(string(details), "stacktrace") {
+			t.Errorf("expected stacktrace fallback, got details = %s", details)
+		}
+	})
+}

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -559,12 +559,10 @@ var serveCmd = &cobra.Command{
 
 			makeDynamicStreamHandler := func(streamMode bamlutils.StreamMode) fiber.Handler {
 				return func(c fiber.Ctx) error {
-					workerInput, statusCode, err := parseDynamicStreamInput(c.Body())
+					workerInput, statusCode, code, err := parseDynamicStreamInput(c.Body())
 					if err != nil {
-						code := apierror.CodeInvalidRequest
 						if statusCode >= fiber.StatusInternalServerError {
 							logger.Error().Err(err).Msg("dynamic stream input parsing failed")
-							code = apierror.CodeInternalError
 						}
 						return writeFiberJSONErrorWithCode(c, err.Error(), code, nil, statusCode)
 					}
@@ -704,22 +702,27 @@ var serveCmd = &cobra.Command{
 	},
 }
 
-func parseDynamicStreamInput(rawBody []byte) (workerInput []byte, statusCode int, err error) {
+// parseDynamicStreamInput parses + validates the JSON body for a
+// dynamic streaming endpoint and returns the worker-shaped input
+// alongside the apierror.Code that classifies any failure (so callers
+// preserve machine-readable codes instead of collapsing every 4xx into
+// invalid_request). On success: code is "" and statusCode is 0.
+func parseDynamicStreamInput(rawBody []byte) (workerInput []byte, statusCode int, code apierror.Code, err error) {
 	var input bamlutils.DynamicInput
 	if err := json.Unmarshal(rawBody, &input); err != nil {
-		return nil, fiber.StatusBadRequest, fmt.Errorf("invalid JSON: %w", err)
+		return nil, fiber.StatusBadRequest, apierror.CodeInvalidJSON, fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	if err := input.Validate(); err != nil {
-		return nil, fiber.StatusBadRequest, err
+		return nil, fiber.StatusBadRequest, apierror.CodeInvalidRequest, err
 	}
 
 	workerInput, err = input.ToWorkerInput()
 	if err != nil {
-		return nil, fiber.StatusInternalServerError, fmt.Errorf("failed to convert input: %w", err)
+		return nil, fiber.StatusInternalServerError, apierror.CodeInternalError, fmt.Errorf("failed to convert input: %w", err)
 	}
 
-	return workerInput, 0, nil
+	return workerInput, 0, "", nil
 }
 
 func init() {

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -333,10 +333,22 @@ var serveCmd = &cobra.Command{
 		logger.Info().Int("size", poolSize).Msg("Worker pool initialized")
 
 		// Create Fiber app
+		//
+		// ErrorHandler maps framework-emitted *fiber.Error values into
+		// the apierror response shape so framework-level failures
+		// (BodyLimit/413 in particular, but also 404 / 405 / etc.)
+		// surface as the same coded JSON envelope our handlers emit
+		// instead of Fiber's default text/plain body. Without this,
+		// a 413 from BodyLimit bypassed writeFiberJSONErrorWithCode
+		// and clients lost the request_too_large code that the chi
+		// path already produces via writeChiBodyReadError. Non-
+		// *fiber.Error errors (uncaught from a handler) default to
+		// 500 internal_error.
 		app := fiber.New(fiber.Config{
-			JSONEncoder: json.Marshal,
-			JSONDecoder: json.Unmarshal,
-			BodyLimit:   maxRequestBodyBytes,
+			JSONEncoder:  json.Marshal,
+			JSONDecoder:  json.Unmarshal,
+			BodyLimit:    maxRequestBodyBytes,
+			ErrorHandler: fiberErrorHandler,
 		})
 
 		// Set global panic recovery handler to use structured logging

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -575,6 +575,15 @@ var serveCmd = &cobra.Command{
 					if err != nil {
 						if statusCode >= fiber.StatusInternalServerError {
 							logger.Error().Err(err).Msg("dynamic stream input parsing failed")
+							// 5xx tail: route through writeFiberInternalError so
+							// httplogger.SetError attaches the error to the request-
+							// scoped structured log alongside the discrete logger
+							// line above. Wire shape is unchanged —
+							// parseDynamicStreamInput only returns statusCode>=500
+							// from the ToWorkerInput path, which already classifies
+							// as CodeInternalError, so the helper produces an
+							// identical envelope.
+							return writeFiberInternalError(c, err)
 						}
 						return writeFiberJSONErrorWithCode(c, err.Error(), code, nil, statusCode)
 					}

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gregwebs/go-recovery"
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/bamlutils/buildrequest"
+	"github.com/invakid404/baml-rest/internal/apierror"
 	"github.com/invakid404/baml-rest/internal/memlimit"
 	"github.com/invakid404/baml-rest/introspected"
 	"github.com/invakid404/baml-rest/pool"
@@ -444,13 +445,7 @@ var serveCmd = &cobra.Command{
 					}
 					if err != nil {
 						logger.Error().Err(err).Str("method", methodName).Msg("worker call failed")
-						// Mirror writeChiWorkerError (cmd/serve/unary.go):
-						// classify context cancellation / deadline as 408 so
-						// client-driven aborts don't inflate 5xx error metrics.
-						if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-							return writeFiberJSONError(c, "request canceled", fiber.StatusRequestTimeout)
-						}
-						return writeFiberJSONError(c, "failed to process request", fiber.StatusInternalServerError)
+						return writeFiberWorkerError(c, err)
 					}
 					c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
 					if streamMode.NeedsRaw() {
@@ -475,7 +470,7 @@ var serveCmd = &cobra.Command{
 					case contentTypeSSE:
 						return HandleSSEStreamFiber(c, methodName, c.Body(), streamMode, workerPool, false)
 					default:
-						return writeFiberJSONError(c, "Not Acceptable: server can produce text/event-stream or application/x-ndjson", fiber.StatusNotAcceptable)
+						return writeFiberJSONErrorWithCode(c, "Not Acceptable: server can produce text/event-stream or application/x-ndjson", apierror.CodeNotAcceptable, nil, fiber.StatusNotAcceptable)
 					}
 				}
 			}
@@ -491,7 +486,7 @@ var serveCmd = &cobra.Command{
 				result, err := workerPool.Parse(ctx, methodName, c.Body())
 				if err != nil {
 					logger.Error().Err(err).Str("method", methodName).Msg("worker parse failed")
-					return writeFiberJSONError(c, "failed to parse response", fiber.StatusInternalServerError)
+					return writeFiberParseWorkerError(c, err)
 				}
 
 				c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
@@ -516,18 +511,18 @@ var serveCmd = &cobra.Command{
 					// Parse and validate dynamic input
 					var input bamlutils.DynamicInput
 					if err := json.Unmarshal(rawBody, &input); err != nil {
-						return writeFiberJSONError(c, "invalid JSON payload", fiber.StatusBadRequest)
+						return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidJSON, nil, fiber.StatusBadRequest)
 					}
 
 					if err := input.Validate(); err != nil {
-						return writeFiberJSONError(c, err.Error(), fiber.StatusBadRequest)
+						return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidRequest, nil, fiber.StatusBadRequest)
 					}
 
 					// Convert to internal format
 					workerInput, err := input.ToWorkerInput()
 					if err != nil {
 						logger.Error().Err(err).Msg("dynamic input conversion failed")
-						return writeFiberJSONError(c, "failed to process dynamic input", fiber.StatusInternalServerError)
+						return writeFiberInternalError(c, err)
 					}
 
 					result, err := workerPool.Call(ctx, bamlutils.DynamicMethodName, workerInput, streamMode)
@@ -538,20 +533,14 @@ var serveCmd = &cobra.Command{
 					}
 					if err != nil {
 						logger.Error().Err(err).Msg("dynamic worker call failed")
-						// Mirror writeChiWorkerError (cmd/serve/unary.go):
-						// classify context cancellation / deadline as 408 so
-						// client-driven aborts don't inflate 5xx error metrics.
-						if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-							return writeFiberJSONError(c, "request canceled", fiber.StatusRequestTimeout)
-						}
-						return writeFiberJSONError(c, "failed to process request", fiber.StatusInternalServerError)
+						return writeFiberWorkerError(c, err)
 					}
 
 					// Flatten DynamicProperties to root level for better UX
 					flattenedData, err := bamlutils.FlattenDynamicOutput(result.Data)
 					if err != nil {
 						logger.Error().Err(err).Msg("dynamic response flatten failed")
-						return writeFiberJSONError(c, "failed to process response", fiber.StatusInternalServerError)
+						return writeFiberInternalError(c, err)
 					}
 					c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
 					if streamMode.NeedsRaw() {
@@ -572,12 +561,12 @@ var serveCmd = &cobra.Command{
 				return func(c fiber.Ctx) error {
 					workerInput, statusCode, err := parseDynamicStreamInput(c.Body())
 					if err != nil {
-						message := err.Error()
+						code := apierror.CodeInvalidRequest
 						if statusCode >= fiber.StatusInternalServerError {
 							logger.Error().Err(err).Msg("dynamic stream input parsing failed")
-							message = "failed to process dynamic stream input"
+							code = apierror.CodeInternalError
 						}
-						return writeFiberJSONError(c, message, statusCode)
+						return writeFiberJSONErrorWithCode(c, err.Error(), code, nil, statusCode)
 					}
 
 					switch c.Accepts(contentTypeSSE, ContentTypeNDJSON) {
@@ -586,7 +575,7 @@ var serveCmd = &cobra.Command{
 					case contentTypeSSE:
 						return HandleSSEStreamFiber(c, bamlutils.DynamicMethodName, workerInput, streamMode, workerPool, true)
 					default:
-						return writeFiberJSONError(c, "Not Acceptable: server can produce text/event-stream or application/x-ndjson", fiber.StatusNotAcceptable)
+						return writeFiberJSONErrorWithCode(c, "Not Acceptable: server can produce text/event-stream or application/x-ndjson", apierror.CodeNotAcceptable, nil, fiber.StatusNotAcceptable)
 					}
 				}
 			}
@@ -604,30 +593,30 @@ var serveCmd = &cobra.Command{
 				// Parse and validate dynamic parse input
 				var input bamlutils.DynamicParseInput
 				if err := json.Unmarshal(rawBody, &input); err != nil {
-					return writeFiberJSONError(c, "invalid JSON payload", fiber.StatusBadRequest)
+					return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidJSON, nil, fiber.StatusBadRequest)
 				}
 				if err := input.Validate(); err != nil {
-					return writeFiberJSONError(c, err.Error(), fiber.StatusBadRequest)
+					return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidRequest, nil, fiber.StatusBadRequest)
 				}
 
 				// Convert to internal format
 				workerInput, err := input.ToWorkerInput()
 				if err != nil {
 					logger.Error().Err(err).Msg("dynamic parse input conversion failed")
-					return writeFiberJSONError(c, "failed to process dynamic input", fiber.StatusInternalServerError)
+					return writeFiberInternalError(c, err)
 				}
 
 				result, err := workerPool.Parse(ctx, bamlutils.DynamicMethodName, workerInput)
 				if err != nil {
 					logger.Error().Err(err).Msg("dynamic worker parse failed")
-					return writeFiberJSONError(c, "failed to parse response", fiber.StatusInternalServerError)
+					return writeFiberParseWorkerError(c, err)
 				}
 
 				// Flatten DynamicProperties to root level for better UX
 				flattenedData, err := bamlutils.FlattenDynamicOutput(result.Data)
 				if err != nil {
 					logger.Error().Err(err).Msg("dynamic parse response flatten failed")
-					return writeFiberJSONError(c, "failed to process response", fiber.StatusInternalServerError)
+					return writeFiberInternalError(c, err)
 				}
 
 				c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)

--- a/cmd/serve/streamwriter.go
+++ b/cmd/serve/streamwriter.go
@@ -199,13 +199,18 @@ func HandleNDJSONStreamFiber(
 
 // classifyStreamResultError extracts the error code and structured
 // details for a mid-stream StreamResultKindError frame. Worker-supplied
-// fields on the StreamResult itself (ErrorCode / ErrorDetails, populated
-// from the proto) take priority over heuristic classification of the
-// embedded error value.
+// fields on the StreamResult itself (ErrorCode / ErrorDetails / Stacktrace,
+// populated from the proto) take priority over heuristic classification
+// of the embedded error value. When ErrorDetails is empty but Stacktrace
+// is set (the typical worker-panic shape), the stacktrace is wrapped as
+// {"stacktrace": "..."} so the response carries the same panic trace
+// classifyWorkerError would expose for unary endpoints.
 func classifyStreamResultError(result *workerplugin.StreamResult) (apierror.Code, json.RawMessage) {
 	var details json.RawMessage
 	if len(result.ErrorDetails) > 0 && json.Valid(result.ErrorDetails) {
 		details = json.RawMessage(result.ErrorDetails)
+	} else if result.Stacktrace != "" {
+		details = stacktraceDetailsJSON(result.Stacktrace)
 	}
 	if result.ErrorCode != "" {
 		return apierror.Code(result.ErrorCode), details

--- a/cmd/serve/streamwriter.go
+++ b/cmd/serve/streamwriter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/goccy/go-json"
 	"github.com/gofiber/fiber/v3"
 	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/apierror"
 	"github.com/invakid404/baml-rest/internal/unsafeutil"
 	"github.com/invakid404/baml-rest/pool"
 	"github.com/invakid404/baml-rest/workerplugin"
@@ -33,11 +34,17 @@ const (
 )
 
 // NDJSONEvent represents a single NDJSON streaming event.
+//
+// Code and Details are populated only on Type=="error" events. Both are
+// omitempty so non-error frames stay compact and existing consumers
+// pinned on {type, data, raw, error} continue to deserialize cleanly.
 type NDJSONEvent struct {
-	Type  NDJSONEventType `json:"type"`
-	Data  json.RawMessage `json:"data,omitempty"`
-	Raw   string          `json:"raw,omitempty"`
-	Error string          `json:"error,omitempty"`
+	Type    NDJSONEventType `json:"type"`
+	Data    json.RawMessage `json:"data,omitempty"`
+	Raw     string          `json:"raw,omitempty"`
+	Error   string          `json:"error,omitempty"`
+	Code    apierror.Code   `json:"code,omitempty"`
+	Details json.RawMessage `json:"details,omitempty"`
 }
 
 // NDJSONStreamWriterPublisher implements StreamPublisher for native Fiber streaming.
@@ -141,8 +148,8 @@ func (p *NDJSONStreamWriterPublisher) PublishMetadata(payload json.RawMessage) e
 	return p.writeEvent(&NDJSONEvent{Type: NDJSONEventMetadata, Data: payload})
 }
 
-func (p *NDJSONStreamWriterPublisher) PublishError(errMsg string) error {
-	return p.writeEvent(&NDJSONEvent{Type: NDJSONEventError, Error: errMsg})
+func (p *NDJSONStreamWriterPublisher) PublishError(errMsg string, code apierror.Code, details json.RawMessage) error {
+	return p.writeEvent(&NDJSONEvent{Type: NDJSONEventError, Error: errMsg, Code: code, Details: details})
 }
 
 func (p *NDJSONStreamWriterPublisher) Close() {
@@ -181,12 +188,33 @@ func HandleNDJSONStreamFiber(
 
 		results, err := workerPool.CallStream(streamCtx, methodName, rawBody, streamMode)
 		if err != nil {
-			_ = publisher.PublishError(err.Error())
+			code, details := classifyWorkerError(err)
+			_ = publisher.PublishError(err.Error(), code, details)
 			return
 		}
 
 		consumeStream(results, publisher, streamMode, flattenDynamic)
 	})
+}
+
+// classifyStreamResultError extracts the error code and structured
+// details for a mid-stream StreamResultKindError frame. Worker-supplied
+// fields on the StreamResult itself (ErrorCode / ErrorDetails, populated
+// from the proto) take priority over heuristic classification of the
+// embedded error value.
+func classifyStreamResultError(result *workerplugin.StreamResult) (apierror.Code, json.RawMessage) {
+	var details json.RawMessage
+	if len(result.ErrorDetails) > 0 && json.Valid(result.ErrorDetails) {
+		details = json.RawMessage(result.ErrorDetails)
+	}
+	if result.ErrorCode != "" {
+		return apierror.Code(result.ErrorCode), details
+	}
+	code, fallbackDetails := classifyWorkerError(result.Error)
+	if details == nil {
+		details = fallbackDetails
+	}
+	return code, details
 }
 
 // StreamPublisher is the unified interface for publishing stream events.
@@ -199,8 +227,10 @@ type StreamPublisher interface {
 	PublishFinal(data []byte, raw string) error
 	// PublishReset sends a reset event indicating client should discard state.
 	PublishReset() error
-	// PublishError sends an error event.
-	PublishError(errMsg string) error
+	// PublishError sends an error event. code and details may be empty/nil
+	// when no classification is available — the underlying transport
+	// omits those fields from the wire.
+	PublishError(errMsg string, code apierror.Code, details json.RawMessage) error
 	// PublishMetadata sends a routing/retry metadata event.
 	// payload is the JSON-encoded bamlutils.Metadata value.
 	PublishMetadata(payload json.RawMessage) error
@@ -361,9 +391,16 @@ func (p *SSEStreamWriterPublisher) PublishMetadata(payload json.RawMessage) erro
 	return p.writeEvent(sseEventMetadata, unsafeutil.BytesToString(payload))
 }
 
-func (p *SSEStreamWriterPublisher) PublishError(errMsg string) error {
-	payload, err := json.Marshal(map[string]string{"error": errMsg})
+func (p *SSEStreamWriterPublisher) PublishError(errMsg string, code apierror.Code, details json.RawMessage) error {
+	envelope := struct {
+		Error   string          `json:"error"`
+		Code    apierror.Code   `json:"code,omitempty"`
+		Details json.RawMessage `json:"details,omitempty"`
+	}{Error: errMsg, Code: code, Details: details}
+	payload, err := json.Marshal(envelope)
 	if err != nil {
+		// Fallback: at least surface the message as the data payload so
+		// the client sees the failure even if envelope marshaling broke.
 		return p.writeEvent(sseEventError, errMsg)
 	}
 
@@ -407,7 +444,8 @@ func HandleSSEStreamFiber(
 
 		results, err := workerPool.CallStream(streamCtx, methodName, rawBody, streamMode)
 		if err != nil {
-			_ = publisher.PublishError(err.Error())
+			code, details := classifyWorkerError(err)
+			_ = publisher.PublishError(err.Error(), code, details)
 			return
 		}
 
@@ -431,7 +469,13 @@ func consumeStream(
 		switch result.Kind {
 		case workerplugin.StreamResultKindError:
 			if result.Error != nil {
-				_ = publisher.PublishError(result.Error.Error())
+				// Worker-supplied code/details (carried over the gRPC
+				// boundary on StreamResult) take precedence over the
+				// host-side classifier; if absent, classifyWorkerError
+				// falls back to pool.IsRetryableWorkerError to choose
+				// between worker_unavailable and worker_error.
+				code, details := classifyStreamResultError(result)
+				_ = publisher.PublishError(result.Error.Error(), code, details)
 			}
 
 		case workerplugin.StreamResultKindMetadata:

--- a/cmd/serve/streamwriter.go
+++ b/cmd/serve/streamwriter.go
@@ -201,19 +201,20 @@ func HandleNDJSONStreamFiber(
 // details for a mid-stream StreamResultKindError frame. Worker-supplied
 // fields on the StreamResult itself (ErrorCode / ErrorDetails / Stacktrace,
 // populated from the proto) take priority over heuristic classification
-// of the embedded error value. When ErrorDetails is empty but Stacktrace
-// is set (the typical worker-panic shape), the stacktrace is wrapped as
+// of the embedded error value, but worker code/details are routed
+// through normalizeWorkerMetadata first so off-contract values
+// (unknown codes, non-object details) are dropped instead of
+// forwarded. When ErrorDetails is empty (or fails normalization) and
+// Stacktrace is set, the stacktrace is wrapped as
 // {"stacktrace": "..."} so the response carries the same panic trace
 // classifyWorkerError would expose for unary endpoints.
 func classifyStreamResultError(result *workerplugin.StreamResult) (apierror.Code, json.RawMessage) {
-	var details json.RawMessage
-	if len(result.ErrorDetails) > 0 && json.Valid(result.ErrorDetails) {
-		details = json.RawMessage(result.ErrorDetails)
-	} else if result.Stacktrace != "" {
+	workerCode, details := normalizeWorkerMetadata(result.ErrorCode, result.ErrorDetails)
+	if details == nil && result.Stacktrace != "" {
 		details = stacktraceDetailsJSON(result.Stacktrace)
 	}
-	if result.ErrorCode != "" {
-		return apierror.Code(result.ErrorCode), details
+	if workerCode != "" {
+		return workerCode, details
 	}
 	code, fallbackDetails := classifyWorkerError(result.Error)
 	if details == nil {

--- a/cmd/serve/streamwriter_test.go
+++ b/cmd/serve/streamwriter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/goccy/go-json"
 	"github.com/gofiber/fiber/v3"
 	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/apierror"
 	"github.com/invakid404/baml-rest/workerplugin"
 )
 
@@ -17,6 +18,8 @@ type recordingPublisher struct {
 	metadataFrames [][]byte
 	resetCount     int
 	errors         []string
+	errorCodes     []apierror.Code
+	errorDetails   [][]byte
 }
 
 func (p *recordingPublisher) PublishData(data []byte, raw string) error {
@@ -31,8 +34,14 @@ func (p *recordingPublisher) PublishFinal(data []byte, raw string) error {
 	return nil
 }
 
-func (p *recordingPublisher) PublishError(errMsg string) error {
+func (p *recordingPublisher) PublishError(errMsg string, code apierror.Code, details json.RawMessage) error {
 	p.errors = append(p.errors, errMsg)
+	p.errorCodes = append(p.errorCodes, code)
+	if details == nil {
+		p.errorDetails = append(p.errorDetails, nil)
+	} else {
+		p.errorDetails = append(p.errorDetails, append([]byte(nil), details...))
+	}
 	return nil
 }
 

--- a/cmd/serve/streamwriter_test.go
+++ b/cmd/serve/streamwriter_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -305,5 +306,68 @@ func TestConsumeStream_HonorsResetOnMetadata(t *testing.T) {
 	}
 	if len(publisher.finalFrames) != 1 {
 		t.Fatalf("expected 1 final frame, got %d", len(publisher.finalFrames))
+	}
+}
+
+// TestConsumeStream_ForwardsErrorCodeAndDetails pins the pool→publisher
+// contract that worker-supplied ErrorCode and ErrorDetails on a
+// StreamResultKindError frame propagate verbatim into the published
+// error event. Regression guard: any future refactor that drops these
+// fields silently degrades the stream error envelope back to a
+// message-only string and breaks LLM-agent error-feedback loops.
+func TestConsumeStream_ForwardsErrorCodeAndDetails(t *testing.T) {
+	t.Parallel()
+
+	wantDetails := []byte(`{"field":"sentiment","expected":"positive|negative|neutral"}`)
+	results := make(chan *workerplugin.StreamResult, 1)
+	results <- &workerplugin.StreamResult{
+		Kind:         workerplugin.StreamResultKindError,
+		Error:        fmt.Errorf("BAML parse error: invalid enum value"),
+		ErrorCode:    string(apierror.CodeParseError),
+		ErrorDetails: wantDetails,
+	}
+	close(results)
+
+	publisher := &recordingPublisher{}
+	consumeStream(results, publisher, bamlutils.StreamModeStream, false)
+
+	if len(publisher.errors) != 1 {
+		t.Fatalf("expected 1 error frame, got %d", len(publisher.errors))
+	}
+	if publisher.errors[0] != "BAML parse error: invalid enum value" {
+		t.Errorf("error message = %q, want %q", publisher.errors[0], "BAML parse error: invalid enum value")
+	}
+	if len(publisher.errorCodes) != 1 || publisher.errorCodes[0] != apierror.CodeParseError {
+		t.Errorf("error code = %q, want %q", publisher.errorCodes, apierror.CodeParseError)
+	}
+	if len(publisher.errorDetails) != 1 || string(publisher.errorDetails[0]) != string(wantDetails) {
+		t.Errorf("error details = %q, want %q", publisher.errorDetails, wantDetails)
+	}
+}
+
+// TestConsumeStream_ClassifiesUnclassifiedErrorsAsWorkerError covers
+// the fallback path: when the worker emits an error without an
+// ErrorCode (the common case today, before BAML exposes typed errors),
+// the publisher still receives a host-side classification — not an
+// empty string — so clients always see a usable code.
+func TestConsumeStream_ClassifiesUnclassifiedErrorsAsWorkerError(t *testing.T) {
+	t.Parallel()
+
+	results := make(chan *workerplugin.StreamResult, 1)
+	results <- &workerplugin.StreamResult{
+		Kind:  workerplugin.StreamResultKindError,
+		Error: fmt.Errorf("upstream LLM returned 429"),
+		// No ErrorCode / ErrorDetails — exercises classifyWorkerError
+		// fallback. The error is plain (not a gRPC status, not a
+		// retries-exhausted sentinel), so the classifier returns
+		// worker_error.
+	}
+	close(results)
+
+	publisher := &recordingPublisher{}
+	consumeStream(results, publisher, bamlutils.StreamModeStream, false)
+
+	if len(publisher.errorCodes) != 1 || publisher.errorCodes[0] != apierror.CodeWorkerError {
+		t.Errorf("error code = %q, want %q", publisher.errorCodes, apierror.CodeWorkerError)
 	}
 }

--- a/cmd/serve/unary_handlers.go
+++ b/cmd/serve/unary_handlers.go
@@ -9,7 +9,6 @@ import (
 	"github.com/goccy/go-json"
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/internal/apierror"
-	"github.com/invakid404/baml-rest/internal/httplogger"
 	"github.com/invakid404/baml-rest/pool"
 	"github.com/invakid404/baml-rest/workerplugin"
 )
@@ -63,7 +62,7 @@ func makeChiCallHandler(p *pool.Pool, methodName string, streamMode bamlutils.St
 
 		body, statusCode, err := readUnaryBody(r)
 		if err != nil {
-			writeChiJSONError(w, r, "failed to read request body", statusCode)
+			writeChiBodyReadError(w, r, err, statusCode)
 			return
 		}
 
@@ -76,7 +75,7 @@ func makeChiCallHandler(p *pool.Pool, methodName string, streamMode bamlutils.St
 			setBAMLHeaders(netHTTPHeaderSetter(w.Header()), decodeMetadataJSON(result.Planned), decodeMetadataJSON(result.Outcome))
 		}
 		if err != nil {
-			writeChiWorkerError(w, r, err, "failed to process request")
+			writeChiWorkerErrorClassified(w, r, err)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -101,13 +100,13 @@ func makeChiParseHandler(p *pool.Pool, methodName string) http.HandlerFunc {
 
 		body, statusCode, err := readUnaryBody(r)
 		if err != nil {
-			writeChiJSONError(w, r, "failed to read request body", statusCode)
+			writeChiBodyReadError(w, r, err, statusCode)
 			return
 		}
 
 		result, err := p.Parse(ctx, methodName, body)
 		if err != nil {
-			writeChiWorkerError(w, r, err, "failed to parse response")
+			writeChiParseWorkerError(w, r, err)
 			return
 		}
 
@@ -132,24 +131,23 @@ func makeChiDynamicCallHandlerWithEmitter(p unaryCaller, streamMode bamlutils.St
 
 		body, statusCode, err := readUnaryBody(r)
 		if err != nil {
-			writeChiJSONError(w, r, "failed to read request body", statusCode)
+			writeChiBodyReadError(w, r, err, statusCode)
 			return
 		}
 
 		var input bamlutils.DynamicInput
 		if err := json.Unmarshal(body, &input); err != nil {
-			writeChiJSONError(w, r, "invalid JSON payload", http.StatusBadRequest)
+			writeChiJSONErrorWithCode(w, r, err.Error(), apierror.CodeInvalidJSON, nil, http.StatusBadRequest)
 			return
 		}
 		if err := input.Validate(); err != nil {
-			writeChiJSONError(w, r, err.Error(), http.StatusBadRequest)
+			writeChiJSONErrorWithCode(w, r, err.Error(), apierror.CodeInvalidRequest, nil, http.StatusBadRequest)
 			return
 		}
 
 		workerInput, err := input.ToWorkerInput()
 		if err != nil {
-			httplogger.SetError(r.Context(), err)
-			writeChiJSONError(w, r, "failed to process dynamic input", http.StatusInternalServerError)
+			writeChiInternalError(w, r, err)
 			return
 		}
 
@@ -162,14 +160,13 @@ func makeChiDynamicCallHandlerWithEmitter(p unaryCaller, streamMode bamlutils.St
 			emit(w, result.Planned, result.Outcome)
 		}
 		if err != nil {
-			writeChiWorkerError(w, r, err, "failed to process request")
+			writeChiWorkerErrorClassified(w, r, err)
 			return
 		}
 
 		flattenedData, err := bamlutils.FlattenDynamicOutput(result.Data)
 		if err != nil {
-			httplogger.SetError(r.Context(), err)
-			writeChiJSONError(w, r, "failed to process response", http.StatusInternalServerError)
+			writeChiInternalError(w, r, err)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -194,37 +191,35 @@ func makeChiDynamicParseHandler(p *pool.Pool) http.HandlerFunc {
 
 		body, statusCode, err := readUnaryBody(r)
 		if err != nil {
-			writeChiJSONError(w, r, "failed to read request body", statusCode)
+			writeChiBodyReadError(w, r, err, statusCode)
 			return
 		}
 
 		var input bamlutils.DynamicParseInput
 		if err := json.Unmarshal(body, &input); err != nil {
-			writeChiJSONError(w, r, "invalid JSON payload", http.StatusBadRequest)
+			writeChiJSONErrorWithCode(w, r, err.Error(), apierror.CodeInvalidJSON, nil, http.StatusBadRequest)
 			return
 		}
 		if err := input.Validate(); err != nil {
-			writeChiJSONError(w, r, err.Error(), http.StatusBadRequest)
+			writeChiJSONErrorWithCode(w, r, err.Error(), apierror.CodeInvalidRequest, nil, http.StatusBadRequest)
 			return
 		}
 
 		workerInput, err := input.ToWorkerInput()
 		if err != nil {
-			httplogger.SetError(r.Context(), err)
-			writeChiJSONError(w, r, "failed to process dynamic input", http.StatusInternalServerError)
+			writeChiInternalError(w, r, err)
 			return
 		}
 
 		result, err := p.Parse(ctx, bamlutils.DynamicMethodName, workerInput)
 		if err != nil {
-			writeChiWorkerError(w, r, err, "failed to parse response")
+			writeChiParseWorkerError(w, r, err)
 			return
 		}
 
 		flattenedData, err := bamlutils.FlattenDynamicOutput(result.Data)
 		if err != nil {
-			httplogger.SetError(r.Context(), err)
-			writeChiJSONError(w, r, "failed to process response", http.StatusInternalServerError)
+			writeChiInternalError(w, r, err)
 			return
 		}
 
@@ -248,18 +243,13 @@ func readUnaryBody(r *http.Request) ([]byte, int, error) {
 	return body, 0, nil
 }
 
-// writeChiJSONError writes a JSON error response using the standard apierror envelope.
-func writeChiJSONError(w http.ResponseWriter, r *http.Request, message string, statusCode int) {
-	apierror.WriteJSON(w, message, statusCode, unaryRequestID(r.Context()))
-}
-
-// writeChiWorkerError classifies worker errors: context cancellation is reported
-// as 408 (not 500) so it doesn't inflate error metrics.
-func writeChiWorkerError(w http.ResponseWriter, r *http.Request, err error, fallbackMessage string) {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		writeChiJSONError(w, r, "request canceled", http.StatusRequestTimeout)
-		return
+// writeChiBodyReadError classifies a body-read failure: 413
+// request_too_large for MaxBytesReader exhaustion (statusCode 413
+// produced by readUnaryBody), other I/O failures as 400 body_read_error.
+func writeChiBodyReadError(w http.ResponseWriter, r *http.Request, err error, statusCode int) {
+	code := apierror.CodeBodyReadError
+	if statusCode == http.StatusRequestEntityTooLarge {
+		code = apierror.CodeRequestTooLarge
 	}
-	httplogger.SetError(r.Context(), err)
-	writeChiJSONError(w, r, fallbackMessage, http.StatusInternalServerError)
+	writeChiJSONErrorWithCode(w, r, err.Error(), code, nil, statusCode)
 }

--- a/internal/apierror/error.go
+++ b/internal/apierror/error.go
@@ -134,11 +134,20 @@ func WriteJSON(w http.ResponseWriter, message string, statusCode int, requestID 
 // WriteJSONWithCode writes a JSON-formatted error response carrying a
 // machine-readable code and optional structured details. Pass code=""
 // and details=nil to omit those fields from the response.
+//
+// details is validated with json.Valid before being placed on the
+// response: invalid bytes are dropped and Details is omitted, so the
+// encoded body is always well-formed JSON. Upstream callers
+// (cmd/serve/error.go normalizeWorkerMetadata) already gate to JSON
+// objects, but this helper is exported and the validation here is
+// defense-in-depth — without it, a future caller passing an invalid
+// json.RawMessage would emit malformed bytes verbatim because
+// json.RawMessage's MarshalJSON returns its input as-is.
 func WriteJSONWithCode(w http.ResponseWriter, message string, code Code, details json.RawMessage, statusCode int, requestID string) {
 	resp := Response{
 		Error:     message,
 		Code:      code,
-		Details:   details,
+		Details:   ValidDetails(details),
 		RequestID: requestID,
 	}
 
@@ -147,4 +156,21 @@ func WriteJSONWithCode(w http.ResponseWriter, message string, code Code, details
 
 	// Best effort - if encoding fails, we've already written the status code
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// ValidDetails returns details unchanged when the bytes parse as
+// valid JSON, or nil otherwise. Callers placing a json.RawMessage
+// onto the Response envelope should run it through this helper so
+// the encoded body is always well-formed — RawMessage is verbatim-
+// marshalled, so an invalid payload would otherwise corrupt the
+// response stream. nil and empty inputs are passed through (and
+// omit from the envelope via the omitempty json tag).
+func ValidDetails(details json.RawMessage) json.RawMessage {
+	if len(details) == 0 {
+		return details
+	}
+	if !json.Valid(details) {
+		return nil
+	}
+	return details
 }

--- a/internal/apierror/error.go
+++ b/internal/apierror/error.go
@@ -54,6 +54,29 @@ func (c Code) IsKnown() bool {
 	return false
 }
 
+// IsWorkerFacing reports whether c is a code a worker is allowed to
+// self-classify as. Workers can only emit codes that describe what
+// happened inside the worker process — request-layer codes
+// (invalid_json, request_too_large, request_canceled, ...) and pool-
+// admission codes (worker_unavailable) are owned by the host and
+// must NOT be honored if a worker supplies them: doing so would let
+// worker-side text dictate HTTP status semantics (e.g. claiming
+// request_canceled to force a 408 from the host's classifier).
+//
+// The allow-list is intentionally narrow: the worker-classified
+// outcomes the host trusts are exactly worker_error (BAML / LLM
+// application error), parse_error (BAML couldn't validate raw
+// output against the method schema), and internal_error (a Go-side
+// processing bug inside the worker). Unknown or non-worker-facing
+// codes fall back to host-side classification.
+func (c Code) IsWorkerFacing() bool {
+	switch c {
+	case CodeWorkerError, CodeParseError, CodeInternalError:
+		return true
+	}
+	return false
+}
+
 const (
 	// CodeInvalidJSON: request body wasn't valid JSON.
 	CodeInvalidJSON Code = "invalid_json"

--- a/internal/apierror/error.go
+++ b/internal/apierror/error.go
@@ -12,6 +12,23 @@ import (
 // on these without parsing free-form messages.
 type Code string
 
+// IsKnown reports whether c is one of the documented Code constants.
+// The HTTP layer validates worker-supplied codes against this set
+// before forwarding them so the public OpenAPI enum stays
+// authoritative — a worker emitting an unknown code falls back to
+// host-side classification rather than introducing an off-contract
+// value into the response envelope.
+func (c Code) IsKnown() bool {
+	switch c {
+	case CodeInvalidJSON, CodeInvalidRequest, CodeRequestTooLarge,
+		CodeBodyReadError, CodeNotAcceptable, CodeRequestCanceled,
+		CodeWorkerUnavailable, CodeWorkerError, CodeParseError,
+		CodeInternalError:
+		return true
+	}
+	return false
+}
+
 const (
 	// CodeInvalidJSON: request body wasn't valid JSON.
 	CodeInvalidJSON Code = "invalid_json"

--- a/internal/apierror/error.go
+++ b/internal/apierror/error.go
@@ -7,17 +7,73 @@ import (
 	"github.com/goccy/go-json"
 )
 
+// Code is a stable, machine-readable identifier for an error class.
+// Clients (including LLM agents consuming errors as tool feedback) can branch
+// on these without parsing free-form messages.
+type Code string
+
+const (
+	// CodeInvalidJSON: request body wasn't valid JSON.
+	CodeInvalidJSON Code = "invalid_json"
+	// CodeInvalidRequest: request was syntactically valid JSON but failed
+	// schema/semantic validation (e.g. dynamic input Validate()).
+	CodeInvalidRequest Code = "invalid_request"
+	// CodeRequestTooLarge: request body exceeded the configured size limit.
+	CodeRequestTooLarge Code = "request_too_large"
+	// CodeBodyReadError: I/O error reading the request body.
+	CodeBodyReadError Code = "body_read_error"
+	// CodeNotAcceptable: client's Accept header doesn't intersect with
+	// formats the endpoint can produce.
+	CodeNotAcceptable Code = "not_acceptable"
+	// CodeRequestCanceled: client disconnected or the request deadline
+	// was exceeded before completion.
+	CodeRequestCanceled Code = "request_canceled"
+	// CodeWorkerUnavailable: the BAML worker pool exhausted retries on
+	// retryable infrastructure failures (worker crash, gRPC Unavailable,
+	// transport reset). Retrying the request later may succeed.
+	CodeWorkerUnavailable Code = "worker_unavailable"
+	// CodeWorkerError: the BAML worker returned an application-level
+	// error — typically a BAML validation failure, a parse error against
+	// the BAML schema, or an upstream LLM provider error. The accompanying
+	// message comes verbatim from BAML / the LLM provider.
+	CodeWorkerError Code = "worker_error"
+	// CodeParseError: the /parse endpoint failed to parse raw LLM output
+	// against the BAML method's schema. Distinguished from CodeWorkerError
+	// because parse failures don't involve an LLM call.
+	CodeParseError Code = "parse_error"
+	// CodeInternalError: an internal Go-side processing error (output
+	// flattening, input conversion, panic). Indicates a bug in this
+	// server, not in the BAML schema or LLM call.
+	CodeInternalError Code = "internal_error"
+)
+
 // Response is the standard JSON error response format.
+//
+// Code is a stable identifier for the error class; clients should branch
+// on Code rather than parsing Error. Details carries optional structured
+// context (e.g. stacktrace from a worker panic) when available — the field
+// is omitted entirely when there's nothing structured to report.
 type Response struct {
-	Error     string `json:"error"`
-	RequestID string `json:"request_id,omitempty"`
+	Error     string          `json:"error"`
+	Code      Code            `json:"code,omitempty"`
+	Details   json.RawMessage `json:"details,omitempty"`
+	RequestID string          `json:"request_id,omitempty"`
 }
 
 // WriteJSON writes a JSON-formatted error response with the given status code.
 // The requestID parameter is optional and will be omitted from the response if empty.
 func WriteJSON(w http.ResponseWriter, message string, statusCode int, requestID string) {
+	WriteJSONWithCode(w, message, "", nil, statusCode, requestID)
+}
+
+// WriteJSONWithCode writes a JSON-formatted error response carrying a
+// machine-readable code and optional structured details. Pass code=""
+// and details=nil to omit those fields from the response.
+func WriteJSONWithCode(w http.ResponseWriter, message string, code Code, details json.RawMessage, statusCode int, requestID string) {
 	resp := Response{
 		Error:     message,
+		Code:      code,
+		Details:   details,
 		RequestID: requestID,
 	}
 

--- a/internal/apierror/error.go
+++ b/internal/apierror/error.go
@@ -12,6 +12,33 @@ import (
 // on these without parsing free-form messages.
 type Code string
 
+// allCodes is the canonical ordered list of public Code constants.
+// Single source of truth for IsKnown() (membership check) and
+// AllCodes() (enum exposed to the OpenAPI generator). Add new codes
+// here so both consumers stay in sync.
+var allCodes = []Code{
+	CodeInvalidJSON,
+	CodeInvalidRequest,
+	CodeRequestTooLarge,
+	CodeBodyReadError,
+	CodeNotAcceptable,
+	CodeRequestCanceled,
+	CodeWorkerUnavailable,
+	CodeWorkerError,
+	CodeParseError,
+	CodeInternalError,
+}
+
+// AllCodes returns the canonical list of public Code constants in
+// declaration order. Returned slice is a copy so callers can't mutate
+// the package-level source. Used by the OpenAPI schema generator to
+// build the error-code enum without duplicating the list.
+func AllCodes() []Code {
+	out := make([]Code, len(allCodes))
+	copy(out, allCodes)
+	return out
+}
+
 // IsKnown reports whether c is one of the documented Code constants.
 // The HTTP layer validates worker-supplied codes against this set
 // before forwarding them so the public OpenAPI enum stays
@@ -19,12 +46,10 @@ type Code string
 // host-side classification rather than introducing an off-contract
 // value into the response envelope.
 func (c Code) IsKnown() bool {
-	switch c {
-	case CodeInvalidJSON, CodeInvalidRequest, CodeRequestTooLarge,
-		CodeBodyReadError, CodeNotAcceptable, CodeRequestCanceled,
-		CodeWorkerUnavailable, CodeWorkerError, CodeParseError,
-		CodeInternalError:
-		return true
+	for _, k := range allCodes {
+		if c == k {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/apierror/error_test.go
+++ b/internal/apierror/error_test.go
@@ -1,0 +1,132 @@
+package apierror
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+)
+
+// TestValidDetails pins the json.Valid contract: invalid bytes drop
+// to nil so callers placing a json.RawMessage on the response
+// envelope can't accidentally corrupt the encoded body.
+func TestValidDetails(t *testing.T) {
+	tests := []struct {
+		name string
+		in   json.RawMessage
+		want bool // true if expect input passed through, false if dropped
+	}{
+		{"nil passes", nil, true},
+		{"empty passes", json.RawMessage{}, true},
+		{"valid object", json.RawMessage(`{"k":"v"}`), true},
+		{"valid nested object", json.RawMessage(`{"a":{"b":[1,2]}}`), true},
+		{"valid array", json.RawMessage(`[1,2,3]`), true},
+		{"valid scalar string", json.RawMessage(`"x"`), true},
+		{"valid scalar number", json.RawMessage(`42`), true},
+		{"valid null", json.RawMessage(`null`), true},
+		{"truncated object dropped", json.RawMessage(`{"k":`), false},
+		{"garbage dropped", json.RawMessage(`}garbage{`), false},
+		{"unterminated string dropped", json.RawMessage(`"abc`), false},
+		{"trailing junk dropped", json.RawMessage(`{}xx`), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidDetails(tt.in)
+			if tt.want {
+				if string(got) != string(tt.in) {
+					t.Errorf("ValidDetails(%q) = %q, want pass-through %q", tt.in, got, tt.in)
+				}
+			} else {
+				if got != nil {
+					t.Errorf("ValidDetails(%q) = %q, want nil", tt.in, got)
+				}
+			}
+		})
+	}
+}
+
+// TestWriteJSONWithCode_DropsInvalidDetails pins the defensive guard
+// in WriteJSONWithCode: an invalid json.RawMessage must not corrupt
+// the encoded body. Without ValidDetails the invalid bytes would be
+// emitted verbatim because json.RawMessage's MarshalJSON returns its
+// input as-is. Verified by re-parsing the response body — if the
+// guard is removed, this test fails on json.Unmarshal.
+func TestWriteJSONWithCode_DropsInvalidDetails(t *testing.T) {
+	rr := httptest.NewRecorder()
+	WriteJSONWithCode(rr, "boom", CodeWorkerError, json.RawMessage(`{"k":`), 500, "req-1")
+
+	var parsed Response
+	if err := json.Unmarshal(rr.Body.Bytes(), &parsed); err != nil {
+		t.Fatalf("response body is not valid JSON: %v\nbody: %s", err, rr.Body.String())
+	}
+	if parsed.Error != "boom" {
+		t.Errorf("Error = %q, want %q", parsed.Error, "boom")
+	}
+	if parsed.Code != CodeWorkerError {
+		t.Errorf("Code = %q, want %q", parsed.Code, CodeWorkerError)
+	}
+	// Details must be omitted when invalid: the omitempty json tag
+	// drops nil RawMessage from the wire.
+	if len(parsed.Details) != 0 {
+		t.Errorf("Details = %q, want empty (invalid input dropped)", parsed.Details)
+	}
+	if strings.Contains(rr.Body.String(), `"details"`) {
+		t.Errorf("response body must not include details field when invalid; body: %s", rr.Body.String())
+	}
+}
+
+// TestWriteJSONWithCode_PreservesValidDetails verifies the guard is
+// pass-through for legitimate object payloads — the production case.
+func TestWriteJSONWithCode_PreservesValidDetails(t *testing.T) {
+	rr := httptest.NewRecorder()
+	WriteJSONWithCode(rr, "boom", CodeWorkerError, json.RawMessage(`{"stacktrace":"goroutine 1 ..."}`), 500, "req-1")
+
+	var parsed struct {
+		Error   string `json:"error"`
+		Code    Code   `json:"code"`
+		Details struct {
+			Stacktrace string `json:"stacktrace"`
+		} `json:"details"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &parsed); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if parsed.Details.Stacktrace != "goroutine 1 ..." {
+		t.Errorf("Details.Stacktrace = %q, want forwarded value", parsed.Details.Stacktrace)
+	}
+}
+
+// TestIsWorkerFacing pins the worker-facing whitelist used to gate
+// worker-supplied codes at the host. Request-layer and pool-admission
+// codes must be rejected even though they're IsKnown(), so a worker
+// can't claim e.g. request_canceled to force the host's 408 branch.
+func TestIsWorkerFacing(t *testing.T) {
+	tests := []struct {
+		code Code
+		want bool
+	}{
+		{CodeWorkerError, true},
+		{CodeParseError, true},
+		{CodeInternalError, true},
+		// Request-layer (host-owned) — not worker-facing.
+		{CodeInvalidJSON, false},
+		{CodeInvalidRequest, false},
+		{CodeRequestTooLarge, false},
+		{CodeBodyReadError, false},
+		{CodeNotAcceptable, false},
+		{CodeRequestCanceled, false},
+		// Pool-admission (host-owned) — not worker-facing.
+		{CodeWorkerUnavailable, false},
+		// Unknown / empty.
+		{Code(""), false},
+		{Code("made_up"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.code), func(t *testing.T) {
+			if got := tt.code.IsWorkerFacing(); got != tt.want {
+				t.Errorf("Code(%q).IsWorkerFacing() = %v, want %v", tt.code, got, tt.want)
+			}
+		})
+	}
+}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1277,7 +1277,7 @@ func (p *Pool) Parse(ctx context.Context, methodName string, inputJSON []byte) (
 		return nil, err
 	}
 
-	return nil, fmt.Errorf("all parse retries exhausted: %w", lastErr)
+	return nil, fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, lastErr)
 }
 
 // Call executes a BAML method and returns the final result.
@@ -1418,6 +1418,14 @@ func (p *Pool) CallStream(ctx context.Context, methodName string, inputJSON []by
 		currentHandle := handle
 		var lastFailed *workerHandle
 		var sentAnyResults bool
+		// lastRetryableErr is the most recent retryable worker error
+		// observed across attempts. Captured both pre-stream (CallStream
+		// dial/handshake failure) and mid-stream (StreamResultKindError
+		// classified as retryable). On retry exhaustion it's wrapped into
+		// the terminal sendStreamError so the HTTP layer's classifier sees
+		// the underlying gRPC code (Unavailable / Canceled / etc.) and
+		// surfaces worker_unavailable instead of worker_error.
+		var lastRetryableErr error
 		// currentAttempt is the pool-level attempt number stamped onto every
 		// metadata event before forwarding. The orchestrator inside the worker
 		// always emits Attempt=0; the pool owns this field because only the
@@ -1479,6 +1487,7 @@ func (p *Pool) CallStream(ctx context.Context, methodName string, inputJSON []by
 						Err(err).
 						Msg("Retrying stream after worker failure")
 					lastFailed = currentHandle
+					lastRetryableErr = err
 					continue
 				}
 
@@ -1563,6 +1572,10 @@ func (p *Pool) CallStream(ctx context.Context, methodName string, inputJSON []by
 						Int("attempt", attempt+1).
 						Err(result.Error).
 						Msg("Retryable error mid-stream, will retry")
+					// Capture the error before Release zeroes the
+					// StreamResult: the interface value is copied here,
+					// so the underlying error survives the pool put-back.
+					lastRetryableErr = result.Error
 					workerplugin.ReleaseStreamResult(result)
 					shouldRetry = true
 					break
@@ -1643,8 +1656,22 @@ func (p *Pool) CallStream(ctx context.Context, methodName string, inputJSON []by
 			lastFailed = currentHandle
 		}
 
-		// All retries exhausted
-		sendStreamError(ctx, wrappedResults, fmt.Errorf("all stream retries exhausted"))
+		// All retries exhausted. Wrap the last retryable error so the
+		// HTTP layer's IsRetryableWorkerError check sees the
+		// ErrPoolRetriesExhausted sentinel and surfaces
+		// worker_unavailable to the client. lastRetryableErr is nil
+		// only on the rare path where the worker channel closed
+		// without a terminal frame on every attempt; in that case we
+		// emit the bare sentinel — still classified correctly thanks
+		// to the errors.Is short-circuit at the top of
+		// isRetryableWorkerError.
+		var exhaustedErr error
+		if lastRetryableErr != nil {
+			exhaustedErr = fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, lastRetryableErr)
+		} else {
+			exhaustedErr = fmt.Errorf("%w (no terminal stream frame)", ErrPoolRetriesExhausted)
+		}
+		sendStreamError(ctx, wrappedResults, exhaustedErr)
 	}()
 
 	return wrappedResults, nil
@@ -2032,9 +2059,20 @@ func parseSerializedGRPCCode(errStr string) (string, bool) {
 	return rest[:end], true
 }
 
+// ErrPoolRetriesExhausted is the sentinel wrapped (via fmt.Errorf %w)
+// into the terminal error returned by Pool.Call, Pool.CallStream, and
+// Pool.Parse when the pool gives up after exhausting all configured
+// retry attempts on retryable worker infrastructure failures. It is
+// itself a worker_unavailable signal: the failures that drove
+// exhaustion were each individually classified as retryable
+// infrastructure, so the cumulative outcome is too. errors.Is detects
+// this regardless of the wrapped chain shape.
+var ErrPoolRetriesExhausted = errors.New("pool retries exhausted")
+
 // IsRetryableWorkerError reports whether err indicates a worker
 // infrastructure failure (crash, network issue, gRPC Unavailable /
-// Canceled / DeadlineExceeded, transport reset / EOF) rather than an
+// Canceled / DeadlineExceeded, transport reset / EOF, or pool-level
+// retry exhaustion via ErrPoolRetriesExhausted) rather than an
 // application-level error from BAML or the upstream LLM. The pool uses
 // this to decide whether to retry on another worker; the HTTP layer
 // uses it to distinguish a transient infrastructure failure from a real
@@ -2049,6 +2087,18 @@ func IsRetryableWorkerError(err error) bool {
 func isRetryableWorkerError(err error) bool {
 	if err == nil {
 		return false
+	}
+
+	// Pool-level retry exhaustion (ErrPoolRetriesExhausted) is by
+	// definition retryable infrastructure: the loop only exhausts on
+	// per-attempt errors that were each individually retryable. The
+	// terminal sentinel is detected up front so callers don't have to
+	// reason about the wrapped error chain. Inside the pool's per-
+	// attempt retry loop the sentinel never appears (it's emitted only
+	// at the post-loop terminal site), so this short-circuit doesn't
+	// change retry semantics.
+	if errors.Is(err, ErrPoolRetriesExhausted) {
+		return true
 	}
 
 	// First, try to extract gRPC status code (preferred method).

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1266,14 +1266,24 @@ func (p *Pool) Parse(ctx context.Context, methodName string, inputJSON []byte) (
 			// Pool-side give-up before completing all attempts: no
 			// healthy worker available for the next attempt (workers
 			// dead, pool draining/closed, restart still in flight).
-			// Wrap with the sentinel so HTTP classifies as
-			// worker_unavailable instead of falling through to
-			// worker_error — same outcome class as the post-loop
-			// exhaustion tail.
+			// HTTP classification lands on worker_unavailable either
+			// way — both ErrPoolRetriesExhausted and the source-wrap
+			// ErrPoolUnavailable on err map to that class via the
+			// sentinel short-circuit in IsRetryableWorkerError.
+			//
+			// When lastErr != nil at least one attempt actually ran,
+			// so wrapping with ErrPoolRetriesExhausted is the
+			// accurate sentinel. When lastErr == nil this is the
+			// initial attempt and no retries happened — claiming
+			// "retries exhausted" would be misleading; return err
+			// directly so the chain carries only ErrPoolUnavailable
+			// (already wrapped at the source by awaitRestart /
+			// awaitAnyRestart / getWorkerAccepted), matching the
+			// pre-loop tail in Pool.CallStream.
 			if lastErr != nil {
 				return nil, fmt.Errorf("%w: retry failed, no workers available: %w (previous: %v)", ErrPoolRetriesExhausted, err, lastErr)
 			}
-			return nil, fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, err)
+			return nil, err
 		}
 
 		attemptCtx, cancel := context.WithCancel(ctx)

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1420,7 +1420,19 @@ func (p *Pool) CallStream(ctx context.Context, methodName string, inputJSON []by
 	handle, err := p.getWorkerForRetry(ctx, nil)
 	if err != nil {
 		done()
-		return nil, err
+		// Pre-loop admission tail: getWorkerForRetry can return
+		// awaitRestart/awaitAnyRestart errors as bare strings ("pool
+		// is draining", "no workers restarting") that don't carry
+		// the ErrPoolUnavailable wrap getWorkerAccepted applies. Wrap
+		// here so classifyWorkerError surfaces worker_unavailable
+		// rather than falling through to worker_error. Caller-cancel
+		// path uses ctx.Err() (the typed cancellation) so the HTTP
+		// classifier lands on request_canceled — see Pool.Parse for
+		// the race-window rationale.
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("could not acquire worker: %w (pool error: %v)", ctx.Err(), err)
+		}
+		return nil, fmt.Errorf("%w: %w", ErrPoolUnavailable, err)
 	}
 
 	// Generate a stable request id and thread it through every attempt.
@@ -2231,12 +2243,46 @@ func isRetryableWorkerError(err error) bool {
 // caller-side cancellation (context.Canceled / context.DeadlineExceeded
 // or a gRPC Canceled / DeadlineExceeded status, including the
 // string-serialized forms that lose their *status.Status across the
-// boundary). Use this at the HTTP layer to distinguish a client-driven
-// abort (request_canceled) from a retryable worker infrastructure
-// failure (worker_unavailable) — the underlying gRPC code is the same
-// for both, so IsRetryableWorkerError alone can't tell them apart.
+// boundary). The pool's per-attempt retry loop uses this to decide
+// whether to skip restart on a cancelled request — false positives
+// from the trailing string-match fallback are tolerable there because
+// the worst case is a missed restart, not a misclassified response.
+// HTTP-layer code classification should prefer IsTypedCancellationError
+// instead.
 func IsCallerCancellationError(err error) bool {
 	return isCallerCancellationError(err)
+}
+
+// IsTypedCancellationError reports whether err is shaped like
+// caller-side cancellation using ONLY typed signals: errors.Is against
+// context.Canceled / DeadlineExceeded, *status.Status code, or a
+// serialized "rpc error: code = Canceled/DeadlineExceeded ..." string
+// produced by gRPC's String boundary. Unlike IsCallerCancellationError,
+// it does NOT fall back to plain substring matching of "context
+// canceled" / "context deadline exceeded" — those strings appear
+// verbatim inside worker / LLM-provider application errors (e.g.
+// "openai: request failed: context deadline exceeded"), and matching
+// them would let the HTTP layer misreport a real worker_error /
+// parse_error as 408 request_canceled. Use this at boundaries where
+// the err under inspection might be plain worker text.
+func IsTypedCancellationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.Canceled, codes.DeadlineExceeded:
+			return true
+		}
+		return false
+	}
+	if code, ok := parseSerializedGRPCCode(err.Error()); ok {
+		return code == "Canceled" || code == "DeadlineExceeded"
+	}
+	return false
 }
 
 func isCallerCancellationError(err error) bool {

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1240,10 +1240,31 @@ func (p *Pool) Parse(ctx context.Context, methodName string, inputJSON []byte) (
 	for attempt := 0; attempt <= p.config.MaxRetries; attempt++ {
 		handle, err := p.getWorkerForRetry(ctx, lastFailed)
 		if err != nil {
-			if lastErr != nil {
-				return nil, fmt.Errorf("retry failed, no workers available: %w (previous: %v)", err, lastErr)
+			// Caller-cancellation path: propagate err (and lastErr
+			// context) without the retry-exhaustion sentinel.
+			// classifyWorkerError checks the sentinel before
+			// IsCallerCancellationError — wrapping here would hijack
+			// a client-driven abort and surface it as
+			// worker_unavailable. The post-loop exhaustion path can
+			// safely wrap because at that point the loop only ran
+			// because the caller didn't cancel.
+			if ctx.Err() != nil {
+				if lastErr != nil {
+					return nil, fmt.Errorf("retry failed, no workers available: %w (previous: %v)", err, lastErr)
+				}
+				return nil, err
 			}
-			return nil, err
+			// Pool-side give-up before completing all attempts: no
+			// healthy worker available for the next attempt (workers
+			// dead, pool draining/closed, restart still in flight).
+			// Wrap with the sentinel so HTTP classifies as
+			// worker_unavailable instead of falling through to
+			// worker_error — same outcome class as the post-loop
+			// exhaustion tail.
+			if lastErr != nil {
+				return nil, fmt.Errorf("%w: retry failed, no workers available: %w (previous: %v)", ErrPoolRetriesExhausted, err, lastErr)
+			}
+			return nil, fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, err)
 		}
 
 		attemptCtx, cancel := context.WithCancel(ctx)
@@ -1440,7 +1461,19 @@ func (p *Pool) CallStream(ctx context.Context, methodName string, inputJSON []by
 				var err error
 				currentHandle, err = p.getWorkerForRetry(ctx, lastFailed)
 				if err != nil {
-					sendStreamError(ctx, wrappedResults, fmt.Errorf("retry failed, no workers available: %w", err))
+					// Wrap with the retry-exhaustion sentinel only
+					// when this is a pool-side give-up, not a client-
+					// driven abort — see Pool.Parse for the full
+					// rationale. ctx.Err() is the discriminator: if
+					// caller cancelled, propagate raw so
+					// classifyWorkerError lands on request_canceled.
+					var sendErr error
+					if ctx.Err() != nil {
+						sendErr = fmt.Errorf("retry failed, no workers available: %w", err)
+					} else {
+						sendErr = fmt.Errorf("%w: retry failed, no workers available: %w", ErrPoolRetriesExhausted, err)
+					}
+					sendStreamError(ctx, wrappedResults, sendErr)
 					return
 				}
 			}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -885,10 +885,10 @@ func (p *Pool) beginLogicalRequest() (done func(), err error) {
 	defer p.admissionMu.Unlock()
 
 	if p.closed.Load() {
-		return nil, fmt.Errorf("pool is closed")
+		return nil, fmt.Errorf("%w: pool is closed", ErrPoolUnavailable)
 	}
 	if p.draining.Load() {
-		return nil, fmt.Errorf("pool is draining, not accepting new requests")
+		return nil, fmt.Errorf("%w: pool is draining, not accepting new requests", ErrPoolUnavailable)
 	}
 	p.logicalInFlight.Add(1)
 	var once sync.Once
@@ -904,7 +904,7 @@ func (p *Pool) beginLogicalRequest() (done func(), err error) {
 // drain in progress does not abort their retries.
 func (p *Pool) getWorker() (*workerHandle, error) {
 	if p.draining.Load() {
-		return nil, fmt.Errorf("pool is draining, not accepting new requests")
+		return nil, fmt.Errorf("%w: pool is draining, not accepting new requests", ErrPoolUnavailable)
 	}
 	return p.getWorkerAccepted()
 }
@@ -920,7 +920,7 @@ func (p *Pool) getWorkerAccepted() (*workerHandle, error) {
 	defer p.mu.RUnlock()
 
 	if p.closed.Load() {
-		return nil, fmt.Errorf("pool is closed")
+		return nil, fmt.Errorf("%w: pool is closed", ErrPoolUnavailable)
 	}
 
 	// Round-robin selection
@@ -933,7 +933,7 @@ func (p *Pool) getWorkerAccepted() (*workerHandle, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("no healthy workers available")
+	return nil, fmt.Errorf("%w: no healthy workers available", ErrPoolUnavailable)
 }
 
 // awaitRestart waits for an in-progress restart of handle to complete,
@@ -2102,6 +2102,17 @@ func parseSerializedGRPCCode(errStr string) (string, bool) {
 // this regardless of the wrapped chain shape.
 var ErrPoolRetriesExhausted = errors.New("pool retries exhausted")
 
+// ErrPoolUnavailable is the sentinel wrapped into pre-retry pool
+// availability failures: "pool is closed", "pool is draining, not
+// accepting new requests", "no healthy workers available". These are
+// host-side decisions that block the request from ever reaching a
+// worker — distinct from per-attempt retryable failures (which use
+// ErrPoolRetriesExhausted only after the loop gives up). Both
+// sentinels classify as worker_unavailable at the HTTP layer; the
+// distinction matters only to consumers that want to log the
+// admission-vs-execution boundary separately.
+var ErrPoolUnavailable = errors.New("pool unavailable")
+
 // IsRetryableWorkerError reports whether err indicates a worker
 // infrastructure failure (crash, network issue, gRPC Unavailable /
 // Canceled / DeadlineExceeded, transport reset / EOF, or pool-level
@@ -2130,7 +2141,15 @@ func isRetryableWorkerError(err error) bool {
 	// attempt retry loop the sentinel never appears (it's emitted only
 	// at the post-loop terminal site), so this short-circuit doesn't
 	// change retry semantics.
-	if errors.Is(err, ErrPoolRetriesExhausted) {
+	//
+	// ErrPoolUnavailable is the admission-side counterpart: pool
+	// closed/draining or no healthy workers means the request never
+	// reached a worker. Same outcome class — worker_unavailable at
+	// the HTTP layer. The retry loop only classifies errors returned
+	// by worker.CallStream / worker.Parse (gRPC), so this sentinel
+	// also never appears in the loop's classification calls and the
+	// short-circuit is safe.
+	if errors.Is(err, ErrPoolRetriesExhausted) || errors.Is(err, ErrPoolUnavailable) {
 		return true
 	}
 

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1298,7 +1298,7 @@ func (p *Pool) Call(ctx context.Context, methodName string, inputJSON []byte, st
 	for result := range results {
 		switch result.Kind {
 		case workerplugin.StreamResultKindError:
-			err := workerplugin.NewErrorWithStack(result.Error, result.Stacktrace)
+			err := workerplugin.NewErrorWithMetadata(result.Error, result.Stacktrace, result.ErrorCode, result.ErrorDetails)
 			workerplugin.ReleaseStreamResult(result)
 			// Return a CallResult carrying any accumulated metadata
 			// alongside the error so the unary handler can still set
@@ -2030,6 +2030,17 @@ func parseSerializedGRPCCode(errStr string) (string, bool) {
 		return "", false
 	}
 	return rest[:end], true
+}
+
+// IsRetryableWorkerError reports whether err indicates a worker
+// infrastructure failure (crash, network issue, gRPC Unavailable /
+// Canceled / DeadlineExceeded, transport reset / EOF) rather than an
+// application-level error from BAML or the upstream LLM. The pool uses
+// this to decide whether to retry on another worker; the HTTP layer
+// uses it to distinguish a transient infrastructure failure from a real
+// BAML/LLM error in the response code surfaced to the client.
+func IsRetryableWorkerError(err error) bool {
+	return isRetryableWorkerError(err)
 }
 
 // isRetryableWorkerError returns true if the error indicates a worker infrastructure

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -956,7 +956,7 @@ func (p *Pool) awaitRestart(ctx context.Context, handle *workerHandle) error {
 			case <-ch:
 				return nil
 			case <-p.drainCh:
-				return fmt.Errorf("pool is draining")
+				return errPoolDraining()
 			case <-ctx.Done():
 				return ctx.Err()
 			}
@@ -973,7 +973,7 @@ func (p *Pool) awaitRestart(ctx context.Context, handle *workerHandle) error {
 
 		select {
 		case <-p.drainCh:
-			return fmt.Errorf("pool is draining")
+			return errPoolDraining()
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
@@ -988,7 +988,7 @@ func (p *Pool) awaitRestart(ctx context.Context, handle *workerHandle) error {
 
 	select {
 	case <-p.drainCh:
-		return fmt.Errorf("pool is draining")
+		return errPoolDraining()
 	default:
 	}
 
@@ -1002,7 +1002,7 @@ func (p *Pool) awaitRestart(ctx context.Context, handle *workerHandle) error {
 	case <-done:
 		return nil
 	case <-p.drainCh:
-		return fmt.Errorf("pool is draining")
+		return errPoolDraining()
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -1150,7 +1150,7 @@ func (p *Pool) awaitAnyRestart(ctx context.Context) error {
 			if sawPending {
 				return nil
 			}
-			return fmt.Errorf("no workers restarting")
+			return fmt.Errorf("%w: no workers restarting", ErrPoolUnavailable)
 		}
 		sawPending = true
 
@@ -1161,7 +1161,7 @@ func (p *Pool) awaitAnyRestart(ctx context.Context) error {
 				case 0:
 					return ctx.Err()
 				case 1:
-					return fmt.Errorf("pool is draining")
+					return errPoolDraining()
 				default:
 					return nil
 				}
@@ -1176,7 +1176,7 @@ func (p *Pool) awaitAnyRestart(ctx context.Context) error {
 			case 0:
 				return ctx.Err()
 			case 1:
-				return fmt.Errorf("pool is draining")
+				return errPoolDraining()
 			case len(cases) - 1:
 			default:
 				return nil
@@ -1186,7 +1186,7 @@ func (p *Pool) awaitAnyRestart(ctx context.Context) error {
 			case <-ctx.Done():
 				return ctx.Err()
 			case <-p.drainCh:
-				return fmt.Errorf("pool is draining")
+				return errPoolDraining()
 			default:
 			}
 		}
@@ -1198,7 +1198,7 @@ func (p *Pool) awaitAnyRestart(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-p.drainCh:
-			return fmt.Errorf("pool is draining")
+			return errPoolDraining()
 		default:
 		}
 
@@ -2136,6 +2136,17 @@ var ErrPoolRetriesExhausted = errors.New("pool retries exhausted")
 // distinction matters only to consumers that want to log the
 // admission-vs-execution boundary separately.
 var ErrPoolUnavailable = errors.New("pool unavailable")
+
+// errPoolDraining is the canonical "pool is draining" error returned
+// from the restart-wait helpers (awaitRestart, awaitAnyRestart). It
+// wraps ErrPoolUnavailable at the source so callers (Parse,
+// CallStream, getWorkerForRetry) don't have to remember the wrap and
+// future call sites get worker_unavailable classification by default.
+// Mirrors the source-wrap pattern getWorkerAccepted uses for
+// "pool is closed" / "no healthy workers available".
+func errPoolDraining() error {
+	return fmt.Errorf("%w: pool is draining", ErrPoolUnavailable)
+}
 
 // IsRetryableWorkerError reports whether err indicates a worker
 // infrastructure failure (crash, network issue, gRPC Unavailable /

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -2088,6 +2088,16 @@ type Stats struct {
 	InFlight       int64
 }
 
+// grpcSerializedPrefix is the gRPC error-string serialization header.
+// Callers that need to be sure they're inspecting a TOP-LEVEL gRPC
+// error (rather than a worker-wrapped string that merely embeds the
+// header somewhere) must HasPrefix-match against this constant
+// before calling parseSerializedGRPCCode. The retry classifier and
+// IsTypedCancellationError both do this so wrapped worker errors
+// like "provider failed: rpc error: code = Unavailable ..." don't
+// flip retry / cancellation rungs.
+const grpcSerializedPrefix = "rpc error: code = "
+
 // parseSerializedGRPCCode extracts the top-level gRPC status code name from
 // a serialized gRPC error string. gRPC errors serialize as
 // "rpc error: code = <Code> desc = <Message>". This function parses only
@@ -2095,13 +2105,17 @@ type Stats struct {
 // descriptions like "rpc error: code = Internal desc = rpc error: code = Canceled ...".
 // Returns the code name (e.g. "Internal", "Canceled") and true, or ("", false)
 // if the string doesn't match the format.
+//
+// Uses substring search (not prefix match) so callers can opt into
+// either lenience or strictness: HasPrefix-guard the input first when
+// you want strictness (see grpcSerializedPrefix), pass the raw string
+// when you want lenience.
 func parseSerializedGRPCCode(errStr string) (string, bool) {
-	const prefix = "rpc error: code = "
-	idx := strings.Index(errStr, prefix)
+	idx := strings.Index(errStr, grpcSerializedPrefix)
 	if idx < 0 {
 		return "", false
 	}
-	start := idx + len(prefix)
+	start := idx + len(grpcSerializedPrefix)
 	if start >= len(errStr) {
 		return "", false
 	}
@@ -2224,15 +2238,24 @@ func isRetryableWorkerError(err error) bool {
 	errStr := err.Error()
 
 	// Serialized gRPC errors: parse the top-level code and use it as the
-	// authoritative signal. This correctly handles nested errors like
-	// "rpc error: code = Internal desc = rpc error: code = Canceled ..."
-	// by only looking at the first (top-level) code.
-	if code, ok := parseSerializedGRPCCode(errStr); ok {
-		switch code {
-		case "Unavailable", "Canceled", "DeadlineExceeded":
-			return true
+	// authoritative signal. parseSerializedGRPCCode itself uses substring
+	// search so callers in other contexts can pick up nested codes; here
+	// we require the "rpc error: code = " header at offset 0 so a worker
+	// / provider error like "openai: provider returned: rpc error: code =
+	// Unavailable ..." does NOT auto-trigger retry. Top-level boundary-
+	// serialized gRPC errors (the legitimate case that survives
+	// fmt.Errorf("%s", resp.Error) reconstruction) always start with the
+	// prefix; anything wrapped is the worker's classification choice and
+	// must surface as worker_error rather than being retried as if it
+	// were transport infrastructure.
+	if strings.HasPrefix(errStr, grpcSerializedPrefix) {
+		if code, ok := parseSerializedGRPCCode(errStr); ok {
+			switch code {
+			case "Unavailable", "Canceled", "DeadlineExceeded":
+				return true
+			}
+			return false
 		}
-		return false
 	}
 
 	// Plain error without gRPC structure — only match transport-level
@@ -2302,9 +2325,8 @@ func IsTypedCancellationError(err error) bool {
 		}
 		return false
 	}
-	const grpcPrefix = "rpc error: code = "
 	errStr := err.Error()
-	if !strings.HasPrefix(errStr, grpcPrefix) {
+	if !strings.HasPrefix(errStr, grpcSerializedPrefix) {
 		return false
 	}
 	if code, ok := parseSerializedGRPCCode(errStr); ok {

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -2265,6 +2265,18 @@ func IsCallerCancellationError(err error) bool {
 // them would let the HTTP layer misreport a real worker_error /
 // parse_error as 408 request_canceled. Use this at boundaries where
 // the err under inspection might be plain worker text.
+//
+// The serialized-gRPC fallback requires the "rpc error: code = "
+// header at the START of the error string. parseSerializedGRPCCode
+// itself uses substring search (so the retry classifier can pick up
+// gRPC codes inside wrapped errors), but applying that lenience to
+// cancellation classification would let a plain worker error like
+// "provider failed: rpc error: code = DeadlineExceeded ..." surface
+// as 408 — exactly the false-positive class this helper exists to
+// avoid. Top-level boundary-serialized gRPC errors (the legitimate
+// case that survives fmt.Errorf("%s", resp.Error) reconstruction)
+// always start with the prefix, so the prefix check catches them
+// while rejecting the embedded-substring case.
 func IsTypedCancellationError(err error) bool {
 	if err == nil {
 		return false
@@ -2279,7 +2291,12 @@ func IsTypedCancellationError(err error) bool {
 		}
 		return false
 	}
-	if code, ok := parseSerializedGRPCCode(err.Error()); ok {
+	const grpcPrefix = "rpc error: code = "
+	errStr := err.Error()
+	if !strings.HasPrefix(errStr, grpcPrefix) {
+		return false
+	}
+	if code, ok := parseSerializedGRPCCode(errStr); ok {
 		return code == "Canceled" || code == "DeadlineExceeded"
 	}
 	return false

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -2163,6 +2163,18 @@ func isRetryableWorkerError(err error) bool {
 	return false
 }
 
+// IsCallerCancellationError reports whether err originated from
+// caller-side cancellation (context.Canceled / context.DeadlineExceeded
+// or a gRPC Canceled / DeadlineExceeded status, including the
+// string-serialized forms that lose their *status.Status across the
+// boundary). Use this at the HTTP layer to distinguish a client-driven
+// abort (request_canceled) from a retryable worker infrastructure
+// failure (worker_unavailable) — the underlying gRPC code is the same
+// for both, so IsRetryableWorkerError alone can't tell them apart.
+func IsCallerCancellationError(err error) bool {
+	return isCallerCancellationError(err)
+}
+
 func isCallerCancellationError(err error) bool {
 	if err == nil {
 		return false

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1240,19 +1240,28 @@ func (p *Pool) Parse(ctx context.Context, methodName string, inputJSON []byte) (
 	for attempt := 0; attempt <= p.config.MaxRetries; attempt++ {
 		handle, err := p.getWorkerForRetry(ctx, lastFailed)
 		if err != nil {
-			// Caller-cancellation path: propagate err (and lastErr
-			// context) without the retry-exhaustion sentinel.
-			// classifyWorkerError checks the sentinel before
-			// IsCallerCancellationError — wrapping here would hijack
-			// a client-driven abort and surface it as
-			// worker_unavailable. The post-loop exhaustion path can
-			// safely wrap because at that point the loop only ran
-			// because the caller didn't cancel.
+			// Caller-cancellation path: wrap ctx.Err() (which IS
+			// context.Canceled or context.DeadlineExceeded), not the
+			// raw getWorkerForRetry err. There's a race window where
+			// ctx becomes cancelled between getWorkerForRetry's
+			// internal getWorkerAccepted call and its return — in
+			// that window err can be e.g. "no healthy workers
+			// available" while ctx.Err() is set. Wrapping err would
+			// leave classifyWorkerError unable to detect the
+			// cancellation (errors.Is(outer, context.Canceled) ==
+			// false), so the request would surface as
+			// worker_unavailable instead of request_canceled. The
+			// pool err is preserved as a %v diagnostic so logs still
+			// show why the pool couldn't recover before the caller
+			// gave up. classifyWorkerError checks the
+			// retry-exhaustion sentinel before
+			// IsCallerCancellationError, so omitting the sentinel
+			// here is what makes the cancellation path win.
 			if ctx.Err() != nil {
 				if lastErr != nil {
-					return nil, fmt.Errorf("retry failed, no workers available: %w (previous: %v)", err, lastErr)
+					return nil, fmt.Errorf("retry failed, no workers available: %w (pool error: %v, previous: %v)", ctx.Err(), err, lastErr)
 				}
-				return nil, err
+				return nil, fmt.Errorf("retry failed, no workers available: %w (pool error: %v)", ctx.Err(), err)
 			}
 			// Pool-side give-up before completing all attempts: no
 			// healthy worker available for the next attempt (workers
@@ -1463,13 +1472,16 @@ func (p *Pool) CallStream(ctx context.Context, methodName string, inputJSON []by
 				if err != nil {
 					// Wrap with the retry-exhaustion sentinel only
 					// when this is a pool-side give-up, not a client-
-					// driven abort — see Pool.Parse for the full
-					// rationale. ctx.Err() is the discriminator: if
-					// caller cancelled, propagate raw so
-					// classifyWorkerError lands on request_canceled.
+					// driven abort. On the cancel branch, wrap
+					// ctx.Err() rather than err so classifyWorkerError
+					// observes context.Canceled / DeadlineExceeded
+					// regardless of what getWorkerForRetry returned —
+					// see Pool.Parse for the full race-window
+					// rationale. The pool err is preserved as a %v
+					// diagnostic in the message.
 					var sendErr error
 					if ctx.Err() != nil {
-						sendErr = fmt.Errorf("retry failed, no workers available: %w", err)
+						sendErr = fmt.Errorf("retry failed, no workers available: %w (pool error: %v)", ctx.Err(), err)
 					} else {
 						sendErr = fmt.Errorf("%w: retry failed, no workers available: %w", ErrPoolRetriesExhausted, err)
 					}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1735,11 +1735,48 @@ func TestAwaitRestartReturnsOnDrain(t *testing.T) {
 	p.drainOnce.Do(func() { close(p.drainCh) })
 
 	err := p.awaitRestart(context.Background(), failed)
-	if err == nil || err.Error() != "pool is draining" {
-		t.Fatalf("expected pool is draining error, got %v", err)
+	if err == nil {
+		t.Fatalf("expected pool is draining error, got nil")
+	}
+	// Source-wrap contract: drain-path return must carry
+	// ErrPoolUnavailable so HTTP-layer classification lands on
+	// worker_unavailable without callers having to re-wrap. The
+	// human-readable "pool is draining" suffix is preserved as a
+	// diagnostic — pin both shape and message.
+	if !errors.Is(err, ErrPoolUnavailable) {
+		t.Fatalf("expected ErrPoolUnavailable in chain, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "pool is draining") {
+		t.Fatalf("expected message to mention 'pool is draining', got %q", err.Error())
 	}
 	if got := startCalls.Load(); got != 0 {
 		t.Fatalf("awaitRestart spawned %d replacement(s); want 0", got)
+	}
+}
+
+// TestAwaitAnyRestartWrapsNoRestartsWithSentinel pins the source-wrap
+// contract for awaitAnyRestart's "no workers restarting" return: it
+// must surface as ErrPoolUnavailable so the HTTP layer classifies the
+// pre-loop initial-attempt give-up (CallStream / Parse on a pool with
+// no healthy or restarting workers) as worker_unavailable instead of
+// falling through to worker_error. Without source-wrap, this only
+// worked because every getWorkerForRetry caller remembered to wrap;
+// future callers shouldn't have to.
+func TestAwaitAnyRestartWrapsNoRestartsWithSentinel(t *testing.T) {
+	p := newTestPool(t, 1, goodFactory)
+	defer p.Close()
+
+	// All workers healthy and no restarts in progress — awaitAnyRestart
+	// should immediately return its no-restarts error.
+	err := p.awaitAnyRestart(context.Background())
+	if err == nil {
+		t.Fatalf("expected no-restarts error, got nil")
+	}
+	if !errors.Is(err, ErrPoolUnavailable) {
+		t.Fatalf("expected ErrPoolUnavailable in chain, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "no workers restarting") {
+		t.Fatalf("expected message to mention 'no workers restarting', got %q", err.Error())
 	}
 }
 

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1308,6 +1308,15 @@ func TestIsRetryableWorkerError(t *testing.T) {
 		{"nested Canceled over Internal", fmt.Errorf("rpc error: code = Canceled desc = rpc error: code = Internal desc = something"), true},
 		{"nested Unavailable over Internal", fmt.Errorf("rpc error: code = Unavailable desc = rpc error: code = Internal desc = something"), true},
 		{"wrapped Unavailable message", status.Error(codes.Unknown, "connection reset"), true},
+		// ErrPoolRetriesExhausted: the pool's terminal error after all
+		// retryable attempts gave up. Itself a worker_unavailable
+		// signal — every wrapped form must classify retryable so the
+		// HTTP layer surfaces worker_unavailable, not worker_error.
+		{"ErrPoolRetriesExhausted bare", ErrPoolRetriesExhausted, true},
+		{"ErrPoolRetriesExhausted wrapping Unavailable", fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, status.Error(codes.Unavailable, "worker died")), true},
+		{"ErrPoolRetriesExhausted wrapping serialized Canceled", fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, errors.New("rpc error: code = Canceled desc = hung")), true},
+		{"ErrPoolRetriesExhausted with bare suffix", fmt.Errorf("%w (no terminal stream frame)", ErrPoolRetriesExhausted), true},
+		{"ErrPoolRetriesExhausted double-wrapped", fmt.Errorf("downstream gave up: %w", fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, status.Error(codes.Unavailable, "x"))), true},
 	}
 
 	for _, tt := range tests {

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1335,6 +1335,17 @@ func TestIsRetryableWorkerError(t *testing.T) {
 		{"ErrPoolUnavailable wrapping pool draining", fmt.Errorf("%w: pool is draining, not accepting new requests", ErrPoolUnavailable), true},
 		{"ErrPoolUnavailable wrapping no healthy workers", fmt.Errorf("%w: no healthy workers available", ErrPoolUnavailable), true},
 		{"ErrPoolUnavailable through outer wrap", fmt.Errorf("call failed: %w", fmt.Errorf("%w: pool is closed", ErrPoolUnavailable)), true},
+		// Embedded serialized-gRPC text must NOT trigger retry. The
+		// prefix guard requires "rpc error: code = " at offset 0 so a
+		// worker / provider error like "openai: provider returned: rpc
+		// error: code = Unavailable ..." surfaces as worker_error
+		// instead of being retried as if it were transport
+		// infrastructure. Top-level boundary-serialized gRPC errors
+		// (preceding cases) still classify because the prefix is at
+		// offset 0 after fmt.Errorf("%s", resp.Error) reconstruction.
+		{"embedded gRPC Unavailable in worker text", errors.New("provider returned: rpc error: code = Unavailable desc = down"), false},
+		{"embedded gRPC Canceled in worker text", errors.New("upstream: rpc error: code = Canceled desc = abort"), false},
+		{"embedded gRPC DeadlineExceeded in worker text", errors.New("openai: rpc error: code = DeadlineExceeded desc = timeout"), false},
 	}
 
 	for _, tt := range tests {

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -649,6 +649,37 @@ func TestParseRetryAfterRestart(t *testing.T) {
 
 // TestParseExhaustsRetries verifies that Parse returns an error after
 // MaxRetries when every worker fails.
+// TestParseInitialAttemptDoesNotClaimRetriesExhausted pins the
+// initial-attempt branch in Pool.Parse: when getWorkerForRetry fails
+// before any worker call (admission OK, but no healthy workers and
+// no restart in progress), the returned error must wrap
+// ErrPoolUnavailable (the source-wrap from awaitAnyRestart /
+// getWorkerAccepted) and NOT ErrPoolRetriesExhausted — no retries
+// happened, so claiming "retries exhausted" would be misleading.
+// HTTP classification stays on worker_unavailable either way; the
+// distinction is semantic accuracy in the chain.
+func TestParseInitialAttemptDoesNotClaimRetriesExhausted(t *testing.T) {
+	p := newTestPool(t, 1, goodFactory)
+	defer p.Close()
+
+	// Mark the only worker unhealthy without dispatching a restart so
+	// the initial getWorkerForRetry call fails: getWorkerAccepted
+	// returns ErrPoolUnavailable ("no healthy workers"), awaitAnyRestart
+	// finds no restarts in progress and also returns ErrPoolUnavailable.
+	p.workers[0].healthy.Store(false)
+
+	_, err := p.Parse(context.Background(), "Test", []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error from initial attempt with no healthy workers")
+	}
+	if !errors.Is(err, ErrPoolUnavailable) {
+		t.Errorf("expected ErrPoolUnavailable in chain, got %v", err)
+	}
+	if errors.Is(err, ErrPoolRetriesExhausted) {
+		t.Errorf("ErrPoolRetriesExhausted must NOT appear on initial-attempt failure (no retries happened); chain: %v", err)
+	}
+}
+
 func TestParseExhaustsRetries(t *testing.T) {
 	factory := func(id int) (*workerHandle, error) {
 		w := newMockWorker()

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1326,6 +1326,15 @@ func TestIsRetryableWorkerError(t *testing.T) {
 		{"ErrPoolRetriesExhausted wrapping pool closed", fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, errors.New("pool is closed")), true},
 		{"ErrPoolRetriesExhausted wrapping pool draining", fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, errors.New("pool is draining")), true},
 		{"ErrPoolRetriesExhausted wrapping no-workers-with-previous", fmt.Errorf("%w: retry failed, no workers available: %w (previous: dead worker)", ErrPoolRetriesExhausted, errors.New("no healthy workers available")), true},
+		// ErrPoolUnavailable: admission-side counterpart, wrapped at
+		// the pool's user-facing entry points (beginLogicalRequest,
+		// getWorker, getWorkerAccepted) when the pool can't accept a
+		// request at all (closed/draining/no-healthy-workers).
+		{"ErrPoolUnavailable bare", ErrPoolUnavailable, true},
+		{"ErrPoolUnavailable wrapping pool closed", fmt.Errorf("%w: pool is closed", ErrPoolUnavailable), true},
+		{"ErrPoolUnavailable wrapping pool draining", fmt.Errorf("%w: pool is draining, not accepting new requests", ErrPoolUnavailable), true},
+		{"ErrPoolUnavailable wrapping no healthy workers", fmt.Errorf("%w: no healthy workers available", ErrPoolUnavailable), true},
+		{"ErrPoolUnavailable through outer wrap", fmt.Errorf("call failed: %w", fmt.Errorf("%w: pool is closed", ErrPoolUnavailable)), true},
 	}
 
 	for _, tt := range tests {

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1437,6 +1437,16 @@ func TestIsTypedCancellationError(t *testing.T) {
 		{"wrapped plain canceled string", fmt.Errorf("upstream: context canceled"), false},
 		{"upstream provider deadline message", fmt.Errorf("openai: provider error: context deadline exceeded"), false},
 
+		// Embedded serialized-gRPC text must NOT classify as
+		// cancellation. parseSerializedGRPCCode accepts the prefix
+		// anywhere in the string, so without the prefix-only guard a
+		// wrapped worker error like "provider failed: rpc error:
+		// code = Canceled ..." would surface as 408 request_canceled.
+		// Top-level boundary-serialized gRPC errors (preceding case)
+		// still classify because the prefix is at offset 0.
+		{"embedded serialized gRPC Canceled", fmt.Errorf("provider failed: rpc error: code = Canceled desc = x"), false},
+		{"embedded serialized gRPC DeadlineExceeded", fmt.Errorf("upstream call: rpc error: code = DeadlineExceeded desc = x"), false},
+
 		{"unrelated text", fmt.Errorf("something broke"), false},
 	}
 

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1317,6 +1317,15 @@ func TestIsRetryableWorkerError(t *testing.T) {
 		{"ErrPoolRetriesExhausted wrapping serialized Canceled", fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, errors.New("rpc error: code = Canceled desc = hung")), true},
 		{"ErrPoolRetriesExhausted with bare suffix", fmt.Errorf("%w (no terminal stream frame)", ErrPoolRetriesExhausted), true},
 		{"ErrPoolRetriesExhausted double-wrapped", fmt.Errorf("downstream gave up: %w", fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, status.Error(codes.Unavailable, "x"))), true},
+		// No-workers retry tail: the pool wraps with the sentinel
+		// when getWorkerForRetry fails for a non-cancel reason (no
+		// healthy workers, pool closed, restart not ready). Plain
+		// strings like "no healthy workers available" don't carry a
+		// gRPC code — the sentinel is what carries the classification.
+		{"ErrPoolRetriesExhausted wrapping no healthy workers", fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, errors.New("no healthy workers available")), true},
+		{"ErrPoolRetriesExhausted wrapping pool closed", fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, errors.New("pool is closed")), true},
+		{"ErrPoolRetriesExhausted wrapping pool draining", fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, errors.New("pool is draining")), true},
+		{"ErrPoolRetriesExhausted wrapping no-workers-with-previous", fmt.Errorf("%w: retry failed, no workers available: %w (previous: dead worker)", ErrPoolRetriesExhausted, errors.New("no healthy workers available")), true},
 	}
 
 	for _, tt := range tests {

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1399,6 +1399,56 @@ func TestIsCallerCancellationError(t *testing.T) {
 	}
 }
 
+// TestIsTypedCancellationError pins the typed-only contract: same as
+// IsCallerCancellationError EXCEPT plain string fallbacks for "context
+// canceled" / "context deadline exceeded" return false. The HTTP
+// classifier uses this so worker / LLM-provider error text mentioning
+// those substrings doesn't get misreported as request_canceled.
+func TestIsTypedCancellationError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// Typed signals that MUST still classify as cancellation —
+		// these have to keep working or real caller aborts misroute.
+		{"nil", nil, false},
+		{"context.Canceled", context.Canceled, true},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, true},
+		{"wrapped context.Canceled", fmt.Errorf("call failed: %w", context.Canceled), true},
+		{"wrapped context.DeadlineExceeded", fmt.Errorf("call failed: %w", context.DeadlineExceeded), true},
+		{"gRPC Canceled", status.Error(codes.Canceled, "request canceled"), true},
+		{"gRPC DeadlineExceeded", status.Error(codes.DeadlineExceeded, "deadline"), true},
+		{"serialized gRPC Canceled", fmt.Errorf("rpc error: code = Canceled desc = x"), true},
+		{"serialized gRPC DeadlineExceeded", fmt.Errorf("rpc error: code = DeadlineExceeded desc = x"), true},
+
+		// gRPC status authoritative — non-cancel codes stay non-cancel.
+		{"gRPC Internal", status.Error(codes.Internal, "panic"), false},
+		{"gRPC Unavailable with cancel text", status.Error(codes.Unavailable, "context canceled"), false},
+		{"serialized gRPC Internal with deadline text", fmt.Errorf("rpc error: code = Internal desc = context deadline exceeded"), false},
+
+		// THE DIFFERENTIATOR: plain strings that look like cancellation
+		// but aren't typed get rejected here even though they pass
+		// IsCallerCancellationError. Worker text containing these
+		// substrings (upstream LLM provider errors, BAML diagnostics)
+		// must NOT classify as caller cancellation at the HTTP layer.
+		{"plain context canceled string", fmt.Errorf("context canceled"), false},
+		{"plain context deadline exceeded string", fmt.Errorf("context deadline exceeded"), false},
+		{"wrapped plain canceled string", fmt.Errorf("upstream: context canceled"), false},
+		{"upstream provider deadline message", fmt.Errorf("openai: provider error: context deadline exceeded"), false},
+
+		{"unrelated text", fmt.Errorf("something broke"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTypedCancellationError(tt.err); got != tt.want {
+				t.Errorf("IsTypedCancellationError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Tests: getWorker / getWorkerForRetry
 // ---------------------------------------------------------------------------

--- a/workerplugin/grpc.go
+++ b/workerplugin/grpc.go
@@ -194,12 +194,16 @@ func (s *GRPCServer) Parse(ctx context.Context, req *pb.ParseRequest) (*pb.Parse
 			resp.Stacktrace = fullErr
 		}
 		// Forward any worker-side classification + structured details.
-		// If the worker returned an *ErrorWithStack with a Code/Details
-		// already set, prefer those; the host treats them as authoritative.
-		if codedErr, ok := err.(interface{ GetCode() string }); ok {
+		// errors.As walks the wrap chain so a worker that wraps an
+		// *ErrorWithStack (e.g. fmt.Errorf("parse %s: %w", method, err))
+		// still surfaces its code/details — a direct type assertion
+		// would only match the top-level value and silently drop them.
+		var codedErr interface{ GetCode() string }
+		if errors.As(err, &codedErr) {
 			resp.ErrorCode = codedErr.GetCode()
 		}
-		if detailsErr, ok := err.(interface{ GetDetails() []byte }); ok {
+		var detailsErr interface{ GetDetails() []byte }
+		if errors.As(err, &detailsErr) {
 			resp.ErrorDetailsJson = detailsErr.GetDetails()
 		}
 		return resp, nil

--- a/workerplugin/grpc.go
+++ b/workerplugin/grpc.go
@@ -132,6 +132,12 @@ func (s *GRPCServer) CallStream(req *pb.CallRequest, stream pb.Worker_CallStream
 			if fullErr := fmt.Sprintf("%+v", result.Error); fullErr != pbResult.Error {
 				pbResult.Stacktrace = fullErr
 			}
+			// Forward any worker-side classification + structured
+			// details verbatim. The host inspects ErrorCode to choose
+			// the HTTP error code and forwards ErrorDetails to the
+			// client envelope as-is, so the worker controls both.
+			pbResult.ErrorCode = result.ErrorCode
+			pbResult.ErrorDetailsJson = result.ErrorDetails
 		}
 		if err := stream.Send(pbResult); err != nil {
 			ReleaseStreamResult(result)
@@ -186,6 +192,15 @@ func (s *GRPCServer) Parse(ctx context.Context, req *pb.ParseRequest) (*pb.Parse
 		// Extract stacktrace using %+v formatting (works with go-recovery and pkg/errors style errors)
 		if fullErr := fmt.Sprintf("%+v", err); fullErr != resp.Error {
 			resp.Stacktrace = fullErr
+		}
+		// Forward any worker-side classification + structured details.
+		// If the worker returned an *ErrorWithStack with a Code/Details
+		// already set, prefer those; the host treats them as authoritative.
+		if codedErr, ok := err.(interface{ GetCode() string }); ok {
+			resp.ErrorCode = codedErr.GetCode()
+		}
+		if detailsErr, ok := err.(interface{ GetDetails() []byte }); ok {
+			resp.ErrorDetailsJson = detailsErr.GetDetails()
 		}
 		return resp, nil
 	}
@@ -245,6 +260,8 @@ func (c *GRPCClient) CallStream(ctx context.Context, methodName string, inputJSO
 			if resp.Error != "" {
 				result.Error = fmt.Errorf("%s", resp.Error)
 				result.Stacktrace = resp.Stacktrace
+				result.ErrorCode = resp.ErrorCode
+				result.ErrorDetails = resp.ErrorDetailsJson
 			}
 			results <- result
 		}
@@ -290,7 +307,7 @@ func (c *GRPCClient) Parse(ctx context.Context, methodName string, inputJSON []b
 		return nil, err
 	}
 	if resp.Error != "" {
-		return nil, NewErrorWithStack(fmt.Errorf("%s", resp.Error), resp.Stacktrace)
+		return nil, NewErrorWithMetadata(fmt.Errorf("%s", resp.Error), resp.Stacktrace, resp.ErrorCode, resp.ErrorDetailsJson)
 	}
 	return &ParseResult{Data: resp.DataJson}, nil
 }

--- a/workerplugin/grpc.go
+++ b/workerplugin/grpc.go
@@ -138,6 +138,24 @@ func (s *GRPCServer) CallStream(req *pb.CallRequest, stream pb.Worker_CallStream
 			// client envelope as-is, so the worker controls both.
 			pbResult.ErrorCode = result.ErrorCode
 			pbResult.ErrorDetailsJson = result.ErrorDetails
+			// Mirror the Parse extraction: when the worker's Impl
+			// wraps an *ErrorWithStack into result.Error without
+			// also setting the explicit StreamResult fields,
+			// errors.As walks the chain and recovers code/details
+			// so they survive the gRPC boundary instead of falling
+			// back to host-side worker_error classification.
+			if pbResult.ErrorCode == "" {
+				var codedErr interface{ GetCode() string }
+				if errors.As(result.Error, &codedErr) {
+					pbResult.ErrorCode = codedErr.GetCode()
+				}
+			}
+			if pbResult.ErrorDetailsJson == nil {
+				var detailsErr interface{ GetDetails() []byte }
+				if errors.As(result.Error, &detailsErr) {
+					pbResult.ErrorDetailsJson = detailsErr.GetDetails()
+				}
+			}
 		}
 		if err := stream.Send(pbResult); err != nil {
 			ReleaseStreamResult(result)

--- a/workerplugin/plugin.go
+++ b/workerplugin/plugin.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"runtime"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-plugin"
@@ -129,12 +130,7 @@ func NewErrorWithMetadata(err error, stacktrace, code string, details []byte) er
 	if stacktrace == "" && code == "" && len(details) == 0 {
 		return err
 	}
-	var detailsCopy []byte
-	if len(details) > 0 {
-		detailsCopy = make([]byte, len(details))
-		copy(detailsCopy, details)
-	}
-	return &ErrorWithStack{Err: err, Stacktrace: stacktrace, Code: code, Details: detailsCopy}
+	return &ErrorWithStack{Err: err, Stacktrace: stacktrace, Code: code, Details: slices.Clone(details)}
 }
 
 // StreamResult represents a streaming result from a BAML method

--- a/workerplugin/plugin.go
+++ b/workerplugin/plugin.go
@@ -67,11 +67,20 @@ type CallResult struct {
 	Outcome []byte
 }
 
-// ErrorWithStack wraps an error with an optional stacktrace.
-// Used to propagate stacktraces from worker panics through the pool to the server.
+// ErrorWithStack wraps an error with an optional stacktrace and an
+// optional worker-supplied classification code + structured details.
+// Used to propagate diagnostic info from worker errors through the pool
+// to the HTTP layer, where the code/details surface in the API error
+// envelope and the stacktrace lands in the request log.
 type ErrorWithStack struct {
 	Err        error
 	Stacktrace string
+	// Code is the worker's machine-readable classification of this error,
+	// when available. Empty when the worker did not classify.
+	Code string
+	// Details is JSON-encoded structured context (e.g. parse failure
+	// fields, BAML diagnostic info), when available. nil when none.
+	Details []byte
 }
 
 func (e *ErrorWithStack) Error() string {
@@ -87,12 +96,34 @@ func (e *ErrorWithStack) GetStacktrace() string {
 	return e.Stacktrace
 }
 
+// GetCode returns the worker-supplied error code, or empty string if none.
+func (e *ErrorWithStack) GetCode() string {
+	return e.Code
+}
+
+// GetDetails returns the worker-supplied JSON-encoded details, or nil if none.
+func (e *ErrorWithStack) GetDetails() []byte {
+	return e.Details
+}
+
 // NewErrorWithStack creates an error that carries a stacktrace.
 func NewErrorWithStack(err error, stacktrace string) error {
 	if stacktrace == "" {
 		return err
 	}
 	return &ErrorWithStack{Err: err, Stacktrace: stacktrace}
+}
+
+// NewErrorWithMetadata creates an error that carries a stacktrace, an
+// optional classification code, and optional JSON-encoded details. When
+// all three optional fields are empty the original err is returned
+// unwrapped, so callers can use this unconditionally without paying for
+// a wrapper allocation when there's nothing to carry.
+func NewErrorWithMetadata(err error, stacktrace, code string, details []byte) error {
+	if stacktrace == "" && code == "" && len(details) == 0 {
+		return err
+	}
+	return &ErrorWithStack{Err: err, Stacktrace: stacktrace, Code: code, Details: details}
 }
 
 // StreamResult represents a streaming result from a BAML method
@@ -103,6 +134,14 @@ type StreamResult struct {
 	Error      error  // Error (populated on Error kind)
 	Stacktrace string // Stacktrace (populated on Error kind, when available)
 	Reset      bool   // When true, client should discard accumulated state (retry occurred)
+	// ErrorCode is the worker's machine-readable classification of
+	// Error, when available. Empty when the worker did not classify.
+	// Populated only on StreamResultKindError.
+	ErrorCode string
+	// ErrorDetails is JSON-encoded structured context for Error
+	// (e.g. parse failure fields), when available. nil when none.
+	// Populated only on StreamResultKindError.
+	ErrorDetails []byte
 }
 
 type StreamResultKind int

--- a/workerplugin/plugin.go
+++ b/workerplugin/plugin.go
@@ -119,11 +119,22 @@ func NewErrorWithStack(err error, stacktrace string) error {
 // all three optional fields are empty the original err is returned
 // unwrapped, so callers can use this unconditionally without paying for
 // a wrapper allocation when there's nothing to carry.
+//
+// The details slice is copied before storage so the wrapped error
+// owns its own buffer. Callers commonly pass StreamResult.ErrorDetails
+// fields whose backing arrays come from pooled gRPC decode buffers —
+// without a copy, releasing the StreamResult back to its pool would
+// alias an in-use buffer that the wrapped error still holds.
 func NewErrorWithMetadata(err error, stacktrace, code string, details []byte) error {
 	if stacktrace == "" && code == "" && len(details) == 0 {
 		return err
 	}
-	return &ErrorWithStack{Err: err, Stacktrace: stacktrace, Code: code, Details: details}
+	var detailsCopy []byte
+	if len(details) > 0 {
+		detailsCopy = make([]byte, len(details))
+		copy(detailsCopy, details)
+	}
+	return &ErrorWithStack{Err: err, Stacktrace: stacktrace, Code: code, Details: detailsCopy}
 }
 
 // StreamResult represents a streaming result from a BAML method

--- a/workerplugin/plugin_test.go
+++ b/workerplugin/plugin_test.go
@@ -1,0 +1,52 @@
+package workerplugin
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestNewErrorWithMetadata_CopiesDetails pins the defensive-copy
+// contract: ErrorWithStack.Details must own its bytes so that
+// callers reusing pooled decode buffers (StreamResult.ErrorDetails
+// from a streamResultPool entry that's about to be released) can't
+// mutate the wrapped error's payload after-the-fact. Without the
+// copy, releasing the StreamResult and re-using the buffer would
+// race with any later read of the wrapped error's Details.
+func TestNewErrorWithMetadata_CopiesDetails(t *testing.T) {
+	original := []byte(`{"code":"parse_error","field":"x"}`)
+	wrapped := NewErrorWithMetadata(errors.New("boom"), "", "parse_error", original)
+
+	stackErr, ok := wrapped.(*ErrorWithStack)
+	if !ok {
+		t.Fatalf("expected *ErrorWithStack, got %T", wrapped)
+	}
+
+	// Mutate the input slice — simulating buffer reuse after the
+	// wrap. The wrapped error must NOT observe the mutation.
+	for i := range original {
+		original[i] = 'X'
+	}
+
+	if got := string(stackErr.GetDetails()); got != `{"code":"parse_error","field":"x"}` {
+		t.Errorf("wrapped Details aliased input slice; got %q", got)
+	}
+}
+
+// TestNewErrorWithMetadata_NoMetadataReturnsRaw verifies the
+// fast-path: when stacktrace, code, and details are all empty, the
+// original err is returned unwrapped (no allocation). Pinned so a
+// later refactor can't accidentally pay the wrapper cost on every
+// happy-path return through helpers that call NewErrorWithMetadata
+// unconditionally.
+func TestNewErrorWithMetadata_NoMetadataReturnsRaw(t *testing.T) {
+	orig := errors.New("plain")
+	got := NewErrorWithMetadata(orig, "", "", nil)
+	if got != orig {
+		t.Errorf("expected raw err returned when no metadata; got %v", got)
+	}
+
+	got = NewErrorWithMetadata(orig, "", "", []byte{})
+	if got != orig {
+		t.Errorf("expected raw err returned for empty details slice; got %v", got)
+	}
+}

--- a/workerplugin/proto/worker.pb.go
+++ b/workerplugin/proto/worker.pb.go
@@ -205,15 +205,17 @@ func (x *CallRequest) GetRequestId() string {
 
 // Streaming result
 type StreamResult struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Kind          StreamResult_Kind      `protobuf:"varint,1,opt,name=kind,proto3,enum=workerplugin.StreamResult_Kind" json:"kind,omitempty"`
-	DataJson      []byte                 `protobuf:"bytes,2,opt,name=data_json,json=dataJson,proto3" json:"data_json,omitempty"` // JSON-encoded stream/final/metadata data
-	Raw           string                 `protobuf:"bytes,3,opt,name=raw,proto3" json:"raw,omitempty"`                           // Raw LLM response text (populated on FINAL)
-	Error         string                 `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`                       // Error message (populated on ERROR)
-	Stacktrace    string                 `protobuf:"bytes,5,opt,name=stacktrace,proto3" json:"stacktrace,omitempty"`             // Stacktrace (populated on ERROR, when available)
-	Reset_        bool                   `protobuf:"varint,6,opt,name=reset,proto3" json:"reset,omitempty"`                      // When true, client should discard accumulated state (retry occurred)
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Kind             StreamResult_Kind      `protobuf:"varint,1,opt,name=kind,proto3,enum=workerplugin.StreamResult_Kind" json:"kind,omitempty"`
+	DataJson         []byte                 `protobuf:"bytes,2,opt,name=data_json,json=dataJson,proto3" json:"data_json,omitempty"`                           // JSON-encoded stream/final/metadata data
+	Raw              string                 `protobuf:"bytes,3,opt,name=raw,proto3" json:"raw,omitempty"`                                                     // Raw LLM response text (populated on FINAL)
+	Error            string                 `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`                                                 // Error message (populated on ERROR)
+	Stacktrace       string                 `protobuf:"bytes,5,opt,name=stacktrace,proto3" json:"stacktrace,omitempty"`                                       // Stacktrace (populated on ERROR, when available)
+	Reset_           bool                   `protobuf:"varint,6,opt,name=reset,proto3" json:"reset,omitempty"`                                                // When true, client should discard accumulated state (retry occurred)
+	ErrorCode        string                 `protobuf:"bytes,7,opt,name=error_code,json=errorCode,proto3" json:"error_code,omitempty"`                        // Machine-readable error class (populated on ERROR, when worker can classify)
+	ErrorDetailsJson []byte                 `protobuf:"bytes,8,opt,name=error_details_json,json=errorDetailsJson,proto3" json:"error_details_json,omitempty"` // JSON-encoded structured error details (populated on ERROR, when available)
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *StreamResult) Reset() {
@@ -286,6 +288,20 @@ func (x *StreamResult) GetReset_() bool {
 		return x.Reset_
 	}
 	return false
+}
+
+func (x *StreamResult) GetErrorCode() string {
+	if x != nil {
+		return x.ErrorCode
+	}
+	return ""
+}
+
+func (x *StreamResult) GetErrorDetailsJson() []byte {
+	if x != nil {
+		return x.ErrorDetailsJson
+	}
+	return nil
 }
 
 // Health check
@@ -532,12 +548,14 @@ func (x *ParseRequest) GetInputJson() []byte {
 
 // Parse response
 type ParseResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	DataJson      []byte                 `protobuf:"bytes,1,opt,name=data_json,json=dataJson,proto3" json:"data_json,omitempty"` // JSON-encoded parsed result
-	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`                       // Error message (if parsing failed)
-	Stacktrace    string                 `protobuf:"bytes,3,opt,name=stacktrace,proto3" json:"stacktrace,omitempty"`             // Stacktrace (if parsing failed, when available)
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	DataJson         []byte                 `protobuf:"bytes,1,opt,name=data_json,json=dataJson,proto3" json:"data_json,omitempty"`                           // JSON-encoded parsed result
+	Error            string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`                                                 // Error message (if parsing failed)
+	Stacktrace       string                 `protobuf:"bytes,3,opt,name=stacktrace,proto3" json:"stacktrace,omitempty"`                                       // Stacktrace (if parsing failed, when available)
+	ErrorCode        string                 `protobuf:"bytes,4,opt,name=error_code,json=errorCode,proto3" json:"error_code,omitempty"`                        // Machine-readable error class (when worker can classify)
+	ErrorDetailsJson []byte                 `protobuf:"bytes,5,opt,name=error_details_json,json=errorDetailsJson,proto3" json:"error_details_json,omitempty"` // JSON-encoded structured error details (when available)
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ParseResponse) Reset() {
@@ -589,6 +607,20 @@ func (x *ParseResponse) GetStacktrace() string {
 		return x.Stacktrace
 	}
 	return ""
+}
+
+func (x *ParseResponse) GetErrorCode() string {
+	if x != nil {
+		return x.ErrorCode
+	}
+	return ""
+}
+
+func (x *ParseResponse) GetErrorDetailsJson() []byte {
+	if x != nil {
+		return x.ErrorDetailsJson
+	}
+	return nil
 }
 
 // Goroutines request - for getting pprof data from worker
@@ -868,7 +900,7 @@ const file_workerplugin_proto_worker_proto_rawDesc = "" +
 	"\vstream_mode\x18\x03 \x01(\x0e2\x18.workerplugin.StreamModeR\n" +
 	"streamMode\x12\x1d\n" +
 	"\n" +
-	"request_id\x18\x04 \x01(\tR\trequestId\"\x85\x02\n" +
+	"request_id\x18\x04 \x01(\tR\trequestId\"\xd2\x02\n" +
 	"\fStreamResult\x123\n" +
 	"\x04kind\x18\x01 \x01(\x0e2\x1f.workerplugin.StreamResult.KindR\x04kind\x12\x1b\n" +
 	"\tdata_json\x18\x02 \x01(\fR\bdataJson\x12\x10\n" +
@@ -877,7 +909,10 @@ const file_workerplugin_proto_worker_proto_rawDesc = "" +
 	"\n" +
 	"stacktrace\x18\x05 \x01(\tR\n" +
 	"stacktrace\x12\x14\n" +
-	"\x05reset\x18\x06 \x01(\bR\x05reset\"E\n" +
+	"\x05reset\x18\x06 \x01(\bR\x05reset\x12\x1d\n" +
+	"\n" +
+	"error_code\x18\a \x01(\tR\terrorCode\x12,\n" +
+	"\x12error_details_json\x18\b \x01(\fR\x10errorDetailsJson\"E\n" +
 	"\x04Kind\x12\n" +
 	"\n" +
 	"\x06STREAM\x10\x00\x12\t\n" +
@@ -899,13 +934,16 @@ const file_workerplugin_proto_worker_proto_rawDesc = "" +
 	"\vmethod_name\x18\x01 \x01(\tR\n" +
 	"methodName\x12\x1d\n" +
 	"\n" +
-	"input_json\x18\x02 \x01(\fR\tinputJson\"b\n" +
+	"input_json\x18\x02 \x01(\fR\tinputJson\"\xaf\x01\n" +
 	"\rParseResponse\x12\x1b\n" +
 	"\tdata_json\x18\x01 \x01(\fR\bdataJson\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12\x1e\n" +
 	"\n" +
 	"stacktrace\x18\x03 \x01(\tR\n" +
-	"stacktrace\".\n" +
+	"stacktrace\x12\x1d\n" +
+	"\n" +
+	"error_code\x18\x04 \x01(\tR\terrorCode\x12,\n" +
+	"\x12error_details_json\x18\x05 \x01(\fR\x10errorDetailsJson\".\n" +
 	"\x14GetGoroutinesRequest\x12\x16\n" +
 	"\x06filter\x18\x01 \x01(\tR\x06filter\"\x80\x01\n" +
 	"\x15GetGoroutinesResponse\x12\x1f\n" +

--- a/workerplugin/proto/worker.proto
+++ b/workerplugin/proto/worker.proto
@@ -40,6 +40,8 @@ message StreamResult {
   string error = 4;            // Error message (populated on ERROR)
   string stacktrace = 5;       // Stacktrace (populated on ERROR, when available)
   bool reset = 6;              // When true, client should discard accumulated state (retry occurred)
+  string error_code = 7;       // Machine-readable error class (populated on ERROR, when worker can classify)
+  bytes error_details_json = 8; // JSON-encoded structured error details (populated on ERROR, when available)
 }
 
 // Health check
@@ -74,6 +76,8 @@ message ParseResponse {
   bytes data_json = 1;         // JSON-encoded parsed result
   string error = 2;            // Error message (if parsing failed)
   string stacktrace = 3;       // Stacktrace (if parsing failed, when available)
+  string error_code = 4;       // Machine-readable error class (when worker can classify)
+  bytes error_details_json = 5; // JSON-encoded structured error details (when available)
 }
 
 // Goroutines request - for getting pprof data from worker


### PR DESCRIPTION
## Summary

Errors returned to API consumers were uniformly replaced with generic strings (`"failed to process request"`, `"failed to parse response"`, `"failed to process dynamic input"`, `"failed to process response"`) while the real error was logged server-side only. For a developer tool whose secondary consumer is an LLM agent receiving errors as feedback, that strands both audiences: humans can't debug, agents can't self-correct.

This PR forwards the underlying `err.Error()` to the client and adds a stable machine-readable `code` field plus optional structured `details` to the JSON envelope.

**Wire format is additive** — existing consumers see new fields they can ignore; HTTP statuses are unchanged so existing dashboards keep working.

## What changed

- **`internal/apierror`** — `Response` gains `code` and `details` (both `omitempty`); `WriteJSONWithCode` helper added.
- **`workerplugin/proto`** — `StreamResult` and `ParseResponse` gain `error_code` and `error_details_json` so worker-supplied classification survives the gRPC boundary; `ErrorWithStack` gains `Code`/`Details` and a new `NewErrorWithMetadata` constructor.
- **`pool`** — `IsRetryableWorkerError` exported so the HTTP layer can distinguish `worker_unavailable` (transient infra, retries exhausted) from `worker_error` (real BAML/LLM failure). `NewErrorWithMetadata` used during `Pool.Call`'s stream drain so worker-supplied codes survive to the handler.
- **`cmd/serve`** — `classifyWorkerError` prefers worker-supplied codes and falls back to `IsRetryableWorkerError`. New `writeFiber*` / `writeChi*` helpers replace the generic-string sites in `main.go` and `unary_handlers.go`. Streaming `PublishError` extended with `code` + `details` (NDJSON event and SSE error frame both gain optional fields). On mid-stream errors, `StreamResult.ErrorCode`/`ErrorDetails` take priority over heuristic classification.

### Codes

`invalid_json`, `invalid_request`, `request_too_large`, `body_read_error`, `not_acceptable`, `request_canceled`, `worker_unavailable`, `worker_error`, `parse_error`, `internal_error`.

## Test plan

- [x] `go build ./...`
- [x] `go build -tags unaryserver ./...`
- [x] `go build -tags integration ./integration/...`
- [x] `go test ./...` (unit + short)
- [x] `go test -tags unaryserver ./cmd/serve/...`
- [x] `go vet -tags unaryserver ./...`
- [ ] Manually hit a failing BAML method and confirm the body now contains the BAML message + `code: "worker_error"`
- [ ] Manually hit a failing `/parse/*` and confirm `code: "parse_error"`
- [ ] Kill a worker mid-call and confirm pool retry-exhaustion surfaces `code: "worker_unavailable"`
- [ ] Stream a failing call (NDJSON + SSE) and confirm the error frame carries `code` and any worker-supplied `details`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Machine-readable error codes, optional structured JSON details, and request IDs in API responses; worker-supplied codes/details are validated.

* **HTTP Behavior**
  * Unified JSON error envelopes across endpoints and frameworks; cancellations map to 408 and size/body/parse/validation errors return explicit codes.

* **Streaming**
  * NDJSON & SSE streams emit structured error events with code/details and safe fallbacks.

* **Schema**
  * OpenAPI updated with error code enum and optional details schema.

* **Infrastructure**
  * Clearer pool/worker retry, availability, and cancellation classification.

* **Tests**
  * Expanded coverage for classification, normalization, propagation, and stream error behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/225)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->