### PR TITLE
fix: filter Gemini thought parts from parseable extraction

### DIFF
--- a/bamlutils/buildrequest/response_extract.go
+++ b/bamlutils/buildrequest/response_extract.go
@@ -219,7 +219,11 @@ func extractAnthropicContent(provider string, responseBody string, includeThinki
 }
 
 // extractGeminiContent extracts text from a Google AI / Vertex AI (Gemini)
-// non-streaming response.
+// non-streaming response. Parts flagged thought:true are filtered out
+// entirely so reasoning text never enters parseable — aligned with
+// upstream BAML's text_content_part filter
+// (engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs).
+// Non-thought parts retain the existing strict validation.
 func extractGeminiContent(provider string, responseBody string) (string, error) {
 	parts := gjson.Get(responseBody, "candidates.0.content.parts")
 
@@ -231,6 +235,11 @@ func extractGeminiContent(provider string, responseBody string) (string, error) 
 			if !part.IsObject() {
 				iterErr = fmt.Errorf("%s: non-object element in parts array (got %s)", provider, part.Type)
 				return false
+			}
+			// Skip thought parts before any text validation; their text
+			// field shape is irrelevant to parseable output.
+			if part.Get("thought").Bool() {
+				return true
 			}
 			text := part.Get("text")
 			if text.Exists() {

--- a/bamlutils/buildrequest/response_extract_test.go
+++ b/bamlutils/buildrequest/response_extract_test.go
@@ -794,6 +794,70 @@ func TestExtractResponseContent_VertexMultipleParts(t *testing.T) {
 	}
 }
 
+// TestExtractResponseContent_GeminiThoughtAtIndexZero asserts that a thought
+// part at index 0 is filtered out and the visible text from the next part is
+// returned as both parseable and raw, with no error.
+//
+// Aligned with upstream BAML's text_content_part filter
+// (engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs).
+func TestExtractResponseContent_GeminiThoughtAtIndexZero(t *testing.T) {
+	body := `{"candidates":[{"content":{"parts":[
+		{"text":"internal reasoning","thought":true},
+		{"text":"Visible answer"}
+	],"role":"model"}}]}`
+
+	for _, provider := range []string{"google-ai", "vertex-ai"} {
+		t.Run(provider, func(t *testing.T) {
+			parseable, raw, err := ExtractResponseContent(provider, body, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if parseable != "Visible answer" {
+				t.Errorf("parseable = %q, want %q", parseable, "Visible answer")
+			}
+			if raw != "Visible answer" {
+				t.Errorf("raw = %q, want %q (Phase 2: raw == parseable for Gemini)", raw, "Visible answer")
+			}
+
+			// Parseable must be byte-identical regardless of the
+			// includeThinking flag. Raw is intentionally not compared across
+			// the flag — Phase 3 will diverge Gemini raw under opt-in.
+			parseableThinking, _, err := ExtractResponseContent(provider, body, true)
+			if err != nil {
+				t.Fatalf("unexpected error with includeThinking=true: %v", err)
+			}
+			if parseableThinking != parseable {
+				t.Errorf("parseable diverged across includeThinking: false=%q true=%q", parseable, parseableThinking)
+			}
+		})
+	}
+}
+
+// TestExtractResponseContent_GeminiThoughtOnly asserts that a response whose
+// only parts are thought:true returns empty parseable and raw with no error,
+// matching upstream BAML's unwrap_or_default behavior.
+func TestExtractResponseContent_GeminiThoughtOnly(t *testing.T) {
+	body := `{"candidates":[{"content":{"parts":[
+		{"text":"reasoning a","thought":true},
+		{"text":"reasoning b","thought":true}
+	],"role":"model"}}]}`
+
+	for _, provider := range []string{"google-ai", "vertex-ai"} {
+		t.Run(provider, func(t *testing.T) {
+			parseable, raw, err := ExtractResponseContent(provider, body, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if parseable != "" {
+				t.Errorf("parseable = %q, want empty string", parseable)
+			}
+			if raw != "" {
+				t.Errorf("raw = %q, want empty string (Phase 2: raw == parseable for Gemini)", raw)
+			}
+		})
+	}
+}
+
 func TestExtractResponseContent_UnsupportedProvider(t *testing.T) {
 	_, _, err := ExtractResponseContent("aws-bedrock", `{}`, false)
 	if err == nil {

--- a/bamlutils/sse/extract.go
+++ b/bamlutils/sse/extract.go
@@ -137,7 +137,11 @@ func ExtractDeltaPartsFromText(provider string, rawText string, includeThinking 
 				if part.Get("thought").Bool() {
 					return true
 				}
-				sb.WriteString(part.Get("text").String())
+				text := part.Get("text")
+				if text.Type != gjson.String {
+					return true
+				}
+				sb.WriteString(text.String())
 				return true
 			})
 		}

--- a/bamlutils/sse/extract.go
+++ b/bamlutils/sse/extract.go
@@ -122,9 +122,26 @@ func ExtractDeltaPartsFromText(provider string, rawText string, includeThinking 
 		return DeltaParts{}, nil
 
 	// Google (both use same format)
-	// Path: candidates[0].content.parts[0].text
+	// Path: candidates[0].content.parts[]
+	// Iterate all parts, skip those flagged thought:true so reasoning text
+	// never enters Parseable. Concatenate the remaining text fields with no
+	// separator — matches upstream BAML's text_content_part filter
+	// (engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs).
+	// Missing or non-array parts yields an empty delta with no error,
+	// preserving the prior forgiving streaming semantics.
 	case "google-ai", "vertex-ai":
-		delta := gjson.Get(rawText, "candidates.0.content.parts.0.text").String()
+		parts := gjson.Get(rawText, "candidates.0.content.parts")
+		var sb strings.Builder
+		if parts.IsArray() {
+			parts.ForEach(func(_, part gjson.Result) bool {
+				if part.Get("thought").Bool() {
+					return true
+				}
+				sb.WriteString(part.Get("text").String())
+				return true
+			})
+		}
+		delta := sb.String()
 		return DeltaParts{Parseable: delta, Raw: delta}, nil
 
 	// AWS Bedrock (Debug string format)

--- a/bamlutils/sse/extract_test.go
+++ b/bamlutils/sse/extract_test.go
@@ -601,3 +601,71 @@ func TestDeltaProviderSupportMatchesExtractor(t *testing.T) {
 		}
 	}
 }
+
+// TestExtractDeltaPartsFromText_GeminiThoughtFiltering asserts that the
+// Google AI / Vertex AI streaming branch iterates all parts, skips entries
+// flagged thought:true, and concatenates the surviving text fields.
+//
+// Aligned with upstream BAML's text_content_part filter
+// (engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs).
+//
+// Parseable invariance across includeThinking is asserted; Raw equality
+// across the flag is intentionally NOT asserted here — Phase 3 will diverge
+// Gemini Raw under opt-in, and locking it now would block that.
+func TestExtractDeltaPartsFromText_GeminiThoughtFiltering(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "single part",
+			body: `{"candidates":[{"content":{"parts":[{"text":"Answer"}]}}]}`,
+			want: "Answer",
+		},
+		{
+			name: "multi part concatenation",
+			body: `{"candidates":[{"content":{"parts":[{"text":"Hello "},{"text":"world"}]}}]}`,
+			want: "Hello world",
+		},
+		{
+			name: "thought at index 0 is skipped",
+			body: `{"candidates":[{"content":{"parts":[{"text":"internal","thought":true},{"text":"Visible"}]}}]}`,
+			want: "Visible",
+		},
+		{
+			name: "thought-only yields empty",
+			body: `{"candidates":[{"content":{"parts":[{"text":"internal","thought":true}]}}]}`,
+			want: "",
+		},
+	}
+
+	for _, provider := range []string{"google-ai", "vertex-ai"} {
+		for _, tc := range cases {
+			t.Run(provider+"/"+tc.name, func(t *testing.T) {
+				parts, err := ExtractDeltaPartsFromText(provider, tc.body, false)
+				if err != nil {
+					t.Fatalf("ExtractDeltaPartsFromText returned error: %v", err)
+				}
+				if parts.Parseable != tc.want {
+					t.Errorf("Parseable = %q, want %q", parts.Parseable, tc.want)
+				}
+				if parts.Raw != tc.want {
+					t.Errorf("Raw = %q, want %q (Phase 2: Raw == Parseable for Gemini)", parts.Raw, tc.want)
+				}
+
+				// Parseable must be byte-identical regardless of the
+				// includeThinking flag. Raw is intentionally not compared
+				// across the flag — Phase 3 will diverge Gemini Raw under
+				// opt-in, and locking it here would block that.
+				partsThinking, err := ExtractDeltaPartsFromText(provider, tc.body, true)
+				if err != nil {
+					t.Fatalf("ExtractDeltaPartsFromText(includeThinking=true) returned error: %v", err)
+				}
+				if partsThinking.Parseable != parts.Parseable {
+					t.Errorf("Parseable diverged across includeThinking: false=%q true=%q", parts.Parseable, partsThinking.Parseable)
+				}
+			})
+		}
+	}
+}

--- a/bamlutils/sse/extract_test.go
+++ b/bamlutils/sse/extract_test.go
@@ -638,6 +638,14 @@ func TestExtractDeltaPartsFromText_GeminiThoughtFiltering(t *testing.T) {
 			body: `{"candidates":[{"content":{"parts":[{"text":"internal","thought":true}]}}]}`,
 			want: "",
 		},
+		{
+			// Defensive guard: gjson stringifies non-string scalars via
+			// String(), so an unguarded WriteString on a numeric text
+			// field would emit "42Visible" instead of "Visible".
+			name: "non-string text field is skipped",
+			body: `{"candidates":[{"content":{"parts":[{"text":42},{"text":"Visible"}]}}]}`,
+			want: "Visible",
+		},
 	}
 
 	for _, provider := range []string{"google-ai", "vertex-ai"} {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Phase 2 of the #195 phased plan. Independent of the opt-in feature — fixes a parseable-safety bug.

The current Gemini extraction has two related bugs:
- **Streaming** (`bamlutils/sse/extract.go`): reads `candidates.0.content.parts.0.text` only — both single-part-blind (drops visible text in `parts[1]+`) and thought-blind (a `thought:true` part at index 0 contaminates Parseable).
- **Non-streaming** (`bamlutils/buildrequest/response_extract.go::extractGeminiContent`): iterates parts but doesn't filter `thought == true`.

Aligned with upstream BAML's `text_content_part` ([`google/response_handler.rs:108-119`](https://github.com/BoundaryML/baml/blob/v0.219.0/engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs#L108-L119)): iterate all parts, skip those where `thought == Some(true)`, concatenate surviving `text` with no separator, return empty for thought-only.

Phase 3 (Gemini opt-in surfacing of thought into Raw) is intentionally NOT in this PR.

## Test plan

- [ ] `bamlutils/sse/extract_test.go::TestExtractDeltaPartsFromText_GeminiThoughtFiltering` table: single-part / multi-part / thought-at-index-0 / thought-only across google-ai + vertex-ai.
- [ ] `bamlutils/buildrequest/response_extract_test.go::TestExtractResponseContent_GeminiThoughtAtIndexZero` and `…ThoughtOnly`.
- [ ] Existing Gemini extraction tests still pass.
- [ ] `go test ./bamlutils/...` clean.
- [ ] Per-adapter `GOWORK=off go test ./adapter/` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Responses and streaming output from Gemini/Vertex AI providers now ignore internal “thought”/reasoning parts so extracted and streamed text contains only visible user-facing content.

* **Tests**
  * Added tests validating that thought/reasoning parts are skipped and visible text is concatenated correctly across extraction and streaming scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/229)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->