### PR TITLE
feat: surface OpenAI Responses reasoning summaries in raw under opt-in

### DIFF
--- a/bamlutils/buildrequest/response_extract.go
+++ b/bamlutils/buildrequest/response_extract.go
@@ -27,7 +27,8 @@ import (
 //     contract). When includeThinking is true, raw additionally carries
 //     provider-specific reasoning content (Anthropic thinking blocks,
 //     Gemini thought-tagged parts, OpenAI Chat Completions
-//     reasoning_content).
+//     reasoning_content, OpenAI Responses reasoning summary[].text
+//     entries from output[].type == "reasoning" items).
 //
 // Returns an error for unsupported providers, empty bodies, invalid JSON,
 // and when a non-empty response body does not contain the expected structure.
@@ -52,8 +53,7 @@ func ExtractResponseContent(provider string, responseBody string, includeThinkin
 		return extractAnthropicContent(provider, responseBody, includeThinking)
 
 	case "openai-responses":
-		text, extractErr := extractOpenAIResponsesContent(provider, responseBody)
-		return text, text, extractErr
+		return extractOpenAIResponsesContent(provider, responseBody, includeThinking)
 
 	case "google-ai", "vertex-ai":
 		return extractGeminiContent(provider, responseBody, includeThinking)
@@ -308,28 +308,51 @@ func extractGeminiContent(provider string, responseBody string, includeThinking 
 //
 //	{
 //	  "output": [
-//	    {"type": "reasoning", "content": [], "summary": []},
+//	    {"type": "reasoning", "content": [], "summary": [
+//	      {"type": "summary_text", "text": "..."}
+//	    ], "encrypted_content": "..."},
 //	    {"type": "message", "status": "completed", "content": [
 //	      {"type": "output_text", "text": "The response text."}
 //	    ], "role": "assistant"}
 //	  ]
 //	}
 //
-// We concatenate assistant text across all output items with type ==
-// "message". Responses API output ordering/count is model-dependent, so we
-// must not assume the first message item contains the whole answer. Reasoning
-// items are skipped (they are not part of the model's answer).
-func extractOpenAIResponsesContent(provider string, responseBody string) (string, error) {
+// Returns two strings:
+//   - parseable: assistant text from all output items with type == "message",
+//     concatenated in array order. Reasoning surfaces never enter this value
+//     so the BAML parser cannot be influenced by reasoning text.
+//   - raw: assistant message text always; when includeThinking is true,
+//     reasoning items' summary[].text entries are additionally written into
+//     raw at the position they appear in output[]. Output-array order is
+//     preserved — if a reasoning item comes before the message, raw is
+//     "summary + message"; if it comes after, raw is "message + summary".
+//
+// Responses API output ordering/count is model-dependent, so we walk the
+// array in order rather than assume the first message item contains the
+// whole answer.
+//
+// OpenAI's underlying reasoning chain-of-thought is server-encrypted for
+// o1/o3-style models. Phase 5 only surfaces the human-readable summaries
+// OpenAI exposes via summary[].text; reasoning.content[].text and
+// encrypted_content are intentionally not surfaced.
+//
+// Reasoning summary shape is treated as optional telemetry: non-array
+// summary, non-object entries, missing text, and non-string text are all
+// silently skipped — they never produce errors. The strict no-message-item
+// contract is preserved: a reasoning-only response (no message item) still
+// errors regardless of the flag.
+func extractOpenAIResponsesContent(provider, responseBody string, includeThinking bool) (parseable, raw string, err error) {
 	output := gjson.Get(responseBody, "output")
 	if !output.IsArray() {
-		return "", fmt.Errorf("%s: could not extract text content from response (output array not found)", provider)
+		return "", "", fmt.Errorf("%s: could not extract text content from response (output array not found)", provider)
 	}
 
 	// Validate ALL output elements are objects, then aggregate all message
 	// items. We must not stop early because trailing output items still need
 	// validation and may contain additional assistant text.
-	var found bool
-	var sb strings.Builder
+	var foundMessage bool
+	var parseableSB strings.Builder
+	var rawSB strings.Builder
 	var outputErr error
 	output.ForEach(func(_, item gjson.Result) bool {
 		if !item.IsObject() {
@@ -342,8 +365,9 @@ func extractOpenAIResponsesContent(provider string, responseBody string) (string
 			outputErr = fmt.Errorf("%s: output array element missing required 'type' field", provider)
 			return false
 		}
-		if itemTypeField.String() == "message" {
-			found = true
+		switch itemTypeField.String() {
+		case "message":
+			foundMessage = true
 			contentArray := item.Get("content")
 			if !contentArray.IsArray() {
 				outputErr = fmt.Errorf("%s: message item has no content array", provider)
@@ -367,7 +391,8 @@ func extractOpenAIResponsesContent(provider string, responseBody string) (string
 						outputErr = fmt.Errorf("%s: unexpected type for output_text text field (got %s)", provider, textField.Type)
 						return false
 					}
-					sb.WriteString(textField.String())
+					parseableSB.WriteString(textField.String())
+					rawSB.WriteString(textField.String())
 				case "refusal":
 					refusalField := entry.Get("refusal")
 					refusalText := "unknown reason"
@@ -382,16 +407,41 @@ func extractOpenAIResponsesContent(provider string, responseBody string) (string
 			if outputErr != nil {
 				return false
 			}
+
+		case "reasoning":
+			if includeThinking {
+				appendOpenAIResponsesReasoningSummary(item, &rawSB)
+			}
 		}
 		return true
 	})
 
 	if outputErr != nil {
-		return "", outputErr
+		return "", "", outputErr
 	}
-	if !found {
-		return "", fmt.Errorf("%s: no message item found in output array", provider)
+	if !foundMessage {
+		return "", "", fmt.Errorf("%s: no message item found in output array", provider)
 	}
 
-	return sb.String(), nil
+	return parseableSB.String(), rawSB.String(), nil
+}
+
+// appendOpenAIResponsesReasoningSummary writes the human-readable summary
+// entries of an OpenAI Responses reasoning item to rawSB. The summary shape
+// is treated as optional telemetry — non-array summary, non-object entries,
+// missing text, and non-string text are silently skipped. reasoning.content
+// and encrypted_content are NOT inspected; the underlying chain-of-thought
+// is server-encrypted and intentionally not surfaced.
+func appendOpenAIResponsesReasoningSummary(item gjson.Result, rawSB *strings.Builder) {
+	summary := item.Get("summary")
+	if !summary.IsArray() {
+		return
+	}
+	summary.ForEach(func(_, entry gjson.Result) bool {
+		text := entry.Get("text")
+		if text.Type == gjson.String {
+			rawSB.WriteString(text.String())
+		}
+		return true
+	})
 }

--- a/bamlutils/buildrequest/response_extract_test.go
+++ b/bamlutils/buildrequest/response_extract_test.go
@@ -1079,6 +1079,174 @@ func TestExtractResponseContent_OpenAIReasoningContentMissingContent(t *testing.
 	}
 }
 
+// TestExtractResponseContent_OpenAIResponsesReasoningSummary asserts the
+// Phase 5 dual-output behavior for the OpenAI Responses API non-streaming
+// branch (provider key "openai-responses"):
+//
+//   - parseable always reflects only message output_text. Reasoning summary
+//     surfaces never enter parseable so the BAML parser cannot be influenced.
+//   - raw mirrors parseable when includeThinking is false; when true, raw
+//     additionally surfaces reasoning items' summary[].text entries written
+//     into raw at the position they appear in output[]. Output-array order
+//     is preserved (no canonical reorder).
+//   - Reasoning summary shape is treated as optional telemetry: non-array
+//     summary, non-object entries, missing text, and non-string text are all
+//     silently skipped — they never produce errors.
+//   - The strict no-message-item contract is preserved: a reasoning-only
+//     response (no message item) still errors regardless of the flag.
+//
+// Parseable invariance across the includeThinking flag is asserted for every
+// successful fixture; rawOff equality with parseable is also asserted (when
+// flag is off, raw must mirror parseable byte-for-byte). rawOn equality is
+// intentionally allowed to diverge — that is the whole point of opt-in.
+//
+// OpenAI's underlying reasoning chain-of-thought is server-encrypted for
+// o1/o3-style models. We only surface the human-readable summaries OpenAI
+// exposes via summary[].text; reasoning.content[].text and encrypted_content
+// are intentionally not surfaced.
+func TestExtractResponseContent_OpenAIResponsesReasoningSummary(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		parseable string
+		rawOn     string
+	}{
+		{
+			name:      "message only",
+			body:      `{"output":[{"type":"message","content":[{"type":"output_text","text":"Hello"}],"role":"assistant"}]}`,
+			parseable: "Hello",
+			rawOn:     "Hello",
+		},
+		{
+			// Reasoning before message: raw under opt-in is summary + message.
+			name: "reasoning before message",
+			body: `{"output":[
+				{"type":"reasoning","summary":[{"type":"summary_text","text":"thought"}]},
+				{"type":"message","content":[{"type":"output_text","text":"Hello"}],"role":"assistant"}
+			]}`,
+			parseable: "Hello",
+			rawOn:     "thoughtHello",
+		},
+		{
+			// Reasoning AFTER message: raw under opt-in preserves output
+			// order, so it is message + summary (no canonical reorder).
+			name: "reasoning after message",
+			body: `{"output":[
+				{"type":"message","content":[{"type":"output_text","text":"Hello"}],"role":"assistant"},
+				{"type":"reasoning","summary":[{"type":"summary_text","text":"thought"}]}
+			]}`,
+			parseable: "Hello",
+			rawOn:     "Hellothought",
+		},
+		{
+			// Multiple reasoning items, multiple summary[] entries each, all
+			// concatenated under opt-in in output[]/summary[] order.
+			name: "multiple reasoning items multiple summary entries",
+			body: `{"output":[
+				{"type":"reasoning","summary":[
+					{"type":"summary_text","text":"r1a"},
+					{"type":"summary_text","text":"r1b"}
+				]},
+				{"type":"message","content":[{"type":"output_text","text":"Hi"}],"role":"assistant"},
+				{"type":"reasoning","summary":[
+					{"type":"summary_text","text":"r2a"},
+					{"type":"summary_text","text":"r2b"}
+				]}
+			]}`,
+			parseable: "Hi",
+			rawOn:     "r1ar1bHir2ar2b",
+		},
+		{
+			// Reasoning + message-with-empty-content-array: parseable is
+			// empty (valid — empty content is a valid Responses message),
+			// raw under opt-in is just the summary. This proves the message
+			// item is still required (no error here because a message item
+			// with empty content IS present).
+			name: "reasoning plus message with empty content array",
+			body: `{"output":[
+				{"type":"reasoning","summary":[{"type":"summary_text","text":"thought"}]},
+				{"type":"message","content":[],"role":"assistant"}
+			]}`,
+			parseable: "",
+			rawOn:     "thought",
+		},
+		{
+			// Malformed reasoning summary shape: non-array summary, non-object
+			// entries, missing text, non-string text are all silently skipped.
+			// The message item still extracts correctly and no error is raised.
+			name: "malformed reasoning summary silently skipped",
+			body: `{"output":[
+				{"type":"reasoning","summary":"not an array"},
+				{"type":"reasoning","summary":[
+					"not an object",
+					{"type":"summary_text"},
+					{"type":"summary_text","text":42},
+					{"type":"summary_text","text":"valid"}
+				]},
+				{"type":"message","content":[{"type":"output_text","text":"Hello"}],"role":"assistant"}
+			]}`,
+			parseable: "Hello",
+			rawOn:     "validHello",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parseableOff, rawOff, err := ExtractResponseContent("openai-responses", tc.body, false)
+			if err != nil {
+				t.Fatalf("ExtractResponseContent(includeThinking=false) returned error: %v", err)
+			}
+			if parseableOff != tc.parseable {
+				t.Errorf("flag=false parseable = %q, want %q", parseableOff, tc.parseable)
+			}
+			// Flag-off: raw must mirror parseable byte-for-byte.
+			if rawOff != parseableOff {
+				t.Errorf("flag=false raw = %q, want raw == parseable = %q", rawOff, parseableOff)
+			}
+
+			parseableOn, rawOn, err := ExtractResponseContent("openai-responses", tc.body, true)
+			if err != nil {
+				t.Fatalf("ExtractResponseContent(includeThinking=true) returned error: %v", err)
+			}
+			if parseableOn != tc.parseable {
+				t.Errorf("flag=true parseable = %q, want %q", parseableOn, tc.parseable)
+			}
+			if rawOn != tc.rawOn {
+				t.Errorf("flag=true raw = %q, want %q", rawOn, tc.rawOn)
+			}
+
+			// Structural parseable invariance: byte-identical across both flag
+			// values for every successful fixture.
+			if parseableOff != parseableOn {
+				t.Errorf("parseable diverged across includeThinking: false=%q true=%q", parseableOff, parseableOn)
+			}
+		})
+	}
+}
+
+// TestExtractResponseContent_OpenAIResponsesReasoningSummaryNoMessageStillErrors
+// locks in the contract that reasoning summaries are telemetry — their
+// presence does NOT relax the existing "message item required" contract for
+// the OpenAI Responses API non-streaming branch. A reasoning-only response
+// (no message item) must error in both flag values, and must return empty
+// parseable AND empty raw (no telemetry leakage from a malformed response).
+func TestExtractResponseContent_OpenAIResponsesReasoningSummaryNoMessageStillErrors(t *testing.T) {
+	body := `{"output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"thought"}]}]}`
+
+	for _, flag := range []bool{false, true} {
+		parseable, raw, err := ExtractResponseContent("openai-responses", body, flag)
+		if err == nil {
+			t.Errorf("includeThinking=%v: expected error for missing message item (reasoning-only response is not a valid response)", flag)
+		}
+		if parseable != "" {
+			t.Errorf("includeThinking=%v: expected empty parseable on error, got %q", flag, parseable)
+		}
+		if raw != "" {
+			t.Errorf("includeThinking=%v: expected empty raw on error (no telemetry leakage), got %q", flag, raw)
+		}
+	}
+}
+
 func TestExtractResponseContent_UnsupportedProvider(t *testing.T) {
 	_, _, err := ExtractResponseContent("aws-bedrock", `{}`, false)
 	if err == nil {

--- a/bamlutils/sse/extract.go
+++ b/bamlutils/sse/extract.go
@@ -16,7 +16,7 @@ import (
 // the includeThinking parameter on ExtractDeltaPartsFromText, Raw
 // additionally carries provider-specific reasoning text (Anthropic
 // thinking_delta, Gemini thought-tagged parts, OpenAI Chat Completions
-// reasoning_content).
+// reasoning_content, OpenAI Responses reasoning_summary_text deltas).
 type DeltaParts struct {
 	Parseable string
 	Raw       string
@@ -47,7 +47,8 @@ type StreamingData struct {
 // specific reasoning content. False (default) yields BAML-aligned text-only
 // content; true additionally accumulates provider-specific reasoning text
 // (Anthropic thinking_delta, Gemini thought-tagged parts, OpenAI Chat
-// Completions reasoning_content) into the returned string.
+// Completions reasoning_content, OpenAI Responses reasoning_summary_text
+// deltas) into the returned string.
 func GetCurrentContent(data *StreamingData, includeThinking bool) (string, error) {
 	if len(data.Calls) == 0 {
 		return "", nil
@@ -86,9 +87,9 @@ func ExtractDeltaContent(provider string, chunk SSEChunk, includeThinking bool) 
 // and reasoning events are dropped — matching BAML's RawLLMResponse()
 // text-only contract. When true, provider-specific reasoning text
 // (Anthropic thinking_delta, Gemini thought-tagged parts, OpenAI Chat
-// Completions reasoning_content) contributes to Raw only; Parseable is
-// unaffected by construction so the BAML parser cannot be influenced by
-// reasoning text.
+// Completions reasoning_content, OpenAI Responses reasoning_summary_text
+// deltas) contributes to Raw only; Parseable is unaffected by construction
+// so the BAML parser cannot be influenced by reasoning text.
 func ExtractDeltaPartsFromText(provider string, rawText string, includeThinking bool) (DeltaParts, error) {
 	switch provider {
 	// OpenAI-compatible providers (Chat Completions API format)
@@ -110,11 +111,30 @@ func ExtractDeltaPartsFromText(provider string, rawText string, includeThinking 
 		return DeltaParts{Parseable: delta, Raw: raw}, nil
 
 	// OpenAI Responses API (different format)
-	// Path: delta (when type == "response.output_text.delta")
+	// Path: delta (when type == "response.output_text.delta") for parseable+raw.
+	// Path: delta (when type == "response.reasoning_summary_text.delta") for raw
+	// only, opt-in. Surfacing the human-readable reasoning summary OpenAI
+	// exposes for o1/o3-style models; the underlying chain-of-thought is
+	// server-encrypted and intentionally not surfaced. Only the *_text.delta
+	// event contributes — the bracketing *_part.added / *_part.done and the
+	// *_text.done event are no-ops here, since the stateless extractor has no
+	// dedupe and acting on done-events would duplicate text already emitted by
+	// the deltas (mirroring the existing response.output_text.done treatment).
 	case "openai-responses":
-		if gjson.Get(rawText, "type").String() == "response.output_text.delta" {
+		switch gjson.Get(rawText, "type").String() {
+		case "response.output_text.delta":
 			delta := gjson.Get(rawText, "delta").String()
 			return DeltaParts{Parseable: delta, Raw: delta}, nil
+
+		case "response.reasoning_summary_text.delta":
+			if !includeThinking {
+				return DeltaParts{}, nil
+			}
+			delta := gjson.Get(rawText, "delta")
+			if delta.Type != gjson.String {
+				return DeltaParts{}, nil
+			}
+			return DeltaParts{Raw: delta.String()}, nil
 		}
 		return DeltaParts{}, nil
 
@@ -267,8 +287,9 @@ func IsDeltaProviderSupported(provider string) bool {
 //   - raw accumulates wire-output deltas (from DeltaParts.Raw). When
 //     includeThinkingInRaw is true, this additionally carries provider-
 //     specific reasoning text (Anthropic thinking_delta, Gemini thought-
-//     tagged parts, OpenAI Chat Completions reasoning_content); otherwise
-//     it equals the parseable buffer byte-for-byte.
+//     tagged parts, OpenAI Chat Completions reasoning_content, OpenAI
+//     Responses reasoning_summary_text deltas); otherwise it equals the
+//     parseable buffer byte-for-byte.
 //
 // Under the default flag-off configuration the two buffers always hold
 // identical content. Under opt-in they diverge whenever a non-text content
@@ -292,18 +313,20 @@ type IncrementalExtractor struct {
 	// aligned text-only output across both buffers; true additionally
 	// accumulates provider-specific reasoning text (Anthropic
 	// thinking_delta, Gemini thought-tagged parts, OpenAI Chat Completions
-	// reasoning_content) into raw only.
+	// reasoning_content, OpenAI Responses reasoning_summary_text deltas)
+	// into raw only.
 	includeThinkingInRaw bool
 }
 
 // NewIncrementalExtractor creates a new incremental extractor. Pass
 // includeThinking=true to opt the extractor into accumulating provider-
 // specific reasoning content (Anthropic thinking_delta, Gemini thought-
-// tagged parts, OpenAI Chat Completions reasoning_content) alongside text
-// deltas in the raw buffer; pass false (default) for BAML-aligned
-// text-only output across both the parseable and raw buffers. The
-// parseable buffer is text-only regardless of this flag — the gate only
-// affects the raw buffer.
+// tagged parts, OpenAI Chat Completions reasoning_content, OpenAI
+// Responses reasoning_summary_text deltas) alongside text deltas in the
+// raw buffer; pass false (default) for BAML-aligned text-only output
+// across both the parseable and raw buffers. The parseable buffer is
+// text-only regardless of this flag — the gate only affects the raw
+// buffer.
 func NewIncrementalExtractor(includeThinking bool) *IncrementalExtractor {
 	return &IncrementalExtractor{includeThinkingInRaw: includeThinking}
 }
@@ -452,8 +475,9 @@ func ExtractFrom[T SSEChunk](e *IncrementalExtractor, callCount int, provider st
 // RawFull returns the complete accumulated raw content without processing
 // new data. Under IncludeThinkingInRaw=true this includes provider-specific
 // reasoning text (Anthropic thinking_delta, Gemini thought-tagged parts,
-// OpenAI Chat Completions reasoning_content); otherwise it matches
-// ParseableFull byte-for-byte.
+// OpenAI Chat Completions reasoning_content, OpenAI Responses
+// reasoning_summary_text deltas); otherwise it matches ParseableFull
+// byte-for-byte.
 func (e *IncrementalExtractor) RawFull() string {
 	return e.raw.String()
 }

--- a/bamlutils/sse/extract.go
+++ b/bamlutils/sse/extract.go
@@ -123,8 +123,12 @@ func ExtractDeltaPartsFromText(provider string, rawText string, includeThinking 
 	case "openai-responses":
 		switch gjson.Get(rawText, "type").String() {
 		case "response.output_text.delta":
-			delta := gjson.Get(rawText, "delta").String()
-			return DeltaParts{Parseable: delta, Raw: delta}, nil
+			delta := gjson.Get(rawText, "delta")
+			if delta.Type != gjson.String {
+				return DeltaParts{}, nil
+			}
+			text := delta.String()
+			return DeltaParts{Parseable: text, Raw: text}, nil
 
 		case "response.reasoning_summary_text.delta":
 			if !includeThinking {

--- a/bamlutils/sse/extract_test.go
+++ b/bamlutils/sse/extract_test.go
@@ -984,3 +984,195 @@ func TestIncrementalExtractor_GeminiThinking_ParseableInvariant(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractDeltaPartsFromText_OpenAIResponsesReasoningSummary asserts the
+// Phase 5 dual-output behavior for the OpenAI Responses API (`/v1/responses`)
+// streaming branch (provider key "openai-responses"):
+//
+//   - response.output_text.delta contributes to both Parseable and Raw
+//     regardless of includeThinking (text-only message stream).
+//   - response.reasoning_summary_text.delta contributes to Raw only, and
+//     only when includeThinking is true. Parseable always stays empty.
+//   - Non-string delta on a reasoning_summary_text.delta event is silently
+//     skipped under opt-in (defensive gjson.String guard).
+//   - response.reasoning_summary_part.added is a bracket/setup event and
+//     contributes nothing.
+//   - response.reasoning_summary_part.done and response.reasoning_summary_text.done
+//     deliberately contribute nothing — acting on them in this stateless
+//     extractor would duplicate text already emitted by the deltas (mirrors
+//     the existing response.output_text.done treatment).
+//
+// Parseable invariance across the includeThinking flag is asserted for
+// every fixture; Raw equality across the flag is intentionally NOT
+// asserted, because the whole point of opt-in is that Raw diverges.
+func TestExtractDeltaPartsFromText_OpenAIResponsesReasoningSummary(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		parseable string
+		rawOff    string
+		rawOn     string
+	}{
+		{
+			name:      "output_text.delta",
+			body:      `{"type":"response.output_text.delta","delta":"Hello"}`,
+			parseable: "Hello",
+			rawOff:    "Hello",
+			rawOn:     "Hello",
+		},
+		{
+			name:      "reasoning_summary_text.delta opt-in surfaces summary",
+			body:      `{"type":"response.reasoning_summary_text.delta","delta":"thought"}`,
+			parseable: "",
+			rawOff:    "",
+			rawOn:     "thought",
+		},
+		{
+			// Defensive: non-string delta on a reasoning summary event is
+			// silently skipped under opt-in, matching the gjson.String guard
+			// in the extractor.
+			name:      "reasoning_summary_text.delta non-string delta ignored",
+			body:      `{"type":"response.reasoning_summary_text.delta","delta":42}`,
+			parseable: "",
+			rawOff:    "",
+			rawOn:     "",
+		},
+		{
+			name:      "reasoning_summary_part.added is a no-op",
+			body:      `{"type":"response.reasoning_summary_part.added","part":{"type":"summary_text","text":""}}`,
+			parseable: "",
+			rawOff:    "",
+			rawOn:     "",
+		},
+		{
+			// Done event carries the full summary text but is intentionally
+			// not extracted — acting on it would duplicate text from the
+			// preceding *_text.delta events in this stateless extractor.
+			name:      "reasoning_summary_part.done is a no-op (avoids duplicate text)",
+			body:      `{"type":"response.reasoning_summary_part.done","part":{"type":"summary_text","text":"thought complete"}}`,
+			parseable: "",
+			rawOff:    "",
+			rawOn:     "",
+		},
+		{
+			// Same rationale as part.done; mirrors the current
+			// response.output_text.done treatment.
+			name:      "reasoning_summary_text.done is a no-op (avoids duplicate text)",
+			body:      `{"type":"response.reasoning_summary_text.done","text":"thought complete"}`,
+			parseable: "",
+			rawOff:    "",
+			rawOn:     "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			off, err := ExtractDeltaPartsFromText("openai-responses", tc.body, false)
+			if err != nil {
+				t.Fatalf("ExtractDeltaPartsFromText(includeThinking=false) returned error: %v", err)
+			}
+			if off.Parseable != tc.parseable {
+				t.Errorf("flag=false Parseable = %q, want %q", off.Parseable, tc.parseable)
+			}
+			if off.Raw != tc.rawOff {
+				t.Errorf("flag=false Raw = %q, want %q", off.Raw, tc.rawOff)
+			}
+
+			on, err := ExtractDeltaPartsFromText("openai-responses", tc.body, true)
+			if err != nil {
+				t.Fatalf("ExtractDeltaPartsFromText(includeThinking=true) returned error: %v", err)
+			}
+			if on.Parseable != tc.parseable {
+				t.Errorf("flag=true Parseable = %q, want %q", on.Parseable, tc.parseable)
+			}
+			if on.Raw != tc.rawOn {
+				t.Errorf("flag=true Raw = %q, want %q", on.Raw, tc.rawOn)
+			}
+
+			// Structural parseable invariance: byte-identical across both
+			// flag values for every fixture.
+			if off.Parseable != on.Parseable {
+				t.Errorf("Parseable diverged across includeThinking: false=%q true=%q", off.Parseable, on.Parseable)
+			}
+		})
+	}
+}
+
+// TestIncrementalExtractor_OpenAIResponsesReasoningSummary_StreamOrder
+// verifies that the stored includeThinkingInRaw flag reaches
+// ExtractDeltaPartsFromText through IncrementalExtractor.ExtractFrom for
+// the openai-responses provider, and that event order is preserved across
+// SSE chunks: interleaved summary/text deltas yield the expected
+// concatenation in raw under opt-in, while parseable stays text-only and
+// flag-off RawFull mirrors ParseableFull byte-for-byte.
+func TestIncrementalExtractor_OpenAIResponsesReasoningSummary_StreamOrder(t *testing.T) {
+	chunks := []SSEChunk{
+		mockChunk{`{"type":"response.reasoning_summary_text.delta","delta":"think1 "}`},
+		mockChunk{`{"type":"response.output_text.delta","delta":"Hello "}`},
+		mockChunk{`{"type":"response.reasoning_summary_text.delta","delta":"think2 "}`},
+		mockChunk{`{"type":"response.output_text.delta","delta":"world"}`},
+	}
+
+	off := NewIncrementalExtractor(false)
+	resOff := off.Extract(1, "openai-responses", chunks)
+	if resOff.ParseableFull != "Hello world" {
+		t.Errorf("flag=false ParseableFull = %q, want %q", resOff.ParseableFull, "Hello world")
+	}
+	if resOff.RawFull != "Hello world" {
+		t.Errorf("flag=false RawFull = %q, want %q (must mirror ParseableFull when flag is off)", resOff.RawFull, "Hello world")
+	}
+
+	on := NewIncrementalExtractor(true)
+	resOn := on.Extract(1, "openai-responses", chunks)
+	if resOn.ParseableFull != "Hello world" {
+		t.Errorf("flag=true ParseableFull = %q, want %q (parseable invariant violated!)", resOn.ParseableFull, "Hello world")
+	}
+	if resOn.RawFull != "think1 Hello think2 world" {
+		t.Errorf("flag=true RawFull = %q, want %q (event order must be preserved)", resOn.RawFull, "think1 Hello think2 world")
+	}
+
+	// Structural parseable invariance across the IncrementalExtractor.
+	if resOff.ParseableFull != resOn.ParseableFull {
+		t.Errorf("ParseableFull diverged across includeThinkingInRaw: false=%q true=%q", resOff.ParseableFull, resOn.ParseableFull)
+	}
+}
+
+// TestGetCurrentContent_OpenAIResponsesReasoningSummaryOptIn proves the
+// includeThinking parameter on GetCurrentContent reaches ExtractDeltaContent
+// for the openai-responses arm. This is a separate code path from
+// IncrementalExtractor.ExtractFrom (covered by
+// TestIncrementalExtractor_OpenAIResponsesReasoningSummary_StreamOrder), so
+// the flag-plumbing needs its own coverage.
+//
+// A summary-only chunk yields:
+//   - flag=false: "" (reasoning summary not surfaced)
+//   - flag=true:  "thought" (summary delta concatenated into Raw, which
+//     GetCurrentContent returns)
+func TestGetCurrentContent_OpenAIResponsesReasoningSummaryOptIn(t *testing.T) {
+	data := &StreamingData{
+		Calls: []StreamingCall{
+			{
+				Provider: "openai-responses",
+				Chunks: []SSEChunk{
+					mockChunk{`{"type":"response.reasoning_summary_text.delta","delta":"thought"}`},
+				},
+			},
+		},
+	}
+
+	off, err := GetCurrentContent(data, false)
+	if err != nil {
+		t.Fatalf("flag=false: unexpected error: %v", err)
+	}
+	if off != "" {
+		t.Errorf("flag=false: expected empty content (reasoning summary not surfaced), got %q", off)
+	}
+
+	on, err := GetCurrentContent(data, true)
+	if err != nil {
+		t.Fatalf("flag=true: unexpected error: %v", err)
+	}
+	if on != "thought" {
+		t.Errorf("flag=true: expected %q (reasoning summary surfaced), got %q", "thought", on)
+	}
+}

--- a/bamlutils/sse/extract_test.go
+++ b/bamlutils/sse/extract_test.go
@@ -1021,6 +1021,21 @@ func TestExtractDeltaPartsFromText_OpenAIResponsesReasoningSummary(t *testing.T)
 			rawOn:     "Hello",
 		},
 		{
+			// Defensive: non-string delta on output_text.delta is silently
+			// skipped, matching the gjson.String guard in the extractor.
+			// The wire format always emits a string here, so this is a
+			// belt-and-braces guard mirroring the adjacent
+			// reasoning_summary_text.delta arm — it prevents gjson coercing
+			// a non-string into the literal string representation of the
+			// JSON value (which would land in Parseable and be fed to the
+			// BAML parser).
+			name:      "non-string output_text delta is skipped",
+			body:      `{"type":"response.output_text.delta","delta":42}`,
+			parseable: "",
+			rawOff:    "",
+			rawOn:     "",
+		},
+		{
 			name:      "reasoning_summary_text.delta opt-in surfaces summary",
 			body:      `{"type":"response.reasoning_summary_text.delta","delta":"thought"}`,
 			parseable: "",

--- a/embed.go
+++ b/embed.go
@@ -15,7 +15,7 @@ import (
 	"github.com/invakid404/baml-rest/workerplugin"
 )
 
-//go:embed adapter.go adapters cmd/build cmd/embed cmd/hacks cmd/introspect/main.go cmd/schema cmd/serve/debug.go cmd/serve/debug_stub.go cmd/serve/error.go cmd/serve/headers.go cmd/serve/main.go cmd/serve/openapi.json cmd/serve/streamwriter.go cmd/serve/unary.go cmd/serve/unary_handlers.go cmd/serve/unary_stub.go cmd/serve/worker cmd/verify-adapter-pins cmd/verify-framework-adapter/main.go cmd/worker/main.go embed.go go.mod go.sum go.work go.work.sum internal/apierror internal/httplogger internal/memlimit/memlimit.go internal/unsafeutil renovate.json scripts
+//go:embed adapter.go adapters cmd/build cmd/embed cmd/hacks cmd/introspect/main.go cmd/schema cmd/serve/debug.go cmd/serve/debug_stub.go cmd/serve/error.go cmd/serve/headers.go cmd/serve/main.go cmd/serve/openapi.json cmd/serve/streamwriter.go cmd/serve/unary.go cmd/serve/unary_handlers.go cmd/serve/unary_stub.go cmd/serve/worker cmd/verify-adapter-pins cmd/verify-framework-adapter/main.go cmd/worker/main.go embed.go go.mod go.sum go.work go.work.sum internal/apierror/error.go internal/httplogger internal/memlimit/memlimit.go internal/unsafeutil renovate.json scripts
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Phase 5 of the #195 phased plan. Builds on Phase 4 (#231)'s dual-output pattern.

When `IncludeThinkingInRaw=true`, OpenAI Responses API reasoning summaries are surfaced in `Raw` for telemetry. `Parseable` (the BAML parser input) stays text-only regardless. Default behavior (flag off) is unchanged — reasoning items continue to be skipped, matching upstream BAML.

Distinct from Phase 4 — that covered Chat Completions; Phase 5 covers the Responses API (`/v1/responses`, used for o1/o3 reasoning models). Different SSE event format and non-streaming response shape.

## Server-encrypted underlying reasoning

OpenAI's underlying reasoning chain-of-thought is server-encrypted for o1/o3. Phase 5 only surfaces the human-readable summaries OpenAI exposes via the `reasoning_summary_*` events (streaming) and `output[].type == "reasoning"` items' `summary[].text` (non-streaming). The encrypted reasoning content is intentionally NOT surfaced.

## Implementation

- **Streaming** (`bamlutils/sse/extract.go`): `openai-responses` case switches on event type. Adds `response.reasoning_summary_text.delta` arm — under opt-in, returns `DeltaParts{Raw: delta}`; under flag-off, returns empty. Other reasoning events (`*_part.added`, `*_part.done`, `*_text.done`) explicitly NOT extracted to avoid duplicate text from the stateless extractor.
- **Non-streaming** (`bamlutils/buildrequest/response_extract.go::extractOpenAIResponsesContent`): signature gains `includeThinking bool` and returns `(parseable, raw string, err error)`. Walks `output[]` in array order. `message` items write to both builders; `reasoning` items contribute `summary[].text` to `rawSB` only under opt-in. Existing no-message-item error contract preserved. Non-array `summary`, non-string `text`, etc. are silently skipped (telemetry shape is optional).

Output-array order is preserved — reasoning summaries land in raw at the position they appear in `output[]`.

## Out of scope

- Phase 6 (AWS Bedrock).
- Adapter / codegen / worker plumbing changes (Phase 1's territory).
- OpenAI Responses underlying encrypted reasoning content (`reasoning.content[].text`, `encrypted_content`).
- Stateful done-event deduplication for Responses streaming.

## Test plan

- [ ] `bamlutils/sse/extract_test.go::TestExtractDeltaPartsFromText_OpenAIResponsesReasoningSummary` — text delta, summary delta off/on, non-string summary delta defensive, `*_part.added`, `*_part.done`, `*_text.done`.
- [ ] `TestIncrementalExtractor_OpenAIResponsesReasoningSummary_StreamOrder` — interleaved summary+text events; raw preserves event order under opt-in.
- [ ] `TestGetCurrentContent_OpenAIResponsesReasoningSummaryOptIn` — exercises standalone `GetCurrentContent` path.
- [ ] `bamlutils/buildrequest/response_extract_test.go::TestExtractResponseContent_OpenAIResponsesReasoningSummary` — message-only, reasoning-before-message, multi-reasoning/multi-summary, reasoning-after-message, empty-content-array, malformed-summary, no-message-item-still-errors.
- [ ] Existing `TestExtractResponseContent_OpenAIResponsesNoMessageItem` still PASS unchanged.
- [ ] `go test ./bamlutils/...` clean.
- [ ] Per-adapter `GOWORK=off go test ./adapter/` clean.
- [ ] `cmd/verify-framework-adapter` 9/9 PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional inclusion of AI reasoning summaries in "raw" outputs while keeping "parseable" outputs message-only; applies to streaming and non-streaming responses and preserves original ordering when enabled.
* **Bug Fixes**
  * Malformed or non-string reasoning entries are skipped safely; responses with no message still error to prevent telemetry leakage.
* **Tests**
  * Added tests covering opt-in behavior, ordering, malformed summaries, and error conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/232)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->