### PR TITLE
refactor(buildrequest): model fallback child targets in metadata

### DIFF
--- a/bamlutils/buildrequest/call_orchestrator.go
+++ b/bamlutils/buildrequest/call_orchestrator.go
@@ -62,6 +62,20 @@ type CallConfig struct {
 	// Mirrors StreamConfig.LegacyChildren — see that field for details.
 	LegacyChildren map[string]bool
 
+	// FallbackTargets mirrors StreamConfig.FallbackTargets — see that
+	// field (and Metadata.FallbackTargets) for the contract. PR 1 adds
+	// the field; PR 2 (issue #237) wires the call-side BuildRequest
+	// dispatch loop to honour FallbackTargets[child] when computing the
+	// WithClient target for centrally-unwrapped RR fallback children.
+	FallbackTargets map[string]string
+
+	// FallbackRoundRobin mirrors StreamConfig.FallbackRoundRobin —
+	// per-child RR decisions for fallback children resolved through
+	// BuildRequest centralization. PR 1 adds the field; PR 2 populates
+	// it from resolver output so outgoing planned metadata describes
+	// the selected leaf alongside the RR decision behind it.
+	FallbackRoundRobin map[string]*bamlutils.RoundRobinInfo
+
 	// MetadataPlan is the pre-computed planned metadata for this request.
 	// See StreamConfig.MetadataPlan for the contract; the call orchestrator
 	// behaves identically — planned metadata is emitted upfront from the
@@ -404,6 +418,12 @@ func RunCallOrchestration(
 		outcome.RetryPolicy = ""
 		outcome.Chain = nil
 		outcome.LegacyChildren = nil
+		// See the streaming orchestrator's outcome builder for the
+		// rationale on clearing these planned-only fallback-target
+		// fields — issue #237's planned shape describes intent, the
+		// realised winner already appears in WinnerClient.
+		outcome.FallbackTargets = nil
+		outcome.FallbackRoundRobin = nil
 		outcome.Strategy = ""
 		outcome.Provider = ""
 

--- a/bamlutils/buildrequest/metadata.go
+++ b/bamlutils/buildrequest/metadata.go
@@ -78,6 +78,21 @@ const (
 	// composition and know not to expect fleet-wide rotation for the
 	// nested client.
 	PathReasonFallbackRoundRobinChildLegacy = "fallback-roundrobin-child-legacy"
+	// PathReasonFallbackRoundRobinChildBuildRequest reports that an
+	// immediate baml-roundrobin fallback child was centrally unwrapped
+	// to a leaf and dispatched via the BuildRequest path, rather than
+	// handed off to BAML's per-worker runtime through the legacy
+	// callback. The selected leaf appears in Metadata.FallbackTargets
+	// keyed by the RR wrapper's chain-position name, and the RR
+	// decision itself appears in Metadata.FallbackRoundRobin under the
+	// same key.
+	//
+	// Distinct from PathReasonFallbackRoundRobinChildLegacy, which
+	// keeps describing nested RR children that remain on the legacy
+	// callback (deferred shapes, unsupported leaves, invalid
+	// `options.strategy` / `options.start` overrides). New in issue
+	// #237 PR 1 (vocabulary only); consumed starting in PR 2.
+	PathReasonFallbackRoundRobinChildBuildRequest = "fallback-roundrobin-child-buildrequest"
 	// PathReasonBuildRequestDisabled: BAML_REST_USE_BUILD_REQUEST is off.
 	// Deliberate configuration — no operator alert.
 	PathReasonBuildRequestDisabled = "buildrequest-disabled"

--- a/bamlutils/buildrequest/metadata_orchestrator_test.go
+++ b/bamlutils/buildrequest/metadata_orchestrator_test.go
@@ -256,6 +256,143 @@ func TestRunCallOrchestration_NoMetadataPlanIsNoop(t *testing.T) {
 	}
 }
 
+// TestRunStreamOrchestration_OutcomeClearsFallbackTargetFields pins
+// that the outcome event drops the planned-only fallback-target
+// vocabulary added in issue #237 PR 1 (FallbackTargets,
+// FallbackRoundRobin), alongside the existing Chain / LegacyChildren
+// clearing. Planned metadata describes intent (which RR-wrapper child
+// was unwrapped to which leaf, which RR decision was behind it); the
+// realised winner is already encoded in WinnerClient on outcome, so
+// duplicating the planned-shape on outcome only inflates the payload.
+//
+// PR 1 never populates these fields, but the test seeds the plan with
+// representative values so the clearing logic is observable. PR 2 will
+// have the resolver actually populate them; this test pins the
+// contract before the producer lands so PR 2 cannot accidentally leak
+// planned-only intent into outcome.
+func TestRunStreamOrchestration_OutcomeClearsFallbackTargetFields(t *testing.T) {
+	server := makeOpenAIServer([]string{"hi"})
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	plan := &bamlutils.Metadata{
+		Path:     "buildrequest",
+		Client:   "MyClient",
+		Provider: "openai",
+		FallbackTargets: map[string]string{
+			"InnerRR": "A",
+		},
+		FallbackRoundRobin: map[string]*bamlutils.RoundRobinInfo{
+			"InnerRR": {Name: "InnerRR", Children: []string{"A", "B"}, Selected: "A"},
+		},
+	}
+
+	config := &StreamConfig{
+		Provider:          "openai",
+		MetadataPlan:      plan,
+		NewMetadataResult: newTestMetadataResult,
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(),
+		out,
+		config,
+		client,
+		func(ctx context.Context, _ string) (*llmhttp.Request, error) {
+			return &llmhttp.Request{URL: server.URL, Method: "POST", Body: `{}`}, nil
+		},
+		func(ctx context.Context, s string) (any, error) { return s, nil },
+		func(ctx context.Context, s string) (any, error) { return s, nil },
+		newTestResult,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	close(out)
+
+	planned, outcome, _, _ := collectMetadata(t, out)
+	if planned == nil || outcome == nil {
+		t.Fatalf("expected both planned and outcome metadata; got planned=%v outcome=%v", planned, outcome)
+	}
+	// Sanity: planned event carries the seeded values so the test
+	// proves the clearing happened on outcome specifically, not that
+	// the seeded values silently dropped through marshaling.
+	if planned.FallbackTargets["InnerRR"] != "A" {
+		t.Errorf("planned FallbackTargets[InnerRR]: got %q, want A", planned.FallbackTargets["InnerRR"])
+	}
+	if planned.FallbackRoundRobin["InnerRR"] == nil {
+		t.Errorf("planned FallbackRoundRobin[InnerRR]: nil, want non-nil")
+	}
+	// Contract: outcome event clears the planned-only fields.
+	if outcome.FallbackTargets != nil {
+		t.Errorf("outcome FallbackTargets must be cleared; got %v", outcome.FallbackTargets)
+	}
+	if outcome.FallbackRoundRobin != nil {
+		t.Errorf("outcome FallbackRoundRobin must be cleared; got %v", outcome.FallbackRoundRobin)
+	}
+}
+
+// TestRunCallOrchestration_OutcomeClearsFallbackTargetFields mirrors
+// the streaming test above for the non-streaming call path. See the
+// streaming test for rationale on why the planned-only fields must
+// clear on outcome.
+func TestRunCallOrchestration_OutcomeClearsFallbackTargetFields(t *testing.T) {
+	server := makeJSONServer(200, `{"choices":[{"message":{"content":"hi"}}]}`)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	plan := &bamlutils.Metadata{
+		Path:     "buildrequest",
+		Client:   "MyClient",
+		Provider: "openai",
+		FallbackTargets: map[string]string{
+			"InnerRR": "A",
+		},
+		FallbackRoundRobin: map[string]*bamlutils.RoundRobinInfo{
+			"InnerRR": {Name: "InnerRR", Children: []string{"A", "B"}, Selected: "A"},
+		},
+	}
+
+	config := &CallConfig{
+		Provider:          "openai",
+		MetadataPlan:      plan,
+		NewMetadataResult: newTestMetadataResult,
+	}
+
+	err := RunCallOrchestration(
+		context.Background(), out, config, client,
+		makeBuildCallRequest(server.URL),
+		identityParseFinal,
+		ExtractResponseContent,
+		newTestResult,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	close(out)
+
+	planned, outcome, _, _ := collectMetadata(t, out)
+	if planned == nil || outcome == nil {
+		t.Fatalf("expected both planned and outcome metadata; got planned=%v outcome=%v", planned, outcome)
+	}
+	if planned.FallbackTargets["InnerRR"] != "A" {
+		t.Errorf("planned FallbackTargets[InnerRR]: got %q, want A", planned.FallbackTargets["InnerRR"])
+	}
+	if planned.FallbackRoundRobin["InnerRR"] == nil {
+		t.Errorf("planned FallbackRoundRobin[InnerRR]: nil, want non-nil")
+	}
+	if outcome.FallbackTargets != nil {
+		t.Errorf("outcome FallbackTargets must be cleared; got %v", outcome.FallbackTargets)
+	}
+	if outcome.FallbackRoundRobin != nil {
+		t.Errorf("outcome FallbackRoundRobin must be cleared; got %v", outcome.FallbackRoundRobin)
+	}
+}
+
 // TestRunStreamOrchestration_NoMetadataPlanIsNoop verifies that callers
 // who don't care about routing metadata (legacy tests, deliberate opt-out)
 // see no metadata events at all.

--- a/bamlutils/buildrequest/metadata_resolve_test.go
+++ b/bamlutils/buildrequest/metadata_resolve_test.go
@@ -3,6 +3,7 @@ package buildrequest
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/invakid404/baml-rest/bamlutils"
@@ -155,6 +156,17 @@ func TestBuildSingleProviderPlan(t *testing.T) {
 	if plan.RetryMax != nil {
 		t.Errorf("RetryMax should be nil when policy is nil; got %v", plan.RetryMax)
 	}
+	// Issue #237 PR 1 introduces FallbackTargets / FallbackRoundRobin
+	// as vocabulary fields. Single-provider plans never have fallback
+	// children to describe, so the builder must leave both nil. PR 2
+	// only ever populates them for fallback-chain plans whose immediate
+	// RR children resolve to a BR-drivable leaf.
+	if plan.FallbackTargets != nil {
+		t.Errorf("single-provider plan must not set FallbackTargets; got %v", plan.FallbackTargets)
+	}
+	if plan.FallbackRoundRobin != nil {
+		t.Errorf("single-provider plan must not set FallbackRoundRobin; got %v", plan.FallbackRoundRobin)
+	}
 }
 
 func TestBuildSingleProviderPlan_StreamRequestAPI(t *testing.T) {
@@ -178,6 +190,69 @@ func TestBuildFallbackChainPlan_APIFieldCarriesThrough(t *testing.T) {
 	}
 	if plan.PathReason != "" {
 		t.Errorf("pathReason: got %q, want empty (no reason passed)", plan.PathReason)
+	}
+}
+
+// TestBuildFallbackChainPlan_FallbackTargetFieldsLeftEmpty pins that
+// the PR 1 vocabulary additions stay nil under the existing plan-builder
+// signatures (issue #237). PR 2 introduces the producer that populates
+// these maps for the narrow centralised-RR case; PR 1 keeps the wire
+// shape identical to pre-#237 for every plan the builders emit.
+func TestBuildFallbackChainPlan_FallbackTargetFieldsLeftEmpty(t *testing.T) {
+	adapter := &mockAdapter{Context: context.Background()}
+	chain := []string{"A", "B"}
+	providers := map[string]string{"A": "openai", "B": "anthropic"}
+
+	t.Run("adapter-based builder", func(t *testing.T) {
+		plan := BuildFallbackChainPlan(adapter, "Strategy", chain, providers, nil, nil, BuildRequestAPIStreamRequest, "")
+		if plan.FallbackTargets != nil {
+			t.Errorf("FallbackTargets must be nil before PR 2 wires the producer; got %v", plan.FallbackTargets)
+		}
+		if plan.FallbackRoundRobin != nil {
+			t.Errorf("FallbackRoundRobin must be nil before PR 2 wires the producer; got %v", plan.FallbackRoundRobin)
+		}
+		// JSON encoding must omit the new keys entirely so the wire
+		// shape remains byte-identical to pre-#237 for these plans.
+		data, err := json.Marshal(plan)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if got := string(data); strings.Contains(got, `"fallback_targets"`) || strings.Contains(got, `"fallback_round_robin"`) {
+			t.Errorf("planned JSON must not carry the new fallback-target keys; got %s", got)
+		}
+	})
+
+	t.Run("client-name builder", func(t *testing.T) {
+		plan := BuildFallbackChainPlanForClient("Strategy", chain, providers, nil, nil, BuildRequestAPIStreamRequest, "")
+		if plan.FallbackTargets != nil {
+			t.Errorf("FallbackTargets must be nil before PR 2 wires the producer; got %v", plan.FallbackTargets)
+		}
+		if plan.FallbackRoundRobin != nil {
+			t.Errorf("FallbackRoundRobin must be nil before PR 2 wires the producer; got %v", plan.FallbackRoundRobin)
+		}
+	})
+}
+
+// TestBuildLegacyMetadataPlan_FallbackTargetFieldsLeftEmpty pins the
+// same vocabulary-only invariant for the legacy plan builders. PR 1
+// never produces fallback-target metadata on the legacy path either —
+// the centralisation behaviour PR 2 adds is BuildRequest-only.
+func TestBuildLegacyMetadataPlan_FallbackTargetFieldsLeftEmpty(t *testing.T) {
+	adapter := &mockAdapter{Context: context.Background()}
+	plan := BuildLegacyMetadataPlan(adapter, "MyClient", "aws-bedrock", nil, nil, IsProviderSupported, nil)
+	if plan.FallbackTargets != nil {
+		t.Errorf("legacy plan must not set FallbackTargets; got %v", plan.FallbackTargets)
+	}
+	if plan.FallbackRoundRobin != nil {
+		t.Errorf("legacy plan must not set FallbackRoundRobin; got %v", plan.FallbackRoundRobin)
+	}
+
+	planForClient := BuildLegacyMetadataPlanForClient(nil, "MyClient", "aws-bedrock", nil, nil, IsProviderSupported, nil)
+	if planForClient.FallbackTargets != nil {
+		t.Errorf("legacy plan (for-client) must not set FallbackTargets; got %v", planForClient.FallbackTargets)
+	}
+	if planForClient.FallbackRoundRobin != nil {
+		t.Errorf("legacy plan (for-client) must not set FallbackRoundRobin; got %v", planForClient.FallbackRoundRobin)
 	}
 }
 

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -241,6 +241,24 @@ type StreamConfig struct {
 	// fails up-front validation otherwise.
 	LegacyChildren map[string]bool
 
+	// FallbackTargets is the dispatch-target counterpart of the metadata
+	// field of the same name on bamlutils.Metadata — see that field's
+	// doc string for the wire-shape contract. PR 1 adds the field; PR 2
+	// (issue #237) wires the BuildRequest dispatch loop to honour
+	// FallbackTargets[child] when computing the WithClient target for
+	// an immediate RR fallback child that was centrally unwrapped to a
+	// leaf. The orchestrator is the consumer; resolver/planning
+	// upstream is the producer.
+	FallbackTargets map[string]string
+
+	// FallbackRoundRobin mirrors Metadata.FallbackRoundRobin — the
+	// per-child RR decision for fallback children resolved through
+	// BuildRequest centralization. PR 1 adds the field; PR 2 wires
+	// resolver output to populate it so outgoing planned metadata
+	// describes both the selected leaf (FallbackTargets[child]) and
+	// the RR decision behind that selection.
+	FallbackRoundRobin map[string]*bamlutils.RoundRobinInfo
+
 	// MetadataPlan is the pre-computed planned metadata for this request.
 	// When non-nil, the orchestrator emits a single planned metadata event
 	// upfront — before any HTTP work — so the routing decision is observable
@@ -629,6 +647,16 @@ func RunStreamOrchestration(
 		outcome.RetryPolicy = ""
 		outcome.Chain = nil
 		outcome.LegacyChildren = nil
+		// FallbackTargets / FallbackRoundRobin describe PLANNED
+		// fallback-chain intent — which RR-wrapper children were
+		// centrally unwrapped to leaves and which leaves the RR
+		// decision picked (issue #237). The realised winner is
+		// encoded in WinnerClient on outcome, so retaining these
+		// planned-only fields duplicates information and inflates
+		// the outcome payload. Clear them alongside Chain /
+		// LegacyChildren for the same reason.
+		outcome.FallbackTargets = nil
+		outcome.FallbackRoundRobin = nil
 		outcome.Strategy = ""
 		outcome.Provider = ""
 

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -56,10 +56,20 @@ const (
 // only on one path (e.g. RetryCount on BuildRequest, BamlCallCount on
 // legacy) — see per-field doc strings for the contract.
 type Metadata struct {
-	Phase      MetadataPhase `json:"phase"`                 // "planned" or "outcome"
-	Attempt    int           `json:"attempt"`               // pool-level attempt number (0-based). Orchestrator emits 0; pool rewrites.
-	Path       string        `json:"path"`                  // "buildrequest" or "legacy"
-	PathReason string        `json:"path_reason,omitempty"` // legacy classification enum; empty when Path=="buildrequest"
+	Phase   MetadataPhase `json:"phase"`   // "planned" or "outcome"
+	Attempt int           `json:"attempt"` // pool-level attempt number (0-based). Orchestrator emits 0; pool rewrites.
+	Path    string        `json:"path"`    // "buildrequest" or "legacy"
+	// PathReason is an informational routing-classification token. It
+	// historically reported only legacy-side classifications (unsupported
+	// provider, empty provider, fallback-empty-chain, etc.) and was
+	// documented as "empty when Path==buildrequest". Since #237 PR 1 it
+	// also carries BuildRequest-side informational reasons — most
+	// notably PathReasonFallbackRoundRobinChildBuildRequest, set when an
+	// immediate RR fallback child was centrally unwrapped to a leaf and
+	// dispatched via BuildRequest rather than the legacy callback. The
+	// field still defaults to empty when there's nothing informational
+	// to report.
+	PathReason string `json:"path_reason,omitempty"`
 
 	// BuildRequestAPI identifies which BAML API drove a Path=="buildrequest"
 	// request. "request" means the non-streaming Request API (unary HTTP,
@@ -105,6 +115,38 @@ type Metadata struct {
 	// decision — inner RR strategies still advance their own counters but are
 	// not reported separately.
 	RoundRobin *RoundRobinInfo `json:"round_robin,omitempty"`
+
+	// FallbackTargets is a sparse map from fallback chain child names to
+	// the target client actually dispatched, populated when an immediate
+	// RR fallback child is centrally unwrapped to a leaf and driven via
+	// BuildRequest rather than handed to BAML's per-worker runtime
+	// through the legacy callback (see issue #237). The map is sparse —
+	// entries are omitted when target == child, so a chain whose
+	// children all dispatch verbatim leaves this field nil.
+	//
+	// PR 1 introduces the field; consumers populate it starting in
+	// PR 2 (resolver/orchestrator dispatch). Outcome events clear this
+	// field — the planned phase describes intent, while the realised
+	// winner is encoded in WinnerClient on outcome.
+	FallbackTargets map[string]string `json:"fallback_targets,omitempty"`
+
+	// FallbackRoundRobin reports the round-robin selection for fallback
+	// chain children that resolved through BuildRequest centralization
+	// (see issue #237). Keyed by the fallback chain child name (the RR
+	// wrapper), valued by the per-child RoundRobinInfo describing which
+	// leaf was picked.
+	//
+	// Distinct from the top-level RoundRobin field, which always
+	// describes the OUTERMOST RR decision — reusing it for nested
+	// fallback RR would collide with compositions like
+	// rr[fallback[rr[A,B], C], D] and would change the meaning of
+	// existing unary headers. A per-child map keeps the two concepts
+	// separate.
+	//
+	// PR 1 introduces the field; consumers populate it starting in
+	// PR 2. Outcome events clear this field for the same reason
+	// FallbackTargets is cleared.
+	FallbackRoundRobin map[string]*RoundRobinInfo `json:"fallback_round_robin,omitempty"`
 }
 
 // RoundRobinInfo captures the outcome of resolving a baml-roundrobin strategy

--- a/bamlutils/metadata_test.go
+++ b/bamlutils/metadata_test.go
@@ -1,6 +1,7 @@
 package bamlutils
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -150,6 +151,107 @@ func TestMetadata_JSONRoundtrip(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMetadata_FallbackTargetsAndRoundRobinRoundtrip verifies the new
+// fallback-target vocabulary added in issue #237 PR 1 (FallbackTargets,
+// FallbackRoundRobin) survives a JSON encode → decode cycle, AND that
+// both fields honour their `omitempty` JSON tags for the nil and empty-
+// map cases.
+//
+// The nil / empty-map invariant is load-bearing: PR 2 will start
+// populating these fields on a narrow set of plans, so the existing wire
+// shape (no `fallback_targets` / `fallback_round_robin` keys at all) must
+// hold for every plan PR 1's behaviour-neutral builders emit. A regression
+// that emits empty-but-non-nil maps would change the wire shape for every
+// existing caller.
+func TestMetadata_FallbackTargetsAndRoundRobinRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populated", func(t *testing.T) {
+		t.Parallel()
+		md := Metadata{
+			Phase:    MetadataPhasePlanned,
+			Path:     "buildrequest",
+			Client:   "Strategy",
+			Strategy: "baml-fallback",
+			Chain:    []string{"InnerRR", "Backup"},
+			FallbackTargets: map[string]string{
+				"InnerRR": "A",
+			},
+			FallbackRoundRobin: map[string]*RoundRobinInfo{
+				"InnerRR": {
+					Name:     "InnerRR",
+					Children: []string{"A", "B"},
+					Index:    0,
+					Selected: "A",
+				},
+			},
+		}
+		data, err := json.Marshal(&md)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !bytes.Contains(data, []byte(`"fallback_targets"`)) {
+			t.Errorf("populated FallbackTargets should appear on the wire; got %s", data)
+		}
+		if !bytes.Contains(data, []byte(`"fallback_round_robin"`)) {
+			t.Errorf("populated FallbackRoundRobin should appear on the wire; got %s", data)
+		}
+		var got Metadata
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.FallbackTargets["InnerRR"] != "A" {
+			t.Errorf("FallbackTargets[InnerRR]: got %q, want A", got.FallbackTargets["InnerRR"])
+		}
+		rr, ok := got.FallbackRoundRobin["InnerRR"]
+		if !ok || rr == nil {
+			t.Fatalf("FallbackRoundRobin[InnerRR] missing; got map=%v", got.FallbackRoundRobin)
+		}
+		if rr.Name != "InnerRR" || rr.Selected != "A" || rr.Index != 0 || len(rr.Children) != 2 {
+			t.Errorf("FallbackRoundRobin[InnerRR]: got %+v", rr)
+		}
+	})
+
+	t.Run("nil fields are omitted", func(t *testing.T) {
+		t.Parallel()
+		md := Metadata{Phase: MetadataPhasePlanned, Path: "buildrequest"}
+		data, err := json.Marshal(&md)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if bytes.Contains(data, []byte(`"fallback_targets"`)) {
+			t.Errorf("nil FallbackTargets must be omitted from wire; got %s", data)
+		}
+		if bytes.Contains(data, []byte(`"fallback_round_robin"`)) {
+			t.Errorf("nil FallbackRoundRobin must be omitted from wire; got %s", data)
+		}
+	})
+
+	t.Run("empty maps are omitted", func(t *testing.T) {
+		t.Parallel()
+		md := Metadata{
+			Phase:              MetadataPhasePlanned,
+			Path:               "buildrequest",
+			FallbackTargets:    map[string]string{},
+			FallbackRoundRobin: map[string]*RoundRobinInfo{},
+		}
+		data, err := json.Marshal(&md)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		// Maps with `omitempty` drop on len()==0, so the wire shape
+		// for an explicit empty map is identical to nil. PR 2 will
+		// populate these maps for a narrow set of plans only, so every
+		// other plan keeps the existing wire payload byte-for-byte.
+		if bytes.Contains(data, []byte(`"fallback_targets"`)) {
+			t.Errorf("empty FallbackTargets must be omitted from wire; got %s", data)
+		}
+		if bytes.Contains(data, []byte(`"fallback_round_robin"`)) {
+			t.Errorf("empty FallbackRoundRobin must be omitted from wire; got %s", data)
+		}
+	})
 }
 
 // TestMetadata_AbsenceVsZero verifies the distinction between an absent


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

PR 1 of #237's 3-PR plan. **Behavior-neutral** vocabulary additions; consumers land in PR 2 (resolver/orchestrator dispatch) and PR 3 (codegen + integration tests).

## What's added

- `Metadata.FallbackTargets map[string]string` — sparse map from fallback chain child names to the actual dispatch target. Wire shape: `omitempty`, `"fallback_targets"`.
- `Metadata.FallbackRoundRobin map[string]*RoundRobinInfo` — RR selection per fallback chain child that resolved through BuildRequest centralization. Distinct from top-level `Metadata.RoundRobin` (which stays the outermost-RR field).
- Same fields on `StreamConfig` and `CallConfig`.
- New constant `PathReasonFallbackRoundRobinChildBuildRequest = "fallback-roundrobin-child-buildrequest"`.
- `Metadata.PathReason` doc broadened to allow informational BuildRequest reasons (it was previously documented as legacy-only).

## Behavior preservation

All new fields use `omitempty` JSON tags. Builders leave them nil/empty for now. Outcome metadata clears them alongside the existing `Chain` / `LegacyChildren` clearing — since they describe planned-only intent.

No existing test changes expected.

## Test plan

- [ ] `Metadata` JSON round-trip tests for the new fields (populated, nil, empty-map cases).
- [ ] Existing plan-builder tests still pass; new assertions that builders leave the fields empty.
- [ ] Existing outcome-metadata tests still pass; assertions that the new fields are cleared on outcome events.
- [ ] `verify-framework-adapter` 9/9.
- [ ] `verify-adapter-pins` 4/4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced metadata system to explicitly track fallback dispatch targets and round-robin selection information, providing clearer visibility into routing decisions across both planned and outcome phases.

* **Tests**
  * Added comprehensive test coverage for metadata serialization and orchestration behavior, validating proper handling of fallback-target fields.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/238)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->