### PR TITLE
feat(apierror): introduce provider_error; broaden parse_error scope (PR 1/3 of #245)

### DIFF
--- a/cmd/serve/error.go
+++ b/cmd/serve/error.go
@@ -192,8 +192,8 @@ func classifyWorkerError(err error) (apierror.Code, json.RawMessage) {
 // them, so off-contract values are dropped rather than forwarded:
 //
 //   - code is preserved only if it's worker-facing
-//     (apierror.Code.IsWorkerFacing): worker_error, parse_error, or
-//     internal_error. Request-layer codes (invalid_json,
+//     (apierror.Code.IsWorkerFacing): worker_error, provider_error,
+//     parse_error, or internal_error. Request-layer codes (invalid_json,
 //     request_canceled, etc.) and pool-admission codes
 //     (worker_unavailable) are owned by the host — honoring a worker
 //     that claimed e.g. request_canceled would let worker-side text

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -513,6 +513,7 @@ func TestClassifyWorkerError_NonWorkerFacingCodeRejected(t *testing.T) {
 		// Worker-facing codes still pass through.
 		{"worker claims worker_error", string(apierror.CodeWorkerError), apierror.CodeWorkerError},
 		{"worker claims parse_error", string(apierror.CodeParseError), apierror.CodeParseError},
+		{"worker claims provider_error", string(apierror.CodeProviderError), apierror.CodeProviderError},
 		{"worker claims internal_error", string(apierror.CodeInternalError), apierror.CodeInternalError},
 	}
 	for _, tt := range tests {

--- a/cmd/serve/error_test.go
+++ b/cmd/serve/error_test.go
@@ -491,15 +491,15 @@ func TestClassifyWorkerError_UnknownWorkerCodeFallsThrough(t *testing.T) {
 // TestClassifyWorkerError_NonWorkerFacingCodeRejected pins the
 // IsWorkerFacing whitelist: even when the worker emits a known
 // apierror.Code, the host honors it only for worker-facing classes
-// (worker_error / parse_error / internal_error). Request-layer codes
-// (request_canceled, invalid_json, ...) and pool-admission codes
-// (worker_unavailable) are owned by the host — honoring a worker
-// that claimed e.g. request_canceled would let worker text force
-// the 408 branch in writeFiberWorkerError and dictate HTTP status
-// semantics. The wrapped err here has gRPC code Internal (which
-// would normally classify as worker_error via the fall-through), so
-// rejection of the worker code surfaces worker_error, not the
-// claimed request_canceled.
+// (worker_error / provider_error / parse_error / internal_error).
+// Request-layer codes (request_canceled, invalid_json, ...) and
+// pool-admission codes (worker_unavailable) are owned by the host
+// — honoring a worker that claimed e.g. request_canceled would let
+// worker text force the 408 branch in writeFiberWorkerError and
+// dictate HTTP status semantics. The wrapped err here has gRPC code
+// Internal (which would normally classify as worker_error via the
+// fall-through), so rejection of the worker code surfaces
+// worker_error, not the claimed request_canceled.
 func TestClassifyWorkerError_NonWorkerFacingCodeRejected(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/apierror/error.go
+++ b/internal/apierror/error.go
@@ -25,6 +25,7 @@ var allCodes = []Code{
 	CodeRequestCanceled,
 	CodeWorkerUnavailable,
 	CodeWorkerError,
+	CodeProviderError,
 	CodeParseError,
 	CodeInternalError,
 }
@@ -64,14 +65,16 @@ func (c Code) IsKnown() bool {
 // request_canceled to force a 408 from the host's classifier).
 //
 // The allow-list is intentionally narrow: the worker-classified
-// outcomes the host trusts are exactly worker_error (BAML / LLM
-// application error), parse_error (BAML couldn't validate raw
-// output against the method schema), and internal_error (a Go-side
-// processing bug inside the worker). Unknown or non-worker-facing
-// codes fall back to host-side classification.
+// outcomes the host trusts are exactly worker_error (residual
+// BAML/worker failure), provider_error (upstream LLM provider
+// returned a non-2xx HTTP status or transport failed), parse_error
+// (BAML couldn't coerce raw text into the method schema), and
+// internal_error (a Go-side processing bug inside the worker).
+// Unknown or non-worker-facing codes fall back to host-side
+// classification.
 func (c Code) IsWorkerFacing() bool {
 	switch c {
-	case CodeWorkerError, CodeParseError, CodeInternalError:
+	case CodeWorkerError, CodeProviderError, CodeParseError, CodeInternalError:
 		return true
 	}
 	return false
@@ -97,14 +100,22 @@ const (
 	// retryable infrastructure failures (worker crash, gRPC Unavailable,
 	// transport reset). Retrying the request later may succeed.
 	CodeWorkerUnavailable Code = "worker_unavailable"
-	// CodeWorkerError: the BAML worker returned an application-level
-	// error — typically a BAML validation failure, a parse error against
-	// the BAML schema, or an upstream LLM provider error. The accompanying
-	// message comes verbatim from BAML / the LLM provider.
+	// CodeWorkerError: residual BAML/worker failure that doesn't fit a
+	// more specific code (parse, provider, internal, cancellation,
+	// pool-unavailable, etc.). Should be rare once the per-class codes
+	// are wired through both the BuildRequest and legacy paths; remains
+	// the catch-all for unclassified worker-side failures.
 	CodeWorkerError Code = "worker_error"
-	// CodeParseError: the /parse endpoint failed to parse raw LLM output
-	// against the BAML method's schema. Distinguished from CodeWorkerError
-	// because parse failures don't involve an LLM call.
+	// CodeProviderError: upstream LLM provider returned a non-2xx HTTP
+	// status or the transport failed before BAML could parse a
+	// response. Always carries details.status_code when the upstream
+	// produced an HTTP response; the field is absent when the failure
+	// was at the transport layer (DNS, TCP, TLS, mid-stream reset).
+	CodeProviderError Code = "provider_error"
+	// CodeParseError: BAML couldn't coerce or validate raw text into
+	// the method's schema. Applies to both /parse (raw input from the
+	// request body) and /call / /call-with-raw / /stream (raw LLM
+	// output that didn't conform to the method's return type).
 	CodeParseError Code = "parse_error"
 	// CodeInternalError: an internal Go-side processing error (output
 	// flattening, input conversion, panic). Indicates a bug in this

--- a/internal/apierror/error_test.go
+++ b/internal/apierror/error_test.go
@@ -107,6 +107,7 @@ func TestIsWorkerFacing(t *testing.T) {
 		want bool
 	}{
 		{CodeWorkerError, true},
+		{CodeProviderError, true},
 		{CodeParseError, true},
 		{CodeInternalError, true},
 		// Request-layer (host-owned) — not worker-facing.


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

PR 1 of #245. Adds `provider_error` to the apierror taxonomy and broadens `parse_error`'s docstring to cover post-LLM coercion failures. **Behavior-neutral** — nothing emits `provider_error` yet; PRs 2 and 3 do the wiring.

## What's included

- `CodeProviderError` constant + `allCodes` + `IsWorkerFacing` extension.
- `CodeParseError` docstring broadened to cover post-LLM coercion on `/call` and `/stream`. Wire value unchanged — zero migration risk for existing consumers.
- `CodeWorkerError` docstring narrowed to reflect its residual role.
- Unit test extensions for `IsWorkerFacing` + `normalizeWorkerMetadata` worker-facing allow-list.

## Note on the OpenAPI schema

`cmd/serve/openapi.json` is intentionally a stub at HEAD — `cmd/build/build.sh` generates the real schema from `apierror.AllCodes()` at build time and removes it post-build. The new constant flows into the embedded OpenAPI enum automatically; nothing to commit here.

## What's NOT included

- BuildRequest typed classification (PR 2).
- Legacy `CallStream+OnTick` classifier (PR 3).
- Integration test coverage of new codes (PR 3).
- `details.stacktrace` changes — kept as-is per scoping.

## Verification

- `go build ./...` clean.
- `go vet ./...` clean.
- `go test ./...` green (extended table tests pass).
- `verify-framework-adapter`: 9/9.
- `verify-adapter-pins`: 4/4.
- `gofmt -l adapters/ bamlutils/ cmd/ workerplugin/ pool/ integration/ internal/` reports only pre-existing drift; nothing this PR touches.

References #245.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to validate provider-error classification and how worker-supplied error codes are handled.

* **Bug Fixes**
  * Provider errors are now treated as worker-facing in error responses, ensuring correct rejection and reporting behavior.

* **Documentation**
  * Clarified examples and comments describing which error types are preserved during normalization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/246)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->