### PR TITLE
fix(introspect): recognize shorthand client specs so functions reach BuildRequest

### DIFF
--- a/bamlutils/buildrequest/metadata_resolve_test.go
+++ b/bamlutils/buildrequest/metadata_resolve_test.go
@@ -1926,3 +1926,110 @@ func TestRebuildLegacyChainMetadata(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveClientProvider_ShorthandIntrospectedEntry pins the
+// routing contract for BAML shorthand client specs
+// (`<provider>/<model>`). The cmd/introspect enrichment populates
+// cfg.clientProvider with one entry per shorthand spec referenced by a
+// function default or strategy chain. ResolveClientProvider must
+// honour those entries the same way it honours regular `client<llm>`
+// names; the codegen-side gate keys off the returned provider string,
+// so a missing or misclassified entry sends shorthand-defaulted
+// functions to legacy via PathReasonEmptyProvider (the closed bug).
+//
+// The test simulates the post-enrichment introspected map and confirms
+// the resolver returns the provider component without help from the
+// runtime registry.
+func TestResolveClientProvider_ShorthandIntrospectedEntry(t *testing.T) {
+	// Simulated post-enrichment ClientProvider map: cmd/introspect
+	// populates the shorthand keys with the parsed provider.
+	intro := map[string]string{
+		"openai/gpt-4o":                        "openai",
+		"anthropic/claude-3-5-sonnet-20241022": "anthropic",
+		"openai-responses/gpt-4o":              "openai-responses",
+	}
+
+	cases := []struct {
+		name   string
+		client string
+		want   string
+	}{
+		{"openai shorthand", "openai/gpt-4o", "openai"},
+		{"anthropic shorthand", "anthropic/claude-3-5-sonnet-20241022", "anthropic"},
+		{"openai-responses shorthand", "openai-responses/gpt-4o", "openai-responses"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// No registry override — resolver must fall back to the
+			// introspected entry, the same path the BuildRequest gate
+			// uses for shorthand-defaulted functions at runtime.
+			got := ResolveClientProvider(nil, tc.client, intro)
+			if got != tc.want {
+				t.Errorf("ResolveClientProvider(%q): got %q, want %q", tc.client, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveProviderWithReason_ShorthandUnsupportedProvider pins the
+// negative case for shorthand resolution: a shorthand spec whose
+// provider is recognized by upstream BAML but NOT in baml-rest's
+// BuildRequest supported set (aws-bedrock is the canonical example —
+// upstream parses `aws-bedrock/foo` as a valid ClientSpec::Shorthand,
+// but its SSE/Request format isn't handled here).
+//
+// Pre-fix: this would land as PathReasonEmptyProvider because the
+// introspector left ClientProvider["aws-bedrock/foo"] empty.
+// Post-fix: it lands as PathReasonUnsupportedProvider — provider
+// resolution succeeds; the BuildRequest support gate rejects.
+// The distinction matters because the two reasons signal different
+// follow-up work (operator config fix vs. baml-rest provider-support
+// enhancement).
+func TestResolveProviderWithReason_ShorthandUnsupportedProvider(t *testing.T) {
+	adapter := &mockAdapter{Context: context.Background()}
+
+	res := ResolveProviderWithReason(adapter, "aws-bedrock/anthropic.claude-3", "aws-bedrock", IsProviderSupported)
+
+	if res.Path != "legacy" {
+		t.Errorf("path: got %q, want legacy — aws-bedrock not in BuildRequest supported set", res.Path)
+	}
+	if res.PathReason != PathReasonUnsupportedProvider {
+		t.Errorf("reason: got %q, want %q — shorthand with recognised-but-unsupported provider must classify as unsupported, not empty", res.PathReason, PathReasonUnsupportedProvider)
+	}
+	if res.Provider != "aws-bedrock" {
+		t.Errorf("provider: got %q, want aws-bedrock", res.Provider)
+	}
+}
+
+// TestResolveProviderWithReason_ShorthandFunctionDefault pins the
+// end-to-end routing decision for a function whose declared default
+// client is a shorthand spec. With cmd/introspect's enrichment in
+// place, the introspected provider passed in here is "openai" rather
+// than the empty string the pre-fix introspector emitted; the
+// classifier must therefore route the request through BuildRequest
+// rather than emit PathReasonEmptyProvider.
+//
+// The introspectedProvider parameter mirrors what the generated router
+// passes: introspected.ClientProvider[functionDefaultClient]. Pre-fix
+// that lookup returned "" for shorthand specs because the introspector
+// recorded the literal string as the function client name without
+// extracting the provider component. Post-fix the enrichment pass
+// populates the map so the lookup returns the provider.
+func TestResolveProviderWithReason_ShorthandFunctionDefault(t *testing.T) {
+	adapter := &mockAdapter{Context: context.Background()}
+
+	res := ResolveProviderWithReason(adapter, "openai/gpt-4o", "openai", IsProviderSupported)
+
+	if res.Path != "buildrequest" {
+		t.Errorf("path: got %q, want buildrequest — shorthand-defaulted function must reach BuildRequest after enrichment", res.Path)
+	}
+	if res.PathReason != "" {
+		t.Errorf("reason: got %q, want empty — BuildRequest path carries no reason; PathReasonEmptyProvider here would mean the introspector regression is back", res.PathReason)
+	}
+	if res.Provider != "openai" {
+		t.Errorf("provider: got %q, want openai", res.Provider)
+	}
+	if res.Client != "openai/gpt-4o" {
+		t.Errorf("client: got %q, want openai/gpt-4o — metadata should report the shorthand spec verbatim so operators see the declared default", res.Client)
+	}
+}

--- a/cmd/introspect/baml_parser_test.go
+++ b/cmd/introspect/baml_parser_test.go
@@ -1498,8 +1498,33 @@ func TestParseShorthandClient(t *testing.T) {
 		{"aws-bedrock", "aws-bedrock/claude-3", "aws-bedrock", "claude-3", true},
 		{"baml-openai-chat legacy alias", "baml-openai-chat/gpt-4", "baml-openai-chat", "gpt-4", true},
 		{"baml-anthropic-chat legacy alias", "baml-anthropic-chat/claude-3", "baml-anthropic-chat", "claude-3", true},
+		// Legacy alias: `baml-azure-chat` is accepted by upstream
+		// BAML's ClientProvider::from_str (clientspec.rs:125, v0.219.0)
+		// and passes through canonicaliseProvider unchanged — only the
+		// strategy aliases (round-robin / fallback) get folded.
+		{"baml-azure-chat legacy alias", "baml-azure-chat/my-deployment", "baml-azure-chat", "my-deployment", true},
+		// Legacy alias: `baml-ollama-chat` is accepted by upstream
+		// BAML's ClientProvider::from_str (clientspec.rs:129, v0.219.0)
+		// and passes through canonicaliseProvider unchanged.
+		{"baml-ollama-chat legacy alias", "baml-ollama-chat/llama3", "baml-ollama-chat", "llama3", true},
 		{"fallback strategy shorthand canonicalised", "fallback/foo", "baml-fallback", "foo", true},
+		// Strategy alias: `baml-fallback` is the already-canonical
+		// spelling — upstream accepts it (clientspec.rs:140) and
+		// canonicaliseProvider returns it as-is. Unlike round-robin,
+		// the canonical-output and upstream-input forms agree here,
+		// so this row complements the "fallback" row above without
+		// the canonical-vs-input asymmetry that the no-hyphen
+		// `baml-roundrobin/foo` negative row pins.
+		{"baml-fallback strategy shorthand canonical", "baml-fallback/foo", "baml-fallback", "foo", true},
 		{"round-robin strategy shorthand canonicalised", "round-robin/foo", "baml-roundrobin", "foo", true},
+		// Strategy alias: `baml-round-robin` (hyphenated) IS accepted
+		// by upstream BAML's ClientProvider::from_str
+		// (clientspec.rs:142) and canonicaliseProvider folds it to
+		// `baml-roundrobin` (no hyphen — baml-rest's emit-side
+		// canonical). Contrast with the negative `baml-roundrobin/foo`
+		// row below, where the no-hyphen form is explicitly rejected
+		// because upstream does not accept it as shorthand input.
+		{"baml-round-robin strategy shorthand canonicalised", "baml-round-robin/foo", "baml-roundrobin", "foo", true},
 		// Negative: baml-rest's INTERNAL canonical spelling for the
 		// round-robin strategy is `baml-roundrobin` (no hyphen between
 		// "round" and "robin"). Upstream BAML's ClientProvider::from_str

--- a/cmd/introspect/baml_parser_test.go
+++ b/cmd/introspect/baml_parser_test.go
@@ -1500,6 +1500,32 @@ func TestParseShorthandClient(t *testing.T) {
 		{"baml-anthropic-chat legacy alias", "baml-anthropic-chat/claude-3", "baml-anthropic-chat", "claude-3", true},
 		{"fallback strategy shorthand canonicalised", "fallback/foo", "baml-fallback", "foo", true},
 		{"round-robin strategy shorthand canonicalised", "round-robin/foo", "baml-roundrobin", "foo", true},
+		// Negative: baml-rest's INTERNAL canonical spelling for the
+		// round-robin strategy is `baml-roundrobin` (no hyphen between
+		// "round" and "robin"). Upstream BAML's ClientProvider::from_str
+		// (clientspec.rs:119-143, v0.219.0) only accepts the hyphenated
+		// forms `round-robin` and `baml-round-robin` as shorthand input;
+		// the no-hyphen form is baml-rest's emit-side canonical
+		// (X-BAML-RoundRobin-* headers, downstream classification
+		// switches) and was never an upstream-recognized provider input.
+		//
+		// Adding `baml-roundrobin` to isKnownShorthandProvider would
+		// make the introspector recognize a shorthand that upstream
+		// BAML would reject at request time — silent introspect-vs-
+		// runtime divergence, the exact shape the upstream-parity
+		// allowlist is designed to prevent. This row pins that
+		// asymmetry so any future widening attempt (e.g. a code-review
+		// suggestion to "round out the canonical aliases") fails
+		// loudly with the explanation above.
+		//
+		// The fallback strategy is intentionally symmetric: upstream
+		// accepts both `fallback` and `baml-fallback`, and
+		// canonicaliseProvider folds them onto `baml-fallback` — so the
+		// canonical-output spelling happens to also be a valid
+		// upstream input. Only round-robin has the canonical-vs-input
+		// asymmetry; not coincidentally, only round-robin's canonical
+		// drops a hyphen that the upstream form keeps.
+		{"no-hyphen baml-roundrobin is canonical-only, not shorthand input", "baml-roundrobin/foo", "", "", false},
 		{"unknown provider rejected", "unknown/model", "", "", false},
 		{"empty string rejected", "", "", "", false},
 		{"no slash rejected", "openai", "", "", false},

--- a/cmd/introspect/baml_parser_test.go
+++ b/cmd/introspect/baml_parser_test.go
@@ -1469,3 +1469,159 @@ func TestParseClientBlock_BareRoundRobinAliasNormalised(t *testing.T) {
 		t.Errorf("fallbackChains[MyRR]: got %v, want [A B] — chain must be captured under the bare alias too", chain)
 	}
 }
+
+// TestParseShorthandClient covers the BAML shorthand spec parser used
+// by the introspector to recognize `<provider>/<model>` function-default
+// clients. The provider allowlist must match upstream BAML v0.219.0's
+// ClientProvider::from_str (clientspec.rs:119-144) — additions or
+// removals in a future BAML release require lockstep updates here.
+//
+// The provider component is run through canonicaliseProvider, so the
+// strategy aliases collapse onto the baml-rest canonical spellings.
+func TestParseShorthandClient(t *testing.T) {
+	cases := []struct {
+		name         string
+		in           string
+		wantProvider string
+		wantModel    string
+		wantOK       bool
+	}{
+		{"openai chat-style model", "openai/gpt-4o", "openai", "gpt-4o", true},
+		{"anthropic versioned model", "anthropic/claude-3-5-sonnet-20241022", "anthropic", "claude-3-5-sonnet-20241022", true},
+		{"openai-generic", "openai-generic/some-model", "openai-generic", "some-model", true},
+		{"openai-responses", "openai-responses/gpt-4o", "openai-responses", "gpt-4o", true},
+		{"azure-openai", "azure-openai/my-deployment", "azure-openai", "my-deployment", true},
+		{"ollama", "ollama/llama3", "ollama", "llama3", true},
+		{"openrouter", "openrouter/anthropic/claude-3", "openrouter", "anthropic/claude-3", true},
+		{"google-ai", "google-ai/gemini-1.5", "google-ai", "gemini-1.5", true},
+		{"vertex-ai", "vertex-ai/gemini-1.5", "vertex-ai", "gemini-1.5", true},
+		{"aws-bedrock", "aws-bedrock/claude-3", "aws-bedrock", "claude-3", true},
+		{"baml-openai-chat legacy alias", "baml-openai-chat/gpt-4", "baml-openai-chat", "gpt-4", true},
+		{"baml-anthropic-chat legacy alias", "baml-anthropic-chat/claude-3", "baml-anthropic-chat", "claude-3", true},
+		{"fallback strategy shorthand canonicalised", "fallback/foo", "baml-fallback", "foo", true},
+		{"round-robin strategy shorthand canonicalised", "round-robin/foo", "baml-roundrobin", "foo", true},
+		{"unknown provider rejected", "unknown/model", "", "", false},
+		{"empty string rejected", "", "", "", false},
+		{"no slash rejected", "openai", "", "", false},
+		{"empty provider rejected", "/gpt-4o", "", "", false},
+		{"empty model rejected", "openai/", "", "", false},
+		{"named client with slash-looking name not recognised", "MyClient", "", "", false},
+		{"case-sensitive provider", "OpenAI/gpt-4", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotProvider, gotModel, gotOK := parseShorthandClient(tc.in)
+			if gotProvider != tc.wantProvider || gotModel != tc.wantModel || gotOK != tc.wantOK {
+				t.Errorf("parseShorthandClient(%q) = (%q, %q, %t), want (%q, %q, %t)",
+					tc.in, gotProvider, gotModel, gotOK, tc.wantProvider, tc.wantModel, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestEnrichShorthandClientProviders_FunctionDefault verifies that a
+// function defaulting to a shorthand client lands in cfg.clientProvider
+// with the parsed provider after the enrichment pass. Without this
+// entry the FunctionProvider materialization in generateBamlConfigVars
+// silently drops the function and the BuildRequest gate falls to
+// legacy with PathReasonEmptyProvider for every call.
+func TestEnrichShorthandClientProviders_FunctionDefault(t *testing.T) {
+	cfg := newTestBamlConfig()
+	cfg.functionClient["MyFunc"] = "openai/gpt-4o"
+
+	enrichShorthandClientProviders(cfg)
+
+	if got := cfg.clientProvider["openai/gpt-4o"]; got != "openai" {
+		t.Errorf("clientProvider[openai/gpt-4o] = %q, want %q", got, "openai")
+	}
+}
+
+// TestEnrichShorthandClientProviders_FallbackChild covers strategy-
+// wrapper children referencing a shorthand spec. Fallback-chain
+// resolution looks up cfg.clientProvider[child] for each entry; a
+// shorthand child without enrichment would classify as empty-provider
+// inside the chain.
+func TestEnrichShorthandClientProviders_FallbackChild(t *testing.T) {
+	cfg := newTestBamlConfig()
+	cfg.clientProvider["MyFallback"] = "baml-fallback"
+	cfg.fallbackChains["MyFallback"] = []string{"openai/gpt-4o", "anthropic/claude-3-5-sonnet"}
+
+	enrichShorthandClientProviders(cfg)
+
+	if got := cfg.clientProvider["openai/gpt-4o"]; got != "openai" {
+		t.Errorf("clientProvider[openai/gpt-4o] = %q, want %q", got, "openai")
+	}
+	if got := cfg.clientProvider["anthropic/claude-3-5-sonnet"]; got != "anthropic" {
+		t.Errorf("clientProvider[anthropic/claude-3-5-sonnet] = %q, want %q", got, "anthropic")
+	}
+}
+
+// TestEnrichShorthandClientProviders_DoesNotOverrideExisting pins that
+// a named client whose own provider declaration would happen to share
+// the shorthand syntax (theoretically possible — a `client<llm>` block
+// can be named anything) keeps its declared provider. The enrichment
+// pass only fills holes; it never overwrites a parsed provider entry.
+func TestEnrichShorthandClientProviders_DoesNotOverrideExisting(t *testing.T) {
+	cfg := newTestBamlConfig()
+	cfg.clientProvider["openai/gpt-4o"] = "anthropic"
+	cfg.functionClient["MyFunc"] = "openai/gpt-4o"
+
+	enrichShorthandClientProviders(cfg)
+
+	if got := cfg.clientProvider["openai/gpt-4o"]; got != "anthropic" {
+		t.Errorf("clientProvider[openai/gpt-4o] = %q, want preserved %q", got, "anthropic")
+	}
+}
+
+// TestEnrichShorthandClientProviders_UnknownProviderIgnored verifies
+// that a function defaulting to a `provider/model` literal with an
+// unrecognised provider does not pollute cfg.clientProvider. Upstream
+// would also reject this at ClientSpec::new_from_id parse time; the
+// introspector must agree so downstream behaviour stays unchanged
+// (falls to legacy as PathReasonEmptyProvider, just like before).
+func TestEnrichShorthandClientProviders_UnknownProviderIgnored(t *testing.T) {
+	cfg := newTestBamlConfig()
+	cfg.functionClient["MyFunc"] = "made-up-provider/some-model"
+
+	enrichShorthandClientProviders(cfg)
+
+	if _, exists := cfg.clientProvider["made-up-provider/some-model"]; exists {
+		t.Error("clientProvider should not contain entry for unknown shorthand provider")
+	}
+}
+
+// TestParseBamlSourceDir_ShorthandFunctionClient exercises the full
+// parse pipeline: a .baml fixture with a function defaulting to a
+// shorthand client should produce a populated ClientProvider entry for
+// that shorthand string, so the FunctionProvider materialization in
+// generateBamlConfigVars sees a non-empty provider and the BuildRequest
+// dispatch gate engages instead of falling through to legacy.
+func TestParseBamlSourceDir_ShorthandFunctionClient(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+function Extract(text: string) -> string {
+    client "openai/gpt-4o"
+    prompt #"Extract: {{ text }}"#
+}
+
+function Summarize(text: string) -> string {
+    client "anthropic/claude-3-5-sonnet-20241022"
+    prompt #"Summarize: {{ text }}"#
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "functions.baml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := parseBamlSourceDir(dir)
+
+	if got := cfg.functionClient["Extract"]; got != "openai/gpt-4o" {
+		t.Errorf("functionClient[Extract] = %q, want %q", got, "openai/gpt-4o")
+	}
+	if got := cfg.clientProvider["openai/gpt-4o"]; got != "openai" {
+		t.Errorf("clientProvider[openai/gpt-4o] = %q, want %q — shorthand-defaulted function would fall to legacy with empty provider", got, "openai")
+	}
+	if got := cfg.clientProvider["anthropic/claude-3-5-sonnet-20241022"]; got != "anthropic" {
+		t.Errorf("clientProvider[anthropic/claude-3-5-sonnet-20241022] = %q, want %q", got, "anthropic")
+	}
+}

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -1199,7 +1199,51 @@ func parseBamlSourceDir(dir string) *bamlConfig {
 		return cfg
 	}
 
+	enrichShorthandClientProviders(cfg)
 	return cfg
+}
+
+// enrichShorthandClientProviders walks every client name referenced by a
+// function default or by a strategy chain and, for shorthand specs
+// (`<provider>/<model>` per upstream BAML's ClientSpec::Shorthand) that
+// have no entry in cfg.clientProvider yet, registers the parsed provider.
+//
+// Why this pass exists. BAML supports defaulting a function to a
+// shorthand client without declaring a named `client<llm>` block —
+// `function MyFunc { client "openai/gpt-4o" ... }`. The introspector
+// records the literal "openai/gpt-4o" as the function's client name, but
+// without this enrichment cfg.clientProvider has no entry for it, so the
+// FunctionProvider materialization at generateBamlConfigVars never sets
+// a provider, and the BuildRequest gate falls through to legacy via
+// PathReasonEmptyProvider for every function defaulting to shorthand.
+//
+// The same lookup is performed for strategy-wrapper children
+// (cfg.fallbackChains values) so a fallback or RR child written as a
+// shorthand spec also lights up the BuildRequest path.
+//
+// Already-registered names take precedence; this pass only fills holes.
+func enrichShorthandClientProviders(cfg *bamlConfig) {
+	register := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, exists := cfg.clientProvider[name]; exists {
+			return
+		}
+		provider, _, ok := parseShorthandClient(name)
+		if !ok {
+			return
+		}
+		cfg.clientProvider[name] = provider
+	}
+	for _, clientName := range cfg.functionClient {
+		register(clientName)
+	}
+	for _, chain := range cfg.fallbackChains {
+		for _, child := range chain {
+			register(child)
+		}
+	}
 }
 
 // parseBamlFile extracts client, function, and retry_policy blocks from a
@@ -1779,6 +1823,68 @@ func canonicaliseProvider(provider string) string {
 		return "baml-fallback"
 	}
 	return provider
+}
+
+// parseShorthandClient splits a BAML shorthand client spec ("<provider>/<model>")
+// into its provider and model parts and reports ok=true when the leading
+// segment is a provider string upstream's ClientSpec::new_from_id would
+// accept. The returned provider is already run through canonicaliseProvider
+// so callers see the same canonical spelling produced by parseClientBlock.
+//
+// Mirrors upstream BAML v0.219.0 clientspec.rs: ClientSpec::new_from_id
+// splits on the first '/' and parses the left side through
+// ClientProvider::from_str (clientspec.rs:28-36, :116-145). The allowlist
+// here is the exact set FromStr accepts, including the `baml-*` legacy
+// aliases — anything outside that set is treated as a non-shorthand
+// (named) client by upstream, and the introspector must agree so
+// FunctionProvider only gets populated for genuinely-shorthand defaults.
+//
+// Strategy providers (fallback, round-robin) are technically accepted by
+// upstream's FromStr and therefore by ClientSpec::new_from_id; we include
+// them for parser fidelity even though shorthand-as-strategy is
+// degenerate (strategies need a children list). After canonicalisation
+// they resolve to baml-fallback / baml-roundrobin and the downstream
+// classifier routes them through the existing strategy paths.
+func parseShorthandClient(spec string) (provider, model string, ok bool) {
+	idx := strings.Index(spec, "/")
+	if idx <= 0 || idx >= len(spec)-1 {
+		return "", "", false
+	}
+	p := spec[:idx]
+	m := spec[idx+1:]
+	if !isKnownShorthandProvider(p) {
+		return "", "", false
+	}
+	return canonicaliseProvider(p), m, true
+}
+
+// isKnownShorthandProvider reports whether p is a provider string that
+// BAML upstream's ClientProvider::from_str would accept. Source list:
+// clientspec.rs:119-144 (v0.219.0). Keep in lockstep with upstream — if
+// a future BAML release adds a provider, this allowlist must follow.
+func isKnownShorthandProvider(p string) bool {
+	switch p {
+	case "openai",
+		"baml-openai-chat",
+		"openai-generic",
+		"azure-openai",
+		"baml-azure-chat",
+		"openai-responses",
+		"ollama",
+		"baml-ollama-chat",
+		"openrouter",
+		"anthropic",
+		"baml-anthropic-chat",
+		"aws-bedrock",
+		"google-ai",
+		"vertex-ai",
+		"fallback",
+		"baml-fallback",
+		"round-robin",
+		"baml-round-robin":
+		return true
+	}
+	return false
 }
 
 func extractStrategyStatement(line string) string {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes the only concrete baml-rest-local gap inside the #167 "ensure provider resolution always populated" bullet.

## The bug

BAML supports shorthand client specs (`client "openai/gpt-4o"`). Upstream's `ClientSpec::Shorthand(provider, model)` handles them directly at runtime, but baml-rest's introspector recorded the full shorthand string as the function client name and didn't extract the provider component. Result: `FunctionProvider` for any shorthand-defaulted function was empty; the BuildRequest gate saw `PathReasonEmptyProvider` and fell through to legacy. Affected every function whose declared default was a shorthand spec.

## Fix

- `cmd/introspect/main.go` parses shorthand specs (`<provider>/<model>`) with a provider allowlist matching upstream BAML v0.219.0's `ClientProvider::from_str` (clientspec.rs:119-144).
- An enrichment pass after parsing registers the parsed provider for every function default and every fallback-chain child that's a shorthand spec without an existing `cfg.clientProvider` entry. Already-registered names keep their declared provider.
- The strategy aliases (`fallback`, `round-robin`) are folded through `canonicaliseProvider` so downstream classification sees one canonical spelling per strategy.

`WithClient("provider/model")` already works out-of-the-box: the generated router threads the client name string through to BAML's runtime, which parses shorthand via `ClientSpec::new_from_id`. No special-case dispatch was needed.

## Out of scope

- Synthesizing providers for arbitrary runtime-only clients with omitted `provider` (config-level — upstream BAML also requires it).
- Explicit `"provider": ""` runtime override (intentionally preserved — surfaces upstream's invalid-provider error).
- Unsupported provider support like `aws-bedrock` (separate work; this PR moves it from `PathReasonEmptyProvider` to the more honest `PathReasonUnsupportedProvider`, which is itself a small win).

## Test plan

- [x] `TestParseShorthandClient` — 21 sub-cases covering happy path (every allowlisted provider), strategy-alias canonicalisation, and edge/negative shapes (no slash, empty halves, unknown provider, case sensitivity).
- [x] `TestEnrichShorthandClientProviders_*` — direct tests of the enrichment pass for function defaults, fallback children, override-preservation, and unknown-provider ignoring.
- [x] `TestParseBamlSourceDir_ShorthandFunctionClient` — end-to-end parse of a fixture with `client "openai/gpt-4o"` proves the populated `ClientProvider` entry. (Confirmed pre-fix: the same test fails with empty provider when the enrichment call is disabled.)
- [x] `TestResolveClientProvider_ShorthandIntrospectedEntry` — the buildrequest-side resolver sees the post-enrichment map and returns the parsed provider.
- [x] `TestResolveProviderWithReason_ShorthandFunctionDefault` — full routing decision: a shorthand-defaulted function reaches `buildrequest` path with no `PathReason` (no `PathReasonEmptyProvider`).
- [x] `TestResolveProviderWithReason_ShorthandUnsupportedProvider` — negative classification for `aws-bedrock/...` shorthand (legacy, `PathReasonUnsupportedProvider`, not empty-provider).
- [x] `verify-framework-adapter` — 9/9 checks green across v0.204.0, v0.215.0, v0.219.0.
- [x] `verify-adapter-pins` — 4/4 pinned versions match.
- [x] Per-adapter smoke tests pass for v0_204_0, v0_215_0, v0_219_0.
- [x] Full `./bamlutils/...` and `./cmd/introspect/...` test suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive tests for shorthand "<provider>/<model>" client parsing, validation, enrichment, and end-to-end behavior to ensure correct handling across provider variants and malformed inputs.

* **Chores**
  * Enhanced parsing and enrichment so shorthand client notation in function defaults and fallback chains reliably populates provider mappings, canonicalizes aliases, and avoids legacy empty-provider fallbacks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/241)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->