### PR TITLE
fix(schema): mark POST endpoint requestBody.required (#252)

### DIFF
--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -674,17 +674,9 @@ func generateOpenAPISchema() *openapi3.T {
 		paths.Set(path, &openapi3.PathItem{
 			Post: &openapi3.Operation{
 				OperationID: methodName,
-				RequestBody: &openapi3.RequestBodyRef{
-					Value: &openapi3.RequestBody{
-						Content: map[string]*openapi3.MediaType{
-							"application/json": {
-								Schema: &openapi3.SchemaRef{
-									Ref: fmt.Sprintf("#/components/schemas/%s", inputSchemaName),
-								},
-							},
-						},
-					},
-				},
+				RequestBody: jsonRequestBody(&openapi3.SchemaRef{
+					Ref: fmt.Sprintf("#/components/schemas/%s", inputSchemaName),
+				}),
 				Responses: responses,
 			},
 		})
@@ -752,17 +744,9 @@ func generateOpenAPISchema() *openapi3.T {
 		paths.Set(rawPath, &openapi3.PathItem{
 			Post: &openapi3.Operation{
 				OperationID: fmt.Sprintf("%sWithRaw", methodName),
-				RequestBody: &openapi3.RequestBodyRef{
-					Value: &openapi3.RequestBody{
-						Content: map[string]*openapi3.MediaType{
-							"application/json": {
-								Schema: &openapi3.SchemaRef{
-									Ref: fmt.Sprintf("#/components/schemas/%s", inputSchemaName),
-								},
-							},
-						},
-					},
-				},
+				RequestBody: jsonRequestBody(&openapi3.SchemaRef{
+					Ref: fmt.Sprintf("#/components/schemas/%s", inputSchemaName),
+				}),
 				Responses: rawResponses,
 			},
 		})
@@ -845,17 +829,9 @@ func generateOpenAPISchema() *openapi3.T {
 					"Without an Accept header, returns Server-Sent Events (text/event-stream) by default. " +
 					"Events have type 'data' for partial results (fields may be null), 'final' for the complete validated result, " +
 					"'heartbeat' for keepalive during idle periods (clients should ignore it), 'reset' if the stream restarts due to a retry, or 'error' for failures.",
-				RequestBody: &openapi3.RequestBodyRef{
-					Value: &openapi3.RequestBody{
-						Content: map[string]*openapi3.MediaType{
-							"application/json": {
-								Schema: &openapi3.SchemaRef{
-									Ref: fmt.Sprintf("#/components/schemas/%s", inputSchemaName),
-								},
-							},
-						},
-					},
-				},
+				RequestBody: jsonRequestBody(&openapi3.SchemaRef{
+					Ref: fmt.Sprintf("#/components/schemas/%s", inputSchemaName),
+				}),
 				Responses: streamResponses,
 			},
 		})
@@ -922,17 +898,9 @@ func generateOpenAPISchema() *openapi3.T {
 					"Events have type 'data' for partial results (fields may be null, includes 'raw' field and an optional 'reasoning' field populated only when __baml_options__.include_reasoning is true), " +
 					"'final' for the complete validated result (also includes full 'raw' output and optional 'reasoning' when __baml_options__.include_reasoning is true), " +
 					"'heartbeat' for keepalive during idle periods (clients should ignore it), 'reset' if the stream restarts due to a retry, or 'error' for failures.",
-				RequestBody: &openapi3.RequestBodyRef{
-					Value: &openapi3.RequestBody{
-						Content: map[string]*openapi3.MediaType{
-							"application/json": {
-								Schema: &openapi3.SchemaRef{
-									Ref: fmt.Sprintf("#/components/schemas/%s", inputSchemaName),
-								},
-							},
-						},
-					},
-				},
+				RequestBody: jsonRequestBody(&openapi3.SchemaRef{
+					Ref: fmt.Sprintf("#/components/schemas/%s", inputSchemaName),
+				}),
 				Responses: streamWithRawResponses,
 			},
 		})
@@ -1594,17 +1562,9 @@ func generateDynamicEndpoints(schemas openapi3.Schemas, paths *openapi3.Paths, b
 				"The output_schema defines what fields the LLM should return. " +
 				"Messages support both plain text (with {output_format} placeholder) and " +
 				"multi-part content with media (images, audio, PDF, video) and explicit output_format parts.",
-			RequestBody: &openapi3.RequestBodyRef{
-				Value: &openapi3.RequestBody{
-					Content: map[string]*openapi3.MediaType{
-						"application/json": {
-							Schema: &openapi3.SchemaRef{
-								Ref: fmt.Sprintf("#/components/schemas/%s", dynamicInputSchemaName),
-							},
-						},
-					},
-				},
-			},
+			RequestBody: jsonRequestBody(&openapi3.SchemaRef{
+				Ref: fmt.Sprintf("#/components/schemas/%s", dynamicInputSchemaName),
+			}),
 			Responses: callResponses,
 		},
 	})
@@ -1673,17 +1633,9 @@ func generateDynamicEndpoints(schemas openapi3.Schemas, paths *openapi3.Paths, b
 			OperationID: "dynamicCallWithRaw",
 			Summary:     "Call dynamic prompt with raw output",
 			Description: "Execute a dynamic prompt and return both the parsed result and raw LLM output, plus an optional 'reasoning' field populated only when __baml_options__.include_reasoning is true.",
-			RequestBody: &openapi3.RequestBodyRef{
-				Value: &openapi3.RequestBody{
-					Content: map[string]*openapi3.MediaType{
-						"application/json": {
-							Schema: &openapi3.SchemaRef{
-								Ref: fmt.Sprintf("#/components/schemas/%s", dynamicInputSchemaName),
-							},
-						},
-					},
-				},
-			},
+			RequestBody: jsonRequestBody(&openapi3.SchemaRef{
+				Ref: fmt.Sprintf("#/components/schemas/%s", dynamicInputSchemaName),
+			}),
 			Responses: callWithRawResponses,
 		},
 	})
@@ -1759,17 +1711,9 @@ func generateDynamicEndpoints(schemas openapi3.Schemas, paths *openapi3.Paths, b
 				"Use `Accept: application/x-ndjson` header for typed NDJSON responses (recommended for generated clients). " +
 				"Without an Accept header, returns Server-Sent Events (text/event-stream) by default. " +
 				"NDJSON may include 'heartbeat' events during idle periods (including before the first data event); clients should ignore them.",
-			RequestBody: &openapi3.RequestBodyRef{
-				Value: &openapi3.RequestBody{
-					Content: map[string]*openapi3.MediaType{
-						"application/json": {
-							Schema: &openapi3.SchemaRef{
-								Ref: fmt.Sprintf("#/components/schemas/%s", dynamicInputSchemaName),
-							},
-						},
-					},
-				},
-			},
+			RequestBody: jsonRequestBody(&openapi3.SchemaRef{
+				Ref: fmt.Sprintf("#/components/schemas/%s", dynamicInputSchemaName),
+			}),
 			Responses: streamResponses,
 		},
 	})
@@ -1830,17 +1774,9 @@ func generateDynamicEndpoints(schemas openapi3.Schemas, paths *openapi3.Paths, b
 			Summary:     "Stream dynamic prompt results with raw output",
 			Description: "Returns a stream of events containing partial results and the accumulated raw LLM output as they become available, plus an optional 'reasoning' field on data/final events populated only when __baml_options__.include_reasoning is true. " +
 				"NDJSON may include 'heartbeat' events during idle periods (including before the first data event); clients should ignore them.",
-			RequestBody: &openapi3.RequestBodyRef{
-				Value: &openapi3.RequestBody{
-					Content: map[string]*openapi3.MediaType{
-						"application/json": {
-							Schema: &openapi3.SchemaRef{
-								Ref: fmt.Sprintf("#/components/schemas/%s", dynamicInputSchemaName),
-							},
-						},
-					},
-				},
-			},
+			RequestBody: jsonRequestBody(&openapi3.SchemaRef{
+				Ref: fmt.Sprintf("#/components/schemas/%s", dynamicInputSchemaName),
+			}),
 			Responses: streamWithRawResponses,
 		},
 	})
@@ -1887,17 +1823,9 @@ func generateDynamicEndpoints(schemas openapi3.Schemas, paths *openapi3.Paths, b
 			OperationID: "dynamicParse",
 			Summary:     "Parse raw LLM output with dynamic schema",
 			Description: "Parse raw LLM output text using the provided output schema definition.",
-			RequestBody: &openapi3.RequestBodyRef{
-				Value: &openapi3.RequestBody{
-					Content: map[string]*openapi3.MediaType{
-						"application/json": {
-							Schema: &openapi3.SchemaRef{
-								Ref: fmt.Sprintf("#/components/schemas/%s", dynamicParseInputSchemaName),
-							},
-						},
-					},
-				},
-			},
+			RequestBody: jsonRequestBody(&openapi3.SchemaRef{
+				Ref: fmt.Sprintf("#/components/schemas/%s", dynamicParseInputSchemaName),
+			}),
 			Responses: parseResponses,
 		},
 	})
@@ -2133,6 +2061,22 @@ func parseJSONTag(tag, fieldName string) (name string, omitEmpty, skip bool) {
 		}
 	}
 	return
+}
+
+// jsonRequestBody builds a RequestBodyRef for an application/json POST
+// body with Required:true. All generated POST endpoints take a body the
+// server semantically requires, but omitting Required:true would emit
+// requestBody.required = false (the OpenAPI 3.0 default), letting
+// downstream client generators mark the body parameter as optional.
+func jsonRequestBody(schemaRef *openapi3.SchemaRef) *openapi3.RequestBodyRef {
+	return &openapi3.RequestBodyRef{
+		Value: &openapi3.RequestBody{
+			Required: true,
+			Content: map[string]*openapi3.MediaType{
+				"application/json": {Schema: schemaRef},
+			},
+		},
+	}
 }
 
 // makeNullableRef returns a SchemaRef equivalent to ref but with

--- a/cmd/schema/main_test.go
+++ b/cmd/schema/main_test.go
@@ -2,11 +2,26 @@ package main
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	baml_rest "github.com/invakid404/baml-rest"
+	"github.com/invakid404/baml-rest/bamlutils"
 )
+
+// SchemaPostRequiredStubInput is the input type wired into the stub
+// StreamingMethod injected by TestPostRequestBodyRequired. It must have a
+// stable, exported name because generateOpenAPISchema derives the component
+// schema name via reflect.Type.Name().
+type SchemaPostRequiredStubInput struct {
+	Foo string `json:"foo"`
+}
+
+// SchemaPostRequiredStubOutput is the final-output type for the stub method.
+type SchemaPostRequiredStubOutput struct {
+	Bar string `json:"bar"`
+}
 
 // TestSchemaRequiredAndNullability pins the contract the schema customizer
 // is expected to honour for `json:omitempty`, `json:"-"`, and pointer-slice
@@ -106,6 +121,82 @@ func TestSchemaRequiredAndNullability(t *testing.T) {
 			t.Errorf("ClientRegistry.clients.items expected nullable wrap (got %+v)", clients.Value.Items)
 		}
 	})
+}
+
+// TestPostRequestBodyRequired pins #252: every generated POST operation
+// must emit requestBody.required = true. The OpenAPI 3.0 default is
+// false, and an absent flag lets downstream client generators mark the
+// body parameter as optional even though every endpoint here
+// semantically requires a body. The test seeds baml_rest.Methods with
+// a stub static method and the dynamic-method sentinel so both static
+// and dynamic codepaths in generateOpenAPISchema fire.
+func TestPostRequestBodyRequired(t *testing.T) {
+	baml_rest.InitBamlRuntime()
+
+	origMethods := baml_rest.Methods
+	t.Cleanup(func() { baml_rest.Methods = origMethods })
+
+	baml_rest.Methods = map[string]bamlutils.StreamingMethod{
+		"StubMethod": {
+			MakeInput:        func() any { return &SchemaPostRequiredStubInput{} },
+			MakeOutput:       func() any { return &SchemaPostRequiredStubOutput{} },
+			MakeStreamOutput: func() any { return &SchemaPostRequiredStubOutput{} },
+		},
+		bamlutils.DynamicMethodName: {
+			MakeInput:        func() any { return &SchemaPostRequiredStubInput{} },
+			MakeOutput:       func() any { return &SchemaPostRequiredStubOutput{} },
+			MakeStreamOutput: func() any { return &SchemaPostRequiredStubOutput{} },
+		},
+	}
+
+	doc := generateOpenAPISchema()
+	if doc == nil || doc.Paths == nil {
+		t.Fatalf("generated schema has no paths")
+	}
+
+	dynamicPathPrefixes := []string{
+		"/call/_dynamic",
+		"/call-with-raw/_dynamic",
+		"/stream/_dynamic",
+		"/stream-with-raw/_dynamic",
+		"/parse/_dynamic",
+	}
+	seenDynamic := make(map[string]bool, len(dynamicPathPrefixes))
+
+	for _, path := range doc.Paths.InMatchingOrder() {
+		item := doc.Paths.Value(path)
+		if item == nil || item.Post == nil {
+			continue
+		}
+		op := item.Post
+		if op.RequestBody == nil || op.RequestBody.Value == nil {
+			t.Errorf("POST %s missing RequestBody value", path)
+			continue
+		}
+		if !op.RequestBody.Value.Required {
+			t.Errorf("POST %s requestBody.required = false (want true); downstream client generators will emit the body parameter as optional", path)
+		}
+		for _, prefix := range dynamicPathPrefixes {
+			if strings.HasPrefix(path, prefix) {
+				seenDynamic[prefix] = true
+			}
+		}
+	}
+
+	for _, prefix := range dynamicPathPrefixes {
+		if !seenDynamic[prefix] {
+			t.Errorf("dynamic operation %s missing from generated paths; test cannot cover the dynamic codepath", prefix)
+		}
+	}
+
+	staticSpot := "/call/StubMethod"
+	item := doc.Paths.Value(staticSpot)
+	if item == nil || item.Post == nil {
+		t.Fatalf("static spot-check %s not generated; static codepath uncovered", staticSpot)
+	}
+	if item.Post.RequestBody == nil || item.Post.RequestBody.Value == nil || !item.Post.RequestBody.Value.Required {
+		t.Errorf("static spot-check %s requestBody.required = false (want true)", staticSpot)
+	}
 }
 
 // isNullable reports whether a SchemaRef carries explicit nullability —


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Closes #252. Sets `requestBody.required: true` on every generated POST endpoint. Long-standing schema-gen quirk surfaced when a downstream Orval regen produced optional body parameters on `dynamicCall` and siblings — the spec was actually emitting `requestBody.required` as absent (defaulting to `false` in OpenAPI 3.0), so Orval was following the spec faithfully. Server-side, every one of these endpoints needs a body.

## What's included

- `cmd/schema/main.go::jsonRequestBody` helper for JSON POST endpoints with `Required: true` baked in.
- Applied at 9 sites: 5 dynamic endpoints + 4 static call/stream endpoints.
- `TestPostRequestBodyRequired` pinning `requestBody.required == true` on every dynamic operation, plus static spot-check. Seeds `baml_rest.Methods` with a stub + dynamic-method entry so both codepaths fire under test.

## What's NOT included (verified out of scope)

- `BamlOptions.client_registry` requiredness — spec correctly emits as optional + nullable. Downstream Orval interpretation if observed as required.
- `ClientRegistry.clients` items nullability — spec correctly emits `{nullable: true, allOf: [{$ref}]}` per #250. Downstream Orval interpretation if observed as non-nullable.
- The dynamic-input component schema `__DynamicInput__.required` (which intentionally requires `messages`, `client_registry`, `output_schema`) — that's the dynamic request body's own required list, separate from `requestBody.required`.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./cmd/schema -count=1 -v` — both schema tests pass
- [x] `go test ./...` — all packages green
- [x] `go run ./cmd/verify-framework-adapter` — 9/9 green
- [x] `go run ./cmd/verify-adapter-pins` — 4/4 green
- [x] `gofmt -l` — no new drift introduced
- [x] Regression test verified to fail under pre-fix state (10 errors across 9 operations + 1 spot-check) and pass after fix

Closes #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved OpenAPI schema generation to ensure all POST endpoints properly declare request bodies as required, enhancing schema compliance and API documentation accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/260)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->