### PR TITLE
fix(buildrequest): respect strategy-wrapper retry_policy after RR unwrap

### DIFF
--- a/adapters/common/codegen/codegen_router.go
+++ b/adapters/common/codegen/codegen_router.go
@@ -32,18 +32,27 @@ func (me *methodEmitter) emitRouter() {
 		jen.Var().Id("err").Error(),
 		jen.Id("mode").Op(":=").Id("adapter").Dot("StreamMode").Call(),
 	}
-	// Always seed __effective from ResolvePrimaryClient and leave
-	// __rrInfo nil. This is the legacy-equivalent shape: primary
-	// override applied, no RR unwrap, no coordinator advance, no
-	// RR metadata. supportsWithClient adapters with the flag on
-	// upgrade these via ResolveEffectiveClient below; everyone
+	// Seed __retryClient and __effective from ResolvePrimaryClient
+	// and leave __rrInfo nil. This is the legacy-equivalent shape:
+	// primary override applied, no RR unwrap, no coordinator advance,
+	// no RR metadata. supportsWithClient adapters with the flag on
+	// upgrade __effective via ResolveEffectiveClient below; everyone
 	// else (older adapters, or modern adapters with the flag off)
 	// keeps this baseline so BAML's own strategy rotation owns RR.
+	//
+	// __retryClient preserves the pre-unwrap client name (the strategy
+	// wrapper itself, or the function's primary-override target).
+	// __effective may later become an RR-selected leaf, but
+	// retry-policy resolution must be wrapper-first to honor BAML's
+	// LLMStrategyProvider::WithRetryPolicy semantics — when an RR or
+	// fallback wrapper carries its own retry_policy, BAML applies it
+	// AROUND the strategy iteration rather than per-leaf.
 	routerBody = append(routerBody,
-		jen.Id("__effective").Op(":=").Qual(common.BuildRequestPkg, "ResolvePrimaryClient").Call(
+		jen.Id("__retryClient").Op(":=").Qual(common.BuildRequestPkg, "ResolvePrimaryClient").Call(
 			jen.Id("adapter"),
 			jen.Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(me.methodName)),
 		),
+		jen.Id("__effective").Op(":=").Id("__retryClient"),
 		jen.Var().Id("__rrInfo").Op("*").Qual(common.InterfacesPkg, "RoundRobinInfo"),
 	)
 	if g.supportsWithClient {
@@ -107,17 +116,24 @@ func (me *methodEmitter) emitRouter() {
 	// Helper to generate the common retry policy resolution + dispatch call
 	// for both single-provider and fallback-chain paths.
 	//
-	// Keyed on __effective (the post-RR leaf) rather than
-	// FunctionClient[methodName] (the function's declared default
-	// client, which may be an RR wrapper). For non-RR functions the
-	// two are identical; for RR, we must use the child that will
-	// actually handle the request, otherwise the retry policy would
-	// come from the wrapper — retry config isn't inherited from
-	// strategy wrappers in BAML semantics.
+	// Wrapper-first, leaf-fallback. BAML's LLMStrategyProvider
+	// implements WithRetryPolicy
+	// (engine/baml-runtime/src/internal/llm_client/strategy/mod.rs):
+	// when the strategy wrapper has its own retry_policy, BAML wraps
+	// the whole strategy iteration in ExecutionScope::Retry; only
+	// when the wrapper has none does the selected leaf's retry_policy
+	// apply. ResolveStrategyAwareRetryPolicy honors that order: it
+	// consults __retryClient (pre-unwrap wrapper / primary override)
+	// first and falls back to __effective (post-RR leaf) only when
+	// the wrapper has no policy and the unwrap actually changed the
+	// client name. The per-request __baml_options__.retry override
+	// remains highest priority via the underlying ResolveRetryPolicy.
 	resolveRetryPolicy := func() jen.Code {
-		return jen.Id("retryPolicy").Op(":=").Qual(common.BuildRequestPkg, "ResolveRetryPolicy").Call(
+		return jen.Id("retryPolicy").Op(":=").Qual(common.BuildRequestPkg, "ResolveStrategyAwareRetryPolicy").Call(
 			jen.Id("adapter"),
+			jen.Id("__retryClient"),
 			jen.Id("__effective"),
+			jen.Qual(common.IntrospectedPkg, "ClientRetryPolicy").Index(jen.Id("__retryClient")),
 			jen.Qual(common.IntrospectedPkg, "ClientRetryPolicy").Index(jen.Id("__effective")),
 			jen.Qual(common.IntrospectedPkg, "RetryPolicies"),
 		)
@@ -404,24 +420,26 @@ func (me *methodEmitter) emitRouter() {
 	// the generator).
 	routerBody = append(routerBody,
 		jen.Comment("Legacy path: CallStream + OnTick (for unsupported providers or when BuildRequest is disabled)"),
-		// Retry policy and client identity for the legacy dispatch
-		// derive from __effective, not FunctionClient[methodName].
-		// __effective already accounts for both the RR unwrap and
-		// any client_registry primary override, so this keys both
-		// the retry policy and the WithClient/plan on the client
-		// that will actually handle the request.
+		// Retry policy resolution mirrors the BuildRequest paths:
+		// wrapper-first (__retryClient — the pre-unwrap strategy /
+		// primary-override target) with leaf-fallback to __effective
+		// (the post-RR leaf, which also folds in any client_registry
+		// primary override). The dispatched client identity for
+		// WithClient / SetPrimaryClient is __effective so the legacy
+		// dispatcher actually contacts the resolved leaf, but retry
+		// honors BAML's LLMStrategyProvider::WithRetryPolicy.
 		//
-		// Without this, a request with `primary` set to a client
-		// whose retry_policy is only statically declared (not
-		// redeclared in the runtime registry) would fall through to
-		// ResolveRetryPolicy's step-4 default — which looked up
-		// FunctionRetryPolicy[methodName] and therefore returned the
-		// FUNCTION's declared client's policy, not the primary-
-		// overridden client's. The BuildRequest path had the same
-		// bug; the legacy branch was missed.
-		jen.Id("__legacyRetryPolicy").Op(":=").Qual(common.BuildRequestPkg, "ResolveRetryPolicy").Call(
+		// Without this seam, a request that resolved __effective to
+		// a leaf via RR unwrap or primary override would lose the
+		// strategy wrapper's retry_policy: ResolveRetryPolicy on the
+		// leaf alone cannot see the wrapper's introspected entry,
+		// since ClientRetryPolicy is keyed by client name and the
+		// wrapper's name was thrown away at __effective assignment.
+		jen.Id("__legacyRetryPolicy").Op(":=").Qual(common.BuildRequestPkg, "ResolveStrategyAwareRetryPolicy").Call(
 			jen.Id("adapter"),
+			jen.Id("__retryClient"),
 			jen.Id("__effective"),
+			jen.Qual(common.IntrospectedPkg, "ClientRetryPolicy").Index(jen.Id("__retryClient")),
 			jen.Qual(common.IntrospectedPkg, "ClientRetryPolicy").Index(jen.Id("__effective")),
 			jen.Qual(common.IntrospectedPkg, "RetryPolicies"),
 		),

--- a/adapters/common/codegen/codegen_test.go
+++ b/adapters/common/codegen/codegen_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/dave/jennifer/jen"
+	"github.com/invakid404/baml-rest/adapters/common"
+	"github.com/invakid404/baml-rest/introspected"
 )
 
 // Self-referential types for testing cycle detection in structContainsMedia.
@@ -622,5 +624,118 @@ func TestEnumValueAttrsCode_Order(t *testing.T) {
 
 	if !(descIdx < aliasIdx && aliasIdx < skipIdx) {
 		t.Error("enumValueAttrsCode() methods not in expected order (Description, Alias, Skip)")
+	}
+}
+
+// TestEmitRouter_RetryResolutionUsesStrategyAwareHelper pins the
+// post-fix shape of the per-method router: retry resolution calls
+// ResolveStrategyAwareRetryPolicy and is keyed on BOTH __retryClient
+// (the pre-unwrap strategy / primary-override target) and __effective
+// (the post-RR-unwrap leaf). The legacy retry-resolution emit at the
+// bottom of the router is always emitted, so this test asserts on
+// that site directly. With the introspected.Request /
+// introspected.StreamRequest singletons set non-nil, the BuildRequest
+// landing-block retry calls are also emitted and the assertion
+// catches a regression at every site.
+//
+// A regression to the previous shape — keying retry on __effective
+// only, after ResolveEffectiveClient overwrote it to the RR leaf —
+// silently dropped any retry_policy declared on a strategy wrapper
+// (RR or fallback) on the v0.219+ BuildRequest path, contradicting
+// BAML's LLMStrategyProvider::WithRetryPolicy semantics.
+func TestEmitRouter_RetryResolutionUsesStrategyAwareHelper(t *testing.T) {
+	// Save + restore the introspected BuildRequest singletons. The
+	// codegen package treats both nil as "legacy-only adapter", which
+	// would skip the BR landing blocks (and their resolveRetryPolicy
+	// emits) entirely. Setting both non-nil exercises every retry
+	// emit site so the assertions catch a regression at any of them.
+	savedRequest := introspected.Request
+	savedStreamRequest := introspected.StreamRequest
+	t.Cleanup(func() {
+		introspected.Request = savedRequest
+		introspected.StreamRequest = savedStreamRequest
+	})
+	introspected.Request = struct{}{}
+	introspected.StreamRequest = struct{}{}
+
+	// Minimal generator: only fields emitRouter reads.
+	g := &generator{
+		out:                common.MakeFile(),
+		supportsWithClient: true,
+	}
+	me := &methodEmitter{
+		g:                          g,
+		methodName:                 "GreetUser",
+		buildRequestMethodName:     "greetUser_buildRequest",
+		buildCallRequestMethodName: "greetUser_buildCallRequest",
+		noRawMethodName:            "greetUser_noRaw",
+		fullMethodName:             "greetUser_full",
+	}
+
+	me.emitRouter()
+	rendered := g.out.GoString()
+
+	// Pin the __retryClient declaration. The pre-unwrap client name
+	// must be captured BEFORE __effective is overwritten by
+	// ResolveEffectiveClient; without this, the wrapper-first retry
+	// resolution downstream cannot see the strategy-wrapper name.
+	if !strings.Contains(rendered, "__retryClient :=") {
+		t.Errorf("router must declare __retryClient (pre-unwrap client name); rendered:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "buildrequest.ResolvePrimaryClient(adapter, introspected.FunctionClient[\"GreetUser\"])") {
+		t.Errorf("__retryClient must seed from ResolvePrimaryClient (applies primary override but no RR unwrap); rendered:\n%s", rendered)
+	}
+
+	// Pin that __effective starts at __retryClient and is only
+	// overwritten by the conditional ResolveEffectiveClient block.
+	// "__effective := __retryClient" couples the two so we never
+	// emit the legacy shape that seeded __effective directly from
+	// ResolvePrimaryClient (which would lose the wrapper name when
+	// the conditional block reassigns __effective).
+	if !strings.Contains(rendered, "__effective := __retryClient") {
+		t.Errorf("__effective must alias __retryClient at seed time so the wrapper name survives the RR-unwrap reassignment; rendered:\n%s", rendered)
+	}
+
+	// Pin: every retry resolution call must be the strategy-aware
+	// helper. The plain ResolveRetryPolicy call (the pre-fix shape)
+	// must not appear anywhere in the router.
+	if strings.Contains(rendered, "buildrequest.ResolveRetryPolicy(") {
+		t.Errorf("router must not call buildrequest.ResolveRetryPolicy directly — wrapper-first semantics require ResolveStrategyAwareRetryPolicy; rendered:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "buildrequest.ResolveStrategyAwareRetryPolicy(") {
+		t.Errorf("router must call buildrequest.ResolveStrategyAwareRetryPolicy for retry resolution; rendered:\n%s", rendered)
+	}
+
+	// Pin the actual argument shape. Both __retryClient and
+	// __effective (and the corresponding ClientRetryPolicy lookups
+	// keyed by each) must be passed into every helper invocation.
+	// A regression that passed __effective in both wrapper and leaf
+	// slots would compile but quietly revert to leaf-only retry.
+	wantArgs := "ResolveStrategyAwareRetryPolicy(adapter, __retryClient, __effective, introspected.ClientRetryPolicy[__retryClient], introspected.ClientRetryPolicy[__effective], introspected.RetryPolicies)"
+	if !strings.Contains(rendered, wantArgs) {
+		t.Errorf("ResolveStrategyAwareRetryPolicy call missing expected (strategy, effective) argument shape:\nwant fragment:\n%s\nrendered:\n%s", wantArgs, rendered)
+	}
+	// Negative pin: the symmetric wrong-shape — keying both wrapper
+	// and leaf slots on __effective — would silently revert to
+	// leaf-only retry. The strategy-aware helper short-circuits its
+	// leaf-fallback when strategyClient == effectiveClient, so a
+	// regression that passed __effective in both positions would
+	// type-check and compile cleanly.
+	wrongArgs := "ResolveStrategyAwareRetryPolicy(adapter, __effective, __effective,"
+	if strings.Contains(rendered, wrongArgs) {
+		t.Errorf("ResolveStrategyAwareRetryPolicy must not be called with __effective in both strategy and effective slots — that silently reverts to leaf-only retry; rendered:\n%s", rendered)
+	}
+
+	// Pin: the legacy retry resolution (always-emitted, at router
+	// bottom) is keyed on __retryClient too. Detect by counting
+	// __legacyRetryPolicy occurrences and asserting the strategy-
+	// aware helper appears between them and the next blank line.
+	legacyIdx := strings.Index(rendered, "__legacyRetryPolicy :=")
+	if legacyIdx < 0 {
+		t.Fatalf("router must declare __legacyRetryPolicy for the legacy fallthrough path; rendered:\n%s", rendered)
+	}
+	helperAfterLegacy := strings.Index(rendered[legacyIdx:], "buildrequest.ResolveStrategyAwareRetryPolicy(")
+	if helperAfterLegacy < 0 {
+		t.Errorf("__legacyRetryPolicy must be assigned from ResolveStrategyAwareRetryPolicy (not the leaf-only ResolveRetryPolicy); rendered:\n%s", rendered)
 	}
 }

--- a/bamlutils/buildrequest/resolve_test.go
+++ b/bamlutils/buildrequest/resolve_test.go
@@ -698,10 +698,14 @@ func TestResolveStrategyAwareRetryPolicy(t *testing.T) {
 // TestResolveStrategyAwareRetryPolicy_LeafFallbackUsesEffectiveName
 // pins the priority-3 path: wrapper has no policy in either runtime
 // registry or introspected map, but the leaf does. The helper must
-// invoke ResolveRetryPolicy with the EFFECTIVE name on the second
-// call so the runtime registry lookup keys off the leaf, not the
-// wrapper. A regression that mistakenly passed strategyClient on the
-// fallback call would miss the leaf's runtime-registry retry_policy.
+// invoke the runtime-registry lookup with the EFFECTIVE name on the
+// second call so it keys off the leaf, not the wrapper. A regression
+// that mistakenly passed strategyClient on the fallback call would
+// miss the leaf's runtime-registry retry_policy.
+//
+// This test exercises the primary-nil registry shape; the
+// reg.Primary-set companion lives in
+// TestResolveStrategyAwareRetryPolicy_LeafFallbackUnshadowedByPrimary.
 func TestResolveStrategyAwareRetryPolicy_LeafFallbackUsesEffectiveName(t *testing.T) {
 	leafPolicy := "LeafRetry"
 	adapter := &mockAdapter{
@@ -722,5 +726,58 @@ func TestResolveStrategyAwareRetryPolicy_LeafFallbackUsesEffectiveName(t *testin
 	}
 	if got.MaxRetries != 4 {
 		t.Errorf("expected leaf MaxRetries=4, got %d", got.MaxRetries)
+	}
+}
+
+// TestResolveStrategyAwareRetryPolicy_LeafFallbackUnshadowedByPrimary
+// pins the production-shaped scenario CodeRabbit verdict-1 surfaced:
+// when the strategy wrapper IS the runtime registry primary, the
+// inner ResolveRetryPolicy short-circuits to a primary-only scan
+// (retry_policy.go: the `reg.Primary != nil && *reg.Primary != ""`
+// branch), so the leaf-fallback's second call — even with the
+// leaf's effective name passed in — never reaches the leaf's entry.
+// The fix is to use a primary-ignoring helper for the leaf-fallback
+// call so the leaf's runtime-registry retry_policy is honored.
+//
+// Failure mode without the fix: ResolveStrategyAwareRetryPolicy
+// returns nil even though the leaf's runtime-registry retry_policy
+// is fully populated. The first-call wrapper path returns nil
+// (primary entry exists but has no RetryPolicy and no introspected
+// fallback), and the second-call leaf path is shadowed by the same
+// primary-only scan and also returns nil.
+//
+// The fix path: leaf-fallback uses resolveRetryPolicyForClient, which
+// scans by direct client name instead of *reg.Primary. The wrapper-
+// first call still uses ResolveRetryPolicy so its primary-aware
+// behavior + per-request override priority are unchanged.
+func TestResolveStrategyAwareRetryPolicy_LeafFallbackUnshadowedByPrimary(t *testing.T) {
+	primary := "MyRR"
+	leafPolicy := "LeafRetry"
+	adapter := &mockAdapter{
+		Context: context.Background(),
+		originalRegistry: &bamlutils.ClientRegistry{
+			Primary: &primary,
+			Clients: []*bamlutils.ClientProperty{
+				// Wrapper is the registry primary but carries no
+				// retry policy of its own — and has no introspected
+				// fallback either (strategyPolicyName="").
+				{Name: "MyRR", Provider: "baml-roundrobin"},
+				// Leaf has a runtime-registry retry policy. This is
+				// what the strategy-aware helper must surface via
+				// the leaf-fallback path.
+				{Name: "Leaf", Provider: "openai", RetryPolicy: &leafPolicy},
+			},
+		},
+	}
+	policies := map[string]*retry.Policy{
+		"LeafRetry": {MaxRetries: 9, Strategy: &retry.ConstantDelay{DelayMs: 75}},
+	}
+
+	got := ResolveStrategyAwareRetryPolicy(adapter, "MyRR", "Leaf", "", "", policies)
+	if got == nil {
+		t.Fatal("expected leaf-fallback to find Leaf's runtime-registry retry_policy despite MyRR being the registry primary; got nil (leaf-fallback shadowed by primary-only scan in inner ResolveRetryPolicy)")
+	}
+	if got.MaxRetries != 9 {
+		t.Errorf("expected leaf MaxRetries=9, got %d", got.MaxRetries)
 	}
 }

--- a/bamlutils/buildrequest/resolve_test.go
+++ b/bamlutils/buildrequest/resolve_test.go
@@ -667,6 +667,41 @@ func TestResolveStrategyAwareRetryPolicy(t *testing.T) {
 			policies:            commonPolicies,
 			wantNil:             true,
 		},
+		{
+			// Equal-name no-unwrap WITH a populated effective fallback
+			// policy. This is the load-bearing pin on the
+			// `strategyClient != effectiveClient` guard inside
+			// ResolveStrategyAwareRetryPolicy.
+			//
+			// Trace WITH the guard: wrapper-first call sees
+			// strategyPolicyName="" and no matching runtime registry
+			// entry → returns nil. The guard then suppresses the
+			// leaf-fallback because strategyClient == effectiveClient,
+			// so the helper returns nil. wantNil=true holds.
+			//
+			// Trace WITHOUT the guard: wrapper-first returns nil as
+			// before, but then the leaf-fallback fires unconditionally
+			// → resolveRetryPolicyForClient picks up
+			// effectivePolicyName="LeafRetry" → returns the LeafRetry
+			// policy (MaxRetries=3). The test would fail with
+			// "expected nil, got MaxRetries=3", catching the
+			// regression.
+			//
+			// This sub-case differs from no-unwrap-no-policy-nil
+			// (where effectivePolicyName="" makes the leaf-fallback
+			// also return nil and the guard becomes a no-op) and from
+			// no-unwrap-equal-names-matches-single-call (where the
+			// wrapper-first call returns non-nil and short-circuits
+			// before the guard matters).
+			name:                "no-unwrap-equal-names-suppresses-leaf-fallback",
+			adapter:             &mockAdapter{Context: context.Background()},
+			strategyClient:      "Solo",
+			effectiveClient:     "Solo",
+			strategyPolicyName:  "",
+			effectivePolicyName: "LeafRetry",
+			policies:            commonPolicies,
+			wantNil:             true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/bamlutils/buildrequest/resolve_test.go
+++ b/bamlutils/buildrequest/resolve_test.go
@@ -521,3 +521,206 @@ func TestResolveRetryPolicy_PrimaryWithoutRetryNoIntrospected(t *testing.T) {
 		t.Errorf("expected nil policy when primary has no retry and no introspected default, got MaxRetries=%d", got.MaxRetries)
 	}
 }
+
+// ============================================================================
+// ResolveStrategyAwareRetryPolicy tests
+// ============================================================================
+//
+// These pin the wrapper-first / leaf-fallback contract that mirrors
+// BAML's LLMStrategyProvider::WithRetryPolicy semantics. Each table
+// row builds an adapter + introspected policies map and asserts the
+// resolved MaxRetries (or nil) for a (strategyClient, effectiveClient)
+// pair.
+
+func TestResolveStrategyAwareRetryPolicy(t *testing.T) {
+	// Shared introspected map used across cases. Case-specific overrides
+	// rebind locally.
+	commonPolicies := map[string]*retry.Policy{
+		"WrapperRetry": {MaxRetries: 7, Strategy: &retry.ConstantDelay{DelayMs: 50}},
+		"LeafRetry":    {MaxRetries: 3, Strategy: &retry.ConstantDelay{DelayMs: 200}},
+	}
+
+	type testCase struct {
+		name                string
+		adapter             *mockAdapter
+		strategyClient      string
+		effectiveClient     string
+		strategyPolicyName  string
+		effectivePolicyName string
+		policies            map[string]*retry.Policy
+		wantNil             bool
+		wantMaxRetries      int
+	}
+
+	cases := []testCase{
+		{
+			// Wrapper has a static introspected policy, leaf has none.
+			// BAML semantics: wrapper retry is applied around the
+			// strategy iteration.
+			name:                "wrapper-static-leaf-none",
+			adapter:             &mockAdapter{Context: context.Background()},
+			strategyClient:      "MyRR",
+			effectiveClient:     "Leaf",
+			strategyPolicyName:  "WrapperRetry",
+			effectivePolicyName: "",
+			policies:            commonPolicies,
+			wantMaxRetries:      7,
+		},
+		{
+			// Both wrapper and leaf have policies. Wrapper wins.
+			name:                "wrapper-static-leaf-static",
+			adapter:             &mockAdapter{Context: context.Background()},
+			strategyClient:      "MyRR",
+			effectiveClient:     "Leaf",
+			strategyPolicyName:  "WrapperRetry",
+			effectivePolicyName: "LeafRetry",
+			policies:            commonPolicies,
+			wantMaxRetries:      7,
+		},
+		{
+			// Wrapper has none, leaf has policy. Leaf-fallback fires.
+			name:                "wrapper-none-leaf-static",
+			adapter:             &mockAdapter{Context: context.Background()},
+			strategyClient:      "MyRR",
+			effectiveClient:     "Leaf",
+			strategyPolicyName:  "",
+			effectivePolicyName: "LeafRetry",
+			policies:            commonPolicies,
+			wantMaxRetries:      3,
+		},
+		{
+			// Runtime client_registry policy on the wrapper wins over a
+			// leaf static introspected policy.
+			name: "wrapper-runtime-registry-beats-leaf-static",
+			adapter: func() *mockAdapter {
+				name := "WrapperRetry"
+				return &mockAdapter{
+					Context: context.Background(),
+					originalRegistry: &bamlutils.ClientRegistry{
+						Clients: []*bamlutils.ClientProperty{
+							{Name: "MyRR", Provider: "baml-roundrobin", RetryPolicy: &name},
+						},
+					},
+				}
+			}(),
+			strategyClient:      "MyRR",
+			effectiveClient:     "Leaf",
+			strategyPolicyName:  "",
+			effectivePolicyName: "LeafRetry",
+			policies:            commonPolicies,
+			wantMaxRetries:      7,
+		},
+		{
+			// Per-request __baml_options__.retry override wins
+			// regardless of which client name is keyed. Verify that
+			// the override short-circuits the wrapper-first call AND
+			// is not double-applied (it's the same value either way).
+			name: "per-request-override-wins-over-everything",
+			adapter: &mockAdapter{
+				Context:     context.Background(),
+				retryConfig: &bamlutils.RetryConfig{MaxRetries: 11, Strategy: "constant_delay", DelayMs: 1},
+			},
+			strategyClient:      "MyRR",
+			effectiveClient:     "Leaf",
+			strategyPolicyName:  "WrapperRetry",
+			effectivePolicyName: "LeafRetry",
+			policies:            commonPolicies,
+			wantMaxRetries:      11,
+		},
+		{
+			// strategyClient == effectiveClient (no RR unwrap
+			// happened). Behavior must match a single
+			// ResolveRetryPolicy call — leaf-fallback path is
+			// suppressed by the equality guard, so a nil wrapper
+			// resolution yields nil even if a separate "leaf" entry
+			// existed in the policies map.
+			name:                "no-unwrap-equal-names-matches-single-call",
+			adapter:             &mockAdapter{Context: context.Background()},
+			strategyClient:      "MyClient",
+			effectiveClient:     "MyClient",
+			strategyPolicyName:  "WrapperRetry",
+			effectivePolicyName: "WrapperRetry",
+			policies:            commonPolicies,
+			wantMaxRetries:      7,
+		},
+		{
+			// Both nil → returns nil (no retries).
+			name:                "both-nil",
+			adapter:             &mockAdapter{Context: context.Background()},
+			strategyClient:      "MyRR",
+			effectiveClient:     "Leaf",
+			strategyPolicyName:  "",
+			effectivePolicyName: "",
+			policies:            commonPolicies,
+			wantNil:             true,
+		},
+		{
+			// Equal-name no-unwrap with no policies → nil. Pins that
+			// the equal-name short-circuit doesn't accidentally
+			// double-resolve.
+			name:                "no-unwrap-no-policy-nil",
+			adapter:             &mockAdapter{Context: context.Background()},
+			strategyClient:      "Solo",
+			effectiveClient:     "Solo",
+			strategyPolicyName:  "",
+			effectivePolicyName: "",
+			policies:            commonPolicies,
+			wantNil:             true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveStrategyAwareRetryPolicy(
+				tc.adapter,
+				tc.strategyClient,
+				tc.effectiveClient,
+				tc.strategyPolicyName,
+				tc.effectivePolicyName,
+				tc.policies,
+			)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil policy, got MaxRetries=%d", got.MaxRetries)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil policy with MaxRetries=%d, got nil", tc.wantMaxRetries)
+			}
+			if got.MaxRetries != tc.wantMaxRetries {
+				t.Errorf("expected MaxRetries=%d, got %d", tc.wantMaxRetries, got.MaxRetries)
+			}
+		})
+	}
+}
+
+// TestResolveStrategyAwareRetryPolicy_LeafFallbackUsesEffectiveName
+// pins the priority-3 path: wrapper has no policy in either runtime
+// registry or introspected map, but the leaf does. The helper must
+// invoke ResolveRetryPolicy with the EFFECTIVE name on the second
+// call so the runtime registry lookup keys off the leaf, not the
+// wrapper. A regression that mistakenly passed strategyClient on the
+// fallback call would miss the leaf's runtime-registry retry_policy.
+func TestResolveStrategyAwareRetryPolicy_LeafFallbackUsesEffectiveName(t *testing.T) {
+	leafPolicy := "LeafRetry"
+	adapter := &mockAdapter{
+		Context: context.Background(),
+		originalRegistry: &bamlutils.ClientRegistry{
+			Clients: []*bamlutils.ClientProperty{
+				{Name: "Leaf", Provider: "openai", RetryPolicy: &leafPolicy},
+			},
+		},
+	}
+	policies := map[string]*retry.Policy{
+		"LeafRetry": {MaxRetries: 4, Strategy: &retry.ConstantDelay{DelayMs: 25}},
+	}
+
+	got := ResolveStrategyAwareRetryPolicy(adapter, "MyRR", "Leaf", "", "", policies)
+	if got == nil {
+		t.Fatal("expected leaf-fallback to find the runtime-registry policy on Leaf, got nil")
+	}
+	if got.MaxRetries != 4 {
+		t.Errorf("expected leaf MaxRetries=4, got %d", got.MaxRetries)
+	}
+}

--- a/bamlutils/buildrequest/retry_policy.go
+++ b/bamlutils/buildrequest/retry_policy.go
@@ -90,6 +90,45 @@ func ResolveRetryPolicy(
 	return nil
 }
 
+// ResolveStrategyAwareRetryPolicy resolves the retry policy for a request
+// where the originally-routed client (a strategy wrapper, like
+// baml-roundrobin or baml-fallback) may have been unwrapped to a leaf
+// for dispatch. Priority order:
+//
+//  1. Per-request override (`__baml_options__.retry`) — handled inside
+//     the underlying ResolveRetryPolicy and short-circuits regardless of
+//     which client name is keyed.
+//  2. Strategy-wrapper retry_policy — runtime client_registry entry for
+//     strategyClient, falling back to its static introspected name.
+//  3. Effective-leaf retry_policy — same shape on effectiveClient, only
+//     consulted when strategyClient != effectiveClient (i.e. an RR or
+//     fallback unwrap actually happened) AND the wrapper had no policy.
+//  4. nil.
+//
+// This mirrors BAML's runtime: LLMStrategyProvider::WithRetryPolicy
+// (engine/baml-runtime/src/internal/llm_client/strategy/mod.rs) wraps
+// the whole strategy in ExecutionScope::Retry when the wrapper has its
+// own retry_policy; otherwise the selected child's policy applies.
+//
+// Pre-RR-unwrap callers (where strategyClient == effectiveClient) get
+// behavior identical to a single ResolveRetryPolicy call.
+func ResolveStrategyAwareRetryPolicy(
+	adapter bamlutils.Adapter,
+	strategyClient, effectiveClient string,
+	strategyPolicyName, effectivePolicyName string,
+	introspectedPolicies map[string]*retry.Policy,
+) *retry.Policy {
+	if p := ResolveRetryPolicy(adapter, strategyClient, strategyPolicyName, introspectedPolicies); p != nil {
+		return p
+	}
+	if strategyClient != effectiveClient {
+		if p := ResolveRetryPolicy(adapter, effectiveClient, effectivePolicyName, introspectedPolicies); p != nil {
+			return p
+		}
+	}
+	return nil
+}
+
 // EncodeRetryPolicy formats a retry.Policy into the compact string used by
 // the Metadata.RetryPolicy field. Examples:
 //

--- a/bamlutils/buildrequest/retry_policy.go
+++ b/bamlutils/buildrequest/retry_policy.go
@@ -90,6 +90,55 @@ func ResolveRetryPolicy(
 	return nil
 }
 
+// resolveRetryPolicyForClient is a primary-ignoring variant of
+// ResolveRetryPolicy used by ResolveStrategyAwareRetryPolicy's
+// leaf-fallback path. It mirrors the non-primary branch of
+// ResolveRetryPolicy exactly — same registry / introspected
+// priority, same nil-guards — but scans for clientName directly
+// rather than *reg.Primary.
+//
+// Why this is needed: ResolveRetryPolicy short-circuits to
+// reg.Primary when set, scanning ONLY for the primary entry and
+// then falling through to step 3 if the primary has no
+// retry_policy. So when the strategy wrapper is itself the
+// registry primary (a common production shape: client_registry
+// override pinned to the wrapper), calling ResolveRetryPolicy
+// with the leaf's name still keys the registry scan off the
+// primary and never reaches the leaf entry, silently shadowing
+// the leaf's runtime-registry retry_policy. The leaf-fallback
+// path needs a direct client-name scan to unshadow this.
+//
+// Per-request override priority is intentionally NOT consulted
+// here: the wrapper-first call in ResolveStrategyAwareRetryPolicy
+// already routes through ResolveRetryPolicy, which handles the
+// override before ever reaching the leaf-fallback. Re-checking
+// the override here would either no-op (override already
+// returned) or double-count (impossible since the override is
+// idempotent). Keeping this helper override-free keeps the
+// priority chain explicit at the strategy-aware level.
+func resolveRetryPolicyForClient(
+	adapter bamlutils.Adapter,
+	clientName, introspectedPolicyName string,
+	introspectedPolicies map[string]*retry.Policy,
+) *retry.Policy {
+	if reg := adapter.OriginalClientRegistry(); reg != nil && clientName != "" {
+		for _, client := range reg.Clients {
+			if client == nil {
+				continue
+			}
+			if client.Name == clientName && client.RetryPolicy != nil {
+				if p, ok := introspectedPolicies[*client.RetryPolicy]; ok {
+					return p
+				}
+			}
+		}
+	}
+	if introspectedPolicyName != "" {
+		return introspectedPolicies[introspectedPolicyName]
+	}
+	return nil
+}
+
 // ResolveStrategyAwareRetryPolicy resolves the retry policy for a request
 // where the originally-routed client (a strategy wrapper, like
 // baml-roundrobin or baml-fallback) may have been unwrapped to a leaf
@@ -112,6 +161,12 @@ func ResolveRetryPolicy(
 //
 // Pre-RR-unwrap callers (where strategyClient == effectiveClient) get
 // behavior identical to a single ResolveRetryPolicy call.
+//
+// The leaf-fallback (priority 3) deliberately routes through
+// resolveRetryPolicyForClient rather than ResolveRetryPolicy: when the
+// strategy wrapper is itself the registry primary, ResolveRetryPolicy's
+// primary-only scan never reaches the leaf entry, silently shadowing
+// the leaf's runtime-registry retry_policy.
 func ResolveStrategyAwareRetryPolicy(
 	adapter bamlutils.Adapter,
 	strategyClient, effectiveClient string,
@@ -122,7 +177,7 @@ func ResolveStrategyAwareRetryPolicy(
 		return p
 	}
 	if strategyClient != effectiveClient {
-		if p := ResolveRetryPolicy(adapter, effectiveClient, effectivePolicyName, introspectedPolicies); p != nil {
+		if p := resolveRetryPolicyForClient(adapter, effectiveClient, effectivePolicyName, introspectedPolicies); p != nil {
 			return p
 		}
 	}

--- a/integration/roundrobin_retry_test.go
+++ b/integration/roundrobin_retry_test.go
@@ -1,0 +1,118 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// ============================================================
+// baml-roundrobin wrapper retry_policy integration test
+//
+// Pins that the wrapper's retry_policy is honored even after
+// ResolveEffectiveClient unwraps the strategy to a leaf for
+// dispatch. Pre-fix the codegen keyed retry on the post-unwrap
+// leaf and silently dropped any retry_policy declared on the RR
+// wrapper itself; BAML's runtime
+// (LLMStrategyProvider::WithRetryPolicy) actually applies it
+// AROUND the strategy iteration, so the dropped policy was a
+// genuine semantic regression on the v0.219+ BuildRequest path.
+//
+// The test deliberately decouples its assertion from baml-rest's
+// once-per-REST-request RR cadence: it counts TOTAL hits across
+// the leaves rather than asserting that each retry hits a
+// different leaf. baml-rest intentionally diverges from upstream
+// here (advancing the RR coordinator once per request rather
+// than once per attempt); locking either rotation pattern into
+// the assertion would couple this fix to the separate cadence-
+// alignment work tracked in #167.
+// ============================================================
+
+func TestRoundRobinWrapperRetry(t *testing.T) {
+	skipIfNoBuildRequest(t)
+	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
+		t.Run("wrapper_retry_policy_applies_after_rr_unwrap", func(t *testing.T) {
+			if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+				t.Skip("Skipping: BuildRequest RR unwrap requires BAML >= 0.219.0")
+			}
+			waitForHealthy(t, 30*time.Second)
+			clearRoundRobinScenarios(t)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			// Both leaves fail every request. The wrapper has
+			// retry_policy max_retries=2 (3 attempts total). With
+			// the fix, the wrapper's policy applies despite the
+			// RR-unwrap reassigning __effective to a leaf with no
+			// retry_policy of its own. Without the fix the leaf
+			// is keyed for retry resolution and yields no retries
+			// → 1 hit total, 1 attempt, request fails immediately.
+			for _, id := range []string{"fallback-primary", "fallback-secondary"} {
+				registerRoundRobinScenario(t, &mockllm.Scenario{
+					ID:          id,
+					Provider:    "openai",
+					Content:     "unused",
+					FailAfter:   1,
+					FailureMode: "500",
+				})
+			}
+
+			resp, err := client.Call(ctx, testutil.CallRequest{
+				Method: "GetGreetingRoundRobinWithRetry",
+				Input:  map[string]any{"name": "World"},
+			})
+			if err != nil {
+				t.Fatalf("Call failed: %v", err)
+			}
+			// All RR children fail every attempt; baml-rest must
+			// surface the error rather than 200ing.
+			if resp.StatusCode == 200 {
+				t.Fatalf("Expected non-200 status when all RR children fail, got 200")
+			}
+
+			// Total hits == 1 initial + 2 retries from the
+			// wrapper's retry_policy (max_retries=2). A regression
+			// to leaf-keyed retry resolution would surface as
+			// total=1. We sum across both leaves rather than
+			// asserting a per-leaf count to remain agnostic to
+			// baml-rest's once-per-REST-request RR cadence (an
+			// intentional divergence from upstream's per-attempt
+			// rotation, tracked separately in #167).
+			ctxCount, cancelCount := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancelCount()
+			primaryHits, err := MockClient.GetRequestCount(ctxCount, "fallback-primary")
+			if err != nil {
+				t.Fatalf("Failed to get primary hit count: %v", err)
+			}
+			secondaryHits, err := MockClient.GetRequestCount(ctxCount, "fallback-secondary")
+			if err != nil {
+				t.Fatalf("Failed to get secondary hit count: %v", err)
+			}
+			total := primaryHits + secondaryHits
+			if total != 3 {
+				t.Errorf("Expected 3 total hits across RR leaves (1 initial + 2 retries from wrapper retry_policy max_retries=2), got %d (primary=%d, secondary=%d). Total of 1 indicates the wrapper's retry_policy was dropped by leaf-keyed retry resolution.", total, primaryHits, secondaryHits)
+			}
+
+			// X-BAML-Retry-Max must reflect the wrapper's
+			// retry_policy. This is a direct positive check on
+			// the metadata pipeline: even if the orchestrator
+			// somehow attempted 3 calls without honoring the
+			// wrapper's policy, the header would still expose the
+			// regression.
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLRetryMax, "2")
+
+			// X-BAML-RoundRobin-Name pins the strategy identity
+			// on the response — the planned-metadata pipeline
+			// must still report the wrapper as the routing
+			// origin, even though dispatch landed on a leaf.
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLRoundRobinName, "TestRoundRobinWithRetry")
+		})
+	})
+}

--- a/integration/testdata/baml_src/clients.baml
+++ b/integration/testdata/baml_src/clients.baml
@@ -90,3 +90,31 @@ client<llm> TestRoundRobinChain {
         strategy [FallbackPrimary, FallbackSecondary, FallbackTertiary]
     }
 }
+
+// ============================================================
+// Round-robin wrapper with its own retry_policy
+//
+// Pins the BAML semantic that LLMStrategyProvider::WithRetryPolicy
+// honors a retry_policy declared on the strategy wrapper itself
+// (applied AROUND the strategy iteration). The leaf clients here
+// have NO retry_policy of their own, so any retry behavior observed
+// when the wrapper is unwrapped to a leaf must be inherited from
+// the wrapper. Used by integration tests to verify codegen routes
+// wrapper retry through the post-RR-unwrap path on v0.219+.
+// ============================================================
+
+retry_policy RoundRobinWrapperRetry {
+    max_retries 2
+    strategy {
+        type constant_delay
+        delay_ms 50
+    }
+}
+
+client<llm> TestRoundRobinWithRetry {
+    provider round-robin
+    retry_policy RoundRobinWrapperRetry
+    options {
+        strategy [FallbackPrimary, FallbackSecondary]
+    }
+}

--- a/integration/testdata/baml_src/functions.baml
+++ b/integration/testdata/baml_src/functions.baml
@@ -219,3 +219,11 @@ function GetSimpleRoundRobin(input: string) -> SimpleOutput {
     prompt #"{{ ctx.output_format }}
     Process: {{ input }}"#
 }
+
+// RR wrapper that carries its own retry_policy. Verifies the
+// wrapper's max_retries propagates after RR unwrap (previously
+// dropped by codegen keying retry on the post-unwrap leaf).
+function GetGreetingRoundRobinWithRetry(name: string) -> string {
+    client TestRoundRobinWithRetry
+    prompt #"Say hello to {{ name }}"#
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes one item from the #167 follow-up tracker (strategy-wrapper retry policy ignored post-`__effective` unwrap).

## Bug

`adapters/common/codegen/codegen_router.go` emitted a retry resolution that keys `ClientRetryPolicy` on `__effective`. On the v0.219+ BuildRequest path, `ResolveEffectiveClient` overwrites `__effective` to the RR-selected leaf, so a `retry_policy` declared on the RR / fallback wrapper itself was dropped. BAML's runtime would have honored it: `LLMStrategyProvider::WithRetryPolicy` (`engine/baml-runtime/src/internal/llm_client/strategy/mod.rs:84-90`) returns the wrapper's policy, and `LLMProvider::call_with_strategy` wraps the whole provider in `ExecutionScope::Retry` BEFORE delegating into the inner orchestrator. The semantic is uniform across v0.204.0 / v0.215.0 / v0.219.0 — only v0.219+ BuildRequest unwrap exposed the codegen bug.

This was originally surfaced during PR #192 cold-review-1 BAML source rebuttal.

## Fix

- New helper `ResolveStrategyAwareRetryPolicy(adapter, strategyClient, effectiveClient, strategyPolicyName, effectivePolicyName, policies)` in `bamlutils/buildrequest/retry_policy.go`. Priority: per-request override → wrapper retry policy → leaf retry policy → nil. The `strategyClient != effectiveClient` guard suppresses the leaf-fallback branch when no RR unwrap happened, preserving identical behavior to a single `ResolveRetryPolicy` call.
- Codegen preserves the pre-unwrap client name as `__retryClient` (seeded from `ResolvePrimaryClient`). `__effective` is aliased from `__retryClient` at seed time and only the conditional `ResolveEffectiveClient` block reassigns `__effective`. Both flow into the new helper at the BuildRequest landing-block emit AND the always-emitted legacy `__legacyRetryPolicy` emit.
- Stale comment at `codegen_router.go:107-116` (which asserted retry config "isn't inherited from strategy wrappers") replaced with one that cites the BAML source path and explains the wrapper-first / leaf-fallback layering. Companion comment at the legacy-retry emit was also rewritten.

No introspection change — `cmd/introspect/main.go` already records wrapper retry policies; the codegen just didn't consult them.

## Out of scope

- baml-rest's once-per-REST-request RR advancement (intentional divergence from upstream's per-attempt rotation; separate #167 item).
- Fallback→RR composition broad fix (separate #167 item).
- Other #167 follow-ups.

## Test plan

- [x] `TestResolveStrategyAwareRetryPolicy` unit test covers wrapper-first / leaf-fallback / per-request override / both-nil / equal-name-no-unwrap / runtime-registry / leaf-fallback-uses-effective-name cases.
- [x] `TestEmitRouter_RetryResolutionUsesStrategyAwareHelper` renders the router and pins both `__retryClient` and `__effective` (and the corresponding `ClientRetryPolicy[]` lookups) into every retry resolution call. Includes a negative pin against the symmetric wrong-shape that would silently revert to leaf-only retry.
- [x] Integration test `TestRoundRobinWrapperRetry` exercises an RR wrapper carrying `retry_policy max_retries=2` with both leaves failing. Total leaf hits = 3 (1 initial + 2 retries) confirms the wrapper's policy applies; assertion sums across leaves to remain agnostic to baml-rest's once-per-REST-request RR cadence.
- [x] Existing retry/fallback/RR integration tests pass unchanged (BAML_REST_USE_BUILD_REQUEST=true).
- [x] Per-adapter `GOWORK=off go test ./adapter/` for v0.204.0 / v0.215.0 / v0.219.0 — all PASS.
- [x] `cmd/verify-framework-adapter` — 9/9.
- [x] `cmd/verify-adapter-pins` — all 4 pinned versions match.
- [x] `go run ./cmd/embed && git diff embed.go` — empty (no embedded file changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry resolution now follows wrapper-first, leaf-fallback semantics so wrapper-level retry settings are preserved after dispatch, fixing dropped wrapper retry behavior.

* **Tests**
  * Added unit and integration tests validating strategy-aware retry resolution, leaf-fallback behavior, and round-robin wrapper retry propagation (ensuring correct retry counts and retry-related response metadata).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/236)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->