### PR TITLE
feat(worker): forward accumulated raw on legacy error envelopes (PR 1/2 of #256)

### DIFF
--- a/adapters/common/codegen/codegen_legacy_stream.go
+++ b/adapters/common/codegen/codegen_legacy_stream.go
@@ -480,9 +480,13 @@ func (me *methodEmitter) emitLegacyStream() {
 				jen.Id("__r").Dot("kind").Op("=").Qual(common.InterfacesPkg, "StreamResultKindHeartbeat"),
 				jen.Return(jen.Id("__r")),
 			),
-			// newError
-			jen.Func().Params(jen.Id("err").Error()).Qual(common.InterfacesPkg, "StreamResult").Block(
-				jen.Return(jen.Id(me.errorConstructorName).Call(jen.Id("err"))),
+			// newError: error envelope carries the accumulated raw text
+			// from runFullOrchestration (per #256) so the worker bridge
+			// can forward it as details.raw.
+			jen.Func().Params(jen.Id("err").Error(), jen.Id("raw").String()).Qual(common.InterfacesPkg, "StreamResult").Block(
+				jen.Id("__r").Op(":=").Id(me.errorConstructorName).Call(jen.Id("err")),
+				jen.Id("__r").Dot("raw").Op("=").Id("raw"),
+				jen.Return(jen.Id("__r")),
 			),
 			// release
 			jen.Func().Params(jen.Id("__r").Qual(common.InterfacesPkg, "StreamResult")).Block(

--- a/adapters/common/codegen/codegen_stream_helpers.go
+++ b/adapters/common/codegen/codegen_stream_helpers.go
@@ -242,7 +242,12 @@ func generateStreamHelpers(out *jen.File) {
 			jen.Id("out").Chan().Add(streamResultIface.Clone()),
 			jen.Id("options").Op("[]").Qual(common.GeneratedClientPkg, "CallOptionFunc"),
 			jen.Id("newHeartbeat").Func().Params().Add(streamResultIface.Clone()),
-			jen.Id("newError").Func().Params(jen.Error()).Add(streamResultIface.Clone()),
+			// newError carries the accumulated raw text seen up to the point of
+			// failure (per #256) so the worker bridge can attach it as
+			// details.raw on the apierror envelope. Pass "" when no raw is
+			// available (panic-before-any-tick); the bridge omits the detail
+			// when the string is empty.
+			jen.Id("newError").Func().Params(jen.Error(), jen.String()).Add(streamResultIface.Clone()),
 			jen.Id("release").Func().Params(streamResultIface.Clone()),
 			// plannedMetadata: pre-built planned-phase Metadata for this request,
 			// or nil to disable metadata emission entirely. The orchestrator
@@ -326,6 +331,51 @@ func generateStreamHelpers(out *jen.File) {
 			// final state — useful when the last onTick fires before the last
 			// SSE chunk arrives.
 			jen.Var().Id("lastFuncLog").Qual("sync/atomic", "Value"),
+
+			// reconcileRaw applies the same RawLLMResponse splice/fallback used
+			// by the success-final path, factored so error frames (#256) carry
+			// the most complete raw text available. See the success-final
+			// reconciliation block below for the splice rationale; here we just
+			// reuse it without the reasoning/parseable-side reads.
+			jen.Id("reconcileRaw").Op(":=").Func().Params(
+				jen.Id("finalRaw").String(),
+				jen.Id("parseableFull").String(),
+			).String().Block(
+				jen.If(
+					jen.List(jen.Id("fl"), jen.Id("flOk")).Op(":=").Id("lastFuncLog").Dot("Load").Call().Assert(jen.Qual(BamlPkg, "FunctionLog")),
+					jen.Id("flOk"),
+				).Block(
+					jen.If(
+						jen.List(jen.Id("authRaw"), jen.Id("rawErr")).Op(":=").Id("fl").Dot("RawLLMResponse").Call(),
+						jen.Id("rawErr").Op("==").Nil(),
+					).Block(
+						jen.If(
+							jen.Len(jen.Id("authRaw")).Op(">").Len(jen.Id("parseableFull")).
+								Op("&&").
+								Qual("strings", "HasPrefix").Call(jen.Id("authRaw"), jen.Id("parseableFull")),
+						).Block(
+							jen.Id("finalRaw").Op("=").Id("finalRaw").Op("+").Id("authRaw").Index(jen.Len(jen.Id("parseableFull")), jen.Empty()),
+						).Else().If(
+							jen.Len(jen.Id("authRaw")).Op(">").Len(jen.Id("finalRaw")),
+						).Block(
+							jen.Id("finalRaw").Op("=").Id("authRaw"),
+						),
+					),
+				),
+				jen.Return(jen.Id("finalRaw")),
+			),
+
+			// computeErrorRaw reads the extractor's accumulator under
+			// extractorMu and applies reconcileRaw, returning the best raw
+			// text available for an error frame. Returns "" when neither the
+			// extractor nor lastFuncLog have content.
+			jen.Id("computeErrorRaw").Op(":=").Func().Params().String().Block(
+				jen.Id("extractorMu").Dot("Lock").Call(),
+				jen.Id("__raw").Op(":=").Id("extractor").Dot("RawFull").Call(),
+				jen.Id("__parseable").Op(":=").Id("extractor").Dot("ParseableFull").Call(),
+				jen.Id("extractorMu").Dot("Unlock").Call(),
+				jen.Return(jen.Id("reconcileRaw").Call(jen.Id("__raw"), jen.Id("__parseable"))),
+			),
 
 			// doShutdown
 			jen.Id("doShutdown").Op(":=").Func().Params().Block(
@@ -486,7 +536,12 @@ func generateStreamHelpers(out *jen.File) {
 				jen.Qual("github.com/gregwebs/go-recovery", "GoHandler").Call(
 					jen.Func().Params(jen.Id("err").Error()).Block(
 						jen.Id("shutdownOnce").Dot("Do").Call(jen.Id("doShutdown")),
-						jen.Id("__errR").Op(":=").Id("newError").Call(jen.Id("err")),
+						// Panic recovery: a panic can leave extractorMu held by
+						// the panicking goroutine, so we do not call
+						// computeErrorRaw here — passing "" keeps the bridge
+						// from waiting on a poisoned mutex. The worker bridge
+						// omits details.raw when raw is empty.
+						jen.Id("__errR").Op(":=").Id("newError").Call(jen.Id("err"), jen.Lit("")),
 						jen.Select().Block(
 							jen.Case(jen.Id("out").Op("<-").Id("__errR")).Block(),
 							jen.Case(jen.Op("<-").Id("adapter").Dot("Done").Call()).Block(jen.Id("release").Call(jen.Id("__errR"))),
@@ -502,7 +557,7 @@ func generateStreamHelpers(out *jen.File) {
 						jen.Id("fatalErrCopy").Op(":=").Id("fatalErr"),
 						jen.Id("fatalMu").Dot("Unlock").Call(),
 						jen.If(jen.Id("fatalErrCopy").Op("!=").Nil()).Block(
-							jen.Id("__errR").Op(":=").Id("newError").Call(jen.Id("fatalErrCopy")),
+							jen.Id("__errR").Op(":=").Id("newError").Call(jen.Id("fatalErrCopy"), jen.Id("computeErrorRaw").Call()),
 							jen.Select().Block(
 								jen.Case(jen.Id("out").Op("<-").Id("__errR")).Block(),
 								jen.Case(jen.Op("<-").Id("adapter").Dot("Done").Call()).Block(jen.Id("release").Call(jen.Id("__errR"))),
@@ -512,7 +567,7 @@ func generateStreamHelpers(out *jen.File) {
 
 						// Check stream error
 						jen.If(jen.Id("lastErr").Op("!=").Nil()).Block(
-							jen.Id("__errR").Op(":=").Id("newError").Call(jen.Id("lastErr")),
+							jen.Id("__errR").Op(":=").Id("newError").Call(jen.Id("lastErr"), jen.Id("computeErrorRaw").Call()),
 							jen.Select().Block(
 								jen.Case(jen.Id("out").Op("<-").Id("__errR")).Block(),
 								jen.Case(jen.Op("<-").Id("adapter").Dot("Done").Call()).Block(jen.Id("release").Call(jen.Id("__errR"))),
@@ -560,24 +615,7 @@ func generateStreamHelpers(out *jen.File) {
 						jen.Id("parseableFull").Op(":=").Id("extractor").Dot("ParseableFull").Call(),
 						jen.Id("finalReasoning").Op(":=").Id("extractor").Dot("ReasoningFull").Call(),
 						jen.Id("extractorMu").Dot("Unlock").Call(),
-						jen.If(jen.Id("flOk")).Block(
-							jen.If(
-								jen.List(jen.Id("authRaw"), jen.Id("rawErr")).Op(":=").Id("fl").Dot("RawLLMResponse").Call(),
-								jen.Id("rawErr").Op("==").Nil(),
-							).Block(
-								jen.If(
-									jen.Len(jen.Id("authRaw")).Op(">").Len(jen.Id("parseableFull")).
-										Op("&&").
-										Qual("strings", "HasPrefix").Call(jen.Id("authRaw"), jen.Id("parseableFull")),
-								).Block(
-									jen.Id("finalRaw").Op("=").Id("finalRaw").Op("+").Id("authRaw").Index(jen.Len(jen.Id("parseableFull")), jen.Empty()),
-								).Else().If(
-									jen.Len(jen.Id("authRaw")).Op(">").Len(jen.Id("finalRaw")),
-								).Block(
-									jen.Id("finalRaw").Op("=").Id("authRaw"),
-								),
-							),
-						),
+						jen.Id("finalRaw").Op("=").Id("reconcileRaw").Call(jen.Id("finalRaw"), jen.Id("parseableFull")),
 
 						// Outcome metadata: build from the winning attempt's
 						// FunctionLog and emit just before the final, so clients

--- a/adapters/common/codegen/stream_helpers_test.go
+++ b/adapters/common/codegen/stream_helpers_test.go
@@ -109,6 +109,86 @@ func TestGenerateStreamHelpers_ContainsExpectedSymbols(t *testing.T) {
 	}
 }
 
+// TestRunFullOrchestration_NewErrorCarriesRaw pins #256 PR1's codegen
+// contract: runFullOrchestration's newError parameter widens to
+// (error, string) so the per-method closure (in codegen_legacy_stream.go)
+// can stamp the accumulator's raw text onto the error StreamResult.
+// The contract has three structural assertions:
+//
+//  1. The newError parameter type appears with the widened signature.
+//  2. Both error-emit sites in the stream-drain goroutine (fatalErrCopy,
+//     lastErr) thread the accumulator-derived raw via computeErrorRaw().
+//  3. The panic-recovery path passes "" (defensive: the extractor mutex
+//     may be held by the panicking goroutine — see the doc comment at
+//     the emit site).
+//
+// All three are textual checks against the rendered source. Brittle to
+// minor rewrites but cheap; the alternative (parse + AST inspection)
+// is over-engineered for a contract this narrow.
+func TestRunFullOrchestration_NewErrorCarriesRaw(t *testing.T) {
+	t.Parallel()
+
+	out := common.MakeFile()
+	generateStreamHelpers(out)
+	rendered := out.GoString()
+
+	// 1. Widened signature on runFullOrchestration. Use a substring that
+	// only matches the full path's newError (the noRaw path keeps the
+	// old func(error) shape).
+	if !strings.Contains(rendered, "newError func(error, string) bamlutils.StreamResult") {
+		t.Errorf("runFullOrchestration must accept newError func(error, string) bamlutils.StreamResult; rendered:\n%s",
+			snippet(rendered, 4000))
+	}
+
+	// 2. Both terminal error sites thread the accumulator via
+	// computeErrorRaw(). Search bounded to runFullOrchestration so a
+	// future addition of a newError call site in runNoRawOrchestration
+	// (which keeps the single-arg signature) cannot satisfy these
+	// assertions by accident.
+	fnStart := strings.Index(rendered, "func runFullOrchestration(")
+	if fnStart < 0 {
+		t.Fatal("could not locate runFullOrchestration in generated source")
+	}
+	nextFn := strings.Index(rendered[fnStart+1:], "\nfunc ")
+	end := len(rendered)
+	if nextFn >= 0 {
+		end = fnStart + 1 + nextFn
+	}
+	fullBody := rendered[fnStart:end]
+
+	if !strings.Contains(fullBody, "newError(fatalErrCopy, computeErrorRaw())") {
+		t.Errorf("fatalErrCopy emit must pass computeErrorRaw(); runFullOrchestration body:\n%s",
+			snippet(fullBody, 4000))
+	}
+	if !strings.Contains(fullBody, "newError(lastErr, computeErrorRaw())") {
+		t.Errorf("lastErr emit must pass computeErrorRaw(); runFullOrchestration body:\n%s",
+			snippet(fullBody, 4000))
+	}
+
+	// 3. The panic recovery handler emits newError(err, "") because the
+	// extractor mutex may be poisoned by the panicking goroutine.
+	if !strings.Contains(fullBody, `newError(err, "")`) {
+		t.Errorf("panic recovery must pass empty raw to newError; runFullOrchestration body:\n%s",
+			snippet(fullBody, 4000))
+	}
+
+	// reconcileRaw closure must be present so error frames pick up the
+	// authoritative RawLLMResponse splice (matches the success-final
+	// reconciliation). Without this, error raw could be truncated under
+	// the same stale-SSE-view race the success path defends against.
+	if !strings.Contains(fullBody, "reconcileRaw :=") {
+		t.Errorf("runFullOrchestration must declare a reconcileRaw closure; body:\n%s",
+			snippet(fullBody, 4000))
+	}
+	// reconcileRaw must still be used by the success-final path so a
+	// future refactor doesn't accidentally split the reconciliation
+	// between two codepaths and let error/success drift apart.
+	if !strings.Contains(fullBody, "finalRaw = reconcileRaw(finalRaw, parseableFull)") {
+		t.Errorf("success-final path must reuse reconcileRaw; body:\n%s",
+			snippet(fullBody, 4000))
+	}
+}
+
 func snippet(s string, n int) string {
 	if len(s) <= n {
 		return s

--- a/cmd/worker/error_classify.go
+++ b/cmd/worker/error_classify.go
@@ -113,6 +113,59 @@ func (d providerErrorDetails) marshal() []byte {
 	return data
 }
 
+// mergeRawDetail merges the accumulated raw text from a legacy
+// CallStream+OnTick failure (see #256) into the JSON-encoded details
+// object returned by classifyBAMLError. The forwarding is not gated on
+// classification: parse_error, provider_error, and unclassified errors
+// all get details.raw when the extractor accumulated bytes before the
+// failure. Consumers reading the apierror envelope no longer need to
+// regex-scrape "\nRaw Response: ..." out of BAML's free-form error
+// string — same posture as provider_error's details.body (#248).
+//
+// Behavior:
+//   - raw == "": returns details unchanged (the helper is a no-op so
+//     omitempty stays in force on the worker→host wire).
+//   - details == nil: returns {"raw": raw} as a fresh JSON object.
+//   - details is a JSON object: unmarshals, sets "raw", marshals back.
+//
+// All existing details fields (status_code, body, client_name, etc.)
+// are preserved. The marshal-back step uses map[string]any rather than
+// the typed struct so we don't drop unrecognized fields a future
+// classifier may add.
+//
+// Defensive fallback: if details is non-empty but isn't a JSON object,
+// the helper returns a fresh {"raw": raw} object rather than dropping
+// raw on the floor. Today every classifyBAMLError path returns either
+// nil or a marshalled providerErrorDetails (always object-shaped), so
+// this branch is dead — kept so a future classifier returning
+// non-object details doesn't silently lose the diagnostic.
+func mergeRawDetail(details []byte, raw string) []byte {
+	if raw == "" {
+		return details
+	}
+	if len(details) == 0 {
+		out, err := json.Marshal(map[string]any{"raw": raw})
+		if err != nil {
+			return details
+		}
+		return out
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(details, &obj); err != nil || obj == nil {
+		out, marshalErr := json.Marshal(map[string]any{"raw": raw})
+		if marshalErr != nil {
+			return details
+		}
+		return out
+	}
+	obj["raw"] = raw
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return details
+	}
+	return out
+}
+
 // classifyBAMLError inspects a worker-side error from a BAML call /
 // BuildRequest path and returns the apierror.Code that best fits, plus
 // optional JSON-encoded details. Returns ("", nil) when no surface

--- a/cmd/worker/error_classify_test.go
+++ b/cmd/worker/error_classify_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -396,6 +397,122 @@ func TestClassifyBAMLErrorHTTPErrorPrefersInnermost(t *testing.T) {
 	if !strings.Contains(string(details), `"status_code":418`) {
 		t.Fatalf("details missing status_code 418: %s", string(details))
 	}
+}
+
+// TestMergeRawDetail pins the helper's four cases: empty-raw no-op,
+// nil-details fresh object, object-details merge, and invalid-JSON
+// defensive fallback. The helper is the worker-side gate that
+// determines whether legacy CallStream+OnTick error envelopes carry
+// the accumulated raw text on the wire (per #256), so each branch is
+// load-bearing.
+func TestMergeRawDetail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		details []byte
+		raw     string
+		want    string
+	}{
+		{
+			name:    "empty raw and nil details is no-op",
+			details: nil,
+			raw:     "",
+			want:    "",
+		},
+		{
+			name:    "empty raw with object details is no-op",
+			details: []byte(`{"status_code":500}`),
+			raw:     "",
+			want:    `{"status_code":500}`,
+		},
+		{
+			name:    "nil details produces fresh raw object",
+			details: nil,
+			raw:     "unparseable prose",
+			want:    `{"raw":"unparseable prose"}`,
+		},
+		{
+			name:    "empty-bytes details produces fresh raw object",
+			details: []byte{},
+			raw:     "x",
+			want:    `{"raw":"x"}`,
+		},
+		{
+			name:    "object details get raw merged in",
+			details: []byte(`{"status_code":500,"body":"oops"}`),
+			raw:     "tail",
+			want:    `{"body":"oops","raw":"tail","status_code":500}`,
+		},
+		{
+			name:    "invalid JSON details fall back to fresh raw object",
+			details: []byte(`not json`),
+			raw:     "salvaged",
+			want:    `{"raw":"salvaged"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := mergeRawDetail(tc.details, tc.raw)
+			gotStr := string(got)
+			// Object cases require key-set comparison rather than byte
+			// equality because Go's map iteration is unordered; the
+			// helper marshals from map[string]any so encoding/json's
+			// alphabetical key order applies but pre-existing details
+			// in the test case may not already be sorted.
+			if tc.raw != "" && len(tc.details) > 0 && isJSONObject(tc.details) {
+				wantSet := jsonObjectKeyset(t, []byte(tc.want))
+				gotSet := jsonObjectKeyset(t, got)
+				if !equalKeyset(wantSet, gotSet) {
+					t.Errorf("merged details mismatch:\n  got  %s\n  want %s", gotStr, tc.want)
+				}
+				return
+			}
+			if gotStr != tc.want {
+				t.Errorf("got %q, want %q", gotStr, tc.want)
+			}
+		})
+	}
+}
+
+// isJSONObject reports whether b begins (after any leading whitespace)
+// with '{'. Used by TestMergeRawDetail to pick between byte-equality
+// and key-set comparison for object-shaped inputs.
+func isJSONObject(b []byte) bool {
+	for _, c := range b {
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			continue
+		}
+		return c == '{'
+	}
+	return false
+}
+
+func jsonObjectKeyset(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal %s: %v", string(b), err)
+	}
+	return m
+}
+
+func equalKeyset(a, b map[string]any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		vb, ok := b[k]
+		if !ok {
+			return false
+		}
+		if fmt.Sprintf("%v", va) != fmt.Sprintf("%v", vb) {
+			return false
+		}
+	}
+	return true
 }
 
 // TestClassifyBAMLErrorTypedBeforeLegacy pins the resolution order:

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -403,10 +403,22 @@ func bridgeStreamResults(ctx context.Context, resultChan <-chan bamlutils.Stream
 				// so the host's classifyWorkerError forwards it verbatim
 				// instead of defaulting to worker_error. classifyBAMLError
 				// returns ("", nil) for unrecognized errors, leaving
-				// pluginResult.ErrorCode / ErrorDetails at their zero
-				// values for host-side fallback.
-				if code, details := classifyBAMLError(result.Error()); code != "" {
+				// pluginResult.ErrorCode at its zero value for host-side
+				// fallback.
+				//
+				// mergeRawDetail attaches the accumulator's text (per #256)
+				// to details regardless of classification arm: parse_error,
+				// provider_error, and unclassified errors all carry
+				// details.raw when result.Raw() is non-empty. Unclassified
+				// errors keep their empty worker code but gain details.raw
+				// via the host's worker_error fallback path. Empty raw
+				// leaves details untouched (omitempty contract).
+				code, details := classifyBAMLError(result.Error())
+				details = mergeRawDetail(details, result.Raw())
+				if code != "" {
 					pluginResult.ErrorCode = code
+				}
+				if details != nil {
 					pluginResult.ErrorDetails = details
 				}
 			case bamlutils.StreamResultKindStream:

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1059,3 +1059,197 @@ func TestDrainStreamResultsNoWarningOnFastClose(t *testing.T) {
 		t.Fatalf("expected no warnings for fast drain, got: %v", warnings)
 	}
 }
+
+// TestBridgeStreamResultsForwardsRawOnParseError pins #256's contract
+// for the legacy parse_error arm: when the orchestrator emits an error
+// StreamResult whose Raw() carries the accumulated unparseable prose,
+// the bridge must attach it as ErrorDetails.raw alongside the
+// classifier's parse_error code. Without this, consumers reading
+// /call-with-raw error envelopes have to regex-scrape BAML's free-form
+// "Parsing error:" message to recover the same diagnostic.
+func TestBridgeStreamResultsForwardsRawOnParseError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const proseSentinel = "Apologies — I cannot answer that without more context."
+
+	in := make(chan bamlutils.StreamResult, 1)
+	fake := newFakeStreamResult(bamlutils.StreamResultKindError)
+	// Legacy parse-error envelope: BAML's runtime renders this exact
+	// "Parsing error: " prefix via ValidationError's Display impl
+	// (engine/baml-runtime/src/errors.rs).
+	fake.err = errors.New("Parsing error: Failed to parse LLM response: not a JSON envelope")
+	fake.raw = proseSentinel
+	in <- fake
+	close(in)
+
+	out := bridgeStreamResults(ctx, in, nil)
+
+	select {
+	case got, ok := <-out:
+		if !ok {
+			t.Fatal("expected bridged parse_error result")
+		}
+		defer workerplugin.ReleaseStreamResult(got)
+		if got.ErrorCode != "parse_error" {
+			t.Errorf("expected ErrorCode=parse_error, got %q", got.ErrorCode)
+		}
+		if !strings.Contains(string(got.ErrorDetails), `"raw":"`) {
+			t.Fatalf("ErrorDetails must carry the raw key; got %s", string(got.ErrorDetails))
+		}
+		// Match against the marshaled JSON; the sentinel contains "—"
+		// which Go's encoding/json passes through unescaped under the
+		// default settings used by mergeRawDetail.
+		if !strings.Contains(string(got.ErrorDetails), proseSentinel) {
+			t.Errorf("ErrorDetails.raw must contain the unparseable prose %q; got %s",
+				proseSentinel, string(got.ErrorDetails))
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for bridged parse_error result")
+	}
+}
+
+// TestBridgeStreamResultsForwardsRawOnProviderError pins that the raw
+// forwarding sits NEXT TO the existing provider_error details (not
+// replacing them): a typed *llmhttp.HTTPError still produces
+// details.status_code and details.body from the classifier, and #256
+// now adds details.raw from the accumulator.
+func TestBridgeStreamResultsForwardsRawOnProviderError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const bodySentinel = "rate limit: distinctive body sentinel"
+	const rawSentinel = "raw-from-extractor-sentinel"
+
+	in := make(chan bamlutils.StreamResult, 1)
+	fake := newFakeStreamResult(bamlutils.StreamResultKindError)
+	fake.err = &llmhttp.HTTPError{StatusCode: 429, Body: bodySentinel}
+	fake.raw = rawSentinel
+	in <- fake
+	close(in)
+
+	out := bridgeStreamResults(ctx, in, nil)
+
+	select {
+	case got, ok := <-out:
+		if !ok {
+			t.Fatal("expected bridged provider_error result")
+		}
+		defer workerplugin.ReleaseStreamResult(got)
+		if got.ErrorCode != "provider_error" {
+			t.Errorf("expected ErrorCode=provider_error, got %q", got.ErrorCode)
+		}
+		details := string(got.ErrorDetails)
+		// Three assertions on the same payload: existing typed details
+		// survive the merge AND the new raw key joins them.
+		if !strings.Contains(details, `"status_code":429`) {
+			t.Errorf("ErrorDetails missing status_code; got %s", details)
+		}
+		if !strings.Contains(details, bodySentinel) {
+			t.Errorf("ErrorDetails missing body sentinel; got %s", details)
+		}
+		if !strings.Contains(details, rawSentinel) {
+			t.Errorf("ErrorDetails missing raw sentinel; got %s", details)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for bridged provider_error result")
+	}
+}
+
+// TestBridgeStreamResultsForwardsRawOnUnclassifiedError pins the
+// load-bearing #256 behavior: even when classifyBAMLError returns
+// ("", nil) — i.e. the error doesn't match any typed surface or
+// legacy prefix — the bridge MUST still set ErrorDetails when raw is
+// non-empty. The host's classifyWorkerError then defaults the wire
+// code to worker_error, and consumers still get details.raw for
+// diagnostics.
+//
+// This is the surprising arm of the contract: forwarding is not gated
+// on classification, only on raw non-emptiness.
+func TestBridgeStreamResultsForwardsRawOnUnclassifiedError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const rawSentinel = "unclassified-error-raw"
+
+	in := make(chan bamlutils.StreamResult, 1)
+	fake := newFakeStreamResult(bamlutils.StreamResultKindError)
+	fake.err = errors.New("boom") // no typed surface, no legacy prefix match
+	fake.raw = rawSentinel
+	in <- fake
+	close(in)
+
+	out := bridgeStreamResults(ctx, in, nil)
+
+	select {
+	case got, ok := <-out:
+		if !ok {
+			t.Fatal("expected bridged unclassified error result")
+		}
+		defer workerplugin.ReleaseStreamResult(got)
+		// ErrorCode stays empty because the classifier didn't match;
+		// the host's worker_error default kicks in downstream.
+		if got.ErrorCode != "" {
+			t.Errorf("expected empty ErrorCode on unclassified error, got %q", got.ErrorCode)
+		}
+		// But ErrorDetails MUST still carry raw — that's the whole
+		// point of decoupling raw forwarding from classification.
+		if !strings.Contains(string(got.ErrorDetails), rawSentinel) {
+			t.Errorf("ErrorDetails must carry raw on unclassified error; got %s",
+				string(got.ErrorDetails))
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for bridged unclassified error result")
+	}
+}
+
+// TestBridgeStreamResultsOmitsDetailsWhenRawEmpty pins the
+// omitempty contract: when result.Raw() is empty AND the classifier
+// returns no details, the bridge must NOT synthesize a bare
+// `{"raw":""}` details object. Empty accumulator (e.g. provider
+// errored before any chunk arrived) keeps the wire frame's details
+// nil, preserving the existing wire-shape expectations for
+// no-context provider failures.
+func TestBridgeStreamResultsOmitsDetailsWhenRawEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	in := make(chan bamlutils.StreamResult, 1)
+	fake := newFakeStreamResult(bamlutils.StreamResultKindError)
+	fake.err = errors.New("Parsing error: garbage") // classifier returns parse_error + nil details
+	// fake.raw left empty — the surprise-flat-failure case where the
+	// orchestrator surfaces a parse error without any accumulator
+	// content (e.g. BAML pre-stream validation rejected the request).
+	in <- fake
+	close(in)
+
+	out := bridgeStreamResults(ctx, in, nil)
+
+	select {
+	case got, ok := <-out:
+		if !ok {
+			t.Fatal("expected bridged parse_error result")
+		}
+		defer workerplugin.ReleaseStreamResult(got)
+		if got.ErrorCode != "parse_error" {
+			t.Errorf("expected ErrorCode=parse_error, got %q", got.ErrorCode)
+		}
+		// ErrorDetails must stay nil: classifier returned nil details,
+		// raw is empty, mergeRawDetail is a no-op. A non-nil details
+		// here would mean the helper invented a `{"raw":""}` object.
+		if got.ErrorDetails != nil {
+			t.Errorf("expected nil ErrorDetails when raw is empty (omitempty contract); got %s",
+				string(got.ErrorDetails))
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for bridged parse_error result")
+	}
+}

--- a/integration/error_taxonomy_test.go
+++ b/integration/error_taxonomy_test.go
@@ -111,7 +111,10 @@ func TestLegacyClassification_ParseErrorFromProse(t *testing.T) {
 // TestLegacyClassification_ParseErrorFromProseCallWithRaw mirrors the
 // /call case for /call-with-raw — same code path, but the response
 // envelope is otherwise different on success. Pins that the error
-// branch shares the classifier wiring.
+// branch shares the classifier wiring AND (per #256) that the
+// accumulated raw text flows through to ErrorDetails.raw so consumers
+// don't need to regex-scrape BAML's "Parsing error: ..." free-form
+// message.
 func TestLegacyClassification_ParseErrorFromProseCallWithRaw(t *testing.T) {
 	requireLegacyMode(t)
 	requireLegacyParseEnvelope(t)
@@ -119,8 +122,8 @@ func TestLegacyClassification_ParseErrorFromProseCallWithRaw(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		opts := setupNonStreamingScenario(t, "legacy-parse-error-prose-raw",
-			"Apologies — I cannot answer that without more context.")
+		const unparseable = "Apologies — I cannot answer that without more context."
+		opts := setupNonStreamingScenario(t, "legacy-parse-error-prose-raw", unparseable)
 
 		resp, err := client.CallWithRaw(ctx, testutil.CallRequest{
 			Method:  "GetPerson",
@@ -136,6 +139,28 @@ func TestLegacyClassification_ParseErrorFromProseCallWithRaw(t *testing.T) {
 		}
 		if resp.ErrorCode != "parse_error" {
 			t.Errorf("ErrorCode: got %q, want parse_error; body=%s", resp.ErrorCode, resp.Error)
+		}
+		// #256: legacy CallStream+OnTick error envelopes must carry
+		// details.raw with the accumulator's text at the time of
+		// failure. Without this, consumers have to regex BAML's
+		// free-form error string for "\nRaw Response: ..." to recover
+		// the same diagnostic.
+		if len(resp.ErrorDetails) == 0 {
+			t.Fatalf("ErrorDetails missing — expected details.raw with the unparseable prose")
+		}
+		var details struct {
+			Raw string `json:"raw"`
+		}
+		if err := json.Unmarshal(resp.ErrorDetails, &details); err != nil {
+			t.Fatalf("failed to unmarshal ErrorDetails %s: %v", resp.ErrorDetails, err)
+		}
+		if details.Raw == "" {
+			t.Fatalf("ErrorDetails.raw is empty; expected the unparseable prose (raw details=%s)",
+				resp.ErrorDetails)
+		}
+		if !strings.Contains(details.Raw, unparseable) {
+			t.Errorf("ErrorDetails.raw must contain the mock prose %q; got %q",
+				unparseable, details.Raw)
 		}
 	})
 }


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

PR 1 of #256. Adds `details.raw` to legacy `CallStream+OnTick` error envelopes so consumers reading parse failures (or any error class) can pick up the accumulated raw structurally instead of regex-scraping BAML's free-form error string.

## What's included

- `runFullOrchestration` codegen: the error path now reads `extractor.RawFull()` + applies the existing `RawLLMResponse` reconciliation (factored into a shared `reconcileRaw` closure so success and error paths cannot drift), threads raw through `newError(err, raw)` to the emitted error `StreamResult`.
- `cmd/worker/error_classify.go`: new `mergeRawDetail` helper.
- `cmd/worker/main.go`: bridge attaches `details.raw` on every error frame regardless of classification. Unclassified errors get `worker_error` + `details.raw` via the host's fallback. Panic-recovery emits keep raw empty (the extractor mutex may be poisoned).
- `omitempty` when the accumulator is empty.
- Per-adapter regen for v0.204 / v0.215 / v0.219 verified via `verify-framework-adapter` (3/3 green).
- Unit + codegen + integration tests pinning the contract on parse_error, provider_error, unclassified, and empty-raw cases.

## What's NOT included (tracked in #256)

- BuildRequest path parity — PR 2.
- `/parse` endpoint diagnostic shape — different contract (user-supplied input, not accumulated LLM output).
- Capping `details.raw` size — operator-tool framing, no cap.

## Verification

- `go build ./...` / `go vet ./...` clean.
- New unit tests pin the merge helper + bridge wiring across classification arms.
- New integration-test extension on `TestLegacyClassification_ParseErrorFromProseCallWithRaw` asserts `details.raw` contains the mock prose.
- 3/3 `verify-framework-adapter` adapters green.
- 4/4 `verify-adapter-pins` adapters green.

References #256.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error responses now systematically include raw LLM response data in error details, ensuring complete error context is captured when streaming encounters parse failures or provider errors.

* **Tests**
  * Added comprehensive test coverage validating raw data inclusion across parse errors, provider errors, and unclassified error scenarios with proper JSON serialization verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/257)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->