### PR TITLE
fix(schema): honor json:omitempty and json:"-" tags in the OpenAPI generator

### DIFF
--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -283,8 +283,15 @@ func (r *ClientRegistry) Validate() error {
 }
 
 type ClientProperty struct {
-	Name        string         `json:"name"`
-	Provider    string         `json:"provider"`
+	Name string `json:"name"`
+	// Provider's wire-level optionality is enforced by ClientProperty.MarshalJSON
+	// (an outer *string field with omitempty shadows this tag during marshal)
+	// and consumed by ClientProperty.UnmarshalJSON via a raw-key probe that
+	// populates ProviderSet. The tag carries omitempty so the schema
+	// generator, which reads struct tags, agrees with the actual wire
+	// contract: provider may be absent. See the field's three-state contract
+	// documented on ProviderSet/IsProviderPresent.
+	Provider    string         `json:"provider,omitempty"`
 	RetryPolicy *string        `json:"retry_policy"`
 	Options     map[string]any `json:"options,omitempty"`
 

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -374,53 +374,49 @@ func generateOpenAPISchema() *openapi3.T {
 					return err
 				}
 			} else {
-				// Handle required vs optional fields based on pointer types
+				// Honour json struct tags when computing required/nullable.
+				// The kin-openapi library parses tags internally, but this
+				// customizer overwrites its required-list, so we must
+				// reproduce the tag semantics here:
+				//   - json:"-"           → skip the field entirely.
+				//   - json:",omitempty"  → omit from required regardless of pointer-ness.
+				//   - pointer field      → optional + nullable at the property site.
+				//   - pointer slice elem → items nullable (runtime tolerates nil entries).
 				if t.Kind() == reflect.Struct {
-					var requiredFields []string
+					requiredFields := make([]string, 0)
 					for field := range t.Fields() {
-						// Skip unexported fields
 						if !field.IsExported() {
 							continue
 						}
 
-						// Get the JSON tag name, default to field name if no tag
-						jsonTag := field.Tag.Get("json")
-						fieldName := field.Name
-						if jsonTag != "" && jsonTag != "-" {
-							// Handle "name,omitempty" format
-							if parts := strings.Split(jsonTag, ","); len(parts) > 0 && parts[0] != "" {
-								fieldName = parts[0]
-							}
+						fieldName, omitEmpty, skip := parseJSONTag(field.Tag.Get("json"), field.Name)
+						if skip {
+							continue
 						}
 
-						// If field is not a pointer, it's required
-						if field.Type.Kind() != reflect.Ptr {
+						isPointer := field.Type.Kind() == reflect.Ptr
+						if !isPointer && !omitEmpty {
 							requiredFields = append(requiredFields, fieldName)
-						} else {
-							// Pointer fields are nullable - mark them in the schema
+						}
+
+						if isPointer {
 							if propSchema, ok := schema.Properties[fieldName]; ok {
-								if propSchema.Ref != "" && strings.HasPrefix(propSchema.Ref, "#/") {
-									// For proper $ref schemas (like #/components/schemas/Foo),
-									// wrap with allOf to add nullable without modifying the referenced schema
-									schema.Properties[fieldName] = &openapi3.SchemaRef{
-										Value: &openapi3.Schema{
-											Nullable: true,
-											AllOf: openapi3.SchemaRefs{
-												{Ref: propSchema.Ref},
-											},
-										},
-									}
-								} else if propSchema.Value != nil {
-									// For inline schemas, directly set nullable
-									propSchema.Value.Nullable = true
-								}
+								schema.Properties[fieldName] = makeNullableRef(propSchema)
+							}
+						}
+
+						// Pointer slice/array elements: []*T tolerates nil
+						// entries on the wire; reflect that in the schema.
+						if (field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Array) &&
+							field.Type.Elem().Kind() == reflect.Ptr {
+							if propSchema, ok := schema.Properties[fieldName]; ok &&
+								propSchema.Value != nil && propSchema.Value.Items != nil {
+								propSchema.Value.Items = makeNullableRef(propSchema.Value.Items)
 							}
 						}
 					}
 
-					if len(requiredFields) > 0 {
-						schema.Required = requiredFields
-					}
+					schema.Required = requiredFields
 				}
 
 				return nil
@@ -2112,6 +2108,56 @@ func boolPtr(b bool) *bool {
 
 func uint64Ptr(v uint64) *uint64 {
 	return &v
+}
+
+// parseJSONTag interprets a struct field's json tag and reports the
+// effective wire name, whether the `omitempty` option is set, and
+// whether the field should be skipped entirely (`json:"-"`). The tag
+// value `-,` (literal name "-") is treated as a normal name, matching
+// encoding/json semantics.
+func parseJSONTag(tag, fieldName string) (name string, omitEmpty, skip bool) {
+	if tag == "-" {
+		return "", false, true
+	}
+	name = fieldName
+	if tag == "" {
+		return
+	}
+	parts := strings.Split(tag, ",")
+	if parts[0] != "" {
+		name = parts[0]
+	}
+	for _, opt := range parts[1:] {
+		if opt == "omitempty" {
+			omitEmpty = true
+		}
+	}
+	return
+}
+
+// makeNullableRef returns a SchemaRef equivalent to ref but with
+// nullable semantics. For a $ref pointer this wraps the reference in
+// an `allOf` with `nullable: true` to avoid mutating the referenced
+// component; for an inline schema it sets Nullable on the inline value
+// in place. Idempotent when ref is already wrapped this way.
+func makeNullableRef(ref *openapi3.SchemaRef) *openapi3.SchemaRef {
+	if ref == nil {
+		return ref
+	}
+	if ref.Ref != "" && strings.HasPrefix(ref.Ref, "#/") {
+		return &openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				Nullable: true,
+				AllOf: openapi3.SchemaRefs{
+					{Ref: ref.Ref},
+				},
+			},
+		}
+	}
+	if ref.Value != nil {
+		ref.Value.Nullable = true
+	}
+	return ref
 }
 
 // registerSchema adds a schema to the schemas map and returns a $ref to it.

--- a/cmd/schema/main_test.go
+++ b/cmd/schema/main_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	baml_rest "github.com/invakid404/baml-rest"
+)
+
+// TestSchemaRequiredAndNullability pins the contract the schema customizer
+// is expected to honour for `json:omitempty`, `json:"-"`, and pointer-slice
+// elements.
+//
+// The bug fixed alongside this test: the customizer previously derived the
+// per-struct `required` list from pointer-ness only, ignoring tag options.
+// Fields like BamlOptions.IncludeReasoning (bool, omitempty) were emitted
+// as required, ClientProperty.ProviderSet (json:"-") leaked into required
+// despite having no property, and `[]*T` slice items lost their pointer
+// nullability. Each assertion below maps to one of those failure modes.
+func TestSchemaRequiredAndNullability(t *testing.T) {
+	baml_rest.InitBamlRuntime()
+	doc := generateOpenAPISchema()
+	if doc == nil || doc.Components == nil {
+		t.Fatalf("generated schema has no components")
+	}
+	schemas := doc.Components.Schemas
+
+	type assertion struct {
+		schema             string
+		mustNotRequire     []string
+		mustRequire        []string
+		nullableProperties []string
+	}
+	cases := []assertion{
+		{
+			schema:             "BamlOptions",
+			mustNotRequire:     []string{"include_reasoning", "client_registry", "retry", "type_builder"},
+			nullableProperties: []string{"client_registry", "type_builder", "retry"},
+		},
+		{
+			schema:      "ClientRegistry",
+			mustRequire: []string{"clients"},
+		},
+		{
+			schema:         "ClientProperty",
+			mustNotRequire: []string{"provider", "options", "ProviderSet", "retry_policy"},
+			mustRequire:    []string{"name"},
+		},
+		{
+			schema:         "RetryConfig",
+			mustNotRequire: []string{"strategy", "delay_ms", "multiplier", "max_delay_ms"},
+			mustRequire:    []string{"max_retries"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.schema, func(t *testing.T) {
+			ref, ok := schemas[tc.schema]
+			if !ok || ref == nil || ref.Value == nil {
+				t.Fatalf("schema %q not registered", tc.schema)
+			}
+			schema := ref.Value
+
+			for _, name := range tc.mustNotRequire {
+				if slices.Contains(schema.Required, name) {
+					t.Errorf("%s.required unexpectedly contains %q (required=%v)", tc.schema, name, schema.Required)
+				}
+				if _, hasProperty := schema.Properties[name]; !hasProperty && name == "ProviderSet" {
+					// json:"-" fields must be absent from properties entirely.
+					continue
+				}
+			}
+			for _, name := range tc.mustRequire {
+				if !slices.Contains(schema.Required, name) {
+					t.Errorf("%s.required missing %q (required=%v)", tc.schema, name, schema.Required)
+				}
+			}
+			for _, name := range tc.nullableProperties {
+				prop, ok := schema.Properties[name]
+				if !ok || prop == nil {
+					t.Errorf("%s.properties missing nullable property %q", tc.schema, name)
+					continue
+				}
+				if !isNullable(prop) {
+					t.Errorf("%s.%s expected nullable wrap", tc.schema, name)
+				}
+			}
+		})
+	}
+
+	t.Run("ClientProperty.ProviderSet absent from properties", func(t *testing.T) {
+		ref := schemas["ClientProperty"]
+		if _, present := ref.Value.Properties["ProviderSet"]; present {
+			t.Errorf("ClientProperty must skip json:\"-\" ProviderSet from properties")
+		}
+	})
+
+	t.Run("ClientRegistry.clients items nullable", func(t *testing.T) {
+		ref := schemas["ClientRegistry"]
+		clients, ok := ref.Value.Properties["clients"]
+		if !ok || clients == nil || clients.Value == nil || clients.Value.Items == nil {
+			t.Fatalf("ClientRegistry.clients missing items schema")
+		}
+		if !isNullable(clients.Value.Items) {
+			t.Errorf("ClientRegistry.clients.items expected nullable wrap (got %+v)", clients.Value.Items)
+		}
+	})
+}
+
+// isNullable reports whether a SchemaRef carries explicit nullability —
+// either inline Nullable=true on its value, or the allOf+nullable wrap
+// emitted for $ref pointers.
+func isNullable(ref *openapi3.SchemaRef) bool {
+	if ref == nil {
+		return false
+	}
+	if ref.Value != nil && ref.Value.Nullable {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Closes #249. Fixes a long-standing schema-generator bug at `cmd/schema/main.go` that ignored `json:omitempty` (emitting affected fields as `required`) and `json:"-"` (leaking the Go field name into the `required` list despite having no schema property). Pointer-slice elements (`[]*T`) now also emit `items.nullable: true` to match the runtime's tolerance of nil entries.

Surfaced when downstream consumers regenerated their TypeScript clients after PR #242's wire-field rename. The bug is **not** a regression from #242 — the rename simply forced regeneration which exposed the pre-existing quirk under a new property name (`include_thinking_in_raw` → `include_reasoning`).

## What's included

- `cmd/schema/main.go`: tag-aware required/nullability logic in the customizer.
  - `parseJSONTag` helper splits `(name, omitEmpty, skip)`.
  - `json:"-"` fields are skipped from properties *and* required.
  - `omitempty` fields are emitted as optional regardless of pointer-ness.
  - Pointer slice/array elements ([]*T) emit `items.nullable: true` via the same allOf+nullable wrap the customizer already uses for pointer `$ref` properties.
  - `schema.Required` is now set unconditionally (including when empty) so stale generator defaults can't survive.
- `bamlutils/interfaces.go`: `ClientProperty.Provider` tag adjusted from `json:"provider"` to `json:"provider,omitempty"`. The custom `MarshalJSON` already shadows this field with an outer `*string`+`omitempty` to preserve the three-state contract (absent / present-empty / present-non-empty); `UnmarshalJSON` still populates `ProviderSet` via a raw-map probe. `omitempty` is a marshal-only option, so unmarshal semantics are unchanged. The tag now agrees with the actual wire contract that the schema reads.
- `cmd/schema/main_test.go`: schema-regression test pinning the new optionality contract for `BamlOptions`, `ClientRegistry`, `ClientProperty`, and `RetryConfig`, plus explicit checks that `ProviderSet` (json:"-") is absent from properties and that `ClientRegistry.clients.items` is nullable.

## Affected fields (representative sample)

`required` entries that flip from required → optional after this fix:

- `BamlOptions.include_reasoning` (bool, omitempty)
- `ClientProperty.provider` (string, now omitempty)
- `ClientProperty.options` (map, omitempty)
- `ClientProperty.ProviderSet` (json:"-" — was leaking the Go field name)
- `RetryConfig.{strategy,delay_ms,multiplier,max_delay_ms}` (all omitempty)
- `DynamicClass.{description,alias,properties}`, `DynamicEnum.{description,alias,values}`, `DynamicEnumValue.{description,alias,skip}`, `DynamicProperty.{type,ref,description,alias,oneOf,value}`, `DynamicTypeSpec.{type,ref,oneOf,value}`, `DynamicTypes.{classes,enums}`, `TypeBuilder.baml_snippets` — all carry `omitempty` in Go and are now correctly optional.

Items-nullability additions (`[]*T` → `items: {allOf:[{$ref}], nullable: true}`):

- `ClientRegistry.clients`
- `DynamicEnum.values`
- `DynamicProperty.oneOf`
- `DynamicTypeSpec.oneOf`

Fields that stay required (sanity check that the fix isn't too aggressive): `ClientProperty.name`, `ClientRegistry.clients`, `RetryConfig.max_retries`.

## Impact on downstream consumers

Net-positive: fields that were always wrongly required are now correctly optional. Consumers who were always providing the fields keep working; those who want to omit can now do so. No breaking change to the runtime — the schema is being brought into alignment with the Go marshal/unmarshal behaviour that has always existed.

## Verification

- `go build ./...` clean.
- `go vet ./...` clean.
- `go test ./...` green, including the new `TestSchemaRequiredAndNullability`.
- `go run ./cmd/verify-framework-adapter`: 9/9 green.
- `go run ./cmd/verify-adapter-pins`: 4/4 green.
- `gofmt`: no new drift on touched files (pre-existing drift in `bamlutils/interfaces.go` Planned-fields comment alignment is unrelated to this PR).
- Regenerated schema diffed against current — confirmed only the expected required-list and items-nullable flips, no spurious changes.

Closes #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenAPI schema generation to accurately represent required and optional fields based on wire protocol behavior
  * Improved nullable type handling in generated API schemas

* **Tests**
  * Added comprehensive test coverage for schema generation and field requirement validation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/250)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->