### PR TITLE
feat: surface OpenAI Chat Completions reasoning_content in raw under opt-in

### DIFF
--- a/bamlutils/buildrequest/response_extract.go
+++ b/bamlutils/buildrequest/response_extract.go
@@ -26,7 +26,8 @@ import (
 //     equals parseable (matches BAML's RawLLMResponse() text-only
 //     contract). When includeThinking is true, raw additionally carries
 //     provider-specific reasoning content (Anthropic thinking blocks,
-//     Gemini thought-tagged parts).
+//     Gemini thought-tagged parts, OpenAI Chat Completions
+//     reasoning_content).
 //
 // Returns an error for unsupported providers, empty bodies, invalid JSON,
 // and when a non-empty response body does not contain the expected structure.
@@ -45,8 +46,7 @@ func ExtractResponseContent(provider string, responseBody string, includeThinkin
 
 	switch provider {
 	case "openai", "openai-generic", "azure-openai", "ollama", "openrouter":
-		text, extractErr := extractOpenAIContent(provider, responseBody)
-		return text, text, extractErr
+		return extractOpenAIContent(provider, responseBody, includeThinking)
 
 	case "anthropic":
 		return extractAnthropicContent(provider, responseBody, includeThinking)
@@ -66,6 +66,16 @@ func ExtractResponseContent(provider string, responseBody string, includeThinkin
 // extractOpenAIContent extracts text from an OpenAI Chat Completions
 // non-streaming response.
 //
+// Returns two strings:
+//   - parseable: text content only — message.content (scalar string, array
+//     text parts, or explicit null). Reasoning content never enters this
+//     value, so the BAML parser cannot be influenced by reasoning text.
+//   - raw: text content always; when includeThinking is true, additionally
+//     carries message.reasoning_content (the de-facto reasoning surface for
+//     DeepSeek-R1 and several OAI-compat gateways) appended after content.
+//     Non-string reasoning_content is silently skipped, matching the
+//     defensive pattern used elsewhere for optional reasoning surfaces.
+//
 // Handles:
 //   - Scalar string content (common case)
 //   - Array content parts (multimodal / tool-use)
@@ -73,8 +83,20 @@ func ExtractResponseContent(provider string, responseBody string, includeThinkin
 //   - Refusal responses (message.refusal field or {"type":"refusal"} parts)
 //
 // Returns an error for refusals, missing/malformed content, and non-object
-// array elements.
-func extractOpenAIContent(provider string, responseBody string) (string, error) {
+// array elements. reasoning_content is telemetry — its presence does not
+// change content's strict error semantics.
+func extractOpenAIContent(provider, responseBody string, includeThinking bool) (parseable, raw string, err error) {
+	appendReasoning := func(parseable string) string {
+		if !includeThinking {
+			return parseable
+		}
+		reasoning := gjson.Get(responseBody, "choices.0.message.reasoning_content")
+		if reasoning.Type != gjson.String {
+			return parseable
+		}
+		return parseable + reasoning.String()
+	}
+
 	// Check for refusal first. OpenAI returns refusals either as a
 	// top-level message.refusal field or as a content array part with
 	// type == "refusal". The presence of the refusal field means the model
@@ -85,14 +107,15 @@ func extractOpenAIContent(provider string, responseBody string) (string, error) 
 		if refusal.Type == gjson.String && refusal.String() != "" {
 			refusalText = refusal.String()
 		}
-		return "", fmt.Errorf("%s: model refused request: %s", provider, refusalText)
+		return "", "", fmt.Errorf("%s: model refused request: %s", provider, refusalText)
 	}
 
 	content := gjson.Get(responseBody, "choices.0.message.content")
 
 	// Scalar string — the common case
 	if content.Type == gjson.String {
-		return content.String(), nil
+		text := content.String()
+		return text, appendReasoning(text), nil
 	}
 
 	// Array of content parts
@@ -136,21 +159,22 @@ func extractOpenAIContent(provider string, responseBody string) (string, error) 
 			return true
 		})
 		if iterErr != nil {
-			return "", iterErr
+			return "", "", iterErr
 		}
-		return sb.String(), nil
+		text := sb.String()
+		return text, appendReasoning(text), nil
 	}
 
 	// Explicitly null content (e.g. function-call-only responses) — valid.
 	if content.Exists() && content.Type == gjson.Null {
-		return "", nil
+		return "", appendReasoning(""), nil
 	}
 
 	if content.Exists() {
-		return "", fmt.Errorf("%s: unexpected content type in response (got %s)", provider, content.Type)
+		return "", "", fmt.Errorf("%s: unexpected content type in response (got %s)", provider, content.Type)
 	}
 
-	return "", fmt.Errorf("%s: could not extract text content from response (choices[0].message.content not found)", provider)
+	return "", "", fmt.Errorf("%s: could not extract text content from response (choices[0].message.content not found)", provider)
 }
 
 // extractAnthropicContent extracts text from an Anthropic Messages API

--- a/bamlutils/buildrequest/response_extract_test.go
+++ b/bamlutils/buildrequest/response_extract_test.go
@@ -949,6 +949,108 @@ func TestExtractResponseContent_GeminiIncludeThinkingInRaw(t *testing.T) {
 	}
 }
 
+// TestExtractResponseContent_OpenAIReasoningContent asserts the Phase 4
+// dual-output behavior for the OpenAI-compatible Chat Completions
+// non-streaming branch (openai, openai-generic, azure-openai, ollama,
+// openrouter):
+//
+//   - parseable always reflects only message.content. Reasoning content
+//     never enters parseable so the BAML parser cannot be influenced.
+//   - raw mirrors parseable when includeThinking is false; when true, raw
+//     additionally surfaces message.reasoning_content appended after content.
+//   - Non-string reasoning_content is silently skipped under both flag
+//     values, matching the defensive pattern used elsewhere for optional
+//     reasoning surfaces. reasoning_content is telemetry — its presence
+//     does not change content's strict error semantics.
+//
+// Parseable invariance across the includeThinking flag is asserted for
+// every fixture × provider; raw equality across the flag is intentionally
+// allowed to diverge.
+func TestExtractResponseContent_OpenAIReasoningContent(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		parseable string
+		rawOff    string
+		rawOn     string
+	}{
+		{
+			name:      "scalar content plus reasoning",
+			body:      `{"choices":[{"message":{"content":"Hello world","reasoning_content":"chain of thought"}}]}`,
+			parseable: "Hello world",
+			rawOff:    "Hello world",
+			rawOn:     "Hello worldchain of thought",
+		},
+		{
+			name: "array text content plus reasoning",
+			body: `{"choices":[{"message":{"content":[
+				{"type":"text","text":"Hello "},
+				{"type":"text","text":"world"}
+			],"reasoning_content":"chain of thought"}}]}`,
+			parseable: "Hello world",
+			rawOff:    "Hello world",
+			rawOn:     "Hello worldchain of thought",
+		},
+		{
+			name:      "empty-string content plus reasoning",
+			body:      `{"choices":[{"message":{"content":"","reasoning_content":"chain of thought"}}]}`,
+			parseable: "",
+			rawOff:    "",
+			rawOn:     "chain of thought",
+		},
+		{
+			name:      "explicit-null content plus reasoning",
+			body:      `{"choices":[{"message":{"content":null,"reasoning_content":"chain of thought"}}]}`,
+			parseable: "",
+			rawOff:    "",
+			rawOn:     "chain of thought",
+		},
+		{
+			// Defensive: non-string reasoning_content is silently skipped
+			// under opt-in. content's strict error semantics are unaffected.
+			name:      "non-string reasoning ignored under opt-in",
+			body:      `{"choices":[{"message":{"content":"Hello","reasoning_content":42}}]}`,
+			parseable: "Hello",
+			rawOff:    "Hello",
+			rawOn:     "Hello",
+		},
+	}
+
+	for _, provider := range []string{"openai", "openai-generic", "azure-openai", "ollama", "openrouter"} {
+		for _, tc := range cases {
+			t.Run(provider+"/"+tc.name, func(t *testing.T) {
+				parseableOff, rawOff, err := ExtractResponseContent(provider, tc.body, false)
+				if err != nil {
+					t.Fatalf("ExtractResponseContent(includeThinking=false) returned error: %v", err)
+				}
+				if parseableOff != tc.parseable {
+					t.Errorf("flag=false parseable = %q, want %q", parseableOff, tc.parseable)
+				}
+				if rawOff != tc.rawOff {
+					t.Errorf("flag=false raw = %q, want %q", rawOff, tc.rawOff)
+				}
+
+				parseableOn, rawOn, err := ExtractResponseContent(provider, tc.body, true)
+				if err != nil {
+					t.Fatalf("ExtractResponseContent(includeThinking=true) returned error: %v", err)
+				}
+				if parseableOn != tc.parseable {
+					t.Errorf("flag=true parseable = %q, want %q", parseableOn, tc.parseable)
+				}
+				if rawOn != tc.rawOn {
+					t.Errorf("flag=true raw = %q, want %q", rawOn, tc.rawOn)
+				}
+
+				// Structural parseable invariance: byte-identical across
+				// both flag values for every fixture.
+				if parseableOff != parseableOn {
+					t.Errorf("parseable diverged across includeThinking: false=%q true=%q", parseableOff, parseableOn)
+				}
+			})
+		}
+	}
+}
+
 func TestExtractResponseContent_UnsupportedProvider(t *testing.T) {
 	_, _, err := ExtractResponseContent("aws-bedrock", `{}`, false)
 	if err == nil {

--- a/bamlutils/buildrequest/response_extract_test.go
+++ b/bamlutils/buildrequest/response_extract_test.go
@@ -1051,6 +1051,34 @@ func TestExtractResponseContent_OpenAIReasoningContent(t *testing.T) {
 	}
 }
 
+// TestExtractResponseContent_OpenAIReasoningContentMissingContent locks in
+// the contract that reasoning_content is telemetry — its presence does NOT
+// relax message.content's required-ness for the OpenAI-compatible Chat
+// Completions providers. A response that omits message.content but includes
+// message.reasoning_content must error in both flag values, and must return
+// empty parseable AND empty raw (no telemetry leakage from a malformed
+// response).
+func TestExtractResponseContent_OpenAIReasoningContentMissingContent(t *testing.T) {
+	body := `{"choices":[{"message":{"reasoning_content":"chain of thought"}}]}`
+
+	for _, provider := range []string{"openai", "openai-generic", "azure-openai", "ollama", "openrouter"} {
+		t.Run(provider, func(t *testing.T) {
+			for _, flag := range []bool{false, true} {
+				parseable, raw, err := ExtractResponseContent(provider, body, flag)
+				if err == nil {
+					t.Errorf("includeThinking=%v: expected error for missing message.content (reasoning_content alone is not a valid response)", flag)
+				}
+				if parseable != "" {
+					t.Errorf("includeThinking=%v: expected empty parseable on error, got %q", flag, parseable)
+				}
+				if raw != "" {
+					t.Errorf("includeThinking=%v: expected empty raw on error (no telemetry leakage), got %q", flag, raw)
+				}
+			}
+		})
+	}
+}
+
 func TestExtractResponseContent_UnsupportedProvider(t *testing.T) {
 	_, _, err := ExtractResponseContent("aws-bedrock", `{}`, false)
 	if err == nil {

--- a/bamlutils/sse/extract.go
+++ b/bamlutils/sse/extract.go
@@ -15,7 +15,8 @@ import (
 // caller opts in via IncludeThinkingInRaw on the IncrementalExtractor or
 // the includeThinking parameter on ExtractDeltaPartsFromText, Raw
 // additionally carries provider-specific reasoning text (Anthropic
-// thinking_delta, Gemini thought-tagged parts).
+// thinking_delta, Gemini thought-tagged parts, OpenAI Chat Completions
+// reasoning_content).
 type DeltaParts struct {
 	Parseable string
 	Raw       string
@@ -45,8 +46,8 @@ type StreamingData struct {
 // includeThinking is the per-request opt-in flag for surfacing provider-
 // specific reasoning content. False (default) yields BAML-aligned text-only
 // content; true additionally accumulates provider-specific reasoning text
-// (Anthropic thinking_delta, Gemini thought-tagged parts) into the
-// returned string.
+// (Anthropic thinking_delta, Gemini thought-tagged parts, OpenAI Chat
+// Completions reasoning_content) into the returned string.
 func GetCurrentContent(data *StreamingData, includeThinking bool) (string, error) {
 	if len(data.Calls) == 0 {
 		return "", nil
@@ -84,16 +85,29 @@ func ExtractDeltaContent(provider string, chunk SSEChunk, includeThinking bool) 
 // specific reasoning content in Raw. When false (default), Parseable == Raw
 // and reasoning events are dropped — matching BAML's RawLLMResponse()
 // text-only contract. When true, provider-specific reasoning text
-// (Anthropic thinking_delta, Gemini thought-tagged parts) contributes to
-// Raw only; Parseable is unaffected by construction so the BAML parser
-// cannot be influenced by reasoning text.
+// (Anthropic thinking_delta, Gemini thought-tagged parts, OpenAI Chat
+// Completions reasoning_content) contributes to Raw only; Parseable is
+// unaffected by construction so the BAML parser cannot be influenced by
+// reasoning text.
 func ExtractDeltaPartsFromText(provider string, rawText string, includeThinking bool) (DeltaParts, error) {
 	switch provider {
 	// OpenAI-compatible providers (Chat Completions API format)
-	// Path: choices[0].delta.content
+	// Path: choices[0].delta.content (parseable+raw); choices[0].delta.reasoning_content
+	// (raw only, opt-in). reasoning_content is the de-facto reasoning surface
+	// for DeepSeek-R1 and several OAI-compat gateways; non-string values are
+	// silently skipped, matching the forgiving streaming semantics. Order is
+	// content-first within a single delta; event order is preserved across
+	// SSE chunks by IncrementalExtractor.
 	case "openai", "openai-generic", "azure-openai", "ollama", "openrouter":
 		delta := gjson.Get(rawText, "choices.0.delta.content").String()
-		return DeltaParts{Parseable: delta, Raw: delta}, nil
+		raw := delta
+		if includeThinking {
+			reasoning := gjson.Get(rawText, "choices.0.delta.reasoning_content")
+			if reasoning.Type == gjson.String {
+				raw += reasoning.String()
+			}
+		}
+		return DeltaParts{Parseable: delta, Raw: raw}, nil
 
 	// OpenAI Responses API (different format)
 	// Path: delta (when type == "response.output_text.delta")
@@ -253,7 +267,8 @@ func IsDeltaProviderSupported(provider string) bool {
 //   - raw accumulates wire-output deltas (from DeltaParts.Raw). When
 //     includeThinkingInRaw is true, this additionally carries provider-
 //     specific reasoning text (Anthropic thinking_delta, Gemini thought-
-//     tagged parts); otherwise it equals the parseable buffer byte-for-byte.
+//     tagged parts, OpenAI Chat Completions reasoning_content); otherwise
+//     it equals the parseable buffer byte-for-byte.
 //
 // Under the default flag-off configuration the two buffers always hold
 // identical content. Under opt-in they diverge whenever a non-text content
@@ -276,17 +291,19 @@ type IncrementalExtractor struct {
 	// provider-specific reasoning content. False (default) yields BAML-
 	// aligned text-only output across both buffers; true additionally
 	// accumulates provider-specific reasoning text (Anthropic
-	// thinking_delta, Gemini thought-tagged parts) into raw only.
+	// thinking_delta, Gemini thought-tagged parts, OpenAI Chat Completions
+	// reasoning_content) into raw only.
 	includeThinkingInRaw bool
 }
 
 // NewIncrementalExtractor creates a new incremental extractor. Pass
 // includeThinking=true to opt the extractor into accumulating provider-
 // specific reasoning content (Anthropic thinking_delta, Gemini thought-
-// tagged parts) alongside text deltas in the raw buffer; pass false
-// (default) for BAML-aligned text-only output across both the parseable
-// and raw buffers. The parseable buffer is text-only regardless of this
-// flag — the gate only affects the raw buffer.
+// tagged parts, OpenAI Chat Completions reasoning_content) alongside text
+// deltas in the raw buffer; pass false (default) for BAML-aligned
+// text-only output across both the parseable and raw buffers. The
+// parseable buffer is text-only regardless of this flag — the gate only
+// affects the raw buffer.
 func NewIncrementalExtractor(includeThinking bool) *IncrementalExtractor {
 	return &IncrementalExtractor{includeThinkingInRaw: includeThinking}
 }
@@ -434,8 +451,9 @@ func ExtractFrom[T SSEChunk](e *IncrementalExtractor, callCount int, provider st
 
 // RawFull returns the complete accumulated raw content without processing
 // new data. Under IncludeThinkingInRaw=true this includes provider-specific
-// reasoning text (Anthropic thinking_delta, Gemini thought-tagged parts);
-// otherwise it matches ParseableFull byte-for-byte.
+// reasoning text (Anthropic thinking_delta, Gemini thought-tagged parts,
+// OpenAI Chat Completions reasoning_content); otherwise it matches
+// ParseableFull byte-for-byte.
 func (e *IncrementalExtractor) RawFull() string {
 	return e.raw.String()
 }

--- a/bamlutils/sse/extract_test.go
+++ b/bamlutils/sse/extract_test.go
@@ -359,6 +359,50 @@ func TestGetCurrentContent_OnlyUsesLastCall(t *testing.T) {
 	}
 }
 
+// TestGetCurrentContent_OpenAIReasoningOptIn proves the includeThinking
+// parameter on GetCurrentContent reaches ExtractDeltaContent for the OpenAI-
+// compatible Chat Completions arm. This is a separate code path from
+// IncrementalExtractor.ExtractFrom (covered by
+// TestIncrementalExtractor_OpenAIReasoning_StreamOrder), so the flag-
+// plumbing needs its own coverage.
+//
+// A reasoning-only delta (no delta.content) yields:
+//   - flag=false: "" (reasoning_content not surfaced)
+//   - flag=true:  "think" (reasoning_content concatenated into Raw, which
+//     GetCurrentContent returns)
+func TestGetCurrentContent_OpenAIReasoningOptIn(t *testing.T) {
+	for _, provider := range []string{"openai", "openai-generic", "azure-openai", "ollama", "openrouter"} {
+		t.Run(provider, func(t *testing.T) {
+			data := &StreamingData{
+				Calls: []StreamingCall{
+					{
+						Provider: provider,
+						Chunks: []SSEChunk{
+							mockChunk{`{"choices":[{"delta":{"reasoning_content":"think"}}]}`},
+						},
+					},
+				},
+			}
+
+			off, err := GetCurrentContent(data, false)
+			if err != nil {
+				t.Fatalf("flag=false: unexpected error: %v", err)
+			}
+			if off != "" {
+				t.Errorf("flag=false: expected empty content (reasoning_content not surfaced), got %q", off)
+			}
+
+			on, err := GetCurrentContent(data, true)
+			if err != nil {
+				t.Fatalf("flag=true: unexpected error: %v", err)
+			}
+			if on != "think" {
+				t.Errorf("flag=true: expected %q (reasoning_content surfaced), got %q", "think", on)
+			}
+		})
+	}
+}
+
 func TestIncrementalExtractor_ZeroCallCount(t *testing.T) {
 	extractor := NewIncrementalExtractor(false)
 

--- a/bamlutils/sse/extract_test.go
+++ b/bamlutils/sse/extract_test.go
@@ -770,6 +770,136 @@ func TestExtractDeltaPartsFromText_GeminiIncludeThinkingInRaw(t *testing.T) {
 	}
 }
 
+// TestExtractDeltaPartsFromText_OpenAIReasoningContent asserts the Phase 4
+// dual-output behavior for the OpenAI-compatible Chat Completions streaming
+// branch (openai, openai-generic, azure-openai, ollama, openrouter):
+//
+//   - Parseable always reflects only delta.content (text-only, fed to the
+//     BAML parser via ParseStream).
+//   - Raw mirrors Parseable when includeThinking is false; when true, Raw
+//     additionally surfaces delta.reasoning_content appended after content.
+//   - Non-string reasoning_content is silently skipped under both flag
+//     values, matching the forgiving streaming semantics for optional
+//     reasoning surfaces.
+//
+// Parseable invariance across the includeThinking flag is asserted for
+// every fixture × provider; Raw equality across the flag is intentionally
+// NOT asserted, because the whole point of opt-in is that Raw diverges.
+func TestExtractDeltaPartsFromText_OpenAIReasoningContent(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		parseable string
+		rawOff    string
+		rawOn     string
+	}{
+		{
+			name:      "content only",
+			body:      `{"choices":[{"delta":{"content":"Hello"}}]}`,
+			parseable: "Hello",
+			rawOff:    "Hello",
+			rawOn:     "Hello",
+		},
+		{
+			name:      "reasoning only",
+			body:      `{"choices":[{"delta":{"reasoning_content":"think"}}]}`,
+			parseable: "",
+			rawOff:    "",
+			rawOn:     "think",
+		},
+		{
+			name:      "content plus reasoning",
+			body:      `{"choices":[{"delta":{"content":"Hello","reasoning_content":"think"}}]}`,
+			parseable: "Hello",
+			rawOff:    "Hello",
+			rawOn:     "Hellothink",
+		},
+		{
+			// Defensive: non-string reasoning_content is silently skipped
+			// under opt-in, matching the gjson.String guard in the extractor.
+			name:      "non-string reasoning ignored under opt-in",
+			body:      `{"choices":[{"delta":{"content":"Hello","reasoning_content":42}}]}`,
+			parseable: "Hello",
+			rawOff:    "Hello",
+			rawOn:     "Hello",
+		},
+	}
+
+	for _, provider := range []string{"openai", "openai-generic", "azure-openai", "ollama", "openrouter"} {
+		for _, tc := range cases {
+			t.Run(provider+"/"+tc.name, func(t *testing.T) {
+				off, err := ExtractDeltaPartsFromText(provider, tc.body, false)
+				if err != nil {
+					t.Fatalf("ExtractDeltaPartsFromText(includeThinking=false) returned error: %v", err)
+				}
+				if off.Parseable != tc.parseable {
+					t.Errorf("flag=false Parseable = %q, want %q", off.Parseable, tc.parseable)
+				}
+				if off.Raw != tc.rawOff {
+					t.Errorf("flag=false Raw = %q, want %q", off.Raw, tc.rawOff)
+				}
+
+				on, err := ExtractDeltaPartsFromText(provider, tc.body, true)
+				if err != nil {
+					t.Fatalf("ExtractDeltaPartsFromText(includeThinking=true) returned error: %v", err)
+				}
+				if on.Parseable != tc.parseable {
+					t.Errorf("flag=true Parseable = %q, want %q", on.Parseable, tc.parseable)
+				}
+				if on.Raw != tc.rawOn {
+					t.Errorf("flag=true Raw = %q, want %q", on.Raw, tc.rawOn)
+				}
+
+				// Structural parseable invariance: byte-identical across
+				// both flag values for every fixture.
+				if off.Parseable != on.Parseable {
+					t.Errorf("Parseable diverged across includeThinking: false=%q true=%q", off.Parseable, on.Parseable)
+				}
+			})
+		}
+	}
+}
+
+// TestIncrementalExtractor_OpenAIReasoning_StreamOrder verifies that the
+// stored includeThinkingInRaw flag reaches ExtractDeltaPartsFromText through
+// IncrementalExtractor.ExtractFrom, and that event order is preserved across
+// SSE chunks: a reasoning-only event followed by a content-only event yields
+// "reasoning + content" in raw under opt-in, but only the content under the
+// default flag.
+func TestIncrementalExtractor_OpenAIReasoning_StreamOrder(t *testing.T) {
+	chunks := []SSEChunk{
+		mockChunk{`{"choices":[{"delta":{"reasoning_content":"think"}}]}`},
+		mockChunk{`{"choices":[{"delta":{"content":"Hello"}}]}`},
+	}
+
+	for _, provider := range []string{"openai", "openai-generic", "azure-openai", "ollama", "openrouter"} {
+		t.Run(provider, func(t *testing.T) {
+			off := NewIncrementalExtractor(false)
+			resOff := off.Extract(1, provider, chunks)
+			if resOff.ParseableFull != "Hello" {
+				t.Errorf("flag=false ParseableFull = %q, want %q", resOff.ParseableFull, "Hello")
+			}
+			if resOff.RawFull != "Hello" {
+				t.Errorf("flag=false RawFull = %q, want %q", resOff.RawFull, "Hello")
+			}
+
+			on := NewIncrementalExtractor(true)
+			resOn := on.Extract(1, provider, chunks)
+			if resOn.ParseableFull != "Hello" {
+				t.Errorf("flag=true ParseableFull = %q, want %q (parseable invariant violated!)", resOn.ParseableFull, "Hello")
+			}
+			if resOn.RawFull != "thinkHello" {
+				t.Errorf("flag=true RawFull = %q, want %q (event order: reasoning event first)", resOn.RawFull, "thinkHello")
+			}
+
+			// Structural parseable invariance across the IncrementalExtractor.
+			if resOff.ParseableFull != resOn.ParseableFull {
+				t.Errorf("ParseableFull diverged across includeThinkingInRaw: false=%q true=%q", resOff.ParseableFull, resOn.ParseableFull)
+			}
+		})
+	}
+}
+
 // TestIncrementalExtractor_GeminiThinking_ParseableInvariant exercises
 // ExtractFrom on a Gemini SSE chunk through both flag-off and flag-on
 // IncrementalExtractor instances, proving that the stored


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Phase 4 of the #195 phased plan. Builds on Phase 3 (#230)'s established dual-output pattern.

When `IncludeThinkingInRaw=true`, OpenAI Chat Completions `delta.reasoning_content` (streaming) / `message.reasoning_content` (non-streaming) is surfaced in `Raw` for telemetry. `Parseable` (the BAML parser input) stays text-only regardless of flag. Default behavior (flag off) is unchanged — no `reasoning_content` extraction.

This is the de-facto reasoning surface for DeepSeek-R1 over Chat Completions and several OAI-compat gateways.

## Implementation

- **Streaming** (`bamlutils/sse/extract.go`): OpenAI-compat case appends `delta.reasoning_content` to `raw` only when flag on; `parseable` extraction (`delta.content`) unchanged. `gjson.String` type guard, silent skip on non-string. Order: content-first within a single delta; event order preserved across SSE chunks.
- **Non-streaming** (`bamlutils/buildrequest/response_extract.go::extractOpenAIContent`): signature gains `includeThinking bool` and returns `(parseable, raw string, err error)`. A small `appendReasoning` helper concatenates `message.reasoning_content` to raw on successful content paths (scalar / array / explicit null). Strict error semantics for content (missing, malformed, refusal) preserved.

Affects providers: `openai`, `openai-generic`, `azure-openai`, `ollama`, `openrouter` — all in one switch arm.

## Parseable invariance — structural

`includeThinking` only gates additions to `raw` / `rawSB` (tracked separately from parseable from this PR onward in the non-streaming function). Tests assert byte-identity of `Parseable` across both flag values for every fixture.

## Out of scope

- Phase 5 (OpenAI Responses reasoning summaries — distinct API path).
- Phase 6 (AWS Bedrock).
- Adapter / codegen / worker plumbing changes (Phase 1's territory).

## Test plan

- [ ] \`bamlutils/sse/extract_test.go::TestExtractDeltaPartsFromText_OpenAIReasoningContent\` — 5 providers × {content-only, reasoning-only, content+reasoning, non-string-reasoning} sub-cases with parseable invariance.
- [ ] \`bamlutils/buildrequest/response_extract_test.go::TestExtractResponseContent_OpenAIReasoningContent\` — same providers × {scalar, array, empty, null, non-string-reasoning} content shapes.
- [ ] Existing OpenAI extraction tests pass without modification.
- [ ] \`go test ./bamlutils/...\` clean.
- [ ] Per-adapter \`GOWORK=off go test ./adapter/\` clean.
- [ ] \`cmd/verify-framework-adapter\` 9/9 PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAI Chat Completions can optionally include assistant "reasoning" text in raw outputs for both streaming and non‑streaming flows while keeping parseable content unchanged.
* **Tests**
  * Added comprehensive tests covering reasoning-content behavior, stream ordering, and failure cases; removed an outdated invariant test.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/231)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->