### PR TITLE
fix(buildrequest): classify strategy children with nil support predicate

### DIFF
--- a/bamlutils/buildrequest/client_resolution.go
+++ b/bamlutils/buildrequest/client_resolution.go
@@ -362,7 +362,7 @@ func hasExplicitStrategyProviderWithoutStrategy(reg *bamlutils.ClientRegistry, c
 // parents are the ones whose runtime overrides are dropped from the
 // BuildRequest-safe view and silently masked when invalid.
 func isStrategyProvider(p string) bool {
-	return roundrobin.IsRoundRobinProvider(p) || p == "baml-fallback" || p == "fallback"
+	return roundrobin.IsRoundRobinProvider(p) || normalizeStrategyProvider(p) == "baml-fallback"
 }
 
 

--- a/bamlutils/buildrequest/fallback_resolve.go
+++ b/bamlutils/buildrequest/fallback_resolve.go
@@ -139,6 +139,8 @@ func ResolveFallbackChainForClientWithReason(
 		}
 		chainProviders[child] = p
 
+		isStrategyChild := isStrategyProvider(p)
+
 		// Preflight (strategy/start): a nested strategy-parent child,
 		// or any strategy parent transitively reachable from it,
 		// carrying an invalid runtime override (malformed strategy,
@@ -164,7 +166,7 @@ func ResolveFallbackChainForClientWithReason(
 		// use a visited set to guard cycles. So a valid runtime
 		// override at any depth keeps the mixed-mode path, and an
 		// invalid override at any depth re-routes uniformly.
-		if isStrategyProvider(p) {
+		if isStrategyChild {
 			if reason := FindInvalidReachableStrategyOverride(
 				reg, child, clientProviders, fallbackChains,
 			); reason != "" {
@@ -173,10 +175,17 @@ func ResolveFallbackChainForClientWithReason(
 		}
 
 		// A nil support check means the caller couldn't determine support,
-		// not "nothing is supported" — treat every child as drivable in
-		// that case rather than panicking on the nil-func call or
-		// misclassifying the whole chain as legacy.
-		if isProviderSupported != nil && !isProviderSupported(p) {
+		// not "nothing is supported" — treat ordinary leaf providers as
+		// drivable in that case (unknown support → not legacy) rather
+		// than panicking on the nil-func call or misclassifying the
+		// whole chain as legacy.
+		//
+		// Strategy-provider children (round-robin, fallback) are always
+		// classified legacy here regardless of the support predicate:
+		// BuildRequest cannot drive a strategy wrapper as a leaf, so
+		// the wrapper child must take the legacy callback path even
+		// when the caller passed nil for isProviderSupported.
+		if isStrategyChild || (isProviderSupported != nil && !isProviderSupported(p)) {
 			chainLegacy[child] = true
 			legacyPositions++
 		}

--- a/bamlutils/buildrequest/fallback_resolve_test.go
+++ b/bamlutils/buildrequest/fallback_resolve_test.go
@@ -978,3 +978,118 @@ func TestResolveFallbackChain_FallbackAllowed(t *testing.T) {
 		t.Errorf("expected no legacy children for all-supported chain, got %v", legacyChildren)
 	}
 }
+
+// TestResolveFallbackChainForClientWithReason_NilSupportCheck_StrategyChildrenLegacy
+// pins the nil-isProviderSupported contract for strategy-provider
+// children: BuildRequest cannot drive a strategy wrapper as a leaf,
+// so RR / fallback children must always land on the legacy child
+// list regardless of whether the caller passed a support predicate.
+//
+// Ordinary leaf providers in the same chain stay drivable (unknown
+// support → not legacy) under nil-support, so the chain itself
+// resolves with at least one supported sibling.
+//
+// PathReasonFallbackRoundRobinChildLegacy must continue to fire
+// only for RR children — fallback children become legacy children
+// without the RR-specific informational reason.
+func TestResolveFallbackChainForClientWithReason_NilSupportCheck_StrategyChildrenLegacy(t *testing.T) {
+	cases := []struct {
+		name           string
+		outerClient    string
+		fallbackChains map[string][]string
+		providers      map[string]string
+		legacyChild    string
+		drivableChild  string
+		wantReason     string
+	}{
+		{
+			name:        "roundrobin-child",
+			outerClient: "MyFallback",
+			fallbackChains: map[string][]string{
+				"MyFallback": {"FastLeaf", "InnerRR"},
+			},
+			providers: map[string]string{
+				"MyFallback": "baml-fallback",
+				"FastLeaf":   "openai",
+				"InnerRR":    "baml-roundrobin",
+			},
+			legacyChild:   "InnerRR",
+			drivableChild: "FastLeaf",
+			wantReason:    PathReasonFallbackRoundRobinChildLegacy,
+		},
+		{
+			name:        "fallback-child",
+			outerClient: "MyOuterFallback",
+			fallbackChains: map[string][]string{
+				"MyOuterFallback": {"FastLeaf", "InnerFallback"},
+			},
+			providers: map[string]string{
+				"MyOuterFallback": "baml-fallback",
+				"FastLeaf":        "openai",
+				"InnerFallback":   "baml-fallback",
+			},
+			legacyChild:   "InnerFallback",
+			drivableChild: "FastLeaf",
+			wantReason:    "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			chain, providers, legacy, reason := ResolveFallbackChainForClientWithReason(
+				nil, tc.outerClient, tc.fallbackChains, tc.providers,
+				nil,
+			)
+			if chain == nil {
+				t.Fatalf("expected chain to resolve under nil isProviderSupported (mixed-mode strategy child + drivable leaf), got nil with reason=%q", reason)
+			}
+			if len(chain) != 2 {
+				t.Fatalf("expected len=2 chain, got %d: %v", len(chain), chain)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason: got %q, want %q", reason, tc.wantReason)
+			}
+			if !legacy[tc.legacyChild] {
+				t.Errorf("%s must be classified legacy under nil-support (strategy wrapper), legacyChildren=%v", tc.legacyChild, legacy)
+			}
+			if legacy[tc.drivableChild] {
+				t.Errorf("%s is an ordinary leaf provider — must not be legacy under nil-support, legacyChildren=%v", tc.drivableChild, legacy)
+			}
+			if providers[tc.legacyChild] == "" {
+				t.Errorf("providers[%s] must be populated even when child is legacy, providers=%v", tc.legacyChild, providers)
+			}
+		})
+	}
+}
+
+// TestResolveFallbackChainForClient_NilSupportCheck_StrategyChildClassified
+// pins that the no-reason sibling helper returns the same
+// legacyChildren map after discarding reason. Regression guard
+// against a future divergence between the two exported entry
+// points' nil-support handling.
+func TestResolveFallbackChainForClient_NilSupportCheck_StrategyChildClassified(t *testing.T) {
+	fallbackChains := map[string][]string{
+		"MyFallback": {"FastLeaf", "InnerRR"},
+	}
+	clientProviders := map[string]string{
+		"MyFallback": "baml-fallback",
+		"FastLeaf":   "openai",
+		"InnerRR":    "baml-roundrobin",
+	}
+
+	chain, providers, legacy := ResolveFallbackChainForClient(
+		nil, "MyFallback", fallbackChains, clientProviders, nil,
+	)
+
+	if len(chain) != 2 {
+		t.Fatalf("expected len=2 chain (mixed-mode RR child + drivable leaf) under nil-support, got %d: %v", len(chain), chain)
+	}
+	if !legacy["InnerRR"] {
+		t.Errorf("InnerRR must be classified legacy via the no-reason sibling, legacyChildren=%v", legacy)
+	}
+	if legacy["FastLeaf"] {
+		t.Errorf("FastLeaf must not be misclassified as legacy under nil-support, legacyChildren=%v", legacy)
+	}
+	if providers["InnerRR"] != "baml-roundrobin" {
+		t.Errorf("providers[InnerRR]: got %q, want baml-roundrobin", providers["InnerRR"])
+	}
+}

--- a/bamlutils/buildrequest/metadata.go
+++ b/bamlutils/buildrequest/metadata.go
@@ -535,7 +535,12 @@ func BuildLegacyMetadataPlan(
 			for _, child := range chain {
 				p := ResolveClientProvider(reg, child, clientProviders)
 				providers[child] = p
-				if p == "" || (isProviderSupported != nil && !isProviderSupported(p)) {
+				// Strategy-provider children (RR, fallback) are always
+				// legacy — BuildRequest can't drive a strategy wrapper
+				// as a leaf — independent of the support predicate, so
+				// the rebuild stays consistent with the resolver's own
+				// classification when isProviderSupported is nil.
+				if p == "" || isStrategyProvider(p) || (isProviderSupported != nil && !isProviderSupported(p)) {
 					legacy[child] = true
 				}
 			}
@@ -645,7 +650,12 @@ func BuildLegacyMetadataPlanForClient(
 			for _, child := range chain {
 				p := ResolveClientProvider(reg, child, clientProviders)
 				providers[child] = p
-				if p == "" || (isProviderSupported != nil && !isProviderSupported(p)) {
+				// Strategy-provider children (RR, fallback) are always
+				// legacy — BuildRequest can't drive a strategy wrapper
+				// as a leaf — independent of the support predicate, so
+				// the rebuild stays consistent with the resolver's own
+				// classification when isProviderSupported is nil.
+				if p == "" || isStrategyProvider(p) || (isProviderSupported != nil && !isProviderSupported(p)) {
 					legacy[child] = true
 				}
 			}

--- a/bamlutils/buildrequest/metadata_resolve_test.go
+++ b/bamlutils/buildrequest/metadata_resolve_test.go
@@ -1662,3 +1662,45 @@ func TestEncodeRetryPolicy_Formats(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildLegacyMetadataPlanForClient_NilSupportRebuildClassifiesStrategyChildren
+// pins the rebuild path's strategy-child classification under nil
+// isProviderSupported. When every chain child is a strategy
+// wrapper, ResolveFallbackChainForClientWithReason returns
+// (chain=nil, reason=PathReasonFallbackAllLegacy); the metadata
+// builder then rebuilds the chain shape for observability. Without
+// the predicate fix at the rebuild sites, strategy children would
+// be omitted from LegacyChildren under nil-support — leaving the
+// metadata inconsistent with the resolver's classification.
+//
+// Both BuildLegacyMetadataPlan and BuildLegacyMetadataPlanForClient
+// share the same rebuild shape; the For-Client sibling is the seam
+// codegen invokes, so the test pins that variant.
+func TestBuildLegacyMetadataPlanForClient_NilSupportRebuildClassifiesStrategyChildren(t *testing.T) {
+	chains := map[string][]string{
+		"MyFallback": {"InnerRR1", "InnerRR2"},
+	}
+	providers := map[string]string{
+		"MyFallback": "baml-fallback",
+		"InnerRR1":   "baml-roundrobin",
+		"InnerRR2":   "baml-roundrobin",
+	}
+
+	plan := BuildLegacyMetadataPlanForClient(
+		nil, "MyFallback", "baml-fallback", chains, providers,
+		nil, nil,
+	)
+
+	if plan.PathReason != PathReasonFallbackAllLegacy {
+		t.Fatalf("PathReason: got %q, want %q (every child is a strategy wrapper under nil-support)",
+			plan.PathReason, PathReasonFallbackAllLegacy)
+	}
+	if got, want := plan.Chain, []string{"InnerRR1", "InnerRR2"}; !equalStringSlice(got, want) {
+		t.Errorf("Chain: got %v, want %v (rebuild must surface introspected chain for observability)", got, want)
+	}
+	wantLegacy := []string{"InnerRR1", "InnerRR2"}
+	if !equalStringSlice(plan.LegacyChildren, wantLegacy) {
+		t.Errorf("LegacyChildren: got %v, want %v (strategy wrappers must be marked legacy in the rebuild even under nil-support)",
+			plan.LegacyChildren, wantLegacy)
+	}
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes one item from the #167 follow-up tracker (strategy-child slip-through with nil `isProviderSupported`).

`ResolveFallbackChainForClientWithReason` and `ResolveFallbackChainForClient` only marked children legacy when `isProviderSupported != nil && !isProviderSupported(p)`. With nil, RR/fallback strategy children slipped through as drivable — but BuildRequest can't drive a strategy wrapper as a leaf. No current production path exposes this (all callers pass non-nil), but the exported helpers' nil-tolerant contract had this hole.

This PR closes the gap by reusing the existing `isStrategyProvider` helper to classify strategy children unconditionally, ORing it with the nil-aware support predicate. Ordinary leaf providers stay drivable under nil-support (unknown support → not legacy). Strategy children are always legacy.

The same fix applies to the metadata rebuild paths at `bamlutils/buildrequest/metadata.go:538` and `:648` — folded in here for consistency. The rebuild fires only when the resolver returned `chain == nil` with a non-invalid-override reason; an all-strategy-child chain under nil-support now resolves to `PathReasonFallbackAllLegacy`, triggering the rebuild, which must classify strategy children consistently with the resolver.

Also a micro-cleanup of `isStrategyProvider`'s body to use `normalizeStrategyProvider(p) == "baml-fallback"` (matches the form used elsewhere; reduces magic-string coupling).

## Non-broadening of reasons

`PathReasonFallbackRoundRobinChildLegacy` continues to fire **only** for RR children. Fallback children become legacy children without that RR-specific informational reason. This preserves the existing reason classification.

## Test plan

- [x] `TestResolveFallbackChainForClientWithReason_NilSupportCheck_StrategyChildrenLegacy` — RR-child + fallback-child sub-cases with `isProviderSupported=nil`.
- [x] `TestResolveFallbackChainForClient_NilSupportCheck_StrategyChildClassified` — no-reason sibling parity.
- [x] `TestBuildLegacyMetadataPlanForClient_NilSupportRebuildClassifiesStrategyChildren` — metadata rebuild for the folded-in `metadata.go` sites.
- [x] Existing tests pass unchanged.
- [x] `go test ./bamlutils/...` clean.
- [x] Per-adapter `GOWORK=off go test ./adapter/` clean for v0_204_0, v0_215_0, v0_219_0.
- [x] `cmd/verify-framework-adapter` 9/9 PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved strategy provider detection to normalize aliases before comparison for consistent identification
  * Enhanced fallback chain resolution logic to properly classify strategy children as legacy consistently
  * Fixed legacy classification behavior to remain accurate when provider support checking is unavailable

* **Tests**
  * Added test coverage for fallback chain resolution with strategy children and disabled support checking
  * Added tests validating legacy child classification in metadata planning scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/234)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->