### PR TITLE
feat: surface Gemini thought parts in raw under opt-in

### DIFF
--- a/bamlutils/buildrequest/response_extract.go
+++ b/bamlutils/buildrequest/response_extract.go
@@ -25,7 +25,8 @@ import (
 //   - raw: the text used for /call-with-raw's Raw() field. By default
 //     equals parseable (matches BAML's RawLLMResponse() text-only
 //     contract). When includeThinking is true, raw additionally carries
-//     provider-specific reasoning content (Anthropic thinking blocks).
+//     provider-specific reasoning content (Anthropic thinking blocks,
+//     Gemini thought-tagged parts).
 //
 // Returns an error for unsupported providers, empty bodies, invalid JSON,
 // and when a non-empty response body does not contain the expected structure.
@@ -55,8 +56,7 @@ func ExtractResponseContent(provider string, responseBody string, includeThinkin
 		return text, text, extractErr
 
 	case "google-ai", "vertex-ai":
-		text, extractErr := extractGeminiContent(provider, responseBody)
-		return text, text, extractErr
+		return extractGeminiContent(provider, responseBody, includeThinking)
 
 	default:
 		return "", "", fmt.Errorf("unsupported provider for non-streaming extraction: %s", provider)
@@ -219,16 +219,28 @@ func extractAnthropicContent(provider string, responseBody string, includeThinki
 }
 
 // extractGeminiContent extracts text from a Google AI / Vertex AI (Gemini)
-// non-streaming response. Parts flagged thought:true are filtered out
-// entirely so reasoning text never enters parseable — aligned with
-// upstream BAML's text_content_part filter
-// (engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs).
-// Non-thought parts retain the existing strict validation.
-func extractGeminiContent(provider string, responseBody string) (string, error) {
+// non-streaming response.
+//
+// Returns two strings:
+//   - parseable: only non-thought string text. Thought-tagged parts never
+//     enter parseable — aligned with upstream BAML's text_content_part
+//     filter at
+//     engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs.
+//   - raw: non-thought string text always; thought-tagged parts only when
+//     includeThinking is true (the per-request opt-in for surfacing
+//     reasoning text via /call-with-raw's Raw()).
+//
+// Non-thought parts retain the existing strict validation: missing parts,
+// non-object array elements, and non-string text on a non-thought part
+// remain errors. Thought parts are filtered, not validated — non-string
+// text on a thought part is silently skipped, since the part contributes
+// to neither parseable nor (validated) raw output.
+func extractGeminiContent(provider string, responseBody string, includeThinking bool) (parseable, raw string, err error) {
 	parts := gjson.Get(responseBody, "candidates.0.content.parts")
 
 	if parts.IsArray() {
-		var sb strings.Builder
+		var parseableSB strings.Builder
+		var rawSB strings.Builder
 		var iterErr error
 		parts.ForEach(func(_, part gjson.Result) bool {
 			// Reject non-object array elements
@@ -236,9 +248,15 @@ func extractGeminiContent(provider string, responseBody string) (string, error) 
 				iterErr = fmt.Errorf("%s: non-object element in parts array (got %s)", provider, part.Type)
 				return false
 			}
-			// Skip thought parts before any text validation; their text
-			// field shape is irrelevant to parseable output.
+			// Thought parts are filtered, not validated. They never enter
+			// parseable; they enter raw only as opt-in string text.
 			if part.Get("thought").Bool() {
+				if includeThinking {
+					text := part.Get("text")
+					if text.Type == gjson.String {
+						rawSB.WriteString(text.String())
+					}
+				}
 				return true
 			}
 			text := part.Get("text")
@@ -247,17 +265,18 @@ func extractGeminiContent(provider string, responseBody string) (string, error) 
 					iterErr = fmt.Errorf("%s: unexpected type for part text field (got %s)", provider, text.Type)
 					return false
 				}
-				sb.WriteString(text.String())
+				parseableSB.WriteString(text.String())
+				rawSB.WriteString(text.String())
 			}
 			return true
 		})
 		if iterErr != nil {
-			return "", iterErr
+			return "", "", iterErr
 		}
-		return sb.String(), nil
+		return parseableSB.String(), rawSB.String(), nil
 	}
 
-	return "", fmt.Errorf("%s: could not extract text content from response (candidates[0].content.parts not found)", provider)
+	return "", "", fmt.Errorf("%s: could not extract text content from response (candidates[0].content.parts not found)", provider)
 }
 
 // extractOpenAIResponsesContent extracts text from an OpenAI Responses API

--- a/bamlutils/buildrequest/response_extract_test.go
+++ b/bamlutils/buildrequest/response_extract_test.go
@@ -858,6 +858,97 @@ func TestExtractResponseContent_GeminiThoughtOnly(t *testing.T) {
 	}
 }
 
+// TestExtractResponseContent_GeminiIncludeThinkingInRaw asserts the
+// Phase 3 dual-builder behavior for the Gemini non-streaming branch:
+//
+//   - Parseable always excludes thought-tagged parts (text-only, fed to
+//     Parse.Method via /call).
+//   - Raw mirrors Parseable when includeThinking is false; when true,
+//     Raw additionally surfaces thought-tagged string text in wire order
+//     for /call-with-raw telemetry.
+//   - Strict validation is preserved for non-thought parts (non-string
+//     text errors). Thought parts are filtered, not validated, so non-
+//     string text on a thought part is silently skipped under both flag
+//     values — consistent with Phase 2's behavior.
+//
+// Parseable invariance across the includeThinking flag is asserted for
+// every fixture; Raw is intentionally allowed to diverge.
+func TestExtractResponseContent_GeminiIncludeThinkingInRaw(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		parseable string
+		rawOff    string
+		rawOn     string
+	}{
+		{
+			name:      "thought then visible",
+			body:      `{"candidates":[{"content":{"parts":[{"text":"thought","thought":true},{"text":"Visible"}]}}]}`,
+			parseable: "Visible",
+			rawOff:    "Visible",
+			rawOn:     "thoughtVisible",
+		},
+		{
+			name:      "interleaved thought preserves order",
+			body:      `{"candidates":[{"content":{"parts":[{"text":"A"},{"text":"B","thought":true},{"text":"C"}]}}]}`,
+			parseable: "AC",
+			rawOff:    "AC",
+			rawOn:     "ABC",
+		},
+		{
+			name:      "thought only",
+			body:      `{"candidates":[{"content":{"parts":[{"text":"thought","thought":true}]}}]}`,
+			parseable: "",
+			rawOff:    "",
+			rawOn:     "thought",
+		},
+		{
+			// Numeric text on a thought part: silently skipped (no error)
+			// under both flag values, since thought parts contribute to
+			// neither parseable nor validated raw output.
+			name:      "thought non-string text skipped under opt-in",
+			body:      `{"candidates":[{"content":{"parts":[{"text":42,"thought":true},{"text":"Visible"}]}}]}`,
+			parseable: "Visible",
+			rawOff:    "Visible",
+			rawOn:     "Visible",
+		},
+	}
+
+	for _, provider := range []string{"google-ai", "vertex-ai"} {
+		for _, tc := range cases {
+			t.Run(provider+"/"+tc.name, func(t *testing.T) {
+				parseableOff, rawOff, err := ExtractResponseContent(provider, tc.body, false)
+				if err != nil {
+					t.Fatalf("ExtractResponseContent(includeThinking=false) returned error: %v", err)
+				}
+				if parseableOff != tc.parseable {
+					t.Errorf("flag=false parseable = %q, want %q", parseableOff, tc.parseable)
+				}
+				if rawOff != tc.rawOff {
+					t.Errorf("flag=false raw = %q, want %q", rawOff, tc.rawOff)
+				}
+
+				parseableOn, rawOn, err := ExtractResponseContent(provider, tc.body, true)
+				if err != nil {
+					t.Fatalf("ExtractResponseContent(includeThinking=true) returned error: %v", err)
+				}
+				if parseableOn != tc.parseable {
+					t.Errorf("flag=true parseable = %q, want %q", parseableOn, tc.parseable)
+				}
+				if rawOn != tc.rawOn {
+					t.Errorf("flag=true raw = %q, want %q", rawOn, tc.rawOn)
+				}
+
+				// Structural parseable invariance: byte-identical across
+				// both flag values for every fixture.
+				if parseableOff != parseableOn {
+					t.Errorf("parseable diverged across includeThinking: false=%q true=%q", parseableOff, parseableOn)
+				}
+			})
+		}
+	}
+}
+
 func TestExtractResponseContent_UnsupportedProvider(t *testing.T) {
 	_, _, err := ExtractResponseContent("aws-bedrock", `{}`, false)
 	if err == nil {

--- a/bamlutils/sse/extract.go
+++ b/bamlutils/sse/extract.go
@@ -11,10 +11,11 @@ import (
 // DeltaParts contains the parseable/raw split for a single SSE event.
 // Parseable is always text-only — reasoning/thinking content never enters
 // it, so the BAML parser cannot be influenced by reasoning text. Raw
-// matches Parseable for providers without a reasoning surface; for
-// Anthropic, raw additionally carries thinking_delta content when the
+// matches Parseable for providers without a reasoning surface; when the
 // caller opts in via IncludeThinkingInRaw on the IncrementalExtractor or
-// the includeThinking parameter on ExtractDeltaPartsFromText.
+// the includeThinking parameter on ExtractDeltaPartsFromText, Raw
+// additionally carries provider-specific reasoning text (Anthropic
+// thinking_delta, Gemini thought-tagged parts).
 type DeltaParts struct {
 	Parseable string
 	Raw       string
@@ -43,7 +44,8 @@ type StreamingData struct {
 //
 // includeThinking is the per-request opt-in flag for surfacing provider-
 // specific reasoning content. False (default) yields BAML-aligned text-only
-// content; true additionally accumulates Anthropic thinking_delta into the
+// content; true additionally accumulates provider-specific reasoning text
+// (Anthropic thinking_delta, Gemini thought-tagged parts) into the
 // returned string.
 func GetCurrentContent(data *StreamingData, includeThinking bool) (string, error) {
 	if len(data.Calls) == 0 {
@@ -80,10 +82,11 @@ func ExtractDeltaContent(provider string, chunk SSEChunk, includeThinking bool) 
 //
 // includeThinking is the per-request opt-in flag for surfacing provider-
 // specific reasoning content in Raw. When false (default), Parseable == Raw
-// and Anthropic thinking_delta events are dropped — matching BAML's
-// RawLLMResponse() text-only contract. When true, Anthropic thinking_delta
-// events contribute to Raw only; Parseable is unaffected by construction so
-// the BAML parser cannot be influenced by reasoning text.
+// and reasoning events are dropped — matching BAML's RawLLMResponse()
+// text-only contract. When true, provider-specific reasoning text
+// (Anthropic thinking_delta, Gemini thought-tagged parts) contributes to
+// Raw only; Parseable is unaffected by construction so the BAML parser
+// cannot be influenced by reasoning text.
 func ExtractDeltaPartsFromText(provider string, rawText string, includeThinking bool) (DeltaParts, error) {
 	switch provider {
 	// OpenAI-compatible providers (Chat Completions API format)
@@ -123,30 +126,37 @@ func ExtractDeltaPartsFromText(provider string, rawText string, includeThinking 
 
 	// Google (both use same format)
 	// Path: candidates[0].content.parts[]
-	// Iterate all parts, skip those flagged thought:true so reasoning text
-	// never enters Parseable. Concatenate the remaining text fields with no
-	// separator — matches upstream BAML's text_content_part filter
-	// (engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs).
-	// Missing or non-array parts yields an empty delta with no error,
-	// preserving the prior forgiving streaming semantics.
+	// Iterate all parts. Non-thought string text writes to Parseable and Raw;
+	// thought-tagged parts never enter Parseable (matching upstream BAML's
+	// text_content_part filter at
+	// engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs)
+	// and write to Raw only when includeThinking is on, so thought text is
+	// surfaced for telemetry while staying out of the BAML parser input.
+	// Missing/non-array parts yields an empty delta with no error, and
+	// non-string text on any part is silently skipped — preserving the
+	// forgiving streaming semantics.
 	case "google-ai", "vertex-ai":
 		parts := gjson.Get(rawText, "candidates.0.content.parts")
-		var sb strings.Builder
+		var parseableSB strings.Builder
+		var rawSB strings.Builder
 		if parts.IsArray() {
 			parts.ForEach(func(_, part gjson.Result) bool {
-				if part.Get("thought").Bool() {
-					return true
-				}
 				text := part.Get("text")
 				if text.Type != gjson.String {
 					return true
 				}
-				sb.WriteString(text.String())
+				if part.Get("thought").Bool() {
+					if includeThinking {
+						rawSB.WriteString(text.String())
+					}
+					return true
+				}
+				parseableSB.WriteString(text.String())
+				rawSB.WriteString(text.String())
 				return true
 			})
 		}
-		delta := sb.String()
-		return DeltaParts{Parseable: delta, Raw: delta}, nil
+		return DeltaParts{Parseable: parseableSB.String(), Raw: rawSB.String()}, nil
 
 	// AWS Bedrock (Debug string format)
 	// Path: debug (then parsed via regex)
@@ -241,9 +251,9 @@ func IsDeltaProviderSupported(provider string) bool {
 //     content never enters this buffer regardless of includeThinkingInRaw,
 //     so a malformed JSON-ish thinking fragment cannot influence parsing.
 //   - raw accumulates wire-output deltas (from DeltaParts.Raw). When
-//     includeThinkingInRaw is true, this additionally carries Anthropic
-//     thinking_delta content; otherwise it equals the parseable buffer
-//     byte-for-byte.
+//     includeThinkingInRaw is true, this additionally carries provider-
+//     specific reasoning text (Anthropic thinking_delta, Gemini thought-
+//     tagged parts); otherwise it equals the parseable buffer byte-for-byte.
 //
 // Under the default flag-off configuration the two buffers always hold
 // identical content. Under opt-in they diverge whenever a non-text content
@@ -265,16 +275,18 @@ type IncrementalExtractor struct {
 	// includeThinkingInRaw mirrors the per-request opt-in for surfacing
 	// provider-specific reasoning content. False (default) yields BAML-
 	// aligned text-only output across both buffers; true additionally
-	// accumulates Anthropic thinking_delta into raw only.
+	// accumulates provider-specific reasoning text (Anthropic
+	// thinking_delta, Gemini thought-tagged parts) into raw only.
 	includeThinkingInRaw bool
 }
 
 // NewIncrementalExtractor creates a new incremental extractor. Pass
-// includeThinking=true to opt the extractor into accumulating Anthropic
-// thinking_delta content alongside text deltas in the raw buffer; pass
-// false (default) for BAML-aligned text-only output across both the
-// parseable and raw buffers. The parseable buffer is text-only regardless
-// of this flag — the gate only affects the raw buffer.
+// includeThinking=true to opt the extractor into accumulating provider-
+// specific reasoning content (Anthropic thinking_delta, Gemini thought-
+// tagged parts) alongside text deltas in the raw buffer; pass false
+// (default) for BAML-aligned text-only output across both the parseable
+// and raw buffers. The parseable buffer is text-only regardless of this
+// flag — the gate only affects the raw buffer.
 func NewIncrementalExtractor(includeThinking bool) *IncrementalExtractor {
 	return &IncrementalExtractor{includeThinkingInRaw: includeThinking}
 }
@@ -421,8 +433,9 @@ func ExtractFrom[T SSEChunk](e *IncrementalExtractor, callCount int, provider st
 }
 
 // RawFull returns the complete accumulated raw content without processing
-// new data. Under IncludeThinkingInRaw=true this includes thinking_delta
-// content for Anthropic; otherwise it matches ParseableFull byte-for-byte.
+// new data. Under IncludeThinkingInRaw=true this includes provider-specific
+// reasoning text (Anthropic thinking_delta, Gemini thought-tagged parts);
+// otherwise it matches ParseableFull byte-for-byte.
 func (e *IncrementalExtractor) RawFull() string {
 	return e.raw.String()
 }

--- a/bamlutils/sse/extract_test.go
+++ b/bamlutils/sse/extract_test.go
@@ -677,3 +677,136 @@ func TestExtractDeltaPartsFromText_GeminiThoughtFiltering(t *testing.T) {
 		}
 	}
 }
+
+// TestExtractDeltaPartsFromText_GeminiIncludeThinkingInRaw asserts the
+// Phase 3 dual-builder behavior for the Google AI / Vertex AI streaming
+// branch:
+//
+//   - Parseable always excludes thought-tagged parts (text-only, fed to
+//     the BAML parser via ParseStream).
+//   - Raw mirrors Parseable when includeThinking is false; when true, Raw
+//     additionally surfaces thought-tagged string text in wire order for
+//     /with-raw telemetry.
+//   - Non-string text on a thought part is silently skipped under both
+//     flag values (thought parts are filtered, not validated, in keeping
+//     with the forgiving streaming semantics).
+//
+// Parseable invariance across the includeThinking flag is asserted for
+// every fixture; Raw equality across the flag is intentionally NOT
+// asserted, because Phase 3's whole point is that Raw diverges under
+// opt-in.
+func TestExtractDeltaPartsFromText_GeminiIncludeThinkingInRaw(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		parseable string
+		rawOff    string
+		rawOn     string
+	}{
+		{
+			name:      "thought then visible",
+			body:      `{"candidates":[{"content":{"parts":[{"text":"thought","thought":true},{"text":"Visible"}]}}]}`,
+			parseable: "Visible",
+			rawOff:    "Visible",
+			rawOn:     "thoughtVisible",
+		},
+		{
+			name:      "interleaved thought preserves order",
+			body:      `{"candidates":[{"content":{"parts":[{"text":"A"},{"text":"B","thought":true},{"text":"C"}]}}]}`,
+			parseable: "AC",
+			rawOff:    "AC",
+			rawOn:     "ABC",
+		},
+		{
+			name:      "thought only",
+			body:      `{"candidates":[{"content":{"parts":[{"text":"thought","thought":true}]}}]}`,
+			parseable: "",
+			rawOff:    "",
+			rawOn:     "thought",
+		},
+		{
+			// Numeric text on a thought part: silently skipped under both
+			// flag values. The visible part still flows through normally.
+			name:      "thought non-string text skipped under opt-in",
+			body:      `{"candidates":[{"content":{"parts":[{"text":42,"thought":true},{"text":"Visible"}]}}]}`,
+			parseable: "Visible",
+			rawOff:    "Visible",
+			rawOn:     "Visible",
+		},
+	}
+
+	for _, provider := range []string{"google-ai", "vertex-ai"} {
+		for _, tc := range cases {
+			t.Run(provider+"/"+tc.name, func(t *testing.T) {
+				off, err := ExtractDeltaPartsFromText(provider, tc.body, false)
+				if err != nil {
+					t.Fatalf("ExtractDeltaPartsFromText(includeThinking=false) returned error: %v", err)
+				}
+				if off.Parseable != tc.parseable {
+					t.Errorf("flag=false Parseable = %q, want %q", off.Parseable, tc.parseable)
+				}
+				if off.Raw != tc.rawOff {
+					t.Errorf("flag=false Raw = %q, want %q", off.Raw, tc.rawOff)
+				}
+
+				on, err := ExtractDeltaPartsFromText(provider, tc.body, true)
+				if err != nil {
+					t.Fatalf("ExtractDeltaPartsFromText(includeThinking=true) returned error: %v", err)
+				}
+				if on.Parseable != tc.parseable {
+					t.Errorf("flag=true Parseable = %q, want %q", on.Parseable, tc.parseable)
+				}
+				if on.Raw != tc.rawOn {
+					t.Errorf("flag=true Raw = %q, want %q", on.Raw, tc.rawOn)
+				}
+
+				// Structural parseable invariance: Parseable must be
+				// byte-identical across both flag values for every fixture.
+				if off.Parseable != on.Parseable {
+					t.Errorf("Parseable diverged across includeThinking: false=%q true=%q", off.Parseable, on.Parseable)
+				}
+			})
+		}
+	}
+}
+
+// TestIncrementalExtractor_GeminiThinking_ParseableInvariant exercises
+// ExtractFrom on a Gemini SSE chunk through both flag-off and flag-on
+// IncrementalExtractor instances, proving that the stored
+// includeThinkingInRaw flag reaches ExtractDeltaPartsFromText in both the
+// rebuild and incremental paths and that the parseable buffer is
+// byte-identical regardless of the flag.
+func TestIncrementalExtractor_GeminiThinking_ParseableInvariant(t *testing.T) {
+	chunks := []SSEChunk{
+		mockChunk{`{"candidates":[{"content":{"parts":[{"text":"think","thought":true},{"text":"Hello"}]}}]}`},
+		mockChunk{`{"candidates":[{"content":{"parts":[{"text":" more","thought":true},{"text":" world"}]}}]}`},
+	}
+
+	for _, provider := range []string{"google-ai", "vertex-ai"} {
+		t.Run(provider, func(t *testing.T) {
+			off := NewIncrementalExtractor(false)
+			resOff := off.Extract(1, provider, chunks)
+
+			on := NewIncrementalExtractor(true)
+			resOn := on.Extract(1, provider, chunks)
+
+			if resOff.ParseableFull != "Hello world" {
+				t.Errorf("flag=false ParseableFull = %q, want %q", resOff.ParseableFull, "Hello world")
+			}
+			if resOff.RawFull != "Hello world" {
+				t.Errorf("flag=false RawFull = %q, want %q", resOff.RawFull, "Hello world")
+			}
+			if resOn.ParseableFull != "Hello world" {
+				t.Errorf("flag=true ParseableFull = %q, want %q", resOn.ParseableFull, "Hello world")
+			}
+			if resOn.RawFull != "thinkHello more world" {
+				t.Errorf("flag=true RawFull = %q, want %q", resOn.RawFull, "thinkHello more world")
+			}
+
+			// Structural parseable invariance under the IncrementalExtractor.
+			if resOff.ParseableFull != resOn.ParseableFull {
+				t.Errorf("ParseableFull diverged across includeThinkingInRaw: false=%q true=%q", resOff.ParseableFull, resOn.ParseableFull)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Phase 3 of the #195 phased plan. Builds on Phase 2 (#229)'s iteration shape.

When `IncludeThinkingInRaw=true`, Gemini `thought == true` part text is surfaced in `Raw` for telemetry, while `Parseable` (the BAML parser input) stays text-only regardless of flag value. Default behavior (flag off) is unchanged from Phase 2.

## Implementation

- **Streaming** (`bamlutils/sse/extract.go`): Google/Vertex case splits the single `strings.Builder` into `parseableSB`+`rawSB`. Non-thought string text writes to both; thought string text writes to `rawSB` only when the flag is on. Wire order preserved in `Raw`.
- **Non-streaming** (`bamlutils/buildrequest/response_extract.go::extractGeminiContent`): signature gains `includeThinking bool` and returns `(parseable, raw string, err error)`. Same dual-builder shape inside. Strict error semantics for non-thought parts preserved (missing parts, non-object elements, malformed text on non-thought parts still error). Thought parts are filtered, not validated — non-string `text` on a thought part is silently skipped.

## Parseable invariance — structural

`includeThinking` only gates writes to `rawSB`; `parseableSB` writes are unconditional. Tests assert byte-identity of `Parseable` across both flag values for every fixture.

## Out of scope

- Phase 4 (OpenAI Chat Completions `reasoning_content`)
- Phase 5 (OpenAI Responses reasoning summaries)
- Phase 6 (AWS Bedrock)
- Adapter / codegen / worker plumbing changes (Phase 1's territory)

## Test plan

- [x] `bamlutils/sse/extract_test.go::TestExtractDeltaPartsFromText_GeminiIncludeThinkingInRaw` — 4 sub-cases × 2 providers, with parseable invariance assertion.
- [x] `bamlutils/sse/extract_test.go::TestIncrementalExtractor_GeminiThinking_ParseableInvariant` — buffer-level test proving the stored flag reaches `ExtractDeltaPartsFromText` through `ExtractFrom`.
- [x] `bamlutils/buildrequest/response_extract_test.go::TestExtractResponseContent_GeminiIncludeThinkingInRaw` — same 4 cases at the non-streaming entry.
- [x] Existing Gemini extraction tests pass without modification.
- [x] `go test ./bamlutils/...` clean.
- [x] Per-adapter `GOWORK=off go test ./adapter/` clean (v0_204_0, v0_215_0, v0_219_0).
- [x] `cmd/verify-framework-adapter` 9/9 PASS.
- [x] `cmd/verify-adapter-pins` clean.
- [x] `go run ./cmd/embed` produces no diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for surfacing AI reasoning/thinking content in raw outputs when requested. This is available for Gemini and Vertex AI providers and can be toggled on/off.

* **Tests**
  * Added comprehensive test coverage for thinking content handling in both standard and streaming response scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/230)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->