### PR TITLE
feat(bedrock): endpoint_url + region parity via local introspect layer (#254)

### DIFF
--- a/adapters/common/codegen/codegen_bedrock_test.go
+++ b/adapters/common/codegen/codegen_bedrock_test.go
@@ -128,19 +128,22 @@ func newBedrockTestMethodEmitter(t *testing.T) *methodEmitter {
 	}
 }
 
-// TestEmitBuildCallRequest_EmitsMaybeAttachBedrockAuth pins the
-// real call-branch emission (not just the helper): the generated
-// _buildCallRequest closure must invoke llmhttp.MaybeAttachBedrockAuth
-// after BAML's Request.<Method> builds the body. A regression that
-// dropped the postProcess argument from emitBuildCallRequest's
-// emitBAMLHTTPRequestConversion call would compile cleanly (the
-// parameter is variadic-shaped via nil-safety) and silently revert to
-// streaming-style "no attach". This test catches that.
+// TestEmitBuildCallRequest_EmitsBedrockAuthDispatch pins the real
+// call-branch emission (not just the helper): the generated
+// _buildCallRequest closure must invoke the client-aware Bedrock
+// dispatch — resolve the selected client name, look up
+// introspected.BedrockClientOptionsByName, then call
+// llmhttp.AttachBedrockAuthForClient with the resolved endpoint and
+// region values. A regression that dropped the postProcess argument
+// from emitBuildCallRequest's emitBAMLHTTPRequestConversion call would
+// compile cleanly (the parameter is variadic-shaped via nil-safety)
+// and silently revert to streaming-style "no attach". This test
+// catches that.
 //
 // Gated on introspected.Request being non-nil because emitBuildCallRequest
 // no-ops for adapters without the BAML Request API. The test restores
 // the singleton on cleanup so adjacent tests are not perturbed.
-func TestEmitBuildCallRequest_EmitsMaybeAttachBedrockAuth(t *testing.T) {
+func TestEmitBuildCallRequest_EmitsBedrockAuthDispatch(t *testing.T) {
 	savedRequest := introspected.Request
 	t.Cleanup(func() { introspected.Request = savedRequest })
 	introspected.Request = struct{}{}
@@ -149,18 +152,35 @@ func TestEmitBuildCallRequest_EmitsMaybeAttachBedrockAuth(t *testing.T) {
 	me.emitBuildCallRequest()
 	rendered := me.g.out.GoString()
 
-	if !strings.Contains(rendered, "llmhttp.MaybeAttachBedrockAuth(ctx, req)") {
-		t.Errorf("emitBuildCallRequest must emit llmhttp.MaybeAttachBedrockAuth(ctx, req); rendered:\n%s", rendered)
+	// Selected-client resolve: clientOverride first, then fall back to
+	// introspected.FunctionClient[<methodName>] for the default client.
+	if !strings.Contains(rendered, "selectedClient := clientOverride") {
+		t.Errorf("dispatch must resolve selectedClient from clientOverride; rendered:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `introspected.FunctionClient["GreetUser"]`) {
+		t.Errorf("dispatch must fall back to introspected.FunctionClient[%q] when clientOverride is empty; rendered:\n%s", "GreetUser", rendered)
+	}
+	// BedrockClientOptionsByName lookup keyed on the resolved selected client.
+	if !strings.Contains(rendered, "introspected.BedrockClientOptionsByName[selectedClient]") {
+		t.Errorf("dispatch must look up introspected.BedrockClientOptionsByName[selectedClient]; rendered:\n%s", rendered)
+	}
+	// The dispatch must invoke AttachBedrockAuthForClient with the
+	// resolved endpoint and region locals. AttachBedrockAuthForClient
+	// internally falls through to MaybeAttachBedrockAuth when both
+	// values are empty, so the URL-pattern detection contract holds
+	// without re-emitting the helper here.
+	if !strings.Contains(rendered, "llmhttp.AttachBedrockAuthForClient(ctx, req, bedrockEndpointURL, bedrockRegion)") {
+		t.Errorf("dispatch must call llmhttp.AttachBedrockAuthForClient with resolved endpoint+region; rendered:\n%s", rendered)
 	}
 	// The attach lives inside the buildRequestFn closure, between the
 	// httpReq construction and the closure's final return. Pin both
 	// neighbours positionally so a refactor that moves the attach
 	// outside the closure (e.g. into the orchestrator) fails this
 	// test rather than silently changing semantics.
-	bedrockIdx := strings.Index(rendered, "llmhttp.MaybeAttachBedrockAuth(ctx, req)")
+	dispatchIdx := strings.Index(rendered, "llmhttp.AttachBedrockAuthForClient(ctx, req")
 	buildFnIdx := strings.Index(rendered, "buildRequestFn :=")
-	if buildFnIdx < 0 || bedrockIdx < 0 || !(buildFnIdx < bedrockIdx) {
-		t.Errorf("attach must sit inside the buildRequestFn closure; positions buildFn=%d attach=%d", buildFnIdx, bedrockIdx)
+	if buildFnIdx < 0 || dispatchIdx < 0 || !(buildFnIdx < dispatchIdx) {
+		t.Errorf("dispatch must sit inside the buildRequestFn closure; positions buildFn=%d dispatch=%d", buildFnIdx, dispatchIdx)
 	}
 }
 
@@ -212,11 +232,52 @@ func TestEmitBuildRequest_EmitsBedrockStreamingClosure(t *testing.T) {
 	if !strings.Contains(rendered, `req.Headers["Accept"] = llmhttp.AWSStreamContentType`) {
 		t.Errorf("bedrock streaming closure must set req.Headers[\"Accept\"] = llmhttp.AWSStreamContentType; rendered:\n%s", rendered)
 	}
-	// Auth attach still uses MaybeAttachBedrockAuth so non-bedrock
-	// URLs no-op (defensive: production codegen only routes bedrock
-	// providers here, but the helper is the shared entry point).
-	if !strings.Contains(rendered, "llmhttp.MaybeAttachBedrockAuth(ctx, req)") {
-		t.Errorf("bedrock streaming closure must call MaybeAttachBedrockAuth; rendered:\n%s", rendered)
+	// Auth attach uses the client-aware dispatch (which internally
+	// falls through to MaybeAttachBedrockAuth for the default-endpoint
+	// case) — the streaming closure picks up the same per-client
+	// endpoint_url + region overrides as the call closure.
+	if !strings.Contains(rendered, "llmhttp.AttachBedrockAuthForClient(ctx, req, bedrockEndpointURL, bedrockRegion)") {
+		t.Errorf("bedrock streaming closure must call llmhttp.AttachBedrockAuthForClient with resolved endpoint+region; rendered:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "introspected.BedrockClientOptionsByName[selectedClient]") {
+		t.Errorf("bedrock streaming closure must look up introspected.BedrockClientOptionsByName[selectedClient]; rendered:\n%s", rendered)
+	}
+	// Order invariant: URL mutation /converse → /converse-stream must
+	// emit BEFORE the dispatch so AttachBedrockAuthForClient (and any
+	// endpoint_url override it routes to) joins on the streaming path.
+	mutationIdx := strings.Index(rendered, `strings.Replace(req.URL, "/converse", "/converse-stream", 1)`)
+	dispatchIdx := strings.Index(rendered, "llmhttp.AttachBedrockAuthForClient(ctx, req")
+	if mutationIdx < 0 || dispatchIdx < 0 || !(mutationIdx < dispatchIdx) {
+		t.Errorf("URL mutation must precede the bedrock dispatch in the stream closure; positions mutation=%d dispatch=%d", mutationIdx, dispatchIdx)
+	}
+}
+
+// TestEmitBedrockAuthDispatchFor_Shape pins the standalone shape of
+// the dispatch helper so any future tweak to the resolve-name +
+// look-up + dispatch sequence surfaces immediately rather than only
+// via the closure-emission tests above. The shape is the load-bearing
+// contract that makes per-client `endpoint_url` parity work without
+// reading from BAML's HTTPRequest surface.
+func TestEmitBedrockAuthDispatchFor_Shape(t *testing.T) {
+	f := jen.NewFilePathName("github.com/example/test", "test")
+	f.Func().Id("emit").Params(jen.Id("clientOverride").String()).Params(jen.Op("*").Id("Request"), jen.Error()).BlockFunc(func(g *jen.Group) {
+		emitBedrockAuthDispatchFor("MyMethod")(g)
+	})
+	rendered := f.GoString()
+
+	wantSubstrings := []string{
+		"selectedClient := clientOverride",
+		`introspected.FunctionClient["MyMethod"]`,
+		"introspected.BedrockClientOptionsByName[selectedClient]",
+		"bedrockOpts.EndpointURL.Resolve()",
+		"bedrockOpts.Region.Resolve()",
+		"llmhttp.AttachBedrockAuthForClient(ctx, req, bedrockEndpointURL, bedrockRegion)",
+		"return nil, authErr",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("dispatch emission missing %q; rendered:\n%s", want, rendered)
+		}
 	}
 }
 

--- a/adapters/common/codegen/codegen_buildrequest.go
+++ b/adapters/common/codegen/codegen_buildrequest.go
@@ -15,6 +15,11 @@ import (
 // AND assert it does not appear in the streaming-path emission (which
 // passes nil postProcess to emitBAMLHTTPRequestConversion for
 // non-bedrock providers).
+//
+// Kept as a callable target for the codegen-emission tests that pin
+// the simple URL-pattern shape; production codegen routes through
+// emitBedrockAuthDispatchFor so the explicit endpoint_url + region
+// override path is honoured when the operator has configured one.
 func emitMaybeAttachBedrockAuth(g *jen.Group) {
 	g.If(
 		jen.Id("authErr").Op(":=").Qual(common.LLMHTTPPkg, "MaybeAttachBedrockAuth").Call(jen.Id("ctx"), jen.Id("req")),
@@ -24,48 +29,114 @@ func emitMaybeAttachBedrockAuth(g *jen.Group) {
 	)
 }
 
-// emitBedrockStreamPostProcess emits the streaming-side postProcess
-// block: URL mutation /converse → /converse-stream, AWS event-stream
-// Accept header injection, and SigV4 auth attach. BAML's non-streaming
-// modular AWS builder produces a /converse URL; baml-rest streams
-// against /converse-stream because BAML's StreamRequest path is
-// upstream-blocked for aws-bedrock.
+// emitBedrockAuthDispatchFor returns a postProcess emitter that, for
+// the given BAML method name, resolves the selected client at runtime
+// and dispatches Bedrock auth attachment.
+//
+// Generated body (per closure):
+//
+//	selectedClient := clientOverride
+//	if selectedClient == "" {
+//	    selectedClient = introspected.FunctionClient["<methodName>"]
+//	}
+//	var bedrockEndpointURL, bedrockRegion string
+//	if bedrockOpts, ok := introspected.BedrockClientOptionsByName[selectedClient]; ok {
+//	    bedrockEndpointURL, _ = bedrockOpts.EndpointURL.Resolve()
+//	    bedrockRegion, _ = bedrockOpts.Region.Resolve()
+//	}
+//	if authErr := llmhttp.AttachBedrockAuthForClient(ctx, req, bedrockEndpointURL, bedrockRegion); authErr != nil {
+//	    return nil, authErr
+//	}
+//
+// Empty endpoint+region falls through to MaybeAttachBedrockAuth's URL-
+// pattern detection inside AttachBedrockAuthForClient, preserving the
+// default-endpoint contract for clients without an `.baml` override.
+//
+// The closure variable `clientOverride` is in scope at the postProcess
+// emission site (both buildRequestFn and buildBedrockStreamRequestFn
+// declare it as a parameter), so the resolve-name step does not need
+// any new closure plumbing.
+func emitBedrockAuthDispatchFor(methodName string) func(*jen.Group) {
+	return func(g *jen.Group) {
+		g.Id("selectedClient").Op(":=").Id("clientOverride")
+		g.If(jen.Id("selectedClient").Op("==").Lit("")).Block(
+			jen.Id("selectedClient").Op("=").Qual(common.IntrospectedPkg, "FunctionClient").Index(jen.Lit(methodName)),
+		)
+		g.Var().Defs(
+			jen.Id("bedrockEndpointURL").String(),
+			jen.Id("bedrockRegion").String(),
+		)
+		g.If(
+			jen.List(jen.Id("bedrockOpts"), jen.Id("ok")).Op(":=").Qual(common.IntrospectedPkg, "BedrockClientOptionsByName").Index(jen.Id("selectedClient")),
+			jen.Id("ok"),
+		).Block(
+			jen.List(jen.Id("bedrockEndpointURL"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("EndpointURL").Dot("Resolve").Call(),
+			jen.List(jen.Id("bedrockRegion"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("Region").Dot("Resolve").Call(),
+		)
+		g.If(
+			jen.Id("authErr").Op(":=").Qual(common.LLMHTTPPkg, "AttachBedrockAuthForClient").Call(
+				jen.Id("ctx"),
+				jen.Id("req"),
+				jen.Id("bedrockEndpointURL"),
+				jen.Id("bedrockRegion"),
+			),
+			jen.Id("authErr").Op("!=").Nil(),
+		).Block(
+			jen.Return(jen.Nil(), jen.Id("authErr")),
+		)
+	}
+}
+
+// emitBedrockStreamPostProcessFor returns a postProcess emitter for
+// the streaming-side closure: URL mutation /converse → /converse-stream,
+// AWS event-stream Accept header injection, and Bedrock auth attach.
+// BAML's non-streaming modular AWS builder produces a /converse URL;
+// baml-rest streams against /converse-stream because BAML's
+// StreamRequest path is upstream-blocked for aws-bedrock.
 //
 // Order matters:
-//  1. URL rewrite BEFORE auth attach so SigV4 signs over the
+//  1. URL rewrite BEFORE auth attach so the endpoint override (when
+//     configured) and the SigV4 signature both run over the
 //     /converse-stream path.
 //  2. Accept header AFTER the conversion populates req.Headers from
 //     the BAML output (overwriting the Content-Type-only default
 //     headers BAML emits).
-//  3. MaybeAttachBedrockAuth last so the SigV4 hook reads the final
-//     URL.
+//  3. AttachBedrockAuthForClient last so the SigV4 hook reads the
+//     final URL — including any operator-configured `endpoint_url`
+//     override resolved through the introspected
+//     BedrockClientOptionsByName map.
 //
 // Emitted only on the bedrock streaming closure; the SSE-path
 // streaming closure still passes nil postProcess.
-func emitBedrockStreamPostProcess(g *jen.Group) {
-	// URL mutation: single replacement of /converse → /converse-stream.
-	// The Bedrock URL pattern is
-	// https://bedrock-runtime.<region>.amazonaws.com/model/<modelId>/converse,
-	// so a single-replacement pass is safe; double-replacement would
-	// be a problem only if a model id contained `/converse`, which
-	// AWS model id rules forbid.
-	g.Id("req").Dot("URL").Op("=").Qual("strings", "Replace").Call(
-		jen.Id("req").Dot("URL"),
-		jen.Lit("/converse"),
-		jen.Lit("/converse-stream"),
-		jen.Lit(1),
-	)
-	// Inject the AWS event-stream Accept header. BAML's modular AWS
-	// builder doesn't set Accept (it sets Content-Type only), and
-	// without this header the Bedrock service responds with JSON
-	// instead of the event-stream wire format.
-	g.If(jen.Id("req").Dot("Headers").Op("==").Nil()).Block(
-		jen.Id("req").Dot("Headers").Op("=").Make(jen.Map(jen.String()).String()),
-	)
-	g.Id("req").Dot("Headers").Index(jen.Lit("Accept")).Op("=").Qual(common.LLMHTTPPkg, "AWSStreamContentType")
+func emitBedrockStreamPostProcessFor(methodName string) func(*jen.Group) {
+	dispatch := emitBedrockAuthDispatchFor(methodName)
+	return func(g *jen.Group) {
+		// URL mutation: single replacement of /converse → /converse-stream.
+		// The Bedrock URL pattern is
+		// https://bedrock-runtime.<region>.amazonaws.com/model/<modelId>/converse,
+		// so a single-replacement pass is safe; double-replacement would
+		// be a problem only if a model id contained `/converse`, which
+		// AWS model id rules forbid.
+		g.Id("req").Dot("URL").Op("=").Qual("strings", "Replace").Call(
+			jen.Id("req").Dot("URL"),
+			jen.Lit("/converse"),
+			jen.Lit("/converse-stream"),
+			jen.Lit(1),
+		)
+		// Inject the AWS event-stream Accept header. BAML's modular AWS
+		// builder doesn't set Accept (it sets Content-Type only), and
+		// without this header the Bedrock service responds with JSON
+		// instead of the event-stream wire format.
+		g.If(jen.Id("req").Dot("Headers").Op("==").Nil()).Block(
+			jen.Id("req").Dot("Headers").Op("=").Make(jen.Map(jen.String()).String()),
+		)
+		g.Id("req").Dot("Headers").Index(jen.Lit("Accept")).Op("=").Qual(common.LLMHTTPPkg, "AWSStreamContentType")
 
-	// SigV4 attach last so it signs the rewritten URL.
-	emitMaybeAttachBedrockAuth(g)
+		// Bedrock auth dispatch: explicit endpoint_url + region override
+		// when configured for the selected client; URL-pattern fallback
+		// for the default-endpoint case.
+		dispatch(g)
+	}
 }
 
 // emitBAMLHTTPRequestConversion generates the jen code that converts a
@@ -247,7 +318,7 @@ func (me *methodEmitter) emitBuildRequest() {
 				jg.If(jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Nil(), jen.Id("err")),
 				)
-				emitBAMLHTTPRequestConversion(jg, emitBedrockStreamPostProcess)
+				emitBAMLHTTPRequestConversion(jg, emitBedrockStreamPostProcessFor(me.methodName))
 			}),
 		)
 	}
@@ -584,14 +655,17 @@ func (me *methodEmitter) emitBuildCallRequest() {
 			jg.If(jen.Id("err").Op("!=").Nil()).Block(
 				jen.Return(jen.Nil(), jen.Id("err")),
 			)
-			// The call branch attaches AWS SigV4 metadata when the
-			// BAML-emitted URL looks like a Bedrock Converse endpoint.
-			// MaybeAttachBedrockAuth is a no-op on non-bedrock URLs,
-			// so the unconditional emit costs every other provider
-			// nothing. The streaming branch uses its own sibling
-			// closure (buildBedrockStreamRequestFn) with
-			// emitBedrockStreamPostProcess — see emitBuildRequest above.
-			emitBAMLHTTPRequestConversion(jg, emitMaybeAttachBedrockAuth)
+			// The call branch attaches AWS SigV4 metadata via the
+			// client-aware dispatch. AttachBedrockAuthForClient
+			// honours per-client `endpoint_url` + `region` overrides
+			// (resolved through introspected.BedrockClientOptionsByName)
+			// and falls through to MaybeAttachBedrockAuth's URL-
+			// pattern detection for the default-endpoint case — so
+			// the unconditional emit still costs every non-bedrock
+			// provider nothing. The streaming branch uses its own
+			// sibling closure (buildBedrockStreamRequestFn) with
+			// emitBedrockStreamPostProcessFor — see emitBuildRequest above.
+			emitBAMLHTTPRequestConversion(jg, emitBedrockAuthDispatchFor(me.methodName))
 		}),
 
 		// parseFinalFn: calls Parse.Method(ctx, text, opts...)

--- a/bamlutils/llmhttp/awssigv4.go
+++ b/bamlutils/llmhttp/awssigv4.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -309,4 +310,151 @@ func AttachBedrockAuth(ctx context.Context, req *Request) error {
 		Credentials: creds,
 	}
 	return nil
+}
+
+// BedrockAuthOptions carries the operator-configured aws-bedrock client
+// options that AttachBedrockAuthWithOptions needs to override the BAML-
+// emitted Bedrock URL and pin the SigV4 region. Populated by codegen
+// from the .baml `options { ... }` block via the introspected
+// BedrockClientOptions map.
+type BedrockAuthOptions struct {
+	// EndpointURL overrides the BAML-emitted Bedrock URL host (and
+	// scheme). Empty leaves req.URL untouched, so the existing
+	// bedrock-runtime.<region>.amazonaws.com value is signed as-is.
+	// The override preserves req.URL's path, query, and fragment so
+	// /model/<id>/converse and the streaming /converse-stream path
+	// mutation both flow through unchanged.
+	EndpointURL string
+
+	// Region is the AWS region SigV4 signs with. Empty falls back to
+	// the AWS_REGION env var; if that is also empty, the helper
+	// returns an error rather than guessing — custom endpoints (VPC,
+	// LocalStack, FIPS, China, GovCloud) break the host-based region
+	// extraction MaybeAttachBedrockAuth uses, so the region must come
+	// from config or env, never from URL parsing.
+	Region string
+
+	// Credentials is a forward-compat slot for the static-credentials
+	// follow-up (#254 item 2: access_key_id / secret_access_key /
+	// session_token / profile). Leave unset; nil means "use the default
+	// AWS credential chain" via DefaultAWSCredentialProvider. This PR
+	// does not populate the slot — wiring it is the static-creds PR's
+	// job. Documenting the field here keeps the API stable across the
+	// two PRs so the codegen call site doesn't change again when
+	// static creds land.
+	Credentials aws.CredentialsProvider
+}
+
+// AttachBedrockAuthWithOptions applies an explicit Bedrock endpoint
+// override (when opts.EndpointURL is set), validates region, and
+// attaches the SigV4 metadata so the downstream Execute / ExecuteAWS-
+// Stream path signs the final URL.
+//
+// Unlike MaybeAttachBedrockAuth, this helper does NOT infer "is this a
+// Bedrock request" from the URL host. Callers must only invoke it for
+// requests they have already identified as targeting aws-bedrock — the
+// codegen dispatch in adapters/common/codegen does this by gating on
+// the introspected BedrockClientOptions map (only aws-bedrock clients
+// land in that map). That separation is what lets the override safely
+// rewrite the URL to a non-AWS host (LocalStack, VPC endpoint, FIPS,
+// China, GovCloud) without first re-parsing the host to confirm it is
+// Bedrock.
+func AttachBedrockAuthWithOptions(ctx context.Context, req *Request, opts BedrockAuthOptions) error {
+	if req == nil {
+		return errors.New("llmhttp: AttachBedrockAuthWithOptions: nil request")
+	}
+
+	if opts.EndpointURL != "" {
+		rewritten, err := rewriteBedrockEndpoint(req.URL, opts.EndpointURL)
+		if err != nil {
+			return err
+		}
+		req.URL = rewritten
+	}
+
+	region := opts.Region
+	if region == "" {
+		region = os.Getenv("AWS_REGION")
+	}
+	if region == "" {
+		return errors.New("aws-bedrock: region is required (set via .baml options.region or AWS_REGION env)")
+	}
+
+	creds := opts.Credentials
+	if creds == nil {
+		// Default credential chain. Static credential plumbing is
+		// deferred — see the BedrockAuthOptions.Credentials doc.
+		c, err := DefaultAWSCredentialProvider(ctx)
+		if err != nil {
+			return fmt.Errorf("llmhttp: load AWS credentials: %w", err)
+		}
+		creds = c
+	}
+
+	req.AWSAuth = &AWSAuthConfig{
+		Region:      region,
+		Service:     "bedrock",
+		Credentials: creds,
+	}
+	return nil
+}
+
+// rewriteBedrockEndpoint replaces the scheme + host of originalURL with
+// the scheme + host of endpointURL while preserving the original
+// request's path, query, and fragment. A trailing slash on endpointURL
+// is tolerated so operators don't have to remember to strip it from
+// `endpoint_url "http://localhost:9000/"` shaped configs.
+func rewriteBedrockEndpoint(originalURL, endpointURL string) (string, error) {
+	endpointParsed, err := url.Parse(endpointURL)
+	if err != nil {
+		return "", fmt.Errorf("aws-bedrock: parse endpoint_url %q: %w", endpointURL, err)
+	}
+	if endpointParsed.Scheme == "" {
+		return "", fmt.Errorf("aws-bedrock: endpoint_url %q is missing scheme", endpointURL)
+	}
+	if endpointParsed.Scheme != "http" && endpointParsed.Scheme != "https" {
+		return "", fmt.Errorf("aws-bedrock: endpoint_url %q has unsupported scheme %q (expected http or https)", endpointURL, endpointParsed.Scheme)
+	}
+	if endpointParsed.Host == "" {
+		return "", fmt.Errorf("aws-bedrock: endpoint_url %q is missing host", endpointURL)
+	}
+
+	originalParsed, err := url.Parse(originalURL)
+	if err != nil {
+		return "", fmt.Errorf("aws-bedrock: parse request URL %q: %w", originalURL, err)
+	}
+
+	rewritten := url.URL{
+		Scheme:   endpointParsed.Scheme,
+		Host:     endpointParsed.Host,
+		Path:     originalParsed.Path,
+		RawQuery: originalParsed.RawQuery,
+		Fragment: originalParsed.Fragment,
+	}
+	return rewritten.String(), nil
+}
+
+// AttachBedrockAuthForClient is the codegen dispatch entry point for
+// the aws-bedrock provider. When endpointURL or region is non-empty
+// (i.e., the operator configured an override in `.baml options { ... }`
+// for the selected client), it routes to AttachBedrockAuthWithOptions
+// so the explicit endpoint and region are honored. When both are empty,
+// it falls through to MaybeAttachBedrockAuth's URL-pattern detection —
+// preserving the default-endpoint contract for clients that did not
+// declare an override.
+//
+// The split exists because custom endpoints (VPC, LocalStack, FIPS,
+// China, GovCloud) break the host-based region extraction
+// MaybeAttachBedrockAuth uses; once the operator supplies an override,
+// we must take the explicit path. Codegen looks up
+// `introspected.BedrockClientOptions[selectedClient]` and resolves the
+// literal-vs-env values before calling this helper.
+func AttachBedrockAuthForClient(ctx context.Context, req *Request, endpointURL, region string) error {
+	if endpointURL == "" && region == "" {
+		return MaybeAttachBedrockAuth(ctx, req)
+	}
+	return AttachBedrockAuthWithOptions(ctx, req, BedrockAuthOptions{
+		EndpointURL: endpointURL,
+		Region:      region,
+	})
 }

--- a/bamlutils/llmhttp/awssigv4.go
+++ b/bamlutils/llmhttp/awssigv4.go
@@ -400,10 +400,27 @@ func AttachBedrockAuthWithOptions(ctx context.Context, req *Request, opts Bedroc
 }
 
 // rewriteBedrockEndpoint replaces the scheme + host of originalURL with
-// the scheme + host of endpointURL while preserving the original
-// request's path, query, and fragment. A trailing slash on endpointURL
-// is tolerated so operators don't have to remember to strip it from
+// the scheme + host of endpointURL, concatenates the endpoint's path
+// prefix with the original request's path, merges the endpoint's query
+// with the original request's query, and preserves the original
+// request's fragment. A trailing slash on endpointURL is tolerated so
+// operators don't have to remember to strip it from
 // `endpoint_url "http://localhost:9000/"` shaped configs.
+//
+// Path concatenation matches AWS SDK v2's ResolveEndpointV2 middleware
+// behavior: the endpoint's URI path acts as a prefix on every request
+// URI. Without this, a path-prefixed proxy
+// (`endpoint_url "https://my-proxy/v1/bedrock"`) would silently drop
+// the `/v1/bedrock` prefix and misroute every request.
+//
+// Query merge uses `&` join semantics so endpoint-set query knobs
+// (auth tokens, routing tags) and BAML-set query knobs (none today,
+// but the join is the right semantic) coexist on the wire.
+//
+// Endpoint fragments are rejected — fragments are client-side and
+// have no meaning combined with request routing. The original
+// request's fragment is preserved defensively; BAML's HTTPRequest
+// never sets one in practice.
 func rewriteBedrockEndpoint(originalURL, endpointURL string) (string, error) {
 	endpointParsed, err := url.Parse(endpointURL)
 	if err != nil {
@@ -418,6 +435,9 @@ func rewriteBedrockEndpoint(originalURL, endpointURL string) (string, error) {
 	if endpointParsed.Host == "" {
 		return "", fmt.Errorf("aws-bedrock: endpoint_url %q is missing host", endpointURL)
 	}
+	if endpointParsed.Fragment != "" {
+		return "", fmt.Errorf("aws-bedrock: endpoint_url %q must not contain fragment", endpointURL)
+	}
 
 	originalParsed, err := url.Parse(originalURL)
 	if err != nil {
@@ -427,11 +447,50 @@ func rewriteBedrockEndpoint(originalURL, endpointURL string) (string, error) {
 	rewritten := url.URL{
 		Scheme:   endpointParsed.Scheme,
 		Host:     endpointParsed.Host,
-		Path:     originalParsed.Path,
-		RawQuery: originalParsed.RawQuery,
+		Path:     joinEndpointPath(endpointParsed.Path, originalParsed.Path),
+		RawQuery: joinEndpointRawQuery(endpointParsed.RawQuery, originalParsed.RawQuery),
 		Fragment: originalParsed.Fragment,
 	}
 	return rewritten.String(), nil
+}
+
+// joinEndpointPath joins an endpoint's path prefix with a request's
+// path. Mirrors smithy-go's transport/http.JoinPath: the endpoint
+// prefix's trailing slash and the path's leading slash are reconciled
+// so a single `/` separates them, never zero and never two.
+//
+// Empty / "/" prefix → return path unchanged. Empty path with a
+// non-empty prefix → return the prefix (defensive; in practice the
+// path is always the BAML-supplied `/model/.../converse[-stream]`).
+func joinEndpointPath(prefix, path string) string {
+	if prefix == "" || prefix == "/" {
+		return path
+	}
+	prefix = strings.TrimRight(prefix, "/")
+	if path == "" {
+		return prefix
+	}
+	if !strings.HasPrefix(path, "/") {
+		return prefix + "/" + path
+	}
+	return prefix + path
+}
+
+// joinEndpointRawQuery merges an endpoint's RawQuery with a request's
+// RawQuery using `&` as the joiner. Either side empty → use the other;
+// both empty → empty. Duplicate keys are preserved (the wire format
+// allows them and downstream parsers handle them per their own rules).
+func joinEndpointRawQuery(prefix, suffix string) string {
+	switch {
+	case prefix == "" && suffix == "":
+		return ""
+	case prefix == "":
+		return suffix
+	case suffix == "":
+		return prefix
+	default:
+		return prefix + "&" + suffix
+	}
 }
 
 // AttachBedrockAuthForClient is the codegen dispatch entry point for
@@ -447,8 +506,8 @@ func rewriteBedrockEndpoint(originalURL, endpointURL string) (string, error) {
 // China, GovCloud) break the host-based region extraction
 // MaybeAttachBedrockAuth uses; once the operator supplies an override,
 // we must take the explicit path. Codegen looks up
-// `introspected.BedrockClientOptions[selectedClient]` and resolves the
-// literal-vs-env values before calling this helper.
+// `introspected.BedrockClientOptionsByName[selectedClient]` and resolves
+// the literal-vs-env values before calling this helper.
 func AttachBedrockAuthForClient(ctx context.Context, req *Request, endpointURL, region string) error {
 	if endpointURL == "" && region == "" {
 		return MaybeAttachBedrockAuth(ctx, req)

--- a/bamlutils/llmhttp/awssigv4_e2e_test.go
+++ b/bamlutils/llmhttp/awssigv4_e2e_test.go
@@ -1,0 +1,266 @@
+package llmhttp
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+// TestEndpointOverride_E2E_NonStreaming pins the end-to-end contract
+// for the non-streaming Bedrock dispatch with an `endpoint_url`
+// override: a request whose BAML-emitted URL points at the public
+// Bedrock host gets rewritten to a localhost mock, signed for the
+// configured region, and dispatched via the standard llmhttp.Execute
+// path. The mock server asserts the rewritten host shows up on the
+// wire AND the SigV4 Authorization header references the configured
+// region — together those are what makes operator-facing overrides
+// (LocalStack, VPC endpoints, FIPS, China, GovCloud) actually work.
+//
+// This stitches together the three pieces the codegen generator wires
+// up at build time: AttachBedrockAuthForClient (dispatch), URL rewrite
+// (inside AttachBedrockAuthWithOptions), and signRequest (signs the
+// rewritten URL). A regression in any of them surfaces here as either
+// a wrong host on the wire or a wrong credential-scope substring.
+func TestEndpointOverride_E2E_NonStreaming(t *testing.T) {
+	var (
+		gotHost      string
+		gotPath      string
+		gotAuth      string
+		gotAmzDate   string
+		gotAmzSha256 string
+	)
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotAmzDate = r.Header.Get("X-Amz-Date")
+		gotAmzSha256 = r.Header.Get("X-Amz-Content-Sha256")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		io.WriteString(w, `{"output":{"message":{"content":[{"text":"ok"}]}}}`)
+	}))
+	defer mock.Close()
+
+	mockURL, err := url.Parse(mock.URL)
+	if err != nil {
+		t.Fatalf("parse mock URL: %v", err)
+	}
+
+	req := &Request{
+		URL:     "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-sonnet/converse",
+		Method:  "POST",
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Body:    `{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`,
+	}
+
+	pinned := time.Date(2026, 5, 11, 12, 34, 56, 0, time.UTC)
+	if err := AttachBedrockAuthForClient(context.Background(), req, mock.URL, "us-east-1"); err != nil {
+		t.Fatalf("AttachBedrockAuthForClient: %v", err)
+	}
+	// Pin time + credentials onto the attached metadata so the
+	// signature is deterministic and doesn't pull from the host's
+	// AWS configuration.
+	if req.AWSAuth == nil {
+		t.Fatal("expected AWSAuth attached after dispatch")
+	}
+	req.AWSAuth.NowFunc = func() time.Time { return pinned }
+	req.AWSAuth.Credentials = staticCreds{cred: aws.Credentials{
+		AccessKeyID:     "AKIDEXAMPLE",
+		SecretAccessKey: "SECRETEXAMPLE",
+	}}
+
+	client := NewClient(mock.Client())
+	resp, err := client.Execute(context.Background(), req, nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+
+	if gotHost != mockURL.Host {
+		t.Errorf("Host on wire = %q, want override host %q (URL rewrite did not flow through)", gotHost, mockURL.Host)
+	}
+	if gotPath != "/model/anthropic.claude-3-sonnet/converse" {
+		t.Errorf("Path on wire = %q, want path preserved across override", gotPath)
+	}
+	if !strings.Contains(gotAuth, "/20260511/us-east-1/bedrock/aws4_request") {
+		t.Errorf("Authorization credential scope did not reference us-east-1/bedrock; got: %s", gotAuth)
+	}
+	if gotAmzDate != "20260511T123456Z" {
+		t.Errorf("X-Amz-Date = %q, want 20260511T123456Z", gotAmzDate)
+	}
+	if len(gotAmzSha256) != 64 {
+		t.Errorf("X-Amz-Content-Sha256 length = %d, want 64 hex chars", len(gotAmzSha256))
+	}
+}
+
+// TestEndpointOverride_E2E_Streaming pins the same E2E shape for the
+// streaming path: codegen mutates /converse → /converse-stream BEFORE
+// auth attach, the override rewrites scheme+host while preserving the
+// streaming path, and ExecuteAWSStream dispatches to the mock with the
+// signed Authorization. The mock returns a minimal AWS event-stream
+// frame so ExecuteAWSStream's content-type + decoder gate both run.
+func TestEndpointOverride_E2E_Streaming(t *testing.T) {
+	// Build a minimal valid event-stream frame so the decoder accepts
+	// the response. A messageStop event is enough — we are not
+	// asserting on the decoded content, only on the wire shape that
+	// the override + sign produce.
+	var buf bytes.Buffer
+	buf.Write(encodeAWSStreamFrame(t, map[string]string{
+		":message-type": "event",
+		":event-type":   "messageStop",
+		":content-type": "application/json",
+	}, []byte(`{"stopReason":"end_turn"}`)))
+	wireBody := buf.Bytes()
+
+	var (
+		gotHost   string
+		gotPath   string
+		gotAuth   string
+		gotAccept string
+	)
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotAccept = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", AWSStreamContentType)
+		w.WriteHeader(200)
+		w.Write(wireBody)
+	}))
+	defer mock.Close()
+
+	mockURL, err := url.Parse(mock.URL)
+	if err != nil {
+		t.Fatalf("parse mock URL: %v", err)
+	}
+
+	// Mirror what emitBedrockStreamPostProcessFor emits at build
+	// time: BAML produces /converse, codegen mutates to
+	// /converse-stream, sets Accept, then dispatches the auth attach.
+	req := &Request{
+		URL:     "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-sonnet/converse",
+		Method:  "POST",
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Body:    `{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`,
+	}
+	req.URL = strings.Replace(req.URL, "/converse", "/converse-stream", 1)
+	req.Headers["Accept"] = AWSStreamContentType
+
+	pinned := time.Date(2026, 5, 11, 12, 34, 56, 0, time.UTC)
+	if err := AttachBedrockAuthForClient(context.Background(), req, mock.URL, "us-east-1"); err != nil {
+		t.Fatalf("AttachBedrockAuthForClient: %v", err)
+	}
+	req.AWSAuth.NowFunc = func() time.Time { return pinned }
+	req.AWSAuth.Credentials = staticCreds{cred: aws.Credentials{
+		AccessKeyID:     "AKIDEXAMPLE",
+		SecretAccessKey: "SECRETEXAMPLE",
+	}}
+
+	client := NewClient(mock.Client())
+	resp, err := client.ExecuteAWSStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ExecuteAWSStream: %v", err)
+	}
+	defer resp.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	// Drain at least one event so the decoder runs end-to-end against
+	// the mock response — a regression in the wire format would surface
+	// as a Next() error rather than a silent success.
+	if _, err := resp.Events.Next(); err != nil && err != io.EOF {
+		t.Fatalf("Events.Next: %v", err)
+	}
+
+	if gotHost != mockURL.Host {
+		t.Errorf("Host on wire = %q, want override host %q", gotHost, mockURL.Host)
+	}
+	if gotPath != "/model/anthropic.claude-3-sonnet/converse-stream" {
+		t.Errorf("Path on wire = %q, want streaming path preserved across override", gotPath)
+	}
+	if !strings.Contains(gotAuth, "/20260511/us-east-1/bedrock/aws4_request") {
+		t.Errorf("Authorization credential scope did not reference us-east-1/bedrock; got: %s", gotAuth)
+	}
+	if gotAccept != AWSStreamContentType {
+		t.Errorf("Accept header = %q, want %q (must survive auth attach)", gotAccept, AWSStreamContentType)
+	}
+}
+
+// TestEndpointOverride_E2E_RegionFallback pins the env-fallback path
+// end-to-end: when `.baml options.region` is unset (parser produces
+// empty Region), the dispatcher passes "" through to
+// AttachBedrockAuthForClient, which routes to AttachBedrockAuthWithOptions
+// (because endpoint_url is set), and the helper resolves region from
+// AWS_REGION. The signed credential scope must reflect the env value.
+func TestEndpointOverride_E2E_RegionFallback(t *testing.T) {
+	t.Setenv("AWS_REGION", "ap-southeast-2")
+
+	var gotAuth string
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		io.WriteString(w, `{"output":{"message":{"content":[{"text":"ok"}]}}}`)
+	}))
+	defer mock.Close()
+
+	req := &Request{
+		URL:     "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+		Method:  "POST",
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Body:    `{}`,
+	}
+	if err := AttachBedrockAuthForClient(context.Background(), req, mock.URL, ""); err != nil {
+		t.Fatalf("AttachBedrockAuthForClient: %v", err)
+	}
+	pinned := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	req.AWSAuth.NowFunc = func() time.Time { return pinned }
+	req.AWSAuth.Credentials = staticCreds{cred: aws.Credentials{AccessKeyID: "AK", SecretAccessKey: "SK"}}
+
+	client := NewClient(mock.Client())
+	if _, err := client.Execute(context.Background(), req, nil); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if !strings.Contains(gotAuth, "/20260511/ap-southeast-2/bedrock/aws4_request") {
+		t.Errorf("Authorization scope did not pick up AWS_REGION fallback (ap-southeast-2); got: %s", gotAuth)
+	}
+}
+
+// TestEndpointOverride_E2E_DefaultEndpointFallthrough pins the
+// no-override case end-to-end: when neither endpoint_url nor region is
+// configured, AttachBedrockAuthForClient routes to
+// MaybeAttachBedrockAuth's URL-pattern detection. The request URL is
+// not rewritten — but we can't dispatch to the real Bedrock host
+// without credentials, so this test asserts the AWSAuth attach itself
+// (region pulled from URL host) and leaves dispatch coverage to the
+// override-rewrites-to-mock tests above.
+func TestEndpointOverride_E2E_DefaultEndpointFallthrough(t *testing.T) {
+	req := &Request{
+		URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+		Method: "POST",
+		Body:   `{}`,
+	}
+	if err := AttachBedrockAuthForClient(context.Background(), req, "", ""); err != nil {
+		t.Fatalf("AttachBedrockAuthForClient: %v", err)
+	}
+	if req.AWSAuth == nil {
+		t.Fatal("expected AWSAuth attached via URL-pattern detection")
+	}
+	if req.AWSAuth.Region != "us-east-1" {
+		t.Errorf("Region = %q, want us-east-1 (URL-pattern path)", req.AWSAuth.Region)
+	}
+	if req.URL != "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse" {
+		t.Errorf("URL must NOT be rewritten on the no-override fallthrough path; got %q", req.URL)
+	}
+}

--- a/bamlutils/llmhttp/awssigv4_test.go
+++ b/bamlutils/llmhttp/awssigv4_test.go
@@ -822,6 +822,291 @@ func TestAttachBedrockAuthWithOptions_SigningCoversRewrittenURL(t *testing.T) {
 	}
 }
 
+// TestAttachBedrockAuthWithOptions_EndpointPathConcat pins the
+// path-concatenation contract for path-prefixed proxies.
+//
+// CR Round 1 (PR #262 finding 2) caught that the helper used to drop
+// the endpoint's path silently. Operators setting
+// `endpoint_url "https://my-proxy.example.com/v1/bedrock"` would have
+// requests misrouted to `https://my-proxy.example.com/model/.../converse`
+// without the `/v1/bedrock` prefix. This matches AWS SDK v2's
+// ResolveEndpointV2 middleware semantics: the endpoint URI path
+// prepends every request URI.
+//
+// The matrix here covers the trailing-slash / leading-slash join
+// permutations (Smithy JoinPath semantics) plus the streaming-path
+// preservation invariant — the codegen mutates /converse →
+// /converse-stream BEFORE this helper runs, so the helper sees the
+// already-mutated path and must concatenate against it intact.
+func TestAttachBedrockAuthWithOptions_EndpointPathConcat(t *testing.T) {
+	creds := staticCreds{cred: aws.Credentials{AccessKeyID: "AK", SecretAccessKey: "SK"}}
+	cases := []struct {
+		name        string
+		originalURL string
+		endpoint    string
+		wantURL     string
+	}{
+		{
+			name:        "no path on endpoint preserves original path",
+			originalURL: "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse",
+			endpoint:    "http://h",
+			wantURL:     "http://h/model/x/converse",
+		},
+		{
+			name:        "root-only path on endpoint preserves original path (no double slash)",
+			originalURL: "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse",
+			endpoint:    "http://h/",
+			wantURL:     "http://h/model/x/converse",
+		},
+		{
+			name:        "single-segment endpoint prefix concatenates",
+			originalURL: "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse",
+			endpoint:    "http://h/base",
+			wantURL:     "http://h/base/model/x/converse",
+		},
+		{
+			name:        "single-segment endpoint with trailing slash does not double-slash",
+			originalURL: "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse",
+			endpoint:    "http://h/base/",
+			wantURL:     "http://h/base/model/x/converse",
+		},
+		{
+			name:        "multi-segment endpoint prefix concatenates",
+			originalURL: "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse",
+			endpoint:    "http://h/base/sub",
+			wantURL:     "http://h/base/sub/model/x/converse",
+		},
+		{
+			name: "streaming path concatenates against /converse-stream",
+			// The codegen mutates /converse → /converse-stream BEFORE
+			// AttachBedrockAuthForClient runs (see emitBedrockStreamPostProcessFor),
+			// so this helper must see the already-mutated path and
+			// concatenate the prefix against it without further rewrite.
+			originalURL: "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse-stream",
+			endpoint:    "http://h/v1/bedrock",
+			wantURL:     "http://h/v1/bedrock/model/x/converse-stream",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &Request{
+				URL:     tc.originalURL,
+				Method:  "POST",
+				Headers: map[string]string{"Content-Type": "application/json"},
+				Body:    `{}`,
+			}
+			if err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+				EndpointURL: tc.endpoint,
+				Region:      "us-east-1",
+				Credentials: creds,
+			}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if req.URL != tc.wantURL {
+				t.Errorf("URL = %q, want %q", req.URL, tc.wantURL)
+			}
+		})
+	}
+}
+
+// TestAttachBedrockAuthWithOptions_EndpointQueryMerge pins the query
+// merge contract: endpoint-set query knobs and original query knobs
+// coexist on the wire, joined with `&` so the resulting query string
+// preserves both. Either side empty → use the other; both empty →
+// empty (no stray `?` or `&`).
+func TestAttachBedrockAuthWithOptions_EndpointQueryMerge(t *testing.T) {
+	creds := staticCreds{cred: aws.Credentials{AccessKeyID: "AK", SecretAccessKey: "SK"}}
+	cases := []struct {
+		name        string
+		originalURL string
+		endpoint    string
+		wantURL     string
+	}{
+		{
+			name:        "endpoint query + original query → joined with &",
+			originalURL: "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse?bar=2",
+			endpoint:    "http://h/?foo=1",
+			wantURL:     "http://h/model/x/converse?foo=1&bar=2",
+		},
+		{
+			name:        "endpoint-only query, original has no query",
+			originalURL: "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse",
+			endpoint:    "http://h?foo=1",
+			wantURL:     "http://h/model/x/converse?foo=1",
+		},
+		{
+			name:        "original-only query, endpoint has no query",
+			originalURL: "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse?bar=2",
+			endpoint:    "http://h",
+			wantURL:     "http://h/model/x/converse?bar=2",
+		},
+		{
+			name:        "no query on either side",
+			originalURL: "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse",
+			endpoint:    "http://h",
+			wantURL:     "http://h/model/x/converse",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &Request{
+				URL:    tc.originalURL,
+				Method: "POST",
+				Body:   `{}`,
+			}
+			if err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+				EndpointURL: tc.endpoint,
+				Region:      "us-east-1",
+				Credentials: creds,
+			}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if req.URL != tc.wantURL {
+				t.Errorf("URL = %q, want %q", req.URL, tc.wantURL)
+			}
+		})
+	}
+}
+
+// TestAttachBedrockAuthWithOptions_RejectsEndpointFragment pins the
+// fragment-rejection contract. Fragments are client-side identifiers
+// (RFC 3986 §3.5: not sent in HTTP requests) and have no meaning when
+// combined with request routing — silently dropping or concatenating
+// them would mask operator misconfiguration. The error message must
+// surface both the failing endpoint_url and the word "fragment" so
+// the diagnostic points operators at the actual problem.
+func TestAttachBedrockAuthWithOptions_RejectsEndpointFragment(t *testing.T) {
+	req := &Request{
+		URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/converse",
+		Method: "POST",
+		Body:   `{}`,
+	}
+	err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+		EndpointURL: "http://h#frag",
+		Region:      "us-east-1",
+		Credentials: staticCreds{cred: aws.Credentials{AccessKeyID: "AK", SecretAccessKey: "SK"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for endpoint_url with fragment, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "endpoint_url") {
+		t.Errorf("error must mention endpoint_url; got: %v", err)
+	}
+	if !strings.Contains(msg, "fragment") {
+		t.Errorf("error must mention fragment; got: %v", err)
+	}
+}
+
+// TestAttachBedrockAuthWithOptions_SigningCoversConcatenatedPath pins
+// the post-fix invariant for path-prefixed proxies: SigV4 must sign
+// over the *concatenated* URL, not over the unprefixed one. Without
+// this, an operator routing through `https://proxy/v1/bedrock` would
+// see signature mismatches at the proxy because the canonical request
+// the signer hashed was `/model/.../converse` while the wire URI was
+// `/v1/bedrock/model/.../converse`.
+//
+// We assert two things: req.URL after attach is the concatenated form
+// (so a downstream signer hashing req.URL gets the right canonical
+// path), and signRequest over that req.URL produces the standard
+// SigV4 credential scope tying to the configured region.
+func TestAttachBedrockAuthWithOptions_SigningCoversConcatenatedPath(t *testing.T) {
+	pinned := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	req := &Request{
+		URL:     "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+		Method:  "POST",
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Body:    `{"messages":[]}`,
+	}
+	if err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+		EndpointURL: "http://h/v1/bedrock",
+		Region:      "us-east-1",
+		Credentials: staticCreds{cred: aws.Credentials{
+			AccessKeyID:     "AKIDEXAMPLE",
+			SecretAccessKey: "SECRETEXAMPLE",
+		}},
+	}); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	req.AWSAuth.NowFunc = func() time.Time { return pinned }
+
+	wantURL := "http://h/v1/bedrock/model/foo/converse"
+	if req.URL != wantURL {
+		t.Fatalf("post-attach URL = %q, want %q", req.URL, wantURL)
+	}
+
+	if err := signRequest(context.Background(), req, req.URL); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	auth := req.Headers["Authorization"]
+	if auth == "" {
+		t.Fatal("Authorization header missing")
+	}
+	if !strings.Contains(auth, "/20260511/us-east-1/bedrock/aws4_request") {
+		t.Errorf("credential scope must reference us-east-1/bedrock; got: %s", auth)
+	}
+}
+
+// TestJoinEndpointPath unit-tests the standalone path-join helper so
+// the trailing-slash / leading-slash join semantics are pinned in
+// isolation from the larger AttachBedrockAuthWithOptions plumbing.
+// Mirrors smithy-go's transport/http.JoinPath: a single `/` always
+// separates prefix from path, never zero, never two.
+func TestJoinEndpointPath(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		path   string
+		want   string
+	}{
+		{"empty prefix", "", "/model/x", "/model/x"},
+		{"root prefix", "/", "/model/x", "/model/x"},
+		{"prefix no trailing", "/base", "/model/x", "/base/model/x"},
+		{"prefix trailing slash", "/base/", "/model/x", "/base/model/x"},
+		{"prefix multi-segment", "/base/sub", "/model/x", "/base/sub/model/x"},
+		{"prefix multi-segment trailing slash", "/base/sub/", "/model/x", "/base/sub/model/x"},
+		{"prefix without leading slash + path with leading slash", "base", "/model/x", "base/model/x"},
+		{"empty path with non-empty prefix", "/base", "", "/base"},
+		{"empty path with prefix and trailing slash", "/base/", "", "/base"},
+		{"path without leading slash", "/base", "model/x", "/base/model/x"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := joinEndpointPath(tc.prefix, tc.path); got != tc.want {
+				t.Errorf("joinEndpointPath(%q, %q) = %q, want %q", tc.prefix, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestJoinEndpointRawQuery unit-tests the standalone query-merge
+// helper. Either side empty → use the other; both empty → empty;
+// otherwise join with `&`. Duplicate keys are preserved on the wire
+// (downstream parsers handle them per their own rules — typically
+// last-wins, but we don't enforce a policy here).
+func TestJoinEndpointRawQuery(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		suffix string
+		want   string
+	}{
+		{"both empty", "", "", ""},
+		{"prefix only", "foo=1", "", "foo=1"},
+		{"suffix only", "", "bar=2", "bar=2"},
+		{"both populated joined with &", "foo=1", "bar=2", "foo=1&bar=2"},
+		{"duplicate keys preserved", "foo=1", "foo=2", "foo=1&foo=2"},
+		{"multi-pair on each side", "a=1&b=2", "c=3&d=4", "a=1&b=2&c=3&d=4"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := joinEndpointRawQuery(tc.prefix, tc.suffix); got != tc.want {
+				t.Errorf("joinEndpointRawQuery(%q, %q) = %q, want %q", tc.prefix, tc.suffix, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestAttachBedrockAuthForClient_DispatchesByOptions pins the codegen
 // dispatch contract: empty endpoint+region falls through to URL-pattern
 // detection (so the default-endpoint case still attaches via

--- a/bamlutils/llmhttp/awssigv4_test.go
+++ b/bamlutils/llmhttp/awssigv4_test.go
@@ -523,6 +523,424 @@ func TestDefaultAWSCredentialProvider_RetriesAfterFailure(t *testing.T) {
 	}
 }
 
+// TestAttachBedrockAuthWithOptions_EndpointOverride pins the URL
+// rewrite contract for the new explicit attach helper. The endpoint
+// flavors (custom localhost, VPC, FIPS, China, GovCloud) cover the
+// matrix that the URL-pattern detection helper deliberately does not
+// touch — they are exactly the configs where operators need to set
+// `.baml options.endpoint_url` for the request to reach a real Bedrock
+// surface (or, in the localhost case, a LocalStack-style mock).
+func TestAttachBedrockAuthWithOptions_EndpointOverride(t *testing.T) {
+	const originalURL = "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-sonnet/converse"
+	cases := []struct {
+		name       string
+		endpoint   string
+		region     string
+		wantURL    string
+		wantRegion string
+	}{
+		{
+			name:       "default endpoint (no override) leaves URL unchanged",
+			endpoint:   "",
+			region:     "us-east-1",
+			wantURL:    originalURL,
+			wantRegion: "us-east-1",
+		},
+		{
+			name:       "custom localhost endpoint",
+			endpoint:   "http://localhost:9000",
+			region:     "us-east-1",
+			wantURL:    "http://localhost:9000/model/anthropic.claude-3-sonnet/converse",
+			wantRegion: "us-east-1",
+		},
+		{
+			name:       "VPC endpoint preserves path and region option",
+			endpoint:   "https://vpc-endpoint-id.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+			region:     "us-east-1",
+			wantURL:    "https://vpc-endpoint-id.bedrock-runtime.us-east-1.vpce.amazonaws.com/model/anthropic.claude-3-sonnet/converse",
+			wantRegion: "us-east-1",
+		},
+		{
+			name:       "FIPS endpoint",
+			endpoint:   "https://bedrock-runtime-fips.us-east-1.amazonaws.com",
+			region:     "us-east-1",
+			wantURL:    "https://bedrock-runtime-fips.us-east-1.amazonaws.com/model/anthropic.claude-3-sonnet/converse",
+			wantRegion: "us-east-1",
+		},
+		{
+			name:       "China partition",
+			endpoint:   "https://bedrock-runtime.cn-north-1.amazonaws.com.cn",
+			region:     "cn-north-1",
+			wantURL:    "https://bedrock-runtime.cn-north-1.amazonaws.com.cn/model/anthropic.claude-3-sonnet/converse",
+			wantRegion: "cn-north-1",
+		},
+		{
+			name:       "GovCloud",
+			endpoint:   "https://bedrock-runtime.us-gov-west-1.amazonaws.com",
+			region:     "us-gov-west-1",
+			wantURL:    "https://bedrock-runtime.us-gov-west-1.amazonaws.com/model/anthropic.claude-3-sonnet/converse",
+			wantRegion: "us-gov-west-1",
+		},
+		{
+			name:       "trailing slash on endpoint_url tolerated",
+			endpoint:   "http://localhost:9000/",
+			region:     "us-east-1",
+			wantURL:    "http://localhost:9000/model/anthropic.claude-3-sonnet/converse",
+			wantRegion: "us-east-1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &Request{
+				URL:     originalURL,
+				Method:  "POST",
+				Headers: map[string]string{"Content-Type": "application/json"},
+				Body:    `{"messages":[]}`,
+			}
+			err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+				EndpointURL: tc.endpoint,
+				Region:      tc.region,
+				Credentials: staticCreds{cred: aws.Credentials{
+					AccessKeyID:     "AKIDEXAMPLE",
+					SecretAccessKey: "SECRETEXAMPLE",
+				}},
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if req.URL != tc.wantURL {
+				t.Errorf("URL = %q, want %q", req.URL, tc.wantURL)
+			}
+			if req.AWSAuth == nil {
+				t.Fatal("expected AWSAuth attached")
+			}
+			if req.AWSAuth.Region != tc.wantRegion {
+				t.Errorf("Region = %q, want %q", req.AWSAuth.Region, tc.wantRegion)
+			}
+			if req.AWSAuth.Service != "bedrock" {
+				t.Errorf("Service = %q, want %q", req.AWSAuth.Service, "bedrock")
+			}
+			if req.AWSAuth.Credentials == nil {
+				t.Error("Credentials must not be nil")
+			}
+		})
+	}
+}
+
+// TestAttachBedrockAuthWithOptions_PreservesQueryAndFragment pins that
+// the override only rewrites scheme + host. Path, query, and fragment
+// must survive the rewrite so any auxiliary request shaping (an
+// upstream BAML signed-URL future, debug query knobs, etc.) is
+// preserved into the final request that gets signed.
+func TestAttachBedrockAuthWithOptions_PreservesQueryAndFragment(t *testing.T) {
+	req := &Request{
+		URL:     "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse?trace=1#frag",
+		Method:  "POST",
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Body:    `{}`,
+	}
+	if err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+		EndpointURL: "http://localhost:9000",
+		Region:      "us-east-1",
+		Credentials: staticCreds{cred: aws.Credentials{AccessKeyID: "AK", SecretAccessKey: "SK"}},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "http://localhost:9000/model/foo/converse?trace=1#frag"
+	if req.URL != want {
+		t.Errorf("URL = %q, want %q (path/query/fragment must flow through the rewrite)", req.URL, want)
+	}
+}
+
+// TestAttachBedrockAuthWithOptions_StreamingPathPreserved pins the
+// streaming-mode invariant: when codegen has already mutated /converse
+// → /converse-stream BEFORE auth attach (per
+// emitBedrockStreamPostProcess's documented order), the override join
+// must preserve that mutated path. Without this guarantee the URL
+// rewrite would silently revert to /converse and the SigV4 signature
+// would not match the wire request.
+func TestAttachBedrockAuthWithOptions_StreamingPathPreserved(t *testing.T) {
+	req := &Request{
+		URL:     "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse-stream",
+		Method:  "POST",
+		Headers: map[string]string{"Content-Type": "application/json", "Accept": AWSStreamContentType},
+		Body:    `{}`,
+	}
+	if err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+		EndpointURL: "http://localhost:9000",
+		Region:      "us-east-1",
+		Credentials: staticCreds{cred: aws.Credentials{AccessKeyID: "AK", SecretAccessKey: "SK"}},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "http://localhost:9000/model/foo/converse-stream"
+	if req.URL != want {
+		t.Errorf("URL = %q, want %q (stream path must survive rewrite)", req.URL, want)
+	}
+}
+
+// TestAttachBedrockAuthWithOptions_RegionResolution pins the resolution
+// order documented on BedrockAuthOptions.Region: explicit option, then
+// AWS_REGION env, then error. Region MUST NOT be inferred from the URL
+// host — that is the contract that lets custom endpoints work safely.
+func TestAttachBedrockAuthWithOptions_RegionResolution(t *testing.T) {
+	mkReq := func() *Request {
+		return &Request{
+			URL:     "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+			Method:  "POST",
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    `{}`,
+		}
+	}
+	creds := staticCreds{cred: aws.Credentials{AccessKeyID: "AK", SecretAccessKey: "SK"}}
+
+	t.Run("explicit option wins", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "eu-west-1")
+		req := mkReq()
+		if err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+			Region:      "us-east-1",
+			Credentials: creds,
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.AWSAuth.Region != "us-east-1" {
+			t.Errorf("Region = %q, want us-east-1 (explicit option must win over env)", req.AWSAuth.Region)
+		}
+	})
+
+	t.Run("AWS_REGION env fallback", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "ap-southeast-2")
+		req := mkReq()
+		if err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+			Credentials: creds,
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.AWSAuth.Region != "ap-southeast-2" {
+			t.Errorf("Region = %q, want ap-southeast-2 (AWS_REGION fallback)", req.AWSAuth.Region)
+		}
+	})
+
+	t.Run("missing region with no env errors", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "")
+		req := mkReq()
+		err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+			Credentials: creds,
+		})
+		if err == nil {
+			t.Fatal("expected error when no region is configured")
+		}
+		if !strings.Contains(err.Error(), "region is required") {
+			t.Errorf("error message must mention region requirement; got: %v", err)
+		}
+	})
+
+	t.Run("region NOT inferred from URL host", func(t *testing.T) {
+		// Even though the URL host encodes "us-east-1", the helper
+		// must not pull region from it — this is the load-bearing
+		// invariant that lets the override safely target hosts that
+		// don't encode a region (LocalStack, VPC endpoints, etc.).
+		t.Setenv("AWS_REGION", "")
+		req := mkReq()
+		err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+			Credentials: creds,
+		})
+		if err == nil {
+			t.Fatal("expected error — region must not be inferred from URL host even when present")
+		}
+	})
+}
+
+// TestAttachBedrockAuthWithOptions_RejectsInvalidEndpoint pins the
+// scheme/host validation. A bare host with no scheme, an opaque URI,
+// or a non-http scheme is operator misconfiguration — surface it as an
+// error rather than silently signing a request that won't reach the
+// intended host.
+func TestAttachBedrockAuthWithOptions_RejectsInvalidEndpoint(t *testing.T) {
+	creds := staticCreds{cred: aws.Credentials{AccessKeyID: "AK", SecretAccessKey: "SK"}}
+	cases := []struct {
+		name     string
+		endpoint string
+	}{
+		{"missing scheme", "localhost:9000"},
+		{"non-http scheme", "ftp://localhost:9000"},
+		{"empty host", "http:///foo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &Request{
+				URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+				Method: "POST",
+				Body:   `{}`,
+			}
+			err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+				EndpointURL: tc.endpoint,
+				Region:      "us-east-1",
+				Credentials: creds,
+			})
+			if err == nil {
+				t.Fatalf("expected error for endpoint %q, got nil", tc.endpoint)
+			}
+		})
+	}
+}
+
+// TestAttachBedrockAuthWithOptions_SigningCoversRewrittenURL pins the
+// end-to-end invariant: the explicit-attach + rewrite combo must produce
+// a SigV4 Authorization whose signed Host header references the override
+// host, not the original BAML-emitted Bedrock host. Without this
+// invariant a localhost mock would reject the signature on host mismatch.
+func TestAttachBedrockAuthWithOptions_SigningCoversRewrittenURL(t *testing.T) {
+	pinned := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	req := &Request{
+		URL:     "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+		Method:  "POST",
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Body:    `{"messages":[]}`,
+	}
+	if err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+		EndpointURL: "http://localhost:9000",
+		Region:      "us-east-1",
+		Credentials: staticCreds{cred: aws.Credentials{
+			AccessKeyID:     "AKIDEXAMPLE",
+			SecretAccessKey: "SECRETEXAMPLE",
+		}},
+	}); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	req.AWSAuth.NowFunc = func() time.Time { return pinned }
+
+	if err := signRequest(context.Background(), req, req.URL); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	auth := req.Headers["Authorization"]
+	if auth == "" {
+		t.Fatal("Authorization header missing")
+	}
+	if !strings.Contains(auth, "/20260511/us-east-1/bedrock/aws4_request") {
+		t.Errorf("Authorization credential scope must reference us-east-1/bedrock; got: %s", auth)
+	}
+}
+
+// TestAttachBedrockAuthForClient_DispatchesByOptions pins the codegen
+// dispatch contract: empty endpoint+region falls through to URL-pattern
+// detection (so the default-endpoint case still attaches via
+// MaybeAttachBedrockAuth), and a non-empty endpoint or region routes to
+// the explicit override path (which rewrites the URL).
+func TestAttachBedrockAuthForClient_DispatchesByOptions(t *testing.T) {
+	t.Run("no override falls through to URL-pattern detection", func(t *testing.T) {
+		req := &Request{
+			URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+			Method: "POST",
+			Body:   `{}`,
+		}
+		if err := AttachBedrockAuthForClient(context.Background(), req, "", ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.AWSAuth == nil {
+			t.Fatal("MaybeAttachBedrockAuth fallback must attach for default Bedrock URL")
+		}
+		if req.AWSAuth.Region != "us-east-1" {
+			t.Errorf("Region = %q, want us-east-1 (URL-pattern path)", req.AWSAuth.Region)
+		}
+		if req.URL != "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse" {
+			t.Errorf("URL must NOT be rewritten on the fallback path; got %q", req.URL)
+		}
+	})
+
+	t.Run("non-empty endpoint routes to explicit override", func(t *testing.T) {
+		req := &Request{
+			URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+			Method: "POST",
+			Body:   `{}`,
+		}
+		if err := AttachBedrockAuthForClient(context.Background(), req, "http://localhost:9000", "us-east-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.URL != "http://localhost:9000/model/foo/converse" {
+			t.Errorf("URL = %q, want override-rewritten", req.URL)
+		}
+	})
+
+	t.Run("non-empty region only still routes to explicit", func(t *testing.T) {
+		// region-only override (no endpoint) still must take the
+		// explicit path — the operator has set region in `.baml`,
+		// signaling they don't want the URL-host inference.
+		req := &Request{
+			URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+			Method: "POST",
+			Body:   `{}`,
+		}
+		if err := AttachBedrockAuthForClient(context.Background(), req, "", "eu-west-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.AWSAuth == nil {
+			t.Fatal("expected AWSAuth attached")
+		}
+		if req.AWSAuth.Region != "eu-west-1" {
+			t.Errorf("Region = %q, want eu-west-1 (explicit option)", req.AWSAuth.Region)
+		}
+		if req.URL != "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse" {
+			t.Errorf("URL must NOT be rewritten when only region is overridden; got %q", req.URL)
+		}
+	})
+
+	t.Run("non-bedrock URL with no override is a no-op", func(t *testing.T) {
+		req := &Request{
+			URL:    "https://api.openai.com/v1/chat/completions",
+			Method: "POST",
+			Body:   `{}`,
+		}
+		if err := AttachBedrockAuthForClient(context.Background(), req, "", ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.AWSAuth != nil {
+			t.Errorf("non-bedrock URL must not attach; got %+v", req.AWSAuth)
+		}
+	})
+}
+
+// TestAttachBedrockAuthWithOptions_NilCredentialsUsesDefaultChain pins
+// the documented Credentials slot contract: nil means "use the default
+// AWS credential chain", not "skip auth". The static-creds follow-up
+// will populate the slot; until then nil is the production codegen
+// path. The default chain may fail in CI without AWS creds set, so the
+// test substitutes the package-level loader with a deterministic
+// success.
+func TestAttachBedrockAuthWithOptions_NilCredentialsUsesDefaultChain(t *testing.T) {
+	savedLoader := defaultAWSConfigLoader
+	defaultAWSCredsMu.Lock()
+	savedCreds := defaultAWSCreds
+	defaultAWSCreds = nil
+	defaultAWSCredsMu.Unlock()
+	t.Cleanup(func() {
+		defaultAWSConfigLoader = savedLoader
+		defaultAWSCredsMu.Lock()
+		defaultAWSCreds = savedCreds
+		defaultAWSCredsMu.Unlock()
+	})
+	defaultAWSConfigLoader = func(ctx context.Context) (aws.Config, error) {
+		return aws.Config{Credentials: staticCreds{cred: aws.Credentials{
+			AccessKeyID: "AK", SecretAccessKey: "SK",
+		}}}, nil
+	}
+
+	req := &Request{
+		URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+		Method: "POST",
+		Body:   `{}`,
+	}
+	if err := AttachBedrockAuthWithOptions(context.Background(), req, BedrockAuthOptions{
+		Region: "us-east-1",
+		// Credentials intentionally left nil — should resolve via the default chain.
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.AWSAuth == nil || req.AWSAuth.Credentials == nil {
+		t.Fatal("expected default-chain credentials to be attached")
+	}
+}
+
 func TestParseBedrockRegion(t *testing.T) {
 	cases := []struct {
 		url     string

--- a/cmd/introspect/baml_parser_test.go
+++ b/cmd/introspect/baml_parser_test.go
@@ -1780,11 +1780,21 @@ client<llm> PlainBedrock {
 }
 
 // TestParseClientBlock_BedrockEndpointURL_NonBedrockClient pins the
-// emission-time provider filter contract: even though the parser
-// records the option for any client that declares it, the eventual
-// emitted BedrockClientOptionsByName map must NOT contain non-bedrock
-// clients. This test runs through generateBamlConfigVars and inspects
-// the rendered Go output to confirm the filter.
+// parser-side recording contract for the provider-filter split:
+// the parser records a candidate bedrockClientOptions entry for any
+// client whose options block declares endpoint_url / region,
+// regardless of provider. Provider filtering happens downstream at
+// emission time (generateBamlConfigVars filters cfg.bedrockClientOptions
+// by `cfg.clientProvider[name] == "aws-bedrock"` before emitting
+// `BedrockClientOptionsByName`), so the runtime map only contains
+// aws-bedrock clients even though the parser map can contain others.
+//
+// Keeping the parser permissive avoids threading provider lookahead
+// through the per-line option scan; the emission-time filter is the
+// correctness boundary. Codegen's BedrockClientOptionsByName lookup
+// only ever sees aws-bedrock clients because of that filter — see
+// the dedicated assertion in `cmd/introspect/main.go` (provider
+// filter at the BedrockClientOptionsByName emission site).
 func TestParseClientBlock_BedrockEndpointURL_NonBedrockClient(t *testing.T) {
 	cfg := newTestBamlConfig()
 	content := `

--- a/cmd/introspect/baml_parser_test.go
+++ b/cmd/introspect/baml_parser_test.go
@@ -9,12 +9,13 @@ import (
 
 func newTestBamlConfig() *bamlConfig {
 	return &bamlConfig{
-		clientProvider:    make(map[string]string),
-		clientRetryPolicy: make(map[string]string),
-		functionClient:    make(map[string]string),
-		retryPolicies:     make(map[string]parsedRetryPolicy),
-		fallbackChains:    make(map[string][]string),
-		roundRobinStart:   make(map[string]int),
+		clientProvider:       make(map[string]string),
+		clientRetryPolicy:    make(map[string]string),
+		functionClient:       make(map[string]string),
+		retryPolicies:        make(map[string]parsedRetryPolicy),
+		fallbackChains:       make(map[string][]string),
+		roundRobinStart:      make(map[string]int),
+		bedrockClientOptions: make(map[string]bedrockClientOptions),
 	}
 }
 
@@ -1675,4 +1676,387 @@ function Summarize(text: string) -> string {
 	if got := cfg.clientProvider["anthropic/claude-3-5-sonnet-20241022"]; got != "anthropic" {
 		t.Errorf("clientProvider[anthropic/claude-3-5-sonnet-20241022] = %q, want %q", got, "anthropic")
 	}
+}
+
+// TestParseClientBlock_BedrockEndpointURL_Literal pins the parser
+// extension that captures `endpoint_url "..."` and `region "..."` as
+// literal-provenance values inside an aws-bedrock client's options
+// block. Storage is parser-scoped (not provider-filtered) — emission
+// applies the aws-bedrock filter — so this test asserts the entry is
+// recorded for any aws-bedrock client.
+func TestParseClientBlock_BedrockEndpointURL_Literal(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> CustomBedrock {
+    provider aws-bedrock
+    options {
+        endpoint_url "http://localhost:9000"
+        region "us-east-1"
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	got, ok := cfg.bedrockClientOptions["CustomBedrock"]
+	if !ok {
+		t.Fatalf("bedrockClientOptions[CustomBedrock] missing; got map: %+v", cfg.bedrockClientOptions)
+	}
+	if got.EndpointURL.Provenance != "literal" {
+		t.Errorf("EndpointURL.Provenance = %q, want literal", got.EndpointURL.Provenance)
+	}
+	if got.EndpointURL.Literal != "http://localhost:9000" {
+		t.Errorf("EndpointURL.Literal = %q, want http://localhost:9000", got.EndpointURL.Literal)
+	}
+	if got.EndpointURL.EnvVar != "" {
+		t.Errorf("EndpointURL.EnvVar = %q, want empty for literal", got.EndpointURL.EnvVar)
+	}
+	if got.Region.Provenance != "literal" {
+		t.Errorf("Region.Provenance = %q, want literal", got.Region.Provenance)
+	}
+	if got.Region.Literal != "us-east-1" {
+		t.Errorf("Region.Literal = %q, want us-east-1", got.Region.Literal)
+	}
+}
+
+// TestParseClientBlock_BedrockEndpointURL_EnvRef pins the env.X
+// provenance branch. The bare-identifier `env.NAME` shape (no quotes)
+// is BAML's syntax for env-var references; the introspector preserves
+// the variable name and defers resolution to runtime.
+func TestParseClientBlock_BedrockEndpointURL_EnvRef(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> EnvBedrock {
+    provider aws-bedrock
+    options {
+        endpoint_url env.BEDROCK_ENDPOINT
+        region env.AWS_REGION_OVERRIDE
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	got, ok := cfg.bedrockClientOptions["EnvBedrock"]
+	if !ok {
+		t.Fatalf("bedrockClientOptions[EnvBedrock] missing")
+	}
+	if got.EndpointURL.Provenance != "env" {
+		t.Errorf("EndpointURL.Provenance = %q, want env", got.EndpointURL.Provenance)
+	}
+	if got.EndpointURL.EnvVar != "BEDROCK_ENDPOINT" {
+		t.Errorf("EndpointURL.EnvVar = %q, want BEDROCK_ENDPOINT", got.EndpointURL.EnvVar)
+	}
+	if got.EndpointURL.Literal != "" {
+		t.Errorf("EndpointURL.Literal = %q, want empty for env provenance", got.EndpointURL.Literal)
+	}
+	if got.Region.Provenance != "env" {
+		t.Errorf("Region.Provenance = %q, want env", got.Region.Provenance)
+	}
+	if got.Region.EnvVar != "AWS_REGION_OVERRIDE" {
+		t.Errorf("Region.EnvVar = %q, want AWS_REGION_OVERRIDE", got.Region.EnvVar)
+	}
+}
+
+// TestParseClientBlock_BedrockEndpointURL_Absent pins that an
+// aws-bedrock client without any endpoint_url / region option declared
+// produces NO entry in the parser's bedrockClientOptions map. The
+// absence-of-entry signal is what the codegen dispatcher uses to fall
+// through to MaybeAttachBedrockAuth's URL-pattern detection — a stub
+// entry would silently break that fallback.
+func TestParseClientBlock_BedrockEndpointURL_Absent(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> PlainBedrock {
+    provider aws-bedrock
+    options {
+        model "anthropic.claude-3-sonnet-20240229-v1:0"
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	if _, ok := cfg.bedrockClientOptions["PlainBedrock"]; ok {
+		t.Errorf("plain aws-bedrock client without overrides must not produce a bedrockClientOptions entry; got %+v", cfg.bedrockClientOptions["PlainBedrock"])
+	}
+}
+
+// TestParseClientBlock_BedrockEndpointURL_NonBedrockClient pins the
+// emission-time provider filter contract: even though the parser
+// records the option for any client that declares it, the eventual
+// emitted BedrockClientOptionsByName map must NOT contain non-bedrock
+// clients. This test runs through generateBamlConfigVars and inspects
+// the rendered Go output to confirm the filter.
+func TestParseClientBlock_BedrockEndpointURL_NonBedrockClient(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> NotBedrock {
+    provider openai
+    options {
+        endpoint_url "https://example.com/v1"
+        region "ignored"
+    }
+}
+
+client<llm> RealBedrock {
+    provider aws-bedrock
+    options {
+        endpoint_url "http://localhost:9000"
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	// Parser-side: both entries are recorded (filter is at emission).
+	if _, ok := cfg.bedrockClientOptions["NotBedrock"]; !ok {
+		t.Fatal("parser must record bedrockClientOptions for any client that declares the keys; provider filter is downstream")
+	}
+	if _, ok := cfg.bedrockClientOptions["RealBedrock"]; !ok {
+		t.Fatal("parser must record bedrockClientOptions for the aws-bedrock client too")
+	}
+}
+
+// TestParseClientBlock_BedrockEndpointURL_InlineSingleLine pins the
+// inline-options-block path (`options { ... }` on the same line as the
+// opening brace). The compact form is part of BAML's grammar and must
+// not silently drop endpoint_url / region keys.
+func TestParseClientBlock_BedrockEndpointURL_InlineSingleLine(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `client<llm> InlineBedrock { provider aws-bedrock options { endpoint_url "http://h:1" region "us-east-1" } }`
+	parseBamlFile(cfg, content)
+
+	got, ok := cfg.bedrockClientOptions["InlineBedrock"]
+	if !ok {
+		t.Fatalf("inline options block must produce a bedrockClientOptions entry; got map: %+v", cfg.bedrockClientOptions)
+	}
+	if got.EndpointURL.Literal != "http://h:1" {
+		t.Errorf("inline EndpointURL.Literal = %q, want http://h:1", got.EndpointURL.Literal)
+	}
+	if got.Region.Literal != "us-east-1" {
+		t.Errorf("inline Region.Literal = %q, want us-east-1", got.Region.Literal)
+	}
+}
+
+// TestParseClientBlock_BedrockEndpointURL_InlineCommentsAndQuotes pins
+// the inline-comment + quote-handling edge cases that flow through the
+// shared stripInlineComment / stripBamlQuotes helpers. A trailing `//`
+// comment on the option line, a quoted-with-spaces literal, and a
+// trailing-brace tail must all parse cleanly.
+func TestParseClientBlock_BedrockEndpointURL_InlineCommentsAndQuotes(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> CommentedBedrock {
+    provider aws-bedrock
+    options {
+        endpoint_url "http://localhost:9000"  // operator override for local dev
+        region "us-east-1"  // production region
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	got, ok := cfg.bedrockClientOptions["CommentedBedrock"]
+	if !ok {
+		t.Fatalf("commented-options client must produce an entry")
+	}
+	if got.EndpointURL.Literal != "http://localhost:9000" {
+		t.Errorf("EndpointURL.Literal = %q, want http://localhost:9000 (inline comment must be stripped)", got.EndpointURL.Literal)
+	}
+	if got.Region.Literal != "us-east-1" {
+		t.Errorf("Region.Literal = %q, want us-east-1 (inline comment must be stripped)", got.Region.Literal)
+	}
+}
+
+// TestParseClientBlock_BedrockEndpointURL_OnlyRegion pins that a
+// region-only override (no endpoint_url) still produces an entry. The
+// codegen dispatcher needs to honour region-only overrides too — they
+// pin SigV4 region for clients whose default endpoint host happens to
+// not encode the region the operator wants.
+func TestParseClientBlock_BedrockEndpointURL_OnlyRegion(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> RegionOnlyBedrock {
+    provider aws-bedrock
+    options {
+        region "ap-southeast-2"
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	got, ok := cfg.bedrockClientOptions["RegionOnlyBedrock"]
+	if !ok {
+		t.Fatalf("region-only override must produce a bedrockClientOptions entry")
+	}
+	if got.Region.Literal != "ap-southeast-2" {
+		t.Errorf("Region.Literal = %q, want ap-southeast-2", got.Region.Literal)
+	}
+	if got.EndpointURL.Provenance != "" {
+		t.Errorf("EndpointURL.Provenance = %q, want empty (only region was set)", got.EndpointURL.Provenance)
+	}
+}
+
+// TestExtractBedrockOptionValue_Forms pins each value-shape branch in
+// isolation so a future tweak to splitInlineStatements / quote-handling
+// surfaces immediately rather than only via the higher-level parser
+// tests above.
+func TestExtractBedrockOptionValue_Forms(t *testing.T) {
+	cases := []struct {
+		name     string
+		line     string
+		key      string
+		wantOK   bool
+		wantLit  string
+		wantEnv  string
+		wantProv string
+	}{
+		{
+			name:     "literal with quotes",
+			line:     `endpoint_url "http://localhost:9000"`,
+			key:      "endpoint_url",
+			wantOK:   true,
+			wantLit:  "http://localhost:9000",
+			wantProv: "literal",
+		},
+		{
+			name:     "env reference",
+			line:     `endpoint_url env.BEDROCK_HOST`,
+			key:      "endpoint_url",
+			wantOK:   true,
+			wantEnv:  "BEDROCK_HOST",
+			wantProv: "env",
+		},
+		{
+			name:     "literal with trailing brace",
+			line:     `endpoint_url "http://h" }`,
+			key:      "endpoint_url",
+			wantOK:   true,
+			wantLit:  "http://h",
+			wantProv: "literal",
+		},
+		{
+			name:   "absent key on this line",
+			line:   `model "x"`,
+			key:    "endpoint_url",
+			wantOK: false,
+		},
+		{
+			name:     "region literal",
+			line:     `region "eu-west-1"`,
+			key:      "region",
+			wantOK:   true,
+			wantLit:  "eu-west-1",
+			wantProv: "literal",
+		},
+		{
+			name:     "region env reference",
+			line:     `region env.AWS_REGION_X`,
+			key:      "region",
+			wantOK:   true,
+			wantEnv:  "AWS_REGION_X",
+			wantProv: "env",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := extractBedrockOptionValue(tc.line, tc.key)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (got %+v)", ok, tc.wantOK, got)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.Literal != tc.wantLit {
+				t.Errorf("Literal = %q, want %q", got.Literal, tc.wantLit)
+			}
+			if got.EnvVar != tc.wantEnv {
+				t.Errorf("EnvVar = %q, want %q", got.EnvVar, tc.wantEnv)
+			}
+			if got.Provenance != tc.wantProv {
+				t.Errorf("Provenance = %q, want %q", got.Provenance, tc.wantProv)
+			}
+		})
+	}
+}
+
+// TestParseClientBlock_BedrockEndpointURL_StaleEntryCleared pins the
+// re-parse contract: parsing a client block AFTER a prior parse for the
+// same name must clear the prior bedrockClientOptions entry. Without
+// this, an operator who removes endpoint_url from a client between
+// regen runs would silently keep the old override. Mirrors the
+// roundRobinStart / fallbackChains stale-state cleanup pattern.
+func TestParseClientBlock_BedrockEndpointURL_StaleEntryCleared(t *testing.T) {
+	cfg := newTestBamlConfig()
+	parseBamlFile(cfg, `
+client<llm> Foo {
+    provider aws-bedrock
+    options {
+        endpoint_url "http://h"
+    }
+}
+`)
+	if _, ok := cfg.bedrockClientOptions["Foo"]; !ok {
+		t.Fatal("first parse must populate the entry")
+	}
+	parseBamlFile(cfg, `
+client<llm> Foo {
+    provider aws-bedrock
+    options {
+        model "x"
+    }
+}
+`)
+	if _, ok := cfg.bedrockClientOptions["Foo"]; ok {
+		t.Errorf("re-parse without endpoint_url must clear the stale entry; got %+v", cfg.bedrockClientOptions["Foo"])
+	}
+}
+
+// TestBedrockOptionValue_Resolve_RuntimeBranches exercises the
+// generated Resolve() method indirectly by calling its Go equivalent
+// here on the parser-side type — the generator emits the same switch
+// shape verbatim. Pinning both branches catches regressions in either
+// the parser-side struct fields or the generated method's switch
+// arms.
+func TestBedrockOptionValue_Resolve_RuntimeBranches(t *testing.T) {
+	t.Run("literal returns value with ok=true", func(t *testing.T) {
+		v := bedrockOptionValue{Literal: "x", Provenance: "literal"}
+		got, ok := resolveBedrockOptionValueForTest(v)
+		if got != "x" || !ok {
+			t.Errorf("literal resolve = (%q, %v), want (\"x\", true)", got, ok)
+		}
+	})
+	t.Run("env returns os.LookupEnv result", func(t *testing.T) {
+		t.Setenv("PARSER_RESOLVE_TEST", "from-env")
+		v := bedrockOptionValue{EnvVar: "PARSER_RESOLVE_TEST", Provenance: "env"}
+		got, ok := resolveBedrockOptionValueForTest(v)
+		if got != "from-env" || !ok {
+			t.Errorf("env resolve = (%q, %v), want (\"from-env\", true)", got, ok)
+		}
+	})
+	t.Run("env unset returns empty/false", func(t *testing.T) {
+		v := bedrockOptionValue{EnvVar: "DEFINITELY_NOT_SET_PARSER_TEST", Provenance: "env"}
+		got, ok := resolveBedrockOptionValueForTest(v)
+		if got != "" || ok {
+			t.Errorf("unset env resolve = (%q, %v), want (\"\", false)", got, ok)
+		}
+	})
+	t.Run("unset provenance returns empty/false", func(t *testing.T) {
+		v := bedrockOptionValue{}
+		got, ok := resolveBedrockOptionValueForTest(v)
+		if got != "" || ok {
+			t.Errorf("unset provenance resolve = (%q, %v), want (\"\", false)", got, ok)
+		}
+	})
+}
+
+// resolveBedrockOptionValueForTest mirrors the runtime Resolve() method
+// shape that emitBedrockOptionTypes generates. Lives in the test file
+// so the parser-side type retains a unit-testable resolver without the
+// generator having to expose its shape via a callable hook.
+func resolveBedrockOptionValueForTest(v bedrockOptionValue) (string, bool) {
+	switch v.Provenance {
+	case "literal":
+		return v.Literal, true
+	case "env":
+		return os.LookupEnv(v.EnvVar)
+	}
+	return "", false
 }

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -1156,6 +1156,40 @@ type bamlConfig struct {
 	// parser records the value for any client whose options contain
 	// `start N`, regardless of provider.
 	roundRobinStart map[string]int
+	// bedrockClientOptions maps client name → parsed aws-bedrock
+	// options (endpoint_url + region). The parser records entries for
+	// every client whose options block declares either key (so the map
+	// can carry literal-vs-env provenance) regardless of provider; the
+	// emission step filters to provider == "aws-bedrock" so a non-bedrock
+	// client that happens to use the same option keys for an unrelated
+	// purpose can't leak into the runtime BedrockClientOptions map.
+	bedrockClientOptions map[string]bedrockClientOptions
+}
+
+// bedrockClientOptions captures the per-client aws-bedrock options that
+// codegen needs at request-build time to override BAML's hardcoded
+// modular Bedrock URL. BAML v0.219's HTTPRequest builder hardcodes
+// https://bedrock-runtime.<region>.amazonaws.com and the public Go
+// surface does not expose ClientDetails (see Codex's deep-dive Q1/Q2),
+// so baml-rest carries its own resolved options keyed on client name.
+type bedrockClientOptions struct {
+	EndpointURL bedrockOptionValue
+	Region      bedrockOptionValue
+}
+
+// bedrockOptionValue stores a single .baml option value with its
+// provenance preserved. Resolution to a final string happens at
+// request-build time so an env-var override picks up the worker's
+// current environment rather than the build-time snapshot.
+//
+// Provenance is the discriminator:
+//   - ""          → no value declared
+//   - "literal"   → Literal carries the bare string (quotes already stripped)
+//   - "env"       → EnvVar carries the env var name (no leading "env.")
+type bedrockOptionValue struct {
+	Literal    string
+	EnvVar     string
+	Provenance string
 }
 
 type parsedRetryPolicy struct {
@@ -1172,12 +1206,13 @@ type parsedRetryPolicy struct {
 // are included.
 func parseBamlSourceDir(dir string) *bamlConfig {
 	cfg := &bamlConfig{
-		clientProvider:    make(map[string]string),
-		clientRetryPolicy: make(map[string]string),
-		functionClient:    make(map[string]string),
-		retryPolicies:     make(map[string]parsedRetryPolicy),
-		fallbackChains:    make(map[string][]string),
-		roundRobinStart:   make(map[string]int),
+		clientProvider:       make(map[string]string),
+		clientRetryPolicy:    make(map[string]string),
+		functionClient:       make(map[string]string),
+		retryPolicies:        make(map[string]parsedRetryPolicy),
+		fallbackChains:       make(map[string][]string),
+		roundRobinStart:      make(map[string]int),
+		bedrockClientOptions: make(map[string]bedrockClientOptions),
 	}
 
 	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
@@ -1445,6 +1480,7 @@ func isNestedBlockStart(line string) bool {
 // key-value statements. Sorted longest-first so that `max_delay_ms` is matched
 // before the embedded `delay_ms` substring.
 var bamlConfigKeys = []string{
+	"endpoint_url ",
 	"retry_policy ",
 	"max_delay_ms ",
 	"max_retries ",
@@ -1455,6 +1491,7 @@ var bamlConfigKeys = []string{
 	"options ",
 	"client ",
 	"prompt ",
+	"region ",
 	"start ",
 	"type ",
 }
@@ -1650,6 +1687,7 @@ func parseClientBlock(cfg *bamlConfig, name string, block []string) {
 	delete(cfg.fallbackChains, name)
 	delete(cfg.clientProvider, name)
 	delete(cfg.clientRetryPolicy, name)
+	delete(cfg.bedrockClientOptions, name)
 
 	nestedDepth := 0
 	inOptions := false
@@ -1737,6 +1775,12 @@ func parseClientBlock(cfg *bamlConfig, name string, block []string) {
 				if startVal, ok := extractRoundRobinStart(line); ok {
 					cfg.roundRobinStart[name] = startVal
 				}
+				// Capture aws-bedrock options (endpoint_url + region)
+				// at the top-level options depth. Provider filtering
+				// happens at emission time so a non-bedrock client
+				// using the same keys for an unrelated purpose can't
+				// leak into the runtime BedrockClientOptions map.
+				updateBedrockClientOption(cfg, name, line)
 			}
 			stripped := stripInlineComment(stripStringLiterals(line))
 			optionsDepth += strings.Count(stripped, "{") - strings.Count(stripped, "}")
@@ -1779,6 +1823,7 @@ func parseClientBlock(cfg *bamlConfig, name string, block []string) {
 					if startVal, ok := extractRoundRobinStart(inner); ok {
 						cfg.roundRobinStart[name] = startVal
 					}
+					updateBedrockClientOption(cfg, name, inner)
 				}
 				if optionsDepth <= 0 {
 					inOptions = false
@@ -1945,6 +1990,72 @@ func extractRoundRobinStart(line string) (int, bool) {
 		return int(v), true
 	}
 	return 0, false
+}
+
+// updateBedrockClientOption extracts endpoint_url and region option
+// values from a single options-block line and merges them into the
+// per-client bedrockClientOptions entry. Each call is additive on the
+// keys actually present in `line`, so a multi-line options block whose
+// endpoint_url and region appear on separate lines accumulates both.
+//
+// Provider filtering happens at emission, not here — see the
+// bedrockClientOptions field doc on bamlConfig for the rationale.
+func updateBedrockClientOption(cfg *bamlConfig, clientName, line string) {
+	endpoint, hasEndpoint := extractBedrockOptionValue(line, "endpoint_url")
+	region, hasRegion := extractBedrockOptionValue(line, "region")
+	if !hasEndpoint && !hasRegion {
+		return
+	}
+	cur := cfg.bedrockClientOptions[clientName]
+	if hasEndpoint {
+		cur.EndpointURL = endpoint
+	}
+	if hasRegion {
+		cur.Region = region
+	}
+	cfg.bedrockClientOptions[clientName] = cur
+}
+
+// extractBedrockOptionValue scans a line (or split inline segment) for
+// a `<key> <value>` statement and returns the parsed bedrockOptionValue
+// with provenance set. Recognised value shapes:
+//
+//   - `<key> "literal"`      → Provenance = "literal", Literal = "literal"
+//   - `<key> env.NAME`       → Provenance = "env",     EnvVar  = "NAME"
+//
+// Returns ok=false when the key is absent or the value is empty.
+// Trailing block / list closers (`}`, `]`) are tolerated so a tail like
+// `endpoint_url "x" }` parses cleanly, mirroring extractRoundRobinStart.
+func extractBedrockOptionValue(line, key string) (bedrockOptionValue, bool) {
+	prefix := key + " "
+	for _, stmt := range splitInlineStatements(line) {
+		trimmed := strings.TrimSpace(stripInlineComment(stmt))
+		if !strings.HasPrefix(trimmed, prefix) {
+			continue
+		}
+		raw := strings.TrimPrefix(trimmed, prefix)
+		raw = strings.TrimRight(raw, " \t}]")
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		// env.X form: bare identifier reference, no quotes. BAML
+		// upstream parses these as EnvRef without quotes so the
+		// introspector matches.
+		if strings.HasPrefix(raw, "env.") {
+			envName := strings.TrimSpace(raw[len("env."):])
+			if envName == "" {
+				continue
+			}
+			return bedrockOptionValue{EnvVar: envName, Provenance: "env"}, true
+		}
+		lit := stripBamlQuotes(raw)
+		if lit == "" {
+			continue
+		}
+		return bedrockOptionValue{Literal: lit, Provenance: "literal"}, true
+	}
+	return bedrockOptionValue{}, false
 }
 
 // parseStrategyList extracts client names from a strategy line like
@@ -2419,4 +2530,113 @@ func generateBamlConfigVars(out *jen.File) {
 	// purely through client_registry overrides) bypass this coordinator.
 	out.Comment("RoundRobinCoordinator holds per-client round-robin counters shared across requests")
 	out.Var().Id("RoundRobinCoordinator").Op("=").Qual("github.com/invakid404/baml-rest/bamlutils/buildrequest/roundrobin", "NewCoordinatorWithStarts").Call(jen.Id("RoundRobinStart"))
+
+	// BedrockOptionValue + BedrockClientOptions carry the parsed
+	// aws-bedrock client options (endpoint_url + region) that codegen
+	// reads at request-build time to override BAML v0.219's hardcoded
+	// modular Bedrock URL and pin SigV4 region. Resolution happens at
+	// runtime so env-var values reflect the worker's current
+	// environment rather than the build-time snapshot.
+	emitBedrockOptionTypes(out)
+
+	// BedrockClientOptionsByName: keyed by client name; only aws-bedrock
+	// clients are emitted. The codegen dispatcher in
+	// adapters/common/codegen treats absence-from-map as "no override
+	// configured" and falls through to MaybeAttachBedrockAuth's
+	// URL-pattern detection for the default-endpoint case.
+	//
+	// Variable name disambiguates from the struct type
+	// `BedrockClientOptions`: Go's package namespace would otherwise
+	// reject `var BedrockClientOptions = map[string]BedrockClientOptions{}`.
+	out.Comment("BedrockClientOptionsByName maps aws-bedrock client names to their parsed endpoint_url + region options.")
+	out.Comment("Codegen looks up the resolved client name here at request-build time and dispatches to")
+	out.Comment("llmhttp.AttachBedrockAuthForClient with the resolved values.")
+	{
+		entries := make([]jen.Code, 0, len(cfg.bedrockClientOptions))
+		keys := make([]string, 0, len(cfg.bedrockClientOptions))
+		for k := range cfg.bedrockClientOptions {
+			// Provider filter: a non-bedrock client that happens to
+			// declare endpoint_url / region (a typo, a future
+			// provider sharing the key) must NOT leak into the runtime
+			// map — codegen looks up by client name and would wire
+			// AttachBedrockAuthForClient against a non-Bedrock URL,
+			// silently changing behaviour. Filtering here keeps the
+			// generated map honest.
+			if cfg.clientProvider[k] != "aws-bedrock" {
+				continue
+			}
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, clientName := range keys {
+			opts := cfg.bedrockClientOptions[clientName]
+			entries = append(entries, jen.Lit(clientName).Op(":").Id("BedrockClientOptions").Values(jen.Dict{
+				jen.Id("EndpointURL"): bedrockOptionValueLit(opts.EndpointURL),
+				jen.Id("Region"):      bedrockOptionValueLit(opts.Region),
+			}))
+		}
+		out.Var().Id("BedrockClientOptionsByName").Op("=").Map(jen.String()).Id("BedrockClientOptions").Values(entries...)
+	}
+}
+
+// bedrockOptionValueLit renders a bedrockOptionValue as the
+// generated-Go literal for a BedrockOptionValue struct. Empty
+// (Provenance == "") values still render explicitly so the diff between
+// "EndpointURL set, Region unset" and "both set" is visually obvious in
+// the generated source.
+func bedrockOptionValueLit(v bedrockOptionValue) jen.Code {
+	return jen.Id("BedrockOptionValue").Values(jen.Dict{
+		jen.Id("Literal"):    jen.Lit(v.Literal),
+		jen.Id("EnvVar"):     jen.Lit(v.EnvVar),
+		jen.Id("Provenance"): jen.Lit(v.Provenance),
+	})
+}
+
+// emitBedrockOptionTypes emits the BedrockOptionValue struct, its
+// Resolve() method, and the BedrockClientOptions struct into the
+// generated introspected package. These types are part of the package's
+// stable surface so the codegen-emitted dispatch and the
+// runtime-emitted resolver agree on shape.
+//
+// Resolve() returns:
+//   - (Literal, true)            when Provenance == "literal"
+//   - (os.LookupEnv(EnvVar))     when Provenance == "env"
+//   - ("", false)                when Provenance == ""
+//
+// The runtime branch resolves env vars per-call so a worker that
+// reloads its environment between requests sees the new value.
+func emitBedrockOptionTypes(out *jen.File) {
+	out.Comment("BedrockOptionValue carries one parsed aws-bedrock option value with its provenance preserved.")
+	out.Comment("Provenance discriminates the value source: \"literal\" (Literal carries the bare string),")
+	out.Comment("\"env\" (EnvVar carries the env var name), or \"\" (no value declared).")
+	out.Type().Id("BedrockOptionValue").Struct(
+		jen.Id("Literal").String(),
+		jen.Id("EnvVar").String(),
+		jen.Id("Provenance").String(),
+	)
+
+	out.Comment("Resolve returns (value, ok) for this option:")
+	out.Comment("  - literal provenance: (Literal, true)")
+	out.Comment("  - env provenance:     os.LookupEnv(EnvVar)")
+	out.Comment("  - unset:              (\"\", false)")
+	out.Func().Params(jen.Id("v").Id("BedrockOptionValue")).Id("Resolve").Params().Params(jen.String(), jen.Bool()).Block(
+		jen.Switch(jen.Id("v").Dot("Provenance")).Block(
+			jen.Case(jen.Lit("literal")).Block(
+				jen.Return(jen.Id("v").Dot("Literal"), jen.True()),
+			),
+			jen.Case(jen.Lit("env")).Block(
+				jen.Return(jen.Qual("os", "LookupEnv").Call(jen.Id("v").Dot("EnvVar"))),
+			),
+		),
+		jen.Return(jen.Lit(""), jen.False()),
+	)
+
+	out.Comment("BedrockClientOptions carries the per-client aws-bedrock options that codegen needs at request-build time")
+	out.Comment("to override BAML's hardcoded modular Bedrock URL (BAML v0.219 hardcodes")
+	out.Comment("https://bedrock-runtime.<region>.amazonaws.com and the public Go HTTPRequest surface does not expose")
+	out.Comment("ClientDetails, so baml-rest carries its own resolved options keyed on client name).")
+	out.Type().Id("BedrockClientOptions").Struct(
+		jen.Id("EndpointURL").Id("BedrockOptionValue"),
+		jen.Id("Region").Id("BedrockOptionValue"),
+	)
 }

--- a/introspected/introspected.go
+++ b/introspected/introspected.go
@@ -6,6 +6,7 @@ import (
 	bamlutils "github.com/invakid404/baml-rest/bamlutils"
 	roundrobin "github.com/invakid404/baml-rest/bamlutils/buildrequest/roundrobin"
 	retry "github.com/invakid404/baml-rest/bamlutils/retry"
+	"os"
 )
 
 // Stream is the BAML streaming client instance
@@ -64,26 +65,56 @@ var RetryPolicies = map[string]*retry.Policy{}
 // FunctionRetryPolicy maps BAML function names to their retry policy name
 var FunctionRetryPolicy = map[string]string{}
 
-// ClientRetryPolicy maps BAML client names to their declared retry policy name.
-// Used by the BuildRequest router (keyed on the effective client after any
-// baml-roundrobin unwrap) instead of FunctionRetryPolicy.
+// ClientRetryPolicy maps BAML client names to their declared retry policy name
 var ClientRetryPolicy = map[string]string{}
 
 // FallbackChains maps strategy client names to their ordered list of child client names
 var FallbackChains = map[string][]string{}
 
-// RoundRobinStart maps baml-roundrobin client names to their configured
-// start index. Nil by default so cmd/serve's nil-check on SharedStateSeeds
-// skips provisioning the host-side SharedState broker socket; the
-// generator replaces this stub with an initialised map only when the
-// .baml source defines at least one baml-roundrobin client.
+// RoundRobinStart maps baml-roundrobin client names to their configured start index
+// Nil when the source defines no baml-roundrobin clients; cmd/serve uses that as the gate
+// for provisioning the host-side SharedState server.
 var RoundRobinStart map[string]int
 
-// RoundRobinCoordinator holds the per-process, per-client round-robin
-// counters used by the BuildRequest path. Generated introspection emits
-// a freshly-constructed Coordinator here so static baml-roundrobin
-// clients keep contiguous counters across requests.
+// RoundRobinCoordinator holds per-client round-robin counters shared across requests
 var RoundRobinCoordinator = roundrobin.NewCoordinatorWithStarts(RoundRobinStart)
+
+// BedrockOptionValue carries one parsed aws-bedrock option value with its provenance preserved.
+// Provenance discriminates the value source: "literal" (Literal carries the bare string),
+// "env" (EnvVar carries the env var name), or "" (no value declared).
+type BedrockOptionValue struct {
+	Literal    string
+	EnvVar     string
+	Provenance string
+}
+
+// Resolve returns (value, ok) for this option:
+//   - literal provenance: (Literal, true)
+//   - env provenance:     os.LookupEnv(EnvVar)
+//   - unset:              ("", false)
+func (v BedrockOptionValue) Resolve() (string, bool) {
+	switch v.Provenance {
+	case "literal":
+		return v.Literal, true
+	case "env":
+		return os.LookupEnv(v.EnvVar)
+	}
+	return "", false
+}
+
+// BedrockClientOptions carries the per-client aws-bedrock options that codegen needs at request-build time
+// to override BAML's hardcoded modular Bedrock URL (BAML v0.219 hardcodes
+// https://bedrock-runtime.<region>.amazonaws.com and the public Go HTTPRequest surface does not expose
+// ClientDetails, so baml-rest carries its own resolved options keyed on client name).
+type BedrockClientOptions struct {
+	EndpointURL BedrockOptionValue
+	Region      BedrockOptionValue
+}
+
+// BedrockClientOptionsByName maps aws-bedrock client names to their parsed endpoint_url + region options.
+// Codegen looks up the resolved client name here at request-build time and dispatches to
+// llmhttp.AttachBedrockAuthForClient with the resolved values.
+var BedrockClientOptionsByName = map[string]BedrockClientOptions{}
 
 // TypeBuilder type
 type TypeBuilder struct{}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Implements `endpoint_url` + `region` parity for the `aws-bedrock` provider via a local introspect-side client-options layer. Today BAML v0.219's modular `HTTPRequest` hardcodes `https://bedrock-runtime.<region>.amazonaws.com` and its public Go surface doesn't expose `ClientDetails`, so operator-configured `endpoint_url` in `.baml` was silently dropped. This PR routes those options through `cmd/introspect` → new `AttachBedrockAuthWithOptions` helper → SigV4 signing, supporting VPC, FIPS, China, GovCloud, and custom (LocalStack-style) endpoints.

Closes the `endpoint_url` line item under #254; umbrella tracker stays open for static credentials, tool-use streaming deltas, reasoning signature/redacted content, and usage metadata.

## What's included

- `cmd/introspect` parser extension reading `endpoint_url` and `region` from `aws-bedrock` client `options { ... }` blocks, with literal-vs-`env.X` provenance.
- New `introspected.BedrockClientOptionsByName` map keyed by client name (variable name disambiguates from the struct type `BedrockClientOptions`).
- `bamlutils/llmhttp.AttachBedrockAuthWithOptions(ctx, req, opts)` — applies endpoint URL override (preserving path, query, and fragment), validates region, attaches SigV4 metadata. `AttachBedrockAuthForClient(ctx, req, endpointURL, region)` is the codegen dispatch entry point: routes to the new helper when an override is configured, falls through to today's `MaybeAttachBedrockAuth` URL-pattern detection otherwise.
- `adapters/common/codegen` wiring: resolves the selected client name (clientOverride else `introspected.FunctionClient[methodName]`), looks up `BedrockClientOptionsByName`, and dispatches to the new helper. Streaming closure mutates `/converse → /converse-stream` BEFORE auth attach so SigV4 signs the final URL.
- Unit coverage: VPC, FIPS, China, GovCloud, custom (localhost), trailing-slash on endpoint URL, missing region, `AWS_REGION` env fallback, region-NOT-from-URL invariant, default-chain credentials, dispatcher routing, parser literal/env/inline/comment/stale/non-bedrock cases, codegen emission shape (resolve-name + lookup + dispatch).
- E2E coverage in `bamlutils/llmhttp/awssigv4_e2e_test.go` exercising the override + sign + dispatch path through `httptest.NewServer` for both `/converse` (Execute) and `/converse-stream` (ExecuteAWSStream), plus the AWS_REGION env-fallback round trip.

## What's NOT included (deferred to follow-ups under #254)

- **Static credentials** (`access_key_id`, `secret_access_key`, `session_token`, `profile`). `BedrockAuthOptions.Credentials` is a documented forward-compat slot — same infrastructure, follow-up PR will populate it.
- **URL-pattern widening** for default-endpoint flavors. Rejected per Codex audit: custom endpoints break host-based region extraction. Region now comes from config, not URL parsing.
- **Tool-use streaming deltas, usage metadata, reasoning signature/redacted content** — separate #254 line items.

## Design notes

- Explicit provider/client-tagged attachment (Approach B from Codex's `/tmp/codex-i254-endpoint-url-deep-dive-v1.md`). `MaybeAttachBedrockAuth` continues to handle the default-endpoint case via URL-pattern detection — no regression for existing `.baml` configurations.
- Region resolution order: `opts.Region` (from `.baml options.region` literal or `env.X` resolved) > `AWS_REGION` env > error. The new helper never infers region from URL host.
- Endpoint URL override preserves the original request's path, query, and fragment; trailing slashes on `endpoint_url` are tolerated. The streaming `/converse → /converse-stream` mutation runs before auth attach, so SigV4 signs the final URL.
- `BedrockClientOptionsByName` is the var name (not `BedrockClientOptions`) because the struct type holds the same name; Go's package namespace requires disambiguation.

## Verification

- `go build ./...` / `go vet ./...` clean.
- `verify-framework-adapter`: 9/9. `verify-adapter-pins`: 4/4.
- `gofmt -l` clean for all touched files.
- `go run ./cmd/embed && git status --porcelain` clean.
- Unit tests cover default, VPC, FIPS, China, GovCloud, localhost, trailing slash, missing region, `AWS_REGION` fallback, region-NOT-from-URL, dispatch routing, codegen emission, parser literal/env/inline/comment/stale/non-bedrock.
- E2E tests cover the full override + sign + dispatch path through a real `httptest.NewServer` for both call and stream.

Refs #254.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Per-client Bedrock endpoint and region overrides with runtime-aware auth dispatch
  - Endpoint rewrite for streaming requests (e.g., conversation → conversation-stream) and preserved Accept header
  - Deterministic SigV4 signing that covers rewritten endpoints

* **Tests**
  - Expanded end-to-end and unit tests for endpoint overrides, region resolution, signing, and dispatch routing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/262)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->