### PR TITLE
refactor(buildrequest): extract metadata plan helpers

### DIFF
--- a/bamlutils/buildrequest/metadata.go
+++ b/bamlutils/buildrequest/metadata.go
@@ -308,10 +308,11 @@ func newPlanBase(path, clientName string, retryPolicy *retry.Policy, buildReques
 
 // orderedLegacyChildren returns the chain-ordered subset of children whose
 // legacy[child] is true. Returns nil — not an empty slice — when there are
-// no matches so callers can assign plan.LegacyChildren = orderedLegacyChildren(...)
-// without inadvertently materialising an empty slice in the JSON payload
-// (Metadata.LegacyChildren is `omitempty`, and empty-vs-nil affects whether
-// the field is dropped on the wire).
+// no matches, so plan.LegacyChildren keeps a uniform in-memory shape across
+// every builder: callers (and tests) can treat nil as "no legacy children"
+// without distinguishing it from an empty slice. The wire payload is
+// unaffected either way because Metadata.LegacyChildren is `omitempty` and
+// drops both, but the in-memory consistency is the load-bearing invariant.
 func orderedLegacyChildren(chain []string, legacy map[string]bool) []string {
 	if len(legacy) == 0 {
 		return nil

--- a/bamlutils/buildrequest/metadata.go
+++ b/bamlutils/buildrequest/metadata.go
@@ -278,6 +278,86 @@ func ResolveProviderWithReason(
 	return res
 }
 
+// newPlanBase returns a *bamlutils.Metadata pre-populated with the planned-
+// phase preamble shared by every plan builder in this file: Phase, Path,
+// BuildRequestAPI, Client, RetryPolicy, and the RetryMax pointer-to-copied-
+// local. Callers layer per-flavor fields (Provider, Strategy, PathReason,
+// Chain, LegacyChildren) onto the returned plan.
+//
+// Legacy plans pass buildRequestAPI == "" — bamlutils.Metadata declares the
+// field with `omitempty`, so the empty value is dropped from the JSON
+// payload and matches the previous hand-written literals byte-for-byte.
+//
+// The RetryMax assignment uses a copied local rather than &retryPolicy.MaxRetries
+// directly so the plan owns its own backing int — preserving the existing
+// ownership pattern that downstream consumers (and tests) observe.
+func newPlanBase(path, clientName string, retryPolicy *retry.Policy, buildRequestAPI string) *bamlutils.Metadata {
+	plan := &bamlutils.Metadata{
+		Phase:           bamlutils.MetadataPhasePlanned,
+		Path:            path,
+		BuildRequestAPI: buildRequestAPI,
+		Client:          clientName,
+		RetryPolicy:     EncodeRetryPolicy(retryPolicy),
+	}
+	if retryPolicy != nil {
+		m := retryPolicy.MaxRetries
+		plan.RetryMax = &m
+	}
+	return plan
+}
+
+// orderedLegacyChildren returns the chain-ordered subset of children whose
+// legacy[child] is true. Returns nil — not an empty slice — when there are
+// no matches so callers can assign plan.LegacyChildren = orderedLegacyChildren(...)
+// without inadvertently materialising an empty slice in the JSON payload
+// (Metadata.LegacyChildren is `omitempty`, and empty-vs-nil affects whether
+// the field is dropped on the wire).
+func orderedLegacyChildren(chain []string, legacy map[string]bool) []string {
+	if len(legacy) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(legacy))
+	for _, child := range chain {
+		if legacy[child] {
+			names = append(names, child)
+		}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	return names
+}
+
+// rebuildLegacyChainMetadata walks chain and produces the per-child provider
+// map and the legacy classification map used to populate plan.Chain /
+// plan.LegacyChildren when the resolver returned no chain (typically the
+// runtime-override path: ResolveFallbackChain* returned chain == nil and the
+// caller wants the introspected chain enumerated for observability).
+//
+// Classification mirrors the resolver's own predicate after #234: a child is
+// legacy if its resolved provider is empty, is itself a strategy wrapper
+// (BuildRequest can't drive RR / fallback as a leaf), or is rejected by the
+// supplied support predicate. Passing isProviderSupported == nil keeps
+// strategy children legacy while leaving ordinary leaves drivable, matching
+// the resolver's nil-predicate behaviour.
+func rebuildLegacyChainMetadata(
+	reg *bamlutils.ClientRegistry,
+	chain []string,
+	clientProviders map[string]string,
+	isProviderSupported func(string) bool,
+) (providers map[string]string, legacy map[string]bool) {
+	providers = make(map[string]string, len(chain))
+	legacy = make(map[string]bool)
+	for _, child := range chain {
+		p := ResolveClientProvider(reg, child, clientProviders)
+		providers[child] = p
+		if p == "" || isStrategyProvider(p) || (isProviderSupported != nil && !isProviderSupported(p)) {
+			legacy[child] = true
+		}
+	}
+	return providers, legacy
+}
+
 // BuildSingleProviderPlan constructs planned metadata for a request routed
 // through the BuildRequest path with a single (non-strategy) client. Called
 // by the generated router once the provider has been resolved and the
@@ -292,22 +372,8 @@ func BuildSingleProviderPlan(
 	retryPolicy *retry.Policy,
 	buildRequestAPI string,
 ) *bamlutils.Metadata {
-	clientName := defaultClientName
-	if reg := adapter.OriginalClientRegistry(); reg != nil && reg.Primary != nil && *reg.Primary != "" {
-		clientName = *reg.Primary
-	}
-	plan := &bamlutils.Metadata{
-		Phase:           bamlutils.MetadataPhasePlanned,
-		Path:            "buildrequest",
-		BuildRequestAPI: buildRequestAPI,
-		Client:          clientName,
-		Provider:        provider,
-		RetryPolicy:     EncodeRetryPolicy(retryPolicy),
-	}
-	if retryPolicy != nil {
-		m := retryPolicy.MaxRetries
-		plan.RetryMax = &m
-	}
+	plan := newPlanBase("buildrequest", ResolvePrimaryClient(adapter, defaultClientName), retryPolicy, buildRequestAPI)
+	plan.Provider = provider
 	return plan
 }
 
@@ -321,18 +387,8 @@ func BuildSingleProviderPlanForClient(
 	retryPolicy *retry.Policy,
 	buildRequestAPI string,
 ) *bamlutils.Metadata {
-	plan := &bamlutils.Metadata{
-		Phase:           bamlutils.MetadataPhasePlanned,
-		Path:            "buildrequest",
-		BuildRequestAPI: buildRequestAPI,
-		Client:          clientName,
-		Provider:        provider,
-		RetryPolicy:     EncodeRetryPolicy(retryPolicy),
-	}
-	if retryPolicy != nil {
-		m := retryPolicy.MaxRetries
-		plan.RetryMax = &m
-	}
+	plan := newPlanBase("buildrequest", clientName, retryPolicy, buildRequestAPI)
+	plan.Provider = provider
 	return plan
 }
 
@@ -352,35 +408,11 @@ func BuildFallbackChainPlan(
 	buildRequestAPI string,
 	pathReason string,
 ) *bamlutils.Metadata {
-	clientName := defaultClientName
-	if reg := adapter.OriginalClientRegistry(); reg != nil && reg.Primary != nil && *reg.Primary != "" {
-		clientName = *reg.Primary
-	}
-	plan := &bamlutils.Metadata{
-		Phase:           bamlutils.MetadataPhasePlanned,
-		Path:            "buildrequest",
-		BuildRequestAPI: buildRequestAPI,
-		Client:          clientName,
-		Strategy:        "baml-fallback",
-		PathReason:      pathReason,
-		Chain:           append([]string(nil), chain...),
-		RetryPolicy:     EncodeRetryPolicy(retryPolicy),
-	}
-	if retryPolicy != nil {
-		m := retryPolicy.MaxRetries
-		plan.RetryMax = &m
-	}
-	if len(legacyChildren) > 0 {
-		names := make([]string, 0, len(legacyChildren))
-		for _, child := range chain {
-			if legacyChildren[child] {
-				names = append(names, child)
-			}
-		}
-		if len(names) > 0 {
-			plan.LegacyChildren = names
-		}
-	}
+	plan := newPlanBase("buildrequest", ResolvePrimaryClient(adapter, defaultClientName), retryPolicy, buildRequestAPI)
+	plan.Strategy = "baml-fallback"
+	plan.PathReason = pathReason
+	plan.Chain = append([]string(nil), chain...)
+	plan.LegacyChildren = orderedLegacyChildren(chain, legacyChildren)
 	_ = providers // reserved: future outcome metadata may expose per-child details
 	return plan
 }
@@ -406,31 +438,11 @@ func BuildFallbackChainPlanForClient(
 	buildRequestAPI string,
 	pathReason string,
 ) *bamlutils.Metadata {
-	plan := &bamlutils.Metadata{
-		Phase:           bamlutils.MetadataPhasePlanned,
-		Path:            "buildrequest",
-		BuildRequestAPI: buildRequestAPI,
-		Client:          clientName,
-		Strategy:        "baml-fallback",
-		PathReason:      pathReason,
-		Chain:           append([]string(nil), chain...),
-		RetryPolicy:     EncodeRetryPolicy(retryPolicy),
-	}
-	if retryPolicy != nil {
-		m := retryPolicy.MaxRetries
-		plan.RetryMax = &m
-	}
-	if len(legacyChildren) > 0 {
-		names := make([]string, 0, len(legacyChildren))
-		for _, child := range chain {
-			if legacyChildren[child] {
-				names = append(names, child)
-			}
-		}
-		if len(names) > 0 {
-			plan.LegacyChildren = names
-		}
-	}
+	plan := newPlanBase("buildrequest", clientName, retryPolicy, buildRequestAPI)
+	plan.Strategy = "baml-fallback"
+	plan.PathReason = pathReason
+	plan.Chain = append([]string(nil), chain...)
+	plan.LegacyChildren = orderedLegacyChildren(chain, legacyChildren)
 	_ = providers
 	return plan
 }
@@ -469,14 +481,9 @@ func BuildLegacyMetadataPlan(
 ) *bamlutils.Metadata {
 	resolution := ResolveProviderWithReason(adapter, defaultClientName, introspectedProvider, isProviderSupported)
 
-	plan := &bamlutils.Metadata{
-		Phase:       bamlutils.MetadataPhasePlanned,
-		Path:        "legacy",
-		Client:      resolution.Client,
-		Strategy:    resolution.Strategy,
-		PathReason:  resolution.PathReason,
-		RetryPolicy: EncodeRetryPolicy(retryPolicy),
-	}
+	plan := newPlanBase("legacy", resolution.Client, retryPolicy, "")
+	plan.Strategy = resolution.Strategy
+	plan.PathReason = resolution.PathReason
 	// Only populate Provider for non-strategy routes. When Strategy is set
 	// (e.g. "baml-fallback"), resolution.Provider echoes the strategy name,
 	// which would misrepresent it as a real provider in the header /
@@ -484,10 +491,6 @@ func BuildLegacyMetadataPlan(
 	// provider info lives in Chain / LegacyChildren.
 	if resolution.Strategy == "" {
 		plan.Provider = resolution.Provider
-	}
-	if retryPolicy != nil {
-		m := retryPolicy.MaxRetries
-		plan.RetryMax = &m
 	}
 
 	// If the resolved client is a fallback strategy, enumerate the chain so
@@ -528,34 +531,11 @@ func BuildLegacyMetadataPlan(
 		if chain == nil && !isInvalidOverrideReason(reason) {
 			reg := adapter.OriginalClientRegistry()
 			chain = resolveFallbackStrategyChain(reg, resolution.Client, fallbackChains)
-			// Resolve each child's provider through the runtime registry
-			// before consulting the static introspected map.
-			providers = make(map[string]string, len(chain))
-			legacy = make(map[string]bool)
-			for _, child := range chain {
-				p := ResolveClientProvider(reg, child, clientProviders)
-				providers[child] = p
-				// Strategy-provider children (RR, fallback) are always
-				// legacy — BuildRequest can't drive a strategy wrapper
-				// as a leaf — independent of the support predicate, so
-				// the rebuild stays consistent with the resolver's own
-				// classification when isProviderSupported is nil.
-				if p == "" || isStrategyProvider(p) || (isProviderSupported != nil && !isProviderSupported(p)) {
-					legacy[child] = true
-				}
-			}
+			providers, legacy = rebuildLegacyChainMetadata(reg, chain, clientProviders, isProviderSupported)
 		}
 		if len(chain) > 0 {
 			plan.Chain = append([]string(nil), chain...)
-			if len(legacy) > 0 {
-				names := make([]string, 0, len(legacy))
-				for _, child := range chain {
-					if legacy[child] {
-						names = append(names, child)
-					}
-				}
-				plan.LegacyChildren = names
-			}
+			plan.LegacyChildren = orderedLegacyChildren(chain, legacy)
 			_ = providers // providers reserved for future outcome population
 		}
 	}
@@ -609,16 +589,7 @@ func BuildLegacyMetadataPlanForClient(
 	// this mirrors that for the metadata path.
 	provider = normalizeStrategyProvider(provider)
 
-	plan := &bamlutils.Metadata{
-		Phase:       bamlutils.MetadataPhasePlanned,
-		Path:        "legacy",
-		Client:      clientName,
-		RetryPolicy: EncodeRetryPolicy(retryPolicy),
-	}
-	if retryPolicy != nil {
-		m := retryPolicy.MaxRetries
-		plan.RetryMax = &m
-	}
+	plan := newPlanBase("legacy", clientName, retryPolicy, "")
 
 	switch provider {
 	case "":
@@ -645,32 +616,11 @@ func BuildLegacyMetadataPlanForClient(
 		// is still useful context.
 		if chain == nil && !isInvalidOverrideReason(reason) {
 			chain = resolveFallbackStrategyChain(reg, clientName, fallbackChains)
-			providers = make(map[string]string, len(chain))
-			legacy = make(map[string]bool)
-			for _, child := range chain {
-				p := ResolveClientProvider(reg, child, clientProviders)
-				providers[child] = p
-				// Strategy-provider children (RR, fallback) are always
-				// legacy — BuildRequest can't drive a strategy wrapper
-				// as a leaf — independent of the support predicate, so
-				// the rebuild stays consistent with the resolver's own
-				// classification when isProviderSupported is nil.
-				if p == "" || isStrategyProvider(p) || (isProviderSupported != nil && !isProviderSupported(p)) {
-					legacy[child] = true
-				}
-			}
+			providers, legacy = rebuildLegacyChainMetadata(reg, chain, clientProviders, isProviderSupported)
 		}
 		if len(chain) > 0 {
 			plan.Chain = append([]string(nil), chain...)
-			if len(legacy) > 0 {
-				names := make([]string, 0, len(legacy))
-				for _, child := range chain {
-					if legacy[child] {
-						names = append(names, child)
-					}
-				}
-				plan.LegacyChildren = names
-			}
+			plan.LegacyChildren = orderedLegacyChildren(chain, legacy)
 			_ = providers
 		}
 	case "baml-roundrobin":

--- a/bamlutils/buildrequest/metadata_resolve_test.go
+++ b/bamlutils/buildrequest/metadata_resolve_test.go
@@ -1318,7 +1318,7 @@ func TestResolveProviderWithReason_RoundRobinInvalidStrategyTakesPrecedence(t *t
 					Name:     "MyRR",
 					Provider: "baml-roundrobin",
 					Options: map[string]any{
-						"strategy": "ClientA",  // bare token — invalid
+						"strategy": "ClientA",    // bare token — invalid
 						"start":    "not an int", // also invalid
 					},
 				},
@@ -1702,5 +1702,148 @@ func TestBuildLegacyMetadataPlanForClient_NilSupportRebuildClassifiesStrategyChi
 	if !equalStringSlice(plan.LegacyChildren, wantLegacy) {
 		t.Errorf("LegacyChildren: got %v, want %v (strategy wrappers must be marked legacy in the rebuild even under nil-support)",
 			plan.LegacyChildren, wantLegacy)
+	}
+}
+
+// TestOrderedLegacyChildren pins the chain-order filter that backs the four
+// inline LegacyChildren extraction sites. The nil-when-empty contract is
+// load-bearing for JSON marshaling — promoting nil to []string{} would
+// change observable plan shape for downstream consumers — so the helper
+// returns nil rather than an empty slice in every degenerate case.
+func TestOrderedLegacyChildren(t *testing.T) {
+	cases := []struct {
+		name   string
+		chain  []string
+		legacy map[string]bool
+		want   []string
+	}{
+		{
+			name:   "nil legacy map returns nil",
+			chain:  []string{"a", "b"},
+			legacy: nil,
+			want:   nil,
+		},
+		{
+			name:   "empty legacy map returns nil",
+			chain:  []string{"a", "b"},
+			legacy: map[string]bool{},
+			want:   nil,
+		},
+		{
+			name:   "preserves chain order, not map iteration order",
+			chain:  []string{"a", "b", "c"},
+			legacy: map[string]bool{"c": true, "a": true},
+			want:   []string{"a", "c"},
+		},
+		{
+			name:   "ignores legacy keys not present in chain",
+			chain:  []string{"a", "b"},
+			legacy: map[string]bool{"a": true, "x": true},
+			want:   []string{"a"},
+		},
+		{
+			name:   "all-out-of-chain legacy keys returns nil",
+			chain:  []string{"a", "b"},
+			legacy: map[string]bool{"x": true, "y": true},
+			want:   nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := orderedLegacyChildren(tc.chain, tc.legacy)
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("got %v, want nil (nil-when-empty contract)", got)
+				}
+				return
+			}
+			if !equalStringSlice(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRebuildLegacyChainMetadata pins the per-child provider resolution
+// and classification predicate shared by BuildLegacyMetadataPlan and
+// BuildLegacyMetadataPlanForClient when the resolver returned chain==nil
+// and the metadata builder reconstructs the introspected chain. The
+// predicate must mirror ResolveFallbackChain*WithReason exactly — see
+// #234 for the strategy-child / nil-support classification contract.
+func TestRebuildLegacyChainMetadata(t *testing.T) {
+	clientProviders := map[string]string{
+		"Leaf1":    "openai",
+		"Leaf2":    "anthropic",
+		"Bedrock":  "aws-bedrock",
+		"InnerRR":  "baml-roundrobin",
+		"InnerFB":  "baml-fallback",
+		"Unmapped": "",
+	}
+	supportOnlyOpenAI := func(p string) bool { return p == "openai" }
+	supportOpenAIAndAnthropic := func(p string) bool { return p == "openai" || p == "anthropic" }
+
+	cases := []struct {
+		name        string
+		chain       []string
+		support     func(string) bool
+		wantLegacy  map[string]bool
+		wantProvLen int
+	}{
+		{
+			name:        "all supported leaves",
+			chain:       []string{"Leaf1", "Leaf2"},
+			support:     supportOpenAIAndAnthropic,
+			wantLegacy:  map[string]bool{},
+			wantProvLen: 2,
+		},
+		{
+			name:        "unresolved provider classified legacy",
+			chain:       []string{"Leaf1", "Unmapped"},
+			support:     supportOpenAIAndAnthropic,
+			wantLegacy:  map[string]bool{"Unmapped": true},
+			wantProvLen: 2,
+		},
+		{
+			name:        "strategy child always legacy regardless of support",
+			chain:       []string{"Leaf1", "InnerRR", "InnerFB"},
+			support:     func(string) bool { return true },
+			wantLegacy:  map[string]bool{"InnerRR": true, "InnerFB": true},
+			wantProvLen: 3,
+		},
+		{
+			name:        "nil support keeps ordinary leaves drivable, strategy children still legacy",
+			chain:       []string{"Leaf1", "InnerRR"},
+			support:     nil,
+			wantLegacy:  map[string]bool{"InnerRR": true},
+			wantProvLen: 2,
+		},
+		{
+			name:        "unsupported leaf classified by support function",
+			chain:       []string{"Leaf1", "Bedrock"},
+			support:     supportOnlyOpenAI,
+			wantLegacy:  map[string]bool{"Bedrock": true},
+			wantProvLen: 2,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotProviders, gotLegacy := rebuildLegacyChainMetadata(nil, tc.chain, clientProviders, tc.support)
+			if len(gotProviders) != tc.wantProvLen {
+				t.Errorf("providers length: got %d, want %d (providers map should hold an entry per chain child)", len(gotProviders), tc.wantProvLen)
+			}
+			for _, child := range tc.chain {
+				if _, ok := gotProviders[child]; !ok {
+					t.Errorf("providers missing entry for %q (every chain child must be mapped, even when its provider is empty)", child)
+				}
+			}
+			if len(gotLegacy) != len(tc.wantLegacy) {
+				t.Errorf("legacy size: got %v, want %v", gotLegacy, tc.wantLegacy)
+			}
+			for child, want := range tc.wantLegacy {
+				if gotLegacy[child] != want {
+					t.Errorf("legacy[%q]: got %v, want %v", child, gotLegacy[child], want)
+				}
+			}
+		})
 	}
 }

--- a/bamlutils/buildrequest/metadata_resolve_test.go
+++ b/bamlutils/buildrequest/metadata_resolve_test.go
@@ -1707,9 +1707,11 @@ func TestBuildLegacyMetadataPlanForClient_NilSupportRebuildClassifiesStrategyChi
 
 // TestOrderedLegacyChildren pins the chain-order filter that backs the four
 // inline LegacyChildren extraction sites. The nil-when-empty contract is
-// load-bearing for JSON marshaling — promoting nil to []string{} would
-// change observable plan shape for downstream consumers — so the helper
-// returns nil rather than an empty slice in every degenerate case.
+// load-bearing for in-memory consistency — keeping plan.LegacyChildren the
+// same shape across every builder lets callers (and tests) treat nil as
+// "no legacy children" without distinguishing it from an empty slice — so
+// the helper returns nil rather than an empty slice in every degenerate
+// case.
 func TestOrderedLegacyChildren(t *testing.T) {
 	cases := []struct {
 		name   string


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes one item from the #167 follow-up tracker (extract plan-builder duplication).

`bamlutils/buildrequest/metadata.go` had three sets of duplicated logic across its six plan builders:

1. **Retry / base preamble** (Chunk A) — `Phase` / `Path` / `Client` / `BuildRequestAPI` / `RetryPolicy` + the `RetryMax: &m` pointer-to-copied-local idiom. Present in all 6 builders.
2. **Ordered legacy-child extraction** (Chunk B) — chain-order filter against the legacy map, with the nil-when-empty contract that lets `bamlutils.Metadata.LegacyChildren` `omitempty` drop the field. Present at 4 sites.
3. **Fallback-chain metadata rebuild** — runtime-registry provider resolution + strategy/support classification per child. Present at 2 sites in `BuildLegacyMetadataPlan` and `BuildLegacyMetadataPlanForClient` (textually identical apart from how `reg` is sourced).

This PR extracts all three:

- `newPlanBase(path, clientName, retryPolicy, buildRequestAPI)` returns the common preamble. Legacy plans pass `buildRequestAPI == ""` (omitempty drops it).
- `orderedLegacyChildren(chain, legacy)` returns the chain-ordered subset, preserving the nil-when-empty contract for JSON marshaling.
- `rebuildLegacyChainMetadata(reg, chain, clientProviders, isProviderSupported)` returns the per-child providers map and legacy classification map. The predicate matches the resolver post-#234 — strategy wrappers always classify legacy regardless of the support predicate, so a nil `isProviderSupported` keeps ordinary leaves drivable while still flagging strategy children.

Plus a bonus reuse: `BuildSingleProviderPlan` and `BuildFallbackChainPlan` previously inlined the primary-client lookup; they now call the existing `ResolvePrimaryClient(adapter, defaultClientName)` helper from `client_resolution.go`.

## Behavior preservation

- `RetryMax` pointer-to-copied-local pattern preserved (plans own their own backing int).
- `LegacyChildren` stays `nil` when empty (NOT an empty slice), so `omitempty` continues to drop the field from the JSON payload.
- Classification predicate matches the resolver — strategy wrappers always legacy (per #234).

## Test plan

- [x] `TestOrderedLegacyChildren` direct unit test (5 sub-cases: nil map, empty map, chain-order preservation, out-of-chain key filtering, all-out-of-chain → nil).
- [x] `TestRebuildLegacyChainMetadata` direct unit test (5 sub-cases: all-supported, unresolved provider, strategy children, nil-support, unsupported leaf).
- [x] All existing `Build*Plan*` tests pass unchanged (`go test -run 'BuildSingleProviderPlan|BuildFallbackChainPlan|BuildLegacyMetadataPlan'`).
- [x] `go test ./bamlutils/...` clean.
- [x] `cmd/verify-framework-adapter` 9/9.
- [x] `cmd/verify-adapter-pins` 4/4.
- [x] Per-adapter smoke tests pass for v0.204.0 / v0.215.0 / v0.219.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized internal metadata construction for more consistent and maintainable plan building.

* **Tests**
  * Added unit tests validating legacy chain ordering, filtering behavior, and provider-resolution/legacy-classification scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/235)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->