### PR TITLE
feat(codegen): drive fallback RR children through BuildRequest

### DIFF
--- a/adapters/common/codegen/codegen_buildrequest.go
+++ b/adapters/common/codegen/codegen_buildrequest.go
@@ -293,7 +293,12 @@ func (me *methodEmitter) emitBuildRequest() {
 		// up-front validation passes even when legacyChildren is nil.
 		// MetadataPlan / NewMetadataResult carry the per-request
 		// routing metadata through to the orchestrator's planned +
-		// outcome emissions.
+		// outcome emissions. FallbackTargets / FallbackRoundRobin
+		// carry the per-child dispatch target and RR decision for
+		// centralized RR fallback children — the orchestrator's
+		// dispatch loop consults FallbackTargets[child] when computing
+		// the WithClient target so a centrally-unwrapped RR child
+		// routes to the selected leaf rather than the RR wrapper name.
 		jen.Id("streamConfig").Op(":=").Op("&").Qual(common.BuildRequestPkg, "StreamConfig").Values(jen.Dict{
 			jen.Id("Provider"):             jen.Id("provider"),
 			jen.Id("RetryPolicy"):          jen.Id("retryPolicy"),
@@ -304,6 +309,8 @@ func (me *methodEmitter) emitBuildRequest() {
 			jen.Id("ClientOverride"):       jen.Id("clientOverride"),
 			jen.Id("ClientProviders"):      jen.Id("clientProviders"),
 			jen.Id("LegacyChildren"):       jen.Id("legacyChildren"),
+			jen.Id("FallbackTargets"):      jen.Id("fallbackTargets"),
+			jen.Id("FallbackRoundRobin"):   jen.Id("fallbackRoundRobin"),
 			jen.Id("LegacyStreamChild"):    jen.Id("legacyStreamChildFn"),
 			jen.Id("MetadataPlan"):         jen.Id("plannedMetadata"),
 			jen.Id("NewMetadataResult"): jen.Func().Params(
@@ -368,6 +375,8 @@ func (me *methodEmitter) emitBuildRequest() {
 			jen.Id("fallbackChain").Index().String(),
 			jen.Id("clientProviders").Map(jen.String()).String(),
 			jen.Id("legacyChildren").Map(jen.String()).Bool(),
+			jen.Id("fallbackTargets").Map(jen.String()).String(),
+			jen.Id("fallbackRoundRobin").Map(jen.String()).Op("*").Qual(common.InterfacesPkg, "RoundRobinInfo"),
 			jen.Id("plannedMetadata").Op("*").Qual(common.InterfacesPkg, "Metadata"),
 			jen.Id("clientOverride").String(),
 		).
@@ -539,7 +548,11 @@ func (me *methodEmitter) emitBuildCallRequest() {
 
 		// CallConfig. LegacyChildren is populated for mixed chains;
 		// LegacyCallChild is always wired so validation passes even
-		// when legacyChildren is nil.
+		// when legacyChildren is nil. FallbackTargets / FallbackRound-
+		// Robin mirror StreamConfig — the call-side dispatch loop
+		// also honours FallbackTargets[child] when computing the
+		// per-attempt WithClient target so centralized RR fallback
+		// children dispatch to the leaf rather than the wrapper.
 		jen.Id("callConfig").Op(":=").Op("&").Qual(common.BuildRequestPkg, "CallConfig").Values(jen.Dict{
 			jen.Id("Provider"):             jen.Id("provider"),
 			jen.Id("RetryPolicy"):          jen.Id("retryPolicy"),
@@ -549,6 +562,8 @@ func (me *methodEmitter) emitBuildCallRequest() {
 			jen.Id("ClientOverride"):       jen.Id("clientOverride"),
 			jen.Id("ClientProviders"):      jen.Id("clientProviders"),
 			jen.Id("LegacyChildren"):       jen.Id("legacyChildren"),
+			jen.Id("FallbackTargets"):      jen.Id("fallbackTargets"),
+			jen.Id("FallbackRoundRobin"):   jen.Id("fallbackRoundRobin"),
 			jen.Id("LegacyCallChild"):      jen.Id("legacyCallChildFn"),
 			jen.Id("MetadataPlan"):         jen.Id("plannedMetadata"),
 			jen.Id("NewMetadataResult"): jen.Func().Params(
@@ -611,6 +626,8 @@ func (me *methodEmitter) emitBuildCallRequest() {
 			jen.Id("fallbackChain").Index().String(),
 			jen.Id("clientProviders").Map(jen.String()).String(),
 			jen.Id("legacyChildren").Map(jen.String()).Bool(),
+			jen.Id("fallbackTargets").Map(jen.String()).String(),
+			jen.Id("fallbackRoundRobin").Map(jen.String()).Op("*").Qual(common.InterfacesPkg, "RoundRobinInfo"),
 			jen.Id("plannedMetadata").Op("*").Qual(common.InterfacesPkg, "Metadata"),
 			jen.Id("clientOverride").String(),
 		).

--- a/adapters/common/codegen/codegen_router.go
+++ b/adapters/common/codegen/codegen_router.go
@@ -139,95 +139,89 @@ func (me *methodEmitter) emitRouter() {
 		)
 	}
 
-	// fallbackChainConsumeCond builds the condition guarding the call-side
-	// fallback block. When a StreamRequest bridge exists downstream, the
-	// call block only consumes chains with no call-legacy children; mixed
-	// chains must fall through so the bridge can re-resolve them with
-	// IsProviderSupported and drive call-legacy-but-stream-supported
-	// children through the streaming path rather than legacyCallChildFn.
-	// Without a bridge, the call block is the only BuildRequest landing
-	// spot and accepts any non-empty chain, matching pre-bridge behaviour.
-	//
+	// fallbackChainConsumeCond builds the condition guarding a fallback-
+	// chain landing block: a non-nil resolution with a non-empty chain.
 	// Reads off __resolution (the typed FallbackChainResolution from
-	// ResolveFallbackChainPlanForClient); nil-checking guards against
+	// ResolveFallbackChainPlanForClient); the nil-check guards against
 	// the "not a fallback strategy" return shape.
-	fallbackChainConsumeCond := func(hasBridge bool) jen.Code {
-		nonEmpty := jen.Id("__resolution").Op("!=").Nil().
+	fallbackChainConsumeCond := func() jen.Code {
+		return jen.Id("__resolution").Op("!=").Nil().
 			Op("&&").Len(jen.Id("__resolution").Dot("Chain")).Op(">").Lit(0)
-		if !hasBridge {
-			return nonEmpty
-		}
-		return nonEmpty.Op("&&").Len(jen.Id("__resolution").Dot("LegacyChildren")).Op("==").Lit(0)
 	}
 
 	// Non-streaming BuildRequest path for /call and /call-with-raw.
 	// Uses Request (not StreamRequest) to build non-streaming HTTP requests.
 	// Checked before the streaming path since it's more efficient for call modes.
+	//
+	// When the StreamRequest bridge exists (hasBuildRequest=true) the
+	// call block emits only the single-provider arm and the bridge below
+	// owns ALL fallback-chain resolution for call modes. Two reasons:
+	//
+	//   1. Single resolver per request. If both blocks called the typed
+	//      resolver, a mixed chain (centralised RR child plus any
+	//      call-legacy sibling) would advance the SharedState advancer
+	//      in the call block and again in the bridge after falling
+	//      through — burning two idempotency-cache slots and skewing
+	//      rotation for that request shape.
+	//   2. Stream-side support is a superset of call-side support
+	//      (IsProviderSupported ⊇ IsCallProviderSupported), so the
+	//      bridge's stream-side classification covers every chain the
+	//      call block could have driven directly; the trade-off is SSE
+	//      accumulation overhead vs a unary HTTP attempt, which is
+	//      acceptable next to LLM call latency.
+	//
+	// When no bridge exists (hasBuildRequest=false) the call block is
+	// the sole BuildRequest landing spot for call modes and emits the
+	// fallback-chain arm itself.
 	if hasCallBuildRequest {
-		routerBody = append(routerBody,
-			jen.Comment("Try non-streaming BuildRequest path for /call and /call-with-raw"),
-			jen.If(
-				jen.Id("__useBuildRequest").
-					Op("&&").Qual(common.IntrospectedPkg, "Request").Op("!=").Nil().
-					Op("&&").Parens(jen.Id("mode").Op("==").Qual(common.InterfacesPkg, "StreamModeCall").
-					Op("||").Id("mode").Op("==").Qual(common.InterfacesPkg, "StreamModeCallWithRaw")),
-			).Block(
-				// Single-provider path — keyed off the effective (post-RR)
-				// client. ResolveClientProvider consults the runtime
-				// registry for a per-client provider override before
-				// falling back to the introspected default.
-				jen.Id("provider").Op(":=").Qual(common.BuildRequestPkg, "ResolveClientProvider").Call(
-					jen.Id("__reg"),
+		callBlockBody := []jen.Code{
+			// Single-provider path — keyed off the effective (post-RR)
+			// client. ResolveClientProvider consults the runtime
+			// registry for a per-client provider override before
+			// falling back to the introspected default.
+			jen.Id("provider").Op(":=").Qual(common.BuildRequestPkg, "ResolveClientProvider").Call(
+				jen.Id("__reg"),
+				jen.Id("__effective"),
+				jen.Qual(common.IntrospectedPkg, "ClientProvider"),
+			),
+			jen.If(jen.Id("provider").Op("!=").Lit("").Op("&&").Qual(common.BuildRequestPkg, "IsCallProviderSupported").Call(jen.Id("provider"))).Block(
+				resolveRetryPolicy(),
+				jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildSingleProviderPlanForClient").Call(
 					jen.Id("__effective"),
-					jen.Qual(common.IntrospectedPkg, "ClientProvider"),
+					jen.Id("provider"),
+					jen.Id("retryPolicy"),
+					jen.Qual(common.BuildRequestPkg, "BuildRequestAPIRequest"),
 				),
-				jen.If(jen.Id("provider").Op("!=").Lit("").Op("&&").Qual(common.BuildRequestPkg, "IsCallProviderSupported").Call(jen.Id("provider"))).Block(
-					resolveRetryPolicy(),
-					jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildSingleProviderPlanForClient").Call(
-						jen.Id("__effective"),
-						jen.Id("provider"),
-						jen.Id("retryPolicy"),
-						jen.Qual(common.BuildRequestPkg, "BuildRequestAPIRequest"),
-					),
-					jen.Id("__planned").Dot("RoundRobin").Op("=").Id("__rrInfo"),
-					jen.Id("err").Op("=").Id(me.buildCallRequestMethodName).Call(
-						jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
-						jen.Id("provider"), jen.Id("retryPolicy"),
-						jen.Nil(), jen.Nil(),
-						jen.Nil(),
-						jen.Nil(), jen.Nil(),
-						jen.Id("__planned"),
-						jen.Id("__effective"),
-					),
-					jen.If(jen.Id("err").Op("!=").Nil()).Block(
-						jen.Return(jen.Nil(), jen.Id("err")),
-					),
-					jen.Return(jen.Id("out"), jen.Nil()),
+				jen.Id("__planned").Dot("RoundRobin").Op("=").Id("__rrInfo"),
+				jen.Id("err").Op("=").Id(me.buildCallRequestMethodName).Call(
+					jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
+					jen.Id("provider"), jen.Id("retryPolicy"),
+					jen.Nil(), jen.Nil(),
+					jen.Nil(),
+					jen.Nil(), jen.Nil(),
+					jen.Id("__planned"),
+					jen.Id("__effective"),
 				),
-				// Fallback chain path: if single-provider check failed,
-				// try resolving a fallback chain off the effective client.
-				// When a bridge block exists (hasBuildRequest), a mixed
-				// chain — one with any call-legacy children — must fall
-				// through so the bridge re-resolves it with
-				// IsProviderSupported; a child that is call-legacy may
-				// still be stream-supported, and the bridge's
-				// StreamRequest path drives such children better than
-				// legacyCallChildFn. This block therefore only takes
-				// chains that are fully call-supported. When no bridge
-				// exists (hasBuildRequest=false) mixed chains stay here,
-				// matching the pre-bridge behaviour.
-				//
-				// The typed resolver threads its per-child Targets +
-				// NestedRoundRobin onto the generated config so that
-				// centrally-unwrapped RR fallback children dispatch to
-				// the selected leaf via the BuildRequest path while
-				// rotation stays cross-worker. The advancer preference
-				// (PreferAdvancer) mirrors ResolveEffectiveClient so the
-				// SharedState idempotency key threads identically for
-				// top-level and nested RR. Hard errors from the resolver
-				// (cycle / empty children / advancer transport / duplicate
-				// RR child) propagate request-fatal — matching top-level
-				// RR semantics — rather than silently degrading.
+				jen.If(jen.Id("err").Op("!=").Nil()).Block(
+					jen.Return(jen.Nil(), jen.Id("err")),
+				),
+				jen.Return(jen.Id("out"), jen.Nil()),
+			),
+		}
+		if !hasBuildRequest {
+			// No bridge below — the call block must resolve and consume
+			// fallback chains itself. The typed resolver threads its
+			// per-child Targets + NestedRoundRobin onto the generated
+			// config so that centrally-unwrapped RR fallback children
+			// dispatch to the selected leaf via the BuildRequest path
+			// while rotation stays cross-worker. PreferAdvancer mirrors
+			// ResolveEffectiveClient's per-request RemoteAdvancer
+			// preference so the SharedState idempotency key threads
+			// identically for top-level and nested RR. Hard errors from
+			// the resolver (cycle / empty children / advancer transport /
+			// duplicate RR child) propagate request-fatal — matching
+			// top-level RR semantics — rather than silently degrading.
+			callBlockBody = append(callBlockBody,
 				jen.List(jen.Id("__resolution"), jen.Id("__fbErr")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChainPlanForClient").Call(
 					jen.Id("__reg"),
 					jen.Id("__effective"),
@@ -242,7 +236,7 @@ func (me *methodEmitter) emitRouter() {
 				jen.If(jen.Id("__fbErr").Op("!=").Nil()).Block(
 					jen.Return(jen.Nil(), jen.Id("__fbErr")),
 				),
-				jen.If(fallbackChainConsumeCond(hasBuildRequest)).Block(
+				jen.If(fallbackChainConsumeCond()).Block(
 					resolveRetryPolicy(),
 					jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildFallbackChainPlanFromResolution").Call(
 						jen.Id("__effective"),
@@ -267,7 +261,16 @@ func (me *methodEmitter) emitRouter() {
 					),
 					jen.Return(jen.Id("out"), jen.Nil()),
 				),
-			),
+			)
+		}
+		routerBody = append(routerBody,
+			jen.Comment("Try non-streaming BuildRequest path for /call and /call-with-raw"),
+			jen.If(
+				jen.Id("__useBuildRequest").
+					Op("&&").Qual(common.IntrospectedPkg, "Request").Op("!=").Nil().
+					Op("&&").Parens(jen.Id("mode").Op("==").Qual(common.InterfacesPkg, "StreamModeCall").
+					Op("||").Id("mode").Op("==").Qual(common.InterfacesPkg, "StreamModeCallWithRaw")),
+			).Block(callBlockBody...),
 		)
 	}
 
@@ -337,7 +340,7 @@ func (me *methodEmitter) emitRouter() {
 				jen.If(jen.Id("__fbErr").Op("!=").Nil()).Block(
 					jen.Return(jen.Nil(), jen.Id("__fbErr")),
 				),
-				jen.If(jen.Id("__resolution").Op("!=").Nil().Op("&&").Len(jen.Id("__resolution").Dot("Chain")).Op(">").Lit(0)).Block(
+				jen.If(fallbackChainConsumeCond()).Block(
 					resolveRetryPolicy(),
 					jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildFallbackChainPlanFromResolution").Call(
 						jen.Id("__effective"),
@@ -434,7 +437,7 @@ func (me *methodEmitter) emitRouter() {
 				jen.If(jen.Id("__fbErr").Op("!=").Nil()).Block(
 					jen.Return(jen.Nil(), jen.Id("__fbErr")),
 				),
-				jen.If(jen.Id("__resolution").Op("!=").Nil().Op("&&").Len(jen.Id("__resolution").Dot("Chain")).Op(">").Lit(0)).Block(
+				jen.If(fallbackChainConsumeCond()).Block(
 					resolveRetryPolicy(),
 					jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildFallbackChainPlanFromResolution").Call(
 						jen.Id("__effective"),

--- a/adapters/common/codegen/codegen_router.go
+++ b/adapters/common/codegen/codegen_router.go
@@ -147,12 +147,17 @@ func (me *methodEmitter) emitRouter() {
 	// children through the streaming path rather than legacyCallChildFn.
 	// Without a bridge, the call block is the only BuildRequest landing
 	// spot and accepts any non-empty chain, matching pre-bridge behaviour.
+	//
+	// Reads off __resolution (the typed FallbackChainResolution from
+	// ResolveFallbackChainPlanForClient); nil-checking guards against
+	// the "not a fallback strategy" return shape.
 	fallbackChainConsumeCond := func(hasBridge bool) jen.Code {
-		nonEmpty := jen.Len(jen.Id("__chain")).Op(">").Lit(0)
+		nonEmpty := jen.Id("__resolution").Op("!=").Nil().
+			Op("&&").Len(jen.Id("__resolution").Dot("Chain")).Op(">").Lit(0)
 		if !hasBridge {
 			return nonEmpty
 		}
-		return nonEmpty.Op("&&").Len(jen.Id("__legacyChildren")).Op("==").Lit(0)
+		return nonEmpty.Op("&&").Len(jen.Id("__resolution").Dot("LegacyChildren")).Op("==").Lit(0)
 	}
 
 	// Non-streaming BuildRequest path for /call and /call-with-raw.
@@ -190,6 +195,7 @@ func (me *methodEmitter) emitRouter() {
 						jen.Id("provider"), jen.Id("retryPolicy"),
 						jen.Nil(), jen.Nil(),
 						jen.Nil(),
+						jen.Nil(), jen.Nil(),
 						jen.Id("__planned"),
 						jen.Id("__effective"),
 					),
@@ -210,30 +216,49 @@ func (me *methodEmitter) emitRouter() {
 				// chains that are fully call-supported. When no bridge
 				// exists (hasBuildRequest=false) mixed chains stay here,
 				// matching the pre-bridge behaviour.
-				jen.List(jen.Id("__chain"), jen.Id("__cprov"), jen.Id("__legacyChildren"), jen.Id("__fbReason")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChainForClientWithReason").Call(
+				//
+				// The typed resolver threads its per-child Targets +
+				// NestedRoundRobin onto the generated config so that
+				// centrally-unwrapped RR fallback children dispatch to
+				// the selected leaf via the BuildRequest path while
+				// rotation stays cross-worker. The advancer preference
+				// (PreferAdvancer) mirrors ResolveEffectiveClient so the
+				// SharedState idempotency key threads identically for
+				// top-level and nested RR. Hard errors from the resolver
+				// (cycle / empty children / advancer transport / duplicate
+				// RR child) propagate request-fatal — matching top-level
+				// RR semantics — rather than silently degrading.
+				jen.List(jen.Id("__resolution"), jen.Id("__fbErr")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChainPlanForClient").Call(
 					jen.Id("__reg"),
 					jen.Id("__effective"),
 					jen.Qual(common.IntrospectedPkg, "FallbackChains"),
 					jen.Qual(common.IntrospectedPkg, "ClientProvider"),
 					jen.Qual(common.BuildRequestPkg, "IsCallProviderSupported"),
+					jen.Qual(common.BuildRequestPkg, "PreferAdvancer").Call(
+						jen.Id("adapter"),
+						jen.Qual(common.IntrospectedPkg, "RoundRobinCoordinator"),
+					),
+				),
+				jen.If(jen.Id("__fbErr").Op("!=").Nil()).Block(
+					jen.Return(jen.Nil(), jen.Id("__fbErr")),
 				),
 				jen.If(fallbackChainConsumeCond(hasBuildRequest)).Block(
 					resolveRetryPolicy(),
-					jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildFallbackChainPlanForClient").Call(
+					jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildFallbackChainPlanFromResolution").Call(
 						jen.Id("__effective"),
-						jen.Id("__chain"),
-						jen.Id("__cprov"),
-						jen.Id("__legacyChildren"),
+						jen.Id("__resolution"),
 						jen.Id("retryPolicy"),
 						jen.Qual(common.BuildRequestPkg, "BuildRequestAPIRequest"),
-						jen.Id("__fbReason"),
 					),
 					jen.Id("__planned").Dot("RoundRobin").Op("=").Id("__rrInfo"),
 					jen.Id("err").Op("=").Id(me.buildCallRequestMethodName).Call(
 						jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
 						jen.Lit(""), jen.Id("retryPolicy"),
-						jen.Id("__chain"), jen.Id("__cprov"),
-						jen.Id("__legacyChildren"),
+						jen.Id("__resolution").Dot("Chain"),
+						jen.Id("__resolution").Dot("Providers"),
+						jen.Id("__resolution").Dot("LegacyChildren"),
+						jen.Id("__resolution").Dot("Targets"),
+						jen.Id("__resolution").Dot("NestedRoundRobin"),
 						jen.Id("__planned"),
 						jen.Lit(""),
 					),
@@ -279,6 +304,7 @@ func (me *methodEmitter) emitRouter() {
 						jen.Id("provider"), jen.Id("retryPolicy"),
 						jen.Nil(), jen.Nil(),
 						jen.Nil(),
+						jen.Nil(), jen.Nil(),
 						jen.Id("__planned"),
 						jen.Id("__effective"),
 					),
@@ -290,31 +316,44 @@ func (me *methodEmitter) emitRouter() {
 				// Fallback chain path. Mixed chains (with any legacy
 				// children) route through the BuildRequest path — the
 				// orchestrator dispatches legacy children to the
-				// generated legacyStreamChildFn.
-				jen.List(jen.Id("__chain"), jen.Id("__cprov"), jen.Id("__legacyChildren"), jen.Id("__fbReason")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChainForClientWithReason").Call(
+				// generated legacyStreamChildFn. Centralized RR fallback
+				// children (an immediate RR child whose selected leaf is
+				// BR-supported) reach BuildRequest with the leaf in
+				// __resolution.Targets so dispatch rotates cross-worker
+				// via the same advancer top-level RR uses; ineligible RR
+				// children stay on the legacy callback path. Hard
+				// resolver errors propagate request-fatal.
+				jen.List(jen.Id("__resolution"), jen.Id("__fbErr")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChainPlanForClient").Call(
 					jen.Id("__reg"),
 					jen.Id("__effective"),
 					jen.Qual(common.IntrospectedPkg, "FallbackChains"),
 					jen.Qual(common.IntrospectedPkg, "ClientProvider"),
 					jen.Qual(common.BuildRequestPkg, "IsProviderSupported"),
+					jen.Qual(common.BuildRequestPkg, "PreferAdvancer").Call(
+						jen.Id("adapter"),
+						jen.Qual(common.IntrospectedPkg, "RoundRobinCoordinator"),
+					),
 				),
-				jen.If(jen.Len(jen.Id("__chain")).Op(">").Lit(0)).Block(
+				jen.If(jen.Id("__fbErr").Op("!=").Nil()).Block(
+					jen.Return(jen.Nil(), jen.Id("__fbErr")),
+				),
+				jen.If(jen.Id("__resolution").Op("!=").Nil().Op("&&").Len(jen.Id("__resolution").Dot("Chain")).Op(">").Lit(0)).Block(
 					resolveRetryPolicy(),
-					jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildFallbackChainPlanForClient").Call(
+					jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildFallbackChainPlanFromResolution").Call(
 						jen.Id("__effective"),
-						jen.Id("__chain"),
-						jen.Id("__cprov"),
-						jen.Id("__legacyChildren"),
+						jen.Id("__resolution"),
 						jen.Id("retryPolicy"),
 						jen.Qual(common.BuildRequestPkg, "BuildRequestAPIStreamRequest"),
-						jen.Id("__fbReason"),
 					),
 					jen.Id("__planned").Dot("RoundRobin").Op("=").Id("__rrInfo"),
 					jen.Id("err").Op("=").Id(me.buildRequestMethodName).Call(
 						jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
 						jen.Lit(""), jen.Id("retryPolicy"),
-						jen.Id("__chain"), jen.Id("__cprov"),
-						jen.Id("__legacyChildren"),
+						jen.Id("__resolution").Dot("Chain"),
+						jen.Id("__resolution").Dot("Providers"),
+						jen.Id("__resolution").Dot("LegacyChildren"),
+						jen.Id("__resolution").Dot("Targets"),
+						jen.Id("__resolution").Dot("NestedRoundRobin"),
 						jen.Id("__planned"),
 						jen.Lit(""),
 					),
@@ -365,6 +404,7 @@ func (me *methodEmitter) emitRouter() {
 						jen.Id("provider"), jen.Id("retryPolicy"),
 						jen.Nil(), jen.Nil(),
 						jen.Nil(),
+						jen.Nil(), jen.Nil(),
 						jen.Id("__planned"),
 						jen.Id("__effective"),
 					),
@@ -376,30 +416,41 @@ func (me *methodEmitter) emitRouter() {
 				// Fallback chain path (bridge). Uses IsProviderSupported
 				// (stream side) because the whole point of the bridge is
 				// to accept chains that IsCallProviderSupported rejected.
-				jen.List(jen.Id("__chain"), jen.Id("__cprov"), jen.Id("__legacyChildren"), jen.Id("__fbReason")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChainForClientWithReason").Call(
+				// Threads the typed resolver's per-child Targets +
+				// NestedRoundRobin through to orchestrator dispatch so
+				// centralized RR fallback children rotate cross-worker
+				// even on the bridge path.
+				jen.List(jen.Id("__resolution"), jen.Id("__fbErr")).Op(":=").Qual(common.BuildRequestPkg, "ResolveFallbackChainPlanForClient").Call(
 					jen.Id("__reg"),
 					jen.Id("__effective"),
 					jen.Qual(common.IntrospectedPkg, "FallbackChains"),
 					jen.Qual(common.IntrospectedPkg, "ClientProvider"),
 					jen.Qual(common.BuildRequestPkg, "IsProviderSupported"),
+					jen.Qual(common.BuildRequestPkg, "PreferAdvancer").Call(
+						jen.Id("adapter"),
+						jen.Qual(common.IntrospectedPkg, "RoundRobinCoordinator"),
+					),
 				),
-				jen.If(jen.Len(jen.Id("__chain")).Op(">").Lit(0)).Block(
+				jen.If(jen.Id("__fbErr").Op("!=").Nil()).Block(
+					jen.Return(jen.Nil(), jen.Id("__fbErr")),
+				),
+				jen.If(jen.Id("__resolution").Op("!=").Nil().Op("&&").Len(jen.Id("__resolution").Dot("Chain")).Op(">").Lit(0)).Block(
 					resolveRetryPolicy(),
-					jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildFallbackChainPlanForClient").Call(
+					jen.Id("__planned").Op(":=").Qual(common.BuildRequestPkg, "BuildFallbackChainPlanFromResolution").Call(
 						jen.Id("__effective"),
-						jen.Id("__chain"),
-						jen.Id("__cprov"),
-						jen.Id("__legacyChildren"),
+						jen.Id("__resolution"),
 						jen.Id("retryPolicy"),
 						jen.Qual(common.BuildRequestPkg, "BuildRequestAPIStreamRequest"),
-						jen.Id("__fbReason"),
 					),
 					jen.Id("__planned").Dot("RoundRobin").Op("=").Id("__rrInfo"),
 					jen.Id("err").Op("=").Id(me.buildRequestMethodName).Call(
 						jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
 						jen.Lit(""), jen.Id("retryPolicy"),
-						jen.Id("__chain"), jen.Id("__cprov"),
-						jen.Id("__legacyChildren"),
+						jen.Id("__resolution").Dot("Chain"),
+						jen.Id("__resolution").Dot("Providers"),
+						jen.Id("__resolution").Dot("LegacyChildren"),
+						jen.Id("__resolution").Dot("Targets"),
+						jen.Id("__resolution").Dot("NestedRoundRobin"),
 						jen.Id("__planned"),
 						jen.Lit(""),
 					),

--- a/adapters/common/codegen/codegen_test.go
+++ b/adapters/common/codegen/codegen_test.go
@@ -739,3 +739,147 @@ func TestEmitRouter_RetryResolutionUsesStrategyAwareHelper(t *testing.T) {
 		t.Errorf("__legacyRetryPolicy must be assigned from ResolveStrategyAwareRetryPolicy (not the leaf-only ResolveRetryPolicy); rendered:\n%s", rendered)
 	}
 }
+
+// TestEmitRouter_CallModeFallbackDefersToBridgeWhenAvailable pins the
+// single-resolver-per-request invariant for call-mode requests when a
+// StreamRequest bridge is available: the call block emits ONLY the
+// single-provider arm and the bridge owns the sole typed fallback
+// resolution. A regression that emits ResolveFallbackChainPlanForClient
+// in both the call and bridge blocks would double-advance the
+// SharedState advancer on a mixed chain — the call block's old
+// consume gate (no-call-legacy-children) would decline a centralised-
+// RR-plus-call-legacy-sibling chain after the resolver already
+// committed an RR advance, the chain would fall through to the bridge,
+// and the bridge's own ResolveFallbackChainPlanForClient call would
+// advance a second time. One request → two cross-worker RR slots
+// burned, rotation skewed for that shape.
+//
+// When the bridge does not exist (introspected.StreamRequest == nil),
+// the call block IS the sole BuildRequest landing spot for call modes
+// and must emit its own fallback resolver.
+//
+// Counts ResolveFallbackChainPlanForClient occurrences positionally:
+//
+//   - Request + StreamRequest both non-nil: exactly 2 occurrences,
+//     one in the streaming block (for stream modes) and one in the
+//     bridge block (the sole call-mode resolver).
+//   - Request only: exactly 1 occurrence, inside the call block (call
+//     block is the only landing spot — no bridge, no stream block).
+//   - StreamRequest only: exactly 1 occurrence, inside the streaming
+//     block (no call block, bridge serves call modes alongside).
+func TestEmitRouter_CallModeFallbackDefersToBridgeWhenAvailable(t *testing.T) {
+	// Save + restore the introspected BuildRequest singletons across
+	// sub-tests so each scenario can pin a specific (Request,
+	// StreamRequest) presence combination.
+	savedRequest := introspected.Request
+	savedStreamRequest := introspected.StreamRequest
+	t.Cleanup(func() {
+		introspected.Request = savedRequest
+		introspected.StreamRequest = savedStreamRequest
+	})
+
+	renderRouter := func(t *testing.T) string {
+		t.Helper()
+		g := &generator{
+			out:                common.MakeFile(),
+			supportsWithClient: true,
+		}
+		me := &methodEmitter{
+			g:                          g,
+			methodName:                 "GreetUser",
+			buildRequestMethodName:     "greetUser_buildRequest",
+			buildCallRequestMethodName: "greetUser_buildCallRequest",
+			noRawMethodName:            "greetUser_noRaw",
+			fullMethodName:             "greetUser_full",
+		}
+		me.emitRouter()
+		return g.out.GoString()
+	}
+
+	// resolverFn is the symbol whose call-site count drives the
+	// single-advance assertion. The bridge fix is what removes the
+	// duplicate emission; counting at this granularity catches any
+	// regression that re-introduces a call-block fallback resolver
+	// alongside the bridge.
+	const resolverFn = "buildrequest.ResolveFallbackChainPlanForClient("
+
+	t.Run("call-bridge-both-available-bridge-owns-fallback", func(t *testing.T) {
+		// Both APIs non-nil — the bridge exists. Call block emits
+		// only the single-provider arm; the bridge owns fallback for
+		// call modes. Total resolver calls in the router: 2 (stream
+		// block + bridge block).
+		introspected.Request = struct{}{}
+		introspected.StreamRequest = struct{}{}
+		rendered := renderRouter(t)
+		got := strings.Count(rendered, resolverFn)
+		if got != 2 {
+			t.Errorf("with Request + StreamRequest non-nil, expected exactly 2 ResolveFallbackChainPlanForClient call sites "+
+				"(streaming block + bridge block; the call block must defer to the bridge to avoid double-advance), got %d.\nrendered:\n%s",
+				got, rendered)
+		}
+		// Positional pin: the bridge call site is gated by StreamMode-
+		// Call / StreamModeCallWithRaw. If the call block re-introduced
+		// the fallback resolver, it would also be gated on call modes
+		// — and a second resolver call would appear before the
+		// streaming block's gate. Pin that the FIRST resolver call site
+		// is the streaming block, identified by IsProviderSupported
+		// being the support predicate. The call-block fallback path
+		// uses IsCallProviderSupported, so a regression where the call
+		// block re-emits the resolver would surface IsCallProviderSupp-
+		// orted as the first predicate AND increase the count above 2.
+		firstIdx := strings.Index(rendered, resolverFn)
+		if firstIdx < 0 {
+			t.Fatalf("expected at least one ResolveFallbackChainPlanForClient call site; rendered:\n%s", rendered)
+		}
+		secondIdx := firstIdx + strings.Index(rendered[firstIdx+1:], resolverFn) + 1
+		// IsCallProviderSupported must not appear inside the first
+		// resolver invocation's argument list — that's the streaming
+		// block's resolver and it uses the stream-side predicate. The
+		// only path that could put IsCallProviderSupported in the
+		// first invocation is a regression where the call block emits
+		// its own fallback resolver first.
+		argsRegion := rendered[firstIdx : secondIdx+len(resolverFn)+200]
+		if strings.Count(argsRegion, "buildrequest.IsCallProviderSupported") > 0 {
+			t.Errorf("first resolver call site contains IsCallProviderSupported, suggesting the call block re-introduced a fallback resolver; rendered region:\n%s", argsRegion)
+		}
+	})
+
+	t.Run("call-only-no-bridge-call-block-owns-fallback", func(t *testing.T) {
+		// Request non-nil, StreamRequest nil — no bridge. Call block
+		// is the sole BuildRequest landing spot for call modes and
+		// MUST emit its own fallback resolver. Total resolver calls
+		// in the router: 1 (call block only — no stream block, no
+		// bridge).
+		introspected.Request = struct{}{}
+		introspected.StreamRequest = nil
+		rendered := renderRouter(t)
+		got := strings.Count(rendered, resolverFn)
+		if got != 1 {
+			t.Errorf("with Request-only adapter (no bridge), expected exactly 1 ResolveFallbackChainPlanForClient call site "+
+				"(the call block is the sole landing spot), got %d.\nrendered:\n%s",
+				got, rendered)
+		}
+		// The single resolver invocation must use the call-side
+		// support predicate. Stream-side predicate would mean the
+		// call block accepted chains the call orchestrator cannot
+		// dispatch (call-legacy-but-stream-supported children).
+		if !strings.Contains(rendered, "buildrequest.IsCallProviderSupported") {
+			t.Errorf("call-only adapter must use IsCallProviderSupported in its sole resolver call; rendered:\n%s", rendered)
+		}
+	})
+
+	t.Run("stream-only-no-call-stream-block-owns-fallback", func(t *testing.T) {
+		// Request nil, StreamRequest non-nil — no call block, just
+		// stream + bridge. Stream block handles stream modes; bridge
+		// handles call modes. Two resolver call sites total.
+		introspected.Request = nil
+		introspected.StreamRequest = struct{}{}
+		rendered := renderRouter(t)
+		got := strings.Count(rendered, resolverFn)
+		if got != 2 {
+			t.Errorf("with StreamRequest-only adapter, expected exactly 2 ResolveFallbackChainPlanForClient call sites "+
+				"(streaming block + bridge block), got %d.\nrendered:\n%s",
+				got, rendered)
+		}
+	})
+}

--- a/bamlutils/buildrequest/call_orchestrator.go
+++ b/bamlutils/buildrequest/call_orchestrator.go
@@ -63,17 +63,17 @@ type CallConfig struct {
 	LegacyChildren map[string]bool
 
 	// FallbackTargets mirrors StreamConfig.FallbackTargets — see that
-	// field (and Metadata.FallbackTargets) for the contract. PR 1 adds
-	// the field; PR 2 (issue #237) wires the call-side BuildRequest
-	// dispatch loop to honour FallbackTargets[child] when computing the
-	// WithClient target for centrally-unwrapped RR fallback children.
+	// field (and Metadata.FallbackTargets) for the contract. The call-
+	// side BuildRequest dispatch loop honours FallbackTargets[child]
+	// when computing the WithClient target for centrally-unwrapped RR
+	// fallback children.
 	FallbackTargets map[string]string
 
 	// FallbackRoundRobin mirrors StreamConfig.FallbackRoundRobin —
 	// per-child RR decisions for fallback children resolved through
-	// BuildRequest centralization. PR 1 adds the field; PR 2 populates
-	// it from resolver output so outgoing planned metadata describes
-	// the selected leaf alongside the RR decision behind it.
+	// BuildRequest centralization. Populated from resolver output so
+	// outgoing planned metadata describes the selected leaf alongside
+	// the RR decision behind it.
 	FallbackRoundRobin map[string]*bamlutils.RoundRobinInfo
 
 	// MetadataPlan is the pre-computed planned metadata for this request.
@@ -388,9 +388,9 @@ func RunCallOrchestration(
 				continue
 			}
 			provider := config.ClientProviders[child]
-			// Wrapper-vs-target identity (issue #237 PR 2): when an
-			// immediate RR fallback child was centrally unwrapped to a
-			// leaf, FallbackTargets[child] names that leaf. Mirrors the
+			// Wrapper-vs-target identity: when an immediate RR fallback
+			// child was centrally unwrapped to a leaf,
+			// FallbackTargets[child] names that leaf. Mirrors the
 			// streaming orchestrator — see RunStreamOrchestration for
 			// the full rationale.
 			target := child
@@ -433,8 +433,8 @@ func RunCallOrchestration(
 		outcome.LegacyChildren = nil
 		// See the streaming orchestrator's outcome builder for the
 		// rationale on clearing these planned-only fallback-target
-		// fields — issue #237's planned shape describes intent, the
-		// realised winner already appears in WinnerClient.
+		// fields — the planned shape describes intent, the realised
+		// winner already appears in WinnerClient.
 		outcome.FallbackTargets = nil
 		outcome.FallbackRoundRobin = nil
 		outcome.Strategy = ""

--- a/bamlutils/buildrequest/client_resolution.go
+++ b/bamlutils/buildrequest/client_resolution.go
@@ -133,9 +133,10 @@ func ResolveEffectiveClient(
 	// managed workers observe a single rotation across the fleet —
 	// without it, each worker would rotate off its own coordinator and
 	// round-robin would collapse into independent per-worker draws.
-	if reqAdvancer := adapter.RoundRobinAdvancer(); reqAdvancer != nil {
-		advancer = reqAdvancer
-	}
+	// PreferAdvancer is the shared seam top-level and fallback-RR
+	// resolution use; routing both through it keeps the precedence rule
+	// in one place.
+	advancer = PreferAdvancer(adapter, advancer)
 
 	res, err := roundrobin.Resolve(roundrobin.ResolveInput{
 		ClientName:      clientName,

--- a/bamlutils/buildrequest/client_resolution.go
+++ b/bamlutils/buildrequest/client_resolution.go
@@ -164,6 +164,21 @@ func ResolveEffectiveClient(
 	return res.Selected, res.Info, nil
 }
 
+// PreferAdvancer returns the per-request RoundRobinAdvancer installed on
+// the adapter when set, otherwise the supplied fallback. Mirrors the
+// preference ResolveEffectiveClient applies for top-level RR so that
+// nested fallback-RR resolution observes the same advancer — and the
+// same SharedState idempotency key under pool retries — that top-level
+// RR uses. Callers pass the package-level Coordinator as the fallback
+// so standalone workers without a RemoteAdvancer still rotate
+// deterministically against the introspected starts.
+func PreferAdvancer(adapter bamlutils.Adapter, fallback roundrobin.Advancer) roundrobin.Advancer {
+	if a := adapter.RoundRobinAdvancer(); a != nil {
+		return a
+	}
+	return fallback
+}
+
 // ResolvePrimaryClient returns the request's effective client name after
 // applying the runtime client_registry primary override, without doing
 // any baml-roundrobin unwrap. Used by adapter versions that cannot honor
@@ -269,7 +284,7 @@ func findRuntimeClient(reg *bamlutils.ClientRegistry, clientName string) *bamlut
 // surfaces the empty value verbatim (rather than falling through to
 // the introspected provider) so the codegen gate routes the request
 // to legacy. This helper lets the metadata classifier distinguish
-// "operator sent provider:''" from "no provider configured anywhere"
+// "operator sent provider:”" from "no provider configured anywhere"
 // — emitting PathReasonInvalidProviderOverride versus
 // PathReasonEmptyProvider respectively.
 //
@@ -364,7 +379,6 @@ func hasExplicitStrategyProviderWithoutStrategy(reg *bamlutils.ClientRegistry, c
 func isStrategyProvider(p string) bool {
 	return roundrobin.IsRoundRobinProvider(p) || normalizeStrategyProvider(p) == "baml-fallback"
 }
-
 
 func resolveFallbackStrategyChain(reg *bamlutils.ClientRegistry, clientName string, introspectedChains map[string][]string) []string {
 	chain, present, valid := roundrobin.InspectStrategyOverride(reg, clientName)

--- a/bamlutils/buildrequest/fallback_resolve.go
+++ b/bamlutils/buildrequest/fallback_resolve.go
@@ -13,7 +13,7 @@ import (
 // subset of children that must dispatch through the legacy callback, and
 // — when an immediate baml-roundrobin fallback child is centrally
 // unwrapped to a leaf via BuildRequest — the per-child dispatch target
-// and RR decision (see issue #237 PR 2).
+// and RR decision.
 //
 // Shape contract:
 //
@@ -69,8 +69,7 @@ type FallbackChainResolution struct {
 // (ErrInvalidStrategyOverride / ErrInvalidStartOverride) are converted
 // to the existing PathReasonInvalid* values on the returned resolution
 // with Chain == nil, so the request falls through to top-level legacy
-// and BAML emits the canonical validation error. See section 4 of
-// issue #237 PR 2's brief for the full matrix.
+// and BAML emits the canonical validation error.
 func ResolveFallbackChainPlan(
 	adapter bamlutils.Adapter,
 	defaultClientName string,
@@ -168,9 +167,8 @@ func ResolveFallbackChainPlanForClient(
 			}
 		}
 
-		// Per #237 PR 2: attempt centralization for an immediate
-		// baml-roundrobin fallback child. Eligibility (see brief
-		// section 2):
+		// Attempt centralization for an immediate baml-roundrobin
+		// fallback child. Eligibility:
 		//   1. Resolved provider is RR (this branch).
 		//   2. Invalid-override preflight passed (handled above for
 		//      every strategy child).
@@ -361,7 +359,10 @@ func isCentralizationEligible(leaf, leafProvider string, isProviderSupported fun
 
 // ResolveFallbackChainWithReason wraps ResolveFallbackChain and returns
 // a classification alongside the usual (chain, providers, legacyChildren)
-// triple.
+// triple. The 4-tuple seam is consumed by the legacy-path metadata
+// classifier (BuildLegacyMetadataPlan / BuildLegacyMetadataPlanForClient)
+// for chain-shape enumeration; production routing decisions consume the
+// typed ResolveFallbackChainPlan{,ForClient} sibling instead.
 //
 // `chain == nil` is the hard-failure signal: BuildRequest cannot drive
 // the request and the caller must fall through to legacy. `chain != nil`
@@ -381,31 +382,28 @@ func isCentralizationEligible(leaf, leafProvider string, isProviderSupported fun
 //     PathReasonFallbackEmptyChildProvider, PathReasonFallbackAllLegacy.
 //   - chain != nil, reason == "": fully drivable chain.
 //   - chain != nil, reason == PathReasonFallbackRoundRobinChildLegacy:
-//     drivable chain containing a baml-roundrobin child that runs via
-//     the legacy callback. The 4-tuple seam surfaces this reason for
-//     EVERY immediate RR fallback child until PR 3 (#237) wires
-//     codegen to the typed helper — see the demotion note below.
+//     drivable chain containing a baml-roundrobin child whose
+//     centralization is deferred or not eligible — see the demotion
+//     note below.
 //
 // Callers gate on `len(chain) > 0` for the hard routing decision and
 // pass `reason` straight through to metadata.
 //
-// Centralization demotion (PR 2 codegen back-compat). The typed
-// ResolveFallbackChainPlan{,ForClient} sibling centralizes immediate
-// RR fallback children with a BR-supported leaf — but codegen-emitted
-// call sites consume the 4-tuple shape and have no path to populate
-// the orchestrator's FallbackTargets map. Surfacing the centralized
-// shape here would let BuildRequest dispatch fire against the RR
-// wrapper name (with FallbackTargets[child] empty), which is wrong-
-// client routing. Until PR 3 migrates codegen, this wrapper demotes
-// any centralized resolution back to the legacy classification, so
-// codegen-driven dispatch keeps using the legacy callback for nested
-// RR exactly as it did pre-PR-2. The typed helper continues to
-// centralize for future-codegen consumers and the existing PR 2
-// typed-helper tests cover that path end-to-end.
+// Centralization demotion. The 4-tuple seam exists so metadata-only
+// consumers see a stable legacy-shape regardless of whether the typed
+// resolver centralised a given immediate RR child. The typed helper
+// continues to centralise for routing-decision consumers (the codegen-
+// emitted router calls ResolveFallbackChainPlanForClient directly and
+// threads Targets / NestedRoundRobin through). Surfacing the
+// centralised shape at the 4-tuple seam would leak target identities
+// into the legacy metadata classifier, where they have no consumers
+// and would conflate metadata enumeration with dispatch identity.
+// Demote any centralised resolution back to the legacy classification
+// at this seam so the metadata classifier emits a wrapper-keyed shape.
 //
 // Hard errors from nested RR resolution (cycle, empty children,
 // advancer transport, out-of-range) are also swallowed by this
-// wrapper for the same compat reason — they demote to the same
+// wrapper for the same metadata-stability reason — they demote to the
 // legacy classification. Callers that need the request-fatal posture
 // must use ResolveFallbackChainPlanForClient directly.
 func ResolveFallbackChainWithReason(
@@ -435,20 +433,8 @@ func ResolveFallbackChainWithReason(
 // unwrap happens inside.
 //
 // Return contract matches the sibling — see
-// ResolveFallbackChainWithReason's doc for the full reason matrix.
-//
-// The 4-tuple seam intentionally DEMOTES centralization back to legacy
-// classification (see resolveFallbackChainForClientWithAdvancer). PR 2's
-// typed helper centralizes correctly, but codegen-emitted call sites
-// (`adapters/common/codegen/codegen_router.go:213, 294, 379`) cannot
-// thread Targets through to the orchestrator config until PR 3 wires
-// them to ResolveFallbackChainPlanForClient. Surfacing the centralized
-// shape here would let the orchestrator's BuildRequest dispatch fire
-// against the RR wrapper name (with FallbackTargets[child] empty),
-// which is wrong-client routing. Until codegen migrates, the wrapper
-// keeps the pre-PR-2 shape: every immediate RR fallback child lands on
-// legacyChildren with reason PathReasonFallbackRoundRobinChildLegacy,
-// and BAML's per-worker runtime drives rotation as before.
+// ResolveFallbackChainWithReason's doc for the full reason matrix and
+// the metadata-stability demotion contract.
 func ResolveFallbackChainForClientWithReason(
 	reg *bamlutils.ClientRegistry,
 	clientName string,
@@ -459,8 +445,8 @@ func ResolveFallbackChainForClientWithReason(
 	// No advancer at this seam — the 4-tuple wrapper is kept callable
 	// without an adapter. Nested RR resolution falls back to
 	// AdvanceDynamic for static clients, matching top-level RR's
-	// standalone-worker behaviour. Codegen call sites get this shape
-	// today; PR 3 will switch them to ResolveFallbackChainPlanForClient
+	// standalone-worker behaviour. Routing-decision consumers (the
+	// generated router) use ResolveFallbackChainPlanForClient directly
 	// so the request-scoped RemoteAdvancer threads through.
 	return resolveFallbackChainForClientWithAdvancer(
 		reg, clientName, fallbackChains, clientProviders, isProviderSupported, nil,
@@ -468,28 +454,27 @@ func ResolveFallbackChainForClientWithReason(
 }
 
 // resolveFallbackChainForClientWithAdvancer drives both 4-tuple wrappers
-// off the typed helper. The wrapper preserves pre-PR-2 shape for
-// codegen-driven dispatch by demoting any centralized resolution back
-// to the legacy classification — until PR 3 (#237) wires codegen to
-// the typed ResolveFallbackChainPlanForClient helper, the orchestrator
-// config emitted by codegen has no FallbackTargets entries, and a
-// "BR-drivable, leaf provider" 4-tuple shape would route BR against
-// the RR wrapper name (wrong-client dispatch).
+// off the typed helper. The 4-tuple shape exists for the legacy-path
+// metadata classifier — a stable wrapper-keyed enumeration of the chain
+// regardless of whether the typed resolver would have centralised a
+// given immediate RR child. Surfacing the centralised shape here would
+// leak target identities into a consumer that never dispatches on them
+// and would conflate metadata enumeration with routing decisions.
 //
 // Two demotion triggers, both routed through the same helper so the
 // 4-tuple seam returns identical shape regardless of which path the
 // typed helper would have taken:
 //
 //   - Hard error from nested RR (cycle / empty children / advancer
-//     transport / out-of-range): the 4-tuple compat contract does not
-//     surface errors. Demote to the pre-PR-2 classification so the
-//     request still resolves; the typed helper is the entry point
-//     that propagates request-fatal errors per top-level RR semantics.
+//     transport / out-of-range): the 4-tuple shape has no field for
+//     errors. Demote to the legacy classification so the metadata
+//     classifier still has a chain to enumerate; the typed helper
+//     remains the entry point that propagates request-fatal errors per
+//     top-level RR semantics.
 //   - Successful centralization (Targets / NestedRoundRobin populated):
-//     codegen call sites can't honour the centralization yet, so
-//     demote to legacy classification. The typed helper continues to
-//     centralize for future-codegen consumers and the existing PR 2
-//     typed-helper tests cover that path.
+//     demote to the legacy classification because the 4-tuple shape
+//     carries no field for per-child targets. The typed helper exposes
+//     the same centralisation to routing-decision consumers.
 //
 // Sentinel-class results (Chain == nil with a PathReasonInvalid* reason)
 // and "not a fallback client" results pass through verbatim — both
@@ -515,9 +500,9 @@ func resolveFallbackChainForClientWithAdvancer(
 		return nil, nil, nil, ""
 	}
 	if len(res.Targets) > 0 || len(res.NestedRoundRobin) > 0 {
-		// Centralized result — demote to pre-PR-2 legacy classification
-		// for the codegen-back-compat seam. See doc above for why this
-		// is required until PR 3 lands.
+		// Centralized result — demote to legacy classification for the
+		// 4-tuple metadata-stability seam. See doc above for why this
+		// demotion is required.
 		return resolveFallbackChainLegacyClassification(
 			reg, clientName, fallbackChains, clientProviders, isProviderSupported,
 		)
@@ -527,10 +512,9 @@ func resolveFallbackChainForClientWithAdvancer(
 
 // resolveFallbackChainLegacyClassification runs the chain resolution
 // without attempting RR-child centralization — used by the 4-tuple
-// wrapper as a safety net when the typed helper would otherwise return a
-// hard error. The output matches the pre-PR-2 classification: any
-// baml-roundrobin child lands on legacyChildren with reason
-// PathReasonFallbackRoundRobinChildLegacy.
+// wrapper to emit a stable wrapper-keyed enumeration for the legacy
+// metadata classifier. Any baml-roundrobin child lands on legacyChildren
+// with reason PathReasonFallbackRoundRobinChildLegacy.
 func resolveFallbackChainLegacyClassification(
 	reg *bamlutils.ClientRegistry,
 	clientName string,

--- a/bamlutils/buildrequest/fallback_resolve_plan_test.go
+++ b/bamlutils/buildrequest/fallback_resolve_plan_test.go
@@ -25,7 +25,7 @@ func (c *countingAdvancer) Advance(_ string, _ int) (int, error) {
 }
 
 // pinnedIndexAdvancer returns the same child index every call. Used by
-// the PR 2 resolver tests so a single static RR chain's nested
+// the typed-resolver tests so a single static RR chain's nested
 // resolution is deterministic regardless of process-random
 // AdvanceDynamic ordering — the assertion focuses on classification
 // (legacy/drivable, providers, targets, reason), and a fixed advancer
@@ -44,12 +44,13 @@ func (p *pinnedIndexAdvancer) Advance(_ string, childCount int) (int, error) {
 	return p.idx, nil
 }
 
-// TestResolveFallbackChainPlanForClient covers the PR 2 centralization
-// matrix surfaced through the typed FallbackChainResolution helper. The
-// 4-tuple wrapper sub-cases are pinned by the existing
-// TestResolveFallbackChain_* tests; this table focuses on Targets and
-// NestedRoundRobin shape (the typed-only outputs) plus the
-// sentinel-vs-hard-error matching that the wrapper deliberately demotes.
+// TestResolveFallbackChainPlanForClient covers the RR-child
+// centralization matrix surfaced through the typed
+// FallbackChainResolution helper. The 4-tuple wrapper sub-cases are
+// pinned by the existing TestResolveFallbackChain_* tests; this table
+// focuses on Targets and NestedRoundRobin shape (the typed-only
+// outputs) plus the sentinel-vs-hard-error matching that the wrapper
+// deliberately demotes.
 func TestResolveFallbackChainPlanForClient(t *testing.T) {
 	// Shared support predicate — openai-only so we can pin centralization
 	// eligibility purely off provider strings.
@@ -218,9 +219,9 @@ func TestResolveFallbackChainPlanForClient(t *testing.T) {
 		// has no runtime override is a hard error matching top-level
 		// RR semantics — request-fatal (not silent legacy fallthrough).
 		// The typed helper propagates the error; the 4-tuple wrapper
-		// would demote to legacy, but that's a deliberate codegen
-		// compatibility shim. PR 3's typed call sites will surface
-		// this as a request-fatal failure.
+		// would demote to legacy for the metadata-classifier seam.
+		// Codegen's router call sites consume the typed helper directly
+		// so the failure surfaces request-fatal at dispatch time.
 		fallbackChains := map[string][]string{
 			"MyFallback": {"InnerRR", "C"},
 			// InnerRR's chain is intentionally absent.
@@ -248,9 +249,9 @@ func TestResolveFallbackChainPlanForClient(t *testing.T) {
 		// Two immediate RR children, each with their own BR-supported
 		// leaves. The resolver must centralize both and populate the
 		// per-child Targets / NestedRoundRobin maps without
-		// cross-talk. Mirrors the "multiple immediate RR children"
-		// shape called out as in-scope for #237 (rr1 + rr2 keyed by
-		// distinct names; SharedState idempotency separates them).
+		// cross-talk. The "multiple immediate RR children" shape is
+		// supported because SharedState keys idempotency by RR client
+		// name + request id, so rr1 + rr2 naturally separate.
 		fallbackChains := map[string][]string{
 			"MyFallback": {"RR1", "RR2", "E"},
 			"RR1":        {"A", "B"},
@@ -335,7 +336,7 @@ func TestResolveFallbackChainPlanForClient(t *testing.T) {
 			t.Errorf("Reason: got %q, want %q", res.Reason, PathReasonFallbackRoundRobinChildLegacy)
 		}
 		if got := adv.calls.Load(); got != 0 {
-			t.Errorf("advancer call count under nil-support: got %d, want 0 (must short-circuit BEFORE resolveImmediateRRChild — issue #237 PR 2 F2)",
+			t.Errorf("advancer call count under nil-support: got %d, want 0 (must short-circuit BEFORE resolveImmediateRRChild so a remote advancer never burns an idempotency-cache slot on a branch the resolver already knows is ineligible)",
 				got)
 		}
 	})
@@ -347,10 +348,11 @@ func TestResolveFallbackChainPlanForClient(t *testing.T) {
 		// The orchestrator iterates FallbackChain positionally and
 		// reads FallbackTargets[child] by name, so it'd dispatch BOTH
 		// iterations to the second iteration's target — wrong runtime
-		// routing. Reject request-fatal at the typed seam (issue #237
-		// PR 2 F1). The 4-tuple wrapper's hard-error → legacy
-		// demotion preserves codegen-driven dispatch behaviour;
-		// see Test4TupleWrapper_DemoteCentralizedToLegacy.
+		// routing. Reject request-fatal at the typed seam so codegen-
+		// emitted call sites surface the operator-broken chain. The
+		// 4-tuple wrapper's hard-error → legacy demotion preserves
+		// chain enumeration for the legacy metadata classifier; see
+		// Test4TupleWrapper_DemoteCentralizedToLegacy.
 		fallbackChains := map[string][]string{
 			"MyFallback": {"InnerRR", "InnerRR", "C"},
 			"InnerRR":    {"A", "B"},
@@ -432,7 +434,7 @@ func TestResolveFallbackChainPlanForClient(t *testing.T) {
 }
 
 // TestBuildFallbackChainPlanFromResolution pins that the typed plan
-// builder threads PR 2's per-child outputs (FallbackTargets,
+// builder threads the resolver's per-child outputs (FallbackTargets,
 // FallbackRoundRobin) into planned metadata. Without this seam,
 // downstream consumers (the unary metadata header set, JSON metadata
 // events) would never see which leaf was picked for a centralized RR
@@ -482,7 +484,7 @@ func TestBuildFallbackChainPlanFromResolution(t *testing.T) {
 // sparse-map contract: a resolution with no Targets / no NestedRoundRobin
 // produces a plan with both fields nil (so JSON `omitempty` drops the
 // keys). Important so non-centralized fallback chains emit the same
-// payload shape they did before PR 1.
+// payload shape as plans that predate the fallback-target vocabulary.
 func TestBuildFallbackChainPlanFromResolution_NilEmptyMaps(t *testing.T) {
 	res := &FallbackChainResolution{
 		Chain:          []string{"A", "B"},
@@ -499,11 +501,11 @@ func TestBuildFallbackChainPlanFromResolution_NilEmptyMaps(t *testing.T) {
 }
 
 // TestResolveFallbackChainPlan_SentinelClassificationMatchesTopLevel
-// is the targeted regression guard for issue #237 PR 2 section 4 —
+// is the regression guard for the sentinel-class vs hard-error split:
 // sentinel-class errors from roundrobin.Resolve translate to the
 // existing PathReasonInvalid* reasons (carve-out) while hard errors
-// propagate (request-fatal). Section-by-section parity with
-// ResolveEffectiveClient's posture in client_resolution.go.
+// propagate (request-fatal). Posture parity with
+// ResolveEffectiveClient in client_resolution.go.
 func TestResolveFallbackChainPlan_SentinelClassificationMatchesTopLevel(t *testing.T) {
 	// Defensive guard: even if a future code path skips the
 	// per-child invalid-override preflight, the typed helper's

--- a/bamlutils/buildrequest/fallback_resolve_test.go
+++ b/bamlutils/buildrequest/fallback_resolve_test.go
@@ -429,19 +429,16 @@ func TestResolveFallbackChain_FallbackWithRRChild_SurfacesReason(t *testing.T) {
 	// 4-tuple seam. The PathReason surfaces the composition so
 	// operators can distinguish centralised top-level RR from
 	// per-worker nested RR. The RR child lands on the legacy child
-	// list and BAML's runtime handles its rotation on each worker
-	// independently. Issue #237 PR 2's typed
-	// ResolveFallbackChainPlanForClient helper centralizes immediate
-	// RR fallback children with a BR-supported leaf, but the 4-tuple
-	// wrapper deliberately demotes those results back to legacy
-	// classification because codegen-emitted call sites cannot pass
-	// FallbackTargets through the orchestrator config until PR 3
-	// (#237) wires codegen to the typed helper. Surfacing the
-	// centralized shape here would route BuildRequest against the RR
-	// wrapper name (wrong-client dispatch). The typed-helper tests in
+	// list at this seam because the 4-tuple shape has no field for
+	// per-child Targets — the typed ResolveFallbackChainPlanForClient
+	// helper centralizes immediate RR fallback children with a BR-
+	// supported leaf, but the 4-tuple wrapper demotes those results
+	// back to legacy classification so the metadata classifier sees
+	// a stable wrapper-keyed enumeration. The typed-helper tests in
 	// fallback_resolve_plan_test.go pin centralization at the typed
-	// seam; this test pins the demoted 4-tuple shape codegen relies
-	// on today.
+	// seam (which is what codegen-emitted call sites consume); this
+	// test pins the demoted 4-tuple shape used by the legacy metadata
+	// classifier.
 	fallbackChains := map[string][]string{
 		"MyFallback": {"OpenAIClient", "InnerRR"},
 		"InnerRR":    {"GoogleA", "GoogleB"},
@@ -468,13 +465,13 @@ func TestResolveFallbackChain_FallbackWithRRChild_SurfacesReason(t *testing.T) {
 		t.Fatalf("reason: got %q, want %q", reason, PathReasonFallbackRoundRobinChildLegacy)
 	}
 	if !legacy["InnerRR"] {
-		t.Errorf("InnerRR must be marked legacy at the 4-tuple seam (BAML runtime handles RR rotation per-worker until PR 3), legacyChildren=%v", legacy)
+		t.Errorf("InnerRR must be marked legacy at the 4-tuple seam (the 4-tuple shape carries no Targets field, so centralisation is demoted here for metadata-classifier stability), legacyChildren=%v", legacy)
 	}
 	if legacy["OpenAIClient"] {
 		t.Errorf("OpenAIClient is a supported provider — must not be on legacy list, legacyChildren=%v", legacy)
 	}
 	if providers["InnerRR"] != "baml-roundrobin" {
-		t.Errorf("providers[InnerRR]: got %q, want baml-roundrobin (wrapper provider — leaf-provider demotion is reverted at the 4-tuple seam)", providers["InnerRR"])
+		t.Errorf("providers[InnerRR]: got %q, want baml-roundrobin (wrapper provider — the 4-tuple seam reports the wrapper, not the leaf)", providers["InnerRR"])
 	}
 }
 
@@ -672,11 +669,11 @@ func TestResolveFallbackChain_NestedInvalidProviderOverride(t *testing.T) {
 // mixed-mode orchestration for legitimate runtime overrides; this
 // test guards against that drift.
 //
-// Issue #237 PR 2's typed ResolveFallbackChainPlanForClient
-// centralizes this exact override (TenantLeaf is BR-supported) — see
+// The typed ResolveFallbackChainPlanForClient centralizes this exact
+// override (TenantLeaf is BR-supported) — see
 // fallback_resolve_plan_test.go. The 4-tuple wrapper demotes the
-// centralized result to legacy classification for codegen-back-compat
-// until PR 3 wires codegen to the typed helper.
+// centralized result to legacy classification for the metadata-
+// classifier seam.
 func TestResolveFallbackChain_NestedValidOverrideStillResolves(t *testing.T) {
 	fallbackChains := map[string][]string{
 		"MyFallback": {"FastLeaf", "InnerRR"},
@@ -709,7 +706,7 @@ func TestResolveFallbackChain_NestedValidOverrideStillResolves(t *testing.T) {
 		t.Fatalf("expected chain to resolve for valid nested override, got nil with reason=%q", reason)
 	}
 	if reason != PathReasonFallbackRoundRobinChildLegacy {
-		t.Errorf("reason: got %q, want %q (4-tuple seam demotes centralization until PR 3)",
+		t.Errorf("reason: got %q, want %q (4-tuple seam demotes centralization for metadata-classifier stability)",
 			reason, PathReasonFallbackRoundRobinChildLegacy)
 	}
 	if !legacy["InnerRR"] {
@@ -1111,30 +1108,28 @@ func TestResolveFallbackChainForClient_NilSupportCheck_StrategyChildClassified(t
 }
 
 // Test4TupleWrapper_DemoteCentralizedToLegacy is the regression guard
-// for issue #237 PR 2's compat shim. The typed helper
+// for the 4-tuple wrapper's metadata-classifier seam. The typed helper
 // (ResolveFallbackChainPlanForClient) correctly centralizes immediate
-// RR fallback children with a BR-supported leaf — but codegen-emitted
-// call sites (`adapters/common/codegen/codegen_router.go`) consume the
-// 4-tuple ResolveFallbackChainForClientWithReason wrapper and have no
-// path to thread Targets / NestedRoundRobin through to the
-// orchestrator's StreamConfig / CallConfig until PR 3 (#237) wires
-// codegen to the typed helper.
+// RR fallback children with a BR-supported leaf — but the 4-tuple
+// ResolveFallbackChainForClientWithReason wrapper has no field to
+// thread Targets / NestedRoundRobin, so a caller that consumed the
+// centralized shape here would be reading wrapper-keyed providers
+// for what's actually a leaf-keyed dispatch decision.
 //
-// If the wrapper exposed the centralized shape (legacy[child]=false,
-// providers[child]=leafProvider, reason=ChildBuildRequest), the
-// orchestrator's BuildRequest dispatch — which falls back to the
-// chain-position name when FallbackTargets[child] is empty — would
-// fire against the RR wrapper name. That's wrong-client routing: BAML
-// would receive WithClient("InnerRR") instead of WithClient(leaf), and
-// per-worker rotation (the legacy-callback path) would be silently
-// replaced by a single-leaf BR call with stale wrapper identity.
+// The 4-tuple shape is consumed only by the legacy-path metadata
+// classifier (BuildLegacyMetadataPlan{,ForClient}), which never
+// dispatches against the returned providers — it only enumerates the
+// chain shape for observability. The wrapper-keyed shape is the
+// stable surface for that consumer regardless of whether the typed
+// helper would have centralised a given immediate RR child.
 //
 // This test pins the demotion contract: at the 4-tuple seam, every
 // composition that the typed helper would centralize MUST come back
-// as legacy classification — same shape as pre-PR-2 — so codegen
-// dispatches through the legacy callback exactly as it did before.
-// Centralization metadata is exercised by the typed-helper tests in
-// fallback_resolve_plan_test.go.
+// as legacy classification — the wrapper-keyed shape — so the
+// metadata classifier sees a stable enumeration. Routing-decision
+// consumers (codegen-emitted call sites) drive
+// ResolveFallbackChainPlanForClient directly and observe the
+// centralized shape there.
 func Test4TupleWrapper_DemoteCentralizedToLegacy(t *testing.T) {
 	supportOpenAI := func(p string) bool { return p == "openai" }
 
@@ -1159,7 +1154,7 @@ func Test4TupleWrapper_DemoteCentralizedToLegacy(t *testing.T) {
 			t.Fatalf("expected drivable chain (mixed-mode), got nil with reason=%q", reason)
 		}
 		if !legacy["InnerRR"] {
-			t.Errorf("InnerRR must be DEMOTED to legacy at the 4-tuple seam (codegen back-compat), legacyChildren=%v", legacy)
+			t.Errorf("InnerRR must be DEMOTED to legacy at the 4-tuple seam (the metadata-classifier consumer expects wrapper-keyed shape), legacyChildren=%v", legacy)
 		}
 		if legacy["C"] {
 			t.Errorf("C is a BR-supported leaf; must not be misclassified as legacy, legacyChildren=%v", legacy)
@@ -1278,15 +1273,12 @@ func Test4TupleWrapper_DemoteCentralizedToLegacy(t *testing.T) {
 
 	t.Run("duplicate-rr-child-demoted-to-legacy", func(t *testing.T) {
 		// The typed helper rejects a duplicate-named RR fallback
-		// child request-fatal (issue #237 PR 2 F1). The 4-tuple
-		// wrapper's hard-error → legacy demotion shim must catch
-		// that error and return the pre-PR-2 legacy classification
-		// shape, so codegen-driven dispatch keeps using the legacy
-		// callback regardless of whether the operator's chain
-		// contains the duplicate name. This test pins the demotion
-		// path for the F1 case specifically — without it, the
-		// 4-tuple wrapper would surface a centralized-shape mistake
-		// the moment codegen migrates partially.
+		// child request-fatal. The 4-tuple wrapper's hard-error →
+		// legacy demotion shim catches that error and returns the
+		// wrapper-keyed legacy classification shape so the metadata
+		// classifier still has a chain to enumerate even when the
+		// operator's chain is malformed. This test pins the
+		// demotion path for the duplicate-child case specifically.
 		fallbackChains := map[string][]string{
 			"MyFallback": {"InnerRR", "InnerRR", "C"},
 			"InnerRR":    {"A", "B"},

--- a/bamlutils/buildrequest/fallback_targets_dispatch_test.go
+++ b/bamlutils/buildrequest/fallback_targets_dispatch_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 // TestRunStreamOrchestration_FallbackTargets_RoutesBuildRequestToLeaf
-// pins the streaming orchestrator's wrapper-vs-target dispatch
-// (issue #237 PR 2). When the resolver has centralized an immediate
-// RR fallback child to a leaf, StreamConfig.FallbackTargets[child]
-// names that leaf and the orchestrator must pass IT (not the wrapper
-// child) as the clientOverride to buildRequest. On success,
-// WinnerClient must report the leaf — the dispatch target is the
-// realised serving identity.
+// pins the streaming orchestrator's wrapper-vs-target dispatch. When
+// the resolver has centralized an immediate RR fallback child to a
+// leaf, StreamConfig.FallbackTargets[child] names that leaf and the
+// orchestrator must pass IT (not the wrapper child) as the
+// clientOverride to buildRequest. On success, WinnerClient must
+// report the leaf — the dispatch target is the realised serving
+// identity.
 func TestRunStreamOrchestration_FallbackTargets_RoutesBuildRequestToLeaf(t *testing.T) {
 	server := makeOpenAIServer([]string{"hi"})
 	defer server.Close()
@@ -49,7 +49,7 @@ func TestRunStreamOrchestration_FallbackTargets_RoutesBuildRequestToLeaf(t *test
 			"InnerRR": "openai",
 			"Sibling": "openai",
 		},
-		// PR 2 resolver populates this when InnerRR's RR resolution
+		// Resolver populates this when InnerRR's RR resolution
 		// selected the leaf "A". The orchestrator must dispatch BR
 		// against "A", not "InnerRR".
 		FallbackTargets:   map[string]string{"InnerRR": "A"},
@@ -99,11 +99,12 @@ func TestRunStreamOrchestration_FallbackTargets_RoutesBuildRequestToLeaf(t *test
 }
 
 // TestRunStreamOrchestration_FallbackTargets_EmptyPassesThrough pins
-// the backward-compatible shape: a chain with no FallbackTargets
-// entries (or an entry equal to child) keeps the pre-PR-2 dispatch
-// identity — clientOverride equals the chain-position name. Crucial
-// for codegen sites that haven't migrated to populating FallbackTargets
-// yet (PR 3 wires those).
+// the pass-through shape: a chain with no FallbackTargets entries (or
+// an entry equal to child) dispatches BuildRequest against the chain-
+// position name verbatim — the dispatch identity equals the configured
+// child name. Required for any chain that didn't centralise an RR
+// child: the orchestrator must not silently mutate the dispatch target
+// when FallbackTargets is empty.
 func TestRunStreamOrchestration_FallbackTargets_EmptyPassesThrough(t *testing.T) {
 	server := makeOpenAIServer([]string{"ok"})
 	defer server.Close()
@@ -124,7 +125,7 @@ func TestRunStreamOrchestration_FallbackTargets_EmptyPassesThrough(t *testing.T)
 		ClientProviders: map[string]string{
 			"OnlyChild": "openai",
 		},
-		// No FallbackTargets — pre-PR-2 shape.
+		// No FallbackTargets — pass-through dispatch shape.
 	}
 
 	err := RunStreamOrchestration(
@@ -152,7 +153,7 @@ func TestRunStreamOrchestration_FallbackTargets_EmptyPassesThrough(t *testing.T)
 // dispatch with the chain-position name (the wrapper) as the
 // clientOverride. The legacy callback's scoped registry depends on
 // the wrapper identity to preserve runtime strategy overrides for
-// genuinely-deferred RR shapes (see #199 / #224 codegen scope split).
+// genuinely-deferred RR shapes.
 func TestRunStreamOrchestration_FallbackTargets_LegacyChildStaysAtWrapper(t *testing.T) {
 	out := make(chan bamlutils.StreamResult, 100)
 

--- a/bamlutils/buildrequest/metadata.go
+++ b/bamlutils/buildrequest/metadata.go
@@ -90,8 +90,7 @@ const (
 	// Distinct from PathReasonFallbackRoundRobinChildLegacy, which
 	// keeps describing nested RR children that remain on the legacy
 	// callback (deferred shapes, unsupported leaves, invalid
-	// `options.strategy` / `options.start` overrides). New in issue
-	// #237 PR 1 (vocabulary only); consumed starting in PR 2.
+	// `options.strategy` / `options.start` overrides).
 	PathReasonFallbackRoundRobinChildBuildRequest = "fallback-roundrobin-child-buildrequest"
 	// PathReasonBuildRequestDisabled: BAML_REST_USE_BUILD_REQUEST is off.
 	// Deliberate configuration — no operator alert.
@@ -436,15 +435,16 @@ func BuildFallbackChainPlan(
 // BuildFallbackChainPlanFromResolution constructs planned metadata for a
 // request routed through the BuildRequest path as a fallback strategy,
 // consuming the typed FallbackChainResolution produced by
-// ResolveFallbackChainPlanForClient. Distinct from the 4-tuple-input
-// sibling (BuildFallbackChainPlanForClient) so issue #237 PR 2's
-// per-child Targets and NestedRoundRobin information survives into the
-// planned metadata payload.
+// ResolveFallbackChainPlanForClient. The typed builder preserves
+// per-child Targets and NestedRoundRobin so the planned metadata
+// payload describes centralised RR-child dispatch end-to-end.
 //
-// Callers consuming the new typed resolver pass the resolution directly;
-// the 4-tuple plan builders stay as a compatibility surface for code
-// (notably the generated router) that hasn't migrated yet. PR 3 wires
-// the router through this typed builder.
+// Callers driving the typed resolver pass the resolution directly; the
+// 4-tuple BuildFallbackChainPlan / BuildFallbackChainPlanForClient
+// siblings stay as the metadata-classifier surface for legacy-path
+// plans (BuildLegacyMetadataPlanForClient calls
+// ResolveFallbackChainForClientWithReason to enumerate the chain for
+// observability on the legacy path, never to drive dispatch).
 //
 // Sparse-map contract:
 //   - FallbackTargets entries are omitted when target == child (the

--- a/bamlutils/buildrequest/metadata_orchestrator_test.go
+++ b/bamlutils/buildrequest/metadata_orchestrator_test.go
@@ -258,18 +258,17 @@ func TestRunCallOrchestration_NoMetadataPlanIsNoop(t *testing.T) {
 
 // TestRunStreamOrchestration_OutcomeClearsFallbackTargetFields pins
 // that the outcome event drops the planned-only fallback-target
-// vocabulary added in issue #237 PR 1 (FallbackTargets,
-// FallbackRoundRobin), alongside the existing Chain / LegacyChildren
-// clearing. Planned metadata describes intent (which RR-wrapper child
-// was unwrapped to which leaf, which RR decision was behind it); the
-// realised winner is already encoded in WinnerClient on outcome, so
-// duplicating the planned-shape on outcome only inflates the payload.
+// vocabulary (FallbackTargets, FallbackRoundRobin) alongside the
+// existing Chain / LegacyChildren clearing. Planned metadata describes
+// intent (which RR-wrapper child was unwrapped to which leaf, which
+// RR decision was behind it); the realised winner is already encoded
+// in WinnerClient on outcome, so duplicating the planned-shape on
+// outcome only inflates the payload.
 //
-// PR 1 never populates these fields, but the test seeds the plan with
-// representative values so the clearing logic is observable. PR 2 will
-// have the resolver actually populate them; this test pins the
-// contract before the producer lands so PR 2 cannot accidentally leak
-// planned-only intent into outcome.
+// The test seeds the plan with representative values so the clearing
+// logic is observable independent of whether a real resolver run
+// would have populated them — the outcome contract must hold whenever
+// the resolver does centralise an RR child.
 func TestRunStreamOrchestration_OutcomeClearsFallbackTargetFields(t *testing.T) {
 	server := makeOpenAIServer([]string{"hi"})
 	defer server.Close()

--- a/bamlutils/buildrequest/metadata_resolve_test.go
+++ b/bamlutils/buildrequest/metadata_resolve_test.go
@@ -156,11 +156,11 @@ func TestBuildSingleProviderPlan(t *testing.T) {
 	if plan.RetryMax != nil {
 		t.Errorf("RetryMax should be nil when policy is nil; got %v", plan.RetryMax)
 	}
-	// Issue #237 PR 1 introduces FallbackTargets / FallbackRoundRobin
-	// as vocabulary fields. Single-provider plans never have fallback
-	// children to describe, so the builder must leave both nil. PR 2
-	// only ever populates them for fallback-chain plans whose immediate
-	// RR children resolve to a BR-drivable leaf.
+	// FallbackTargets / FallbackRoundRobin are populated only on
+	// fallback-chain plans whose immediate RR children centrally
+	// resolve to a BR-drivable leaf. Single-provider plans never have
+	// fallback children to describe, so the builder must leave both
+	// nil.
 	if plan.FallbackTargets != nil {
 		t.Errorf("single-provider plan must not set FallbackTargets; got %v", plan.FallbackTargets)
 	}
@@ -194,10 +194,11 @@ func TestBuildFallbackChainPlan_APIFieldCarriesThrough(t *testing.T) {
 }
 
 // TestBuildFallbackChainPlan_FallbackTargetFieldsLeftEmpty pins that
-// the PR 1 vocabulary additions stay nil under the existing plan-builder
-// signatures (issue #237). PR 2 introduces the producer that populates
-// these maps for the narrow centralised-RR case; PR 1 keeps the wire
-// shape identical to pre-#237 for every plan the builders emit.
+// the 4-tuple plan builders never populate FallbackTargets /
+// FallbackRoundRobin. The typed BuildFallbackChainPlanFromResolution
+// is the only producer of these fields; the 4-tuple builders feed the
+// legacy metadata classifier, which describes the chain shape for
+// observability and never carries per-child Targets.
 func TestBuildFallbackChainPlan_FallbackTargetFieldsLeftEmpty(t *testing.T) {
 	adapter := &mockAdapter{Context: context.Background()}
 	chain := []string{"A", "B"}
@@ -206,37 +207,38 @@ func TestBuildFallbackChainPlan_FallbackTargetFieldsLeftEmpty(t *testing.T) {
 	t.Run("adapter-based builder", func(t *testing.T) {
 		plan := BuildFallbackChainPlan(adapter, "Strategy", chain, providers, nil, nil, BuildRequestAPIStreamRequest, "")
 		if plan.FallbackTargets != nil {
-			t.Errorf("FallbackTargets must be nil before PR 2 wires the producer; got %v", plan.FallbackTargets)
+			t.Errorf("FallbackTargets must be nil on 4-tuple plan; got %v", plan.FallbackTargets)
 		}
 		if plan.FallbackRoundRobin != nil {
-			t.Errorf("FallbackRoundRobin must be nil before PR 2 wires the producer; got %v", plan.FallbackRoundRobin)
+			t.Errorf("FallbackRoundRobin must be nil on 4-tuple plan; got %v", plan.FallbackRoundRobin)
 		}
 		// JSON encoding must omit the new keys entirely so the wire
-		// shape remains byte-identical to pre-#237 for these plans.
+		// shape stays minimal for plans whose builder doesn't populate
+		// the fallback-target vocabulary.
 		data, err := json.Marshal(plan)
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
 		}
 		if got := string(data); strings.Contains(got, `"fallback_targets"`) || strings.Contains(got, `"fallback_round_robin"`) {
-			t.Errorf("planned JSON must not carry the new fallback-target keys; got %s", got)
+			t.Errorf("planned JSON must not carry the fallback-target keys for 4-tuple plans; got %s", got)
 		}
 	})
 
 	t.Run("client-name builder", func(t *testing.T) {
 		plan := BuildFallbackChainPlanForClient("Strategy", chain, providers, nil, nil, BuildRequestAPIStreamRequest, "")
 		if plan.FallbackTargets != nil {
-			t.Errorf("FallbackTargets must be nil before PR 2 wires the producer; got %v", plan.FallbackTargets)
+			t.Errorf("FallbackTargets must be nil on 4-tuple plan; got %v", plan.FallbackTargets)
 		}
 		if plan.FallbackRoundRobin != nil {
-			t.Errorf("FallbackRoundRobin must be nil before PR 2 wires the producer; got %v", plan.FallbackRoundRobin)
+			t.Errorf("FallbackRoundRobin must be nil on 4-tuple plan; got %v", plan.FallbackRoundRobin)
 		}
 	})
 }
 
 // TestBuildLegacyMetadataPlan_FallbackTargetFieldsLeftEmpty pins the
-// same vocabulary-only invariant for the legacy plan builders. PR 1
-// never produces fallback-target metadata on the legacy path either —
-// the centralisation behaviour PR 2 adds is BuildRequest-only.
+// same vocabulary-only invariant for the legacy plan builders. The
+// legacy path never carries fallback-target metadata — centralisation
+// is BuildRequest-only.
 func TestBuildLegacyMetadataPlan_FallbackTargetFieldsLeftEmpty(t *testing.T) {
 	adapter := &mockAdapter{Context: context.Background()}
 	plan := BuildLegacyMetadataPlan(adapter, "MyClient", "aws-bedrock", nil, nil, IsProviderSupported, nil)

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -243,20 +243,19 @@ type StreamConfig struct {
 
 	// FallbackTargets is the dispatch-target counterpart of the metadata
 	// field of the same name on bamlutils.Metadata — see that field's
-	// doc string for the wire-shape contract. PR 1 adds the field; PR 2
-	// (issue #237) wires the BuildRequest dispatch loop to honour
-	// FallbackTargets[child] when computing the WithClient target for
-	// an immediate RR fallback child that was centrally unwrapped to a
-	// leaf. The orchestrator is the consumer; resolver/planning
-	// upstream is the producer.
+	// doc string for the wire-shape contract. The BuildRequest dispatch
+	// loop consults FallbackTargets[child] when computing the WithClient
+	// target for an immediate RR fallback child that was centrally
+	// unwrapped to a leaf. The orchestrator is the consumer; resolver/
+	// planning upstream is the producer.
 	FallbackTargets map[string]string
 
 	// FallbackRoundRobin mirrors Metadata.FallbackRoundRobin — the
 	// per-child RR decision for fallback children resolved through
-	// BuildRequest centralization. PR 1 adds the field; PR 2 wires
-	// resolver output to populate it so outgoing planned metadata
-	// describes both the selected leaf (FallbackTargets[child]) and
-	// the RR decision behind that selection.
+	// BuildRequest centralization. Populated from resolver output so
+	// outgoing planned metadata describes both the selected leaf
+	// (FallbackTargets[child]) and the RR decision behind that
+	// selection.
 	FallbackRoundRobin map[string]*bamlutils.RoundRobinInfo
 
 	// MetadataPlan is the pre-computed planned metadata for this request.
@@ -650,11 +649,11 @@ func RunStreamOrchestration(
 		// FallbackTargets / FallbackRoundRobin describe PLANNED
 		// fallback-chain intent — which RR-wrapper children were
 		// centrally unwrapped to leaves and which leaves the RR
-		// decision picked (issue #237). The realised winner is
-		// encoded in WinnerClient on outcome, so retaining these
-		// planned-only fields duplicates information and inflates
-		// the outcome payload. Clear them alongside Chain /
-		// LegacyChildren for the same reason.
+		// decision picked. The realised winner is encoded in
+		// WinnerClient on outcome, so retaining these planned-only
+		// fields duplicates information and inflates the outcome
+		// payload. Clear them alongside Chain / LegacyChildren for
+		// the same reason.
 		outcome.FallbackTargets = nil
 		outcome.FallbackRoundRobin = nil
 		outcome.Strategy = ""
@@ -792,16 +791,16 @@ func RunStreamOrchestration(
 				path = "legacy"
 			} else {
 				provider := config.ClientProviders[child]
-				// Wrapper-vs-target identity (issue #237 PR 2): when an
-				// immediate RR fallback child was centrally unwrapped
-				// to a leaf, FallbackTargets[child] names that leaf.
-				// Dispatch BuildRequest against the leaf so BAML's
-				// runtime sees the resolved client identity directly,
-				// not the RR wrapper (which would re-rotate per-worker
-				// inside BAML and defeat the centralization). When the
-				// map has no entry or the entry equals child, dispatch
-				// passes the chain-position name verbatim — preserving
-				// the pre-PR-2 shape for chains with no centralization.
+				// Wrapper-vs-target identity: when an immediate RR
+				// fallback child was centrally unwrapped to a leaf,
+				// FallbackTargets[child] names that leaf. Dispatch
+				// BuildRequest against the leaf so BAML's runtime sees
+				// the resolved client identity directly, not the RR
+				// wrapper (which would re-rotate per-worker inside
+				// BAML and defeat the centralization). When the map
+				// has no entry or the entry equals child, dispatch
+				// passes the chain-position name verbatim — the
+				// pass-through shape for chains with no centralization.
 				if t, ok := config.FallbackTargets[child]; ok && t != "" {
 					winnerTarget = t
 				}

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -59,16 +59,15 @@ type Metadata struct {
 	Phase   MetadataPhase `json:"phase"`   // "planned" or "outcome"
 	Attempt int           `json:"attempt"` // pool-level attempt number (0-based). Orchestrator emits 0; pool rewrites.
 	Path    string        `json:"path"`    // "buildrequest" or "legacy"
-	// PathReason is an informational routing-classification token. It
-	// historically reported only legacy-side classifications (unsupported
-	// provider, empty provider, fallback-empty-chain, etc.) and was
-	// documented as "empty when Path==buildrequest". Since #237 PR 1 it
-	// also carries BuildRequest-side informational reasons — most
-	// notably PathReasonFallbackRoundRobinChildBuildRequest, set when an
+	// PathReason is an informational routing-classification token. On
+	// Path=="legacy" it names the reason (unsupported provider, empty
+	// provider, fallback-empty-chain, etc.). On Path=="buildrequest" it
+	// can also carry informational classifications — notably
+	// PathReasonFallbackRoundRobinChildBuildRequest, set when an
 	// immediate RR fallback child was centrally unwrapped to a leaf and
 	// dispatched via BuildRequest rather than the legacy callback. The
-	// field still defaults to empty when there's nothing informational
-	// to report.
+	// field defaults to empty when there's nothing informational to
+	// report.
 	PathReason string `json:"path_reason,omitempty"`
 
 	// BuildRequestAPI identifies which BAML API drove a Path=="buildrequest"
@@ -120,21 +119,19 @@ type Metadata struct {
 	// the target client actually dispatched, populated when an immediate
 	// RR fallback child is centrally unwrapped to a leaf and driven via
 	// BuildRequest rather than handed to BAML's per-worker runtime
-	// through the legacy callback (see issue #237). The map is sparse —
-	// entries are omitted when target == child, so a chain whose
-	// children all dispatch verbatim leaves this field nil.
+	// through the legacy callback. The map is sparse — entries are
+	// omitted when target == child, so a chain whose children all
+	// dispatch verbatim leaves this field nil.
 	//
-	// PR 1 introduces the field; consumers populate it starting in
-	// PR 2 (resolver/orchestrator dispatch). Outcome events clear this
-	// field — the planned phase describes intent, while the realised
-	// winner is encoded in WinnerClient on outcome.
+	// Populated on planned events only — the planned phase describes
+	// intent, while the realised winner is encoded in WinnerClient on
+	// outcome. Outcome events clear this field.
 	FallbackTargets map[string]string `json:"fallback_targets,omitempty"`
 
 	// FallbackRoundRobin reports the round-robin selection for fallback
-	// chain children that resolved through BuildRequest centralization
-	// (see issue #237). Keyed by the fallback chain child name (the RR
-	// wrapper), valued by the per-child RoundRobinInfo describing which
-	// leaf was picked.
+	// chain children that resolved through BuildRequest centralization.
+	// Keyed by the fallback chain child name (the RR wrapper), valued
+	// by the per-child RoundRobinInfo describing which leaf was picked.
 	//
 	// Distinct from the top-level RoundRobin field, which always
 	// describes the OUTERMOST RR decision — reusing it for nested
@@ -143,9 +140,8 @@ type Metadata struct {
 	// existing unary headers. A per-child map keeps the two concepts
 	// separate.
 	//
-	// PR 1 introduces the field; consumers populate it starting in
-	// PR 2. Outcome events clear this field for the same reason
-	// FallbackTargets is cleared.
+	// Populated on planned events only. Outcome events clear this
+	// field for the same reason FallbackTargets is cleared.
 	FallbackRoundRobin map[string]*RoundRobinInfo `json:"fallback_round_robin,omitempty"`
 }
 

--- a/bamlutils/metadata_test.go
+++ b/bamlutils/metadata_test.go
@@ -153,18 +153,17 @@ func TestMetadata_JSONRoundtrip(t *testing.T) {
 	}
 }
 
-// TestMetadata_FallbackTargetsAndRoundRobinRoundtrip verifies the new
-// fallback-target vocabulary added in issue #237 PR 1 (FallbackTargets,
-// FallbackRoundRobin) survives a JSON encode → decode cycle, AND that
-// both fields honour their `omitempty` JSON tags for the nil and empty-
-// map cases.
+// TestMetadata_FallbackTargetsAndRoundRobinRoundtrip verifies that the
+// fallback-target vocabulary (FallbackTargets, FallbackRoundRobin)
+// survives a JSON encode → decode cycle, AND that both fields honour
+// their `omitempty` JSON tags for the nil and empty-map cases.
 //
-// The nil / empty-map invariant is load-bearing: PR 2 will start
-// populating these fields on a narrow set of plans, so the existing wire
-// shape (no `fallback_targets` / `fallback_round_robin` keys at all) must
-// hold for every plan PR 1's behaviour-neutral builders emit. A regression
-// that emits empty-but-non-nil maps would change the wire shape for every
-// existing caller.
+// The nil / empty-map invariant is load-bearing: only the narrow set of
+// plans that come out of a centralised RR-child resolution populates
+// these fields, so the wire shape (no `fallback_targets` /
+// `fallback_round_robin` keys at all) must hold for every other plan
+// the builders emit. A regression that emits empty-but-non-nil maps
+// would change the wire shape for every existing consumer.
 func TestMetadata_FallbackTargetsAndRoundRobinRoundtrip(t *testing.T) {
 	t.Parallel()
 
@@ -242,9 +241,10 @@ func TestMetadata_FallbackTargetsAndRoundRobinRoundtrip(t *testing.T) {
 			t.Fatalf("marshal: %v", err)
 		}
 		// Maps with `omitempty` drop on len()==0, so the wire shape
-		// for an explicit empty map is identical to nil. PR 2 will
-		// populate these maps for a narrow set of plans only, so every
-		// other plan keeps the existing wire payload byte-for-byte.
+		// for an explicit empty map is identical to nil. Only the
+		// narrow set of plans coming out of a centralised RR-child
+		// resolution populates these maps; every other plan keeps
+		// the existing wire payload byte-for-byte.
 		if bytes.Contains(data, []byte(`"fallback_targets"`)) {
 			t.Errorf("empty FallbackTargets must be omitted from wire; got %s", data)
 		}

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -1998,6 +1998,116 @@ func parseRetryPolicyBlock(cfg *bamlConfig, name string, block []string) {
 
 // generateBamlConfigVars parses .baml source files and generates introspected
 // variables for provider detection and retry policy configuration.
+// emitFallbackRoundRobinDeferredWarnings logs a build-time warning per
+// (fallback parent, deferred-shape child) pair for compositions that
+// the BuildRequest resolver does NOT centralise — runtime rotation
+// still works, but it routes through BAML's per-worker runtime rather
+// than the cross-worker SharedState advancer. The static
+// `fallback[rr[A,B], C]` shape — RR child whose every leaf is a
+// non-strategy client — is centralised and does NOT warn.
+//
+// Deferred shapes statically introspectable from the chain map alone:
+//
+//  1. Immediate RR fallback child whose chain contains at least one
+//     strategy leaf (e.g. `fallback[rr[fallback[A,B], C], D]`).
+//     Recursive strategy planning inside a fallback child isn't
+//     modelled, so the RR child stays on the legacy callback path.
+//
+//  2. Nested fallback that reaches an RR descendant at any depth
+//     (e.g. `fallback[fallback[rr[A,B], C], D]` AND
+//     `fallback[fallback[fallback[rr[A,B], C], D], E]`).
+//     Centralisation only reaches IMMEDIATE fallback children of the
+//     outer fallback; any RR descendant reached through one or more
+//     nested fallback hops stays on the legacy per-worker path.
+//     A DFS over `cfg.fallbackChains` (following only fallback nodes,
+//     visited-set for cycle safety) finds the first reachable RR
+//     descendant; the loop stops on the first match per (parent,
+//     child) pair so a chain containing multiple paths to the same
+//     RR client emits exactly one warning.
+//
+// Out-of-scope shapes not detectable statically (unsupported leaf
+// providers like aws-bedrock, runtime overrides on options.strategy
+// or options.start) don't warn at introspect time — the runtime
+// resolver handles them via PathReasonFallbackRoundRobinChildLegacy.
+//
+// Keys are sorted so the warning order is stable across runs.
+// `logf` is the writer abstraction (production: log.Printf;
+// tests substitute a capture).
+func emitFallbackRoundRobinDeferredWarnings(cfg *bamlConfig, logf func(string, ...any)) {
+	parents := make([]string, 0, len(cfg.fallbackChains))
+	for parent := range cfg.fallbackChains {
+		parents = append(parents, parent)
+	}
+	sort.Strings(parents)
+	isStrategyProvider := func(p string) bool {
+		return p == "baml-roundrobin" || p == "baml-fallback"
+	}
+	for _, parent := range parents {
+		if cfg.clientProvider[parent] != "baml-fallback" {
+			continue
+		}
+		for _, child := range cfg.fallbackChains[parent] {
+			childProvider := cfg.clientProvider[child]
+			switch childProvider {
+			case "baml-roundrobin":
+				// Deferred shape 1: warn only when at least one RR
+				// leaf is itself a strategy wrapper. RR with purely
+				// non-strategy leaves is centralised.
+				rrHasStrategyLeaf := false
+				for _, leaf := range cfg.fallbackChains[child] {
+					if isStrategyProvider(cfg.clientProvider[leaf]) {
+						rrHasStrategyLeaf = true
+						break
+					}
+				}
+				if !rrHasStrategyLeaf {
+					continue
+				}
+				logf("baml-rest introspect: fallback client %q has round-robin child %q "+
+					"whose chain contains a strategy leaf; this composition stays on the "+
+					"legacy per-worker rotation path because recursive strategy planning "+
+					"inside a fallback child isn't modelled yet",
+					parent, child)
+			case "baml-fallback":
+				// Deferred shape 2: nested fallback containing RR at
+				// any depth. DFS through fallback nodes only; stop on
+				// the first RR descendant per (parent, child) pair.
+				// Visited-set guards against cycles in malformed
+				// configs and against duplicate logs when multiple
+				// paths converge on the same RR client.
+				visited := make(map[string]bool)
+				var findRoundRobinDescendant func(string) (string, bool)
+				findRoundRobinDescendant = func(node string) (string, bool) {
+					if visited[node] {
+						return "", false
+					}
+					visited[node] = true
+					if cfg.clientProvider[node] == "baml-roundrobin" {
+						return node, true
+					}
+					if cfg.clientProvider[node] != "baml-fallback" {
+						// Non-strategy leaf — no RR below this branch.
+						return "", false
+					}
+					for _, next := range cfg.fallbackChains[node] {
+						if rr, ok := findRoundRobinDescendant(next); ok {
+							return rr, true
+						}
+					}
+					return "", false
+				}
+				if rr, ok := findRoundRobinDescendant(child); ok {
+					logf("baml-rest introspect: fallback client %q has nested fallback "+
+						"child %q whose chain reaches round-robin descendant %q; this composition "+
+						"stays on the legacy per-worker rotation path because centralisation "+
+						"only reaches immediate fallback children",
+						parent, child, rr)
+				}
+			}
+		}
+	}
+}
+
 func generateBamlConfigVars(out *jen.File) {
 	retryPkg := "github.com/invakid404/baml-rest/bamlutils/retry"
 
@@ -2123,86 +2233,9 @@ func generateBamlConfigVars(out *jen.File) {
 
 	// Scan for fallback compositions whose RR-child centralisation is
 	// still deferred and emit a one-time build-log warning per (fallback,
-	// rr-child) pair. The static `fallback[rr[A,B], C]` shape — RR child
-	// whose every leaf is a non-strategy client — is centralised via the
-	// BuildRequest path and rotates cross-worker like top-level RR; that
-	// case no longer warns.
-	//
-	// The remaining deferred shapes are statically introspectable from
-	// the chain map alone:
-	//
-	//   1. Immediate RR fallback child whose selected leaf is itself a
-	//      strategy wrapper (e.g. fallback[rr[fallback[A,B], C], D]).
-	//      Recursive fallback planning inside a fallback child isn't
-	//      modelled yet; the RR child stays on the legacy callback so
-	//      BAML's per-worker runtime owns rotation.
-	//
-	//   2. Nested fallback containing an RR child (e.g.
-	//      fallback[fallback[rr[A,B], C], D]). The outer chain's
-	//      classification only inspects immediate children; an RR a level
-	//      deeper isn't reachable for centralisation and runs per-worker.
-	//
-	// Out-of-scope shapes not detectable statically (unsupported leaf
-	// providers like aws-bedrock, runtime overrides on options.strategy
-	// or options.start) don't warn at introspect time — the runtime
-	// resolver handles them via PathReasonFallbackRoundRobinChildLegacy.
-	//
-	// Keys are sorted so the build-log output is stable across runs.
-	{
-		parents := make([]string, 0, len(cfg.fallbackChains))
-		for parent := range cfg.fallbackChains {
-			parents = append(parents, parent)
-		}
-		sort.Strings(parents)
-		isStrategyProvider := func(p string) bool {
-			return p == "baml-roundrobin" || p == "baml-fallback"
-		}
-		for _, parent := range parents {
-			if cfg.clientProvider[parent] != "baml-fallback" {
-				continue
-			}
-			for _, child := range cfg.fallbackChains[parent] {
-				childProvider := cfg.clientProvider[child]
-				switch childProvider {
-				case "baml-roundrobin":
-					// Deferred shape 1: RR child whose every leaf is a
-					// non-strategy client is centralised — no warning.
-					// Warn only when at least one leaf is itself a
-					// strategy wrapper.
-					rrHasStrategyLeaf := false
-					for _, leaf := range cfg.fallbackChains[child] {
-						if isStrategyProvider(cfg.clientProvider[leaf]) {
-							rrHasStrategyLeaf = true
-							break
-						}
-					}
-					if !rrHasStrategyLeaf {
-						continue
-					}
-					log.Printf("baml-rest introspect: fallback client %q has round-robin child %q "+
-						"whose chain contains a strategy leaf; this composition stays on the "+
-						"legacy per-worker rotation path because recursive strategy planning "+
-						"inside a fallback child isn't modelled yet",
-						parent, child)
-				case "baml-fallback":
-					// Deferred shape 2: nested fallback containing RR.
-					// Warn per (parent, nested-fallback child) when the
-					// nested fallback has at least one immediate RR
-					// child; centralisation only reaches immediate
-					// fallback children.
-					for _, grandchild := range cfg.fallbackChains[child] {
-						if cfg.clientProvider[grandchild] == "baml-roundrobin" {
-							log.Printf("baml-rest introspect: fallback client %q has nested fallback "+
-								"child %q whose chain contains round-robin grandchild %q; this composition "+
-								"stays on the legacy per-worker rotation path because centralisation "+
-								"only reaches immediate fallback children",
-								parent, child, grandchild)
-						}
-					}
-				}
-			}
-		}
-	}
+	// rr-child) pair. See emitFallbackRoundRobinDeferredWarnings for the
+	// deferred-shape matrix.
+	emitFallbackRoundRobinDeferredWarnings(cfg, log.Printf)
 
 	// FallbackChains: maps strategy client names (baml-fallback, baml-roundrobin)
 	// to their ordered list of child client names from the strategy option.

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -2121,13 +2121,32 @@ func generateBamlConfigVars(out *jen.File) {
 		out.Var().Id("ClientRetryPolicy").Op("=").Map(jen.String()).String().Values(entries...)
 	}
 
-	// Scan for fallback -> round-robin composition at introspect time
-	// and emit a one-time build-log warning per (fallback, rr-child)
-	// pair. This PR intentionally defers centralised unwrapping of RR
-	// children inside fallback chains. Nested RR still runs
-	// correctly under BAML's per-worker
-	// runtime rotation; the warning just flags the composition so
-	// operators don't mistake pool-wide RR for nested-RR-works-too.
+	// Scan for fallback compositions whose RR-child centralisation is
+	// still deferred and emit a one-time build-log warning per (fallback,
+	// rr-child) pair. The static `fallback[rr[A,B], C]` shape — RR child
+	// whose every leaf is a non-strategy client — is centralised via the
+	// BuildRequest path and rotates cross-worker like top-level RR; that
+	// case no longer warns.
+	//
+	// The remaining deferred shapes are statically introspectable from
+	// the chain map alone:
+	//
+	//   1. Immediate RR fallback child whose selected leaf is itself a
+	//      strategy wrapper (e.g. fallback[rr[fallback[A,B], C], D]).
+	//      Recursive fallback planning inside a fallback child isn't
+	//      modelled yet; the RR child stays on the legacy callback so
+	//      BAML's per-worker runtime owns rotation.
+	//
+	//   2. Nested fallback containing an RR child (e.g.
+	//      fallback[fallback[rr[A,B], C], D]). The outer chain's
+	//      classification only inspects immediate children; an RR a level
+	//      deeper isn't reachable for centralisation and runs per-worker.
+	//
+	// Out-of-scope shapes not detectable statically (unsupported leaf
+	// providers like aws-bedrock, runtime overrides on options.strategy
+	// or options.start) don't warn at introspect time — the runtime
+	// resolver handles them via PathReasonFallbackRoundRobinChildLegacy.
+	//
 	// Keys are sorted so the build-log output is stable across runs.
 	{
 		parents := make([]string, 0, len(cfg.fallbackChains))
@@ -2135,18 +2154,52 @@ func generateBamlConfigVars(out *jen.File) {
 			parents = append(parents, parent)
 		}
 		sort.Strings(parents)
+		isStrategyProvider := func(p string) bool {
+			return p == "baml-roundrobin" || p == "baml-fallback"
+		}
 		for _, parent := range parents {
 			if cfg.clientProvider[parent] != "baml-fallback" {
 				continue
 			}
 			for _, child := range cfg.fallbackChains[parent] {
-				if cfg.clientProvider[child] != "baml-roundrobin" {
-					continue
+				childProvider := cfg.clientProvider[child]
+				switch childProvider {
+				case "baml-roundrobin":
+					// Deferred shape 1: RR child whose every leaf is a
+					// non-strategy client is centralised — no warning.
+					// Warn only when at least one leaf is itself a
+					// strategy wrapper.
+					rrHasStrategyLeaf := false
+					for _, leaf := range cfg.fallbackChains[child] {
+						if isStrategyProvider(cfg.clientProvider[leaf]) {
+							rrHasStrategyLeaf = true
+							break
+						}
+					}
+					if !rrHasStrategyLeaf {
+						continue
+					}
+					log.Printf("baml-rest introspect: fallback client %q has round-robin child %q "+
+						"whose chain contains a strategy leaf; this composition stays on the "+
+						"legacy per-worker rotation path because recursive strategy planning "+
+						"inside a fallback child isn't modelled yet",
+						parent, child)
+				case "baml-fallback":
+					// Deferred shape 2: nested fallback containing RR.
+					// Warn per (parent, nested-fallback child) when the
+					// nested fallback has at least one immediate RR
+					// child; centralisation only reaches immediate
+					// fallback children.
+					for _, grandchild := range cfg.fallbackChains[child] {
+						if cfg.clientProvider[grandchild] == "baml-roundrobin" {
+							log.Printf("baml-rest introspect: fallback client %q has nested fallback "+
+								"child %q whose chain contains round-robin grandchild %q; this composition "+
+								"stays on the legacy per-worker rotation path because centralisation "+
+								"only reaches immediate fallback children",
+								parent, child, grandchild)
+						}
+					}
 				}
-				log.Printf("baml-rest introspect: fallback client %q has baml-roundrobin child %q; "+
-					"nested round-robin rotates per-worker via BAML's runtime (cross-worker "+
-					"centralisation is only applied to top-level round-robin clients)",
-					parent, child)
 			}
 		}
 	}

--- a/cmd/introspect/main_test.go
+++ b/cmd/introspect/main_test.go
@@ -88,32 +88,32 @@ func TestEmitFallbackRoundRobinDeferredWarnings_NestedFallbackContainingRoundRob
 				"InnerRR": {"A", "B"},
 			},
 		}
-		var cap captureLog
-		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
+		var clog captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, clog.Logf)
 
 		// The (Outer, Mid) pair is the regression case — the single-
 		// level loop walked only `cfg.fallbackChains[Mid]` (which is
 		// [Inner, D]) and never recursed into Inner to find InnerRR.
 		// The DFS must reach InnerRR through Mid → Inner → InnerRR
 		// and emit a warning naming Outer/Mid/InnerRR.
-		if n := countLinesMentioning(cap.lines, `"Outer"`, `"Mid"`, `"InnerRR"`, "nested fallback"); n != 1 {
+		if n := countLinesMentioning(clog.lines, `"Outer"`, `"Mid"`, `"InnerRR"`, "nested fallback"); n != 1 {
 			t.Errorf("expected exactly 1 warning for (Outer, Mid) naming InnerRR via DFS; got %d.\nall lines:\n%s",
-				n, strings.Join(cap.lines, "\n"))
+				n, strings.Join(clog.lines, "\n"))
 		}
 		// Sanity-check the intermediate pair too — (Mid, Inner) is
 		// also a valid deferred shape (Mid is itself a fallback whose
 		// nested child Inner reaches InnerRR). The single-level loop
 		// would already catch this one; DFS preserves it.
-		if n := countLinesMentioning(cap.lines, `"Mid"`, `"Inner"`, `"InnerRR"`); n != 1 {
+		if n := countLinesMentioning(clog.lines, `"Mid"`, `"Inner"`, `"InnerRR"`); n != 1 {
 			t.Errorf("expected exactly 1 warning for (Mid, Inner) naming InnerRR; got %d.\nall lines:\n%s",
-				n, strings.Join(cap.lines, "\n"))
+				n, strings.Join(clog.lines, "\n"))
 		}
 		// Negative pin: (Inner, InnerRR) is the centralised
 		// composition (immediate RR child with non-strategy leaves)
 		// and must NOT warn — that's shape 1's centralised case.
-		if n := countLinesMentioning(cap.lines, `"Inner"`, `"InnerRR"`, "round-robin child"); n != 0 {
+		if n := countLinesMentioning(clog.lines, `"Inner"`, `"InnerRR"`, "round-robin child"); n != 0 {
 			t.Errorf("centralised composition (Inner has immediate RR child with non-strategy leaves) must NOT emit a shape-1 warning; got %d.\nall lines:\n%s",
-				n, strings.Join(cap.lines, "\n"))
+				n, strings.Join(clog.lines, "\n"))
 		}
 	})
 
@@ -147,16 +147,16 @@ func TestEmitFallbackRoundRobinDeferredWarnings_NestedFallbackContainingRoundRob
 				"RR":     {"A", "B"},
 			},
 		}
-		var cap captureLog
-		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
+		var clog captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, clog.Logf)
 
 		// Pair (Outer, Mid) must appear exactly once regardless of
 		// which converging path the DFS took first. A regression
 		// that re-walked Mid's children after the first match would
 		// emit two warnings for (Outer, Mid) — one per path.
-		if n := countLinesMentioning(cap.lines, `"Outer"`, `"Mid"`, `"RR"`); n != 1 {
+		if n := countLinesMentioning(clog.lines, `"Outer"`, `"Mid"`, `"RR"`); n != 1 {
 			t.Errorf("expected exactly 1 warning for (Outer, Mid) even with converging paths to RR; got %d.\nall lines:\n%s",
-				n, strings.Join(cap.lines, "\n"))
+				n, strings.Join(clog.lines, "\n"))
 		}
 	})
 
@@ -181,11 +181,11 @@ func TestEmitFallbackRoundRobinDeferredWarnings_NestedFallbackContainingRoundRob
 				"Inner": {"A", "B"},
 			},
 		}
-		var cap captureLog
-		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
-		if len(cap.lines) != 0 {
+		var clog captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, clog.Logf)
+		if len(clog.lines) != 0 {
 			t.Errorf("non-strategy-only nested fallback must emit no warning, got %d:\n%s",
-				len(cap.lines), strings.Join(cap.lines, "\n"))
+				len(clog.lines), strings.Join(clog.lines, "\n"))
 		}
 	})
 
@@ -206,11 +206,11 @@ func TestEmitFallbackRoundRobinDeferredWarnings_NestedFallbackContainingRoundRob
 				"InnerRR": {"A", "B"},
 			},
 		}
-		var cap captureLog
-		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
-		if len(cap.lines) != 0 {
+		var clog captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, clog.Logf)
+		if len(clog.lines) != 0 {
 			t.Errorf("centralised composition must emit no warning, got %d:\n%s",
-				len(cap.lines), strings.Join(cap.lines, "\n"))
+				len(clog.lines), strings.Join(clog.lines, "\n"))
 		}
 	})
 
@@ -233,14 +233,14 @@ func TestEmitFallbackRoundRobinDeferredWarnings_NestedFallbackContainingRoundRob
 				"InnerFall": {"A"},
 			},
 		}
-		var cap captureLog
-		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
-		if len(cap.lines) != 1 {
+		var clog captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, clog.Logf)
+		if len(clog.lines) != 1 {
 			t.Fatalf("RR child with a strategy leaf must still emit a deferred-shape warning, got %d:\n%s",
-				len(cap.lines), strings.Join(cap.lines, "\n"))
+				len(clog.lines), strings.Join(clog.lines, "\n"))
 		}
-		if !strings.Contains(cap.lines[0], "round-robin child") {
-			t.Errorf("warning must classify as shape 1 (round-robin child …); got: %s", cap.lines[0])
+		if !strings.Contains(clog.lines[0], "round-robin child") {
+			t.Errorf("warning must classify as shape 1 (round-robin child …); got: %s", clog.lines[0])
 		}
 	})
 
@@ -260,11 +260,11 @@ func TestEmitFallbackRoundRobinDeferredWarnings_NestedFallbackContainingRoundRob
 				"Mid":   {"Mid", "A"},
 			},
 		}
-		var cap captureLog
-		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
-		if len(cap.lines) != 0 {
+		var clog captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, clog.Logf)
+		if len(clog.lines) != 0 {
 			t.Errorf("cycle without RR descendants must emit no warning, got %d:\n%s",
-				len(cap.lines), strings.Join(cap.lines, "\n"))
+				len(clog.lines), strings.Join(clog.lines, "\n"))
 		}
 	})
 }

--- a/cmd/introspect/main_test.go
+++ b/cmd/introspect/main_test.go
@@ -1,11 +1,273 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/dave/jennifer/jen"
 )
+
+// captureLog implements the func(format, args...) shape that
+// emitFallbackRoundRobinDeferredWarnings expects, recording each
+// formatted line for assertion. Buffer-backed so per-case test setup
+// can read back the emitted warnings.
+type captureLog struct {
+	lines []string
+}
+
+func (c *captureLog) Logf(format string, args ...any) {
+	c.lines = append(c.lines, fmt.Sprintf(format, args...))
+}
+
+// TestEmitFallbackRoundRobinDeferredWarnings_NestedFallbackContaining-
+// RoundRobin pins the multi-level DFS contract: a fallback whose
+// nested-fallback child reaches a round-robin client through any
+// depth of fallback hops must emit a warning. The shape
+// `fallback[fallback[fallback[rr[A,B], C], D], E]` is the canonical
+// regression — the single-level loop only inspected the immediate
+// grandchild and would miss the RR three levels deep.
+//
+// Companion sub-test: when the same nested branch contains multiple
+// fallback paths that converge on the same RR client, the warning
+// emits exactly once per (parent, child) pair (visited-set
+// dedup-by-construction).
+//
+// Negative sub-test: a flat `fallback[fallback[A, B], C]` with no RR
+// anywhere must emit no warning at all.
+func TestEmitFallbackRoundRobinDeferredWarnings_NestedFallbackContainingRoundRobin(t *testing.T) {
+	// countLinesMentioning returns the count of captured warning lines
+	// that mention every supplied substring. Used to verify per-
+	// (parent, child) warning emission while staying agnostic to the
+	// order in which the emitter sorts parents.
+	countLinesMentioning := func(lines []string, substrs ...string) int {
+		count := 0
+	OUTER:
+		for _, line := range lines {
+			for _, s := range substrs {
+				if !strings.Contains(line, s) {
+					continue OUTER
+				}
+			}
+			count++
+		}
+		return count
+	}
+
+	t.Run("rr-three-levels-deep-warns-for-outermost-pair", func(t *testing.T) {
+		// Outer = baml-fallback whose first child is a nested
+		// fallback. The nested fallback's first child is itself a
+		// fallback. That deepest fallback's first child is the RR
+		// wrapper. Without DFS, the (Outer, Mid) pair would inspect
+		// only Mid's immediate children, see no baml-roundrobin
+		// grandchild, and miss the warning — even though the chain
+		// reaches RR two levels below Mid.
+		//
+		// Each baml-fallback in the descent is also enumerated as a
+		// parent in its own right, so the emitter logs one warning
+		// per fallback-with-deferred-child pair. This test pins the
+		// load-bearing assertion: the (Outer, Mid) pair MUST emit
+		// (it's the case the single-level loop missed) and the
+		// warning names InnerRR as the reached descendant.
+		cfg := &bamlConfig{
+			clientProvider: map[string]string{
+				"Outer":   "baml-fallback",
+				"Mid":     "baml-fallback",
+				"Inner":   "baml-fallback",
+				"InnerRR": "baml-roundrobin",
+				"A":       "openai",
+				"B":       "openai",
+				"C":       "openai",
+				"D":       "openai",
+				"E":       "openai",
+			},
+			fallbackChains: map[string][]string{
+				"Outer":   {"Mid", "E"},
+				"Mid":     {"Inner", "D"},
+				"Inner":   {"InnerRR", "C"},
+				"InnerRR": {"A", "B"},
+			},
+		}
+		var cap captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
+
+		// The (Outer, Mid) pair is the regression case — the single-
+		// level loop walked only `cfg.fallbackChains[Mid]` (which is
+		// [Inner, D]) and never recursed into Inner to find InnerRR.
+		// The DFS must reach InnerRR through Mid → Inner → InnerRR
+		// and emit a warning naming Outer/Mid/InnerRR.
+		if n := countLinesMentioning(cap.lines, `"Outer"`, `"Mid"`, `"InnerRR"`, "nested fallback"); n != 1 {
+			t.Errorf("expected exactly 1 warning for (Outer, Mid) naming InnerRR via DFS; got %d.\nall lines:\n%s",
+				n, strings.Join(cap.lines, "\n"))
+		}
+		// Sanity-check the intermediate pair too — (Mid, Inner) is
+		// also a valid deferred shape (Mid is itself a fallback whose
+		// nested child Inner reaches InnerRR). The single-level loop
+		// would already catch this one; DFS preserves it.
+		if n := countLinesMentioning(cap.lines, `"Mid"`, `"Inner"`, `"InnerRR"`); n != 1 {
+			t.Errorf("expected exactly 1 warning for (Mid, Inner) naming InnerRR; got %d.\nall lines:\n%s",
+				n, strings.Join(cap.lines, "\n"))
+		}
+		// Negative pin: (Inner, InnerRR) is the centralised
+		// composition (immediate RR child with non-strategy leaves)
+		// and must NOT warn — that's shape 1's centralised case.
+		if n := countLinesMentioning(cap.lines, `"Inner"`, `"InnerRR"`, "round-robin child"); n != 0 {
+			t.Errorf("centralised composition (Inner has immediate RR child with non-strategy leaves) must NOT emit a shape-1 warning; got %d.\nall lines:\n%s",
+				n, strings.Join(cap.lines, "\n"))
+		}
+	})
+
+	t.Run("converging-paths-emit-single-warning-per-pair", func(t *testing.T) {
+		// Outer's nested-fallback child Mid has two paths to the
+		// same RR client (Mid → Inner1 → RR and Mid → Inner2 → RR).
+		// The DFS visited-set must terminate on the first match so
+		// the (Outer, Mid) pair emits exactly ONE warning even
+		// though the converging chain offers two routes to the same
+		// RR descendant.
+		//
+		// (Mid, Inner1) and (Mid, Inner2) are independent pairs and
+		// emit their own warnings — this test does not pin their
+		// count, only the (Outer, Mid) single-walk-dedup invariant.
+		cfg := &bamlConfig{
+			clientProvider: map[string]string{
+				"Outer":  "baml-fallback",
+				"Mid":    "baml-fallback",
+				"Inner1": "baml-fallback",
+				"Inner2": "baml-fallback",
+				"RR":     "baml-roundrobin",
+				"A":      "openai",
+				"B":      "openai",
+				"C":      "openai",
+			},
+			fallbackChains: map[string][]string{
+				"Outer":  {"Mid", "C"},
+				"Mid":    {"Inner1", "Inner2"},
+				"Inner1": {"RR"},
+				"Inner2": {"RR"},
+				"RR":     {"A", "B"},
+			},
+		}
+		var cap captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
+
+		// Pair (Outer, Mid) must appear exactly once regardless of
+		// which converging path the DFS took first. A regression
+		// that re-walked Mid's children after the first match would
+		// emit two warnings for (Outer, Mid) — one per path.
+		if n := countLinesMentioning(cap.lines, `"Outer"`, `"Mid"`, `"RR"`); n != 1 {
+			t.Errorf("expected exactly 1 warning for (Outer, Mid) even with converging paths to RR; got %d.\nall lines:\n%s",
+				n, strings.Join(cap.lines, "\n"))
+		}
+	})
+
+	t.Run("non-strategy-leaves-emit-no-warning", func(t *testing.T) {
+		// Outer = fallback whose nested-fallback child reaches only
+		// non-strategy leaves. No RR anywhere → no warning. Confirms
+		// the DFS doesn't false-positive on plain nested fallbacks
+		// without an RR descendant.
+		cfg := &bamlConfig{
+			clientProvider: map[string]string{
+				"Outer": "baml-fallback",
+				"Mid":   "baml-fallback",
+				"Inner": "baml-fallback",
+				"A":     "openai",
+				"B":     "openai",
+				"C":     "openai",
+				"D":     "openai",
+			},
+			fallbackChains: map[string][]string{
+				"Outer": {"Mid", "D"},
+				"Mid":   {"Inner", "C"},
+				"Inner": {"A", "B"},
+			},
+		}
+		var cap captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
+		if len(cap.lines) != 0 {
+			t.Errorf("non-strategy-only nested fallback must emit no warning, got %d:\n%s",
+				len(cap.lines), strings.Join(cap.lines, "\n"))
+		}
+	})
+
+	t.Run("immediate-rr-with-non-strategy-leaves-centralised-no-warning", func(t *testing.T) {
+		// The plain `fallback[rr[A,B], C]` shape is centralised via
+		// BuildRequest — no warning. Regression guard against a
+		// future change that re-broadens the shape-1 emitter.
+		cfg := &bamlConfig{
+			clientProvider: map[string]string{
+				"Outer":   "baml-fallback",
+				"InnerRR": "baml-roundrobin",
+				"A":       "openai",
+				"B":       "openai",
+				"C":       "openai",
+			},
+			fallbackChains: map[string][]string{
+				"Outer":   {"InnerRR", "C"},
+				"InnerRR": {"A", "B"},
+			},
+		}
+		var cap captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
+		if len(cap.lines) != 0 {
+			t.Errorf("centralised composition must emit no warning, got %d:\n%s",
+				len(cap.lines), strings.Join(cap.lines, "\n"))
+		}
+	})
+
+	t.Run("immediate-rr-with-strategy-leaf-still-warns", func(t *testing.T) {
+		// Shape 1 deferred path: RR's chain contains a strategy
+		// leaf. Recursive strategy planning inside a fallback child
+		// isn't supported, so the warning still emits.
+		cfg := &bamlConfig{
+			clientProvider: map[string]string{
+				"Outer":     "baml-fallback",
+				"InnerRR":   "baml-roundrobin",
+				"InnerFall": "baml-fallback",
+				"A":         "openai",
+				"B":         "openai",
+				"C":         "openai",
+			},
+			fallbackChains: map[string][]string{
+				"Outer":     {"InnerRR", "C"},
+				"InnerRR":   {"InnerFall", "B"},
+				"InnerFall": {"A"},
+			},
+		}
+		var cap captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
+		if len(cap.lines) != 1 {
+			t.Fatalf("RR child with a strategy leaf must still emit a deferred-shape warning, got %d:\n%s",
+				len(cap.lines), strings.Join(cap.lines, "\n"))
+		}
+		if !strings.Contains(cap.lines[0], "round-robin child") {
+			t.Errorf("warning must classify as shape 1 (round-robin child …); got: %s", cap.lines[0])
+		}
+	})
+
+	t.Run("cycle-in-fallback-chains-does-not-loop", func(t *testing.T) {
+		// Pathological config: Outer's nested fallback child cycles
+		// back to itself via Mid. The DFS visited-set must terminate
+		// the walk. No RR exists, so no warning expected; the test
+		// passes when emit returns instead of hanging.
+		cfg := &bamlConfig{
+			clientProvider: map[string]string{
+				"Outer": "baml-fallback",
+				"Mid":   "baml-fallback",
+				"A":     "openai",
+			},
+			fallbackChains: map[string][]string{
+				"Outer": {"Mid"},
+				"Mid":   {"Mid", "A"},
+			},
+		}
+		var cap captureLog
+		emitFallbackRoundRobinDeferredWarnings(cfg, cap.Logf)
+		if len(cap.lines) != 0 {
+			t.Errorf("cycle without RR descendants must emit no warning, got %d:\n%s",
+				len(cap.lines), strings.Join(cap.lines, "\n"))
+		}
+	})
+}
 
 func TestMethodsDict(t *testing.T) {
 	tests := []struct {

--- a/go.work.sum
+++ b/go.work.sum
@@ -1158,6 +1158,7 @@ golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
+golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 h1:R84qjqJb5nVJMxqWYb3np9L5ZsaDtB+a39EqjV0JSUM=

--- a/integration/composition_test.go
+++ b/integration/composition_test.go
@@ -1,0 +1,403 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// ============================================================
+// fallback[rr[A,B], C] static composition — centralised RR-child
+// dispatch through BuildRequest.
+//
+// The fixture client `TestFallbackRoundRobinPair` in clients.baml
+// has shape:
+//
+//   baml-fallback
+//     |__ TestRoundRobinPair (baml-roundrobin)
+//     |     |__ FallbackPrimary  (openai)
+//     |     |__ FallbackSecondary (openai)
+//     |__ FallbackTertiary (openai)
+//
+// The static composition is BR-eligible: every RR leaf is a non-
+// strategy openai client whose provider is BuildRequest-supported.
+// The resolver centralises the immediate RR child to one of its
+// leaves and dispatches via the BuildRequest path; the same
+// SharedState advancer that drives top-level RR also drives this
+// rotation, so per-leaf hits balance across pool workers identically
+// to a top-level baml-roundrobin client. FallbackTertiary only sees
+// traffic if the RR child fails on a given attempt.
+//
+// Tests deliberately stay agnostic to per-REST-request RR cadence
+// (baml-rest advances once per REST request, BAML upstream advances
+// per LLM call). Per-leaf rotation order is NOT pinned; per-leaf hit
+// counts are summed against the fallback-tertiary baseline so the
+// invariant is "both RR leaves saw traffic and tertiary didn't",
+// not "leaf X served run N".
+// ============================================================
+
+// compositionScenarioIDs lists the mock scenario IDs the composition
+// fixture exercises: the two RR-leaf scenarios plus the fallback
+// sibling that catches RR-leaf failures.
+var compositionScenarioIDs = []string{"fallback-primary", "fallback-secondary", "fallback-tertiary"}
+
+func clearCompositionScenarios(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	for _, id := range compositionScenarioIDs {
+		if err := MockClient.DeleteScenario(ctx, id); err != nil {
+			t.Fatalf("Failed to delete scenario %q: %v", id, err)
+		}
+	}
+}
+
+// TestFallbackRoundRobinComposition_CentralizedAcrossWorkers exercises
+// the static `fallback[rr[A,B], C]` shape end-to-end on the
+// BuildRequest path. Each request rotates one of the RR leaves
+// through the same SharedState advancer top-level RR uses; over N
+// successful requests both leaves see traffic while the fallback
+// sibling stays untouched.
+//
+// Load-bearing assertions:
+//
+//   - X-BAML-Path is "buildrequest" — RR dispatch must NOT have
+//     degraded to the legacy per-worker callback.
+//   - X-BAML-Path-Reason is "fallback-roundrobin-child-buildrequest"
+//     and never "fallback-roundrobin-child-legacy" — the centralised
+//     classification is what the metadata classifier emits, not the
+//     deferred-shape legacy reason.
+//   - X-BAML-Client names the fallback strategy parent so operators
+//     reading headers see the operator-authored client name.
+//   - X-BAML-Winner-Client names the actual RR-leaf openai client
+//     that served the request (one of FallbackPrimary /
+//     FallbackSecondary) — the centralised wrapper-unwrap puts the
+//     served leaf on outcome, not the RR wrapper name.
+//   - Per-leaf hit counts: across `runs` runs the two RR-leaf scenarios
+//     must sum to `runs`, fallback-tertiary must stay at 0. The
+//     RR-cadence-agnostic check is the sum-and-zero invariant, not a
+//     per-call rotation order.
+//   - Streaming metadata event exposes FallbackTargets (wrapper→leaf
+//     mapping) and FallbackRoundRobin (RR decision) on the planned
+//     phase — the planned-vs-outcome shape the metadata vocabulary
+//     commits to.
+func TestFallbackRoundRobinComposition_CentralizedAcrossWorkers(t *testing.T) {
+	skipIfNoBuildRequest(t)
+	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
+		waitForHealthy(t, 30*time.Second)
+		clearCompositionScenarios(t)
+		registerAllGreetingScenarios(t, compositionScenarioIDs)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		// Even runs across the 2-leaf RR child so an idealised cadence
+		// would balance to (runs/2, runs/2). The RR-cadence-agnostic
+		// assertions below tolerate any non-zero distribution as long
+		// as both leaves saw traffic and the sum matches; the cadence
+		// the BuildRequest path actually uses (once per REST request)
+		// would in practice produce strict alternation, but tests don't
+		// pin that.
+		const runs = 6
+		validLeaves := map[string]bool{
+			"FallbackPrimary":   true,
+			"FallbackSecondary": true,
+		}
+		for i := 0; i < runs; i++ {
+			resp, err := client.Call(ctx, testutil.CallRequest{
+				Method: "GetGreetingFallbackRoundRobinPair",
+				Input:  map[string]any{"name": "World"},
+			})
+			if err != nil {
+				t.Fatalf("Call %d failed: %v", i, err)
+			}
+			if resp.StatusCode != 200 {
+				t.Fatalf("Call %d: expected 200, got %d body=%s err=%s",
+					i, resp.StatusCode, string(resp.Body), resp.Error)
+			}
+
+			// Routing classification must always be the centralised
+			// BuildRequest reason; a regression to the legacy callback
+			// would surface "fallback-roundrobin-child-legacy" here and
+			// the load-distribution invariant would still pass.
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPathReason, "fallback-roundrobin-child-buildrequest")
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestFallbackRoundRobinPair")
+
+			// Winner-Client is the served openai leaf, not the RR
+			// wrapper or fallback strategy parent — the centralised
+			// dispatch surfaces the leaf on outcome metadata so the
+			// header reports the actual contacted client.
+			winner := resp.Headers.Get(testutil.HeaderBAMLWinnerClient)
+			if !validLeaves[winner] {
+				t.Errorf("Call %d: Winner-Client=%q is not a valid RR leaf (expected FallbackPrimary or FallbackSecondary)",
+					i, winner)
+			}
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+		}
+
+		// Per-leaf hit counts across the runs. The RR-cadence-agnostic
+		// invariants are:
+		//   - Both leaves saw at least one hit (rotation is active).
+		//   - Combined leaf hits equal `runs` (every request landed on
+		//     a leaf, none were lost).
+		//   - Fallback sibling sees zero hits (RR child succeeded
+		//     every time, sibling never reached).
+		mockCtx, mockCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer mockCancel()
+		primaryHits, err := MockClient.GetRequestCount(mockCtx, "fallback-primary")
+		if err != nil {
+			t.Fatalf("GetRequestCount fallback-primary: %v", err)
+		}
+		secondaryHits, err := MockClient.GetRequestCount(mockCtx, "fallback-secondary")
+		if err != nil {
+			t.Fatalf("GetRequestCount fallback-secondary: %v", err)
+		}
+		tertiaryHits, err := MockClient.GetRequestCount(mockCtx, "fallback-tertiary")
+		if err != nil {
+			t.Fatalf("GetRequestCount fallback-tertiary: %v", err)
+		}
+		if primaryHits == 0 || secondaryHits == 0 {
+			t.Errorf("RR rotation never reached one leaf: primary=%d secondary=%d (centralised RR-child dispatch is stuck on one leaf)",
+				primaryHits, secondaryHits)
+		}
+		if primaryHits+secondaryHits != runs {
+			t.Errorf("RR leaves saw %d total hits, want %d (primary=%d secondary=%d)",
+				primaryHits+secondaryHits, runs, primaryHits, secondaryHits)
+		}
+		if tertiaryHits != 0 {
+			t.Errorf("FallbackTertiary received %d hits; RR child succeeded every run so the sibling must stay at zero",
+				tertiaryHits)
+		}
+	})
+}
+
+// TestFallbackRoundRobinComposition_StreamingMetadataShape exercises
+// the streaming-path planned-metadata event for the same composition.
+// The streaming path is the only path that surfaces FallbackTargets
+// and FallbackRoundRobin on the wire (the unary header surface is
+// intentionally narrow and doesn't expose chain-level details), so
+// this is the load-bearing assertion for the new metadata vocabulary
+// reaching real consumers.
+func TestFallbackRoundRobinComposition_StreamingMetadataShape(t *testing.T) {
+	skipIfNoBuildRequest(t)
+	waitForHealthy(t, 30*time.Second)
+	clearCompositionScenarios(t)
+	registerAllGreetingScenarios(t, compositionScenarioIDs)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	events, errs := BAMLClient.Stream(ctx, testutil.CallRequest{
+		Method: "GetGreetingFallbackRoundRobinPair",
+		Input:  map[string]any{"name": "World"},
+	})
+
+	var planned *testutil.StreamMetadata
+	var outcome *testutil.StreamMetadata
+	for ev := range events {
+		if !ev.IsMetadata() {
+			continue
+		}
+		md, err := ev.ParseMetadata()
+		if err != nil {
+			t.Fatalf("parse metadata event: %v", err)
+		}
+		switch md.Phase {
+		case "planned":
+			planned = md
+		case "outcome":
+			outcome = md
+		}
+	}
+	if err := <-errs; err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+
+	if planned == nil {
+		t.Fatal("no planned metadata event observed")
+	}
+	if planned.Path != "buildrequest" {
+		t.Errorf("planned.path = %q, want buildrequest", planned.Path)
+	}
+	if planned.PathReason != "fallback-roundrobin-child-buildrequest" {
+		t.Errorf("planned.path_reason = %q, want fallback-roundrobin-child-buildrequest", planned.PathReason)
+	}
+	if planned.Client != "TestFallbackRoundRobinPair" {
+		t.Errorf("planned.client = %q, want TestFallbackRoundRobinPair", planned.Client)
+	}
+	// Chain stays as configured (the operator-authored child list);
+	// the centralised wrapper-unwrap is reflected in FallbackTargets,
+	// not by mutating Chain. Sibling FallbackTertiary still appears
+	// in the chain so observers see the fallback shape.
+	wantChain := []string{"TestRoundRobinPair", "FallbackTertiary"}
+	if !equalStringSlice(planned.Chain, wantChain) {
+		t.Errorf("planned.chain = %v, want %v", planned.Chain, wantChain)
+	}
+	// FallbackTargets: the RR wrapper TestRoundRobinPair must have an
+	// entry pointing at the centrally-selected leaf. The selected leaf
+	// depends on the advancer's per-request decision; both
+	// FallbackPrimary and FallbackSecondary are valid here.
+	if planned.FallbackTargets == nil {
+		t.Fatal("planned.fallback_targets is nil; expected entry for TestRoundRobinPair")
+	}
+	target, ok := planned.FallbackTargets["TestRoundRobinPair"]
+	if !ok {
+		t.Errorf("planned.fallback_targets missing TestRoundRobinPair key; got %v", planned.FallbackTargets)
+	}
+	if target != "FallbackPrimary" && target != "FallbackSecondary" {
+		t.Errorf("planned.fallback_targets[TestRoundRobinPair] = %q; want FallbackPrimary or FallbackSecondary", target)
+	}
+	// FallbackRoundRobin: the per-child RR decision for the centralised
+	// wrapper. Selected must match the FallbackTargets entry above so
+	// the two views agree on which leaf the resolver picked.
+	if planned.FallbackRoundRobin == nil {
+		t.Fatal("planned.fallback_round_robin is nil; expected entry for TestRoundRobinPair")
+	}
+	rrInfo, ok := planned.FallbackRoundRobin["TestRoundRobinPair"]
+	if !ok || rrInfo == nil {
+		t.Fatalf("planned.fallback_round_robin missing TestRoundRobinPair entry; got %v", planned.FallbackRoundRobin)
+	}
+	if rrInfo.Name != "TestRoundRobinPair" {
+		t.Errorf("FallbackRoundRobin[TestRoundRobinPair].Name = %q, want TestRoundRobinPair", rrInfo.Name)
+	}
+	if rrInfo.Selected != target {
+		t.Errorf("FallbackRoundRobin[TestRoundRobinPair].Selected = %q != FallbackTargets entry %q (resolver views disagree)",
+			rrInfo.Selected, target)
+	}
+	wantRRChildren := []string{"FallbackPrimary", "FallbackSecondary"}
+	if !equalStringSlice(rrInfo.Children, wantRRChildren) {
+		t.Errorf("FallbackRoundRobin[TestRoundRobinPair].Children = %v, want %v", rrInfo.Children, wantRRChildren)
+	}
+
+	// Outcome metadata: the orchestrator clears the planned-only
+	// FallbackTargets / FallbackRoundRobin fields on outcome (the
+	// realised winner is encoded in WinnerClient instead). Pin that
+	// here so a regression that leaks planned-shape data into outcome
+	// fails fast.
+	if outcome == nil {
+		t.Fatal("no outcome metadata event observed")
+	}
+	if outcome.FallbackTargets != nil {
+		t.Errorf("outcome.fallback_targets must be nil; got %v", outcome.FallbackTargets)
+	}
+	if outcome.FallbackRoundRobin != nil {
+		t.Errorf("outcome.fallback_round_robin must be nil; got %v", outcome.FallbackRoundRobin)
+	}
+	if outcome.WinnerClient != target {
+		t.Errorf("outcome.winner_client = %q, want %q (centralised dispatch must name the served leaf)",
+			outcome.WinnerClient, target)
+	}
+}
+
+// TestFallbackRoundRobinComposition_FailureHandoffToSibling pins the
+// failure path: when the centrally-selected RR leaf returns 500, the
+// orchestrator advances to the fallback sibling (FallbackTertiary)
+// and reports the sibling as the winner. Without this assertion, a
+// regression that wedged the RR child or skipped the fallback-sibling
+// step on RR-leaf failure could ship while every other test still
+// passed.
+func TestFallbackRoundRobinComposition_FailureHandoffToSibling(t *testing.T) {
+	skipIfNoBuildRequest(t)
+	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
+		waitForHealthy(t, 30*time.Second)
+		clearCompositionScenarios(t)
+
+		// Force every RR leaf to return 500 so whichever leaf the
+		// advancer picks, the orchestrator must hand off to the
+		// fallback sibling. Tertiary serves the success payload so
+		// the request still returns 200.
+		for _, id := range []string{"fallback-primary", "fallback-secondary"} {
+			registerRoundRobinScenario(t, &mockllm.Scenario{
+				ID:          id,
+				Provider:    "openai",
+				Content:     "nope",
+				FailAfter:   1,
+				FailureMode: "500",
+			})
+		}
+		registerRoundRobinScenario(t, &mockllm.Scenario{
+			ID:             "fallback-tertiary",
+			Provider:       "openai",
+			Content:        "Hello from fallback-tertiary!",
+			ChunkSize:      0,
+			InitialDelayMs: 10,
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		resp, err := client.Call(ctx, testutil.CallRequest{
+			Method: "GetGreetingFallbackRoundRobinPair",
+			Input:  map[string]any{"name": "World"},
+		})
+		if err != nil {
+			t.Fatalf("Call failed: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected 200 (fallback sibling should win); got %d body=%s err=%s",
+				resp.StatusCode, string(resp.Body), resp.Error)
+		}
+
+		// Routing classification: still BuildRequest, still the
+		// centralised reason — the failure-handoff goes through the
+		// orchestrator's chain walk, not a legacy degradation.
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPathReason, "fallback-roundrobin-child-buildrequest")
+		// Winner is the fallback sibling that succeeded after the RR
+		// child failed. Sibling = FallbackTertiary (declared in the
+		// fixture's strategy list as the second child).
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackTertiary")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+
+		// Hit-count invariant for the failure-handoff path: the RR
+		// child saw exactly one failing leaf attempt (whichever the
+		// advancer picked), and the fallback sibling served the
+		// retry. Cadence-agnostic: the per-leaf identity isn't pinned;
+		// the sum-of-RR-leaves == 1 and tertiary == 1 invariant is
+		// what proves the handoff worked.
+		mockCtx, mockCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer mockCancel()
+		primaryHits, err := MockClient.GetRequestCount(mockCtx, "fallback-primary")
+		if err != nil {
+			t.Fatalf("GetRequestCount fallback-primary: %v", err)
+		}
+		secondaryHits, err := MockClient.GetRequestCount(mockCtx, "fallback-secondary")
+		if err != nil {
+			t.Fatalf("GetRequestCount fallback-secondary: %v", err)
+		}
+		tertiaryHits, err := MockClient.GetRequestCount(mockCtx, "fallback-tertiary")
+		if err != nil {
+			t.Fatalf("GetRequestCount fallback-tertiary: %v", err)
+		}
+		if primaryHits+secondaryHits != 1 {
+			t.Errorf("RR child saw %d total leaf attempts, want 1 (primary=%d secondary=%d); failure-handoff should have moved on after the first leaf failure",
+				primaryHits+secondaryHits, primaryHits, secondaryHits)
+		}
+		if tertiaryHits != 1 {
+			t.Errorf("FallbackTertiary saw %d hits, want 1; failure-handoff to fallback sibling didn't reach the leaf",
+				tertiaryHits)
+		}
+	})
+}
+
+// equalStringSlice is a cheap deep-equality check for []string. Tests
+// in this file use it for chain / children ordering pins where
+// reflect.DeepEqual would also work — this helper just keeps the test
+// file dependency-light.
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/integration/roundrobin_overrides_test.go
+++ b/integration/roundrobin_overrides_test.go
@@ -687,24 +687,23 @@ func TestLegacyMode_RR_NoCentralization(t *testing.T) {
 	})
 }
 
-// TestNestedStrategyOverrides_ValidRRChildHonoured pins the
-// per-callback scoped registry contract end-to-end: a fallback chain
-// whose nested RR child has a valid runtime override
-// (changed-strategy → tenant leaf) must reach BAML inside the mixed-
-// mode legacy callback. The mixed-mode legacy child callback uses a
-// per-callback scoped registry (makeLegacyChildOptionsFromAdapter)
-// rather than the outer BuildRequest-safe options — that scope keeps
-// TestRoundRobinPair plus its strategy override visible to BAML so
-// BAML executes the runtime-defined leaf instead of the compiled
-// static `[FallbackPrimary, FallbackSecondary]`. A regression that
-// reused the outer options would silently dispatch primary/secondary
-// even though the request changed the RR's strategy at runtime.
+// TestNestedStrategyOverrides_ValidRRChildHonoured pins the runtime-
+// override path end-to-end for a fallback whose nested RR child has a
+// changed-strategy override pointing at a single leaf. The resolver
+// detects the runtime override, centralises the RR child by selecting
+// that single leaf, and dispatches it through BuildRequest — the
+// override leaf (FallbackTertiary) must therefore receive the request
+// while the introspected RR chain leaves (FallbackPrimary,
+// FallbackSecondary) stay at zero hits.
 //
 // The load-bearing assertion is the per-mock hit count: tertiary must
-// receive the request, primary/secondary must NOT. Header presence
-// alone would not catch the bug since the mixed-mode classification
-// header (X-BAML-Path-Reason: fallback-round-robin-child-legacy) is
-// emitted whether or not the override actually reached BAML.
+// receive the request, primary/secondary must NOT. Routing metadata
+// (X-BAML-Path=buildrequest, X-BAML-Path-Reason=fallback-roundrobin-
+// child-buildrequest) gets pinned alongside the hit counts so a
+// regression that demotes the centralisation back to the legacy
+// callback would also fail visibly. A regression that dropped the
+// override from the resolver's view would dispatch
+// primary/secondary instead and the hit counts would catch it.
 func TestNestedStrategyOverrides_ValidRRChildHonoured(t *testing.T) {
 	skipIfNoBuildRequest(t)
 	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
@@ -733,11 +732,12 @@ func TestNestedStrategyOverrides_ValidRRChildHonoured(t *testing.T) {
 							},
 						},
 						// Nested RR's runtime strategy override —
-						// must reach BAML for the test to pass.
-						// Without the per-callback scoped registry,
-						// this entry is dropped from BAML's view and
-						// the compiled `[FallbackPrimary,
-						// FallbackSecondary]` runs instead.
+						// must reach the resolver for the test to
+						// pass. The resolver builds the unwrap on the
+						// runtime registry view so a regression that
+						// drops the override would resolve the RR
+						// chain from the introspected `[FallbackPrimary,
+						// FallbackSecondary]` list instead.
 						{
 							Name:     "TestRoundRobinPair",
 							Provider: testutil.StringPtr("round-robin"),
@@ -757,6 +757,19 @@ func TestNestedStrategyOverrides_ValidRRChildHonoured(t *testing.T) {
 				resp.StatusCode, string(resp.Body), resp.Error)
 		}
 
+		// Routing classification: the static composition now lands on
+		// the centralised BuildRequest path, so the metadata reason
+		// must be the BuildRequest informational token rather than the
+		// legacy-callback reason that the pre-centralisation shape
+		// emitted.
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPathReason, "fallback-roundrobin-child-buildrequest")
+		// The centralised dispatch surfaces the served leaf on
+		// outcome — the override targets FallbackTertiary, so that's
+		// what the winner header reports.
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackTertiary")
+		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
+
 		mockCtx, mockCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer mockCancel()
 		primaryHits, err := MockClient.GetRequestCount(mockCtx, "fallback-primary")
@@ -772,16 +785,15 @@ func TestNestedStrategyOverrides_ValidRRChildHonoured(t *testing.T) {
 			t.Fatalf("GetRequestCount fallback-tertiary: %v", err)
 		}
 		if primaryHits != 0 {
-			t.Errorf("FallbackPrimary received %d hits; nested RR runtime strategy override was dropped from BAML's view "+
+			t.Errorf("FallbackPrimary received %d hits; nested RR runtime strategy override was dropped from the resolver's view "+
 				"(static [FallbackPrimary, FallbackSecondary] silently won)", primaryHits)
 		}
 		if secondaryHits != 0 {
-			t.Errorf("FallbackSecondary received %d hits; nested RR runtime strategy override was dropped from BAML's view "+
+			t.Errorf("FallbackSecondary received %d hits; nested RR runtime strategy override was dropped from the resolver's view "+
 				"(static [FallbackPrimary, FallbackSecondary] silently won)", secondaryHits)
 		}
 		if tertiaryHits == 0 {
-			t.Errorf("FallbackTertiary received 0 hits; nested RR runtime strategy override never reached BAML "+
-				"(per-callback scoped registry regression)")
+			t.Errorf("FallbackTertiary received 0 hits; nested RR runtime strategy override never reached the centralised dispatch")
 		}
 	})
 }

--- a/integration/testdata/baml_src/clients.baml
+++ b/integration/testdata/baml_src/clients.baml
@@ -118,3 +118,22 @@ client<llm> TestRoundRobinWithRetry {
         strategy [FallbackPrimary, FallbackSecondary]
     }
 }
+
+// ============================================================
+// Fallback containing an immediate round-robin child
+//
+// Static composition that exercises centralised RR-child
+// unwrapping: the fallback chain's first entry is an RR wrapper
+// whose leaves are ordinary openai leaves. Centralised dispatch
+// rotates across [FallbackPrimary, FallbackSecondary] via the
+// same SharedState advancer top-level RR uses, while the sibling
+// fallback child FallbackTertiary remains a static leaf for
+// failure-handoff coverage.
+// ============================================================
+
+client<llm> TestFallbackRoundRobinPair {
+    provider baml-fallback
+    options {
+        strategy [TestRoundRobinPair, FallbackTertiary]
+    }
+}

--- a/integration/testdata/baml_src/functions.baml
+++ b/integration/testdata/baml_src/functions.baml
@@ -227,3 +227,12 @@ function GetGreetingRoundRobinWithRetry(name: string) -> string {
     client TestRoundRobinWithRetry
     prompt #"Say hello to {{ name }}"#
 }
+
+// Fallback whose first child is a round-robin wrapper. Exercises
+// the centralised RR-child path: the dispatched leaf rotates
+// across the RR child's leaves while the fallback's sibling
+// (FallbackTertiary) only sees traffic if the RR child fails.
+function GetGreetingFallbackRoundRobinPair(name: string) -> string {
+    client TestFallbackRoundRobinPair
+    prompt #"Say hello to {{ name }}"#
+}

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -383,20 +383,23 @@ func (e *StreamEvent) IsPlannedMetadata() bool {
 // server-side bamlutils package, and a full mirror would drift as unused
 // fields get added. Extend this only when a test needs a new field.
 type StreamMetadata struct {
-	Phase           string                `json:"phase"`
-	Path            string                `json:"path,omitempty"`
-	BuildRequestAPI string                `json:"build_request_api,omitempty"`
-	Client          string                `json:"client,omitempty"`
-	Strategy        string                `json:"strategy,omitempty"`
-	Chain           []string              `json:"chain,omitempty"`
-	RetryMax        *int                  `json:"retry_max,omitempty"`
-	RetryCount      *int                  `json:"retry_count,omitempty"`
-	WinnerClient    string                `json:"winner_client,omitempty"`
-	WinnerProvider  string                `json:"winner_provider,omitempty"`
-	WinnerPath      string                `json:"winner_path,omitempty"`
-	UpstreamDurMs   *int64                `json:"upstream_duration_ms,omitempty"`
-	BamlCallCount   *int                  `json:"baml_call_count,omitempty"`
-	RoundRobin      *StreamRoundRobinInfo `json:"round_robin,omitempty"`
+	Phase              string                           `json:"phase"`
+	Path               string                           `json:"path,omitempty"`
+	PathReason         string                           `json:"path_reason,omitempty"`
+	BuildRequestAPI    string                           `json:"build_request_api,omitempty"`
+	Client             string                           `json:"client,omitempty"`
+	Strategy           string                           `json:"strategy,omitempty"`
+	Chain              []string                         `json:"chain,omitempty"`
+	RetryMax           *int                             `json:"retry_max,omitempty"`
+	RetryCount         *int                             `json:"retry_count,omitempty"`
+	WinnerClient       string                           `json:"winner_client,omitempty"`
+	WinnerProvider     string                           `json:"winner_provider,omitempty"`
+	WinnerPath         string                           `json:"winner_path,omitempty"`
+	UpstreamDurMs      *int64                           `json:"upstream_duration_ms,omitempty"`
+	BamlCallCount      *int                             `json:"baml_call_count,omitempty"`
+	RoundRobin         *StreamRoundRobinInfo            `json:"round_robin,omitempty"`
+	FallbackTargets    map[string]string                `json:"fallback_targets,omitempty"`
+	FallbackRoundRobin map[string]*StreamRoundRobinInfo `json:"fallback_round_robin,omitempty"`
 }
 
 // StreamRoundRobinInfo mirrors bamlutils.RoundRobinInfo for integration-test


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Final PR of the #237 3-PR plan. Wires codegen + integration tests; centralization is now production-reachable end-to-end.

## What this changes

- Generated router fallback branches in all 3 call sites now consume `*FallbackChainResolution` (the typed shape).
- Generated `StreamConfig` / `CallConfig` now receive populated `FallbackTargets` + `FallbackRoundRobin` from the resolver. The `_buildRequest` / `_buildCallRequest` signatures gain two new parameters threading these through.
- New `PreferAdvancer(adapter, fallback)` helper mirrors `ResolveEffectiveClient`'s per-request RemoteAdvancer preference so codegen picks the same advancer top-level RR uses.
- `cmd/introspect/main.go` warning narrowed: static `fallback[rr[A,B], C]` with non-strategy leaves no longer warns (it's centralised); deferred shapes (RR leaf is itself a strategy, fallback-nested fallback containing RR) still warn at build time.
- New static composition fixture `TestFallbackRoundRobinPair` in `integration/testdata/baml_src/clients.baml` plus the matching function in `functions.baml`.
- New `integration/composition_test.go`:
  - `TestFallbackRoundRobinComposition_CentralizedAcrossWorkers` — cross-worker rotation under the BuildRequest path; both RR leaves see traffic, fallback sibling stays at zero.
  - `TestFallbackRoundRobinComposition_StreamingMetadataShape` — pins the streaming planned-event shape exposing `FallbackTargets` and `FallbackRoundRobin`; outcome event clears them.
  - `TestFallbackRoundRobinComposition_FailureHandoffToSibling` — RR leaf returns 500, fallback sibling wins.
- `TestNestedStrategyOverrides_ValidRRChildHonoured` updated to assert `X-BAML-Path=buildrequest` and `X-BAML-Path-Reason=fallback-roundrobin-child-buildrequest`; invalid-start test unchanged on the legacy fallthrough.
- Multi-PR breadcrumb scrub across production code and tests.

## End-to-end behavior

For `fallback[rr[A,B], C]` with both leaves BR-supported:
- Cross-worker RR rotation via the same `SharedState` / `RemoteAdvancer` machinery as top-level RR.
- `WinnerClient` reports the actual leaf, not the RR wrapper.
- `metadata.FallbackTargets` / `metadata.FallbackRoundRobin` expose the wrapper→leaf mapping + RR decision on the planned phase; outcome clears them.

Out-of-scope shapes (deferred — still use legacy callback): nested fallback containing RR, RR's selected leaf being itself a strategy, unsupported leaves, invalid runtime overrides.

## Test plan

- [ ] `go run ./cmd/verify-framework-adapter` — 9/9 green (structural equivalence + deterministic emission + per-adapter behavioural tests for all 3 adapters).
- [ ] `go run ./cmd/verify-adapter-pins` — 4/4 pins match.
- [ ] `go test ./bamlutils/... ./cmd/... ./internal/... ./workerplugin/...` — all green.
- [ ] `cd adapters/common && GOWORK=off go test ./codegen/...` — green.
- [ ] Per-adapter `GOWORK=off go test ./adapter/` for v0_204_0, v0_215_0, v0_219_0 — all green.
- [ ] `gofmt -l` on changed paths — clean.
- [ ] `TestFallbackRoundRobinComposition_*` and updated `TestNestedStrategyOverrides_ValidRRChildHonoured` exercise the static composition end-to-end (requires Docker).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced fallback-chain support for round-robin compositions with consistent dispatch across call/stream/bridge paths and richer planned/outcome metadata exposure.

* **Documentation**
  * Clarified fallback semantics, planned-vs-outcome metadata behavior, round-robin centralization/demotion contracts, and introspection warning guidance.

* **Tests**
  * Added integration and unit tests validating fallback-roundrobin compositions, streaming metadata shape, failure handoff, router/codegen resolver behavior, and deferred-warning introspection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/240)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->