### PR TITLE
chore: scrub bedrock breadcrumb comments (PR 4/4 of #243)

### DIFF
--- a/adapters/common/codegen/codegen_bedrock_test.go
+++ b/adapters/common/codegen/codegen_bedrock_test.go
@@ -20,7 +20,6 @@ import (
 // closure (buildBedrockStreamRequestFn) with
 // emitBedrockStreamPostProcess; this assertion guards the SSE
 // closure from accidentally inheriting AWS signing.
-// PR1-bedrock / PR3-bedrock-stream breadcrumb (#243).
 func TestEmitBAMLHTTPRequestConversion_NilPostProcess_NoBedrockAttach(t *testing.T) {
 	f := jen.NewFilePathName("github.com/example/test", "test")
 	f.Func().Id("emit").Params().Params(jen.Op("*").Id("Request"), jen.Error()).BlockFunc(func(g *jen.Group) {
@@ -47,7 +46,7 @@ func TestEmitBAMLHTTPRequestConversion_NilPostProcess_NoBedrockAttach(t *testing
 // with emitMaybeAttachBedrockAuth as postProcess (as the non-streaming
 // _buildCallRequest emit does), the generated body must contain the
 // MaybeAttachBedrockAuth call with the (ctx, req) argument shape and
-// must propagate any error returned by it. PR1-bedrock breadcrumb (#243).
+// must propagate any error returned by it.
 func TestEmitBAMLHTTPRequestConversion_BedrockPostProcess(t *testing.T) {
 	f := jen.NewFilePathName("github.com/example/test", "test")
 	f.Func().Id("emit").Params().Params(jen.Op("*").Id("Request"), jen.Error()).BlockFunc(func(g *jen.Group) {
@@ -165,9 +164,9 @@ func TestEmitBuildCallRequest_EmitsMaybeAttachBedrockAuth(t *testing.T) {
 	}
 }
 
-// TestEmitBuildRequest_EmitsBedrockStreamingClosure pins PR 3's
-// streaming-branch enablement (issue #243): when introspected.Request
-// is non-nil (v0.219), emitBuildRequest emits a
+// TestEmitBuildRequest_EmitsBedrockStreamingClosure pins the
+// streaming-branch enablement: when introspected.Request is non-nil
+// (v0.219), emitBuildRequest emits a
 // buildBedrockStreamRequestFn closure that calls BAML's non-streaming
 // Request.<Method>, mutates the URL to /converse-stream, sets the AWS
 // event-stream Accept header, and attaches AWSAuth. The closure is
@@ -198,8 +197,8 @@ func TestEmitBuildRequest_EmitsBedrockStreamingClosure(t *testing.T) {
 		t.Errorf("StreamConfig must wire BuildBedrockStreamRequest: buildBedrockStreamRequestFn; rendered:\n%s", rendered)
 	}
 	// The closure calls BAML's non-streaming Request.<Method>, not
-	// StreamRequest — BAML's StreamRequest errors for aws-bedrock per
-	// the upstream gate baml-rest works around with #243's scope cuts.
+	// StreamRequest — BAML's StreamRequest errors for aws-bedrock,
+	// which is the upstream gate baml-rest works around here.
 	// (jen renders the import as `bamlclient` — the imported package
 	// alias from GeneratedClientPkg.)
 	if !strings.Contains(rendered, "bamlclient.Request.GreetUser") {

--- a/adapters/common/codegen/codegen_buildrequest.go
+++ b/adapters/common/codegen/codegen_buildrequest.go
@@ -8,14 +8,13 @@ import (
 
 // emitMaybeAttachBedrockAuth emits the call-branch postProcess block
 // that hands the freshly-built *llmhttp.Request to
-// llmhttp.MaybeAttachBedrockAuth, returning early on error. The
-// helper is the URL-pattern attach hook from #243 PR 1: it no-ops on
-// non-bedrock URLs, so the unconditional emit costs every other
-// provider nothing. Extracted as a named function so codegen tests
-// can pin the exact emitted shape AND assert it does not appear in
-// the streaming-path emission (which passes nil postProcess to
-// emitBAMLHTTPRequestConversion for non-bedrock providers).
-// PR1-bedrock breadcrumb.
+// llmhttp.MaybeAttachBedrockAuth, returning early on error. The helper
+// is a URL-pattern attach hook: it no-ops on non-bedrock URLs, so the
+// unconditional emit costs every other provider nothing. Extracted as
+// a named function so codegen tests can pin the exact emitted shape
+// AND assert it does not appear in the streaming-path emission (which
+// passes nil postProcess to emitBAMLHTTPRequestConversion for
+// non-bedrock providers).
 func emitMaybeAttachBedrockAuth(g *jen.Group) {
 	g.If(
 		jen.Id("authErr").Op(":=").Qual(common.LLMHTTPPkg, "MaybeAttachBedrockAuth").Call(jen.Id("ctx"), jen.Id("req")),
@@ -30,7 +29,7 @@ func emitMaybeAttachBedrockAuth(g *jen.Group) {
 // Accept header injection, and SigV4 auth attach. BAML's non-streaming
 // modular AWS builder produces a /converse URL; baml-rest streams
 // against /converse-stream because BAML's StreamRequest path is
-// upstream-blocked for aws-bedrock (per the #243 scope cut).
+// upstream-blocked for aws-bedrock.
 //
 // Order matters:
 //  1. URL rewrite BEFORE auth attach so SigV4 signs over the
@@ -42,8 +41,7 @@ func emitMaybeAttachBedrockAuth(g *jen.Group) {
 //     URL.
 //
 // Emitted only on the bedrock streaming closure; the SSE-path
-// streaming closure still passes nil postProcess. PR3-bedrock-stream
-// breadcrumb (issue #243).
+// streaming closure still passes nil postProcess.
 func emitBedrockStreamPostProcess(g *jen.Group) {
 	// URL mutation: single replacement of /converse → /converse-stream.
 	// The Bedrock URL pattern is
@@ -73,7 +71,7 @@ func emitBedrockStreamPostProcess(g *jen.Group) {
 // emitBAMLHTTPRequestConversion generates the jen code that converts a
 // baml.HTTPRequest (stored in local variable "httpReq") into a
 // *llmhttp.Request stored in local variable "req", emits any postProcess
-// statements (e.g. PR1-bedrock SigV4 metadata attach), and returns
+// statements (e.g. SigV4 metadata attach for aws-bedrock), and returns
 // (req, nil). Shared by both the streaming _buildRequest and
 // non-streaming _buildCallRequest codegen paths so they stay in sync.
 //
@@ -145,13 +143,13 @@ func buildLegacyChildCallParams(args []string, argCallParam func(string) jen.Cod
 // (BAML >= 0.219.0); otherwise the symbol baml_client.StreamRequest
 // doesn't exist and the reference would fail to compile.
 //
-// PR3-bedrock-stream breadcrumb (issue #243): when introspected.Request
-// is also non-nil (v0.219), emit a sibling buildBedrockStreamRequestFn
-// closure that calls BAML's non-streaming Request.<Method> (because
-// BAML's StreamRequest errors for aws-bedrock), mutates the URL from
-// /converse to /converse-stream, sets the AWS event-stream Accept
-// header, and attaches AWSAuth. Wire it into StreamConfig as
-// BuildBedrockStreamRequest. The orchestrator dispatches on provider.
+// When introspected.Request is also non-nil (v0.219), emit a sibling
+// buildBedrockStreamRequestFn closure that calls BAML's non-streaming
+// Request.<Method> (because BAML's StreamRequest errors for
+// aws-bedrock), mutates the URL from /converse to /converse-stream,
+// sets the AWS event-stream Accept header, and attaches AWSAuth. Wire
+// it into StreamConfig as BuildBedrockStreamRequest. The orchestrator
+// dispatches on provider.
 func (me *methodEmitter) emitBuildRequest() {
 	if introspected.StreamRequest == nil {
 		return
@@ -169,11 +167,11 @@ func (me *methodEmitter) emitBuildRequest() {
 	}
 	buildRequestCallParams = append(buildRequestCallParams, jen.Id("callOpts").Op("..."))
 
-	// PR3-bedrock-stream breadcrumb: identical call-param shape for
-	// BAML's non-streaming Request.<Method>. Same args + opts as
-	// StreamRequest because both consume the per-method signature.
-	// Built unconditionally; only inlined into the closure when
-	// introspected.Request is non-nil (the v0.219 gate).
+	// Identical call-param shape for BAML's non-streaming
+	// Request.<Method>. Same args + opts as StreamRequest because both
+	// consume the per-method signature. Built unconditionally; only
+	// inlined into the closure when introspected.Request is non-nil
+	// (the v0.219 gate).
 	var bedrockStreamCallParams []jen.Code
 	bedrockStreamCallParams = append(bedrockStreamCallParams, jen.Id("ctx"))
 	for _, arg := range me.args {
@@ -218,13 +216,12 @@ func (me *methodEmitter) emitBuildRequest() {
 		}),
 	)
 
-	// PR3-bedrock-stream breadcrumb (issue #243): bedrock streaming
-	// uses BAML's non-streaming modular Request.<Method> as the body
-	// assembler (StreamRequest errors for aws-bedrock per upstream),
-	// then mutates URL /converse → /converse-stream, sets the AWS
-	// event-stream Accept header, and attaches AWSAuth. The
-	// orchestrator dispatches to this closure when the per-attempt
-	// provider is aws-bedrock.
+	// Bedrock streaming uses BAML's non-streaming modular
+	// Request.<Method> as the body assembler (StreamRequest errors for
+	// aws-bedrock per upstream), then mutates URL /converse →
+	// /converse-stream, sets the AWS event-stream Accept header, and
+	// attaches AWSAuth. The orchestrator dispatches to this closure
+	// when the per-attempt provider is aws-bedrock.
 	//
 	// Gated on introspected.Request being non-nil because the symbol
 	// baml_client.Request only exists on BAML v0.219+. For v0.204 /
@@ -453,11 +450,10 @@ func (me *methodEmitter) emitBuildRequest() {
 			jen.Id("FallbackTargets"):    jen.Id("fallbackTargets"),
 			jen.Id("FallbackRoundRobin"): jen.Id("fallbackRoundRobin"),
 			jen.Id("LegacyStreamChild"):  jen.Id("legacyStreamChildFn"),
-			// PR3-bedrock-stream breadcrumb (issue #243): wired only
-			// when introspected.Request is non-nil (v0.219). For
-			// v0.204/v0.215 the field stays nil and the orchestrator's
-			// up-front validation rejects aws-bedrock provider
-			// configurations on those adapters — matching the
+			// Wired only when introspected.Request is non-nil (v0.219).
+			// For v0.204/v0.215 the field stays nil and the
+			// orchestrator's up-front validation rejects aws-bedrock
+			// provider configurations on those adapters — matching the
 			// codegen-time gating, since baml_client.Request doesn't
 			// exist there.
 			jen.Id("BuildBedrockStreamRequest"): func() jen.Code {
@@ -592,10 +588,9 @@ func (me *methodEmitter) emitBuildCallRequest() {
 			// BAML-emitted URL looks like a Bedrock Converse endpoint.
 			// MaybeAttachBedrockAuth is a no-op on non-bedrock URLs,
 			// so the unconditional emit costs every other provider
-			// nothing. PR1-bedrock breadcrumb (issue #243). The
-			// streaming branch uses its own sibling closure
-			// (buildBedrockStreamRequestFn) with emitBedrockStreamPostProcess
-			// — see emitBuildRequest above.
+			// nothing. The streaming branch uses its own sibling
+			// closure (buildBedrockStreamRequestFn) with
+			// emitBedrockStreamPostProcess — see emitBuildRequest above.
 			emitBAMLHTTPRequestConversion(jg, emitMaybeAttachBedrockAuth)
 		}),
 

--- a/bamlutils/awsstream/awsstream_test.go
+++ b/bamlutils/awsstream/awsstream_test.go
@@ -72,7 +72,7 @@ func TestDecoder_ReasoningEvent(t *testing.T) {
 	// Bedrock surfaces reasoning content under
 	// contentBlockDelta.delta.reasoningContent.text. The decoder is
 	// payload-agnostic — this test just pins that the raw bytes survive
-	// intact so PR 3's extractor can parse them.
+	// intact so the bedrock extractor can parse them.
 	payload := []byte(`{"delta":{"reasoningContent":{"text":"thinking..."}},"contentBlockIndex":0}`)
 	frame := encode(t, eventHeaders("contentBlockDelta"), payload)
 
@@ -132,8 +132,8 @@ func TestDecoder_MultiEventStream(t *testing.T) {
 
 func TestDecoder_ModeledException(t *testing.T) {
 	// Modeled exceptions are protocol data, not transport failures — they
-	// must surface as ordinary Events so PR 3's extractor can route them
-	// through the same provider-error pipeline as JSON-body errors.
+	// must surface as ordinary Events so the bedrock extractor can route
+	// them through the same provider-error pipeline as JSON-body errors.
 	payload := []byte(`{"message":"the model refused"}`)
 	frame := encode(t, map[string]string{
 		":message-type":   "exception",

--- a/bamlutils/buildrequest/bedrock_call_integration_test.go
+++ b/bamlutils/buildrequest/bedrock_call_integration_test.go
@@ -34,7 +34,7 @@ func (bedrockStaticCreds) Retrieve(ctx context.Context) (aws.Credentials, error)
 // aws-bedrock call branch: build request with AWSAuth attached → SigV4
 // signing inside llmhttp → mock Converse server hit → response
 // extraction → final result with reasoning routed correctly under the
-// IncludeReasoning flag. PR1-bedrock breadcrumb (#243).
+// IncludeReasoning flag.
 func TestRunCallOrchestration_AWSBedrock(t *testing.T) {
 	pinnedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
 

--- a/bamlutils/buildrequest/bedrock_stream_extract.go
+++ b/bamlutils/buildrequest/bedrock_stream_extract.go
@@ -6,8 +6,8 @@
 // response_extract.go; both surface text under Parseable+Raw and route
 // reasoning to Reasoning only when IncludeReasoning is set. The two
 // extractors share strictness invariants (parseable/raw text-only,
-// reasoning opt-in, tool-use / signature variants silently skipped per
-// the PR 3 scope cut).
+// reasoning opt-in, tool-use / signature variants silently skipped —
+// see #254).
 package buildrequest
 
 import (
@@ -30,8 +30,6 @@ import (
 // exception_message}. The raw payload bytes are preserved in Payload
 // so downstream consumers can parse additional fields without
 // revisiting the extractor.
-//
-// PR3-bedrock-stream breadcrumb (issue #243).
 type BedrockStreamException struct {
 	// ExceptionType is the value of the :exception-type header (the
 	// modeled shape name — e.g. "modelStreamErrorException",
@@ -84,16 +82,13 @@ func (e *BedrockStreamException) Message() string {
 //
 // Returns a zero DeltaParts for events that produce no incremental
 // content (messageStart, contentBlockStart/Stop, messageStop,
-// metadata, and tool-use / reasoning signature variants reserved for
-// PR 4). Returns a *BedrockStreamException for modeled exception
-// events so the orchestrator can surface them as provider_error.
+// metadata, and tool-use / reasoning signature variants — see #254).
+// Returns a *BedrockStreamException for modeled exception events so
+// the orchestrator can surface them as provider_error.
 //
-// PR3-bedrock-stream breadcrumb (issue #243): PR 4 will widen the
-// reasoning union (signature / redactedContent), surface tool-use
-// deltas, and pipe metadata.usage stats through the metadata channel.
-// Until then, the unknown-variant arms below stay defensive — silent
-// skip rather than error, so a future Bedrock event shape we haven't
-// modeled yet doesn't fail open requests.
+// The unknown-variant arms below stay defensive — silent skip rather
+// than error, so a future Bedrock event shape we haven't modeled yet
+// doesn't fail open requests.
 func extractBedrockStreamDelta(evt *awsstream.Event, includeReasoning bool) (sse.DeltaParts, error) {
 	if evt == nil {
 		return sse.DeltaParts{}, nil
@@ -134,9 +129,9 @@ func extractBedrockStreamDelta(evt *awsstream.Event, includeReasoning bool) (sse
 	case "contentBlockDelta":
 		return extractBedrockContentBlockDelta(evt.Payload, includeReasoning)
 	case "messageStart", "contentBlockStart", "contentBlockStop", "messageStop", "metadata":
-		// PR3-bedrock-stream breadcrumb: PR 4 surfaces stopReason on
-		// messageStop and usage metadata. For PR 3 these are no-op
-		// frames that produce no incremental DeltaParts content.
+		// No-op frames that produce no incremental DeltaParts content.
+		// Surfacing stopReason / usage from messageStop and metadata is
+		// deferred — see #254.
 		return sse.DeltaParts{}, nil
 	default:
 		// Forward-compat: an unknown event type (a future Bedrock
@@ -150,8 +145,8 @@ func extractBedrockStreamDelta(evt *awsstream.Event, includeReasoning bool) (sse
 // extractBedrockContentBlockDelta routes the contentBlockDelta payload
 // to the right output channel. The delta union (per the AWS
 // ContentBlockDelta spec) carries text, reasoningContent, toolUse,
-// toolResult, or citationsContent — only the first two are surfaced in
-// PR 3.
+// toolResult, or citationsContent — only the first two are surfaced
+// today (see #254 for the deferred tool-use deltas).
 func extractBedrockContentBlockDelta(payload []byte, includeReasoning bool) (sse.DeltaParts, error) {
 	if len(payload) == 0 {
 		return sse.DeltaParts{}, nil
@@ -179,9 +174,8 @@ func extractBedrockContentBlockDelta(payload []byte, includeReasoning bool) (sse
 	}
 
 	// `delta.reasoningContent.text` → Reasoning when opted in.
-	// `signature` and `redactedContent` are PR 4 territory: silently
-	// skip so the existing payload shapes don't accidentally fail
-	// open. Parseable/Raw invariance: reasoning never enters either
+	// `signature` and `redactedContent` are silently skipped — see
+	// #254. Parseable/Raw invariance: reasoning never enters either
 	// regardless of the flag.
 	if rc := delta.Get("reasoningContent"); rc.IsObject() {
 		if !includeReasoning {
@@ -197,12 +191,12 @@ func extractBedrockContentBlockDelta(payload []byte, includeReasoning bool) (sse
 			}
 			return sse.DeltaParts{Reasoning: t.String()}, nil
 		}
-		// `signature` / `redactedContent` — PR 4 territory.
+		// `signature` / `redactedContent` — silently skipped, see #254.
 		return sse.DeltaParts{}, nil
 	}
 
 	// tool-use streaming deltas (delta.toolUse.input, delta.toolResult),
-	// citationsContent, and any other future delta variant: silent
-	// skip per PR 3 scope cuts.
+	// citationsContent, and any other future delta variant: silently
+	// skipped (see #254).
 	return sse.DeltaParts{}, nil
 }

--- a/bamlutils/buildrequest/bedrock_stream_extract_test.go
+++ b/bamlutils/buildrequest/bedrock_stream_extract_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 // encodeBedrockEvent produces wire bytes for a single eventstream frame
-// using the SDK encoder. The PR 2 decoder is the production consumer
-// so round-tripping through it is the most reliable form of fixture.
+// using the SDK encoder. The awsstream decoder is the production
+// consumer so round-tripping through it is the most reliable form of
+// fixture.
 func encodeBedrockEvent(t *testing.T, headers map[string]string, payload []byte) []byte {
 	t.Helper()
 	var hs eventstream.Headers
@@ -111,9 +112,8 @@ func TestExtractBedrockStreamDelta_ReasoningDelta_OptIn(t *testing.T) {
 
 // TestExtractBedrockStreamDelta_NoOpEvents pins that the housekeeping
 // event types (messageStart/Stop, contentBlockStart/Stop, metadata)
-// produce no incremental content and no error in PR 3. PR 4 may
-// surface stopReason / usage on some of these — the test pins the
-// current PR 3 contract.
+// produce no incremental content and no error. Surfacing stopReason /
+// usage on some of these is deferred — see #254.
 func TestExtractBedrockStreamDelta_NoOpEvents(t *testing.T) {
 	cases := []struct {
 		eventType string
@@ -142,10 +142,11 @@ func TestExtractBedrockStreamDelta_NoOpEvents(t *testing.T) {
 
 // TestExtractBedrockStreamDelta_ToolUseSilentSkip pins that tool-use
 // streaming delta variants and citationsContent are silently dropped
-// in PR 3 (they land in PR 4). Failing here would mean a real PR-3
-// stream errors out on tool-use frames the moment a model emits them
-// — surfacing them as deltas would be worse because the orchestrator
-// would forward partial JSON the BAML parser can't make sense of.
+// (see #254 for the deferred tool-use surface). Failing here would
+// mean a real stream errors out on tool-use frames the moment a model
+// emits them — surfacing them as deltas would be worse because the
+// orchestrator would forward partial JSON the BAML parser can't make
+// sense of.
 func TestExtractBedrockStreamDelta_ToolUseSilentSkip(t *testing.T) {
 	payloads := [][]byte{
 		[]byte(`{"delta":{"toolUse":{"input":"{\"x\":1}"}},"contentBlockIndex":0}`),
@@ -169,10 +170,10 @@ func TestExtractBedrockStreamDelta_ToolUseSilentSkip(t *testing.T) {
 
 // TestExtractBedrockStreamDelta_ReasoningSignatureSkip pins that
 // `reasoningContent.signature` / `redactedContent` (encrypted-summary
-// variants) are silently skipped under IncludeReasoning=true. PR 4
-// will decide whether to pipe them through; the strict invariant here
-// is that parseable/raw stay empty AND no spurious reasoning string is
-// produced from these fields.
+// variants) are silently skipped under IncludeReasoning=true. Piping
+// these surfaces through is deferred — see #254; the strict invariant
+// here is that parseable/raw stay empty AND no spurious reasoning
+// string is produced from these fields.
 func TestExtractBedrockStreamDelta_ReasoningSignatureSkip(t *testing.T) {
 	payloads := [][]byte{
 		[]byte(`{"delta":{"reasoningContent":{"signature":"sigbytes"}},"contentBlockIndex":0}`),
@@ -213,7 +214,7 @@ func TestExtractBedrockStreamDelta_UnknownEventTypeSilentSkip(t *testing.T) {
 // TestExtractBedrockStreamDelta_ModeledException pins that an
 // exception event surfaces as *BedrockStreamException with the
 // :exception-type as the modeled name and the payload bytes preserved
-// verbatim for PR 4 to parse.
+// verbatim so downstream consumers can parse them.
 func TestExtractBedrockStreamDelta_ModeledException(t *testing.T) {
 	payload := []byte(`{"message":"the model refused"}`)
 	frame := encodeBedrockEvent(t, map[string]string{
@@ -235,7 +236,7 @@ func TestExtractBedrockStreamDelta_ModeledException(t *testing.T) {
 		t.Errorf("ExceptionType = %q, want modelStreamErrorException", be.ExceptionType)
 	}
 	if !bytes.Equal(be.Payload, payload) {
-		t.Errorf("Payload = %q, want %q (must preserve wire bytes verbatim for PR 4 to parse)", be.Payload, payload)
+		t.Errorf("Payload = %q, want %q (must preserve wire bytes verbatim)", be.Payload, payload)
 	}
 	if got := be.Error(); got == "" {
 		t.Errorf("Error() returned empty string")

--- a/bamlutils/buildrequest/metadata.go
+++ b/bamlutils/buildrequest/metadata.go
@@ -35,7 +35,6 @@ const (
 	// BuildRequest supported set (callSupportedProviders for the call
 	// path, supportedProviders for the streaming path). aws-bedrock is
 	// in both sets — see those vars for the per-version gating.
-	// PR1-bedrock / PR3-bedrock-stream breadcrumb (issue #243).
 	PathReasonUnsupportedProvider = "unsupported-provider"
 	// PathReasonFallbackEmptyChain: the resolved strategy client resolves
 	// to baml-fallback but has no children, so BuildRequest has nothing

--- a/bamlutils/buildrequest/metadata_bugfix_test.go
+++ b/bamlutils/buildrequest/metadata_bugfix_test.go
@@ -249,8 +249,8 @@ func TestBuildLegacyMetadataPlan_RuntimeOverrideRespectedInLegacyChain(t *testin
 		originalRegistry: &bamlutils.ClientRegistry{
 			// Override the child's provider to one that's not supported by
 			// BuildRequest. The introspected static map still says openai.
-			// "mistral" stands in for an unsupported provider after PR 3
-			// of #243 graduated aws-bedrock to the supported set.
+			// "mistral" stands in for an unsupported provider (aws-bedrock
+			// is in the supported set, so it can't stand in here).
 			Clients: []*bamlutils.ClientProperty{
 				{Name: "Child", Provider: "mistral"},
 			},

--- a/bamlutils/buildrequest/metadata_resolve_test.go
+++ b/bamlutils/buildrequest/metadata_resolve_test.go
@@ -54,8 +54,7 @@ func TestResolveProviderWithReason_LegacyUnsupported(t *testing.T) {
 	adapter := &mockAdapter{Context: context.Background()}
 	// "mistral" is a known-recognised-by-BAML provider that is NOT
 	// in baml-rest's BuildRequest supported set. Used as the stand-in
-	// for "unsupported provider" now that aws-bedrock has graduated to
-	// the supported set in PR 3 of #243.
+	// for "unsupported provider" (aws-bedrock is in the supported set).
 	res := ResolveProviderWithReason(adapter, "MyClient", "mistral", IsProviderSupported)
 	if res.Path != "legacy" {
 		t.Errorf("path: got %q, want legacy", res.Path)
@@ -99,9 +98,9 @@ func TestResolveFallbackChainWithReason_AllLegacy(t *testing.T) {
 		},
 	}
 	// Children use mistral — a BAML-recognised but baml-rest-
-	// unsupported provider — so the chain falls to all-legacy. PR 3
-	// of #243 graduated aws-bedrock to the supported set, so it can
-	// no longer stand in for "unsupported" here.
+	// unsupported provider — so the chain falls to all-legacy.
+	// aws-bedrock is in the supported set and can no longer stand in
+	// for "unsupported" here.
 	chains := map[string][]string{"Strategy": {"Leg1", "Leg2"}}
 	providers := map[string]string{
 		"Strategy": "baml-fallback",
@@ -130,10 +129,10 @@ func TestResolveFallbackChainWithReason_MixedDrivable(t *testing.T) {
 		"Strategy": "baml-fallback",
 		"Primary":  "openai",
 		// Backup is an unsupported-by-baml-rest provider so the chain
-		// drives mixed (BR for Primary, legacy for Backup). PR 3 of
-		// #243 graduated aws-bedrock — the previous stand-in — to the
-		// supported set, so a baml-rest-unsupported provider is
-		// needed to keep this test exercising the mixed-chain path.
+		// drives mixed (BR for Primary, legacy for Backup).
+		// aws-bedrock is in the supported set, so a baml-rest-
+		// unsupported provider is needed to keep this test exercising
+		// the mixed-chain path.
 		"Backup": "mistral",
 	}
 	chain, _, legacy, reason := ResolveFallbackChainWithReason(adapter, "Strategy", chains, providers, IsProviderSupported)
@@ -357,8 +356,8 @@ func TestBuildFallbackChainPlan_ReasonPlumbsFromResolver(t *testing.T) {
 
 func TestBuildLegacyMetadataPlan_UnsupportedProvider(t *testing.T) {
 	adapter := &mockAdapter{Context: context.Background()}
-	// "mistral" stands in for an unsupported provider after PR 3 of
-	// #243 graduated aws-bedrock to the BuildRequest supported set.
+	// "mistral" stands in for an unsupported provider (aws-bedrock is
+	// in the BuildRequest supported set).
 	plan := BuildLegacyMetadataPlan(adapter, "MyClient", "mistral", nil, nil, IsProviderSupported, nil)
 	if plan.Path != "legacy" {
 		t.Errorf("path: got %q, want legacy", plan.Path)
@@ -1989,10 +1988,9 @@ func TestResolveClientProvider_ShorthandIntrospectedEntry(t *testing.T) {
 // TestResolveProviderWithReason_ShorthandUnsupportedProvider pins the
 // negative case for shorthand resolution: a shorthand spec whose
 // provider is recognized by upstream BAML but NOT in baml-rest's
-// BuildRequest supported set. Pre-PR-3 (issue #243) this used
-// aws-bedrock as the canonical example; PR 3 graduated aws-bedrock to
-// the supported set, so the test now uses mistral — another upstream-
-// recognised provider that baml-rest doesn't handle.
+// BuildRequest supported set. The test uses mistral — an upstream-
+// recognised provider that baml-rest doesn't handle (aws-bedrock is
+// in the supported set, so it can't stand in here).
 //
 // Pre-fix: this would land as PathReasonEmptyProvider because the
 // introspector left ClientProvider["mistral/foo"] empty.

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -147,7 +147,6 @@ var supportedProviders = map[string]bool{
 	// mutates URL /converse → /converse-stream, signs SigV4 over
 	// the rewritten URL, executes via llmhttp.ExecuteAWSStream, and
 	// pipes decoded awsstream events through extractBedrockStreamDelta.
-	// PR3-bedrock-stream breadcrumb (issue #243).
 	"aws-bedrock": true,
 }
 
@@ -181,14 +180,14 @@ var callSupportedProviders = map[string]bool{
 	"vertex-ai":        true,
 	// aws-bedrock (v0.219+): both call and stream go through
 	// BuildRequest. See supportedProviders above for the streaming
-	// wire-path summary. Scope cuts: v0.204/v0.215 fall through to
-	// legacy (codegen's _buildCallRequest is gated on
+	// wire-path summary. Current scope: v0.204/v0.215 fall through
+	// to legacy (codegen's _buildCallRequest is gated on
 	// introspected.Request, which only resolves on v0.219); the
 	// default credential chain is used (no static .baml creds); the
 	// default Bedrock runtime endpoint is used (no endpoint_url
 	// override); reasoning signature/redactedContent and tool-use
-	// streaming deltas are silently skipped. PR1-bedrock /
-	// PR3-bedrock-stream breadcrumb (issue #243).
+	// streaming deltas are silently skipped — see #254 for the
+	// deferred parity items.
 	"aws-bedrock": true,
 }
 
@@ -324,9 +323,9 @@ type StreamConfig struct {
 	// The two distinct closures (BuildRequest for SSE providers,
 	// BuildBedrockStreamRequest for bedrock) are emitted side-by-side
 	// because BAML's StreamRequest API errors for aws-bedrock — there
-	// is no upstream-streaming builder we can call. PR3-bedrock-stream
-	// breadcrumb (issue #243): PR 4 will swap this to BAML's modular
-	// streaming builder if/when it lands.
+	// is no upstream-streaming builder we can call. If BAML's modular
+	// streaming builder gains aws-bedrock support, this can collapse
+	// back to a single BuildRequest path.
 	BuildBedrockStreamRequest BuildRequestFunc
 
 	// LegacyStreamChild runs a single child via BAML's Stream API. The
@@ -606,8 +605,6 @@ func RunStreamOrchestration(
 	// from a contentBlockDelta extractor surface as
 	// *BedrockStreamException — both routed through the worker
 	// classifier's typed-before-legacy ordering.
-	//
-	// PR3-bedrock-stream breadcrumb (issue #243).
 	tryOneBedrockStreamChild := func(clientOverride string) (any, string, string, error) {
 		if config.BuildBedrockStreamRequest == nil {
 			return nil, "", "", errors.New("buildrequest: aws-bedrock streaming requires StreamConfig.BuildBedrockStreamRequest to be set")
@@ -733,8 +730,7 @@ func RunStreamOrchestration(
 		// aws-bedrock streaming uses a separate transport (AWS
 		// event-stream) and request builder (Request.<Method>, not
 		// StreamRequest — see BuildBedrockStreamRequest doc).
-		// Dispatch to the dedicated bedrock closure. PR3-bedrock-
-		// stream breadcrumb (issue #243).
+		// Dispatch to the dedicated bedrock closure.
 		if provider == "aws-bedrock" {
 			return tryOneBedrockStreamChild(clientOverride)
 		}

--- a/bamlutils/buildrequest/orchestrator_integration_test.go
+++ b/bamlutils/buildrequest/orchestrator_integration_test.go
@@ -703,19 +703,17 @@ func TestRawAccumulation(t *testing.T) {
 // Bedrock fallback test
 // ============================================================================
 
-// TestBedrock_StreamingSupportedPR3 pins PR 3's enablement of
-// aws-bedrock on the streaming BuildRequest path. Streaming requires a
-// separate transport (AWS event-stream) and request builder
-// (Request.<Method> + URL rewrite to /converse-stream); the orchestrator
-// dispatches on provider so callers must wire
-// StreamConfig.BuildBedrockStreamRequest. The call path was enabled in
-// PR 1 (#244). PR3-bedrock-stream breadcrumb (issue #243).
-func TestBedrock_StreamingSupportedPR3(t *testing.T) {
+// TestBedrock_StreamingSupported pins aws-bedrock on the streaming
+// BuildRequest path. Streaming requires a separate transport (AWS
+// event-stream) and request builder (Request.<Method> + URL rewrite
+// to /converse-stream); the orchestrator dispatches on provider so
+// callers must wire StreamConfig.BuildBedrockStreamRequest.
+func TestBedrock_StreamingSupported(t *testing.T) {
 	if !IsProviderSupported("aws-bedrock") {
-		t.Error("aws-bedrock must be supported by the streaming BuildRequest path after PR 3")
+		t.Error("aws-bedrock must be supported by the streaming BuildRequest path")
 	}
 	if !IsCallProviderSupported("aws-bedrock") {
-		t.Error("aws-bedrock must remain supported on the call path (PR 1 enabled it)")
+		t.Error("aws-bedrock must be supported on the call path")
 	}
 }
 
@@ -746,8 +744,7 @@ func TestProvider_WhitelistMatchesExtractor(t *testing.T) {
 		// (extractBedrockStreamDelta on AWS event-stream frames),
 		// not sse.ExtractDeltaFromText, so the
 		// IsDeltaProviderSupported→ExtractDeltaFromText invariant
-		// below explicitly excludes it. PR3-bedrock-stream
-		// breadcrumb (issue #243).
+		// below explicitly excludes it.
 	}
 	for _, p := range supported {
 		if !IsProviderSupported(p) {

--- a/bamlutils/buildrequest/orchestrator_test.go
+++ b/bamlutils/buildrequest/orchestrator_test.go
@@ -462,8 +462,8 @@ func TestIsProviderSupported(t *testing.T) {
 		"openai", "openai-generic", "azure-openai", "anthropic",
 		"google-ai", "vertex-ai", "ollama", "openrouter",
 		"openai-responses",
-		// aws-bedrock streaming enabled in PR 3 of #243 — see
-		// supportedProviders doc-comment for the dispatch contract.
+		// aws-bedrock streaming — see supportedProviders doc-comment
+		// for the dispatch contract.
 		"aws-bedrock",
 	}
 	for _, p := range supported {

--- a/bamlutils/buildrequest/response_extract.go
+++ b/bamlutils/buildrequest/response_extract.go
@@ -59,13 +59,12 @@ func ExtractResponseContent(provider string, responseBody string, includeReasoni
 		return extractGeminiContent(provider, responseBody, includeReasoning)
 
 	case "aws-bedrock":
-		// PR1-bedrock breadcrumb: aws-bedrock non-streaming extractor
-		// for the Converse API. v0.219-only (v0.204 / v0.215 fall
-		// through to the legacy path because their codegen does not
-		// emit the BuildRequest call branch). Scope cuts documented at
-		// #243: default credential chain only, no static .baml creds
-		// (PR 4), no endpoint_url override (PR 4), reasoning block
-		// signature/redactedContent skipped (PR 4).
+		// aws-bedrock non-streaming extractor for the Converse API.
+		// v0.219-only (v0.204 / v0.215 fall through to the legacy path
+		// because their codegen does not emit the BuildRequest call
+		// branch). Current scope: default credential chain only (no
+		// static `.baml` creds), no endpoint_url override, reasoning
+		// block signature/redactedContent skipped (see #254).
 		return extractAWSBedrockContent(provider, responseBody, includeReasoning)
 
 	default:
@@ -459,13 +458,13 @@ func extractOpenAIResponsesContent(provider, responseBody string, includeReasoni
 // response with no text blocks AND no reasoning content surface as
 // errors so a corrupted 200 cannot masquerade as an empty success.
 //
-// PR1-bedrock breadcrumb: `signature` and `redactedContent` reasoning
-// surfaces are intentionally skipped here; PR 4 will decide whether to
-// pipe them through. Tool-use blocks (toolUse, toolResult) are out of
-// scope for this PR and are silently ignored — they do not contribute
-// to any output, which preserves the strict no-empty-success contract
-// because the extractor still errors when the message contains no
-// recognised content blocks at all.
+// `signature` and `redactedContent` reasoning surfaces are
+// intentionally skipped here — neither has an operator-actionable
+// interpretation today; see #254 for the deferred design call.
+// Tool-use blocks (toolUse, toolResult) are silently ignored — they do
+// not contribute to any output, which preserves the strict
+// no-empty-success contract because the extractor still errors when
+// the message contains no recognised content blocks at all.
 func extractAWSBedrockContent(provider, responseBody string, includeReasoning bool) (parseable, raw, reasoning string, err error) {
 	message := gjson.Get(responseBody, "output.message")
 	if !message.IsObject() {
@@ -502,10 +501,9 @@ func extractAWSBedrockContent(provider, responseBody string, includeReasoning bo
 			if !includeReasoning {
 				return true
 			}
-			// PR1-bedrock breadcrumb: only the human-readable
-			// reasoningText.text is surfaced. signature / redactedContent
-			// (encrypted-summary variants) are skipped pending the PR 4
-			// design decision.
+			// Only the human-readable reasoningText.text is surfaced;
+			// signature / redactedContent (encrypted-summary variants)
+			// are skipped — see #254.
 			if rt := reasoningContent.Get("reasoningText"); rt.IsObject() {
 				if t := rt.Get("text"); t.Type == gjson.String {
 					reasoningSB.WriteString(t.String())
@@ -513,11 +511,11 @@ func extractAWSBedrockContent(provider, responseBody string, includeReasoning bo
 			}
 			return true
 		}
-		// PR1-bedrock breadcrumb: toolUse / toolResult and other block
-		// shapes are silently skipped in PR 1. The strict
-		// no-recognised-content guard below still errors if EVERY block
-		// is one of these — so a tool-only Converse response surfaces as
-		// an error rather than an empty success.
+		// toolUse / toolResult and other block shapes are silently
+		// skipped. The strict no-recognised-content guard below still
+		// errors if EVERY block is one of these — so a tool-only
+		// Converse response surfaces as an error rather than an empty
+		// success.
 		return true
 	})
 	if iterErr != nil {

--- a/bamlutils/buildrequest/response_extract_test.go
+++ b/bamlutils/buildrequest/response_extract_test.go
@@ -1460,10 +1460,10 @@ func TestExtractResponseContent_AWSBedrock_IncludeReasoning(t *testing.T) {
 		},
 		{
 			// Reasoning block with no reasoningText field — silently
-			// skipped on the reasoning channel (PR1-bedrock scope cut
-			// for signature/redactedContent), but the block is still
-			// recognised so the no-recognised-content guard does not
-			// fire.
+			// skipped on the reasoning channel (signature/redactedContent
+			// surfaces are not piped through; see #254), but the block
+			// is still recognised so the no-recognised-content guard
+			// does not fire.
 			name: "reasoning block with no text",
 			body: `{"output":{"message":{"role":"assistant","content":[
 				{"text":"Answer"},
@@ -1558,7 +1558,7 @@ func TestExtractResponseContent_AWSBedrock_EmptyContent(t *testing.T) {
 }
 
 func TestExtractResponseContent_AWSBedrock_ToolUseOnly(t *testing.T) {
-	// Tool-use blocks are out of scope for PR 1. A response that
+	// Tool-use blocks are not surfaced (see #254). A response that
 	// contains ONLY unrecognised blocks must error — silently
 	// returning "" would let a tool-call-only completion masquerade as
 	// an empty success.
@@ -1567,7 +1567,7 @@ func TestExtractResponseContent_AWSBedrock_ToolUseOnly(t *testing.T) {
 	]}}}`
 	_, _, _, err := ExtractResponseContent("aws-bedrock", body, false)
 	if err == nil {
-		t.Fatal("expected error when only tool-use blocks are present (PR 1 scope cut)")
+		t.Fatal("expected error when only tool-use blocks are present")
 	}
 }
 

--- a/bamlutils/llmhttp/awssigv4.go
+++ b/bamlutils/llmhttp/awssigv4.go
@@ -6,8 +6,7 @@
 // alike).
 //
 // Used by both the call path (Execute) and the streaming paths
-// (ExecuteStream, ExecuteAWSStream). PR1-bedrock / PR3-bedrock-stream
-// breadcrumb (issue #243).
+// (ExecuteStream, ExecuteAWSStream).
 package llmhttp
 
 import (
@@ -178,9 +177,8 @@ var sigV4OwnedHeaders = []string{
 
 // parseBedrockRegion extracts the AWS region from a BAML-emitted
 // Bedrock URL whose host is bedrock-runtime.<region>.amazonaws.com.
-// PR1-bedrock breadcrumb: PR 4 may revisit this if an endpoint_url
-// override path lands, since custom endpoints break the
-// host-encoded-region assumption.
+// Custom endpoints (e.g. a future endpoint_url override path) would
+// break the host-encoded-region assumption.
 func parseBedrockRegion(rawURL string) (string, error) {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
@@ -237,10 +235,6 @@ var (
 // malformed shared config, IMDS timeout) would otherwise poison Bedrock
 // auth for the rest of the worker's life. Subsequent calls retry via
 // the loader.
-//
-// PR1-bedrock breadcrumb: PR 4 will introduce a path to override this
-// with static `.baml` credentials once the adapter exposes them
-// through a non-public surface.
 func DefaultAWSCredentialProvider(ctx context.Context) (aws.CredentialsProvider, error) {
 	defaultAWSCredsMu.Lock()
 	cached := defaultAWSCreds
@@ -274,7 +268,7 @@ func DefaultAWSCredentialProvider(ctx context.Context) (aws.CredentialsProvider,
 // Safe to call unconditionally from the generated call branch — the
 // URL-pattern check keeps non-bedrock providers untouched, so adding
 // the call to all generated _buildCallRequest implementations costs
-// nothing for openai/anthropic/etc. PR1-bedrock breadcrumb.
+// nothing for openai/anthropic/etc.
 func MaybeAttachBedrockAuth(ctx context.Context, req *Request) error {
 	if req == nil {
 		return nil
@@ -294,8 +288,7 @@ func MaybeAttachBedrockAuth(ctx context.Context, req *Request) error {
 // not match the BAML-emitted bedrock-runtime.<region>.amazonaws.com
 // pattern or if the default credential chain cannot be loaded.
 //
-// PR1-bedrock / PR3-bedrock-stream breadcrumb (issue #243): codegen
-// calls this from the aws-bedrock branch on both the call path
+// Codegen calls this from the aws-bedrock branch on both the call path
 // (Request.<Method>) and the streaming path
 // (Request.<Method> + /converse-stream URL rewrite).
 func AttachBedrockAuth(ctx context.Context, req *Request) error {

--- a/bamlutils/llmhttp/awssigv4_test.go
+++ b/bamlutils/llmhttp/awssigv4_test.go
@@ -296,7 +296,7 @@ func TestSignRequest_MissingFields(t *testing.T) {
 // Scope note: only the default Bedrock runtime endpoint pattern
 // (bedrock-runtime.<region>.amazonaws.com) attaches. FIPS / China /
 // GovCloud / endpoint_url override shapes are intentionally not
-// covered here — that's #243 PR 4 territory.
+// covered here — see #254 for the endpoint_url deferral.
 func TestMaybeAttachBedrockAuth_Detection(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/bamlutils/llmhttp/awsstream_exec.go
+++ b/bamlutils/llmhttp/awsstream_exec.go
@@ -5,13 +5,12 @@
 // different body content-type check and different return type
 // (an awsstream.Decoder instead of an SSE channel).
 //
-// PR3-bedrock-stream breadcrumb (issue #243): this lives in
-// llmhttp/ because the transport responsibilities (URL rewrite, SigV4,
-// HTTP error classification, body limit on error responses) are
-// identical to the rest of the package. The provider-specific event
-// decoding stays in bamlutils/awsstream so non-bedrock callers don't
-// pick up the AWS SDK dependency surface at the llmhttp boundary
-// for no reason.
+// Lives in llmhttp/ because the transport responsibilities (URL
+// rewrite, SigV4, HTTP error classification, body limit on error
+// responses) are identical to the rest of the package. The
+// provider-specific event decoding stays in bamlutils/awsstream so
+// non-bedrock callers don't pick up the AWS SDK dependency surface at
+// the llmhttp boundary for no reason.
 package llmhttp
 
 import (
@@ -43,10 +42,9 @@ const AWSStreamContentType = "application/vnd.amazon.eventstream"
 //   - Close releases the underlying connection. The caller is
 //     responsible for invoking it; idempotent.
 //
-// PR3-bedrock-stream breadcrumb: PR 4 may surface modeled
+// The body channel is the load-bearing contract; modeled
 // initial-response metadata (request id, model name from response
-// headers) on this type; the body channel stays the load-bearing
-// contract.
+// headers) is not surfaced here today.
 type AWSStreamResponse struct {
 	StatusCode int
 	Headers    http.Header
@@ -86,10 +84,10 @@ func (s *AWSStreamResponse) Close() {
 // negotiates HTTP/2 with ALPN, so production traffic always lands on
 // the stdlib HTTP/2 client anyway; the fasthttp branch's
 // SSE-tail-tracking machinery has no equivalent for AWS event-stream
-// framing (which has its own CRC + length-prefix terminator), and
-// duplicating it for PR 3 is out of scope. Mock servers (httptest.NewServer)
-// speak HTTP/1.1 over net/http, which works fine here. PR 4 may revisit
-// if a fasthttp-pinned origin shows up in production.
+// framing (which has its own CRC + length-prefix terminator), so a
+// fasthttp twin isn't worth maintaining. Mock servers
+// (httptest.NewServer) speak HTTP/1.1 over net/http, which works fine
+// here.
 func (c *Client) ExecuteAWSStream(ctx context.Context, req *Request) (*AWSStreamResponse, error) {
 	if c == nil || c.httpClient == nil {
 		return nil, fmt.Errorf("llmhttp: nil client")
@@ -102,8 +100,8 @@ func (c *Client) ExecuteAWSStream(ctx context.Context, req *Request) (*AWSStream
 
 	// SigV4 signing runs after URL rewrite (so the signature matches
 	// the host the request actually goes out with) and before backend
-	// dispatch — identical contract to ExecuteStream. PR3-bedrock-stream
-	// breadcrumb: re-uses the same hook PR 1 added.
+	// dispatch — identical contract to ExecuteStream, reusing the same
+	// signRequest hook.
 	if err := signRequest(ctx, req, rewritten); err != nil {
 		return nil, err
 	}

--- a/bamlutils/llmhttp/llmhttp.go
+++ b/bamlutils/llmhttp/llmhttp.go
@@ -36,8 +36,7 @@ type Request struct {
 	// rewrite and before backend dispatch. nil leaves headers untouched
 	// — every non-bedrock provider hits that path. Used by both the
 	// call path (Execute) and the streaming path (ExecuteStream /
-	// ExecuteAWSStream). PR1-bedrock / PR3-bedrock-stream breadcrumb
-	// (issue #243).
+	// ExecuteAWSStream).
 	AWSAuth *AWSAuthConfig
 }
 
@@ -231,7 +230,7 @@ func (c *Client) ExecuteStream(ctx context.Context, req *Request) (*StreamRespon
 	// SigV4 signing runs after URL rewrite (so the signature matches
 	// the host the request actually goes out with) and before either
 	// backend dispatch (so net/http and fasthttp see the same signed
-	// headers). PR1-bedrock breadcrumb.
+	// headers).
 	if err := signRequest(ctx, req, rewritten); err != nil {
 		return nil, err
 	}
@@ -363,7 +362,7 @@ func (c *Client) Execute(ctx context.Context, req *Request, onSuccess func()) (*
 	// SigV4 signing runs after URL rewrite (so the signature matches
 	// the host the request actually goes out with) and before either
 	// backend dispatch (so net/http and fasthttp see the same signed
-	// headers). PR1-bedrock breadcrumb.
+	// headers).
 	if err := signRequest(ctx, req, rewritten); err != nil {
 		return nil, err
 	}

--- a/cmd/worker/error_classify.go
+++ b/cmd/worker/error_classify.go
@@ -79,7 +79,6 @@ type providerErrorDetails struct {
 	// ErrorCode/ErrorMessage carry the AWS event-stream
 	// :error-code / :error-message header values when a Bedrock
 	// stream surfaces a transport-level error frame.
-	// PR3-bedrock-stream breadcrumb (issue #243).
 	ErrorCode    string `json:"error_code,omitempty"`
 	ErrorMessage string `json:"error_message,omitempty"`
 	// ExceptionType / ExceptionMessage carry the modeled
@@ -91,7 +90,7 @@ type providerErrorDetails struct {
 	// ValidationException, etc.). Distinct from
 	// ErrorCode/ErrorMessage so wire consumers can tell a torn
 	// transport apart from a modeled exception even when both map
-	// to provider_error. PR3-bedrock-stream breadcrumb (issue #243).
+	// to provider_error.
 	ExceptionType    string `json:"exception_type,omitempty"`
 	ExceptionMessage string `json:"exception_message,omitempty"`
 }
@@ -164,7 +163,6 @@ func classifyBAMLError(err error) (code string, details []byte) {
 	// taxonomy treats them the same as an HTTP-layer 5xx. The AWS
 	// codes (e.g. "InternalServerError", "ThrottlingException") and
 	// message ride along in details for caller diagnostics.
-	// PR3-bedrock-stream breadcrumb (issue #243).
 	var awsTransportErr *awsstream.TransportError
 	if errors.As(err, &awsTransportErr) {
 		return string(apierror.CodeProviderError), providerErrorDetails{
@@ -181,7 +179,7 @@ func classifyBAMLError(err error) (code string, details []byte) {
 	// class — model refusal, throttling, validation — so they map
 	// to provider_error alongside transport errors but with their
 	// own detail fields so consumers can tell the two failure
-	// modes apart. PR3-bedrock-stream breadcrumb (issue #243).
+	// modes apart.
 	var bedrockExc *buildrequest.BedrockStreamException
 	if errors.As(err, &bedrockExc) {
 		return string(apierror.CodeProviderError), providerErrorDetails{

--- a/cmd/worker/error_classify_test.go
+++ b/cmd/worker/error_classify_test.go
@@ -77,10 +77,10 @@ func TestClassifyBAMLError(t *testing.T) {
 			wantDetails: "",
 		},
 		{
-			// PR3-bedrock-stream (#243): AWS event-stream transport
-			// errors carry :error-code / :error-message headers; the
-			// arm forwards both into provider_error details so the
-			// AWS-side reason is observable upstream.
+			// AWS event-stream transport errors carry :error-code /
+			// :error-message headers; the arm forwards both into
+			// provider_error details so the AWS-side reason is
+			// observable upstream.
 			name:        "awsstream TransportError direct",
 			err:         &awsstream.TransportError{Code: "InternalServerError", Message: "service unavailable"},
 			wantCode:    string(apierror.CodeProviderError),
@@ -105,8 +105,8 @@ func TestClassifyBAMLError(t *testing.T) {
 			wantDetails: `{"error_code":"InternalServerError"}`,
 		},
 		{
-			// PR3-bedrock-stream (#243): Bedrock modeled exceptions
-			// (in-band :message-type=exception frames) classify as
+			// Bedrock modeled exceptions (in-band
+			// :message-type=exception frames) classify as
 			// provider_error with exception_type + exception_message
 			// — distinct fields from error_code/error_message so
 			// consumers can tell a torn transport apart from a

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -805,7 +805,6 @@ func (e *transportFlakeWrap) Unwrap() error { return e.inner }
 // "buildrequest: delta extraction failed: %w" envelope, and the
 // classifier must walk the chain via errors.As to produce
 // provider_error with exception_type + exception_message details.
-// PR3-bedrock-stream breadcrumb (issue #243).
 func TestBridgeStreamResultsClassifiesBedrockStreamException(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

PR 4 of 4 of #243. Mechanical breadcrumb scrub closing out the bedrock multi-PR sequence. Codex scoping deferred all original PR 4 parity items (`endpoint_url`, static `.baml` creds, reasoning `signature`/`redactedContent`, tool-use streaming deltas, usage metadata propagation) to follow-up tracker #254 — each is upstream-blocked or unscoped today.

## What's included

- Breadcrumb scrub across the `PR1-bedrock` / `PR3-bedrock-stream` comment markers in Go files (21 files, 171 ins / 207 del). Preserves technical rationale where present; deletes pure marker comments.
- `#243` references in code rewritten to present-tense or re-routed to #254 (the follow-up tracker) where applicable.
- Tracker body update for #243 reflecting the closing state.

## What's NOT included (intentionally — see #254)

- `endpoint_url` parity for bedrock (upstream-blocked).
- Literal `.baml` static credentials for bedrock (upstream-blocked).
- Reasoning `signature` / `redactedContent` exposure (no operator-actionable interpretation today).
- Tool-use streaming deltas for bedrock (no end-to-end BAML tool-use coverage on any provider).
- Usage metadata propagation (cross-provider design needed first).

## Test plan

- [x] `rg -n 'PR1-bedrock|PR3-bedrock-stream|PR1-i243|PR3-i243|PR 1 of #243|PR 3 of #243' -g '*.go' -g '*.proto'` returns zero hits.
- [x] `go build ./...` / `go vet ./...` / `go test ./...` (root + bamlutils + workerplugin + pool + introspected + all four adapter modules) all green.
- [x] `cmd/verify-framework-adapter`: 9/9 (all three adapters × structural / deterministic / behavioural).
- [x] `cmd/verify-adapter-pins`: 4/4.
- [x] `gofmt -l` clean on the modified file set (pre-existing drift elsewhere unchanged).

Closes #243.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation and comments across build request, response extraction, and error classification modules to clarify Bedrock streaming behavior and provider support. Removed obsolete breadcrumb references and standardized documentation language.

* **Chores**
  * Cleaned up test documentation and reorganized comment blocks for consistency. Renamed one test function to remove version-specific naming.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/255)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->