### PR TITLE
feat(worker): legacy CallStream+OnTick error classification (PR 3/3 of #245)

### DIFF
--- a/cmd/worker/error_classify.go
+++ b/cmd/worker/error_classify.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"strconv"
+	"strings"
 
 	"github.com/goccy/go-json"
 
@@ -10,17 +12,37 @@ import (
 	"github.com/invakid404/baml-rest/internal/apierror"
 )
 
+// Legacy CallStream+OnTick BAML errors arrive across the Go FFI as plain
+// strings (language_client_go's BamlError carries Message only — its
+// typed BamlClientHttpError is defined but never constructed). BAML's
+// public display envelopes are stable enough to anchor a conservative
+// classifier on the exact prefixes below; broader substrings like
+// "Failed to parse LLM response:" appear in provider response handlers
+// and internal paths too and are deliberately not matched.
+//
+// Source: engine/baml-runtime/src/errors.rs Display impls for
+// ValidationError / ClientHttpError / TimeoutError.
+const (
+	legacyParseErrorPrefix       = "Parsing error: "
+	legacyLLMClientPrefix        = `LLM client "`
+	legacyLLMClientStatusMarker  = `" failed with status code: `
+	legacyLLMClientTimeoutMarker = `" timed out:`
+)
+
 // classifyBAMLError inspects a worker-side error from a BAML call /
 // BuildRequest path and returns the apierror.Code that best fits, plus
-// optional JSON-encoded details. Returns ("", nil) when no typed surface
+// optional JSON-encoded details. Returns ("", nil) when no surface
 // matched, in which case the host's classifyWorkerError preserves any
 // existing pluginResult.ErrorCode or defaults to worker_error.
 //
-// The mapping intentionally only covers typed surfaces — typed parse
-// wrappers from BuildRequest, typed HTTP errors from llmhttp, and the
-// transport-flake umbrella sentinel. Legacy CallStream+OnTick BAML
-// errors arrive as opaque strings and are NOT classified here; PR 3 of
-// #245 adds conservative prefix matching at the same boundary.
+// Typed BuildRequest surfaces are checked first: the typed parse
+// wrapper, llmhttp's *HTTPError, and the transport-flake umbrella
+// sentinel. Legacy CallStream+OnTick errors fall through to exact-
+// prefix matching against BAML's stable public error envelopes. The
+// classifier intentionally fails closed (returns "") rather than
+// stretching a substring match — under-classifying lets the host's
+// worker_error default fire; mis-classifying leaks the wrong code into
+// the public taxonomy.
 //
 // errors.As is used (not a direct type assertion) so wrappers like
 // fmt.Errorf("buildrequest: %w", &llmhttp.HTTPError{...}) still match.
@@ -40,27 +62,65 @@ func classifyBAMLError(err error) (code string, details []byte) {
 
 	var httpErr *llmhttp.HTTPError
 	if errors.As(err, &httpErr) {
-		// status_code is the single piece of structured upstream context
-		// worth surfacing today. The response body is deliberately not
-		// forwarded — provider error bodies can contain partial PII,
-		// raw prompts echoed back, or large diagnostic payloads, and
-		// the brief constrains baml-rest to a minimal structured surface.
-		payload := struct {
-			StatusCode int `json:"status_code"`
-		}{StatusCode: httpErr.StatusCode}
-		data, marshalErr := json.Marshal(payload)
-		if marshalErr != nil {
-			// Marshal of a single-int-field struct can't realistically
-			// fail; if it ever does, fall back to the code without details
-			// rather than dropping the classification altogether.
-			return string(apierror.CodeProviderError), nil
-		}
-		return string(apierror.CodeProviderError), data
+		return string(apierror.CodeProviderError), statusCodeDetails(httpErr.StatusCode)
 	}
 
 	if errors.Is(err, llmhttp.ErrTransportFlake) {
 		return string(apierror.CodeProviderError), nil
 	}
 
+	// Legacy FFI string surfaces — checked only after every typed branch
+	// has been ruled out. Matching against a wrapper's Error() is
+	// acceptable here because BAML's prefixes are anchored at the very
+	// start of the wrapped chain (the FFI String is the root error) and
+	// we never use Contains for the prefix itself.
+	msg := err.Error()
+
+	if strings.HasPrefix(msg, legacyParseErrorPrefix) {
+		return string(apierror.CodeParseError), nil
+	}
+
+	if strings.HasPrefix(msg, legacyLLMClientPrefix) {
+		if idx := strings.Index(msg, legacyLLMClientStatusMarker); idx != -1 {
+			tail := msg[idx+len(legacyLLMClientStatusMarker):]
+			// Trim everything past the status-code digits (BAML appends
+			// the response body and other context after the number).
+			end := 0
+			for end < len(tail) && tail[end] >= '0' && tail[end] <= '9' {
+				end++
+			}
+			if end > 0 {
+				if status, parseErr := strconv.Atoi(tail[:end]); parseErr == nil {
+					return string(apierror.CodeProviderError), statusCodeDetails(status)
+				}
+			}
+			// Status code couldn't be parsed — still a provider failure;
+			// emit the code without details rather than dropping the
+			// classification altogether.
+			return string(apierror.CodeProviderError), nil
+		}
+		if strings.Contains(msg, legacyLLMClientTimeoutMarker) {
+			return string(apierror.CodeProviderError), nil
+		}
+	}
+
 	return "", nil
+}
+
+// statusCodeDetails marshals a {"status_code": N} payload. The response
+// body and other provider context are deliberately not forwarded —
+// upstream bodies can contain partial PII, raw prompts echoed back, or
+// large diagnostic payloads, and the brief constrains baml-rest to a
+// minimal structured surface. Marshal of a single-int-field struct
+// can't realistically fail; if it ever does, fall back to no details
+// rather than dropping the classification.
+func statusCodeDetails(status int) []byte {
+	payload := struct {
+		StatusCode int `json:"status_code"`
+	}{StatusCode: status}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil
+	}
+	return data
 }

--- a/cmd/worker/error_classify.go
+++ b/cmd/worker/error_classify.go
@@ -163,19 +163,26 @@ func classifyBAMLError(err error) (code string, details []byte) {
 		return string(apierror.CodeParseError), nil
 	}
 
-	if strings.HasPrefix(firstLine, legacyLLMClientPrefix) {
-		clientName := extractLegacyClientName(firstLine)
-		if idx := strings.Index(firstLine, legacyLLMClientStatusMarker); idx != -1 {
-			d := providerErrorDetails{Body: body, ClientName: clientName}
-			if status, ok := parseLegacyStatusCode(firstLine[idx+len(legacyLLMClientStatusMarker):]); ok {
+	if name, suffix, ok := splitLegacyLLMClientEnvelope(firstLine); ok {
+		// Markers must begin immediately at the closing client-name
+		// quote — both legacyLLMClientStatusMarker and
+		// legacyLLMClientTimeoutMarker start with `"`, and the suffix
+		// is sliced to include that quote. This forecloses an intra-
+		// line false positive where the marker text appears somewhere
+		// in firstLine but not at the post-quote anchor (e.g. a client
+		// name with embedded quotes whose later content happens to
+		// match the marker substring).
+		if strings.HasPrefix(suffix, legacyLLMClientStatusMarker) {
+			d := providerErrorDetails{Body: body, ClientName: name}
+			if status, ok := parseLegacyStatusCode(suffix[len(legacyLLMClientStatusMarker):]); ok {
 				d.StatusCode = status
 			}
 			return string(apierror.CodeProviderError), d.marshal()
 		}
-		if strings.Contains(firstLine, legacyLLMClientTimeoutMarker) {
+		if strings.HasPrefix(suffix, legacyLLMClientTimeoutMarker) {
 			return string(apierror.CodeProviderError), providerErrorDetails{
 				Body:       body,
-				ClientName: clientName,
+				ClientName: name,
 			}.marshal()
 		}
 	}
@@ -183,18 +190,38 @@ func classifyBAMLError(err error) (code string, details []byte) {
 	return "", nil
 }
 
-// extractLegacyClientName returns the quoted client name from a BAML
-// envelope first line starting with `LLM client "`. Returns "" when
-// the closing quote is missing (a malformed envelope baml-rest can't
-// recover a meaningful name from). Callers must check the prefix
-// before calling.
-func extractLegacyClientName(firstLine string) string {
+// splitLegacyLLMClientEnvelope splits a BAML envelope first line into
+// the client name and the suffix that begins at the closing client-
+// name quote. The suffix includes that quote so it can be matched
+// directly against legacyLLMClientStatusMarker /
+// legacyLLMClientTimeoutMarker (both of which start with `"`).
+//
+// Returns ok=false when firstLine doesn't start with `LLM client "`,
+// has no closing quote, or has an empty client name — three malformed
+// envelope shapes baml-rest can't classify safely. The empty-name
+// case is gated here (rather than at the caller) so the marker check
+// only ever runs against a well-formed envelope.
+func splitLegacyLLMClientEnvelope(firstLine string) (name, suffix string, ok bool) {
+	if !strings.HasPrefix(firstLine, legacyLLMClientPrefix) {
+		return "", "", false
+	}
 	rest := firstLine[len(legacyLLMClientPrefix):]
 	q := strings.IndexByte(rest, '"')
-	if q == -1 {
-		return ""
+	if q <= 0 {
+		// q == -1: missing closing quote; q == 0: empty client name.
+		// Both are malformed envelopes — fail closed.
+		return "", "", false
 	}
-	return rest[:q]
+	return rest[:q], rest[q:], true
+}
+
+// extractLegacyClientName returns just the client-name part of a BAML
+// envelope first line. Thin wrapper around splitLegacyLLMClientEnvelope
+// for call sites that only need the name; the underlying helper also
+// produces the suffix the marker checks anchor against.
+func extractLegacyClientName(firstLine string) string {
+	name, _, _ := splitLegacyLLMClientEnvelope(firstLine)
+	return name
 }
 
 // parseLegacyStatusCode extracts the numeric status code from the

--- a/cmd/worker/error_classify.go
+++ b/cmd/worker/error_classify.go
@@ -62,6 +62,37 @@ var legacyStatusCodeRE = regexp.MustCompile(
 	`^(?:(\d+)|(?:InvalidAuthentication|NotSupported|RateLimited|ServerError|ServiceUnavailable|Timeout) \((\d+)\)|(?:BadResponse|Unspecified error code:)\s+(\d+))`,
 )
 
+// providerErrorDetails is the structured payload attached to
+// provider_error responses. baml-rest is a developer tool — the
+// operator running it is the consumer of these details and is the
+// right place to decide what to do with upstream response bodies. So
+// we forward what we have: the HTTP status code when known, the raw
+// upstream body, and (on legacy envelopes) the BAML client name that
+// failed. Empty fields are omitted so the envelope stays terse for
+// arms that genuinely don't have that signal (e.g. transport flakes
+// carry neither status nor body).
+type providerErrorDetails struct {
+	StatusCode int    `json:"status_code,omitempty"`
+	Body       string `json:"body,omitempty"`
+	ClientName string `json:"client_name,omitempty"`
+}
+
+// marshal returns the JSON-encoded bytes, or nil when every field is
+// at its zero value (in which case the caller drops details entirely
+// rather than emitting a bare `{}`). Marshal of a fixed-shape struct
+// can't realistically fail; if it ever does, fall back to no details
+// rather than dropping the classification.
+func (d providerErrorDetails) marshal() []byte {
+	if d.StatusCode == 0 && d.Body == "" && d.ClientName == "" {
+		return nil
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
 // classifyBAMLError inspects a worker-side error from a BAML call /
 // BuildRequest path and returns the apierror.Code that best fits, plus
 // optional JSON-encoded details. Returns ("", nil) when no surface
@@ -95,7 +126,10 @@ func classifyBAMLError(err error) (code string, details []byte) {
 
 	var httpErr *llmhttp.HTTPError
 	if errors.As(err, &httpErr) {
-		return string(apierror.CodeProviderError), statusCodeDetails(httpErr.StatusCode)
+		return string(apierror.CodeProviderError), providerErrorDetails{
+			StatusCode: httpErr.StatusCode,
+			Body:       httpErr.Body,
+		}.marshal()
 	}
 
 	if errors.Is(err, llmhttp.ErrTransportFlake) {
@@ -116,12 +150,13 @@ func classifyBAMLError(err error) (code string, details []byte) {
 	// line starts with `LLM client "...` but lacks the recognized
 	// marker must not be misclassified just because the message body
 	// happens to contain `failed with status code:` or `timed out:`
-	// verbatim. parseLegacyStatusCode already trims at the first
-	// newline, but doing the slice up front makes the boundary
-	// explicit and removes a hidden body-text dependency.
+	// verbatim. The split here also yields the body forwarded to
+	// callers via providerErrorDetails.Body.
 	firstLine := msg
+	body := ""
 	if nl := strings.IndexByte(msg, '\n'); nl != -1 {
 		firstLine = msg[:nl]
+		body = msg[nl+1:]
 	}
 
 	if strings.HasPrefix(firstLine, legacyParseErrorPrefix) {
@@ -129,39 +164,37 @@ func classifyBAMLError(err error) (code string, details []byte) {
 	}
 
 	if strings.HasPrefix(firstLine, legacyLLMClientPrefix) {
+		clientName := extractLegacyClientName(firstLine)
 		if idx := strings.Index(firstLine, legacyLLMClientStatusMarker); idx != -1 {
+			d := providerErrorDetails{Body: body, ClientName: clientName}
 			if status, ok := parseLegacyStatusCode(firstLine[idx+len(legacyLLMClientStatusMarker):]); ok {
-				return string(apierror.CodeProviderError), statusCodeDetails(status)
+				d.StatusCode = status
 			}
-			// Status code couldn't be parsed — still a provider failure;
-			// emit the code without details rather than dropping the
-			// classification altogether.
-			return string(apierror.CodeProviderError), nil
+			return string(apierror.CodeProviderError), d.marshal()
 		}
 		if strings.Contains(firstLine, legacyLLMClientTimeoutMarker) {
-			return string(apierror.CodeProviderError), nil
+			return string(apierror.CodeProviderError), providerErrorDetails{
+				Body:       body,
+				ClientName: clientName,
+			}.marshal()
 		}
 	}
 
 	return "", nil
 }
 
-// statusCodeDetails marshals a {"status_code": N} payload. The response
-// body and other provider context are deliberately not forwarded —
-// upstream bodies can contain partial PII, raw prompts echoed back, or
-// large diagnostic payloads, and the brief constrains baml-rest to a
-// minimal structured surface. Marshal of a single-int-field struct
-// can't realistically fail; if it ever does, fall back to no details
-// rather than dropping the classification.
-func statusCodeDetails(status int) []byte {
-	payload := struct {
-		StatusCode int `json:"status_code"`
-	}{StatusCode: status}
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return nil
+// extractLegacyClientName returns the quoted client name from a BAML
+// envelope first line starting with `LLM client "`. Returns "" when
+// the closing quote is missing (a malformed envelope baml-rest can't
+// recover a meaningful name from). Callers must check the prefix
+// before calling.
+func extractLegacyClientName(firstLine string) string {
+	rest := firstLine[len(legacyLLMClientPrefix):]
+	q := strings.IndexByte(rest, '"')
+	if q == -1 {
+		return ""
 	}
-	return data
+	return rest[:q]
 }
 
 // parseLegacyStatusCode extracts the numeric status code from the
@@ -170,7 +203,8 @@ func statusCodeDetails(status int) []byte {
 // newline (BAML appends "\nMessage: <body>") before scanning so a
 // digit run inside the trailing provider body can't be misread as the
 // status code. Returns (0, false) when no anchored form matches —
-// callers keep the provider_error classification and drop details.
+// callers keep the provider_error classification with body/client_name
+// details but drop the status_code field.
 func parseLegacyStatusCode(segment string) (int, bool) {
 	if nl := strings.IndexByte(segment, '\n'); nl != -1 {
 		segment = segment[:nl]

--- a/cmd/worker/error_classify.go
+++ b/cmd/worker/error_classify.go
@@ -32,23 +32,34 @@ const (
 
 // legacyStatusCodeRE extracts the numeric status code from BAML
 // v0.219's ClientHttpError envelope. BAML renders the ErrorCode enum
-// via Display before the "\nMessage: " body, producing several shapes
-// the parser must cope with (engine/baml-runtime/.../internal/llm_client/mod.rs:249-259):
+// via Display before the "\nMessage: " body, producing one of these
+// shapes (engine/baml-runtime/.../internal/llm_client/mod.rs:249-259):
 //
-//	ServerError (500)            — named enum, parenthesized digits
-//	RateLimited (429)            — same shape (InvalidAuthentication,
-//	ServiceUnavailable (503)       NotSupported, Timeout follow the
-//	                               same pattern)
-//	BadResponse 418              — bare digits after literal "BadResponse "
-//	Unspecified error code: 418  — bare digits after the colon variant
+//	InvalidAuthentication (401)  — named enum, parenthesized digits
+//	NotSupported (403)             (same shape for all named variants:
+//	RateLimited (429)              from_status maps known HTTP codes
+//	ServerError (500)              into this allowlist)
+//	ServiceUnavailable (503)
+//	Timeout (408)
+//	BadResponse <code>           — UnsupportedResponse(u16) variant
+//	Unspecified error code: <N>  — Other(u16) variant for any code
+//	                               BAML didn't recognize
 //
-// Earlier/future BAML versions could emit bare leading digits as well,
-// so the regex keeps that path as the first alternative for
-// compatibility. The alternatives are anchored on BAML's literal enum
-// names so a stray digit run inside the trailing message body can't
-// be misread as the status code.
+// Earlier/future BAML versions could emit bare leading digits, so the
+// first alternative keeps that path for compatibility.
+//
+// The whole alternation is wrapped under a single `^` anchor — Go's
+// regexp distributes a top-level `^` only to the first alternative,
+// so without the non-capturing group an unrecognized future enum
+// display like `SomeNewEnum (599)` would match the parenthesized
+// branch mid-segment and leak the wrong number. Pinning the
+// parenthesized branch to BAML's exact enum spellings means any new
+// named variant added upstream falls through to provider_error with
+// nil details — under-classify rather than misclassify. Bumping the
+// BAML pin should re-check this allowlist against the current
+// ErrorCode Display impl.
 var legacyStatusCodeRE = regexp.MustCompile(
-	`^(\d+)|\((\d+)\)|(?:BadResponse|Unspecified error code:)\s+(\d+)`,
+	`^(?:(\d+)|(?:InvalidAuthentication|NotSupported|RateLimited|ServerError|ServiceUnavailable|Timeout) \((\d+)\)|(?:BadResponse|Unspecified error code:)\s+(\d+))`,
 )
 
 // classifyBAMLError inspects a worker-side error from a BAML call /

--- a/cmd/worker/error_classify.go
+++ b/cmd/worker/error_classify.go
@@ -109,13 +109,28 @@ func classifyBAMLError(err error) (code string, details []byte) {
 	// we never use Contains for the prefix itself.
 	msg := err.Error()
 
-	if strings.HasPrefix(msg, legacyParseErrorPrefix) {
+	// Marker detection is scoped to the envelope's first line. BAML's
+	// ClientHttpError/TimeoutError Display impls put the recognized
+	// markers on the public envelope line and the upstream body after
+	// "\nMessage:" — so a malformed or future BAML string whose first
+	// line starts with `LLM client "...` but lacks the recognized
+	// marker must not be misclassified just because the message body
+	// happens to contain `failed with status code:` or `timed out:`
+	// verbatim. parseLegacyStatusCode already trims at the first
+	// newline, but doing the slice up front makes the boundary
+	// explicit and removes a hidden body-text dependency.
+	firstLine := msg
+	if nl := strings.IndexByte(msg, '\n'); nl != -1 {
+		firstLine = msg[:nl]
+	}
+
+	if strings.HasPrefix(firstLine, legacyParseErrorPrefix) {
 		return string(apierror.CodeParseError), nil
 	}
 
-	if strings.HasPrefix(msg, legacyLLMClientPrefix) {
-		if idx := strings.Index(msg, legacyLLMClientStatusMarker); idx != -1 {
-			if status, ok := parseLegacyStatusCode(msg[idx+len(legacyLLMClientStatusMarker):]); ok {
+	if strings.HasPrefix(firstLine, legacyLLMClientPrefix) {
+		if idx := strings.Index(firstLine, legacyLLMClientStatusMarker); idx != -1 {
+			if status, ok := parseLegacyStatusCode(firstLine[idx+len(legacyLLMClientStatusMarker):]); ok {
 				return string(apierror.CodeProviderError), statusCodeDetails(status)
 			}
 			// Status code couldn't be parsed — still a provider failure;
@@ -123,7 +138,7 @@ func classifyBAMLError(err error) (code string, details []byte) {
 			// classification altogether.
 			return string(apierror.CodeProviderError), nil
 		}
-		if strings.Contains(msg, legacyLLMClientTimeoutMarker) {
+		if strings.Contains(firstLine, legacyLLMClientTimeoutMarker) {
 			return string(apierror.CodeProviderError), nil
 		}
 	}

--- a/cmd/worker/error_classify.go
+++ b/cmd/worker/error_classify.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -27,6 +28,27 @@ const (
 	legacyLLMClientPrefix        = `LLM client "`
 	legacyLLMClientStatusMarker  = `" failed with status code: `
 	legacyLLMClientTimeoutMarker = `" timed out:`
+)
+
+// legacyStatusCodeRE extracts the numeric status code from BAML
+// v0.219's ClientHttpError envelope. BAML renders the ErrorCode enum
+// via Display before the "\nMessage: " body, producing several shapes
+// the parser must cope with (engine/baml-runtime/.../internal/llm_client/mod.rs:249-259):
+//
+//	ServerError (500)            — named enum, parenthesized digits
+//	RateLimited (429)            — same shape (InvalidAuthentication,
+//	ServiceUnavailable (503)       NotSupported, Timeout follow the
+//	                               same pattern)
+//	BadResponse 418              — bare digits after literal "BadResponse "
+//	Unspecified error code: 418  — bare digits after the colon variant
+//
+// Earlier/future BAML versions could emit bare leading digits as well,
+// so the regex keeps that path as the first alternative for
+// compatibility. The alternatives are anchored on BAML's literal enum
+// names so a stray digit run inside the trailing message body can't
+// be misread as the status code.
+var legacyStatusCodeRE = regexp.MustCompile(
+	`^(\d+)|\((\d+)\)|(?:BadResponse|Unspecified error code:)\s+(\d+)`,
 )
 
 // classifyBAMLError inspects a worker-side error from a BAML call /
@@ -82,17 +104,8 @@ func classifyBAMLError(err error) (code string, details []byte) {
 
 	if strings.HasPrefix(msg, legacyLLMClientPrefix) {
 		if idx := strings.Index(msg, legacyLLMClientStatusMarker); idx != -1 {
-			tail := msg[idx+len(legacyLLMClientStatusMarker):]
-			// Trim everything past the status-code digits (BAML appends
-			// the response body and other context after the number).
-			end := 0
-			for end < len(tail) && tail[end] >= '0' && tail[end] <= '9' {
-				end++
-			}
-			if end > 0 {
-				if status, parseErr := strconv.Atoi(tail[:end]); parseErr == nil {
-					return string(apierror.CodeProviderError), statusCodeDetails(status)
-				}
+			if status, ok := parseLegacyStatusCode(msg[idx+len(legacyLLMClientStatusMarker):]); ok {
+				return string(apierror.CodeProviderError), statusCodeDetails(status)
 			}
 			// Status code couldn't be parsed — still a provider failure;
 			// emit the code without details rather than dropping the
@@ -123,4 +136,34 @@ func statusCodeDetails(status int) []byte {
 		return nil
 	}
 	return data
+}
+
+// parseLegacyStatusCode extracts the numeric status code from the
+// segment of a BAML ClientHttpError envelope that follows
+// `failed with status code: `. The segment is bounded to the first
+// newline (BAML appends "\nMessage: <body>") before scanning so a
+// digit run inside the trailing provider body can't be misread as the
+// status code. Returns (0, false) when no anchored form matches —
+// callers keep the provider_error classification and drop details.
+func parseLegacyStatusCode(segment string) (int, bool) {
+	if nl := strings.IndexByte(segment, '\n'); nl != -1 {
+		segment = segment[:nl]
+	}
+	matches := legacyStatusCodeRE.FindStringSubmatch(segment)
+	if matches == nil {
+		return 0, false
+	}
+	// Alternation captures land in different groups depending on which
+	// alternative matched; the first non-empty group is the digits.
+	for _, group := range matches[1:] {
+		if group == "" {
+			continue
+		}
+		status, err := strconv.Atoi(group)
+		if err != nil {
+			return 0, false
+		}
+		return status, true
+	}
+	return 0, false
 }

--- a/cmd/worker/error_classify_test.go
+++ b/cmd/worker/error_classify_test.go
@@ -263,6 +263,21 @@ func TestClassifyBAMLError(t *testing.T) {
 			wantDetails: "",
 		},
 		{
+			// BAML v0.214's types/response.rs:159 emits this generic
+			// anyhow!() string for the LLMResponse::Success-with-no-
+			// parsed-result case. The underlying parse-failure details
+			// are already discarded by the time the FFI sees this, so
+			// there's no `Parsing error: ` substring to anchor on.
+			// Classifying this as parse_error would conflate baml-rest/
+			// BAML internal fallbacks with prompt-output parse failures
+			// (the #245 taxonomy goal explicitly separates the two), so
+			// it falls through to worker_error.
+			name:        "BAML v0.214 generic no-result fallback is not classified",
+			err:         errors.New("This should never happen - Please report this error to our team with BAML_LOG=info enabled so we can improve this error message"),
+			wantCode:    "",
+			wantDetails: "",
+		},
+		{
 			name:        "broad Failed to parse outside Parsing error envelope falls through",
 			err:         errors.New("Failed to parse LLM response: not a JSON envelope"),
 			wantCode:    "",

--- a/cmd/worker/error_classify_test.go
+++ b/cmd/worker/error_classify_test.go
@@ -146,6 +146,27 @@ func TestClassifyBAMLError(t *testing.T) {
 			wantDetails: "",
 		},
 		{
+			// Pins the first-line-only marker contract: an LLM-client-
+			// prefixed envelope whose first line lacks the recognized
+			// status marker must NOT be classified just because the
+			// later message body happens to contain the marker phrase
+			// verbatim. Without first-line scoping, the body's
+			// "failed with status code: ServerError (500)" would
+			// satisfy the Index check and leak provider_error.
+			name:        "legacy unknown envelope with status marker in body falls through",
+			err:         errors.New("LLM client \"X\" generic-unknown-prefix\nMessage: failed with status code: ServerError (500)\nDetails: ..."),
+			wantCode:    "",
+			wantDetails: "",
+		},
+		{
+			// Same contract for the timeout marker — body text can't
+			// promote an unknown first-line envelope to provider_error.
+			name:        "legacy unknown envelope with timeout marker in body falls through",
+			err:         errors.New("LLM client \"X\" generic-unknown-prefix\nMessage: timed out: 30s elapsed before first byte"),
+			wantCode:    "",
+			wantDetails: "",
+		},
+		{
 			name:        "legacy LLM client timed out",
 			err:         errors.New(`LLM client "GPT4o" timed out: deadline exceeded after 30s`),
 			wantCode:    string(apierror.CodeProviderError),

--- a/cmd/worker/error_classify_test.go
+++ b/cmd/worker/error_classify_test.go
@@ -16,6 +16,12 @@ import (
 // FFI strings. Unrecognized errors must fall through to ("", nil) so
 // the host's residual classifyWorkerError keeps owning them with the
 // worker_error default.
+//
+// provider_error details forward what baml-rest has from the failed
+// upstream: the HTTP status when known, the raw body, and the BAML
+// client name on legacy envelopes. Empty fields are omitted so the
+// envelope stays terse — assertions below use full-string equality
+// against the marshaled JSON to pin field ordering and omission.
 func TestClassifyBAMLError(t *testing.T) {
 	t.Parallel()
 
@@ -44,16 +50,24 @@ func TestClassifyBAMLError(t *testing.T) {
 			wantDetails: "",
 		},
 		{
-			name:        "HTTPError 429",
+			name:        "HTTPError 429 forwards body",
 			err:         &llmhttp.HTTPError{StatusCode: 429, Body: "rate limit"},
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: `{"status_code":429}`,
+			wantDetails: `{"status_code":429,"body":"rate limit"}`,
 		},
 		{
-			name:        "HTTPError 503 wrapped",
+			name:        "HTTPError 503 wrapped forwards body",
 			err:         fmt.Errorf("buildrequest: %w", &llmhttp.HTTPError{StatusCode: 503, Body: "upstream down"}),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: `{"status_code":503}`,
+			wantDetails: `{"status_code":503,"body":"upstream down"}`,
+		},
+		{
+			// Pins the omitempty contract for the BuildRequest arm:
+			// callers with no body get just status_code.
+			name:        "HTTPError with empty body omits body field",
+			err:         &llmhttp.HTTPError{StatusCode: 418},
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: `{"status_code":418}`,
 		},
 		{
 			name:        "transport flake wrapped",
@@ -71,65 +85,73 @@ func TestClassifyBAMLError(t *testing.T) {
 			// BAML v0.219 ClientHttpError envelope (engine/baml-runtime/
 			// internal/llm_client/mod.rs ErrorCode::Display renders the
 			// named enum followed by parenthesized digits, with the
-			// provider body appended after "\nMessage:").
-			name:        "legacy v0.219 ServerError envelope",
+			// provider body appended after "\nMessage:"). The full
+			// body and client name now ride along with status_code.
+			name:        "legacy v0.219 ServerError envelope forwards body and client_name",
 			err:         errors.New("LLM client \"GPT4o\" failed with status code: ServerError (500)\nMessage: Internal Server Error"),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: `{"status_code":500}`,
+			wantDetails: `{"status_code":500,"body":"Message: Internal Server Error","client_name":"GPT4o"}`,
 		},
 		{
-			name:        "legacy v0.219 RateLimited envelope",
+			name:        "legacy v0.219 RateLimited envelope forwards body and client_name",
 			err:         errors.New("LLM client \"Claude\" failed with status code: RateLimited (429)\nMessage: Too Many Requests"),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: `{"status_code":429}`,
+			wantDetails: `{"status_code":429,"body":"Message: Too Many Requests","client_name":"Claude"}`,
 		},
 		{
-			name:        "legacy v0.219 ServiceUnavailable envelope",
+			name:        "legacy v0.219 ServiceUnavailable envelope forwards body and client_name",
 			err:         errors.New("LLM client \"GPT4o\" failed with status code: ServiceUnavailable (503)\nMessage: upstream down"),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: `{"status_code":503}`,
+			wantDetails: `{"status_code":503,"body":"Message: upstream down","client_name":"GPT4o"}`,
 		},
 		{
-			name:        "legacy v0.219 InvalidAuthentication envelope",
+			name:        "legacy v0.219 InvalidAuthentication envelope forwards body and client_name",
 			err:         errors.New("LLM client \"GPT4o\" failed with status code: InvalidAuthentication (401)\nMessage: bad api key"),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: `{"status_code":401}`,
+			wantDetails: `{"status_code":401,"body":"Message: bad api key","client_name":"GPT4o"}`,
 		},
 		{
-			name:        "legacy v0.219 Unspecified error code envelope",
+			name:        "legacy v0.219 Unspecified error code envelope forwards body and client_name",
 			err:         errors.New("LLM client \"GPT4o\" failed with status code: Unspecified error code: 418\nMessage: I'm a teapot"),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: `{"status_code":418}`,
+			wantDetails: `{"status_code":418,"body":"Message: I'm a teapot","client_name":"GPT4o"}`,
 		},
 		{
-			name:        "legacy v0.219 BadResponse envelope",
+			name:        "legacy v0.219 BadResponse envelope forwards body and client_name",
 			err:         errors.New("LLM client \"GPT4o\" failed with status code: BadResponse 599\nMessage: garbled response"),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: `{"status_code":599}`,
+			wantDetails: `{"status_code":599,"body":"Message: garbled response","client_name":"GPT4o"}`,
 		},
 		{
 			// Bare-leading-digits form is kept for compatibility with
 			// earlier BAML versions (and any future revert). Hand-built
 			// or wrapped messages that match this shape continue to parse.
-			name:        "legacy bare-digits compatibility form",
+			// No "\nMessage:" suffix here → body is omitted; client_name
+			// still rides along.
+			name:        "legacy bare-digits compatibility form omits empty body",
 			err:         errors.New(`LLM client "Old" failed with status code: 503 (upstream body: <html>)`),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: `{"status_code":503}`,
+			wantDetails: `{"status_code":503,"client_name":"Old"}`,
 		},
 		{
-			name:        "legacy LLM client failed with unparseable status segment",
+			// Status segment unparseable, single-line envelope → body
+			// stays omitted, status_code dropped, client_name preserved.
+			// Failed-closed: still provider_error, never falls through
+			// to worker_error.
+			name:        "legacy LLM client failed with unparseable status segment keeps client_name",
 			err:         errors.New(`LLM client "X" failed with status code: nope`),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: "",
+			wantDetails: `{"client_name":"X"}`,
 		},
 		{
 			// Digits inside the trailing Message body must NOT leak into
 			// the status_code detail when the enum segment itself has no
-			// recognized digits.
-			name:        "legacy unparseable enum segment ignores Message digits",
+			// recognized digits. The body and client_name still ride
+			// along as provider context.
+			name:        "legacy unparseable enum segment forwards body without status_code",
 			err:         errors.New("LLM client \"X\" failed with status code: SomeNewEnum\nMessage: error 12345 from upstream"),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: "",
+			wantDetails: `{"body":"Message: error 12345 from upstream","client_name":"X"}`,
 		},
 		{
 			// Pins the defensive contract: a future/unrecognized BAML
@@ -143,7 +165,7 @@ func TestClassifyBAMLError(t *testing.T) {
 			name:        "legacy unrecognized enum name with parens does not leak status_code",
 			err:         errors.New("LLM client \"X\" failed with status code: SomeNewEnum (599)\nMessage: who knows"),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: "",
+			wantDetails: `{"body":"Message: who knows","client_name":"X"}`,
 		},
 		{
 			// Pins the first-line-only marker contract: an LLM-client-
@@ -167,10 +189,23 @@ func TestClassifyBAMLError(t *testing.T) {
 			wantDetails: "",
 		},
 		{
-			name:        "legacy LLM client timed out",
+			// Timeout envelope is single-line per BAML's Display impl
+			// (errors.rs:114), so body is empty; client_name still
+			// surfaces. No status_code on timeout (no HTTP response).
+			name:        "legacy LLM client timed out forwards client_name",
 			err:         errors.New(`LLM client "GPT4o" timed out: deadline exceeded after 30s`),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: "",
+			wantDetails: `{"client_name":"GPT4o"}`,
+		},
+		{
+			// Multi-line future-shape timeout envelope: body forwarded
+			// alongside client_name even though BAML doesn't currently
+			// emit one. Mirrors the status-arm body extraction so the
+			// two arms stay symmetric.
+			name:        "legacy timeout with trailing body forwards both",
+			err:         errors.New("LLM client \"GPT4o\" timed out: deadline\nDetails: 30s deadline"),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: `{"body":"Details: 30s deadline","client_name":"GPT4o"}`,
 		},
 		{
 			name:        "untyped unrelated error falls through",

--- a/cmd/worker/error_classify_test.go
+++ b/cmd/worker/error_classify_test.go
@@ -68,20 +68,66 @@ func TestClassifyBAMLError(t *testing.T) {
 			wantDetails: "",
 		},
 		{
-			name:        "legacy LLM client failed with status code parsed",
-			err:         errors.New(`LLM client "GPT4o" failed with status code: 503 (upstream body: <html>)`),
+			// BAML v0.219 ClientHttpError envelope (engine/baml-runtime/
+			// internal/llm_client/mod.rs ErrorCode::Display renders the
+			// named enum followed by parenthesized digits, with the
+			// provider body appended after "\nMessage:").
+			name:        "legacy v0.219 ServerError envelope",
+			err:         errors.New("LLM client \"GPT4o\" failed with status code: ServerError (500)\nMessage: Internal Server Error"),
 			wantCode:    string(apierror.CodeProviderError),
-			wantDetails: `{"status_code":503}`,
+			wantDetails: `{"status_code":500}`,
 		},
 		{
-			name:        "legacy LLM client failed with status code 429",
-			err:         errors.New(`LLM client "Claude" failed with status code: 429`),
+			name:        "legacy v0.219 RateLimited envelope",
+			err:         errors.New("LLM client \"Claude\" failed with status code: RateLimited (429)\nMessage: Too Many Requests"),
 			wantCode:    string(apierror.CodeProviderError),
 			wantDetails: `{"status_code":429}`,
 		},
 		{
-			name:        "legacy LLM client failed with status code unparseable",
+			name:        "legacy v0.219 ServiceUnavailable envelope",
+			err:         errors.New("LLM client \"GPT4o\" failed with status code: ServiceUnavailable (503)\nMessage: upstream down"),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: `{"status_code":503}`,
+		},
+		{
+			name:        "legacy v0.219 InvalidAuthentication envelope",
+			err:         errors.New("LLM client \"GPT4o\" failed with status code: InvalidAuthentication (401)\nMessage: bad api key"),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: `{"status_code":401}`,
+		},
+		{
+			name:        "legacy v0.219 Unspecified error code envelope",
+			err:         errors.New("LLM client \"GPT4o\" failed with status code: Unspecified error code: 418\nMessage: I'm a teapot"),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: `{"status_code":418}`,
+		},
+		{
+			name:        "legacy v0.219 BadResponse envelope",
+			err:         errors.New("LLM client \"GPT4o\" failed with status code: BadResponse 599\nMessage: garbled response"),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: `{"status_code":599}`,
+		},
+		{
+			// Bare-leading-digits form is kept for compatibility with
+			// earlier BAML versions (and any future revert). Hand-built
+			// or wrapped messages that match this shape continue to parse.
+			name:        "legacy bare-digits compatibility form",
+			err:         errors.New(`LLM client "Old" failed with status code: 503 (upstream body: <html>)`),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: `{"status_code":503}`,
+		},
+		{
+			name:        "legacy LLM client failed with unparseable status segment",
 			err:         errors.New(`LLM client "X" failed with status code: nope`),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: "",
+		},
+		{
+			// Digits inside the trailing Message body must NOT leak into
+			// the status_code detail when the enum segment itself has no
+			// recognized digits.
+			name:        "legacy unparseable enum segment ignores Message digits",
+			err:         errors.New("LLM client \"X\" failed with status code: SomeNewEnum\nMessage: error 12345 from upstream"),
 			wantCode:    string(apierror.CodeProviderError),
 			wantDetails: "",
 		},
@@ -164,9 +210,10 @@ func TestClassifyBAMLErrorTypedBeforeLegacy(t *testing.T) {
 	t.Parallel()
 
 	// fmt.Errorf's %w prepends to the chain's Error() string, so msg
-	// starts with the legacy LLM-client prefix and matches 599, but the
+	// starts with the legacy LLM-client prefix and would parse a 599
+	// from the parenthesized v0.219-shape enum segment, but the
 	// wrapped *HTTPError carries the authoritative 404.
-	err := fmt.Errorf(`LLM client "X" failed with status code: 599: %w`, &llmhttp.HTTPError{StatusCode: 404})
+	err := fmt.Errorf("LLM client \"X\" failed with status code: ServerError (599): %w", &llmhttp.HTTPError{StatusCode: 404})
 	code, details := classifyBAMLError(err)
 	if code != string(apierror.CodeProviderError) {
 		t.Fatalf("code: got %q, want provider_error", code)

--- a/cmd/worker/error_classify_test.go
+++ b/cmd/worker/error_classify_test.go
@@ -132,6 +132,20 @@ func TestClassifyBAMLError(t *testing.T) {
 			wantDetails: "",
 		},
 		{
+			// Pins the defensive contract: a future/unrecognized BAML
+			// enum display that happens to use the same `Name (NNN)`
+			// shape must NOT match the parenthesized branch and leak
+			// the wrong status code. Go regexp distributes `^` only to
+			// the first alternative; wrapping the alternation in a
+			// non-capturing group plus an explicit enum allowlist is
+			// what enforces this — without it, this case would parse
+			// 599 and mislabel an unknown variant.
+			name:        "legacy unrecognized enum name with parens does not leak status_code",
+			err:         errors.New("LLM client \"X\" failed with status code: SomeNewEnum (599)\nMessage: who knows"),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: "",
+		},
+		{
 			name:        "legacy LLM client timed out",
 			err:         errors.New(`LLM client "GPT4o" timed out: deadline exceeded after 30s`),
 			wantCode:    string(apierror.CodeProviderError),

--- a/cmd/worker/error_classify_test.go
+++ b/cmd/worker/error_classify_test.go
@@ -189,6 +189,49 @@ func TestClassifyBAMLError(t *testing.T) {
 			wantDetails: "",
 		},
 		{
+			// Pins the post-quote-anchor contract: the status marker
+			// must begin immediately at the closing client-name quote,
+			// not anywhere within firstLine. Here the first `"` ends a
+			// weird client name ("weird-name") followed by extraneous
+			// text, and a LATER `"` happens to be followed by the
+			// marker. A whole-line Index search would classify this as
+			// provider_error with status_code=500; the anchored
+			// HasPrefix must reject it.
+			name:        "legacy status marker after extraneous post-quote text falls through",
+			err:         errors.New("LLM client \"weird-name\" extra stuff\" failed with status code: ServerError (500)\nMessage: not the real envelope"),
+			wantCode:    "",
+			wantDetails: "",
+		},
+		{
+			// Same contract for the timeout marker — extraneous text
+			// after the first closing quote must prevent classification
+			// even when a later embedded `"` is followed by the timeout
+			// marker substring.
+			name:        "legacy timeout marker after extraneous post-quote text falls through",
+			err:         errors.New("LLM client \"weird-name\" extra stuff\" timed out: 30s deadline"),
+			wantCode:    "",
+			wantDetails: "",
+		},
+		{
+			// Empty client name (a malformed BAML envelope) — even
+			// though the suffix immediately after the empty-name quote
+			// matches the status marker, the helper bails on q==0 so
+			// the classifier falls closed. Without this, baml-rest
+			// would emit provider_error with no client_name and a
+			// status pulled from an envelope shape that BAML doesn't
+			// actually produce.
+			name:        "legacy empty client name with status marker falls through",
+			err:         errors.New("LLM client \"\" failed with status code: ServerError (500)\nMessage: ..."),
+			wantCode:    "",
+			wantDetails: "",
+		},
+		{
+			name:        "legacy empty client name with timeout marker falls through",
+			err:         errors.New("LLM client \"\" timed out: 30s"),
+			wantCode:    "",
+			wantDetails: "",
+		},
+		{
 			// Timeout envelope is single-line per BAML's Display impl
 			// (errors.rs:114), so body is empty; client_name still
 			// surfaces. No status_code on timeout (no HTTP response).

--- a/cmd/worker/error_classify_test.go
+++ b/cmd/worker/error_classify_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 // TestClassifyBAMLError pins the worker-side error → code mapping for
-// the typed BuildRequest surfaces this PR wires through. Untyped /
-// legacy errors must fall through to ("", nil) so the host's residual
-// classifyWorkerError keeps owning them; PR 3 of #245 adds conservative
-// string-prefix matching at the same boundary.
+// both typed BuildRequest surfaces and the legacy CallStream+OnTick
+// FFI strings. Unrecognized errors must fall through to ("", nil) so
+// the host's residual classifyWorkerError keeps owning them with the
+// worker_error default.
 func TestClassifyBAMLError(t *testing.T) {
 	t.Parallel()
 
@@ -62,14 +62,56 @@ func TestClassifyBAMLError(t *testing.T) {
 			wantDetails: "",
 		},
 		{
-			name:        "untyped error",
+			name:        "legacy Parsing error prefix",
+			err:         errors.New("Parsing error: Failed to parse LLM response: missing field"),
+			wantCode:    string(apierror.CodeParseError),
+			wantDetails: "",
+		},
+		{
+			name:        "legacy LLM client failed with status code parsed",
+			err:         errors.New(`LLM client "GPT4o" failed with status code: 503 (upstream body: <html>)`),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: `{"status_code":503}`,
+		},
+		{
+			name:        "legacy LLM client failed with status code 429",
+			err:         errors.New(`LLM client "Claude" failed with status code: 429`),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: `{"status_code":429}`,
+		},
+		{
+			name:        "legacy LLM client failed with status code unparseable",
+			err:         errors.New(`LLM client "X" failed with status code: nope`),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: "",
+		},
+		{
+			name:        "legacy LLM client timed out",
+			err:         errors.New(`LLM client "GPT4o" timed out: deadline exceeded after 30s`),
+			wantCode:    string(apierror.CodeProviderError),
+			wantDetails: "",
+		},
+		{
+			name:        "untyped unrelated error falls through",
 			err:         errors.New("some other bug"),
 			wantCode:    "",
 			wantDetails: "",
 		},
 		{
-			name:        "untyped LLM-shaped string is not classified",
-			err:         errors.New(`LLM client "X" failed with status code: 500`),
+			name:        "BAML Internal Failure is not classified",
+			err:         errors.New("Internal Failure: BAML runtime panic"),
+			wantCode:    "",
+			wantDetails: "",
+		},
+		{
+			name:        "broad Failed to parse outside Parsing error envelope falls through",
+			err:         errors.New("Failed to parse LLM response: not a JSON envelope"),
+			wantCode:    "",
+			wantDetails: "",
+		},
+		{
+			name:        "LLM client prefix without recognized marker falls through",
+			err:         errors.New(`LLM client "X" exploded for unknown reasons`),
 			wantCode:    "",
 			wantDetails: "",
 		},
@@ -108,5 +150,28 @@ func TestClassifyBAMLErrorHTTPErrorPrefersInnermost(t *testing.T) {
 	}
 	if !strings.Contains(string(details), `"status_code":418`) {
 		t.Fatalf("details missing status_code 418: %s", string(details))
+	}
+}
+
+// TestClassifyBAMLErrorTypedBeforeLegacy pins the resolution order:
+// typed surfaces win over the legacy string classifier. A wrapper
+// chain whose top-level Error() matches the legacy prefix while
+// carrying a typed *llmhttp.HTTPError inside must emit the typed
+// StatusCode, not the prefix-parsed one — otherwise a future call site
+// that surfaces both shapes simultaneously would lose typed status_code
+// fidelity to a string scrape.
+func TestClassifyBAMLErrorTypedBeforeLegacy(t *testing.T) {
+	t.Parallel()
+
+	// fmt.Errorf's %w prepends to the chain's Error() string, so msg
+	// starts with the legacy LLM-client prefix and matches 599, but the
+	// wrapped *HTTPError carries the authoritative 404.
+	err := fmt.Errorf(`LLM client "X" failed with status code: 599: %w`, &llmhttp.HTTPError{StatusCode: 404})
+	code, details := classifyBAMLError(err)
+	if code != string(apierror.CodeProviderError) {
+		t.Fatalf("code: got %q, want provider_error", code)
+	}
+	if got := string(details); !strings.Contains(got, `"status_code":404`) {
+		t.Fatalf("typed status_code 404 must win over legacy-parsed 599; got %s", got)
 	}
 }

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -702,28 +702,26 @@ func TestBridgeStreamResultsClassifiesOutputParseError(t *testing.T) {
 	}
 }
 
-// TestBridgeStreamResultsClassifiesHTTPError pins that an upstream
-// non-2xx response surfaces as provider_error with details.status_code,
-// so consumers can branch on the upstream HTTP status without parsing
-// free-form error text. Also pins the negative: the HTTP response body
-// (which can echo back partial prompts, PII, or large diagnostic
-// payloads) must NOT ride along in the structured details surface.
-// classifyBAMLError deliberately marshals only the status_code field;
-// this test fails closed if a future refactor widens that surface.
-func TestBridgeStreamResultsClassifiesHTTPError(t *testing.T) {
+// TestBridgeStreamResultsClassifiesHTTPError_ForwardsBody pins that an
+// upstream non-2xx response surfaces as provider_error with both
+// details.status_code (so consumers can branch without parsing free-
+// form error text) and details.body (so the operator running baml-rest
+// — who is the consumer of these details — has the upstream payload
+// for debugging). Body forwarding is policy-on-by-default: baml-rest is
+// a developer tool and the operator owns any downstream decisions
+// about the body.
+func TestBridgeStreamResultsClassifiesHTTPError_ForwardsBody(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	const bodySentinel = "rate limit: prompt echo sentinel"
+	const bodySentinel = "rate limit: distinctive body sentinel"
 
 	in := make(chan bamlutils.StreamResult, 1)
 	fake := newFakeStreamResult(bamlutils.StreamResultKindError)
-	// Non-empty Body so the omission assertion below actively proves
-	// the bridge dropped it, rather than passing vacuously on an empty
-	// body input. The sentinel string is distinctive enough that any
-	// accidental forwarding would be unambiguous.
+	// Distinctive sentinel proves the body specifically (not just any
+	// JSON field) survived the bridge.
 	fake.err = &llmhttp.HTTPError{StatusCode: 429, Body: bodySentinel}
 	in <- fake
 	close(in)
@@ -742,8 +740,8 @@ func TestBridgeStreamResultsClassifiesHTTPError(t *testing.T) {
 		if !strings.Contains(string(got.ErrorDetails), `"status_code":429`) {
 			t.Errorf("expected ErrorDetails to carry status_code=429, got %q", string(got.ErrorDetails))
 		}
-		if strings.Contains(string(got.ErrorDetails), bodySentinel) {
-			t.Errorf("ErrorDetails must not leak the upstream HTTP body; got %q", string(got.ErrorDetails))
+		if !strings.Contains(string(got.ErrorDetails), bodySentinel) {
+			t.Errorf("ErrorDetails must forward the upstream HTTP body; got %q", string(got.ErrorDetails))
 		}
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("timed out waiting for bridged provider_error result")

--- a/integration/error_taxonomy_test.go
+++ b/integration/error_taxonomy_test.go
@@ -1,0 +1,216 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// These tests pin the legacy CallStream+OnTick path's conservative
+// string-prefix classifier end-to-end. The classifier itself is a
+// fall-through inside cmd/worker.classifyBAMLError that only fires
+// when no typed BuildRequest surface matched — so on the
+// BuildRequest-mode CI leg these tests would silently validate PR 2's
+// typed branch instead of the new prefix arms. forcing legacy mode via
+// BAML_REST_USE_BUILD_REQUEST=false (consumed by TestMain into the
+// shared TestEnv) is the only way to actually exercise the new code.
+//
+// The unit tests in cmd/worker/error_classify_test.go cover the prefix
+// matrix in isolation; these integration tests verify the wiring from
+// BAML's FFI string through the worker bridge to the HTTP envelope's
+// code / details fields.
+
+// requireLegacyMode skips the calling test when the shared TestEnv is
+// running BuildRequest. Mirrors the existing TestLegacyMode_* pattern
+// in roundrobin_overrides_test.go.
+func requireLegacyMode(t *testing.T) {
+	t.Helper()
+	if ActuallyBuildRequest() {
+		t.Skip("legacy classifier test; requires BAML_REST_USE_BUILD_REQUEST=false")
+	}
+}
+
+// TestLegacyClassification_ParseErrorFromProse pins that when the LLM
+// returns prose with no parseable JSON envelope, the legacy path's
+// "Parsing error: " prefix is classified as parse_error rather than
+// the worker_error default. This is the prompt-not-doing-its-job case
+// from the brief — the most common reason a /call request fails on a
+// schema'd method.
+func TestLegacyClassification_ParseErrorFromProse(t *testing.T) {
+	requireLegacyMode(t)
+	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Non-streaming, no failure mode — the upstream returns 200 with
+		// prose content. BAML's ValidationError fires post-LLM when it
+		// can't coerce the prose into the Person schema.
+		opts := setupNonStreamingScenario(t, "legacy-parse-error-prose",
+			"I think the person you're asking about is probably John, but I'm not totally sure about the details.")
+
+		resp, err := client.Call(ctx, testutil.CallRequest{
+			Method:  "GetPerson",
+			Input:   map[string]any{"description": "John Doe, 30, developer"},
+			Options: opts,
+		})
+		if err != nil {
+			t.Fatalf("Call failed: %v", err)
+		}
+
+		if resp.StatusCode != 500 {
+			t.Fatalf("expected status 500, got %d: %s", resp.StatusCode, resp.Error)
+		}
+		if resp.ErrorCode != "parse_error" {
+			t.Errorf("ErrorCode: got %q, want parse_error (legacy classifier didn't engage); body=%s",
+				resp.ErrorCode, resp.Error)
+		}
+		// Sanity check the underlying message survives so consumers
+		// branching on Error text still get the BAML envelope.
+		if !strings.Contains(resp.Error, "Parsing error:") {
+			t.Errorf("Error message lost the 'Parsing error:' envelope: %q", resp.Error)
+		}
+	})
+}
+
+// TestLegacyClassification_ParseErrorFromProseCallWithRaw mirrors the
+// /call case for /call-with-raw — same code path, but the response
+// envelope is otherwise different on success. Pins that the error
+// branch shares the classifier wiring.
+func TestLegacyClassification_ParseErrorFromProseCallWithRaw(t *testing.T) {
+	requireLegacyMode(t)
+	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		opts := setupNonStreamingScenario(t, "legacy-parse-error-prose-raw",
+			"Apologies — I cannot answer that without more context.")
+
+		resp, err := client.CallWithRaw(ctx, testutil.CallRequest{
+			Method:  "GetPerson",
+			Input:   map[string]any{"description": "Jane Doe"},
+			Options: opts,
+		})
+		if err != nil {
+			t.Fatalf("CallWithRaw failed: %v", err)
+		}
+
+		if resp.StatusCode != 500 {
+			t.Fatalf("expected status 500, got %d: %s", resp.StatusCode, resp.Error)
+		}
+		if resp.ErrorCode != "parse_error" {
+			t.Errorf("ErrorCode: got %q, want parse_error; body=%s", resp.ErrorCode, resp.Error)
+		}
+	})
+}
+
+// TestLegacyClassification_ProviderHTTPError pins that an upstream
+// non-2xx HTTP response becomes provider_error and that the
+// status_code detail is parsed from BAML's
+// `LLM client "X" failed with status code: NNN` envelope.
+//
+// Uses a single-leaf TestClient so there's no fallback retry — the
+// provider error reaches the bridge directly. mockllm's
+// FailAfter=1+FailureMode="500" returns HTTP 500 before any body, so
+// BAML's ClientHttpError display path fires.
+func TestLegacyClassification_ProviderHTTPError(t *testing.T) {
+	requireLegacyMode(t)
+	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		waitForHealthy(t, 30*time.Second)
+		scenarioID := "legacy-provider-error-500"
+
+		scenario := &mockllm.Scenario{
+			ID:          scenarioID,
+			Provider:    "openai",
+			Content:     "should not see this",
+			FailAfter:   1,
+			FailureMode: "500",
+		}
+		registerCtx, registerCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer registerCancel()
+		if err := MockClient.RegisterScenario(registerCtx, scenario); err != nil {
+			t.Fatalf("RegisterScenario: %v", err)
+		}
+
+		opts := &testutil.BAMLOptions{
+			ClientRegistry: testutil.CreateTestClient(TestEnv.MockLLMInternal, scenarioID),
+		}
+
+		resp, err := client.Call(ctx, testutil.CallRequest{
+			Method:  "GetGreeting",
+			Input:   map[string]any{"name": "World"},
+			Options: opts,
+		})
+		if err != nil {
+			t.Fatalf("Call failed: %v", err)
+		}
+
+		if resp.StatusCode != 500 {
+			t.Fatalf("expected status 500 (host wraps provider failures); got %d: %s",
+				resp.StatusCode, resp.Error)
+		}
+		if resp.ErrorCode != "provider_error" {
+			t.Fatalf("ErrorCode: got %q, want provider_error (legacy classifier didn't match the LLM-client prefix); body=%s",
+				resp.ErrorCode, resp.Error)
+		}
+
+		// Status code extraction is best-effort; pinning it here ensures
+		// the prefix parser stays in sync with BAML's envelope when the
+		// runtime version bumps.
+		if len(resp.ErrorDetails) == 0 {
+			t.Fatalf("ErrorDetails missing — expected {\"status_code\":500}")
+		}
+		var details struct {
+			StatusCode int `json:"status_code"`
+		}
+		if err := json.Unmarshal(resp.ErrorDetails, &details); err != nil {
+			t.Fatalf("failed to unmarshal ErrorDetails %s: %v", resp.ErrorDetails, err)
+		}
+		if details.StatusCode != 500 {
+			t.Errorf("details.status_code: got %d, want 500 (raw details=%s)",
+				details.StatusCode, resp.ErrorDetails)
+		}
+	})
+}
+
+// TestLegacyClassification_ParseEndpointGarbage pins that /parse on a
+// garbage input also goes through the legacy classifier (via
+// cmd/worker.workerImpl.Parse) and emits parse_error from the
+// "Parsing error: " prefix. Without this, /parse-only consumers would
+// silently rely on cmd/serve/error.go's worker_error→parse_error
+// fallback rewrite for the same outcome — useful as back-compat, but
+// the classifier wiring is the contract this PR adds.
+func TestLegacyClassification_ParseEndpointGarbage(t *testing.T) {
+	requireLegacyMode(t)
+	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Garbage input — not even close to a Person envelope. BAML's
+		// validator returns "Parsing error: Failed to parse LLM
+		// response: ...".
+		resp, err := client.Parse(ctx, testutil.ParseRequest{
+			Method: "GetPerson",
+			Raw:    "this is just prose with no JSON anywhere",
+		})
+		if err != nil {
+			t.Fatalf("Parse failed: %v", err)
+		}
+
+		if resp.StatusCode != 500 {
+			t.Fatalf("expected status 500, got %d: %s", resp.StatusCode, resp.Error)
+		}
+		if resp.ErrorCode != "parse_error" {
+			t.Errorf("ErrorCode: got %q, want parse_error; body=%s", resp.ErrorCode, resp.Error)
+		}
+	})
+}

--- a/integration/error_taxonomy_test.go
+++ b/integration/error_taxonomy_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/goccy/go-json"
+	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/integration/mockllm"
 	"github.com/invakid404/baml-rest/integration/testutil"
 )
@@ -37,6 +38,33 @@ func requireLegacyMode(t *testing.T) {
 	}
 }
 
+// requireLegacyParseEnvelope skips the calling test when BAML's
+// runtime loses successful-response parse failures behind a generic
+// no-result fallback. On BAML v0.214,
+// types/response.rs::result_with_constraints_content returns a
+// terminal `This should never happen - Please report this error to
+// our team with BAML_LOG=info enabled so we can improve this error
+// message` anyhow!() string for the LLMResponse::Success-with-no-
+// parsed-result case — the underlying `Parsing error: ...` envelope
+// is already discarded, so there's nothing for the legacy classifier
+// to anchor on. v0.218 and later surface the stable validation-error
+// envelope. Tests that assert end-to-end on parse_error from a live
+// LLM call therefore require >= 0.218.
+//
+// Provider-error tests (TestLegacyClassification_ProviderHTTPError)
+// and the /parse-endpoint test (TestLegacyClassification_
+// ParseEndpointGarbage) don't go through
+// result_with_constraints_content — the former hits the LLMFailure
+// branch which still surfaces ClientHttpError on 0.214, and /parse
+// invokes BAML's parser directly on raw text rather than processing
+// an LLMResponse. Both keep running across the whole BAML matrix.
+func requireLegacyParseEnvelope(t *testing.T) {
+	t.Helper()
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.218.0") {
+		t.Skipf("requires BAML >= 0.218 for the stable `Parsing error:` envelope; got %s", BAMLVersion)
+	}
+}
+
 // TestLegacyClassification_ParseErrorFromProse pins that when the LLM
 // returns prose with no parseable JSON envelope, the legacy path's
 // "Parsing error: " prefix is classified as parse_error rather than
@@ -45,6 +73,7 @@ func requireLegacyMode(t *testing.T) {
 // schema'd method.
 func TestLegacyClassification_ParseErrorFromProse(t *testing.T) {
 	requireLegacyMode(t)
+	requireLegacyParseEnvelope(t)
 	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -85,6 +114,7 @@ func TestLegacyClassification_ParseErrorFromProse(t *testing.T) {
 // branch shares the classifier wiring.
 func TestLegacyClassification_ParseErrorFromProseCallWithRaw(t *testing.T) {
 	requireLegacyMode(t)
+	requireLegacyParseEnvelope(t)
 	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -127,11 +127,13 @@ func extractErrorMessageAndCode(body []byte) (string, string) {
 
 // extractErrorMessageCodeAndDetails extracts the error message, the
 // machine-readable code, and the raw "details" envelope from a JSON
-// error response body. Returns ("", "", nil) when the body isn't a
-// JSON error envelope. Existing call sites that only need the message
-// or message+code keep using the narrower helpers; tests that branch
-// on structured provider context (e.g. provider_error status_code)
-// reach for this one.
+// error response body. When the body is not a JSON error envelope,
+// returns the raw body as the message with empty code and nil details
+// — mirrors extractErrorMessageAndCode's raw-body fallback so callers
+// still surface something useful for malformed/non-envelope responses.
+// Existing call sites that only need the message or message+code keep
+// using the narrower helpers; tests that branch on structured provider
+// context (e.g. provider_error status_code) reach for this one.
 func extractErrorMessageCodeAndDetails(body []byte) (string, string, json.RawMessage) {
 	var errResp errorResponse
 	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error != "" {

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -98,9 +98,10 @@ func isTransientConnError(err error) bool {
 // free-form error text. Kept as a plain string to match the wire
 // representation; testutil does not depend on the apierror package.
 type errorResponse struct {
-	Error     string `json:"error"`
-	Code      string `json:"code,omitempty"`
-	RequestID string `json:"request_id,omitempty"`
+	Error     string          `json:"error"`
+	Code      string          `json:"code,omitempty"`
+	Details   json.RawMessage `json:"details,omitempty"`
+	RequestID string          `json:"request_id,omitempty"`
 }
 
 // extractErrorMessage extracts the error message from a JSON error response body.
@@ -122,6 +123,21 @@ func extractErrorMessageAndCode(body []byte) (string, string) {
 		return errResp.Error, errResp.Code
 	}
 	return string(body), ""
+}
+
+// extractErrorMessageCodeAndDetails extracts the error message, the
+// machine-readable code, and the raw "details" envelope from a JSON
+// error response body. Returns ("", "", nil) when the body isn't a
+// JSON error envelope. Existing call sites that only need the message
+// or message+code keep using the narrower helpers; tests that branch
+// on structured provider context (e.g. provider_error status_code)
+// reach for this one.
+func extractErrorMessageCodeAndDetails(body []byte) (string, string, json.RawMessage) {
+	var errResp errorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error != "" {
+		return errResp.Error, errResp.Code, errResp.Details
+	}
+	return string(body), "", nil
 }
 
 // BAMLRestClient is an HTTP client for testing baml-rest endpoints.
@@ -269,27 +285,30 @@ type DynamicEnumValue struct {
 // ErrorCode mirrors apierror.Response.Code on error paths (StatusCode >=
 // 400); populated when the server's error envelope carries a
 // machine-readable classification. Empty on success and on errors that
-// the server didn't tag with a code.
+// the server didn't tag with a code. ErrorDetails carries the raw JSON
+// "details" object when present (e.g. provider_error's status_code).
 type CallResponse struct {
-	StatusCode int
-	Headers    http.Header // Response headers — used for X-BAML-* assertions
-	Body       json.RawMessage
-	Error      string
-	ErrorCode  string
+	StatusCode   int
+	Headers      http.Header // Response headers — used for X-BAML-* assertions
+	Body         json.RawMessage
+	Error        string
+	ErrorCode    string
+	ErrorDetails json.RawMessage
 }
 
 // CallWithRawResponse represents a response from /call-with-raw endpoint.
 //
-// ErrorCode mirrors apierror.Response.Code on error paths; see
-// CallResponse.ErrorCode.
+// ErrorCode / ErrorDetails mirror apierror.Response.Code / .Details on
+// error paths; see CallResponse.ErrorCode.
 type CallWithRawResponse struct {
-	StatusCode int
-	Headers    http.Header     // Response headers — used for X-BAML-* assertions
-	Data       json.RawMessage `json:"data"`
-	Raw        string          `json:"raw"`
-	Reasoning  string          `json:"reasoning,omitempty"`
-	Error      string
-	ErrorCode  string
+	StatusCode   int
+	Headers      http.Header     // Response headers — used for X-BAML-* assertions
+	Data         json.RawMessage `json:"data"`
+	Raw          string          `json:"raw"`
+	Reasoning    string          `json:"reasoning,omitempty"`
+	Error        string
+	ErrorCode    string
+	ErrorDetails json.RawMessage
 }
 
 // Call executes a /call/{method} request.
@@ -311,7 +330,7 @@ func (c *BAMLRestClient) Call(ctx context.Context, req CallRequest) (*CallRespon
 	}
 
 	if resp.StatusCode >= 400 {
-		result.Error, result.ErrorCode = extractErrorMessageAndCode(respBody)
+		result.Error, result.ErrorCode, result.ErrorDetails = extractErrorMessageCodeAndDetails(respBody)
 	} else {
 		result.Body = respBody
 	}
@@ -338,7 +357,7 @@ func (c *BAMLRestClient) CallWithRaw(ctx context.Context, req CallRequest) (*Cal
 	}
 
 	if resp.StatusCode >= 400 {
-		result.Error, result.ErrorCode = extractErrorMessageAndCode(respBody)
+		result.Error, result.ErrorCode, result.ErrorDetails = extractErrorMessageCodeAndDetails(respBody)
 	} else {
 		if err := json.Unmarshal(respBody, result); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal response: %w", err)
@@ -577,13 +596,14 @@ type ParseRequest struct {
 
 // ParseResponse represents a response from /parse endpoint.
 //
-// ErrorCode mirrors apierror.Response.Code on error paths; see
-// CallResponse.ErrorCode.
+// ErrorCode / ErrorDetails mirror apierror.Response.Code / .Details on
+// error paths; see CallResponse.ErrorCode.
 type ParseResponse struct {
-	StatusCode int
-	Data       json.RawMessage
-	Error      string
-	ErrorCode  string
+	StatusCode   int
+	Data         json.RawMessage
+	Error        string
+	ErrorCode    string
+	ErrorDetails json.RawMessage
 }
 
 // Parse executes a /parse/{method} request.
@@ -605,7 +625,7 @@ func (c *BAMLRestClient) Parse(ctx context.Context, req ParseRequest) (*ParseRes
 	}
 
 	if resp.StatusCode >= 400 {
-		result.Error, result.ErrorCode = extractErrorMessageAndCode(respBody)
+		result.Error, result.ErrorCode, result.ErrorDetails = extractErrorMessageCodeAndDetails(respBody)
 	} else {
 		result.Data = respBody
 	}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

PR 3 of #245 — closes the error-taxonomy work. Adds the legacy `CallStream+OnTick` path's conservative string-prefix classifier and integration coverage forced through `BAML_REST_USE_BUILD_REQUEST=false`. PRs 1 (taxonomy plumbing, #246) and 2 (BuildRequest typed classification, #247) shipped already.

## What's included

- `classifyBAMLError` extension: exact-prefix matching against BAML's `Parsing error: ` / `LLM client "..." failed with status code: ` / `LLM client "..." timed out:` envelopes.
- Status-code extraction from the `failed with status code: NNN` form when parseable; provider_error with no details when not.
- `testutil.BAMLRestClient` exposes `ErrorDetails json.RawMessage` on `CallResponse` / `CallWithRawResponse` / `ParseResponse` so tests can branch on `provider_error`'s `status_code` without re-parsing raw bytes.
- Integration tests forced onto the legacy path (skip on `ActuallyBuildRequest()`):
  - prose-no-JSON via `/call` → `parse_error`.
  - prose-no-JSON via `/call-with-raw` → `parse_error`.
  - provider HTTP 500 via `/call` → `provider_error` with `details.status_code=500`.
  - `/parse` garbage → `parse_error`.
- Unit tests pin every legacy prefix branch (including unparseable status codes and the conservative fallthrough for `Internal Failure:`, bare LLM-client prefixes, and broad `Failed to parse:` outside the `Parsing error:` envelope).
- Resolution order pinned: typed surfaces win over the legacy string classifier.
- Multi-PR breadcrumb scrub (#245 only — #243's `PR1-bedrock` markers stay).

## What's NOT included (explicit scope cuts from #245)

- `validation_error` distinction (BAML FFI is string-only; defer until typed errors exist upstream).
- `provider_rate_limited` / `provider_unavailable` subcodes (single `provider_error` + `details.status_code` is enough for label-only purposes).
- Provider-timeout integration test (BAML's per-client request timeout isn't easily configurable from BAML options used in the integration harness; unit test covers the prefix).
- Unmatched-fallthrough integration test (no reliable way to provoke a non-prefixed BAML error from mockllm; unit test pins the conservative-classifier contract).
- `details.stacktrace` changes — kept as-is per scoping.

## Verification

- `go build ./...` / `go vet ./...` clean.
- `go test ./cmd/worker -count=1 -v -run 'ClassifyBAMLError|BridgeStreamResults|Parse'` — all green.
- `go test ./...` plus submodules (`./bamlutils/...`, `./pool/...`, `./workerplugin/...`, `./adapters/...`) — all green.
- `go test -tags=integration -run=^$ ./integration/` — compile clean.
- 9/9 verify-framework-adapter, 4/4 verify-adapter-pins.
- `rg -n '#245|PR [1-3] of #245' --type go` returns no hits.

Closes #245.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More conservative legacy error classification: only the first line is inspected, legacy prefixes map to parse vs provider errors, numeric HTTP status codes are safely extracted, and provider detail payloads omit empty fields. Upstream HTTP status and response body are forwarded when present.

* **Tests**
  * Added and expanded unit and integration tests to validate legacy formats, typed-error precedence, body forwarding, and end-to-end classification. Test client now captures structured error details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/248)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->