### PR TITLE
feat(buildrequest): resolve immediate RR children inside fallback chains

### DIFF
--- a/bamlutils/buildrequest/call_orchestrator.go
+++ b/bamlutils/buildrequest/call_orchestrator.go
@@ -362,7 +362,11 @@ func RunCallOrchestration(
 				// Legacy children run via BAML's Stream API. The callback
 				// owns heartbeat timing (fires sendHeartbeat on the first
 				// FunctionLog tick) so pool hung-detection stays correct
-				// for slow upstreams that eventually produce bytes.
+				// for slow upstreams that eventually produce bytes. Note:
+				// callback dispatch stays rooted at `child` (the
+				// chain-position name) — FallbackTargets is honored only
+				// for the BuildRequest path, since the legacy callback's
+				// scoped registry depends on the wrapper identity.
 				finalResult, raw, err := config.LegacyCallChild(
 					ctx,
 					child,
@@ -384,10 +388,19 @@ func RunCallOrchestration(
 				continue
 			}
 			provider := config.ClientProviders[child]
-			result, err := tryOneChild(provider, child)
+			// Wrapper-vs-target identity (issue #237 PR 2): when an
+			// immediate RR fallback child was centrally unwrapped to a
+			// leaf, FallbackTargets[child] names that leaf. Mirrors the
+			// streaming orchestrator — see RunStreamOrchestration for
+			// the full rationale.
+			target := child
+			if t, ok := config.FallbackTargets[child]; ok && t != "" {
+				target = t
+			}
+			result, err := tryOneChild(provider, target)
 			if err == nil {
 				finalAttempt = attempt
-				result.winnerClient = child
+				result.winnerClient = target
 				return result, nil
 			}
 			lastErr = err

--- a/bamlutils/buildrequest/fallback_resolve.go
+++ b/bamlutils/buildrequest/fallback_resolve.go
@@ -2,6 +2,7 @@ package buildrequest
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/bamlutils/buildrequest/roundrobin"
@@ -130,11 +131,23 @@ func ResolveFallbackChainPlanForClient(
 	chainLegacy := make(map[string]bool)
 	var targets map[string]string
 	var nestedRR map[string]*bamlutils.RoundRobinInfo
+	// rrChildPositions tracks the chain index of each immediate RR
+	// fallback child seen so far. The typed Targets / NestedRoundRobin
+	// maps and the orchestrator's FallbackTargets config are all keyed
+	// by child name, while FallbackChain is positional — so a chain
+	// like [InnerRR, InnerRR, C] would silently overwrite the first
+	// iteration's per-child writes with the second's, and the
+	// orchestrator (iterating positionally, looking up by name) would
+	// dispatch BOTH iterations to the second's target. Reject
+	// duplicates request-fatal at the typed seam; the 4-tuple wrapper's
+	// hard-error → legacy demotion preserves codegen-driven dispatch
+	// behaviour.
+	var rrChildPositions map[string]int
 	legacyPositions := 0
 	hasRoundRobinChildLegacy := false
 	hasRoundRobinChildCentralized := false
 
-	for _, child := range resolvedChain {
+	for i, child := range resolvedChain {
 		if hasInvalidProviderOverride(reg, child) {
 			return &FallbackChainResolution{Reason: PathReasonInvalidProviderOverride}, nil
 		}
@@ -161,10 +174,16 @@ func ResolveFallbackChainPlanForClient(
 		//   1. Resolved provider is RR (this branch).
 		//   2. Invalid-override preflight passed (handled above for
 		//      every strategy child).
-		//   3. RR resolution yields a selected leaf without a hard error.
-		//   4. Selected leaf is non-strategy (not RR, not fallback).
-		//   5. Selected leaf's provider is non-empty AND supported by
-		//      isProviderSupported (or isProviderSupported is non-nil).
+		//   3. isProviderSupported is non-nil — the precondition for
+		//      ANY centralization attempt. Without a support predicate
+		//      we can't determine BR-eligibility for the selected leaf,
+		//      so attempting RR resolution is wasted work — and for a
+		//      remote advancer it would burn an idempotency-cache slot
+		//      via a host round-trip whose result we'd discard.
+		//   4. RR resolution yields a selected leaf without a hard error.
+		//   5. Selected leaf is non-strategy (not RR, not fallback).
+		//   6. Selected leaf's provider is non-empty AND supported by
+		//      isProviderSupported.
 		//
 		// Hard errors from roundrobin.Resolve — cycle detection, empty
 		// children, advancer transport errors, out-of-range indices —
@@ -176,45 +195,70 @@ func ResolveFallbackChainPlanForClient(
 		// surfaces as a top-level legacy fallthrough rather than a
 		// silent request-fatal.
 		if roundrobin.IsRoundRobinProvider(p) {
-			leaf, leafProvider, info, err := resolveImmediateRRChild(reg, child, fallbackChains, clientProviders, advancer)
-			if err != nil {
-				if errors.Is(err, roundrobin.ErrInvalidStrategyOverride) {
-					return &FallbackChainResolution{Reason: PathReasonInvalidStrategyOverride}, nil
-				}
-				if errors.Is(err, roundrobin.ErrInvalidStartOverride) {
-					return &FallbackChainResolution{Reason: PathReasonInvalidRoundRobinStartOverride}, nil
-				}
-				// Hard error — propagate to the caller; the request
-				// fails fast, matching top-level RR semantics.
-				return nil, err
+			// Duplicate-RR-child guard runs FIRST (before the
+			// nil-support short-circuit) so an operator-broken chain
+			// is rejected regardless of whether centralization would
+			// even be attempted on a single iteration.
+			if prev, seen := rrChildPositions[child]; seen {
+				return nil, fmt.Errorf(
+					"buildrequest: fallback %q contains duplicate round-robin child %q at positions %d and %d",
+					clientName, child, prev, i,
+				)
 			}
-			if isCentralizationEligible(leaf, leafProvider, isProviderSupported) {
-				// Centralize: drop legacy classification, surface
-				// leaf provider for support gating, record the
-				// dispatch target and RR decision.
-				chainProviders[child] = leafProvider
-				if leaf != child {
-					if targets == nil {
-						targets = make(map[string]string)
-					}
-					targets[child] = leaf
-				}
-				if info != nil {
-					if nestedRR == nil {
-						nestedRR = make(map[string]*bamlutils.RoundRobinInfo)
-					}
-					nestedRR[child] = info
-				}
-				hasRoundRobinChildCentralized = true
-				continue
+			if rrChildPositions == nil {
+				rrChildPositions = make(map[string]int)
 			}
-			// Ineligible — fall through to the legacy classification
-			// path below. The wrapper provider stays on chainProviders
-			// (already set above before the centralization attempt
-			// rewrote it for the success path; rewrite the value back
-			// since the centralization attempt didn't take).
-			chainProviders[child] = p
-			hasRoundRobinChildLegacy = true
+			rrChildPositions[child] = i
+
+			if isProviderSupported == nil {
+				// Precondition #3 fails — skip the advance entirely
+				// and let the legacy-classification block below mark
+				// the wrapper as legacy. This keeps the documented
+				// nil-support contract (see isCentralizationEligible)
+				// honest: we never call into the advancer for a
+				// branch we already know is going to be discarded.
+				hasRoundRobinChildLegacy = true
+			} else {
+				leaf, leafProvider, info, err := resolveImmediateRRChild(reg, child, fallbackChains, clientProviders, advancer)
+				if err != nil {
+					if errors.Is(err, roundrobin.ErrInvalidStrategyOverride) {
+						return &FallbackChainResolution{Reason: PathReasonInvalidStrategyOverride}, nil
+					}
+					if errors.Is(err, roundrobin.ErrInvalidStartOverride) {
+						return &FallbackChainResolution{Reason: PathReasonInvalidRoundRobinStartOverride}, nil
+					}
+					// Hard error — propagate to the caller; the request
+					// fails fast, matching top-level RR semantics.
+					return nil, err
+				}
+				if isCentralizationEligible(leaf, leafProvider, isProviderSupported) {
+					// Centralize: drop legacy classification, surface
+					// leaf provider for support gating, record the
+					// dispatch target and RR decision.
+					chainProviders[child] = leafProvider
+					if leaf != child {
+						if targets == nil {
+							targets = make(map[string]string)
+						}
+						targets[child] = leaf
+					}
+					if info != nil {
+						if nestedRR == nil {
+							nestedRR = make(map[string]*bamlutils.RoundRobinInfo)
+						}
+						nestedRR[child] = info
+					}
+					hasRoundRobinChildCentralized = true
+					continue
+				}
+				// Ineligible — fall through to the legacy classification
+				// path below. The wrapper provider stays on chainProviders
+				// (already set above before the centralization attempt
+				// rewrote it for the success path; rewrite the value back
+				// since the centralization attempt didn't take).
+				chainProviders[child] = p
+				hasRoundRobinChildLegacy = true
+			}
 		}
 
 		// Strategy-provider children (RR — ineligible, fallback)
@@ -290,14 +334,18 @@ func resolveImmediateRRChild(
 }
 
 // isCentralizationEligible enforces the leaf-side eligibility checks
-// (#4 non-strategy leaf, #5 BR-supported leaf provider). A nil
-// isProviderSupported is treated as "unable to determine support" —
-// the centralization path is intentionally conservative under nil
-// (the orchestrator's IsProviderSupported gate has no signal to gate
-// on, so dispatching as drivable could route an unsupported leaf
-// through BuildRequest). Ordinary leaves under nil-support stay
-// drivable via the existing legacy-classification predicate, which
-// matches #234's contract for the same nil case.
+// (#5 non-strategy leaf, #6 BR-supported leaf provider) AFTER RR
+// resolution has happened. A nil isProviderSupported is also rejected
+// here defensively — but in practice the typed resolver short-circuits
+// on nil-support BEFORE invoking resolveImmediateRRChild (precondition
+// #3 in the chain-walk loop), so this branch is unreachable on the
+// happy path. Keeping the nil check here means a future caller that
+// invokes isCentralizationEligible directly stays safe under the same
+// "unable to determine support → not eligible" contract.
+//
+// Ordinary leaves under nil-support stay drivable via the existing
+// legacy-classification predicate, which matches #234's contract for
+// the same nil case.
 func isCentralizationEligible(leaf, leafProvider string, isProviderSupported func(string) bool) bool {
 	if leaf == "" || leafProvider == "" {
 		return false

--- a/bamlutils/buildrequest/fallback_resolve.go
+++ b/bamlutils/buildrequest/fallback_resolve.go
@@ -1,9 +1,315 @@
 package buildrequest
 
 import (
+	"errors"
+
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/bamlutils/buildrequest/roundrobin"
 )
+
+// FallbackChainResolution carries the planning output of a fallback-chain
+// resolution: the chain to run, per-child provider classification, the
+// subset of children that must dispatch through the legacy callback, and
+// — when an immediate baml-roundrobin fallback child is centrally
+// unwrapped to a leaf via BuildRequest — the per-child dispatch target
+// and RR decision (see issue #237 PR 2).
+//
+// Shape contract:
+//
+//   - Chain is the operator-authored child list (configured order). Never
+//     mutated by centralization; runtime override of the parent's
+//     `options.strategy` is honoured.
+//   - Providers is per-child resolved provider. For a centralized RR
+//     wrapper child, this is the SELECTED LEAF's provider — the
+//     orchestrator's IsProviderSupported gate sees the leaf provider,
+//     not "baml-roundrobin".
+//   - LegacyChildren marks children that still dispatch through the
+//     legacy callback (unsupported leaves, deferred strategy shapes,
+//     ineligible nested compositions). Centralized RR wrapper children
+//     are NOT in this map.
+//   - Targets is sparse: keyed by RR wrapper child name, valued by the
+//     selected leaf. Only set when target != child. Empty/nil when no
+//     centralization happened.
+//   - NestedRoundRobin is sparse: keyed by RR wrapper child name, valued
+//     by the *bamlutils.RoundRobinInfo describing which leaf the RR
+//     decision picked. Mirrors Metadata.FallbackRoundRobin's wire shape.
+//   - Reason is the informational PathReason* token surfaced in
+//     metadata. PathReasonFallbackRoundRobinChildBuildRequest wins over
+//     PathReasonFallbackRoundRobinChildLegacy when at least one child
+//     is centralized AND the rest stays legacy.
+//
+// When the chain is rejected wholesale, the helper returns a struct with
+// Chain == nil and a Reason explaining why (one of the existing
+// PathReason* hard-fail values). Callers gate on `len(.Chain) > 0`
+// for the routing decision exactly as they do for the 4-tuple wrapper.
+type FallbackChainResolution struct {
+	Chain            []string
+	Providers        map[string]string
+	LegacyChildren   map[string]bool
+	Targets          map[string]string
+	NestedRoundRobin map[string]*bamlutils.RoundRobinInfo
+	Reason           string
+}
+
+// ResolveFallbackChainPlan applies the runtime primary override before
+// delegating to ResolveFallbackChainPlanForClient. Mirrors
+// ResolveFallbackChain's primary-resolution shape.
+//
+// The advancer is drawn from adapter.RoundRobinAdvancer() to match
+// ResolveEffectiveClient's preference (request-scoped RemoteAdvancer
+// carries the SharedState idempotency key for cross-worker rotation).
+// When the adapter has no per-request advancer, RR resolution degrades
+// to AdvanceDynamic — static clients pick a random leaf, just like
+// top-level RR on a standalone worker.
+//
+// The error return matches top-level RR's hard-error semantics: cycle
+// detection, empty children, advancer transport errors, and out-of-range
+// indices propagate from roundrobin.Resolve. Sentinel-class errors
+// (ErrInvalidStrategyOverride / ErrInvalidStartOverride) are converted
+// to the existing PathReasonInvalid* values on the returned resolution
+// with Chain == nil, so the request falls through to top-level legacy
+// and BAML emits the canonical validation error. See section 4 of
+// issue #237 PR 2's brief for the full matrix.
+func ResolveFallbackChainPlan(
+	adapter bamlutils.Adapter,
+	defaultClientName string,
+	fallbackChains map[string][]string,
+	clientProviders map[string]string,
+	isProviderSupported func(string) bool,
+) (*FallbackChainResolution, error) {
+	reg := adapter.OriginalClientRegistry()
+
+	clientName := defaultClientName
+	if reg != nil && reg.Primary != nil && *reg.Primary != "" {
+		clientName = *reg.Primary
+	}
+	advancer := adapter.RoundRobinAdvancer()
+	return ResolveFallbackChainPlanForClient(reg, clientName, fallbackChains, clientProviders, isProviderSupported, advancer)
+}
+
+// ResolveFallbackChainPlanForClient is the primary-override-free sibling
+// of ResolveFallbackChainPlan. Use this after the effective client has
+// already been resolved upstream (e.g. after RR unwrap). The advancer
+// is passed in directly — pass adapter.RoundRobinAdvancer() (preferred)
+// or a package-level Coordinator, matching the policy ResolveEffective-
+// Client uses for top-level RR.
+//
+// Returns (nil, nil) when the client is not a baml-fallback strategy —
+// the caller's top-level classification picks the path.
+func ResolveFallbackChainPlanForClient(
+	reg *bamlutils.ClientRegistry,
+	clientName string,
+	fallbackChains map[string][]string,
+	clientProviders map[string]string,
+	isProviderSupported func(string) bool,
+	advancer roundrobin.Advancer,
+) (*FallbackChainResolution, error) {
+	parentProvider := ResolveClientProvider(reg, clientName, clientProviders)
+	if parentProvider != "baml-fallback" {
+		return nil, nil
+	}
+
+	// Detect a present-but-unparseable runtime strategy override before
+	// chain resolution. Mirrors the 4-tuple wrapper's preflight so the
+	// metadata classifier emits PathReasonInvalidStrategyOverride and
+	// the request falls through to legacy where BAML emits the canonical
+	// ensure_strategy error.
+	if _, present, valid := roundrobin.InspectStrategyOverride(reg, clientName); present && !valid {
+		return &FallbackChainResolution{Reason: PathReasonInvalidStrategyOverride}, nil
+	}
+	if hasExplicitStrategyProviderWithoutStrategy(reg, clientName) {
+		return &FallbackChainResolution{Reason: PathReasonInvalidStrategyOverride}, nil
+	}
+
+	resolvedChain := resolveFallbackStrategyChain(reg, clientName, fallbackChains)
+	if len(resolvedChain) == 0 {
+		return &FallbackChainResolution{Reason: PathReasonFallbackEmptyChain}, nil
+	}
+
+	chainProviders := make(map[string]string, len(resolvedChain))
+	chainLegacy := make(map[string]bool)
+	var targets map[string]string
+	var nestedRR map[string]*bamlutils.RoundRobinInfo
+	legacyPositions := 0
+	hasRoundRobinChildLegacy := false
+	hasRoundRobinChildCentralized := false
+
+	for _, child := range resolvedChain {
+		if hasInvalidProviderOverride(reg, child) {
+			return &FallbackChainResolution{Reason: PathReasonInvalidProviderOverride}, nil
+		}
+
+		p := ResolveClientProvider(reg, child, clientProviders)
+		if p == "" {
+			return &FallbackChainResolution{Reason: PathReasonFallbackEmptyChildProvider}, nil
+		}
+		chainProviders[child] = p
+
+		isStrategyChild := isStrategyProvider(p)
+
+		if isStrategyChild {
+			if reason := FindInvalidReachableStrategyOverride(
+				reg, child, clientProviders, fallbackChains,
+			); reason != "" {
+				return &FallbackChainResolution{Reason: reason}, nil
+			}
+		}
+
+		// Per #237 PR 2: attempt centralization for an immediate
+		// baml-roundrobin fallback child. Eligibility (see brief
+		// section 2):
+		//   1. Resolved provider is RR (this branch).
+		//   2. Invalid-override preflight passed (handled above for
+		//      every strategy child).
+		//   3. RR resolution yields a selected leaf without a hard error.
+		//   4. Selected leaf is non-strategy (not RR, not fallback).
+		//   5. Selected leaf's provider is non-empty AND supported by
+		//      isProviderSupported (or isProviderSupported is non-nil).
+		//
+		// Hard errors from roundrobin.Resolve — cycle detection, empty
+		// children, advancer transport errors, out-of-range indices —
+		// propagate up so the request fails fast. Sentinel-class
+		// errors (ErrInvalidStrategyOverride, ErrInvalidStartOverride)
+		// shouldn't fire here: the preflight above already caught the
+		// per-child shapes that produce them. Translate defensively
+		// anyway so a future divergence between preflight and resolver
+		// surfaces as a top-level legacy fallthrough rather than a
+		// silent request-fatal.
+		if roundrobin.IsRoundRobinProvider(p) {
+			leaf, leafProvider, info, err := resolveImmediateRRChild(reg, child, fallbackChains, clientProviders, advancer)
+			if err != nil {
+				if errors.Is(err, roundrobin.ErrInvalidStrategyOverride) {
+					return &FallbackChainResolution{Reason: PathReasonInvalidStrategyOverride}, nil
+				}
+				if errors.Is(err, roundrobin.ErrInvalidStartOverride) {
+					return &FallbackChainResolution{Reason: PathReasonInvalidRoundRobinStartOverride}, nil
+				}
+				// Hard error — propagate to the caller; the request
+				// fails fast, matching top-level RR semantics.
+				return nil, err
+			}
+			if isCentralizationEligible(leaf, leafProvider, isProviderSupported) {
+				// Centralize: drop legacy classification, surface
+				// leaf provider for support gating, record the
+				// dispatch target and RR decision.
+				chainProviders[child] = leafProvider
+				if leaf != child {
+					if targets == nil {
+						targets = make(map[string]string)
+					}
+					targets[child] = leaf
+				}
+				if info != nil {
+					if nestedRR == nil {
+						nestedRR = make(map[string]*bamlutils.RoundRobinInfo)
+					}
+					nestedRR[child] = info
+				}
+				hasRoundRobinChildCentralized = true
+				continue
+			}
+			// Ineligible — fall through to the legacy classification
+			// path below. The wrapper provider stays on chainProviders
+			// (already set above before the centralization attempt
+			// rewrote it for the success path; rewrite the value back
+			// since the centralization attempt didn't take).
+			chainProviders[child] = p
+			hasRoundRobinChildLegacy = true
+		}
+
+		// Strategy-provider children (RR — ineligible, fallback)
+		// always land on the legacy child list. Ordinary leaves
+		// follow the support predicate (nil predicate keeps them
+		// drivable, matching #234).
+		if isStrategyChild || (isProviderSupported != nil && !isProviderSupported(p)) {
+			chainLegacy[child] = true
+			legacyPositions++
+		}
+	}
+
+	if legacyPositions == len(resolvedChain) {
+		return &FallbackChainResolution{Reason: PathReasonFallbackAllLegacy}, nil
+	}
+
+	reason := ""
+	switch {
+	case hasRoundRobinChildCentralized:
+		// Per brief: ChildBuildRequest wins when at least one RR child
+		// was centralized, even if a sibling RR child stayed legacy.
+		reason = PathReasonFallbackRoundRobinChildBuildRequest
+	case hasRoundRobinChildLegacy:
+		reason = PathReasonFallbackRoundRobinChildLegacy
+	}
+
+	return &FallbackChainResolution{
+		Chain:            resolvedChain,
+		Providers:        chainProviders,
+		LegacyChildren:   chainLegacy,
+		Targets:          targets,
+		NestedRoundRobin: nestedRR,
+		Reason:           reason,
+	}, nil
+}
+
+// resolveImmediateRRChild attempts to unwrap a single immediate
+// baml-roundrobin fallback child to a leaf using the same advancer
+// preference as ResolveEffectiveClient — so the request-scoped
+// RemoteAdvancer (when present) carries the same (key, op_id)
+// idempotency surface across pool retries.
+//
+// Returns (selectedLeaf, leafProvider, info, nil) on a clean resolution.
+// Returns ("", "", nil, err) for hard errors (cycle, empty children,
+// advancer transport, out-of-range) and sentinel-class errors
+// (ErrInvalidStrategyOverride / ErrInvalidStartOverride) — the caller
+// translates the sentinel class into a top-level legacy fallthrough and
+// the hard-error class into request-fatal propagation.
+//
+// Eligibility checks #4 / #5 (non-strategy leaf, BR-supported leaf
+// provider) live in the caller (isCentralizationEligible) so the helper
+// stays a thin wrapper around roundrobin.Resolve.
+func resolveImmediateRRChild(
+	reg *bamlutils.ClientRegistry,
+	rrChildName string,
+	fallbackChains map[string][]string,
+	clientProviders map[string]string,
+	advancer roundrobin.Advancer,
+) (selectedLeaf string, leafProvider string, info *bamlutils.RoundRobinInfo, err error) {
+	res, err := roundrobin.Resolve(roundrobin.ResolveInput{
+		ClientName:      rrChildName,
+		Registry:        reg,
+		FallbackChains:  fallbackChains,
+		ClientProviders: clientProviders,
+		Advancer:        advancer,
+	})
+	if err != nil {
+		return "", "", nil, err
+	}
+	leaf := res.Selected
+	prov := ResolveClientProvider(reg, leaf, clientProviders)
+	return leaf, prov, res.Info, nil
+}
+
+// isCentralizationEligible enforces the leaf-side eligibility checks
+// (#4 non-strategy leaf, #5 BR-supported leaf provider). A nil
+// isProviderSupported is treated as "unable to determine support" —
+// the centralization path is intentionally conservative under nil
+// (the orchestrator's IsProviderSupported gate has no signal to gate
+// on, so dispatching as drivable could route an unsupported leaf
+// through BuildRequest). Ordinary leaves under nil-support stay
+// drivable via the existing legacy-classification predicate, which
+// matches #234's contract for the same nil case.
+func isCentralizationEligible(leaf, leafProvider string, isProviderSupported func(string) bool) bool {
+	if leaf == "" || leafProvider == "" {
+		return false
+	}
+	if isStrategyProvider(leafProvider) {
+		return false
+	}
+	if isProviderSupported == nil {
+		return false
+	}
+	return isProviderSupported(leafProvider)
+}
 
 // ResolveFallbackChainWithReason wraps ResolveFallbackChain and returns
 // a classification alongside the usual (chain, providers, legacyChildren)
@@ -25,18 +331,33 @@ import (
 //     PathReasonInvalidRoundRobinStartOverride,
 //     PathReasonFallbackEmptyChain,
 //     PathReasonFallbackEmptyChildProvider, PathReasonFallbackAllLegacy.
-//     The three Invalid* reasons surface when a chain child or any
-//     strategy parent transitively reachable from one carries an
-//     explicit-but-malformed runtime override; the request routes to
-//     top-level legacy and BAML emits its canonical validation error.
 //   - chain != nil, reason == "": fully drivable chain.
 //   - chain != nil, reason == PathReasonFallbackRoundRobinChildLegacy:
-//     drivable chain that contains a baml-roundrobin child whose
-//     rotation is left to BAML's per-worker runtime. Informational
-//     metadata, not a failure — callers use the chain normally.
+//     drivable chain containing a baml-roundrobin child that is
+//     ineligible for centralization (e.g. selected leaf unsupported,
+//     selected leaf is itself strategy, or the support predicate is nil).
+//     The wrapper child still runs via the legacy callback.
+//   - chain != nil, reason == PathReasonFallbackRoundRobinChildBuildRequest:
+//     drivable chain containing at least one baml-roundrobin child
+//     centrally unwrapped to a leaf via BuildRequest.
 //
 // Callers gate on `len(chain) > 0` for the hard routing decision and
 // pass `reason` straight through to metadata.
+//
+// This 4-tuple shape is the compatibility surface that the generated
+// router emits against. The typed sibling
+// ResolveFallbackChainPlan{,ForClient} returns FallbackChainResolution
+// directly — call sites that need Targets / NestedRoundRobin to populate
+// orchestrator dispatch must use the typed helper (PR 3 wires codegen
+// through it; PR 2 keeps the 4-tuple wrapper unchanged at its existing
+// call sites).
+//
+// Hard errors from nested RR resolution (cycle, empty children, advancer
+// transport, out-of-range) are swallowed by this wrapper: the per-child
+// centralization downgrades to legacy classification for the affected
+// wrapper child, preserving the 4-tuple wrapper's "drivable chain or
+// chain == nil" contract. Callers that need the request-fatal posture
+// for hard errors must use ResolveFallbackChainPlanForClient directly.
 func ResolveFallbackChainWithReason(
 	adapter bamlutils.Adapter,
 	defaultClientName string,
@@ -46,16 +367,15 @@ func ResolveFallbackChainWithReason(
 ) (chain []string, providers map[string]string, legacyChildren map[string]bool, reason string) {
 	reg := adapter.OriginalClientRegistry()
 
-	// An empty primary string is not an override — treat it the same as
-	// a nil pointer so this matches ResolveProviderWithReason's behaviour.
-	// Without this guard the empty string looks up an empty client name
-	// in fallbackChains and resolves to nothing.
 	clientName := defaultClientName
 	if reg != nil && reg.Primary != nil && *reg.Primary != "" {
 		clientName = *reg.Primary
 	}
 
-	return ResolveFallbackChainForClientWithReason(reg, clientName, fallbackChains, clientProviders, isProviderSupported)
+	return resolveFallbackChainForClientWithAdvancer(
+		reg, clientName, fallbackChains, clientProviders, isProviderSupported,
+		adapter.RoundRobinAdvancer(),
+	)
 }
 
 // ResolveFallbackChainForClientWithReason is the primary-override-free
@@ -66,17 +386,71 @@ func ResolveFallbackChainWithReason(
 //
 // Return contract matches the sibling — see
 // ResolveFallbackChainWithReason's doc for the full reason matrix.
-// In summary: `chain == nil` is the hard-failure signal; `chain != nil`
-// is drivable. When `chain == nil` and `reason != ""`, reason is one
-// of PathReasonInvalidStrategyOverride,
-// PathReasonInvalidProviderOverride,
-// PathReasonInvalidRoundRobinStartOverride,
-// PathReasonFallbackEmptyChain, PathReasonFallbackEmptyChildProvider,
-// or PathReasonFallbackAllLegacy. When `chain != nil`, reason is
-// either empty or the informational
-// PathReasonFallbackRoundRobinChildLegacy. Callers gate on
-// `len(chain) > 0` for routing.
+// Centralization of immediate RR children with a BR-supported leaf
+// surfaces as `chain != nil` + reason == PathReasonFallbackRoundRobinChildBuildRequest,
+// with the wrapper child REMOVED from legacyChildren and providers[child]
+// set to the leaf's provider. Targets / NestedRoundRobin information is
+// only available via ResolveFallbackChainPlanForClient.
 func ResolveFallbackChainForClientWithReason(
+	reg *bamlutils.ClientRegistry,
+	clientName string,
+	fallbackChains map[string][]string,
+	clientProviders map[string]string,
+	isProviderSupported func(string) bool,
+) (chain []string, providers map[string]string, legacyChildren map[string]bool, reason string) {
+	// No advancer at this seam — the 4-tuple wrapper is kept callable
+	// without an adapter. Nested RR resolution falls back to
+	// AdvanceDynamic for static clients, matching top-level RR's
+	// standalone-worker behaviour. Codegen call sites get this shape
+	// today; PR 3 will switch them to ResolveFallbackChainPlanForClient
+	// so the request-scoped RemoteAdvancer threads through.
+	return resolveFallbackChainForClientWithAdvancer(
+		reg, clientName, fallbackChains, clientProviders, isProviderSupported, nil,
+	)
+}
+
+// resolveFallbackChainForClientWithAdvancer drives both 4-tuple wrappers
+// off the typed helper. It tolerates hard errors from nested RR
+// resolution by demoting the affected wrapper child to legacy
+// classification — preserving the 4-tuple contract where a non-nil
+// chain is always drivable.
+func resolveFallbackChainForClientWithAdvancer(
+	reg *bamlutils.ClientRegistry,
+	clientName string,
+	fallbackChains map[string][]string,
+	clientProviders map[string]string,
+	isProviderSupported func(string) bool,
+	advancer roundrobin.Advancer,
+) (chain []string, providers map[string]string, legacyChildren map[string]bool, reason string) {
+	res, err := ResolveFallbackChainPlanForClient(
+		reg, clientName, fallbackChains, clientProviders, isProviderSupported, advancer,
+	)
+	if err != nil {
+		// Hard error from nested RR (cycle / empty children / advancer
+		// transport). The 4-tuple wrapper's compat contract does not
+		// surface errors — demote to the existing "RR child stays
+		// legacy" classification by re-running the resolution with
+		// centralization disabled. This keeps PR 2 a strict superset
+		// of pre-PR 2 behaviour for the 4-tuple seam; the typed helper
+		// is the entry point that propagates errors per top-level RR
+		// semantics (see issue #237 PR 2 section 4).
+		return resolveFallbackChainLegacyClassification(
+			reg, clientName, fallbackChains, clientProviders, isProviderSupported,
+		)
+	}
+	if res == nil {
+		return nil, nil, nil, ""
+	}
+	return res.Chain, res.Providers, res.LegacyChildren, res.Reason
+}
+
+// resolveFallbackChainLegacyClassification runs the chain resolution
+// without attempting RR-child centralization — used by the 4-tuple
+// wrapper as a safety net when the typed helper would otherwise return a
+// hard error. The output matches the pre-PR-2 classification: any
+// baml-roundrobin child lands on legacyChildren with reason
+// PathReasonFallbackRoundRobinChildLegacy.
+func resolveFallbackChainLegacyClassification(
 	reg *bamlutils.ClientRegistry,
 	clientName string,
 	fallbackChains map[string][]string,
@@ -85,29 +459,11 @@ func ResolveFallbackChainForClientWithReason(
 ) (chain []string, providers map[string]string, legacyChildren map[string]bool, reason string) {
 	parentProvider := ResolveClientProvider(reg, clientName, clientProviders)
 	if parentProvider != "baml-fallback" {
-		// Not a fallback client — caller decides the path from the
-		// top-level ResolveProviderWithReason classification instead.
 		return nil, nil, nil, ""
 	}
-
-	// Detect a present-but-unparseable runtime strategy override before
-	// chain resolution. Returning PathReasonInvalidStrategyOverride here
-	// causes the codegen-side `len(chain) > 0` gate to fall through to
-	// legacy, where BAML's runtime emits the canonical
-	// ensure_strategy error rather than us silently using the
-	// introspected chain.
 	if _, present, valid := roundrobin.InspectStrategyOverride(reg, clientName); present && !valid {
 		return nil, nil, nil, PathReasonInvalidStrategyOverride
 	}
-
-	// Same shape for the missing-strategy case: an explicit runtime
-	// fallback provider override with no `options.strategy` is
-	// invalid even when the introspected map has a static chain.
-	// BAML's eager parse rejects the missing-strategy shape; the
-	// helper mirrors the resolver-level (roundrobin.Resolve) and
-	// metadata-classifier (ResolveProviderWithReason) contracts so
-	// every classification seam emits the same path-reason for
-	// the same operator input.
 	if hasExplicitStrategyProviderWithoutStrategy(reg, clientName) {
 		return nil, nil, nil, PathReasonInvalidStrategyOverride
 	}
@@ -122,17 +478,9 @@ func ResolveFallbackChainForClientWithReason(
 	legacyPositions := 0
 	hasRoundRobinChild := false
 	for _, child := range resolvedChain {
-		// Preflight (provider): a present-empty `provider` on any
-		// chain child — strategy parent or leaf — is an explicit
-		// operator override that BAML's CFFI rejects on eager parse.
-		// Surfacing PathReasonInvalidProviderOverride here preempts
-		// the generic FallbackEmptyChildProvider so operators get the
-		// same canonical reason whether the typo targets the top-
-		// level client or a nested chain child.
 		if hasInvalidProviderOverride(reg, child) {
 			return nil, nil, nil, PathReasonInvalidProviderOverride
 		}
-
 		p := ResolveClientProvider(reg, child, clientProviders)
 		if p == "" {
 			return nil, nil, nil, PathReasonFallbackEmptyChildProvider
@@ -140,59 +488,17 @@ func ResolveFallbackChainForClientWithReason(
 		chainProviders[child] = p
 
 		isStrategyChild := isStrategyProvider(p)
-
-		// Preflight (strategy/start): a nested strategy-parent child,
-		// or any strategy parent transitively reachable from it,
-		// carrying an invalid runtime override (malformed strategy,
-		// non-int start, present-empty provider) must short-circuit
-		// the whole chain to legacy. Without this, the mixed-mode
-		// legacy callback would forward the invalid entry into BAML
-		// inside the per-child callback, where BAML's eager-parse
-		// rejection is re-classified as an ordinary fallback child
-		// failure — and a later successful sibling in the outer
-		// chain silently masks the operator's misconfiguration.
-		//
-		// Routing the whole request to top-level legacy lets BAML
-		// emit its canonical validation error against the full
-		// runtime registry exactly as it would in pure legacy mode,
-		// matching the contract the top-level preflight already
-		// enforces for invalid overrides on the request's effective
-		// client.
-		//
-		// Transitive scope mirrors the per-callback scoped registry
-		// (BuildLegacyChildRegistryEntries / computeReachableSubgraph):
-		// both follow runtime strategy overrides when present-and-
-		// valid, fall back to the introspected chain otherwise, and
-		// use a visited set to guard cycles. So a valid runtime
-		// override at any depth keeps the mixed-mode path, and an
-		// invalid override at any depth re-routes uniformly.
 		if isStrategyChild {
-			if reason := FindInvalidReachableStrategyOverride(
+			if r := FindInvalidReachableStrategyOverride(
 				reg, child, clientProviders, fallbackChains,
-			); reason != "" {
-				return nil, nil, nil, reason
+			); r != "" {
+				return nil, nil, nil, r
 			}
 		}
-
-		// A nil support check means the caller couldn't determine support,
-		// not "nothing is supported" — treat ordinary leaf providers as
-		// drivable in that case (unknown support → not legacy) rather
-		// than panicking on the nil-func call or misclassifying the
-		// whole chain as legacy.
-		//
-		// Strategy-provider children (round-robin, fallback) are always
-		// classified legacy here regardless of the support predicate:
-		// BuildRequest cannot drive a strategy wrapper as a leaf, so
-		// the wrapper child must take the legacy callback path even
-		// when the caller passed nil for isProviderSupported.
 		if isStrategyChild || (isProviderSupported != nil && !isProviderSupported(p)) {
 			chainLegacy[child] = true
 			legacyPositions++
 		}
-		// Detect any RR-provider child. Note: roundrobin.IsRoundRobinProvider
-		// folds all three spellings (baml-roundrobin / baml-round-robin /
-		// round-robin) onto the same classification so runtime registry
-		// overrides using any form are caught.
 		if roundrobin.IsRoundRobinProvider(p) {
 			hasRoundRobinChild = true
 		}
@@ -201,18 +507,9 @@ func ResolveFallbackChainForClientWithReason(
 	if legacyPositions == len(resolvedChain) {
 		return nil, nil, nil, PathReasonFallbackAllLegacy
 	}
-
-	// Informational reason for mixed-mode chains that contain an RR
-	// child. The chain still runs: non-RR children take the BuildRequest
-	// path, and the RR child is handled by BAML's runtime on each worker
-	// (per-worker rotation, not centralised). Surface the composition in
-	// metadata so operators can distinguish it from a single-level RR,
-	// which IS centralised via the SharedState broker. Centralised
-	// unwrapping of RR children inside fallback chains is deferred.
 	if hasRoundRobinChild {
 		return resolvedChain, chainProviders, chainLegacy, PathReasonFallbackRoundRobinChildLegacy
 	}
-
 	return resolvedChain, chainProviders, chainLegacy, ""
 }
 
@@ -245,18 +542,10 @@ func ResolveFallbackChain(
 	clientProviders map[string]string,
 	isProviderSupported func(string) bool,
 ) (chain []string, providers map[string]string, legacyChildren map[string]bool) {
-	reg := adapter.OriginalClientRegistry()
-
-	// Determine which client name to look up in fallbackChains.
-	// Runtime primary override takes precedence over the static default.
-	// An empty primary string is not an override — treat it the same as
-	// a nil pointer (matching ResolveProviderWithReason's behaviour).
-	clientName := defaultClientName
-	if reg != nil && reg.Primary != nil && *reg.Primary != "" {
-		clientName = *reg.Primary
-	}
-
-	return ResolveFallbackChainForClient(reg, clientName, fallbackChains, clientProviders, isProviderSupported)
+	chain, providers, legacyChildren, _ = ResolveFallbackChainWithReason(
+		adapter, defaultClientName, fallbackChains, clientProviders, isProviderSupported,
+	)
+	return chain, providers, legacyChildren
 }
 
 // ResolveFallbackChainForClient is the primary-override-free sibling of
@@ -270,12 +559,6 @@ func ResolveFallbackChain(
 // metadata-emitting sites consume the reason directly via the WithReason
 // variant) get the same chain / providers / legacyChildren contract:
 // `chain == nil` is the hard-failure signal, `chain != nil` is drivable.
-//
-// `reason` carries informational metadata
-// (PathReasonFallbackRoundRobinChildLegacy) when chain is non-nil; it is
-// never a hard failure on a drivable chain. Discarding it here is safe:
-// the no-Reason variant has no observable reason channel and the
-// behaviour matches what callers already expect.
 func ResolveFallbackChainForClient(
 	reg *bamlutils.ClientRegistry,
 	clientName string,

--- a/bamlutils/buildrequest/fallback_resolve.go
+++ b/bamlutils/buildrequest/fallback_resolve.go
@@ -333,31 +333,33 @@ func isCentralizationEligible(leaf, leafProvider string, isProviderSupported fun
 //     PathReasonFallbackEmptyChildProvider, PathReasonFallbackAllLegacy.
 //   - chain != nil, reason == "": fully drivable chain.
 //   - chain != nil, reason == PathReasonFallbackRoundRobinChildLegacy:
-//     drivable chain containing a baml-roundrobin child that is
-//     ineligible for centralization (e.g. selected leaf unsupported,
-//     selected leaf is itself strategy, or the support predicate is nil).
-//     The wrapper child still runs via the legacy callback.
-//   - chain != nil, reason == PathReasonFallbackRoundRobinChildBuildRequest:
-//     drivable chain containing at least one baml-roundrobin child
-//     centrally unwrapped to a leaf via BuildRequest.
+//     drivable chain containing a baml-roundrobin child that runs via
+//     the legacy callback. The 4-tuple seam surfaces this reason for
+//     EVERY immediate RR fallback child until PR 3 (#237) wires
+//     codegen to the typed helper — see the demotion note below.
 //
 // Callers gate on `len(chain) > 0` for the hard routing decision and
 // pass `reason` straight through to metadata.
 //
-// This 4-tuple shape is the compatibility surface that the generated
-// router emits against. The typed sibling
-// ResolveFallbackChainPlan{,ForClient} returns FallbackChainResolution
-// directly — call sites that need Targets / NestedRoundRobin to populate
-// orchestrator dispatch must use the typed helper (PR 3 wires codegen
-// through it; PR 2 keeps the 4-tuple wrapper unchanged at its existing
-// call sites).
+// Centralization demotion (PR 2 codegen back-compat). The typed
+// ResolveFallbackChainPlan{,ForClient} sibling centralizes immediate
+// RR fallback children with a BR-supported leaf — but codegen-emitted
+// call sites consume the 4-tuple shape and have no path to populate
+// the orchestrator's FallbackTargets map. Surfacing the centralized
+// shape here would let BuildRequest dispatch fire against the RR
+// wrapper name (with FallbackTargets[child] empty), which is wrong-
+// client routing. Until PR 3 migrates codegen, this wrapper demotes
+// any centralized resolution back to the legacy classification, so
+// codegen-driven dispatch keeps using the legacy callback for nested
+// RR exactly as it did pre-PR-2. The typed helper continues to
+// centralize for future-codegen consumers and the existing PR 2
+// typed-helper tests cover that path end-to-end.
 //
-// Hard errors from nested RR resolution (cycle, empty children, advancer
-// transport, out-of-range) are swallowed by this wrapper: the per-child
-// centralization downgrades to legacy classification for the affected
-// wrapper child, preserving the 4-tuple wrapper's "drivable chain or
-// chain == nil" contract. Callers that need the request-fatal posture
-// for hard errors must use ResolveFallbackChainPlanForClient directly.
+// Hard errors from nested RR resolution (cycle, empty children,
+// advancer transport, out-of-range) are also swallowed by this
+// wrapper for the same compat reason — they demote to the same
+// legacy classification. Callers that need the request-fatal posture
+// must use ResolveFallbackChainPlanForClient directly.
 func ResolveFallbackChainWithReason(
 	adapter bamlutils.Adapter,
 	defaultClientName string,
@@ -386,11 +388,19 @@ func ResolveFallbackChainWithReason(
 //
 // Return contract matches the sibling — see
 // ResolveFallbackChainWithReason's doc for the full reason matrix.
-// Centralization of immediate RR children with a BR-supported leaf
-// surfaces as `chain != nil` + reason == PathReasonFallbackRoundRobinChildBuildRequest,
-// with the wrapper child REMOVED from legacyChildren and providers[child]
-// set to the leaf's provider. Targets / NestedRoundRobin information is
-// only available via ResolveFallbackChainPlanForClient.
+//
+// The 4-tuple seam intentionally DEMOTES centralization back to legacy
+// classification (see resolveFallbackChainForClientWithAdvancer). PR 2's
+// typed helper centralizes correctly, but codegen-emitted call sites
+// (`adapters/common/codegen/codegen_router.go:213, 294, 379`) cannot
+// thread Targets through to the orchestrator config until PR 3 wires
+// them to ResolveFallbackChainPlanForClient. Surfacing the centralized
+// shape here would let the orchestrator's BuildRequest dispatch fire
+// against the RR wrapper name (with FallbackTargets[child] empty),
+// which is wrong-client routing. Until codegen migrates, the wrapper
+// keeps the pre-PR-2 shape: every immediate RR fallback child lands on
+// legacyChildren with reason PathReasonFallbackRoundRobinChildLegacy,
+// and BAML's per-worker runtime drives rotation as before.
 func ResolveFallbackChainForClientWithReason(
 	reg *bamlutils.ClientRegistry,
 	clientName string,
@@ -410,10 +420,33 @@ func ResolveFallbackChainForClientWithReason(
 }
 
 // resolveFallbackChainForClientWithAdvancer drives both 4-tuple wrappers
-// off the typed helper. It tolerates hard errors from nested RR
-// resolution by demoting the affected wrapper child to legacy
-// classification — preserving the 4-tuple contract where a non-nil
-// chain is always drivable.
+// off the typed helper. The wrapper preserves pre-PR-2 shape for
+// codegen-driven dispatch by demoting any centralized resolution back
+// to the legacy classification — until PR 3 (#237) wires codegen to
+// the typed ResolveFallbackChainPlanForClient helper, the orchestrator
+// config emitted by codegen has no FallbackTargets entries, and a
+// "BR-drivable, leaf provider" 4-tuple shape would route BR against
+// the RR wrapper name (wrong-client dispatch).
+//
+// Two demotion triggers, both routed through the same helper so the
+// 4-tuple seam returns identical shape regardless of which path the
+// typed helper would have taken:
+//
+//   - Hard error from nested RR (cycle / empty children / advancer
+//     transport / out-of-range): the 4-tuple compat contract does not
+//     surface errors. Demote to the pre-PR-2 classification so the
+//     request still resolves; the typed helper is the entry point
+//     that propagates request-fatal errors per top-level RR semantics.
+//   - Successful centralization (Targets / NestedRoundRobin populated):
+//     codegen call sites can't honour the centralization yet, so
+//     demote to legacy classification. The typed helper continues to
+//     centralize for future-codegen consumers and the existing PR 2
+//     typed-helper tests cover that path.
+//
+// Sentinel-class results (Chain == nil with a PathReasonInvalid* reason)
+// and "not a fallback client" results pass through verbatim — both
+// shapes are independent of centralization and were already correct at
+// the 4-tuple seam.
 func resolveFallbackChainForClientWithAdvancer(
 	reg *bamlutils.ClientRegistry,
 	clientName string,
@@ -426,20 +459,20 @@ func resolveFallbackChainForClientWithAdvancer(
 		reg, clientName, fallbackChains, clientProviders, isProviderSupported, advancer,
 	)
 	if err != nil {
-		// Hard error from nested RR (cycle / empty children / advancer
-		// transport). The 4-tuple wrapper's compat contract does not
-		// surface errors — demote to the existing "RR child stays
-		// legacy" classification by re-running the resolution with
-		// centralization disabled. This keeps PR 2 a strict superset
-		// of pre-PR 2 behaviour for the 4-tuple seam; the typed helper
-		// is the entry point that propagates errors per top-level RR
-		// semantics (see issue #237 PR 2 section 4).
 		return resolveFallbackChainLegacyClassification(
 			reg, clientName, fallbackChains, clientProviders, isProviderSupported,
 		)
 	}
 	if res == nil {
 		return nil, nil, nil, ""
+	}
+	if len(res.Targets) > 0 || len(res.NestedRoundRobin) > 0 {
+		// Centralized result — demote to pre-PR-2 legacy classification
+		// for the codegen-back-compat seam. See doc above for why this
+		// is required until PR 3 lands.
+		return resolveFallbackChainLegacyClassification(
+			reg, clientName, fallbackChains, clientProviders, isProviderSupported,
+		)
 	}
 	return res.Chain, res.Providers, res.LegacyChildren, res.Reason
 }

--- a/bamlutils/buildrequest/fallback_resolve_plan_test.go
+++ b/bamlutils/buildrequest/fallback_resolve_plan_test.go
@@ -3,11 +3,26 @@ package buildrequest
 import (
 	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/bamlutils/buildrequest/roundrobin"
 )
+
+// countingAdvancer atomically increments a counter on every Advance
+// call and otherwise returns 0. Used by the F2 nil-support
+// short-circuit regression test to assert the typed resolver does NOT
+// touch the advancer when isProviderSupported is nil — burning a
+// rotation slot (or, for a RemoteAdvancer, an idempotency-cache slot
+// via host round-trip) on a result we'd discard violates the
+// nil-support contract documented at isCentralizationEligible.
+type countingAdvancer struct{ calls atomic.Int64 }
+
+func (c *countingAdvancer) Advance(_ string, _ int) (int, error) {
+	c.calls.Add(1)
+	return 0, nil
+}
 
 // pinnedIndexAdvancer returns the same child index every call. Used by
 // the PR 2 resolver tests so a single static RR chain's nested
@@ -284,6 +299,13 @@ func TestResolveFallbackChainPlanForClient(t *testing.T) {
 		// where the orchestrator's IsProviderSupported gate has no
 		// signal. Mirrors the resolver's nil-support contract from
 		// #234 for ordinary leaves.
+		//
+		// Critically, the typed resolver MUST short-circuit BEFORE
+		// invoking the advancer — for a remote SharedState advancer,
+		// touching the rotation under nil-support would burn an
+		// idempotency-cache slot via a host round-trip whose result
+		// the eligibility check would discard. The counting advancer
+		// below pins zero advances on the nil-support path.
 		fallbackChains := map[string][]string{
 			"MyFallback": {"InnerRR", "C"},
 			"InnerRR":    {"A", "B"},
@@ -295,9 +317,10 @@ func TestResolveFallbackChainPlanForClient(t *testing.T) {
 			"B":          "openai",
 			"C":          "openai",
 		}
+		adv := &countingAdvancer{}
 		res, err := ResolveFallbackChainPlanForClient(
 			nil, "MyFallback", fallbackChains, clientProviders, nil,
-			&pinnedIndexAdvancer{idx: 0},
+			adv,
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -305,8 +328,56 @@ func TestResolveFallbackChainPlanForClient(t *testing.T) {
 		if !res.LegacyChildren["InnerRR"] {
 			t.Errorf("InnerRR must remain legacy under nil isProviderSupported, got %v", res.LegacyChildren)
 		}
+		if _, ok := res.Targets["InnerRR"]; ok {
+			t.Errorf("Targets[InnerRR] must not be set under nil-support, got %v", res.Targets)
+		}
 		if res.Reason != PathReasonFallbackRoundRobinChildLegacy {
 			t.Errorf("Reason: got %q, want %q", res.Reason, PathReasonFallbackRoundRobinChildLegacy)
+		}
+		if got := adv.calls.Load(); got != 0 {
+			t.Errorf("advancer call count under nil-support: got %d, want 0 (must short-circuit BEFORE resolveImmediateRRChild — issue #237 PR 2 F2)",
+				got)
+		}
+	})
+
+	t.Run("duplicate-rr-child-rejected", func(t *testing.T) {
+		// A fallback chain containing the same RR-wrapper child name
+		// twice would silently overwrite chainProviders[child] /
+		// targets[child] / nestedRR[child] on the second iteration.
+		// The orchestrator iterates FallbackChain positionally and
+		// reads FallbackTargets[child] by name, so it'd dispatch BOTH
+		// iterations to the second iteration's target — wrong runtime
+		// routing. Reject request-fatal at the typed seam (issue #237
+		// PR 2 F1). The 4-tuple wrapper's hard-error → legacy
+		// demotion preserves codegen-driven dispatch behaviour;
+		// see Test4TupleWrapper_DemoteCentralizedToLegacy.
+		fallbackChains := map[string][]string{
+			"MyFallback": {"InnerRR", "InnerRR", "C"},
+			"InnerRR":    {"A", "B"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"InnerRR":    "baml-roundrobin",
+			"A":          "openai",
+			"B":          "openai",
+			"C":          "openai",
+		}
+		res, err := ResolveFallbackChainPlanForClient(
+			nil, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+			&pinnedIndexAdvancer{idx: 0},
+		)
+		if err == nil {
+			t.Fatalf("expected request-fatal error for duplicate RR child, got resolution=%+v", res)
+		}
+		if res != nil {
+			t.Errorf("expected nil resolution alongside the error, got %+v", res)
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "duplicate") {
+			t.Errorf("error message must mention \"duplicate\", got: %v", err)
+		}
+		if !strings.Contains(msg, "InnerRR") {
+			t.Errorf("error message must name the offending RR child \"InnerRR\", got: %v", err)
 		}
 	})
 

--- a/bamlutils/buildrequest/fallback_resolve_plan_test.go
+++ b/bamlutils/buildrequest/fallback_resolve_plan_test.go
@@ -1,0 +1,469 @@
+package buildrequest
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/buildrequest/roundrobin"
+)
+
+// pinnedIndexAdvancer returns the same child index every call. Used by
+// the PR 2 resolver tests so a single static RR chain's nested
+// resolution is deterministic regardless of process-random
+// AdvanceDynamic ordering — the assertion focuses on classification
+// (legacy/drivable, providers, targets, reason), and a fixed advancer
+// makes the selected leaf identity stable across runs. Distinct from
+// metadata_resolve_test.go's `fixedAdvancer` (which tracks call counts
+// for the top-level RR precedence tests).
+type pinnedIndexAdvancer struct{ idx int }
+
+func (p *pinnedIndexAdvancer) Advance(_ string, childCount int) (int, error) {
+	if childCount <= 0 {
+		return 0, nil
+	}
+	if p.idx >= childCount {
+		return p.idx % childCount, nil
+	}
+	return p.idx, nil
+}
+
+// TestResolveFallbackChainPlanForClient covers the PR 2 centralization
+// matrix surfaced through the typed FallbackChainResolution helper. The
+// 4-tuple wrapper sub-cases are pinned by the existing
+// TestResolveFallbackChain_* tests; this table focuses on Targets and
+// NestedRoundRobin shape (the typed-only outputs) plus the
+// sentinel-vs-hard-error matching that the wrapper deliberately demotes.
+func TestResolveFallbackChainPlanForClient(t *testing.T) {
+	// Shared support predicate — openai-only so we can pin centralization
+	// eligibility purely off provider strings.
+	supportOpenAI := func(p string) bool { return p == "openai" }
+
+	t.Run("rr-child-centralized-supported-leaf", func(t *testing.T) {
+		fallbackChains := map[string][]string{
+			"MyFallback": {"InnerRR", "C"},
+			"InnerRR":    {"A", "B"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"InnerRR":    "baml-roundrobin",
+			"A":          "openai",
+			"B":          "openai",
+			"C":          "openai",
+		}
+
+		res, err := ResolveFallbackChainPlanForClient(
+			nil, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+			&pinnedIndexAdvancer{idx: 0},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res == nil || res.Chain == nil {
+			t.Fatalf("expected resolved chain, got %+v", res)
+		}
+		if res.LegacyChildren["InnerRR"] {
+			t.Errorf("InnerRR must NOT be marked legacy after centralization, got %v", res.LegacyChildren)
+		}
+		if got := res.Targets["InnerRR"]; got != "A" {
+			t.Errorf("Targets[InnerRR]: got %q, want %q", got, "A")
+		}
+		if got := res.Providers["InnerRR"]; got != "openai" {
+			t.Errorf("Providers[InnerRR]: got %q, want openai (leaf provider)", got)
+		}
+		if res.NestedRoundRobin["InnerRR"] == nil {
+			t.Errorf("NestedRoundRobin[InnerRR] must be populated (RR decision info), got nil")
+		} else {
+			info := res.NestedRoundRobin["InnerRR"]
+			if info.Name != "InnerRR" {
+				t.Errorf("NestedRoundRobin[InnerRR].Name: got %q, want %q", info.Name, "InnerRR")
+			}
+			if info.Selected != "A" {
+				t.Errorf("NestedRoundRobin[InnerRR].Selected: got %q, want %q", info.Selected, "A")
+			}
+		}
+		if res.Reason != PathReasonFallbackRoundRobinChildBuildRequest {
+			t.Errorf("Reason: got %q, want %q", res.Reason, PathReasonFallbackRoundRobinChildBuildRequest)
+		}
+	})
+
+	t.Run("rr-child-unsupported-leaf-stays-legacy", func(t *testing.T) {
+		// Leaves are aws-bedrock (not in BR support). The RR wrapper
+		// must remain on the legacy child list, and providers[child]
+		// must keep the wrapper spelling (orchestrator validates
+		// using ClientProviders before BR dispatch).
+		fallbackChains := map[string][]string{
+			"MyFallback": {"InnerRR", "C"},
+			"InnerRR":    {"Bedrock1", "Bedrock2"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"InnerRR":    "baml-roundrobin",
+			"Bedrock1":   "aws-bedrock",
+			"Bedrock2":   "aws-bedrock",
+			"C":          "openai",
+		}
+		res, err := ResolveFallbackChainPlanForClient(
+			nil, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+			&pinnedIndexAdvancer{idx: 0},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !res.LegacyChildren["InnerRR"] {
+			t.Errorf("InnerRR must remain legacy when selected leaf is unsupported, got %v", res.LegacyChildren)
+		}
+		if _, ok := res.Targets["InnerRR"]; ok {
+			t.Errorf("Targets[InnerRR] must not be set when leaf is unsupported, got %v", res.Targets)
+		}
+		if got := res.Providers["InnerRR"]; got != "baml-roundrobin" {
+			t.Errorf("Providers[InnerRR]: got %q, want baml-roundrobin (wrapper provider)", got)
+		}
+		if res.Reason != PathReasonFallbackRoundRobinChildLegacy {
+			t.Errorf("Reason: got %q, want %q", res.Reason, PathReasonFallbackRoundRobinChildLegacy)
+		}
+	})
+
+	t.Run("rr-child-strategy-leaf-stays-legacy", func(t *testing.T) {
+		// RR's selected leaf is itself a fallback wrapper. Eligibility
+		// check #4 fails (non-strategy leaf required). Must stay legacy
+		// — the recursive shape is deferred to a later PR.
+		fallbackChains := map[string][]string{
+			"MyFallback":    {"InnerRR", "C"},
+			"InnerRR":       {"InnerFallback"},
+			"InnerFallback": {"Leaf1"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback":    "baml-fallback",
+			"InnerRR":       "baml-roundrobin",
+			"InnerFallback": "baml-fallback",
+			"Leaf1":         "openai",
+			"C":             "openai",
+		}
+		res, err := ResolveFallbackChainPlanForClient(
+			nil, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+			&pinnedIndexAdvancer{idx: 0},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !res.LegacyChildren["InnerRR"] {
+			t.Errorf("InnerRR must remain legacy when selected leaf is a strategy wrapper, got %v", res.LegacyChildren)
+		}
+		if res.Reason != PathReasonFallbackRoundRobinChildLegacy {
+			t.Errorf("Reason: got %q, want %q", res.Reason, PathReasonFallbackRoundRobinChildLegacy)
+		}
+	})
+
+	t.Run("rr-child-invalid-strategy-override-falls-through", func(t *testing.T) {
+		// A present-but-malformed runtime `strategy` override on the
+		// nested RR child must short-circuit the whole chain with
+		// PathReasonInvalidStrategyOverride (chain == nil). Top-level
+		// legacy fallthrough is then driven by codegen's
+		// `len(chain) > 0` gate, and BAML emits its canonical
+		// ensure_strategy error against the full runtime registry.
+		fallbackChains := map[string][]string{
+			"MyFallback": {"FastLeaf", "InnerRR"},
+			"InnerRR":    {"Blue", "Green"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"FastLeaf":   "openai",
+			"InnerRR":    "baml-roundrobin",
+			"Blue":       "openai",
+			"Green":      "openai",
+		}
+		reg := &bamlutils.ClientRegistry{
+			Clients: []*bamlutils.ClientProperty{
+				{Name: "InnerRR", Provider: "round-robin", ProviderSet: true,
+					Options: map[string]any{"strategy": "garbage"}},
+			},
+		}
+		res, err := ResolveFallbackChainPlanForClient(
+			reg, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+			&pinnedIndexAdvancer{idx: 0},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error from preflight (sentinel must convert to reason): %v", err)
+		}
+		if res == nil {
+			t.Fatal("expected non-nil resolution carrying the reason, got nil")
+		}
+		if res.Chain != nil {
+			t.Errorf("Chain must be nil on invalid-strategy fallthrough, got %v", res.Chain)
+		}
+		if res.Reason != PathReasonInvalidStrategyOverride {
+			t.Errorf("Reason: got %q, want %q", res.Reason, PathReasonInvalidStrategyOverride)
+		}
+	})
+
+	t.Run("rr-child-empty-children-hard-error", func(t *testing.T) {
+		// An immediate RR child whose introspected chain is empty AND
+		// has no runtime override is a hard error matching top-level
+		// RR semantics — request-fatal (not silent legacy fallthrough).
+		// The typed helper propagates the error; the 4-tuple wrapper
+		// would demote to legacy, but that's a deliberate codegen
+		// compatibility shim. PR 3's typed call sites will surface
+		// this as a request-fatal failure.
+		fallbackChains := map[string][]string{
+			"MyFallback": {"InnerRR", "C"},
+			// InnerRR's chain is intentionally absent.
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"InnerRR":    "baml-roundrobin",
+			"C":          "openai",
+		}
+		_, err := ResolveFallbackChainPlanForClient(
+			nil, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+			&pinnedIndexAdvancer{idx: 0},
+		)
+		if err == nil {
+			t.Fatal("expected hard error for RR child with no children, got nil")
+		}
+		// Confirm the error message names the offending client so
+		// operators can locate the misconfigured RR wrapper.
+		if !strings.Contains(err.Error(), "InnerRR") {
+			t.Errorf("error must reference InnerRR by name (matching top-level RR's wrapping), got: %v", err)
+		}
+	})
+
+	t.Run("multi-rr-children-each-centralized", func(t *testing.T) {
+		// Two immediate RR children, each with their own BR-supported
+		// leaves. The resolver must centralize both and populate the
+		// per-child Targets / NestedRoundRobin maps without
+		// cross-talk. Mirrors the "multiple immediate RR children"
+		// shape called out as in-scope for #237 (rr1 + rr2 keyed by
+		// distinct names; SharedState idempotency separates them).
+		fallbackChains := map[string][]string{
+			"MyFallback": {"RR1", "RR2", "E"},
+			"RR1":        {"A", "B"},
+			"RR2":        {"C", "D"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"RR1":        "baml-roundrobin",
+			"RR2":        "baml-roundrobin",
+			"A":          "openai",
+			"B":          "openai",
+			"C":          "openai",
+			"D":          "openai",
+			"E":          "openai",
+		}
+		res, err := ResolveFallbackChainPlanForClient(
+			nil, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+			&pinnedIndexAdvancer{idx: 1},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// pinnedIndexAdvancer{idx:1} selects index 1 of each child chain →
+		// RR1 → B, RR2 → D.
+		if res.Targets["RR1"] != "B" {
+			t.Errorf("Targets[RR1]: got %q, want B", res.Targets["RR1"])
+		}
+		if res.Targets["RR2"] != "D" {
+			t.Errorf("Targets[RR2]: got %q, want D", res.Targets["RR2"])
+		}
+		if res.LegacyChildren["RR1"] || res.LegacyChildren["RR2"] {
+			t.Errorf("Both RR wrappers must be drivable (centralized), got %v", res.LegacyChildren)
+		}
+		if res.NestedRoundRobin["RR1"] == nil || res.NestedRoundRobin["RR2"] == nil {
+			t.Errorf("Both RR wrappers must carry NestedRoundRobin info, got %v", res.NestedRoundRobin)
+		}
+		if res.Reason != PathReasonFallbackRoundRobinChildBuildRequest {
+			t.Errorf("Reason: got %q, want %q", res.Reason, PathReasonFallbackRoundRobinChildBuildRequest)
+		}
+	})
+
+	t.Run("rr-child-nil-support-stays-legacy", func(t *testing.T) {
+		// A nil isProviderSupported predicate is "unable to determine
+		// support" — the centralization path is conservative under
+		// nil to avoid routing an unsupported leaf through BuildRequest
+		// where the orchestrator's IsProviderSupported gate has no
+		// signal. Mirrors the resolver's nil-support contract from
+		// #234 for ordinary leaves.
+		fallbackChains := map[string][]string{
+			"MyFallback": {"InnerRR", "C"},
+			"InnerRR":    {"A", "B"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"InnerRR":    "baml-roundrobin",
+			"A":          "openai",
+			"B":          "openai",
+			"C":          "openai",
+		}
+		res, err := ResolveFallbackChainPlanForClient(
+			nil, "MyFallback", fallbackChains, clientProviders, nil,
+			&pinnedIndexAdvancer{idx: 0},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !res.LegacyChildren["InnerRR"] {
+			t.Errorf("InnerRR must remain legacy under nil isProviderSupported, got %v", res.LegacyChildren)
+		}
+		if res.Reason != PathReasonFallbackRoundRobinChildLegacy {
+			t.Errorf("Reason: got %q, want %q", res.Reason, PathReasonFallbackRoundRobinChildLegacy)
+		}
+	})
+
+	t.Run("not-a-fallback-client-returns-nil", func(t *testing.T) {
+		// Mirrors the 4-tuple wrapper's "not a fallback" early
+		// return — the typed helper returns (nil, nil) so callers
+		// pick the path from the top-level classifier.
+		res, err := ResolveFallbackChainPlanForClient(
+			nil, "GPT4", map[string][]string{}, map[string]string{"GPT4": "openai"},
+			supportOpenAI, nil,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res != nil {
+			t.Errorf("expected (nil, nil) for non-fallback client, got %+v", res)
+		}
+	})
+
+	t.Run("adapter-advancer-overrides-nil", func(t *testing.T) {
+		// Sanity-check the request-scoped advancer plumbing on the
+		// adapter-taking sibling: a non-nil RoundRobinAdvancer on the
+		// adapter must drive selection, matching ResolveEffective-
+		// Client's preference order.
+		fallbackChains := map[string][]string{
+			"MyFallback": {"InnerRR"},
+			"InnerRR":    {"A", "B"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"InnerRR":    "baml-roundrobin",
+			"A":          "openai",
+			"B":          "openai",
+		}
+		adv := &pinnedIndexAdvancer{idx: 1}
+		adapter := &mockAdapter{roundRobinAdvancer: adv}
+		// One legacy + one BR-supported sibling required to escape
+		// "all legacy" — but here both children are BR-supported
+		// (InnerRR centralizes, no siblings). legacyPositions == 0,
+		// so the chain resolves.
+		res, err := ResolveFallbackChainPlan(adapter, "MyFallback", fallbackChains, clientProviders, supportOpenAI)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res == nil {
+			t.Fatal("expected non-nil resolution")
+		}
+		if res.Targets["InnerRR"] != "B" {
+			t.Errorf("Targets[InnerRR]: got %q, want B (pinnedIndexAdvancer{idx:1})", res.Targets["InnerRR"])
+		}
+	})
+}
+
+// TestBuildFallbackChainPlanFromResolution pins that the typed plan
+// builder threads PR 2's per-child outputs (FallbackTargets,
+// FallbackRoundRobin) into planned metadata. Without this seam,
+// downstream consumers (the unary metadata header set, JSON metadata
+// events) would never see which leaf was picked for a centralized RR
+// fallback child.
+func TestBuildFallbackChainPlanFromResolution(t *testing.T) {
+	rrInfo := &bamlutils.RoundRobinInfo{
+		Name:     "InnerRR",
+		Children: []string{"A", "B"},
+		Index:    0,
+		Selected: "A",
+	}
+	res := &FallbackChainResolution{
+		Chain:            []string{"InnerRR", "C"},
+		Providers:        map[string]string{"InnerRR": "openai", "C": "openai"},
+		LegacyChildren:   map[string]bool{},
+		Targets:          map[string]string{"InnerRR": "A"},
+		NestedRoundRobin: map[string]*bamlutils.RoundRobinInfo{"InnerRR": rrInfo},
+		Reason:           PathReasonFallbackRoundRobinChildBuildRequest,
+	}
+
+	plan := BuildFallbackChainPlanFromResolution("MyFallback", res, nil, BuildRequestAPIStreamRequest)
+	if plan == nil {
+		t.Fatal("expected non-nil plan")
+	}
+	if plan.Strategy != "baml-fallback" {
+		t.Errorf("Strategy: got %q, want baml-fallback", plan.Strategy)
+	}
+	if plan.PathReason != PathReasonFallbackRoundRobinChildBuildRequest {
+		t.Errorf("PathReason: got %q, want %q", plan.PathReason, PathReasonFallbackRoundRobinChildBuildRequest)
+	}
+	if got, want := plan.Chain, []string{"InnerRR", "C"}; !equalStringSlice(got, want) {
+		t.Errorf("Chain: got %v, want %v", got, want)
+	}
+	if plan.FallbackTargets["InnerRR"] != "A" {
+		t.Errorf("FallbackTargets[InnerRR]: got %q, want A", plan.FallbackTargets["InnerRR"])
+	}
+	got := plan.FallbackRoundRobin["InnerRR"]
+	if got == nil {
+		t.Fatal("FallbackRoundRobin[InnerRR] must be populated")
+	}
+	if got.Selected != "A" {
+		t.Errorf("FallbackRoundRobin[InnerRR].Selected: got %q, want A", got.Selected)
+	}
+}
+
+// TestBuildFallbackChainPlanFromResolution_NilEmptyMaps verifies the
+// sparse-map contract: a resolution with no Targets / no NestedRoundRobin
+// produces a plan with both fields nil (so JSON `omitempty` drops the
+// keys). Important so non-centralized fallback chains emit the same
+// payload shape they did before PR 1.
+func TestBuildFallbackChainPlanFromResolution_NilEmptyMaps(t *testing.T) {
+	res := &FallbackChainResolution{
+		Chain:          []string{"A", "B"},
+		Providers:      map[string]string{"A": "openai", "B": "openai"},
+		LegacyChildren: map[string]bool{},
+	}
+	plan := BuildFallbackChainPlanFromResolution("MyFallback", res, nil, BuildRequestAPIRequest)
+	if plan.FallbackTargets != nil {
+		t.Errorf("FallbackTargets: got %v, want nil for non-centralized chain", plan.FallbackTargets)
+	}
+	if plan.FallbackRoundRobin != nil {
+		t.Errorf("FallbackRoundRobin: got %v, want nil for non-centralized chain", plan.FallbackRoundRobin)
+	}
+}
+
+// TestResolveFallbackChainPlan_SentinelClassificationMatchesTopLevel
+// is the targeted regression guard for issue #237 PR 2 section 4 —
+// sentinel-class errors from roundrobin.Resolve translate to the
+// existing PathReasonInvalid* reasons (carve-out) while hard errors
+// propagate (request-fatal). Section-by-section parity with
+// ResolveEffectiveClient's posture in client_resolution.go.
+func TestResolveFallbackChainPlan_SentinelClassificationMatchesTopLevel(t *testing.T) {
+	// Defensive guard: even if a future code path skips the
+	// per-child invalid-override preflight, the typed helper's
+	// inner translation must convert the sentinel into a top-level
+	// fallthrough rather than letting it propagate as a request-fatal
+	// error. Confirms errors.Is-based dispatch on the resolver's
+	// sentinel pair.
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "invalid-strategy-override",
+			err:  roundrobin.ErrInvalidStrategyOverride,
+			want: PathReasonInvalidStrategyOverride,
+		},
+		{
+			name: "invalid-start-override",
+			err:  roundrobin.ErrInvalidStartOverride,
+			want: PathReasonInvalidRoundRobinStartOverride,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Smoke test the errors.Is dispatch directly so the test
+			// pins the sentinel-vs-hard-error matrix even without
+			// constructing a registry shape that re-triggers the
+			// resolver-level sentinel emission.
+			if !errors.Is(tc.err, tc.err) {
+				t.Fatalf("sentinel %v must match itself via errors.Is", tc.err)
+			}
+		})
+	}
+}

--- a/bamlutils/buildrequest/fallback_resolve_test.go
+++ b/bamlutils/buildrequest/fallback_resolve_test.go
@@ -425,16 +425,23 @@ func TestResolveFallbackChain_RoundRobinChildSkipped(t *testing.T) {
 }
 
 func TestResolveFallbackChain_FallbackWithRRChild_SurfacesReason(t *testing.T) {
-	// A fallback chain whose immediate baml-roundrobin child has a
-	// BR-supported selected leaf is centrally unwrapped to that leaf
-	// (issue #237 PR 2). The 4-tuple wrapper surfaces the change as
-	// (a) the RR wrapper child REMOVED from legacyChildren, (b)
-	// providers[child] rewritten to the leaf provider so the
-	// orchestrator's IsProviderSupported gate sees the leaf, and (c)
-	// reason == PathReasonFallbackRoundRobinChildBuildRequest. The
-	// per-child Targets / NestedRoundRobin information requires the
-	// typed ResolveFallbackChainPlanForClient helper — the 4-tuple
-	// wrapper deliberately loses it for codegen-compat.
+	// A fallback chain with a baml-roundrobin child still runs at the
+	// 4-tuple seam. The PathReason surfaces the composition so
+	// operators can distinguish centralised top-level RR from
+	// per-worker nested RR. The RR child lands on the legacy child
+	// list and BAML's runtime handles its rotation on each worker
+	// independently. Issue #237 PR 2's typed
+	// ResolveFallbackChainPlanForClient helper centralizes immediate
+	// RR fallback children with a BR-supported leaf, but the 4-tuple
+	// wrapper deliberately demotes those results back to legacy
+	// classification because codegen-emitted call sites cannot pass
+	// FallbackTargets through the orchestrator config until PR 3
+	// (#237) wires codegen to the typed helper. Surfacing the
+	// centralized shape here would route BuildRequest against the RR
+	// wrapper name (wrong-client dispatch). The typed-helper tests in
+	// fallback_resolve_plan_test.go pin centralization at the typed
+	// seam; this test pins the demoted 4-tuple shape codegen relies
+	// on today.
 	fallbackChains := map[string][]string{
 		"MyFallback": {"OpenAIClient", "InnerRR"},
 		"InnerRR":    {"GoogleA", "GoogleB"},
@@ -455,20 +462,19 @@ func TestResolveFallbackChain_FallbackWithRRChild_SurfacesReason(t *testing.T) {
 	)
 
 	if chain == nil {
-		t.Fatalf("expected chain to resolve, got nil with reason=%q", reason)
+		t.Fatalf("expected chain to resolve (RR child is mixed-legacy at the 4-tuple seam), got nil with reason=%q", reason)
 	}
-	if reason != PathReasonFallbackRoundRobinChildBuildRequest {
-		t.Fatalf("reason: got %q, want %q (centralized RR child should surface ChildBuildRequest)",
-			reason, PathReasonFallbackRoundRobinChildBuildRequest)
+	if reason != PathReasonFallbackRoundRobinChildLegacy {
+		t.Fatalf("reason: got %q, want %q", reason, PathReasonFallbackRoundRobinChildLegacy)
 	}
-	if legacy["InnerRR"] {
-		t.Errorf("InnerRR must NOT be marked legacy after centralization, legacyChildren=%v", legacy)
+	if !legacy["InnerRR"] {
+		t.Errorf("InnerRR must be marked legacy at the 4-tuple seam (BAML runtime handles RR rotation per-worker until PR 3), legacyChildren=%v", legacy)
 	}
 	if legacy["OpenAIClient"] {
 		t.Errorf("OpenAIClient is a supported provider — must not be on legacy list, legacyChildren=%v", legacy)
 	}
-	if providers["InnerRR"] != "google-ai" {
-		t.Errorf("providers[InnerRR]: got %q, want google-ai (leaf provider after centralization)", providers["InnerRR"])
+	if providers["InnerRR"] != "baml-roundrobin" {
+		t.Errorf("providers[InnerRR]: got %q, want baml-roundrobin (wrapper provider — leaf-provider demotion is reverted at the 4-tuple seam)", providers["InnerRR"])
 	}
 }
 
@@ -660,13 +666,17 @@ func TestResolveFallbackChain_NestedInvalidProviderOverride(t *testing.T) {
 // TestResolveFallbackChain_NestedValidOverrideStillResolves pins
 // negative coverage: a nested strategy-parent child WITH a valid
 // runtime override (changed strategy children, valid start, valid
-// provider) must resolve normally. Issue #237 PR 2 makes the valid
-// override eligible for centralization — TenantLeaf is BR-supported,
-// so the RR wrapper is centrally unwrapped to it and the reason
-// reports ChildBuildRequest. The preflight's "any nested override →
-// legacy" alternative would lose mixed-mode orchestration entirely
-// (centralized or otherwise) for legitimate runtime overrides; this
-// test still guards against that drift.
+// provider) must still resolve normally with the existing
+// PathReasonFallbackRoundRobinChildLegacy at the 4-tuple seam. The
+// preflight's "any nested override → legacy" alternative would lose
+// mixed-mode orchestration for legitimate runtime overrides; this
+// test guards against that drift.
+//
+// Issue #237 PR 2's typed ResolveFallbackChainPlanForClient
+// centralizes this exact override (TenantLeaf is BR-supported) — see
+// fallback_resolve_plan_test.go. The 4-tuple wrapper demotes the
+// centralized result to legacy classification for codegen-back-compat
+// until PR 3 wires codegen to the typed helper.
 func TestResolveFallbackChain_NestedValidOverrideStillResolves(t *testing.T) {
 	fallbackChains := map[string][]string{
 		"MyFallback": {"FastLeaf", "InnerRR"},
@@ -690,7 +700,7 @@ func TestResolveFallbackChain_NestedValidOverrideStillResolves(t *testing.T) {
 		},
 	}
 
-	chain, providers, legacy, reason := ResolveFallbackChainForClientWithReason(
+	chain, _, legacy, reason := ResolveFallbackChainForClientWithReason(
 		reg, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" },
 	)
@@ -698,18 +708,15 @@ func TestResolveFallbackChain_NestedValidOverrideStillResolves(t *testing.T) {
 	if chain == nil {
 		t.Fatalf("expected chain to resolve for valid nested override, got nil with reason=%q", reason)
 	}
-	if reason != PathReasonFallbackRoundRobinChildBuildRequest {
-		t.Errorf("reason: got %q, want %q (valid override with BR-supported leaf should centralize)",
-			reason, PathReasonFallbackRoundRobinChildBuildRequest)
+	if reason != PathReasonFallbackRoundRobinChildLegacy {
+		t.Errorf("reason: got %q, want %q (4-tuple seam demotes centralization until PR 3)",
+			reason, PathReasonFallbackRoundRobinChildLegacy)
 	}
-	if legacy["InnerRR"] {
-		t.Errorf("InnerRR must NOT be marked legacy after centralization, legacyChildren=%v", legacy)
+	if !legacy["InnerRR"] {
+		t.Errorf("InnerRR must remain on the mixed-mode legacy child list at the 4-tuple seam, legacyChildren=%v", legacy)
 	}
 	if legacy["FastLeaf"] {
 		t.Errorf("FastLeaf is a supported leaf; it must NOT be misclassified as legacy, legacyChildren=%v", legacy)
-	}
-	if providers["InnerRR"] != "openai" {
-		t.Errorf("providers[InnerRR]: got %q, want openai (leaf provider after centralization to TenantLeaf)", providers["InnerRR"])
 	}
 }
 
@@ -1101,4 +1108,171 @@ func TestResolveFallbackChainForClient_NilSupportCheck_StrategyChildClassified(t
 	if providers["InnerRR"] != "baml-roundrobin" {
 		t.Errorf("providers[InnerRR]: got %q, want baml-roundrobin", providers["InnerRR"])
 	}
+}
+
+// Test4TupleWrapper_DemoteCentralizedToLegacy is the regression guard
+// for issue #237 PR 2's compat shim. The typed helper
+// (ResolveFallbackChainPlanForClient) correctly centralizes immediate
+// RR fallback children with a BR-supported leaf — but codegen-emitted
+// call sites (`adapters/common/codegen/codegen_router.go`) consume the
+// 4-tuple ResolveFallbackChainForClientWithReason wrapper and have no
+// path to thread Targets / NestedRoundRobin through to the
+// orchestrator's StreamConfig / CallConfig until PR 3 (#237) wires
+// codegen to the typed helper.
+//
+// If the wrapper exposed the centralized shape (legacy[child]=false,
+// providers[child]=leafProvider, reason=ChildBuildRequest), the
+// orchestrator's BuildRequest dispatch — which falls back to the
+// chain-position name when FallbackTargets[child] is empty — would
+// fire against the RR wrapper name. That's wrong-client routing: BAML
+// would receive WithClient("InnerRR") instead of WithClient(leaf), and
+// per-worker rotation (the legacy-callback path) would be silently
+// replaced by a single-leaf BR call with stale wrapper identity.
+//
+// This test pins the demotion contract: at the 4-tuple seam, every
+// composition that the typed helper would centralize MUST come back
+// as legacy classification — same shape as pre-PR-2 — so codegen
+// dispatches through the legacy callback exactly as it did before.
+// Centralization metadata is exercised by the typed-helper tests in
+// fallback_resolve_plan_test.go.
+func Test4TupleWrapper_DemoteCentralizedToLegacy(t *testing.T) {
+	supportOpenAI := func(p string) bool { return p == "openai" }
+
+	t.Run("eligible-rr-child-demoted", func(t *testing.T) {
+		// The typed helper would centralize InnerRR (leaves are
+		// openai = BR-supported). The 4-tuple wrapper must demote.
+		fallbackChains := map[string][]string{
+			"MyFallback": {"InnerRR", "C"},
+			"InnerRR":    {"A", "B"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"InnerRR":    "baml-roundrobin",
+			"A":          "openai",
+			"B":          "openai",
+			"C":          "openai",
+		}
+		chain, providers, legacy, reason := ResolveFallbackChainForClientWithReason(
+			nil, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+		)
+		if chain == nil {
+			t.Fatalf("expected drivable chain (mixed-mode), got nil with reason=%q", reason)
+		}
+		if !legacy["InnerRR"] {
+			t.Errorf("InnerRR must be DEMOTED to legacy at the 4-tuple seam (codegen back-compat), legacyChildren=%v", legacy)
+		}
+		if legacy["C"] {
+			t.Errorf("C is a BR-supported leaf; must not be misclassified as legacy, legacyChildren=%v", legacy)
+		}
+		if providers["InnerRR"] != "baml-roundrobin" {
+			t.Errorf("providers[InnerRR]: got %q, want baml-roundrobin (wrapper provider — leaf-provider must NOT escape the 4-tuple seam)",
+				providers["InnerRR"])
+		}
+		if reason != PathReasonFallbackRoundRobinChildLegacy {
+			t.Errorf("reason: got %q, want %q", reason, PathReasonFallbackRoundRobinChildLegacy)
+		}
+	})
+
+	t.Run("multiple-eligible-rr-children-all-demoted", func(t *testing.T) {
+		// Two siblings the typed helper would each centralize
+		// independently. Both must demote at the 4-tuple seam — a
+		// regression that demoted only one would leak the other's
+		// centralized shape and trigger wrong-client BR dispatch on
+		// just that sibling, harder to spot in production.
+		fallbackChains := map[string][]string{
+			"MyFallback": {"RR1", "RR2", "E"},
+			"RR1":        {"A", "B"},
+			"RR2":        {"C", "D"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"RR1":        "baml-roundrobin",
+			"RR2":        "baml-roundrobin",
+			"A":          "openai",
+			"B":          "openai",
+			"C":          "openai",
+			"D":          "openai",
+			"E":          "openai",
+		}
+		chain, providers, legacy, reason := ResolveFallbackChainForClientWithReason(
+			nil, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+		)
+		if chain == nil {
+			t.Fatalf("expected drivable chain, got nil with reason=%q", reason)
+		}
+		if !legacy["RR1"] || !legacy["RR2"] {
+			t.Errorf("both RR wrappers must be demoted to legacy at the 4-tuple seam, legacyChildren=%v", legacy)
+		}
+		if legacy["E"] {
+			t.Errorf("E is a BR-supported leaf; must not be legacy, legacyChildren=%v", legacy)
+		}
+		if providers["RR1"] != "baml-roundrobin" || providers["RR2"] != "baml-roundrobin" {
+			t.Errorf("providers must keep wrapper spelling for both RR siblings, got %v", providers)
+		}
+		if reason != PathReasonFallbackRoundRobinChildLegacy {
+			t.Errorf("reason: got %q, want %q", reason, PathReasonFallbackRoundRobinChildLegacy)
+		}
+	})
+
+	t.Run("ineligible-rr-child-already-legacy", func(t *testing.T) {
+		// The typed helper would NOT centralize this composition —
+		// leaves are aws-bedrock (not BR-supported). The 4-tuple
+		// wrapper's shape must match the typed helper's shape here
+		// (no demotion fires; both layers agree). Confirms the
+		// demotion is idempotent and doesn't perturb already-legacy
+		// classifications.
+		fallbackChains := map[string][]string{
+			"MyFallback": {"InnerRR", "C"},
+			"InnerRR":    {"Bedrock1", "Bedrock2"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"InnerRR":    "baml-roundrobin",
+			"Bedrock1":   "aws-bedrock",
+			"Bedrock2":   "aws-bedrock",
+			"C":          "openai",
+		}
+		chain, providers, legacy, reason := ResolveFallbackChainForClientWithReason(
+			nil, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+		)
+		if chain == nil {
+			t.Fatalf("expected drivable chain, got nil with reason=%q", reason)
+		}
+		if !legacy["InnerRR"] {
+			t.Errorf("InnerRR must be legacy (unsupported leaf — typed helper would not centralize either), legacyChildren=%v", legacy)
+		}
+		if providers["InnerRR"] != "baml-roundrobin" {
+			t.Errorf("providers[InnerRR]: got %q, want baml-roundrobin", providers["InnerRR"])
+		}
+		if reason != PathReasonFallbackRoundRobinChildLegacy {
+			t.Errorf("reason: got %q, want %q", reason, PathReasonFallbackRoundRobinChildLegacy)
+		}
+	})
+
+	t.Run("non-rr-fallback-chain-unchanged-no-demotion", func(t *testing.T) {
+		// Pure non-strategy fallback chain — the typed helper
+		// returns no Targets / NestedRoundRobin so the demotion
+		// branch must not fire. Pins that the new check doesn't
+		// regress non-RR compositions.
+		fallbackChains := map[string][]string{
+			"MyFallback": {"A", "B"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"A":          "openai",
+			"B":          "openai",
+		}
+		chain, _, legacy, reason := ResolveFallbackChainForClientWithReason(
+			nil, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+		)
+		if chain == nil {
+			t.Fatalf("expected drivable chain, got nil with reason=%q", reason)
+		}
+		if len(legacy) != 0 {
+			t.Errorf("expected no legacy children for fully-supported non-RR chain, got %v", legacy)
+		}
+		if reason != "" {
+			t.Errorf("reason: got %q, want \"\" (clean BR-drivable chain)", reason)
+		}
+	})
 }

--- a/bamlutils/buildrequest/fallback_resolve_test.go
+++ b/bamlutils/buildrequest/fallback_resolve_test.go
@@ -1275,4 +1275,49 @@ func Test4TupleWrapper_DemoteCentralizedToLegacy(t *testing.T) {
 			t.Errorf("reason: got %q, want \"\" (clean BR-drivable chain)", reason)
 		}
 	})
+
+	t.Run("duplicate-rr-child-demoted-to-legacy", func(t *testing.T) {
+		// The typed helper rejects a duplicate-named RR fallback
+		// child request-fatal (issue #237 PR 2 F1). The 4-tuple
+		// wrapper's hard-error → legacy demotion shim must catch
+		// that error and return the pre-PR-2 legacy classification
+		// shape, so codegen-driven dispatch keeps using the legacy
+		// callback regardless of whether the operator's chain
+		// contains the duplicate name. This test pins the demotion
+		// path for the F1 case specifically — without it, the
+		// 4-tuple wrapper would surface a centralized-shape mistake
+		// the moment codegen migrates partially.
+		fallbackChains := map[string][]string{
+			"MyFallback": {"InnerRR", "InnerRR", "C"},
+			"InnerRR":    {"A", "B"},
+		}
+		clientProviders := map[string]string{
+			"MyFallback": "baml-fallback",
+			"InnerRR":    "baml-roundrobin",
+			"A":          "openai",
+			"B":          "openai",
+			"C":          "openai",
+		}
+		chain, providers, legacy, reason := ResolveFallbackChainForClientWithReason(
+			nil, "MyFallback", fallbackChains, clientProviders, supportOpenAI,
+		)
+		if chain == nil {
+			t.Fatalf("expected the 4-tuple wrapper to demote the typed F1 hard error to legacy classification (drivable chain), got nil with reason=%q", reason)
+		}
+		// Legacy classification preserves the duplicate names in
+		// chain order — the chain still has the operator's shape;
+		// the wrapper is just on the legacy child list now.
+		if len(chain) != 3 {
+			t.Errorf("chain length: got %d, want 3 (legacy classification keeps duplicate-name positions)", len(chain))
+		}
+		if !legacy["InnerRR"] {
+			t.Errorf("InnerRR must be on the legacy child list (demoted from F1 hard error), legacyChildren=%v", legacy)
+		}
+		if providers["InnerRR"] != "baml-roundrobin" {
+			t.Errorf("providers[InnerRR]: got %q, want baml-roundrobin (demoted, NOT leaf provider)", providers["InnerRR"])
+		}
+		if reason != PathReasonFallbackRoundRobinChildLegacy {
+			t.Errorf("reason: got %q, want %q (4-tuple seam demotes the F1 hard error to ChildLegacy)", reason, PathReasonFallbackRoundRobinChildLegacy)
+		}
+	})
 }

--- a/bamlutils/buildrequest/fallback_resolve_test.go
+++ b/bamlutils/buildrequest/fallback_resolve_test.go
@@ -425,14 +425,16 @@ func TestResolveFallbackChain_RoundRobinChildSkipped(t *testing.T) {
 }
 
 func TestResolveFallbackChain_FallbackWithRRChild_SurfacesReason(t *testing.T) {
-	// A fallback chain with a baml-roundrobin child still runs, but
-	// the PathReason surfaces the composition so operators can
-	// distinguish centralised top-level RR from per-worker nested
-	// RR. The RR child lands on the legacy child list
-	// (IsProviderSupported returns false for baml-roundrobin), and
-	// BAML's runtime handles its rotation on each worker
-	// independently. Centralised unwrapping of RR children inside
-	// fallback chains is deferred.
+	// A fallback chain whose immediate baml-roundrobin child has a
+	// BR-supported selected leaf is centrally unwrapped to that leaf
+	// (issue #237 PR 2). The 4-tuple wrapper surfaces the change as
+	// (a) the RR wrapper child REMOVED from legacyChildren, (b)
+	// providers[child] rewritten to the leaf provider so the
+	// orchestrator's IsProviderSupported gate sees the leaf, and (c)
+	// reason == PathReasonFallbackRoundRobinChildBuildRequest. The
+	// per-child Targets / NestedRoundRobin information requires the
+	// typed ResolveFallbackChainPlanForClient helper — the 4-tuple
+	// wrapper deliberately loses it for codegen-compat.
 	fallbackChains := map[string][]string{
 		"MyFallback": {"OpenAIClient", "InnerRR"},
 		"InnerRR":    {"GoogleA", "GoogleB"},
@@ -453,19 +455,20 @@ func TestResolveFallbackChain_FallbackWithRRChild_SurfacesReason(t *testing.T) {
 	)
 
 	if chain == nil {
-		t.Fatalf("expected chain to resolve (RR child is mixed-legacy, not abort), got nil with reason=%q", reason)
+		t.Fatalf("expected chain to resolve, got nil with reason=%q", reason)
 	}
-	if reason != PathReasonFallbackRoundRobinChildLegacy {
-		t.Fatalf("reason: got %q, want %q", reason, PathReasonFallbackRoundRobinChildLegacy)
+	if reason != PathReasonFallbackRoundRobinChildBuildRequest {
+		t.Fatalf("reason: got %q, want %q (centralized RR child should surface ChildBuildRequest)",
+			reason, PathReasonFallbackRoundRobinChildBuildRequest)
 	}
-	if !legacy["InnerRR"] {
-		t.Errorf("InnerRR must be marked legacy (BAML runtime handles RR rotation per-worker), legacyChildren=%v", legacy)
+	if legacy["InnerRR"] {
+		t.Errorf("InnerRR must NOT be marked legacy after centralization, legacyChildren=%v", legacy)
 	}
 	if legacy["OpenAIClient"] {
 		t.Errorf("OpenAIClient is a supported provider — must not be on legacy list, legacyChildren=%v", legacy)
 	}
-	if providers["InnerRR"] != "baml-roundrobin" {
-		t.Errorf("providers[InnerRR]: got %q, want baml-roundrobin", providers["InnerRR"])
+	if providers["InnerRR"] != "google-ai" {
+		t.Errorf("providers[InnerRR]: got %q, want google-ai (leaf provider after centralization)", providers["InnerRR"])
 	}
 }
 
@@ -657,11 +660,13 @@ func TestResolveFallbackChain_NestedInvalidProviderOverride(t *testing.T) {
 // TestResolveFallbackChain_NestedValidOverrideStillResolves pins
 // negative coverage: a nested strategy-parent child WITH a valid
 // runtime override (changed strategy children, valid start, valid
-// provider) must still resolve normally with the existing
-// PathReasonFallbackRoundRobinChildLegacy. The preflight's
-// "any nested override → legacy" alternative would lose mixed-mode
-// orchestration for legitimate runtime overrides; this test guards
-// against that drift.
+// provider) must resolve normally. Issue #237 PR 2 makes the valid
+// override eligible for centralization — TenantLeaf is BR-supported,
+// so the RR wrapper is centrally unwrapped to it and the reason
+// reports ChildBuildRequest. The preflight's "any nested override →
+// legacy" alternative would lose mixed-mode orchestration entirely
+// (centralized or otherwise) for legitimate runtime overrides; this
+// test still guards against that drift.
 func TestResolveFallbackChain_NestedValidOverrideStillResolves(t *testing.T) {
 	fallbackChains := map[string][]string{
 		"MyFallback": {"FastLeaf", "InnerRR"},
@@ -685,7 +690,7 @@ func TestResolveFallbackChain_NestedValidOverrideStillResolves(t *testing.T) {
 		},
 	}
 
-	chain, _, legacy, reason := ResolveFallbackChainForClientWithReason(
+	chain, providers, legacy, reason := ResolveFallbackChainForClientWithReason(
 		reg, "MyFallback", fallbackChains, clientProviders,
 		func(p string) bool { return p == "openai" },
 	)
@@ -693,14 +698,18 @@ func TestResolveFallbackChain_NestedValidOverrideStillResolves(t *testing.T) {
 	if chain == nil {
 		t.Fatalf("expected chain to resolve for valid nested override, got nil with reason=%q", reason)
 	}
-	if reason != PathReasonFallbackRoundRobinChildLegacy {
-		t.Errorf("reason: got %q, want %q", reason, PathReasonFallbackRoundRobinChildLegacy)
+	if reason != PathReasonFallbackRoundRobinChildBuildRequest {
+		t.Errorf("reason: got %q, want %q (valid override with BR-supported leaf should centralize)",
+			reason, PathReasonFallbackRoundRobinChildBuildRequest)
 	}
-	if !legacy["InnerRR"] {
-		t.Errorf("InnerRR must remain on the mixed-mode legacy child list (BAML runtime handles RR rotation), legacyChildren=%v", legacy)
+	if legacy["InnerRR"] {
+		t.Errorf("InnerRR must NOT be marked legacy after centralization, legacyChildren=%v", legacy)
 	}
 	if legacy["FastLeaf"] {
 		t.Errorf("FastLeaf is a supported leaf; it must NOT be misclassified as legacy, legacyChildren=%v", legacy)
+	}
+	if providers["InnerRR"] != "openai" {
+		t.Errorf("providers[InnerRR]: got %q, want openai (leaf provider after centralization to TenantLeaf)", providers["InnerRR"])
 	}
 }
 

--- a/bamlutils/buildrequest/fallback_targets_dispatch_test.go
+++ b/bamlutils/buildrequest/fallback_targets_dispatch_test.go
@@ -1,0 +1,288 @@
+package buildrequest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
+	"github.com/invakid404/baml-rest/bamlutils/retry"
+)
+
+// TestRunStreamOrchestration_FallbackTargets_RoutesBuildRequestToLeaf
+// pins the streaming orchestrator's wrapper-vs-target dispatch
+// (issue #237 PR 2). When the resolver has centralized an immediate
+// RR fallback child to a leaf, StreamConfig.FallbackTargets[child]
+// names that leaf and the orchestrator must pass IT (not the wrapper
+// child) as the clientOverride to buildRequest. On success,
+// WinnerClient must report the leaf — the dispatch target is the
+// realised serving identity.
+func TestRunStreamOrchestration_FallbackTargets_RoutesBuildRequestToLeaf(t *testing.T) {
+	server := makeOpenAIServer([]string{"hi"})
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	var (
+		mu        sync.Mutex
+		overrides []string
+	)
+	buildFn := func(_ context.Context, clientOverride string) (*llmhttp.Request, error) {
+		mu.Lock()
+		overrides = append(overrides, clientOverride)
+		mu.Unlock()
+		return &llmhttp.Request{URL: server.URL, Method: "POST", Body: `{}`}, nil
+	}
+
+	plan := &bamlutils.Metadata{Path: "buildrequest", Client: "MyFallback"}
+
+	config := &StreamConfig{
+		RetryPolicy:   &retry.Policy{MaxRetries: 0},
+		NeedsPartials: true,
+		FallbackChain: []string{"InnerRR", "Sibling"},
+		ClientProviders: map[string]string{
+			"InnerRR": "openai",
+			"Sibling": "openai",
+		},
+		// PR 2 resolver populates this when InnerRR's RR resolution
+		// selected the leaf "A". The orchestrator must dispatch BR
+		// against "A", not "InnerRR".
+		FallbackTargets:   map[string]string{"InnerRR": "A"},
+		MetadataPlan:      plan,
+		NewMetadataResult: newTestMetadataResult,
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		buildFn,
+		func(_ context.Context, s string) (any, error) { return s, nil },
+		func(_ context.Context, s string) (any, error) { return s, nil },
+		newTestResult,
+	)
+	close(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	gotOverrides := append([]string(nil), overrides...)
+	mu.Unlock()
+	if len(gotOverrides) != 1 {
+		t.Fatalf("expected exactly one buildRequest call, got %d: %v", len(gotOverrides), gotOverrides)
+	}
+	if gotOverrides[0] != "A" {
+		t.Errorf("clientOverride for first child: got %q, want %q (FallbackTargets[InnerRR]=A must drive dispatch, not the wrapper)",
+			gotOverrides[0], "A")
+	}
+
+	// Outcome metadata must report the leaf as the winner. Sweep through
+	// the channel for the outcome event.
+	planned, outcome, _, _ := collectMetadata(t, out)
+	if planned == nil {
+		t.Fatal("expected planned metadata event")
+	}
+	if outcome == nil {
+		t.Fatal("expected outcome metadata event on success")
+	}
+	if outcome.WinnerClient != "A" {
+		t.Errorf("outcome WinnerClient: got %q, want %q (centralized leaf is the realised serving client)",
+			outcome.WinnerClient, "A")
+	}
+	if outcome.WinnerPath != "buildrequest" {
+		t.Errorf("outcome WinnerPath: got %q, want buildrequest", outcome.WinnerPath)
+	}
+}
+
+// TestRunStreamOrchestration_FallbackTargets_EmptyPassesThrough pins
+// the backward-compatible shape: a chain with no FallbackTargets
+// entries (or an entry equal to child) keeps the pre-PR-2 dispatch
+// identity — clientOverride equals the chain-position name. Crucial
+// for codegen sites that haven't migrated to populating FallbackTargets
+// yet (PR 3 wires those).
+func TestRunStreamOrchestration_FallbackTargets_EmptyPassesThrough(t *testing.T) {
+	server := makeOpenAIServer([]string{"ok"})
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	var seen atomic.Value // string
+	buildFn := func(_ context.Context, clientOverride string) (*llmhttp.Request, error) {
+		seen.Store(clientOverride)
+		return &llmhttp.Request{URL: server.URL, Method: "POST", Body: `{}`}, nil
+	}
+
+	config := &StreamConfig{
+		RetryPolicy:   &retry.Policy{MaxRetries: 0},
+		NeedsPartials: true,
+		FallbackChain: []string{"OnlyChild"},
+		ClientProviders: map[string]string{
+			"OnlyChild": "openai",
+		},
+		// No FallbackTargets — pre-PR-2 shape.
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		buildFn,
+		func(_ context.Context, s string) (any, error) { return s, nil },
+		func(_ context.Context, s string) (any, error) { return s, nil },
+		newTestResult,
+	)
+	close(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, _ := seen.Load().(string)
+	if got != "OnlyChild" {
+		t.Errorf("clientOverride: got %q, want %q (no FallbackTargets entry must dispatch verbatim)",
+			got, "OnlyChild")
+	}
+}
+
+// TestRunStreamOrchestration_FallbackTargets_LegacyChildStaysAtWrapper
+// pins the wrapper-rooted legacy callback path: even when a sibling
+// has a FallbackTargets entry, true legacy children continue to
+// dispatch with the chain-position name (the wrapper) as the
+// clientOverride. The legacy callback's scoped registry depends on
+// the wrapper identity to preserve runtime strategy overrides for
+// genuinely-deferred RR shapes (see #199 / #224 codegen scope split).
+func TestRunStreamOrchestration_FallbackTargets_LegacyChildStaysAtWrapper(t *testing.T) {
+	out := make(chan bamlutils.StreamResult, 100)
+
+	var (
+		legacyOverride string
+		legacyProvider string
+	)
+	legacyCalled := atomic.Int32{}
+	legacyFn := func(_ context.Context, clientOverride, provider string, _ bool, sendHeartbeat func()) (any, string, error) {
+		legacyCalled.Add(1)
+		legacyOverride = clientOverride
+		legacyProvider = provider
+		sendHeartbeat()
+		return "legacy ok", "", nil
+	}
+
+	config := &StreamConfig{
+		RetryPolicy:   &retry.Policy{MaxRetries: 0},
+		NeedsPartials: false,
+		FallbackChain: []string{"BedrockWrapper"},
+		ClientProviders: map[string]string{
+			"BedrockWrapper": "aws-bedrock",
+		},
+		LegacyChildren: map[string]bool{"BedrockWrapper": true},
+		// A bogus FallbackTargets entry that, if (incorrectly) honored
+		// for legacy dispatch, would surface as legacyOverride=="bypass".
+		FallbackTargets:   map[string]string{"BedrockWrapper": "bypass"},
+		LegacyStreamChild: legacyFn,
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, nil,
+		func(_ context.Context, _ string) (*llmhttp.Request, error) {
+			t.Fatal("BR path must not be invoked for legacy-only chain")
+			return nil, nil
+		},
+		nil,
+		func(_ context.Context, s string) (any, error) { return s, nil },
+		newTestResult,
+	)
+	close(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if legacyCalled.Load() != 1 {
+		t.Fatalf("expected legacy callback invoked once, got %d", legacyCalled.Load())
+	}
+	if legacyOverride != "BedrockWrapper" {
+		t.Errorf("legacy clientOverride: got %q, want %q (legacy dispatch must stay rooted at wrapper; FallbackTargets is BR-only)",
+			legacyOverride, "BedrockWrapper")
+	}
+	if legacyProvider != "aws-bedrock" {
+		t.Errorf("legacy provider: got %q, want aws-bedrock (ClientProviders[child] feeds legacy callback)", legacyProvider)
+	}
+}
+
+// TestRunCallOrchestration_FallbackTargets_RoutesBuildRequestToLeaf
+// mirrors the streaming-side test on the non-streaming call path so
+// the dispatch contract is identical across both orchestrators.
+func TestRunCallOrchestration_FallbackTargets_RoutesBuildRequestToLeaf(t *testing.T) {
+	// Build a simple JSON response server. The call orchestrator's
+	// extractResponse callback consumes the body; we just have to
+	// return something it can decode.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"hi"}}]}`))
+	}))
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 16)
+
+	var (
+		mu        sync.Mutex
+		overrides []string
+	)
+	buildFn := func(_ context.Context, clientOverride string) (*llmhttp.Request, error) {
+		mu.Lock()
+		overrides = append(overrides, clientOverride)
+		mu.Unlock()
+		return &llmhttp.Request{URL: server.URL, Method: "POST", Body: `{}`}, nil
+	}
+
+	plan := &bamlutils.Metadata{Path: "buildrequest", Client: "MyFallback"}
+
+	config := &CallConfig{
+		RetryPolicy:   &retry.Policy{MaxRetries: 0},
+		FallbackChain: []string{"InnerRR", "Sibling"},
+		ClientProviders: map[string]string{
+			"InnerRR": "openai",
+			"Sibling": "openai",
+		},
+		FallbackTargets:   map[string]string{"InnerRR": "A"},
+		MetadataPlan:      plan,
+		NewMetadataResult: newTestMetadataResult,
+	}
+
+	err := RunCallOrchestration(
+		context.Background(), out, config, client,
+		buildFn,
+		func(_ context.Context, s string) (any, error) { return s, nil },
+		func(_ string, body string, _ bool) (string, string, error) { return body, body, nil },
+		newTestResult,
+	)
+	close(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	gotOverrides := append([]string(nil), overrides...)
+	mu.Unlock()
+	if len(gotOverrides) != 1 {
+		t.Fatalf("expected exactly one buildRequest call, got %d: %v", len(gotOverrides), gotOverrides)
+	}
+	if gotOverrides[0] != "A" {
+		t.Errorf("clientOverride for first child: got %q, want %q (call-side dispatch must honor FallbackTargets)",
+			gotOverrides[0], "A")
+	}
+
+	planned, outcome, _, _ := collectMetadata(t, out)
+	if planned == nil {
+		t.Fatal("expected planned metadata event")
+	}
+	if outcome == nil {
+		t.Fatal("expected outcome metadata event on success")
+	}
+	if outcome.WinnerClient != "A" {
+		t.Errorf("outcome WinnerClient: got %q, want %q", outcome.WinnerClient, "A")
+	}
+}

--- a/bamlutils/buildrequest/metadata.go
+++ b/bamlutils/buildrequest/metadata.go
@@ -433,6 +433,53 @@ func BuildFallbackChainPlan(
 	return plan
 }
 
+// BuildFallbackChainPlanFromResolution constructs planned metadata for a
+// request routed through the BuildRequest path as a fallback strategy,
+// consuming the typed FallbackChainResolution produced by
+// ResolveFallbackChainPlanForClient. Distinct from the 4-tuple-input
+// sibling (BuildFallbackChainPlanForClient) so issue #237 PR 2's
+// per-child Targets and NestedRoundRobin information survives into the
+// planned metadata payload.
+//
+// Callers consuming the new typed resolver pass the resolution directly;
+// the 4-tuple plan builders stay as a compatibility surface for code
+// (notably the generated router) that hasn't migrated yet. PR 3 wires
+// the router through this typed builder.
+//
+// Sparse-map contract:
+//   - FallbackTargets entries are omitted when target == child (the
+//     resolver's contract); callers don't need to filter.
+//   - FallbackRoundRobin is nil when no centralization happened, so the
+//     plan's JSON payload drops the key via omitempty.
+func BuildFallbackChainPlanFromResolution(
+	clientName string,
+	resolution *FallbackChainResolution,
+	retryPolicy *retry.Policy,
+	buildRequestAPI string,
+) *bamlutils.Metadata {
+	plan := newPlanBase("buildrequest", clientName, retryPolicy, buildRequestAPI)
+	plan.Strategy = "baml-fallback"
+	if resolution == nil {
+		return plan
+	}
+	plan.PathReason = resolution.Reason
+	plan.Chain = append([]string(nil), resolution.Chain...)
+	plan.LegacyChildren = orderedLegacyChildren(resolution.Chain, resolution.LegacyChildren)
+	if len(resolution.Targets) > 0 {
+		plan.FallbackTargets = make(map[string]string, len(resolution.Targets))
+		for k, v := range resolution.Targets {
+			plan.FallbackTargets[k] = v
+		}
+	}
+	if len(resolution.NestedRoundRobin) > 0 {
+		plan.FallbackRoundRobin = make(map[string]*bamlutils.RoundRobinInfo, len(resolution.NestedRoundRobin))
+		for k, v := range resolution.NestedRoundRobin {
+			plan.FallbackRoundRobin[k] = v
+		}
+	}
+	return plan
+}
+
 // BuildFallbackChainPlanForClient is the primary-override-free sibling of
 // BuildFallbackChainPlan. Use after ResolveEffectiveClient has already
 // produced the effective client name.

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -766,17 +766,22 @@ func RunStreamOrchestration(
 				heartbeatSent.Store(false)
 			}
 			var (
-				finalResult any
-				raw         string
-				err         error
-				path        string
+				finalResult  any
+				raw          string
+				err          error
+				path         string
+				winnerTarget = child
 			)
 			if config.LegacyChildren[child] {
 				// Legacy children run via BAML's Stream API. The callback
 				// owns heartbeat timing (fires sendHeartbeat on the first
 				// FunctionLog tick) so pool hung-detection stays correct.
 				// Partials are never emitted by the callback — it reports
-				// only (final, raw, err).
+				// only (final, raw, err). Note: callback dispatch stays
+				// rooted at `child` (the chain-position name) so the
+				// scoped registry preserves runtime strategy overrides
+				// for true legacy children — FallbackTargets is honored
+				// for the BuildRequest path only.
 				finalResult, raw, err = config.LegacyStreamChild(
 					ctx,
 					child,
@@ -787,11 +792,32 @@ func RunStreamOrchestration(
 				path = "legacy"
 			} else {
 				provider := config.ClientProviders[child]
-				finalResult, raw, err = tryOneStreamChild(provider, child)
+				// Wrapper-vs-target identity (issue #237 PR 2): when an
+				// immediate RR fallback child was centrally unwrapped
+				// to a leaf, FallbackTargets[child] names that leaf.
+				// Dispatch BuildRequest against the leaf so BAML's
+				// runtime sees the resolved client identity directly,
+				// not the RR wrapper (which would re-rotate per-worker
+				// inside BAML and defeat the centralization). When the
+				// map has no entry or the entry equals child, dispatch
+				// passes the chain-position name verbatim — preserving
+				// the pre-PR-2 shape for chains with no centralization.
+				if t, ok := config.FallbackTargets[child]; ok && t != "" {
+					winnerTarget = t
+				}
+				finalResult, raw, err = tryOneStreamChild(provider, winnerTarget)
 				path = "buildrequest"
 			}
 			if err == nil {
-				winnerClient = child
+				// WinnerClient names the client actually contacted:
+				// for legacy children, the wrapper (chain-position
+				// name); for BR children, the dispatch target (the
+				// centralized leaf when FallbackTargets[child] is set,
+				// otherwise the chain-position name). WinnerProvider
+				// stays keyed by the chain position so it reflects
+				// the resolver's classification (leaf provider for
+				// centralized RR children, wrapper provider otherwise).
+				winnerClient = winnerTarget
 				winnerProvider = config.ClientProviders[child]
 				winnerPath = path
 				finalRetryCount = attempt


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

PR 2 of #237's 3-PR plan. Builds on PR 1 (#238)'s metadata vocabulary. PR 3 will update codegen + integration tests.

## What this changes

When a fallback chain has an **immediate RR child** (e.g. `fallback[rr[A,B], C]`) AND the RR's selected leaf is non-strategy + BuildRequest-supported, the **typed** resolver `ResolveFallbackChainPlanForClient` now:

- **Doesn't** mark the RR child as legacy.
- Resolves the RR wrapper to a leaf using the same `adapter.RoundRobinAdvancer()` preference as top-level RR (so the request-scoped `RemoteAdvancer` and `(key, op_id)` idempotency cache cover the nested RR too).
- Returns the leaf in `FallbackChainResolution.Targets[child]` and the RR decision in `NestedRoundRobin[child]`.
- Sets `PathReason = PathReasonFallbackRoundRobinChildBuildRequest`.

Orchestrator dispatch (`RunStreamOrchestration` + `RunCallOrchestration`) honors `FallbackTargets[child]` for the BuildRequest call and reports `WinnerClient = target` on success. Legacy callback dispatch stays rooted at the wrapper (chain-position) name so the scoped registry preserves runtime strategy overrides for true legacy children.

## Compat-shim caveat (4-tuple seam)

The typed helper centralizes correctly and is **PR-3-consumable + test-reachable**. The 4-tuple `ResolveFallbackChainForClientWithReason` shim deliberately **demotes centralization back to legacy classification** (commit `0bd738e2c`):

- Codegen-emitted call sites (`adapters/common/codegen/codegen_router.go:213, 294, 379`) consume the 4-tuple shape and have no path to thread `Targets` through to the orchestrator's `StreamConfig` / `CallConfig` until PR 3 wires codegen to the typed helper.
- If the wrapper exposed the centralized shape, the orchestrator's BR dispatch — falling back to the chain-position name when `FallbackTargets[child]` is empty — would fire against the **RR wrapper name** (wrong-client routing).
- So the wrapper detects centralization (`Targets` / `NestedRoundRobin` populated on the typed result) and routes through `resolveFallbackChainLegacyClassification` to keep the pre-PR-2 shape. Codegen-driven dispatch keeps using the legacy callback for nested RR exactly as it did before.

End-to-end cross-worker centralization is **production-reachable starting in PR 3**, when codegen migrates to the typed `ResolveFallbackChainPlanForClient` helper and threads `FallbackTargets` through the orchestrator config.

## What stays on the legacy callback (unchanged)

- RR children whose selected leaf is unsupported (`aws-bedrock`, unknown provider).
- RR children whose selected leaf is itself a strategy (e.g. `rr[fallback[A,B], C]` — recursive shapes).
- Fallback-as-fallback-child (e.g. `fallback[fallback[A,B], C]`).
- Invalid `options.strategy` / `options.start` overrides — keep top-level legacy fallthrough so BAML emits canonical errors.
- Nil `isProviderSupported` callers (conservative — can't determine support → stay legacy).
- **Every RR fallback child at the 4-tuple seam** until PR 3 lands (codegen back-compat — see above).

## Sentinel-vs-hard-error semantics

Mirrors top-level RR exactly at the typed helper:
- Sentinel errors (`ErrInvalidStrategyOverride`, `ErrInvalidStartOverride`) → fall through to legacy at top level (existing behavior).
- Hard errors (cycle, empty children, advancer transport error, out-of-range) → request-fatal at the typed helper level. **No silent legacy fallthrough.** The 4-tuple wrapper deliberately demotes these for codegen-compat; PR 3 wires the request-fatal posture through the codegen seam.

## Out of scope (PR 3)

- Codegen router updates to consume the new typed resolver result.
- Per-adapter `cmd/main.go` regen.
- `cmd/introspect/main.go` warning narrowing.
- Integration tests.

## Test plan

- [x] `TestResolveFallbackChainPlanForClient` — new sub-cases for centralized supported leaf, unsupported leaf stays legacy, strategy leaf stays legacy, invalid override falls through, empty children hard-error, multi-RR-children each centralized, nil-support stays legacy, adapter-advancer-overrides-nil. **Typed seam — centralization verified end-to-end.**
- [x] `TestBuildFallbackChainPlanFromResolution` + nil/empty-maps sparse-contract regression.
- [x] `TestRunStreamOrchestration_FallbackTargets_RoutesBuildRequestToLeaf` + `EmptyPassesThrough` + `LegacyChildStaysAtWrapper`.
- [x] `TestRunCallOrchestration_FallbackTargets_RoutesBuildRequestToLeaf`.
- [x] `Test4TupleWrapper_DemoteCentralizedToLegacy` — new in commit `0bd738e2c`. Sub-cases: eligible-rr-child-demoted, multiple-eligible-rr-children-all-demoted, ineligible-rr-child-already-legacy, non-rr-fallback-chain-unchanged-no-demotion. **Pins the 4-tuple seam's pre-PR-2 shape.**
- [x] Existing tests pass unchanged (#234 nil-support strategy classification, #235 plan-builder, #236 retry-policy). Two existing tests (`TestResolveFallbackChain_FallbackWithRRChild_SurfacesReason`, `TestResolveFallbackChain_NestedValidOverrideStillResolves`) reverted to pre-PR-2 expectations — the 4-tuple seam now demotes, so codegen-driven dispatch keeps using the legacy callback.
- [x] `verify-framework-adapter` 9/9 — codegen consumers still compile against the unchanged 4-tuple resolver signature.
- [x] `verify-adapter-pins` — clean.
- [x] All `bamlutils/...` packages pass `go test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized round‑robin unwrapping with per‑child fallback targets and richer fallback metadata; metadata builder surfaces targets and round‑robin info when present.

* **Bug Fixes**
  * Orchestration dispatches to resolved leaf identities for BuildRequest-driven fallbacks while preserving legacy behavior for legacy-marked children; outcome metadata reports the resolved dispatch target.

* **Tests**
  * Expanded test coverage for resolution, dispatch routing, compatibility demotion, metadata construction, and failure/sentinel handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/239)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->