### PR TITLE
feat(schema): typed apierror.details OpenAPI sub-schema (#259)

### DIFF
--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -499,16 +499,46 @@ func generateOpenAPISchema() *openapi3.T {
 			},
 		}
 	}
-	errorDetailsSchema := func() *openapi3.SchemaRef {
+	stringDetail := func(desc string) *openapi3.SchemaRef {
 		return &openapi3.SchemaRef{
 			Value: &openapi3.Schema{
-				Type:        &openapi3.Types{openapi3.TypeObject},
-				Description: "Optional structured context. May carry {\"stacktrace\": \"...\"} on worker panics, or worker-supplied diagnostic fields when available. Absent when no structured details exist.",
-				AdditionalProperties: openapi3.AdditionalProperties{
-					Has: boolPtr(true),
-				},
+				Type:        &openapi3.Types{openapi3.TypeString},
+				Description: desc,
 			},
 		}
+	}
+	integerDetail := func(desc string) *openapi3.SchemaRef {
+		return &openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				Type:        &openapi3.Types{openapi3.TypeInteger},
+				Description: desc,
+			},
+		}
+	}
+	errorDetailsSchemaName := "__ErrorDetails__"
+	schemas[errorDetailsSchemaName] = &openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			Type:        &openapi3.Types{openapi3.TypeObject},
+			Description: "Optional structured context for error responses. Known fields are typed; additional fields may appear for forward compatibility. May carry {\"stacktrace\": \"...\"} on worker panics, or worker-supplied diagnostic fields when available. Absent when no structured details exist.",
+			Properties: openapi3.Schemas{
+				"raw":               stringDetail("Accumulated raw model output available when a call/stream failed after receiving text."),
+				"body":              stringDetail("Upstream provider response body or legacy provider-error body."),
+				"status_code":       integerDetail("Upstream provider HTTP status code when known."),
+				"client_name":       stringDetail("Legacy BAML client name parsed from provider-error envelopes."),
+				"error_code":        stringDetail("AWS event-stream transport error code."),
+				"error_message":     stringDetail("AWS event-stream transport error message."),
+				"exception_type":    stringDetail("AWS Bedrock modeled exception type."),
+				"exception_message": stringDetail("AWS Bedrock modeled exception message."),
+				"stacktrace":        stringDetail("Worker panic stacktrace when no structured details payload was supplied."),
+			},
+			AdditionalProperties: openapi3.AdditionalProperties{
+				Has: boolPtr(true),
+			},
+		},
+	}
+	errorDetailsRefPath := fmt.Sprintf("#/components/schemas/%s", errorDetailsSchemaName)
+	errorDetailsSchema := func() *openapi3.SchemaRef {
+		return &openapi3.SchemaRef{Ref: errorDetailsRefPath}
 	}
 
 	streamErrorEventSchemaName := "__StreamErrorEvent__"

--- a/cmd/schema/main_test.go
+++ b/cmd/schema/main_test.go
@@ -199,6 +199,80 @@ func TestPostRequestBodyRequired(t *testing.T) {
 	}
 }
 
+// TestErrorDetailsSchema pins #259: the apierror `details` field on
+// both __ErrorResponse__ and __StreamErrorEvent__ must resolve to a
+// named __ErrorDetails__ component declaring each known detail key as
+// a typed optional property, while retaining additionalProperties:true
+// for forward compatibility. Downstream codegen (Orval/etc.) relies on
+// this shape to produce typed access on details.raw, details.body,
+// details.status_code, ... instead of the prior {[k:string]:unknown}.
+func TestErrorDetailsSchema(t *testing.T) {
+	baml_rest.InitBamlRuntime()
+	doc := generateOpenAPISchema()
+	if doc == nil || doc.Components == nil {
+		t.Fatalf("generated schema has no components")
+	}
+	schemas := doc.Components.Schemas
+
+	ref, ok := schemas["__ErrorDetails__"]
+	if !ok || ref == nil || ref.Value == nil {
+		t.Fatalf("__ErrorDetails__ component not registered")
+	}
+	schema := ref.Value
+
+	if schema.Type == nil || !schema.Type.Is(openapi3.TypeObject) {
+		t.Errorf("__ErrorDetails__.type expected object, got %v", schema.Type)
+	}
+	if schema.AdditionalProperties.Has == nil || !*schema.AdditionalProperties.Has {
+		t.Errorf("__ErrorDetails__.additionalProperties expected true (forward compatibility), got %+v", schema.AdditionalProperties)
+	}
+	if len(schema.Required) != 0 {
+		t.Errorf("__ErrorDetails__.required expected empty (every detail field is optional), got %v", schema.Required)
+	}
+
+	expectedFields := map[string]string{
+		"raw":               openapi3.TypeString,
+		"body":              openapi3.TypeString,
+		"status_code":       openapi3.TypeInteger,
+		"client_name":       openapi3.TypeString,
+		"error_code":        openapi3.TypeString,
+		"error_message":     openapi3.TypeString,
+		"exception_type":    openapi3.TypeString,
+		"exception_message": openapi3.TypeString,
+		"stacktrace":        openapi3.TypeString,
+	}
+	for name, wantType := range expectedFields {
+		prop, ok := schema.Properties[name]
+		if !ok || prop == nil || prop.Value == nil {
+			t.Errorf("__ErrorDetails__.properties missing %q", name)
+			continue
+		}
+		if prop.Value.Type == nil || !prop.Value.Type.Is(wantType) {
+			t.Errorf("__ErrorDetails__.properties.%s expected type %s, got %v", name, wantType, prop.Value.Type)
+		}
+		if strings.TrimSpace(prop.Value.Description) == "" {
+			t.Errorf("__ErrorDetails__.properties.%s expected non-empty description", name)
+		}
+	}
+
+	const wantRef = "#/components/schemas/__ErrorDetails__"
+	for _, parent := range []string{"__ErrorResponse__", "__StreamErrorEvent__"} {
+		t.Run(parent+".details ref", func(t *testing.T) {
+			parentRef, ok := schemas[parent]
+			if !ok || parentRef == nil || parentRef.Value == nil {
+				t.Fatalf("%s component not registered", parent)
+			}
+			details, ok := parentRef.Value.Properties["details"]
+			if !ok || details == nil {
+				t.Fatalf("%s.properties.details missing", parent)
+			}
+			if details.Ref != wantRef {
+				t.Errorf("%s.properties.details expected $ref %q, got %q (value=%+v)", parent, wantRef, details.Ref, details.Value)
+			}
+		})
+	}
+}
+
 // isNullable reports whether a SchemaRef carries explicit nullability —
 // either inline Nullable=true on its value, or the allOf+nullable wrap
 // emitted for $ref pointers.


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Closes #259. Adds typed sub-properties to the `details` field on the apierror envelope schema. Downstream-generated TypeScript clients (Orval/etc.) now get autocomplete on `details.raw`, `details.body`, `details.status_code`, `details.client_name`, `details.error_code`, `details.error_message`, `details.exception_type`, `details.exception_message`, and `details.stacktrace` — instead of the prior `{ [key: string]: unknown }` shape.

`additionalProperties: true` is retained for forward compatibility; the runtime is unchanged, and the worker's `normalizeWorkerMetadata` path still preserves any worker-supplied JSON-object details unchanged on the wire.

## What's included

- New `__ErrorDetails__` named component with the 9 canonical typed optional properties.
- `__ErrorResponse__.properties.details` and `__StreamErrorEvent__.properties.details` both `$ref` the new component.
- Schema regression test (`TestErrorDetailsSchema`) pinning the component shape + ref wiring.

## What's NOT included (rejected per scoping)

- Discriminated-union-by-code per-class details schemas. `raw` rides on any error class, `status_code` is optional even within `provider_error`, and Orval support for OpenAPI 3.0 discriminated unions is uneven. The flat typed open shape gives downstream generators typed autocomplete without overfitting the wire.
- Runtime changes — `Response.Details` stays `json.RawMessage`; classifier arms unchanged.
- Removing `additionalProperties: true` — forward compatibility matters; future detail keys must not become schema-invalid.

## Verification

- `go build ./...` / `go vet ./...` clean.
- `go test ./cmd/schema -count=1 -v` — new `TestErrorDetailsSchema` (and its 2 subtests pinning each `$ref` site) passes alongside existing tests.
- `go test ./...` — all packages green.
- `verify-framework-adapter`: 9/9. `verify-adapter-pins`: 4/4.
- Manual `jq` spot-check of generated spec confirms `__ErrorDetails__` shape (9 typed fields, `additionalProperties: true`, no `required`) + both `$ref` sites resolving to `#/components/schemas/__ErrorDetails__`.

Closes #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test for error details schema generation
* **Chores**
  * Enhanced OpenAPI schema generation with structured error details component and expanded property definitions for improved API documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/261)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->