### PR TITLE
feat(bedrock): static credentials parity via .baml options (#254 item 2)

### DIFF
--- a/adapters/common/codegen/codegen_bedrock_test.go
+++ b/adapters/common/codegen/codegen_bedrock_test.go
@@ -172,7 +172,14 @@ func TestEmitBuildCallRequest_EmitsBedrockAuthDispatch(t *testing.T) {
 	if !strings.Contains(rendered, "llmhttp.AttachBedrockAuthForClient(ctx, req, llmhttp.BedrockClientAuthOptions{") {
 		t.Errorf("dispatch must call llmhttp.AttachBedrockAuthForClient with a BedrockClientAuthOptions struct; rendered:\n%s", rendered)
 	}
-	for _, optField := range []string{"ClientName:  selectedClient", "EndpointURL: bedrockEndpointURL", "Region:      bedrockRegion", "Credentials: bedrockCreds"} {
+	for _, optField := range []string{
+		"ClientName:         selectedClient",
+		"EndpointURL:        bedrockEndpointURL",
+		"EndpointURLPresent: bedrockEndpointURLPresent",
+		"Region:             bedrockRegion",
+		"RegionPresent:      bedrockRegionPresent",
+		"Credentials:        bedrockCreds",
+	} {
 		if !strings.Contains(rendered, optField) {
 			t.Errorf("dispatch must populate BedrockClientAuthOptions.%s; rendered:\n%s", optField, rendered)
 		}
@@ -245,7 +252,14 @@ func TestEmitBuildRequest_EmitsBedrockStreamingClosure(t *testing.T) {
 	if !strings.Contains(rendered, "llmhttp.AttachBedrockAuthForClient(ctx, req, llmhttp.BedrockClientAuthOptions{") {
 		t.Errorf("bedrock streaming closure must call llmhttp.AttachBedrockAuthForClient with a BedrockClientAuthOptions struct; rendered:\n%s", rendered)
 	}
-	for _, optField := range []string{"ClientName:  selectedClient", "EndpointURL: bedrockEndpointURL", "Region:      bedrockRegion", "Credentials: bedrockCreds"} {
+	for _, optField := range []string{
+		"ClientName:         selectedClient",
+		"EndpointURL:        bedrockEndpointURL",
+		"EndpointURLPresent: bedrockEndpointURLPresent",
+		"Region:             bedrockRegion",
+		"RegionPresent:      bedrockRegionPresent",
+		"Credentials:        bedrockCreds",
+	} {
 		if !strings.Contains(rendered, optField) {
 			t.Errorf("bedrock streaming closure must populate BedrockClientAuthOptions.%s; rendered:\n%s", optField, rendered)
 		}
@@ -280,8 +294,20 @@ func TestEmitBedrockAuthDispatchFor_Shape(t *testing.T) {
 		"selectedClient := clientOverride",
 		`introspected.FunctionClient["MyMethod"]`,
 		"introspected.BedrockClientOptionsByName[selectedClient]",
+		// EndpointURL and Region get the same IsSet/Resolve split
+		// as credentials. Driving the *Present flags from IsSet()
+		// (declared-in-.baml) rather than Resolve()'s second return
+		// (resolved-to-non-empty) is the load-bearing contract that
+		// makes a declared `endpoint_url env.X` with X unset error
+		// rather than silently fall back to the default Bedrock
+		// host. Same security-significant invariant the credentials
+		// pins below depend on.
 		"bedrockOpts.EndpointURL.Resolve()",
+		"bedrockOpts.EndpointURL.IsSet()",
 		"bedrockOpts.Region.Resolve()",
+		"bedrockOpts.Region.IsSet()",
+		"bedrockEndpointURLPresent = bedrockOpts.EndpointURL.IsSet()",
+		"bedrockRegionPresent = bedrockOpts.Region.IsSet()",
 		// Credentials emit Resolve() for the value AND IsSet() for
 		// the presence flag — driving presence from Resolve()'s ok
 		// would conflate declared-but-env-unset with never-declared
@@ -304,10 +330,12 @@ func TestEmitBedrockAuthDispatchFor_Shape(t *testing.T) {
 		"bedrockCreds.SessionTokenPresent = bedrockOpts.Credentials.SessionToken.IsSet()",
 		"bedrockCreds.ProfilePresent = bedrockOpts.Credentials.Profile.IsSet()",
 		"llmhttp.AttachBedrockAuthForClient(ctx, req, llmhttp.BedrockClientAuthOptions{",
-		"ClientName:  selectedClient",
-		"EndpointURL: bedrockEndpointURL",
-		"Region:      bedrockRegion",
-		"Credentials: bedrockCreds",
+		"ClientName:         selectedClient",
+		"EndpointURL:        bedrockEndpointURL",
+		"EndpointURLPresent: bedrockEndpointURLPresent",
+		"Region:             bedrockRegion",
+		"RegionPresent:      bedrockRegionPresent",
+		"Credentials:        bedrockCreds",
 		"return nil, authErr",
 	}
 	for _, want := range wantSubstrings {

--- a/adapters/common/codegen/codegen_bedrock_test.go
+++ b/adapters/common/codegen/codegen_bedrock_test.go
@@ -240,7 +240,8 @@ func TestEmitBuildRequest_EmitsBedrockStreamingClosure(t *testing.T) {
 	// Auth attach uses the client-aware dispatch (which internally
 	// falls through to MaybeAttachBedrockAuth for the default-endpoint
 	// case) — the streaming closure picks up the same per-client
-	// endpoint_url + region overrides as the call closure.
+	// endpoint_url, region, and credential-selector overrides as the
+	// call closure.
 	if !strings.Contains(rendered, "llmhttp.AttachBedrockAuthForClient(ctx, req, llmhttp.BedrockClientAuthOptions{") {
 		t.Errorf("bedrock streaming closure must call llmhttp.AttachBedrockAuthForClient with a BedrockClientAuthOptions struct; rendered:\n%s", rendered)
 	}
@@ -281,10 +282,27 @@ func TestEmitBedrockAuthDispatchFor_Shape(t *testing.T) {
 		"introspected.BedrockClientOptionsByName[selectedClient]",
 		"bedrockOpts.EndpointURL.Resolve()",
 		"bedrockOpts.Region.Resolve()",
+		// Credentials emit Resolve() for the value AND IsSet() for
+		// the presence flag — driving presence from Resolve()'s ok
+		// would conflate declared-but-env-unset with never-declared
+		// and silently fall through to the default AWS chain. See
+		// emitBedrockAuthDispatchFor's doc-comment for the
+		// security-significant invariant this pins.
 		"bedrockOpts.Credentials.AccessKeyID.Resolve()",
+		"bedrockOpts.Credentials.AccessKeyID.IsSet()",
 		"bedrockOpts.Credentials.SecretAccessKey.Resolve()",
+		"bedrockOpts.Credentials.SecretAccessKey.IsSet()",
 		"bedrockOpts.Credentials.SessionToken.Resolve()",
+		"bedrockOpts.Credentials.SessionToken.IsSet()",
 		"bedrockOpts.Credentials.Profile.Resolve()",
+		"bedrockOpts.Credentials.Profile.IsSet()",
+		// Per-flag assignment lines, pinned individually so a
+		// future refactor that drops one (or wires the IsSet call
+		// to the wrong selector field) surfaces immediately.
+		"bedrockCreds.AccessKeyIDPresent = bedrockOpts.Credentials.AccessKeyID.IsSet()",
+		"bedrockCreds.SecretAccessKeyPresent = bedrockOpts.Credentials.SecretAccessKey.IsSet()",
+		"bedrockCreds.SessionTokenPresent = bedrockOpts.Credentials.SessionToken.IsSet()",
+		"bedrockCreds.ProfilePresent = bedrockOpts.Credentials.Profile.IsSet()",
 		"llmhttp.AttachBedrockAuthForClient(ctx, req, llmhttp.BedrockClientAuthOptions{",
 		"ClientName:  selectedClient",
 		"EndpointURL: bedrockEndpointURL",

--- a/adapters/common/codegen/codegen_bedrock_test.go
+++ b/adapters/common/codegen/codegen_bedrock_test.go
@@ -169,8 +169,13 @@ func TestEmitBuildCallRequest_EmitsBedrockAuthDispatch(t *testing.T) {
 	// internally falls through to MaybeAttachBedrockAuth when both
 	// values are empty, so the URL-pattern detection contract holds
 	// without re-emitting the helper here.
-	if !strings.Contains(rendered, "llmhttp.AttachBedrockAuthForClient(ctx, req, bedrockEndpointURL, bedrockRegion)") {
-		t.Errorf("dispatch must call llmhttp.AttachBedrockAuthForClient with resolved endpoint+region; rendered:\n%s", rendered)
+	if !strings.Contains(rendered, "llmhttp.AttachBedrockAuthForClient(ctx, req, llmhttp.BedrockClientAuthOptions{") {
+		t.Errorf("dispatch must call llmhttp.AttachBedrockAuthForClient with a BedrockClientAuthOptions struct; rendered:\n%s", rendered)
+	}
+	for _, optField := range []string{"ClientName:  selectedClient", "EndpointURL: bedrockEndpointURL", "Region:      bedrockRegion", "Credentials: bedrockCreds"} {
+		if !strings.Contains(rendered, optField) {
+			t.Errorf("dispatch must populate BedrockClientAuthOptions.%s; rendered:\n%s", optField, rendered)
+		}
 	}
 	// The attach lives inside the buildRequestFn closure, between the
 	// httpReq construction and the closure's final return. Pin both
@@ -236,8 +241,13 @@ func TestEmitBuildRequest_EmitsBedrockStreamingClosure(t *testing.T) {
 	// falls through to MaybeAttachBedrockAuth for the default-endpoint
 	// case) — the streaming closure picks up the same per-client
 	// endpoint_url + region overrides as the call closure.
-	if !strings.Contains(rendered, "llmhttp.AttachBedrockAuthForClient(ctx, req, bedrockEndpointURL, bedrockRegion)") {
-		t.Errorf("bedrock streaming closure must call llmhttp.AttachBedrockAuthForClient with resolved endpoint+region; rendered:\n%s", rendered)
+	if !strings.Contains(rendered, "llmhttp.AttachBedrockAuthForClient(ctx, req, llmhttp.BedrockClientAuthOptions{") {
+		t.Errorf("bedrock streaming closure must call llmhttp.AttachBedrockAuthForClient with a BedrockClientAuthOptions struct; rendered:\n%s", rendered)
+	}
+	for _, optField := range []string{"ClientName:  selectedClient", "EndpointURL: bedrockEndpointURL", "Region:      bedrockRegion", "Credentials: bedrockCreds"} {
+		if !strings.Contains(rendered, optField) {
+			t.Errorf("bedrock streaming closure must populate BedrockClientAuthOptions.%s; rendered:\n%s", optField, rendered)
+		}
 	}
 	if !strings.Contains(rendered, "introspected.BedrockClientOptionsByName[selectedClient]") {
 		t.Errorf("bedrock streaming closure must look up introspected.BedrockClientOptionsByName[selectedClient]; rendered:\n%s", rendered)
@@ -271,7 +281,15 @@ func TestEmitBedrockAuthDispatchFor_Shape(t *testing.T) {
 		"introspected.BedrockClientOptionsByName[selectedClient]",
 		"bedrockOpts.EndpointURL.Resolve()",
 		"bedrockOpts.Region.Resolve()",
-		"llmhttp.AttachBedrockAuthForClient(ctx, req, bedrockEndpointURL, bedrockRegion)",
+		"bedrockOpts.Credentials.AccessKeyID.Resolve()",
+		"bedrockOpts.Credentials.SecretAccessKey.Resolve()",
+		"bedrockOpts.Credentials.SessionToken.Resolve()",
+		"bedrockOpts.Credentials.Profile.Resolve()",
+		"llmhttp.AttachBedrockAuthForClient(ctx, req, llmhttp.BedrockClientAuthOptions{",
+		"ClientName:  selectedClient",
+		"EndpointURL: bedrockEndpointURL",
+		"Region:      bedrockRegion",
+		"Credentials: bedrockCreds",
 		"return nil, authErr",
 	}
 	for _, want := range wantSubstrings {

--- a/adapters/common/codegen/codegen_buildrequest.go
+++ b/adapters/common/codegen/codegen_buildrequest.go
@@ -40,22 +40,40 @@ func emitMaybeAttachBedrockAuth(g *jen.Group) {
 //	    selectedClient = introspected.FunctionClient["<methodName>"]
 //	}
 //	var bedrockEndpointURL, bedrockRegion string
+//	var bedrockCreds llmhttp.BedrockCredentialSelector
 //	if bedrockOpts, ok := introspected.BedrockClientOptionsByName[selectedClient]; ok {
 //	    bedrockEndpointURL, _ = bedrockOpts.EndpointURL.Resolve()
 //	    bedrockRegion, _ = bedrockOpts.Region.Resolve()
+//	    bedrockCreds.AccessKeyID, bedrockCreds.AccessKeyIDPresent = bedrockOpts.Credentials.AccessKeyID.Resolve()
+//	    bedrockCreds.SecretAccessKey, bedrockCreds.SecretAccessKeyPresent = bedrockOpts.Credentials.SecretAccessKey.Resolve()
+//	    bedrockCreds.SessionToken, bedrockCreds.SessionTokenPresent = bedrockOpts.Credentials.SessionToken.Resolve()
+//	    bedrockCreds.Profile, bedrockCreds.ProfilePresent = bedrockOpts.Credentials.Profile.Resolve()
 //	}
-//	if authErr := llmhttp.AttachBedrockAuthForClient(ctx, req, bedrockEndpointURL, bedrockRegion); authErr != nil {
+//	if authErr := llmhttp.AttachBedrockAuthForClient(ctx, req, llmhttp.BedrockClientAuthOptions{
+//	    ClientName:  selectedClient,
+//	    EndpointURL: bedrockEndpointURL,
+//	    Region:      bedrockRegion,
+//	    Credentials: bedrockCreds,
+//	}); authErr != nil {
 //	    return nil, authErr
 //	}
 //
-// Empty endpoint+region falls through to MaybeAttachBedrockAuth's URL-
-// pattern detection inside AttachBedrockAuthForClient, preserving the
-// default-endpoint contract for clients without an `.baml` override.
+// Empty endpoint+region+credentials falls through to
+// MaybeAttachBedrockAuth's URL-pattern detection inside
+// AttachBedrockAuthForClient, preserving the default-endpoint contract
+// for clients without any `.baml` override.
 //
 // The closure variable `clientOverride` is in scope at the postProcess
 // emission site (both buildRequestFn and buildBedrockStreamRequestFn
 // declare it as a parameter), so the resolve-name step does not need
 // any new closure plumbing.
+//
+// The credential selector preserves the Present flag from each
+// BedrockOptionValue.Resolve() pair — discarding it would collapse
+// "operator did not declare this field" into "operator declared an
+// empty literal", and the resolver in llmhttp must be able to
+// distinguish them (an empty literal is a configuration error; an
+// undeclared field falls through to the next precedence branch).
 func emitBedrockAuthDispatchFor(methodName string) func(*jen.Group) {
 	return func(g *jen.Group) {
 		g.Id("selectedClient").Op(":=").Id("clientOverride")
@@ -65,6 +83,7 @@ func emitBedrockAuthDispatchFor(methodName string) func(*jen.Group) {
 		g.Var().Defs(
 			jen.Id("bedrockEndpointURL").String(),
 			jen.Id("bedrockRegion").String(),
+			jen.Id("bedrockCreds").Qual(common.LLMHTTPPkg, "BedrockCredentialSelector"),
 		)
 		g.If(
 			jen.List(jen.Id("bedrockOpts"), jen.Id("ok")).Op(":=").Qual(common.IntrospectedPkg, "BedrockClientOptionsByName").Index(jen.Id("selectedClient")),
@@ -72,13 +91,33 @@ func emitBedrockAuthDispatchFor(methodName string) func(*jen.Group) {
 		).Block(
 			jen.List(jen.Id("bedrockEndpointURL"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("EndpointURL").Dot("Resolve").Call(),
 			jen.List(jen.Id("bedrockRegion"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("Region").Dot("Resolve").Call(),
+			jen.List(
+				jen.Id("bedrockCreds").Dot("AccessKeyID"),
+				jen.Id("bedrockCreds").Dot("AccessKeyIDPresent"),
+			).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("AccessKeyID").Dot("Resolve").Call(),
+			jen.List(
+				jen.Id("bedrockCreds").Dot("SecretAccessKey"),
+				jen.Id("bedrockCreds").Dot("SecretAccessKeyPresent"),
+			).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("SecretAccessKey").Dot("Resolve").Call(),
+			jen.List(
+				jen.Id("bedrockCreds").Dot("SessionToken"),
+				jen.Id("bedrockCreds").Dot("SessionTokenPresent"),
+			).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("SessionToken").Dot("Resolve").Call(),
+			jen.List(
+				jen.Id("bedrockCreds").Dot("Profile"),
+				jen.Id("bedrockCreds").Dot("ProfilePresent"),
+			).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("Profile").Dot("Resolve").Call(),
 		)
 		g.If(
 			jen.Id("authErr").Op(":=").Qual(common.LLMHTTPPkg, "AttachBedrockAuthForClient").Call(
 				jen.Id("ctx"),
 				jen.Id("req"),
-				jen.Id("bedrockEndpointURL"),
-				jen.Id("bedrockRegion"),
+				jen.Qual(common.LLMHTTPPkg, "BedrockClientAuthOptions").Values(jen.Dict{
+					jen.Id("ClientName"):  jen.Id("selectedClient"),
+					jen.Id("EndpointURL"): jen.Id("bedrockEndpointURL"),
+					jen.Id("Region"):      jen.Id("bedrockRegion"),
+					jen.Id("Credentials"): jen.Id("bedrockCreds"),
+				}),
 			),
 			jen.Id("authErr").Op("!=").Nil(),
 		).Block(

--- a/adapters/common/codegen/codegen_buildrequest.go
+++ b/adapters/common/codegen/codegen_buildrequest.go
@@ -40,28 +40,36 @@ func emitMaybeAttachBedrockAuth(g *jen.Group) {
 //	if selectedClient == "" {
 //	    selectedClient = introspected.FunctionClient["<methodName>"]
 //	}
-//	var bedrockEndpointURL, bedrockRegion string
+//	var bedrockEndpointURL string
+//	var bedrockEndpointURLPresent bool
+//	var bedrockRegion string
+//	var bedrockRegionPresent bool
 //	var bedrockCreds llmhttp.BedrockCredentialSelector
 //	if bedrockOpts, ok := introspected.BedrockClientOptionsByName[selectedClient]; ok {
 //	    bedrockEndpointURL, _ = bedrockOpts.EndpointURL.Resolve()
+//	    bedrockEndpointURLPresent = bedrockOpts.EndpointURL.IsSet()
 //	    bedrockRegion, _ = bedrockOpts.Region.Resolve()
+//	    bedrockRegionPresent = bedrockOpts.Region.IsSet()
 //	    bedrockCreds.AccessKeyID, _ = bedrockOpts.Credentials.AccessKeyID.Resolve()
 //	    bedrockCreds.AccessKeyIDPresent = bedrockOpts.Credentials.AccessKeyID.IsSet()
 //	    // ...same shape for SecretAccessKey, SessionToken, Profile
 //	}
 //	if authErr := llmhttp.AttachBedrockAuthForClient(ctx, req, llmhttp.BedrockClientAuthOptions{
-//	    ClientName:  selectedClient,
-//	    EndpointURL: bedrockEndpointURL,
-//	    Region:      bedrockRegion,
-//	    Credentials: bedrockCreds,
+//	    ClientName:         selectedClient,
+//	    EndpointURL:        bedrockEndpointURL,
+//	    EndpointURLPresent: bedrockEndpointURLPresent,
+//	    Region:             bedrockRegion,
+//	    RegionPresent:      bedrockRegionPresent,
+//	    Credentials:        bedrockCreds,
 //	}); authErr != nil {
 //	    return nil, authErr
 //	}
 //
-// Empty endpoint+region+credentials falls through to
-// MaybeAttachBedrockAuth's URL-pattern detection inside
-// AttachBedrockAuthForClient, preserving the default-endpoint contract
-// for clients without any `.baml` override.
+// Nothing-declared (all Present flags false, all values empty,
+// credentials empty) falls through to MaybeAttachBedrockAuth's
+// URL-pattern detection inside AttachBedrockAuthForClient, preserving
+// the default-endpoint contract for clients without any `.baml`
+// override.
 //
 // The closure variable `clientOverride` is in scope at the postProcess
 // emission site (both buildRequestFn and buildBedrockStreamRequestFn
@@ -78,7 +86,11 @@ func emitMaybeAttachBedrockAuth(g *jen.Group) {
 // (Present=true, Value="") so the existing "resolved to empty"
 // error fires, rather than collapsing into the same shape as a
 // never-declared field which would silently fall through to the
-// default AWS chain.
+// default AWS chain. The same split applies to EndpointURL and
+// Region: a declared env.X for endpoint_url that resolves unset must
+// error (otherwise an operator routing to a proxy/LocalStack/VPC
+// endpoint via env.MY_PROXY would silently fall back to real AWS
+// Bedrock), not collapse into the no-override path.
 func emitBedrockAuthDispatchFor(methodName string) func(*jen.Group) {
 	return func(g *jen.Group) {
 		g.Id("selectedClient").Op(":=").Id("clientOverride")
@@ -87,7 +99,9 @@ func emitBedrockAuthDispatchFor(methodName string) func(*jen.Group) {
 		)
 		g.Var().Defs(
 			jen.Id("bedrockEndpointURL").String(),
+			jen.Id("bedrockEndpointURLPresent").Bool(),
 			jen.Id("bedrockRegion").String(),
+			jen.Id("bedrockRegionPresent").Bool(),
 			jen.Id("bedrockCreds").Qual(common.LLMHTTPPkg, "BedrockCredentialSelector"),
 		)
 		g.If(
@@ -95,7 +109,9 @@ func emitBedrockAuthDispatchFor(methodName string) func(*jen.Group) {
 			jen.Id("ok"),
 		).Block(
 			jen.List(jen.Id("bedrockEndpointURL"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("EndpointURL").Dot("Resolve").Call(),
+			jen.Id("bedrockEndpointURLPresent").Op("=").Id("bedrockOpts").Dot("EndpointURL").Dot("IsSet").Call(),
 			jen.List(jen.Id("bedrockRegion"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("Region").Dot("Resolve").Call(),
+			jen.Id("bedrockRegionPresent").Op("=").Id("bedrockOpts").Dot("Region").Dot("IsSet").Call(),
 			jen.List(jen.Id("bedrockCreds").Dot("AccessKeyID"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("AccessKeyID").Dot("Resolve").Call(),
 			jen.Id("bedrockCreds").Dot("AccessKeyIDPresent").Op("=").Id("bedrockOpts").Dot("Credentials").Dot("AccessKeyID").Dot("IsSet").Call(),
 			jen.List(jen.Id("bedrockCreds").Dot("SecretAccessKey"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("SecretAccessKey").Dot("Resolve").Call(),
@@ -110,10 +126,12 @@ func emitBedrockAuthDispatchFor(methodName string) func(*jen.Group) {
 				jen.Id("ctx"),
 				jen.Id("req"),
 				jen.Qual(common.LLMHTTPPkg, "BedrockClientAuthOptions").Values(jen.Dict{
-					jen.Id("ClientName"):  jen.Id("selectedClient"),
-					jen.Id("EndpointURL"): jen.Id("bedrockEndpointURL"),
-					jen.Id("Region"):      jen.Id("bedrockRegion"),
-					jen.Id("Credentials"): jen.Id("bedrockCreds"),
+					jen.Id("ClientName"):         jen.Id("selectedClient"),
+					jen.Id("EndpointURL"):        jen.Id("bedrockEndpointURL"),
+					jen.Id("EndpointURLPresent"): jen.Id("bedrockEndpointURLPresent"),
+					jen.Id("Region"):             jen.Id("bedrockRegion"),
+					jen.Id("RegionPresent"):      jen.Id("bedrockRegionPresent"),
+					jen.Id("Credentials"):        jen.Id("bedrockCreds"),
 				}),
 			),
 			jen.Id("authErr").Op("!=").Nil(),

--- a/adapters/common/codegen/codegen_buildrequest.go
+++ b/adapters/common/codegen/codegen_buildrequest.go
@@ -18,8 +18,9 @@ import (
 //
 // Kept as a callable target for the codegen-emission tests that pin
 // the simple URL-pattern shape; production codegen routes through
-// emitBedrockAuthDispatchFor so the explicit endpoint_url + region
-// override path is honoured when the operator has configured one.
+// emitBedrockAuthDispatchFor so the explicit endpoint_url, region, and
+// credential-selector override paths are honoured when the operator
+// has configured them.
 func emitMaybeAttachBedrockAuth(g *jen.Group) {
 	g.If(
 		jen.Id("authErr").Op(":=").Qual(common.LLMHTTPPkg, "MaybeAttachBedrockAuth").Call(jen.Id("ctx"), jen.Id("req")),
@@ -44,10 +45,9 @@ func emitMaybeAttachBedrockAuth(g *jen.Group) {
 //	if bedrockOpts, ok := introspected.BedrockClientOptionsByName[selectedClient]; ok {
 //	    bedrockEndpointURL, _ = bedrockOpts.EndpointURL.Resolve()
 //	    bedrockRegion, _ = bedrockOpts.Region.Resolve()
-//	    bedrockCreds.AccessKeyID, bedrockCreds.AccessKeyIDPresent = bedrockOpts.Credentials.AccessKeyID.Resolve()
-//	    bedrockCreds.SecretAccessKey, bedrockCreds.SecretAccessKeyPresent = bedrockOpts.Credentials.SecretAccessKey.Resolve()
-//	    bedrockCreds.SessionToken, bedrockCreds.SessionTokenPresent = bedrockOpts.Credentials.SessionToken.Resolve()
-//	    bedrockCreds.Profile, bedrockCreds.ProfilePresent = bedrockOpts.Credentials.Profile.Resolve()
+//	    bedrockCreds.AccessKeyID, _ = bedrockOpts.Credentials.AccessKeyID.Resolve()
+//	    bedrockCreds.AccessKeyIDPresent = bedrockOpts.Credentials.AccessKeyID.IsSet()
+//	    // ...same shape for SecretAccessKey, SessionToken, Profile
 //	}
 //	if authErr := llmhttp.AttachBedrockAuthForClient(ctx, req, llmhttp.BedrockClientAuthOptions{
 //	    ClientName:  selectedClient,
@@ -68,12 +68,17 @@ func emitMaybeAttachBedrockAuth(g *jen.Group) {
 // declare it as a parameter), so the resolve-name step does not need
 // any new closure plumbing.
 //
-// The credential selector preserves the Present flag from each
-// BedrockOptionValue.Resolve() pair — discarding it would collapse
-// "operator did not declare this field" into "operator declared an
-// empty literal", and the resolver in llmhttp must be able to
-// distinguish them (an empty literal is a configuration error; an
-// undeclared field falls through to the next precedence branch).
+// Presence semantics: BedrockOptionValue.IsSet() reports whether the
+// field was declared in .baml; BedrockOptionValue.Resolve() returns
+// the resolved value (which can be "" if an env.X reference does not
+// resolve). Driving the *Present flags from IsSet() — NOT from
+// Resolve()'s second return — is load-bearing for the
+// declared-but-env-unset error path: a declared env.X reference whose
+// env var is unset at runtime must enter the resolver's static branch
+// (Present=true, Value="") so the existing "resolved to empty"
+// error fires, rather than collapsing into the same shape as a
+// never-declared field which would silently fall through to the
+// default AWS chain.
 func emitBedrockAuthDispatchFor(methodName string) func(*jen.Group) {
 	return func(g *jen.Group) {
 		g.Id("selectedClient").Op(":=").Id("clientOverride")
@@ -91,22 +96,14 @@ func emitBedrockAuthDispatchFor(methodName string) func(*jen.Group) {
 		).Block(
 			jen.List(jen.Id("bedrockEndpointURL"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("EndpointURL").Dot("Resolve").Call(),
 			jen.List(jen.Id("bedrockRegion"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("Region").Dot("Resolve").Call(),
-			jen.List(
-				jen.Id("bedrockCreds").Dot("AccessKeyID"),
-				jen.Id("bedrockCreds").Dot("AccessKeyIDPresent"),
-			).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("AccessKeyID").Dot("Resolve").Call(),
-			jen.List(
-				jen.Id("bedrockCreds").Dot("SecretAccessKey"),
-				jen.Id("bedrockCreds").Dot("SecretAccessKeyPresent"),
-			).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("SecretAccessKey").Dot("Resolve").Call(),
-			jen.List(
-				jen.Id("bedrockCreds").Dot("SessionToken"),
-				jen.Id("bedrockCreds").Dot("SessionTokenPresent"),
-			).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("SessionToken").Dot("Resolve").Call(),
-			jen.List(
-				jen.Id("bedrockCreds").Dot("Profile"),
-				jen.Id("bedrockCreds").Dot("ProfilePresent"),
-			).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("Profile").Dot("Resolve").Call(),
+			jen.List(jen.Id("bedrockCreds").Dot("AccessKeyID"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("AccessKeyID").Dot("Resolve").Call(),
+			jen.Id("bedrockCreds").Dot("AccessKeyIDPresent").Op("=").Id("bedrockOpts").Dot("Credentials").Dot("AccessKeyID").Dot("IsSet").Call(),
+			jen.List(jen.Id("bedrockCreds").Dot("SecretAccessKey"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("SecretAccessKey").Dot("Resolve").Call(),
+			jen.Id("bedrockCreds").Dot("SecretAccessKeyPresent").Op("=").Id("bedrockOpts").Dot("Credentials").Dot("SecretAccessKey").Dot("IsSet").Call(),
+			jen.List(jen.Id("bedrockCreds").Dot("SessionToken"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("SessionToken").Dot("Resolve").Call(),
+			jen.Id("bedrockCreds").Dot("SessionTokenPresent").Op("=").Id("bedrockOpts").Dot("Credentials").Dot("SessionToken").Dot("IsSet").Call(),
+			jen.List(jen.Id("bedrockCreds").Dot("Profile"), jen.Id("_")).Op("=").Id("bedrockOpts").Dot("Credentials").Dot("Profile").Dot("Resolve").Call(),
+			jen.Id("bedrockCreds").Dot("ProfilePresent").Op("=").Id("bedrockOpts").Dot("Credentials").Dot("Profile").Dot("IsSet").Call(),
 		)
 		g.If(
 			jen.Id("authErr").Op(":=").Qual(common.LLMHTTPPkg, "AttachBedrockAuthForClient").Call(
@@ -171,9 +168,10 @@ func emitBedrockStreamPostProcessFor(methodName string) func(*jen.Group) {
 		)
 		g.Id("req").Dot("Headers").Index(jen.Lit("Accept")).Op("=").Qual(common.LLMHTTPPkg, "AWSStreamContentType")
 
-		// Bedrock auth dispatch: explicit endpoint_url + region override
-		// when configured for the selected client; URL-pattern fallback
-		// for the default-endpoint case.
+		// Bedrock auth dispatch: explicit endpoint_url, region, and/or
+		// credential-selector override when configured for the
+		// selected client; URL-pattern fallback for the
+		// default-endpoint case.
 		dispatch(g)
 	}
 }

--- a/bamlutils/llmhttp/awssigv4.go
+++ b/bamlutils/llmhttp/awssigv4.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 )
 
 // AWSAuthConfig carries the per-request information the SigV4 hook
@@ -334,14 +335,13 @@ type BedrockAuthOptions struct {
 	// from config or env, never from URL parsing.
 	Region string
 
-	// Credentials is a forward-compat slot for the static-credentials
-	// follow-up (#254 item 2: access_key_id / secret_access_key /
-	// session_token / profile). Leave unset; nil means "use the default
-	// AWS credential chain" via DefaultAWSCredentialProvider. This PR
-	// does not populate the slot — wiring it is the static-creds PR's
-	// job. Documenting the field here keeps the API stable across the
-	// two PRs so the codegen call site doesn't change again when
-	// static creds land.
+	// Credentials is the explicit aws.CredentialsProvider to sign
+	// with. nil means "use the default AWS credential chain" via
+	// DefaultAWSCredentialProvider. Populated by codegen from the
+	// resolver in ResolveBedrockCredentials when an aws-bedrock client
+	// declares static credentials or a profile in .baml options
+	// (#254 item 2: access_key_id / secret_access_key / session_token
+	// / profile).
 	Credentials aws.CredentialsProvider
 }
 
@@ -493,14 +493,160 @@ func joinEndpointRawQuery(prefix, suffix string) string {
 	}
 }
 
+// BedrockCredentialSelector carries the resolved per-field selector
+// values that codegen lifts from introspected.BedrockClientOptions.
+// Credentials at request-build time. Each pair is the (value, present)
+// result of BedrockOptionValue.Resolve(): Present=false means the field
+// is unset (either no declaration at all, or an `env.X` reference that
+// did not resolve at runtime). Storing the presence flag separately
+// from the value lets the resolver distinguish "operator did not
+// declare this field" from "operator declared an empty literal" — only
+// the latter is a configuration error.
+//
+// The type intentionally does not depend on the AWS SDK so codegen-
+// emitted call sites can populate it without pulling the SDK into the
+// generated adapter packages. ResolveBedrockCredentials is the
+// translation seam to aws.CredentialsProvider.
+type BedrockCredentialSelector struct {
+	AccessKeyID            string
+	AccessKeyIDPresent     bool
+	SecretAccessKey        string
+	SecretAccessKeyPresent bool
+	SessionToken           string
+	SessionTokenPresent    bool
+	Profile                string
+	ProfilePresent         bool
+}
+
+// isEmpty reports whether the selector declares no credential source.
+// True means the caller should fall back to the default AWS credential
+// chain — preserving the no-override default-endpoint contract from
+// #262.
+func (s BedrockCredentialSelector) isEmpty() bool {
+	return !s.AccessKeyIDPresent && !s.SecretAccessKeyPresent && !s.SessionTokenPresent && !s.ProfilePresent
+}
+
+// profileAWSConfigLoader loads an aws.Config bound to a specific
+// shared-config profile. Indirected through a package-level var so
+// tests can substitute a deterministic loader (e.g. one that records
+// the requested profile name without driving the real AWS SDK chain).
+// Mirrors the defaultAWSConfigLoader test-seam pattern above.
+var profileAWSConfigLoader = func(ctx context.Context, profile string) (aws.Config, error) {
+	return config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile(profile))
+}
+
+// ResolveBedrockCredentials applies the BAML-parity credential
+// resolution precedence to a BedrockCredentialSelector and returns the
+// resulting aws.CredentialsProvider — or (nil, nil) when the caller
+// should fall back to the default AWS credential chain.
+//
+// Precedence matches BAML's upstream runtime
+// (engine/baml-runtime/.../aws_client.rs:587-650):
+//
+//  1. STATIC. If any of AccessKeyID / SecretAccessKey / SessionToken is
+//     declared, AccessKeyID + SecretAccessKey are required (and a bare
+//     SessionToken without the key pair is rejected).
+//  2. PROFILE. If only Profile is declared, the shared-config profile
+//     is loaded via profileAWSConfigLoader and cfg.Credentials is
+//     returned.
+//  3. DEFAULT CHAIN. Nothing declared → return (nil, nil) and let the
+//     caller fall through to DefaultAWSCredentialProvider.
+//
+// Static wins over profile silently when both are declared; that
+// matches BAML's runtime shape and avoids a parser-level error on a
+// configuration that is unambiguous at resolve time.
+//
+// SECURITY: invalid-partial-state errors include clientName and the
+// missing field name, never the configured credential values. Callers
+// that surface these errors must not log the configured selector
+// values either — keep them on the stack as long as possible.
+func ResolveBedrockCredentials(ctx context.Context, clientName string, sel BedrockCredentialSelector) (aws.CredentialsProvider, error) {
+	// Branch 1: any explicit static-field declaration locks us out of
+	// the profile and default branches. A partial static state (e.g.
+	// access_key_id without secret_access_key) is a configuration
+	// error: silently falling through to profile or default could let
+	// a typo escalate to using whatever credentials happen to be on
+	// the host.
+	if sel.AccessKeyIDPresent || sel.SecretAccessKeyPresent || sel.SessionTokenPresent {
+		if !sel.AccessKeyIDPresent {
+			return nil, fmt.Errorf("aws-bedrock: invalid credentials for client %q: access_key_id is required when secret_access_key or session_token is set", clientName)
+		}
+		if !sel.SecretAccessKeyPresent {
+			return nil, fmt.Errorf("aws-bedrock: invalid credentials for client %q: secret_access_key is required when access_key_id is set", clientName)
+		}
+		if sel.AccessKeyID == "" {
+			return nil, fmt.Errorf("aws-bedrock: invalid credentials for client %q: access_key_id resolved to empty", clientName)
+		}
+		if sel.SecretAccessKey == "" {
+			return nil, fmt.Errorf("aws-bedrock: invalid credentials for client %q: secret_access_key resolved to empty", clientName)
+		}
+		// SessionToken is optional. When present but empty (e.g. a
+		// declared env.X that does not exist), reject it — silently
+		// dropping a configured session token would let an STS
+		// short-lived credential silently degrade to long-lived
+		// signing.
+		if sel.SessionTokenPresent && sel.SessionToken == "" {
+			return nil, fmt.Errorf("aws-bedrock: invalid credentials for client %q: session_token resolved to empty", clientName)
+		}
+		return credentials.NewStaticCredentialsProvider(sel.AccessKeyID, sel.SecretAccessKey, sel.SessionToken), nil
+	}
+
+	// Branch 2: profile-only. The shared-config profile loader resolves
+	// against ~/.aws/credentials and ~/.aws/config; the SDK's own cred
+	// cache handles refresh for SSO / IAM-role profiles from there.
+	if sel.ProfilePresent {
+		if sel.Profile == "" {
+			return nil, fmt.Errorf("aws-bedrock: invalid credentials for client %q: profile resolved to empty", clientName)
+		}
+		cfg, err := profileAWSConfigLoader(ctx, sel.Profile)
+		if err != nil {
+			return nil, fmt.Errorf("aws-bedrock: load profile for client %q: %w", clientName, err)
+		}
+		return cfg.Credentials, nil
+	}
+
+	// Branch 3: nothing declared. Caller falls back to the default
+	// chain (DefaultAWSCredentialProvider). nil is a valid sentinel —
+	// AttachBedrockAuthForClient interprets it as "use default".
+	return nil, nil
+}
+
+// BedrockClientAuthOptions is the options-struct form of the codegen
+// dispatch entry point. Codegen builds this from the introspected
+// per-client BedrockClientOptions (endpoint_url, region, and the
+// credential selectors under .Credentials) and hands it to
+// AttachBedrockAuthForClient. The struct shape keeps the call site
+// stable across future #254 follow-ups that need to thread more
+// per-client state without growing a positional argument list.
+type BedrockClientAuthOptions struct {
+	// ClientName is the .baml client name (e.g. "BedrockA"). Used in
+	// error messages from the credential resolver so operators can
+	// pin the misconfiguration to a specific client. Never echoed
+	// with credential values.
+	ClientName string
+
+	// EndpointURL mirrors BedrockAuthOptions.EndpointURL — empty leaves
+	// req.URL untouched.
+	EndpointURL string
+
+	// Region mirrors BedrockAuthOptions.Region — empty falls back to
+	// AWS_REGION env, then errors.
+	Region string
+
+	// Credentials is the resolved-but-not-yet-translated credential
+	// selector. ResolveBedrockCredentials converts it to an
+	// aws.CredentialsProvider applying static > profile > default
+	// chain precedence.
+	Credentials BedrockCredentialSelector
+}
+
 // AttachBedrockAuthForClient is the codegen dispatch entry point for
-// the aws-bedrock provider. When endpointURL or region is non-empty
-// (i.e., the operator configured an override in `.baml options { ... }`
-// for the selected client), it routes to AttachBedrockAuthWithOptions
-// so the explicit endpoint and region are honored. When both are empty,
-// it falls through to MaybeAttachBedrockAuth's URL-pattern detection —
-// preserving the default-endpoint contract for clients that did not
-// declare an override.
+// the aws-bedrock provider. When the options struct declares any
+// override (endpoint_url, region, or a credential selector), it routes
+// to AttachBedrockAuthWithOptions so the explicit values are honored.
+// When all three are empty, it falls through to MaybeAttachBedrockAuth's
+// URL-pattern detection — preserving the default-endpoint contract for
+// clients that did not declare any override.
 //
 // The split exists because custom endpoints (VPC, LocalStack, FIPS,
 // China, GovCloud) break the host-based region extraction
@@ -508,12 +654,17 @@ func joinEndpointRawQuery(prefix, suffix string) string {
 // we must take the explicit path. Codegen looks up
 // `introspected.BedrockClientOptionsByName[selectedClient]` and resolves
 // the literal-vs-env values before calling this helper.
-func AttachBedrockAuthForClient(ctx context.Context, req *Request, endpointURL, region string) error {
-	if endpointURL == "" && region == "" {
+func AttachBedrockAuthForClient(ctx context.Context, req *Request, opts BedrockClientAuthOptions) error {
+	if opts.EndpointURL == "" && opts.Region == "" && opts.Credentials.isEmpty() {
 		return MaybeAttachBedrockAuth(ctx, req)
 	}
+	creds, err := ResolveBedrockCredentials(ctx, opts.ClientName, opts.Credentials)
+	if err != nil {
+		return err
+	}
 	return AttachBedrockAuthWithOptions(ctx, req, BedrockAuthOptions{
-		EndpointURL: endpointURL,
-		Region:      region,
+		EndpointURL: opts.EndpointURL,
+		Region:      opts.Region,
+		Credentials: creds,
 	})
 }

--- a/bamlutils/llmhttp/awssigv4.go
+++ b/bamlutils/llmhttp/awssigv4.go
@@ -618,6 +618,25 @@ func ResolveBedrockCredentials(ctx context.Context, clientName string, sel Bedro
 // AttachBedrockAuthForClient. The struct shape keeps the call site
 // stable across future #254 follow-ups that need to thread more
 // per-client state without growing a positional argument list.
+//
+// Presence flags. EndpointURL and Region carry a sibling
+// EndpointURLPresent / RegionPresent bool, populated by codegen from
+// BedrockOptionValue.IsSet(). The flag means "declared in .baml" and
+// is independent of whether the value resolves to a non-empty string
+// at runtime — exactly the same declared-vs-resolved split the
+// credential selector uses. Without that split, a declared `env.X`
+// reference whose env var is unset would collapse into the same
+// empty-string shape as a never-declared field, and an operator who
+// declared `endpoint_url env.MY_PROXY` and forgot to set MY_PROXY
+// would silently fall back to the default Bedrock host instead of
+// failing. AttachBedrockAuthForClient errors when Present is true
+// and the value is empty.
+//
+// Compatibility: a non-empty raw EndpointURL / Region string is also
+// treated as present even when its Present flag is false, so direct
+// helper callers (existing tests, future ad-hoc dispatches) can keep
+// constructing BedrockClientAuthOptions{EndpointURL: "http://h"}
+// without setting the flag explicitly.
 type BedrockClientAuthOptions struct {
 	// ClientName is the .baml client name (e.g. "BedrockA"). Used in
 	// error messages from the credential resolver so operators can
@@ -625,13 +644,30 @@ type BedrockClientAuthOptions struct {
 	// with credential values.
 	ClientName string
 
-	// EndpointURL mirrors BedrockAuthOptions.EndpointURL — empty leaves
-	// req.URL untouched.
+	// EndpointURL mirrors BedrockAuthOptions.EndpointURL. Empty leaves
+	// req.URL untouched when EndpointURLPresent is false; when
+	// EndpointURLPresent is true, an empty EndpointURL is a
+	// declared-but-env-unset reference and produces an error.
 	EndpointURL string
 
-	// Region mirrors BedrockAuthOptions.Region — empty falls back to
-	// AWS_REGION env, then errors.
+	// EndpointURLPresent reports whether .baml declared endpoint_url
+	// (literal or env.X) for this client. Codegen sets it from
+	// BedrockOptionValue.IsSet(). Direct callers that just want the
+	// non-presence-aware behaviour can leave it false and rely on the
+	// non-empty-string-is-present compatibility shim.
+	EndpointURLPresent bool
+
+	// Region mirrors BedrockAuthOptions.Region. Empty + Present=false
+	// falls back to AWS_REGION env inside AttachBedrockAuthWithOptions
+	// (the legacy contract from #262). Empty + Present=true is a
+	// declared-but-env-unset reference and produces an error before
+	// reaching the AWS_REGION fallback.
 	Region string
+
+	// RegionPresent reports whether .baml declared region (literal or
+	// env.X) for this client. See EndpointURLPresent for the
+	// rationale.
+	RegionPresent bool
 
 	// Credentials is the resolved-but-not-yet-translated credential
 	// selector. ResolveBedrockCredentials converts it to an
@@ -644,7 +680,7 @@ type BedrockClientAuthOptions struct {
 // the aws-bedrock provider. When the options struct declares any
 // override (endpoint_url, region, or a credential selector), it routes
 // to AttachBedrockAuthWithOptions so the explicit values are honored.
-// When all three are empty, it falls through to MaybeAttachBedrockAuth's
+// When nothing is declared, it falls through to MaybeAttachBedrockAuth's
 // URL-pattern detection — preserving the default-endpoint contract for
 // clients that did not declare any override.
 //
@@ -654,8 +690,41 @@ type BedrockClientAuthOptions struct {
 // we must take the explicit path. Codegen looks up
 // `introspected.BedrockClientOptionsByName[selectedClient]` and resolves
 // the literal-vs-env values before calling this helper.
+//
+// Declared-vs-resolved validation. When endpoint_url or region is
+// declared in .baml but resolves to "" at runtime (env.X reference
+// whose env var is unset, or an empty literal), this helper returns a
+// client-scoped error before reaching AttachBedrockAuthWithOptions —
+// silent fallback would let a misconfigured worker route requests to
+// the default Bedrock host or pick up an ambient AWS_REGION instead
+// of the operator-declared override. Same shape as the credential
+// resolver's invalid-state errors; never echoes the resolved (empty)
+// value.
 func AttachBedrockAuthForClient(ctx context.Context, req *Request, opts BedrockClientAuthOptions) error {
-	if opts.EndpointURL == "" && opts.Region == "" && opts.Credentials.isEmpty() {
+	// Validate declared-but-empty endpoint_url and region before
+	// anything else. The Present flag is the load-bearing signal:
+	// without it we cannot tell "operator declared env.X and X is
+	// unset" from "operator declared nothing", and the latter is the
+	// no-override default-endpoint case that MUST fall through.
+	if opts.EndpointURLPresent && opts.EndpointURL == "" {
+		return fmt.Errorf("aws-bedrock: invalid endpoint_url for client %q: endpoint_url resolved to empty", opts.ClientName)
+	}
+	if opts.RegionPresent && opts.Region == "" {
+		return fmt.Errorf("aws-bedrock: invalid region for client %q: region resolved to empty", opts.ClientName)
+	}
+
+	// Compatibility shim: a non-empty raw EndpointURL/Region string is
+	// also "present" for routing purposes. Lets direct callers
+	// (existing tests, future ad-hoc dispatches) keep constructing
+	// BedrockClientAuthOptions{EndpointURL: "http://h"} without
+	// having to also set EndpointURLPresent. The Present flag is
+	// still the only thing that triggers the declared-empty error
+	// above — a never-set Present + empty string is the no-override
+	// case, not an error.
+	endpointDeclared := opts.EndpointURLPresent || opts.EndpointURL != ""
+	regionDeclared := opts.RegionPresent || opts.Region != ""
+
+	if !endpointDeclared && !regionDeclared && opts.Credentials.isEmpty() {
 		return MaybeAttachBedrockAuth(ctx, req)
 	}
 	creds, err := ResolveBedrockCredentials(ctx, opts.ClientName, opts.Credentials)

--- a/bamlutils/llmhttp/awssigv4_e2e_test.go
+++ b/bamlutils/llmhttp/awssigv4_e2e_test.go
@@ -250,14 +250,23 @@ func TestEndpointOverride_E2E_RegionFallback(t *testing.T) {
 // TestEndpointOverride_E2E_NonStreaming with one twist: credentials
 // flow from BedrockClientAuthOptions.Credentials through the resolver,
 // not via test-pinned overrides. The mock asserts the static AKID
-// appears in the wire-side Authorization credential scope — proving
-// the resolver's static provider made it all the way to signRequest.
+// appears in the wire-side Authorization credential scope AND the
+// configured session token appears in X-Amz-Security-Token — together
+// proving the resolver's static provider made it all the way to
+// signRequest and that the SDK signer's session-token copy-back hits
+// the wire.
 //
-// This is the canonical end-to-end pin for #254 item 2.
+// This is the canonical end-to-end pin for #254 item 2 (call path).
+// Mirror coverage for the streaming path lives in
+// TestStaticCreds_E2E_Streaming below.
 func TestStaticCreds_E2E_NonStreaming(t *testing.T) {
-	var gotAuth string
+	var (
+		gotAuth        string
+		gotSecurityTok string
+	)
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
+		gotSecurityTok = r.Header.Get("X-Amz-Security-Token")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
 		io.WriteString(w, `{"output":{"message":{"content":[{"text":"ok"}]}}}`)
@@ -279,6 +288,13 @@ func TestStaticCreds_E2E_NonStreaming(t *testing.T) {
 			AccessKeyIDPresent:     true,
 			SecretAccessKey:        "STATIC_TEST_SECRET_KEY",
 			SecretAccessKeyPresent: true,
+			// Session token is configured here too so the
+			// non-streaming and streaming E2E tests pin the same
+			// header set — STS short-lived credentials are a
+			// realistic call-path shape, not a streaming-only
+			// shape.
+			SessionToken:        "STATIC_TEST_SESSION_TOKEN",
+			SessionTokenPresent: true,
 		},
 	}); err != nil {
 		t.Fatalf("AttachBedrockAuthForClient: %v", err)
@@ -294,12 +310,18 @@ func TestStaticCreds_E2E_NonStreaming(t *testing.T) {
 	if !strings.Contains(gotAuth, "Credential=STATIC_TEST_ACCESS_KEY/20260511/us-east-1/bedrock/aws4_request") {
 		t.Errorf("Authorization must carry static access key in credential scope; got: %s", gotAuth)
 	}
+	if gotSecurityTok != "STATIC_TEST_SESSION_TOKEN" {
+		t.Errorf("X-Amz-Security-Token on the wire = %q, want %q (session token must flow through resolver -> SigV4 -> Execute)", gotSecurityTok, "STATIC_TEST_SESSION_TOKEN")
+	}
 }
 
 // TestStaticCreds_E2E_Streaming pins the same static-credentials
 // dispatch end-to-end on the streaming path. Mirrors
 // TestEndpointOverride_E2E_Streaming but configures the credential
 // selector instead of supplying staticCreds via test-pinned override.
+// Asserts both the AKID-in-credential-scope and the session token on
+// the wire so the streaming path has call-path parity for session
+// token coverage.
 func TestStaticCreds_E2E_Streaming(t *testing.T) {
 	var buf bytes.Buffer
 	buf.Write(encodeAWSStreamFrame(t, map[string]string{
@@ -309,9 +331,13 @@ func TestStaticCreds_E2E_Streaming(t *testing.T) {
 	}, []byte(`{"stopReason":"end_turn"}`)))
 	wireBody := buf.Bytes()
 
-	var gotAuth string
+	var (
+		gotAuth        string
+		gotSecurityTok string
+	)
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
+		gotSecurityTok = r.Header.Get("X-Amz-Security-Token")
 		w.Header().Set("Content-Type", AWSStreamContentType)
 		w.WriteHeader(200)
 		w.Write(wireBody)
@@ -357,6 +383,9 @@ func TestStaticCreds_E2E_Streaming(t *testing.T) {
 
 	if !strings.Contains(gotAuth, "Credential=STATIC_TEST_ACCESS_KEY/20260511/us-east-1/bedrock/aws4_request") {
 		t.Errorf("Authorization must carry static access key in credential scope on the streaming path; got: %s", gotAuth)
+	}
+	if gotSecurityTok != "STATIC_TEST_SESSION_TOKEN" {
+		t.Errorf("X-Amz-Security-Token on the streaming-path wire = %q, want %q (session token must flow through resolver -> SigV4 -> ExecuteAWSStream)", gotSecurityTok, "STATIC_TEST_SESSION_TOKEN")
 	}
 }
 

--- a/bamlutils/llmhttp/awssigv4_e2e_test.go
+++ b/bamlutils/llmhttp/awssigv4_e2e_test.go
@@ -62,7 +62,10 @@ func TestEndpointOverride_E2E_NonStreaming(t *testing.T) {
 	}
 
 	pinned := time.Date(2026, 5, 11, 12, 34, 56, 0, time.UTC)
-	if err := AttachBedrockAuthForClient(context.Background(), req, mock.URL, "us-east-1"); err != nil {
+	if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+		EndpointURL: mock.URL,
+		Region:      "us-east-1",
+	}); err != nil {
 		t.Fatalf("AttachBedrockAuthForClient: %v", err)
 	}
 	// Pin time + credentials onto the attached metadata so the
@@ -157,7 +160,10 @@ func TestEndpointOverride_E2E_Streaming(t *testing.T) {
 	req.Headers["Accept"] = AWSStreamContentType
 
 	pinned := time.Date(2026, 5, 11, 12, 34, 56, 0, time.UTC)
-	if err := AttachBedrockAuthForClient(context.Background(), req, mock.URL, "us-east-1"); err != nil {
+	if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+		EndpointURL: mock.URL,
+		Region:      "us-east-1",
+	}); err != nil {
 		t.Fatalf("AttachBedrockAuthForClient: %v", err)
 	}
 	req.AWSAuth.NowFunc = func() time.Time { return pinned }
@@ -220,7 +226,9 @@ func TestEndpointOverride_E2E_RegionFallback(t *testing.T) {
 		Headers: map[string]string{"Content-Type": "application/json"},
 		Body:    `{}`,
 	}
-	if err := AttachBedrockAuthForClient(context.Background(), req, mock.URL, ""); err != nil {
+	if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+		EndpointURL: mock.URL,
+	}); err != nil {
 		t.Fatalf("AttachBedrockAuthForClient: %v", err)
 	}
 	pinned := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
@@ -234,6 +242,121 @@ func TestEndpointOverride_E2E_RegionFallback(t *testing.T) {
 
 	if !strings.Contains(gotAuth, "/20260511/ap-southeast-2/bedrock/aws4_request") {
 		t.Errorf("Authorization scope did not pick up AWS_REGION fallback (ap-southeast-2); got: %s", gotAuth)
+	}
+}
+
+// TestStaticCreds_E2E_NonStreaming pins the full static-credentials
+// dispatch end-to-end on the non-streaming path. Mirror of
+// TestEndpointOverride_E2E_NonStreaming with one twist: credentials
+// flow from BedrockClientAuthOptions.Credentials through the resolver,
+// not via test-pinned overrides. The mock asserts the static AKID
+// appears in the wire-side Authorization credential scope — proving
+// the resolver's static provider made it all the way to signRequest.
+//
+// This is the canonical end-to-end pin for #254 item 2.
+func TestStaticCreds_E2E_NonStreaming(t *testing.T) {
+	var gotAuth string
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		io.WriteString(w, `{"output":{"message":{"content":[{"text":"ok"}]}}}`)
+	}))
+	defer mock.Close()
+
+	req := &Request{
+		URL:     "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-sonnet/converse",
+		Method:  "POST",
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Body:    `{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`,
+	}
+	if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+		ClientName:  "StaticE2EClient",
+		EndpointURL: mock.URL,
+		Region:      "us-east-1",
+		Credentials: BedrockCredentialSelector{
+			AccessKeyID:            "STATIC_TEST_ACCESS_KEY",
+			AccessKeyIDPresent:     true,
+			SecretAccessKey:        "STATIC_TEST_SECRET_KEY",
+			SecretAccessKeyPresent: true,
+		},
+	}); err != nil {
+		t.Fatalf("AttachBedrockAuthForClient: %v", err)
+	}
+	pinned := time.Date(2026, 5, 11, 12, 34, 56, 0, time.UTC)
+	req.AWSAuth.NowFunc = func() time.Time { return pinned }
+
+	client := NewClient(mock.Client())
+	if _, err := client.Execute(context.Background(), req, nil); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if !strings.Contains(gotAuth, "Credential=STATIC_TEST_ACCESS_KEY/20260511/us-east-1/bedrock/aws4_request") {
+		t.Errorf("Authorization must carry static access key in credential scope; got: %s", gotAuth)
+	}
+}
+
+// TestStaticCreds_E2E_Streaming pins the same static-credentials
+// dispatch end-to-end on the streaming path. Mirrors
+// TestEndpointOverride_E2E_Streaming but configures the credential
+// selector instead of supplying staticCreds via test-pinned override.
+func TestStaticCreds_E2E_Streaming(t *testing.T) {
+	var buf bytes.Buffer
+	buf.Write(encodeAWSStreamFrame(t, map[string]string{
+		":message-type": "event",
+		":event-type":   "messageStop",
+		":content-type": "application/json",
+	}, []byte(`{"stopReason":"end_turn"}`)))
+	wireBody := buf.Bytes()
+
+	var gotAuth string
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", AWSStreamContentType)
+		w.WriteHeader(200)
+		w.Write(wireBody)
+	}))
+	defer mock.Close()
+
+	req := &Request{
+		URL:     "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-sonnet/converse",
+		Method:  "POST",
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Body:    `{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`,
+	}
+	req.URL = strings.Replace(req.URL, "/converse", "/converse-stream", 1)
+	req.Headers["Accept"] = AWSStreamContentType
+
+	if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+		ClientName:  "StaticE2EStreamingClient",
+		EndpointURL: mock.URL,
+		Region:      "us-east-1",
+		Credentials: BedrockCredentialSelector{
+			AccessKeyID:            "STATIC_TEST_ACCESS_KEY",
+			AccessKeyIDPresent:     true,
+			SecretAccessKey:        "STATIC_TEST_SECRET_KEY",
+			SecretAccessKeyPresent: true,
+			SessionToken:           "STATIC_TEST_SESSION_TOKEN",
+			SessionTokenPresent:    true,
+		},
+	}); err != nil {
+		t.Fatalf("AttachBedrockAuthForClient: %v", err)
+	}
+	pinned := time.Date(2026, 5, 11, 12, 34, 56, 0, time.UTC)
+	req.AWSAuth.NowFunc = func() time.Time { return pinned }
+
+	client := NewClient(mock.Client())
+	resp, err := client.ExecuteAWSStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ExecuteAWSStream: %v", err)
+	}
+	defer resp.Close()
+	if _, err := resp.Events.Next(); err != nil && err != io.EOF {
+		t.Fatalf("Events.Next: %v", err)
+	}
+
+	if !strings.Contains(gotAuth, "Credential=STATIC_TEST_ACCESS_KEY/20260511/us-east-1/bedrock/aws4_request") {
+		t.Errorf("Authorization must carry static access key in credential scope on the streaming path; got: %s", gotAuth)
 	}
 }
 
@@ -251,7 +374,7 @@ func TestEndpointOverride_E2E_DefaultEndpointFallthrough(t *testing.T) {
 		Method: "POST",
 		Body:   `{}`,
 	}
-	if err := AttachBedrockAuthForClient(context.Background(), req, "", ""); err != nil {
+	if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{}); err != nil {
 		t.Fatalf("AttachBedrockAuthForClient: %v", err)
 	}
 	if req.AWSAuth == nil {

--- a/bamlutils/llmhttp/awssigv4_test.go
+++ b/bamlutils/llmhttp/awssigv4_test.go
@@ -1119,7 +1119,7 @@ func TestAttachBedrockAuthForClient_DispatchesByOptions(t *testing.T) {
 			Method: "POST",
 			Body:   `{}`,
 		}
-		if err := AttachBedrockAuthForClient(context.Background(), req, "", ""); err != nil {
+		if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if req.AWSAuth == nil {
@@ -1139,7 +1139,10 @@ func TestAttachBedrockAuthForClient_DispatchesByOptions(t *testing.T) {
 			Method: "POST",
 			Body:   `{}`,
 		}
-		if err := AttachBedrockAuthForClient(context.Background(), req, "http://localhost:9000", "us-east-1"); err != nil {
+		if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+			EndpointURL: "http://localhost:9000",
+			Region:      "us-east-1",
+		}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if req.URL != "http://localhost:9000/model/foo/converse" {
@@ -1156,7 +1159,9 @@ func TestAttachBedrockAuthForClient_DispatchesByOptions(t *testing.T) {
 			Method: "POST",
 			Body:   `{}`,
 		}
-		if err := AttachBedrockAuthForClient(context.Background(), req, "", "eu-west-1"); err != nil {
+		if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+			Region: "eu-west-1",
+		}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if req.AWSAuth == nil {
@@ -1176,7 +1181,7 @@ func TestAttachBedrockAuthForClient_DispatchesByOptions(t *testing.T) {
 			Method: "POST",
 			Body:   `{}`,
 		}
-		if err := AttachBedrockAuthForClient(context.Background(), req, "", ""); err != nil {
+		if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if req.AWSAuth != nil {
@@ -1223,6 +1228,441 @@ func TestAttachBedrockAuthWithOptions_NilCredentialsUsesDefaultChain(t *testing.
 	}
 	if req.AWSAuth == nil || req.AWSAuth.Credentials == nil {
 		t.Fatal("expected default-chain credentials to be attached")
+	}
+}
+
+// Static credential fixture values for #254 item 2 tests. Use obvious
+// fakes (NOT AWS doc examples like AKIAIOSFODNN7EXAMPLE) so a security
+// scanner cannot mistake them for compromised credentials.
+const (
+	staticCredsTestAccessKey    = "STATIC_TEST_ACCESS_KEY"
+	staticCredsTestSecretKey    = "STATIC_TEST_SECRET_KEY"
+	staticCredsTestSessionToken = "STATIC_TEST_SESSION_TOKEN"
+)
+
+// TestResolveBedrockCredentials_Static pins the static-credentials
+// branch: AccessKeyID + SecretAccessKey (+ optional SessionToken) →
+// credentials.NewStaticCredentialsProvider. The returned provider
+// must hand out exactly the values we configured.
+func TestResolveBedrockCredentials_Static(t *testing.T) {
+	t.Run("without session token", func(t *testing.T) {
+		sel := BedrockCredentialSelector{
+			AccessKeyID:            staticCredsTestAccessKey,
+			AccessKeyIDPresent:     true,
+			SecretAccessKey:        staticCredsTestSecretKey,
+			SecretAccessKeyPresent: true,
+		}
+		provider, err := ResolveBedrockCredentials(context.Background(), "TestClient", sel)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if provider == nil {
+			t.Fatal("expected non-nil provider for declared static credentials")
+		}
+		creds, err := provider.Retrieve(context.Background())
+		if err != nil {
+			t.Fatalf("Retrieve: %v", err)
+		}
+		if creds.AccessKeyID != staticCredsTestAccessKey {
+			t.Errorf("AccessKeyID = %q, want %q", creds.AccessKeyID, staticCredsTestAccessKey)
+		}
+		if creds.SecretAccessKey != staticCredsTestSecretKey {
+			t.Errorf("SecretAccessKey = %q, want %q", creds.SecretAccessKey, staticCredsTestSecretKey)
+		}
+		if creds.SessionToken != "" {
+			t.Errorf("SessionToken = %q, want empty for static pair without session token", creds.SessionToken)
+		}
+	})
+	t.Run("with session token", func(t *testing.T) {
+		sel := BedrockCredentialSelector{
+			AccessKeyID:            staticCredsTestAccessKey,
+			AccessKeyIDPresent:     true,
+			SecretAccessKey:        staticCredsTestSecretKey,
+			SecretAccessKeyPresent: true,
+			SessionToken:           staticCredsTestSessionToken,
+			SessionTokenPresent:    true,
+		}
+		provider, err := ResolveBedrockCredentials(context.Background(), "TestClient", sel)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		creds, err := provider.Retrieve(context.Background())
+		if err != nil {
+			t.Fatalf("Retrieve: %v", err)
+		}
+		if creds.SessionToken != staticCredsTestSessionToken {
+			t.Errorf("SessionToken = %q, want %q", creds.SessionToken, staticCredsTestSessionToken)
+		}
+	})
+}
+
+// TestResolveBedrockCredentials_Profile pins the profile-only branch:
+// the resolver delegates to profileAWSConfigLoader with the configured
+// profile name and returns cfg.Credentials. Indirected through the
+// test-seam loader so the test doesn't depend on ~/.aws/credentials.
+func TestResolveBedrockCredentials_Profile(t *testing.T) {
+	savedLoader := profileAWSConfigLoader
+	t.Cleanup(func() { profileAWSConfigLoader = savedLoader })
+
+	var seenProfile string
+	stubProvider := staticCreds{cred: aws.Credentials{
+		AccessKeyID:     "FROM_PROFILE_AK",
+		SecretAccessKey: "FROM_PROFILE_SK",
+	}}
+	profileAWSConfigLoader = func(ctx context.Context, profile string) (aws.Config, error) {
+		seenProfile = profile
+		return aws.Config{Credentials: stubProvider}, nil
+	}
+
+	sel := BedrockCredentialSelector{
+		Profile:        "ai-dev",
+		ProfilePresent: true,
+	}
+	provider, err := ResolveBedrockCredentials(context.Background(), "TestClient", sel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if seenProfile != "ai-dev" {
+		t.Errorf("profile passed to loader = %q, want ai-dev", seenProfile)
+	}
+	creds, err := provider.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	if creds.AccessKeyID != "FROM_PROFILE_AK" {
+		t.Errorf("AccessKeyID = %q, want FROM_PROFILE_AK (must come from loader-returned cfg.Credentials)", creds.AccessKeyID)
+	}
+}
+
+// TestResolveBedrockCredentials_ProfileLoaderError pins that a profile
+// load failure is wrapped with the client name and surfaced verbatim
+// (no swallowed errors, no silent fallback to the default chain).
+func TestResolveBedrockCredentials_ProfileLoaderError(t *testing.T) {
+	savedLoader := profileAWSConfigLoader
+	t.Cleanup(func() { profileAWSConfigLoader = savedLoader })
+	profileAWSConfigLoader = func(ctx context.Context, profile string) (aws.Config, error) {
+		return aws.Config{}, errors.New("synthetic load error")
+	}
+
+	_, err := ResolveBedrockCredentials(context.Background(), "ClientName", BedrockCredentialSelector{
+		Profile:        "ai-dev",
+		ProfilePresent: true,
+	})
+	if err == nil {
+		t.Fatal("expected error from synthetic profile load failure")
+	}
+	if !strings.Contains(err.Error(), "ClientName") {
+		t.Errorf("error must name the client; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "synthetic load error") {
+		t.Errorf("error must wrap loader error; got: %v", err)
+	}
+}
+
+// TestResolveBedrockCredentials_StaticWinsOverProfile pins the
+// BAML-parity precedence: when both static keys and profile are
+// declared, static credentials win without consulting the profile
+// loader. The test seam asserts profileAWSConfigLoader is NEVER called
+// in this case — an indirect way to prove static wins silently.
+func TestResolveBedrockCredentials_StaticWinsOverProfile(t *testing.T) {
+	savedLoader := profileAWSConfigLoader
+	t.Cleanup(func() { profileAWSConfigLoader = savedLoader })
+	profileAWSConfigLoader = func(ctx context.Context, profile string) (aws.Config, error) {
+		t.Fatalf("profileAWSConfigLoader must not be called when static creds are declared (got profile=%q)", profile)
+		return aws.Config{}, nil
+	}
+
+	sel := BedrockCredentialSelector{
+		AccessKeyID:            staticCredsTestAccessKey,
+		AccessKeyIDPresent:     true,
+		SecretAccessKey:        staticCredsTestSecretKey,
+		SecretAccessKeyPresent: true,
+		Profile:                "ignored",
+		ProfilePresent:         true,
+	}
+	provider, err := ResolveBedrockCredentials(context.Background(), "TestClient", sel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	creds, err := provider.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	if creds.AccessKeyID != staticCredsTestAccessKey {
+		t.Errorf("AccessKeyID = %q, want static (static must win over profile)", creds.AccessKeyID)
+	}
+}
+
+// TestResolveBedrockCredentials_Default pins that an empty selector
+// returns (nil, nil) — the caller is responsible for routing to the
+// default credential chain. Preserves #262's no-override fallthrough.
+func TestResolveBedrockCredentials_Default(t *testing.T) {
+	provider, err := ResolveBedrockCredentials(context.Background(), "TestClient", BedrockCredentialSelector{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider != nil {
+		t.Errorf("provider = %T, want nil (caller falls back to default chain)", provider)
+	}
+}
+
+// TestResolveBedrockCredentials_InvalidPartialStates pins each partial
+// static-credential configuration rejected by the resolver. Critical
+// invariants:
+//   - the error names the client and the missing field
+//   - the error string DOES NOT contain any configured credential value
+//
+// The security-pin assertion guards against future regressions that
+// would echo the configured AKID/secret/token in the error path —
+// silently breaking the "no secret leakage" contract documented on
+// ResolveBedrockCredentials.
+func TestResolveBedrockCredentials_InvalidPartialStates(t *testing.T) {
+	cases := []struct {
+		name      string
+		sel       BedrockCredentialSelector
+		wantField string
+	}{
+		{
+			name: "access_key_id without secret_access_key",
+			sel: BedrockCredentialSelector{
+				AccessKeyID:        staticCredsTestAccessKey,
+				AccessKeyIDPresent: true,
+			},
+			wantField: "secret_access_key",
+		},
+		{
+			name: "secret_access_key without access_key_id",
+			sel: BedrockCredentialSelector{
+				SecretAccessKey:        staticCredsTestSecretKey,
+				SecretAccessKeyPresent: true,
+			},
+			wantField: "access_key_id",
+		},
+		{
+			name: "session_token without key pair",
+			sel: BedrockCredentialSelector{
+				SessionToken:        staticCredsTestSessionToken,
+				SessionTokenPresent: true,
+			},
+			wantField: "access_key_id",
+		},
+		{
+			name: "access_key_id present but resolved empty",
+			sel: BedrockCredentialSelector{
+				AccessKeyIDPresent:     true,
+				SecretAccessKey:        staticCredsTestSecretKey,
+				SecretAccessKeyPresent: true,
+			},
+			wantField: "access_key_id",
+		},
+		{
+			name: "secret_access_key present but resolved empty",
+			sel: BedrockCredentialSelector{
+				AccessKeyID:            staticCredsTestAccessKey,
+				AccessKeyIDPresent:     true,
+				SecretAccessKeyPresent: true,
+			},
+			wantField: "secret_access_key",
+		},
+		{
+			name: "session_token present but resolved empty",
+			sel: BedrockCredentialSelector{
+				AccessKeyID:            staticCredsTestAccessKey,
+				AccessKeyIDPresent:     true,
+				SecretAccessKey:        staticCredsTestSecretKey,
+				SecretAccessKeyPresent: true,
+				SessionTokenPresent:    true,
+			},
+			wantField: "session_token",
+		},
+		{
+			name: "profile present but resolved empty",
+			sel: BedrockCredentialSelector{
+				ProfilePresent: true,
+			},
+			wantField: "profile",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ResolveBedrockCredentials(context.Background(), "BedrockA", tc.sel)
+			if err == nil {
+				t.Fatal("expected error for partial credential state")
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "BedrockA") {
+				t.Errorf("error must name the client; got: %s", msg)
+			}
+			if !strings.Contains(msg, tc.wantField) {
+				t.Errorf("error must mention missing field %q; got: %s", tc.wantField, msg)
+			}
+			// Security pin: the error must NEVER echo a configured
+			// credential value. This is the load-bearing assertion
+			// for the doc-comment promise on
+			// ResolveBedrockCredentials.
+			for _, secret := range []string{
+				staticCredsTestAccessKey,
+				staticCredsTestSecretKey,
+				staticCredsTestSessionToken,
+			} {
+				if strings.Contains(msg, secret) {
+					t.Errorf("error leaked credential value %q; got: %s", secret, msg)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveBedrockCredentials_EnvRefUnsetIsRejected pins the
+// "unset env reference is an error, not silent fallback" branch.
+// The selector models the codegen output for an `env.UNSET_VAR`
+// reference: Present is preserved from BedrockOptionValue.Resolve()'s
+// (value, ok) shape — false here — even when the field itself was
+// declared in .baml. The resolver must reject this as a partial state
+// rather than silently fall through to profile / default chain.
+func TestResolveBedrockCredentials_EnvRefUnsetIsRejected(t *testing.T) {
+	// env.UNSET_AKID + literal secret. AccessKeyIDPresent = false
+	// because the env lookup failed, even though the field was
+	// declared.
+	sel := BedrockCredentialSelector{
+		AccessKeyIDPresent:     false,
+		SecretAccessKey:        staticCredsTestSecretKey,
+		SecretAccessKeyPresent: true,
+	}
+	_, err := ResolveBedrockCredentials(context.Background(), "ClientName", sel)
+	if err == nil {
+		t.Fatal("expected error when an env.X access_key_id is unset")
+	}
+	if !strings.Contains(err.Error(), "access_key_id") {
+		t.Errorf("error must point to the missing field; got: %v", err)
+	}
+}
+
+// TestAttachBedrockAuthForClient_StaticProviderUsedForSigning pins
+// that static credentials from .baml options flow all the way through
+// AttachBedrockAuthForClient -> AttachBedrockAuthWithOptions ->
+// AWSAuthConfig.Credentials, and that signRequest then uses them to
+// produce an Authorization header referencing the static access key.
+// Cross-checks the dispatch wiring against the resolver in isolation.
+func TestAttachBedrockAuthForClient_StaticProviderUsedForSigning(t *testing.T) {
+	req := &Request{
+		URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+		Method: "POST",
+		Body:   `{}`,
+	}
+	if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+		ClientName: "StaticClient",
+		Region:     "us-east-1",
+		Credentials: BedrockCredentialSelector{
+			AccessKeyID:            staticCredsTestAccessKey,
+			AccessKeyIDPresent:     true,
+			SecretAccessKey:        staticCredsTestSecretKey,
+			SecretAccessKeyPresent: true,
+		},
+	}); err != nil {
+		t.Fatalf("AttachBedrockAuthForClient: %v", err)
+	}
+	if req.AWSAuth == nil || req.AWSAuth.Credentials == nil {
+		t.Fatal("static credentials must flow through to AWSAuth.Credentials")
+	}
+
+	pinned := time.Date(2026, 5, 11, 12, 34, 56, 0, time.UTC)
+	req.AWSAuth.NowFunc = func() time.Time { return pinned }
+	if err := signRequest(context.Background(), req, req.URL); err != nil {
+		t.Fatalf("signRequest: %v", err)
+	}
+
+	auth := req.Headers["Authorization"]
+	if !strings.Contains(auth, "Credential="+staticCredsTestAccessKey+"/20260511/us-east-1/bedrock/aws4_request") {
+		t.Errorf("Authorization must reference the static access key in credential scope; got: %s", auth)
+	}
+}
+
+// TestAttachBedrockAuthForClient_StaticVsDefaultProducesDifferentSignatures
+// is the "did we actually plug the slot in" pin. A regression that
+// silently dropped the resolved provider and re-fetched the default
+// chain would still pass the earlier static-flow test (different
+// AKID would still produce *some* Authorization header) — but the
+// signature it produces would match the default-chain signature
+// instead of the static one. This test signs the same request body
+// twice, once with each provider, and asserts the two Authorization
+// headers differ.
+func TestAttachBedrockAuthForClient_StaticVsDefaultProducesDifferentSignatures(t *testing.T) {
+	// Swap the default-chain loader for a deterministic stub so the
+	// non-static signature is reproducible.
+	savedLoader := defaultAWSConfigLoader
+	defaultAWSCredsMu.Lock()
+	savedCreds := defaultAWSCreds
+	defaultAWSCreds = nil
+	defaultAWSCredsMu.Unlock()
+	t.Cleanup(func() {
+		defaultAWSConfigLoader = savedLoader
+		defaultAWSCredsMu.Lock()
+		defaultAWSCreds = savedCreds
+		defaultAWSCredsMu.Unlock()
+	})
+	defaultAWSConfigLoader = func(ctx context.Context) (aws.Config, error) {
+		return aws.Config{Credentials: staticCreds{cred: aws.Credentials{
+			AccessKeyID:     "DEFAULT_CHAIN_AK",
+			SecretAccessKey: "DEFAULT_CHAIN_SK",
+		}}}, nil
+	}
+
+	pinned := time.Date(2026, 5, 11, 12, 34, 56, 0, time.UTC)
+	makeReq := func() *Request {
+		return &Request{
+			URL:     "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+			Method:  "POST",
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    `{"messages":[]}`,
+		}
+	}
+
+	staticReq := makeReq()
+	if err := AttachBedrockAuthForClient(context.Background(), staticReq, BedrockClientAuthOptions{
+		ClientName: "StaticClient",
+		Region:     "us-east-1",
+		Credentials: BedrockCredentialSelector{
+			AccessKeyID:            staticCredsTestAccessKey,
+			AccessKeyIDPresent:     true,
+			SecretAccessKey:        staticCredsTestSecretKey,
+			SecretAccessKeyPresent: true,
+		},
+	}); err != nil {
+		t.Fatalf("static AttachBedrockAuthForClient: %v", err)
+	}
+	staticReq.AWSAuth.NowFunc = func() time.Time { return pinned }
+	if err := signRequest(context.Background(), staticReq, staticReq.URL); err != nil {
+		t.Fatalf("static signRequest: %v", err)
+	}
+
+	defaultReq := makeReq()
+	if err := AttachBedrockAuthForClient(context.Background(), defaultReq, BedrockClientAuthOptions{
+		ClientName: "DefaultClient",
+		Region:     "us-east-1",
+	}); err != nil {
+		t.Fatalf("default AttachBedrockAuthForClient: %v", err)
+	}
+	defaultReq.AWSAuth.NowFunc = func() time.Time { return pinned }
+	if err := signRequest(context.Background(), defaultReq, defaultReq.URL); err != nil {
+		t.Fatalf("default signRequest: %v", err)
+	}
+
+	staticAuth := staticReq.Headers["Authorization"]
+	defaultAuth := defaultReq.Headers["Authorization"]
+	if staticAuth == "" || defaultAuth == "" {
+		t.Fatalf("missing Authorization headers: static=%q default=%q", staticAuth, defaultAuth)
+	}
+	if staticAuth == defaultAuth {
+		t.Errorf("static and default-chain signatures must differ — the static provider slot is silently being dropped.\n  static:  %s\n  default: %s", staticAuth, defaultAuth)
+	}
+	// And specifically: each Authorization's Credential= prefix must
+	// reference the corresponding access key.
+	if !strings.Contains(staticAuth, "Credential="+staticCredsTestAccessKey+"/") {
+		t.Errorf("static Authorization missing static access key in Credential=; got: %s", staticAuth)
+	}
+	if !strings.Contains(defaultAuth, "Credential=DEFAULT_CHAIN_AK/") {
+		t.Errorf("default Authorization missing default-chain access key; got: %s", defaultAuth)
 	}
 }
 

--- a/bamlutils/llmhttp/awssigv4_test.go
+++ b/bamlutils/llmhttp/awssigv4_test.go
@@ -1598,6 +1598,184 @@ func TestResolveBedrockCredentials_ProfileEnvUnset_Errors(t *testing.T) {
 	}
 }
 
+// TestAttachBedrockAuthForClient_EndpointURLEnvUnset_Errors pins the
+// declared-vs-resolved fix for endpoint_url (CR Round 2). Scenario:
+// operator declared `endpoint_url env.MY_PROXY` in .baml and forgot
+// to set MY_PROXY at runtime. Codegen emits EndpointURLPresent=true
+// (from IsSet()), EndpointURL="" (from Resolve()). The helper MUST
+// error before reaching AttachBedrockAuthWithOptions — silent
+// fallthrough to MaybeAttachBedrockAuth would route traffic to the
+// real default Bedrock host instead of the operator-declared proxy.
+// Error must be client-scoped and must NOT echo any resolved value
+// (no env-var name, no URL fragment), mirroring the credential
+// resolver's error hygiene.
+func TestAttachBedrockAuthForClient_EndpointURLEnvUnset_Errors(t *testing.T) {
+	req := &Request{
+		URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+		Method: "POST",
+		Body:   `{}`,
+	}
+	err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+		ClientName:         "EnvUnsetEndpoint",
+		EndpointURLPresent: true,
+		EndpointURL:        "",
+	})
+	if err == nil {
+		t.Fatal("expected error when declared endpoint_url env.X resolves to empty; silent fallback to MaybeAttachBedrockAuth is the CR Round 2 blocker")
+	}
+	if req.AWSAuth != nil {
+		t.Errorf("declared-empty endpoint_url must not attach AWSAuth; got %+v", req.AWSAuth)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "EnvUnsetEndpoint") {
+		t.Errorf("error must name the client; got: %s", msg)
+	}
+	if !strings.Contains(msg, "endpoint_url") {
+		t.Errorf("error must reference the endpoint_url field; got: %s", msg)
+	}
+}
+
+// TestAttachBedrockAuthForClient_RegionEnvUnset_Errors pins the same
+// declared-but-empty error path for region (CR Round 2). Without this
+// check, a declared `region env.X` with X unset would reach
+// AttachBedrockAuthWithOptions's AWS_REGION env fallback and silently
+// pick up an ambient host region — the operator's broken env ref
+// would be invisible.
+func TestAttachBedrockAuthForClient_RegionEnvUnset_Errors(t *testing.T) {
+	// Force AWS_REGION to a known value so this test would visibly
+	// pick it up if the fallback ran. After the fix, the helper
+	// errors before reaching AttachBedrockAuthWithOptions, so the
+	// env value never gets a chance to win.
+	t.Setenv("AWS_REGION", "ap-southeast-2")
+
+	req := &Request{
+		URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+		Method: "POST",
+		Body:   `{}`,
+	}
+	err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+		ClientName:    "EnvUnsetRegion",
+		RegionPresent: true,
+		Region:        "",
+	})
+	if err == nil {
+		t.Fatal("expected error when declared region env.X resolves to empty; silent fallback to AWS_REGION is the CR Round 2 blocker")
+	}
+	if req.AWSAuth != nil {
+		t.Errorf("declared-empty region must not attach AWSAuth; got %+v", req.AWSAuth)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "EnvUnsetRegion") {
+		t.Errorf("error must name the client; got: %s", msg)
+	}
+	if !strings.Contains(msg, "region") {
+		t.Errorf("error must reference the region field; got: %s", msg)
+	}
+}
+
+// TestAttachBedrockAuthForClient_EndpointURLDeclaredEmptyBeforeRegionFallback
+// pins precedence on a mixed shape: endpoint_url declared-unset +
+// region literal set. The endpoint validation MUST fire first — a
+// regression that re-ordered the checks to validate region first (and
+// happily accept the literal) would lose the endpoint-error signal
+// even when the endpoint env ref is broken.
+func TestAttachBedrockAuthForClient_EndpointURLDeclaredEmptyBeforeRegionFallback(t *testing.T) {
+	req := &Request{
+		URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+		Method: "POST",
+		Body:   `{}`,
+	}
+	err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+		ClientName:         "MixedClient",
+		EndpointURLPresent: true,
+		EndpointURL:        "",
+		Region:             "us-east-1",
+	})
+	if err == nil {
+		t.Fatal("declared-empty endpoint_url must error even when region is set")
+	}
+	if !strings.Contains(err.Error(), "endpoint_url") {
+		t.Errorf("endpoint check must fire before region/credential paths; got: %v", err)
+	}
+}
+
+// TestAttachBedrockAuthForClient_NeitherDeclared_FallsThrough pins
+// the no-override default-endpoint contract from #262: when nothing
+// is declared (all Present flags false, all values empty,
+// credentials empty), the helper must fall through to
+// MaybeAttachBedrockAuth's URL-pattern detection. A regression here
+// would break every aws-bedrock client that did not declare any
+// override.
+func TestAttachBedrockAuthForClient_NeitherDeclared_FallsThrough(t *testing.T) {
+	req := &Request{
+		URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+		Method: "POST",
+		Body:   `{}`,
+	}
+	if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{}); err != nil {
+		t.Fatalf("no-override case must not error: %v", err)
+	}
+	if req.AWSAuth == nil {
+		t.Fatal("no-override case must fall through to MaybeAttachBedrockAuth and attach AWSAuth from URL host")
+	}
+	if req.AWSAuth.Region != "us-east-1" {
+		t.Errorf("Region must be parsed from URL host on fallthrough; got %q", req.AWSAuth.Region)
+	}
+	if req.URL != "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse" {
+		t.Errorf("URL must NOT be rewritten on the fallthrough path; got %q", req.URL)
+	}
+}
+
+// TestAttachBedrockAuthForClient_NonEmptyRawStringTreatedAsPresent
+// pins the compatibility shim: callers that construct
+// BedrockClientAuthOptions{EndpointURL: "http://h"} WITHOUT setting
+// EndpointURLPresent must still take the explicit override path.
+// Production codegen always sets the Present flag, but direct test
+// callers (and any future ad-hoc dispatch) rely on the
+// non-empty-string-is-present shorthand. Same shim applies to
+// Region.
+func TestAttachBedrockAuthForClient_NonEmptyRawStringTreatedAsPresent(t *testing.T) {
+	t.Run("endpoint url only", func(t *testing.T) {
+		req := &Request{
+			URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+			Method: "POST",
+			Body:   `{}`,
+		}
+		if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+			EndpointURL: "http://127.0.0.1:9000",
+			Region:      "us-east-1",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Explicit endpoint path was taken: URL rewritten to the
+		// override host. A regression that ignored the non-empty
+		// raw string (because EndpointURLPresent is false) would
+		// instead route to MaybeAttachBedrockAuth and leave req.URL
+		// untouched.
+		if req.URL != "http://127.0.0.1:9000/model/foo/converse" {
+			t.Errorf("explicit endpoint override path was not taken; URL = %q", req.URL)
+		}
+	})
+	t.Run("region only", func(t *testing.T) {
+		req := &Request{
+			URL:    "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse",
+			Method: "POST",
+			Body:   `{}`,
+		}
+		if err := AttachBedrockAuthForClient(context.Background(), req, BedrockClientAuthOptions{
+			Region: "eu-west-1",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.AWSAuth == nil {
+			t.Fatal("expected AWSAuth attached via explicit-region path")
+		}
+		if req.AWSAuth.Region != "eu-west-1" {
+			t.Errorf("explicit region override was not honoured; got %q", req.AWSAuth.Region)
+		}
+	})
+}
+
 // TestAttachBedrockAuthForClient_StaticProviderUsedForSigning pins
 // that static credentials from .baml options flow all the way through
 // AttachBedrockAuthForClient -> AttachBedrockAuthWithOptions ->

--- a/bamlutils/llmhttp/awssigv4_test.go
+++ b/bamlutils/llmhttp/awssigv4_test.go
@@ -1232,7 +1232,7 @@ func TestAttachBedrockAuthWithOptions_NilCredentialsUsesDefaultChain(t *testing.
 }
 
 // Static credential fixture values for #254 item 2 tests. Use obvious
-// fakes (NOT AWS doc examples like AKIAIOSFODNN7EXAMPLE) so a security
+// fakes (NOT real-looking access-key examples) so a security
 // scanner cannot mistake them for compromised credentials.
 const (
 	staticCredsTestAccessKey    = "STATIC_TEST_ACCESS_KEY"
@@ -1516,16 +1516,20 @@ func TestResolveBedrockCredentials_InvalidPartialStates(t *testing.T) {
 // TestResolveBedrockCredentials_EnvRefUnsetIsRejected pins the
 // "unset env reference is an error, not silent fallback" branch.
 // The selector models the codegen output for an `env.UNSET_VAR`
-// reference: Present is preserved from BedrockOptionValue.Resolve()'s
-// (value, ok) shape — false here — even when the field itself was
-// declared in .baml. The resolver must reject this as a partial state
-// rather than silently fall through to profile / default chain.
+// reference: codegen drives Present from BedrockOptionValue.IsSet()
+// (declared-in-.baml), so a declared env.X with an unset env var
+// produces Present=true, Value="". The resolver must reject this as
+// a partial state rather than silently fall through to profile /
+// default chain.
 func TestResolveBedrockCredentials_EnvRefUnsetIsRejected(t *testing.T) {
-	// env.UNSET_AKID + literal secret. AccessKeyIDPresent = false
-	// because the env lookup failed, even though the field was
-	// declared.
+	// env.UNSET_AKID + literal secret. AccessKeyIDPresent = true
+	// because the field was declared in .baml; AccessKeyID = ""
+	// because the env lookup did not resolve. The resolver enters
+	// the static branch (any *Present is true) and rejects the
+	// empty AKID.
 	sel := BedrockCredentialSelector{
-		AccessKeyIDPresent:     false,
+		AccessKeyIDPresent:     true,
+		AccessKeyID:            "",
 		SecretAccessKey:        staticCredsTestSecretKey,
 		SecretAccessKeyPresent: true,
 	}
@@ -1535,6 +1539,62 @@ func TestResolveBedrockCredentials_EnvRefUnsetIsRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "access_key_id") {
 		t.Errorf("error must point to the missing field; got: %v", err)
+	}
+}
+
+// TestResolveBedrockCredentials_EnvRefAllUnset_Errors is the regression
+// pin for the #263 sign-off blocker. Scenario: operator declared
+// access_key_id AND secret_access_key as env.X refs in .baml, but both
+// env vars are unset at runtime. Codegen sets Present=true (from
+// IsSet()) and Value="" (from Resolve()) for both. The resolver MUST
+// error in the static branch rather than silently fall through to the
+// default AWS credential chain — that fallthrough would let a
+// misconfigured worker sign requests with whatever credentials happen
+// to be on the host, which is the original security-significant bug.
+func TestResolveBedrockCredentials_EnvRefAllUnset_Errors(t *testing.T) {
+	sel := BedrockCredentialSelector{
+		AccessKeyIDPresent:     true,
+		AccessKeyID:            "",
+		SecretAccessKeyPresent: true,
+		SecretAccessKey:        "",
+	}
+	_, err := ResolveBedrockCredentials(context.Background(), "EnvUnset", sel)
+	if err == nil {
+		t.Fatal("expected error when declared env.X access_key_id AND secret_access_key both resolve to empty; silent fallback to default chain is the #263 blocker")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "EnvUnset") {
+		t.Errorf("error must name the client; got: %s", msg)
+	}
+	// The static branch is entered because *Present flags are true.
+	// AccessKeyID is checked first, so that is the field the error
+	// must reference.
+	if !strings.Contains(msg, "access_key_id") {
+		t.Errorf("error must reference the empty static field; got: %s", msg)
+	}
+}
+
+// TestResolveBedrockCredentials_ProfileEnvUnset_Errors pins the same
+// declared-but-env-unset semantics for the profile branch. An operator
+// declaring `profile env.AWS_PROFILE` with AWS_PROFILE unset must get
+// a client-scoped error, not a silent fall-through to the default
+// chain. Codegen emits Present=true (from IsSet()), Value="" (from
+// Resolve()) for an unset env ref.
+func TestResolveBedrockCredentials_ProfileEnvUnset_Errors(t *testing.T) {
+	sel := BedrockCredentialSelector{
+		ProfilePresent: true,
+		Profile:        "",
+	}
+	_, err := ResolveBedrockCredentials(context.Background(), "ProfileEnvUnset", sel)
+	if err == nil {
+		t.Fatal("expected error when declared profile env.X resolves to empty")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ProfileEnvUnset") {
+		t.Errorf("error must name the client; got: %s", msg)
+	}
+	if !strings.Contains(msg, "profile") {
+		t.Errorf("error must reference the profile field; got: %s", msg)
 	}
 }
 

--- a/cmd/introspect/baml_parser_test.go
+++ b/cmd/introspect/baml_parser_test.go
@@ -2070,3 +2070,352 @@ func resolveBedrockOptionValueForTest(v bedrockOptionValue) (string, bool) {
 	}
 	return "", false
 }
+
+// TestParseClientBlock_BedrockStaticCreds_Literal pins the parser
+// extension that captures literal-provenance values for the four
+// credential selector keys (#254 item 2). Asserts that all four
+// destination fields land under Credentials and preserve provenance.
+func TestParseClientBlock_BedrockStaticCreds_Literal(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> StaticCredsBedrock {
+    provider aws-bedrock
+    options {
+        access_key_id     "STATIC_TEST_ACCESS_KEY"
+        secret_access_key "STATIC_TEST_SECRET_KEY"
+        session_token     "STATIC_TEST_SESSION_TOKEN"
+        region            "us-east-1"
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	got, ok := cfg.bedrockClientOptions["StaticCredsBedrock"]
+	if !ok {
+		t.Fatalf("bedrockClientOptions[StaticCredsBedrock] missing")
+	}
+	if got.Credentials.AccessKeyID.Provenance != "literal" {
+		t.Errorf("AccessKeyID.Provenance = %q, want literal", got.Credentials.AccessKeyID.Provenance)
+	}
+	if got.Credentials.AccessKeyID.Literal != "STATIC_TEST_ACCESS_KEY" {
+		t.Errorf("AccessKeyID.Literal = %q, want STATIC_TEST_ACCESS_KEY", got.Credentials.AccessKeyID.Literal)
+	}
+	if got.Credentials.SecretAccessKey.Literal != "STATIC_TEST_SECRET_KEY" {
+		t.Errorf("SecretAccessKey.Literal = %q, want STATIC_TEST_SECRET_KEY", got.Credentials.SecretAccessKey.Literal)
+	}
+	if got.Credentials.SessionToken.Literal != "STATIC_TEST_SESSION_TOKEN" {
+		t.Errorf("SessionToken.Literal = %q, want STATIC_TEST_SESSION_TOKEN", got.Credentials.SessionToken.Literal)
+	}
+	if got.Credentials.Profile.Provenance != "" {
+		t.Errorf("Profile.Provenance = %q, want empty (only static keys set)", got.Credentials.Profile.Provenance)
+	}
+	if got.Region.Literal != "us-east-1" {
+		t.Errorf("Region.Literal = %q, want us-east-1 (sibling field must not be perturbed)", got.Region.Literal)
+	}
+}
+
+// TestParseClientBlock_BedrockStaticCreds_EnvRef pins the env-reference
+// provenance branch for credential selectors. Each env.X reference is
+// resolved at request-build time, not at parse, so the parser captures
+// the env var name.
+func TestParseClientBlock_BedrockStaticCreds_EnvRef(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> EnvCredsBedrock {
+    provider aws-bedrock
+    options {
+        access_key_id     env.AWS_ACCESS_KEY_ID
+        secret_access_key env.AWS_SECRET_ACCESS_KEY
+        session_token     env.AWS_SESSION_TOKEN
+        profile           env.AWS_PROFILE
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	got, ok := cfg.bedrockClientOptions["EnvCredsBedrock"]
+	if !ok {
+		t.Fatalf("bedrockClientOptions[EnvCredsBedrock] missing")
+	}
+	if got.Credentials.AccessKeyID.EnvVar != "AWS_ACCESS_KEY_ID" {
+		t.Errorf("AccessKeyID.EnvVar = %q, want AWS_ACCESS_KEY_ID", got.Credentials.AccessKeyID.EnvVar)
+	}
+	if got.Credentials.AccessKeyID.Provenance != "env" {
+		t.Errorf("AccessKeyID.Provenance = %q, want env", got.Credentials.AccessKeyID.Provenance)
+	}
+	if got.Credentials.SecretAccessKey.EnvVar != "AWS_SECRET_ACCESS_KEY" {
+		t.Errorf("SecretAccessKey.EnvVar = %q, want AWS_SECRET_ACCESS_KEY", got.Credentials.SecretAccessKey.EnvVar)
+	}
+	if got.Credentials.SessionToken.EnvVar != "AWS_SESSION_TOKEN" {
+		t.Errorf("SessionToken.EnvVar = %q, want AWS_SESSION_TOKEN", got.Credentials.SessionToken.EnvVar)
+	}
+	if got.Credentials.Profile.EnvVar != "AWS_PROFILE" {
+		t.Errorf("Profile.EnvVar = %q, want AWS_PROFILE", got.Credentials.Profile.EnvVar)
+	}
+}
+
+// TestParseClientBlock_BedrockStaticCreds_MixedLiteralAndEnv asserts a
+// realistic mixed shape: a literal access_key_id alongside an env-ref
+// secret_access_key (or vice versa). Each field's provenance must be
+// captured independently.
+func TestParseClientBlock_BedrockStaticCreds_MixedLiteralAndEnv(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> MixedCredsBedrock {
+    provider aws-bedrock
+    options {
+        access_key_id     "STATIC_TEST_ACCESS_KEY"
+        secret_access_key env.AWS_SECRET_ACCESS_KEY
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	got := cfg.bedrockClientOptions["MixedCredsBedrock"]
+	if got.Credentials.AccessKeyID.Provenance != "literal" {
+		t.Errorf("AccessKeyID.Provenance = %q, want literal", got.Credentials.AccessKeyID.Provenance)
+	}
+	if got.Credentials.AccessKeyID.Literal != "STATIC_TEST_ACCESS_KEY" {
+		t.Errorf("AccessKeyID.Literal = %q, want STATIC_TEST_ACCESS_KEY", got.Credentials.AccessKeyID.Literal)
+	}
+	if got.Credentials.SecretAccessKey.Provenance != "env" {
+		t.Errorf("SecretAccessKey.Provenance = %q, want env", got.Credentials.SecretAccessKey.Provenance)
+	}
+	if got.Credentials.SecretAccessKey.EnvVar != "AWS_SECRET_ACCESS_KEY" {
+		t.Errorf("SecretAccessKey.EnvVar = %q, want AWS_SECRET_ACCESS_KEY", got.Credentials.SecretAccessKey.EnvVar)
+	}
+}
+
+// TestParseClientBlock_BedrockStaticCreds_ProfileOnly pins that a
+// profile-only declaration produces an entry with only the Profile slot
+// populated; the static-key slots stay zero.
+func TestParseClientBlock_BedrockStaticCreds_ProfileOnly(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> ProfileBedrock {
+    provider aws-bedrock
+    options {
+        profile "ai-dev"
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	got, ok := cfg.bedrockClientOptions["ProfileBedrock"]
+	if !ok {
+		t.Fatalf("profile-only client must produce an entry")
+	}
+	if got.Credentials.Profile.Provenance != "literal" {
+		t.Errorf("Profile.Provenance = %q, want literal", got.Credentials.Profile.Provenance)
+	}
+	if got.Credentials.Profile.Literal != "ai-dev" {
+		t.Errorf("Profile.Literal = %q, want ai-dev", got.Credentials.Profile.Literal)
+	}
+	if got.Credentials.AccessKeyID.Provenance != "" {
+		t.Errorf("AccessKeyID.Provenance = %q, want empty (only profile declared)", got.Credentials.AccessKeyID.Provenance)
+	}
+}
+
+// TestParseClientBlock_BedrockStaticCreds_ProfilePlusStatic_BothCaptured
+// pins that the parser is permissive: a client declaring both profile
+// AND static keys captures both. Resolver picks static at runtime.
+// Keeping the parser permissive matches BAML's own posture
+// (engine/.../aws_client.rs:587-650) and avoids parser-level errors on
+// a configuration that is unambiguous at resolve time.
+func TestParseClientBlock_BedrockStaticCreds_ProfilePlusStatic_BothCaptured(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> BothCredsBedrock {
+    provider aws-bedrock
+    options {
+        access_key_id     "STATIC_TEST_ACCESS_KEY"
+        secret_access_key "STATIC_TEST_SECRET_KEY"
+        profile           "ai-dev"
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	got := cfg.bedrockClientOptions["BothCredsBedrock"]
+	if got.Credentials.AccessKeyID.Literal != "STATIC_TEST_ACCESS_KEY" {
+		t.Errorf("AccessKeyID.Literal = %q, want STATIC_TEST_ACCESS_KEY", got.Credentials.AccessKeyID.Literal)
+	}
+	if got.Credentials.Profile.Literal != "ai-dev" {
+		t.Errorf("Profile.Literal = %q, want ai-dev", got.Credentials.Profile.Literal)
+	}
+}
+
+// TestParseClientBlock_BedrockStaticCreds_NonBedrockClient_Recorded
+// pins that the provider-filter split applies to credential selectors
+// too: the parser records candidate entries for any client declaring
+// the keys; only the emission step filters to aws-bedrock. Mirrors the
+// existing endpoint_url/region parser-permissive behavior so a future
+// non-bedrock provider sharing a key cannot accidentally leak into the
+// generated BedrockClientOptionsByName map (the emission filter is the
+// boundary).
+func TestParseClientBlock_BedrockStaticCreds_NonBedrockClient_Recorded(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `
+client<llm> NotBedrockCreds {
+    provider openai
+    options {
+        access_key_id     "should-not-emit"
+        secret_access_key "should-not-emit"
+    }
+}
+`
+	parseBamlFile(cfg, content)
+
+	if _, ok := cfg.bedrockClientOptions["NotBedrockCreds"]; !ok {
+		t.Fatal("parser must record candidate entries regardless of provider; emission filter is downstream")
+	}
+}
+
+// TestParseClientBlock_BedrockStaticCreds_StaleEntryCleared pins that
+// removing all credential fields between regen runs clears the prior
+// entry. Mirrors the existing endpoint_url stale-state test for the
+// new credential slots.
+func TestParseClientBlock_BedrockStaticCreds_StaleEntryCleared(t *testing.T) {
+	cfg := newTestBamlConfig()
+	parseBamlFile(cfg, `
+client<llm> CredsBedrock {
+    provider aws-bedrock
+    options {
+        access_key_id     "STATIC_TEST_ACCESS_KEY"
+        secret_access_key "STATIC_TEST_SECRET_KEY"
+    }
+}
+`)
+	if _, ok := cfg.bedrockClientOptions["CredsBedrock"]; !ok {
+		t.Fatal("first parse must populate the entry")
+	}
+	parseBamlFile(cfg, `
+client<llm> CredsBedrock {
+    provider aws-bedrock
+    options {
+        model "anthropic.claude-3-sonnet-20240229-v1:0"
+    }
+}
+`)
+	if _, ok := cfg.bedrockClientOptions["CredsBedrock"]; ok {
+		t.Errorf("re-parse without credential fields must clear the stale entry; got %+v", cfg.bedrockClientOptions["CredsBedrock"])
+	}
+}
+
+// TestExtractBedrockOptionValue_CredentialKeys exercises the parser
+// helper for each new credential key in isolation, mirroring the
+// existing endpoint_url / region table test.
+func TestExtractBedrockOptionValue_CredentialKeys(t *testing.T) {
+	cases := []struct {
+		name     string
+		line     string
+		key      string
+		wantOK   bool
+		wantLit  string
+		wantEnv  string
+		wantProv string
+	}{
+		{
+			name:     "access_key_id literal",
+			line:     `access_key_id "STATIC_TEST_ACCESS_KEY"`,
+			key:      "access_key_id",
+			wantOK:   true,
+			wantLit:  "STATIC_TEST_ACCESS_KEY",
+			wantProv: "literal",
+		},
+		{
+			name:     "access_key_id env",
+			line:     `access_key_id env.AWS_ACCESS_KEY_ID`,
+			key:      "access_key_id",
+			wantOK:   true,
+			wantEnv:  "AWS_ACCESS_KEY_ID",
+			wantProv: "env",
+		},
+		{
+			name:     "secret_access_key literal",
+			line:     `secret_access_key "STATIC_TEST_SECRET_KEY"`,
+			key:      "secret_access_key",
+			wantOK:   true,
+			wantLit:  "STATIC_TEST_SECRET_KEY",
+			wantProv: "literal",
+		},
+		{
+			name:     "secret_access_key env",
+			line:     `secret_access_key env.AWS_SECRET_ACCESS_KEY`,
+			key:      "secret_access_key",
+			wantOK:   true,
+			wantEnv:  "AWS_SECRET_ACCESS_KEY",
+			wantProv: "env",
+		},
+		{
+			name:     "session_token literal",
+			line:     `session_token "STATIC_TEST_SESSION_TOKEN"`,
+			key:      "session_token",
+			wantOK:   true,
+			wantLit:  "STATIC_TEST_SESSION_TOKEN",
+			wantProv: "literal",
+		},
+		{
+			name:     "profile literal",
+			line:     `profile "ai-dev"`,
+			key:      "profile",
+			wantOK:   true,
+			wantLit:  "ai-dev",
+			wantProv: "literal",
+		},
+		{
+			name:     "profile env",
+			line:     `profile env.AWS_PROFILE`,
+			key:      "profile",
+			wantOK:   true,
+			wantEnv:  "AWS_PROFILE",
+			wantProv: "env",
+		},
+		{
+			name:   "absent credential key on this line",
+			line:   `region "us-east-1"`,
+			key:    "access_key_id",
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := extractBedrockOptionValue(tc.line, tc.key)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (got %+v)", ok, tc.wantOK, got)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.Literal != tc.wantLit {
+				t.Errorf("Literal = %q, want %q", got.Literal, tc.wantLit)
+			}
+			if got.EnvVar != tc.wantEnv {
+				t.Errorf("EnvVar = %q, want %q", got.EnvVar, tc.wantEnv)
+			}
+			if got.Provenance != tc.wantProv {
+				t.Errorf("Provenance = %q, want %q", got.Provenance, tc.wantProv)
+			}
+		})
+	}
+}
+
+// TestParseClientBlock_BedrockStaticCreds_InlineSingleLine pins that
+// the inline compact options form captures credential keys correctly,
+// mirroring the existing endpoint_url inline test.
+func TestParseClientBlock_BedrockStaticCreds_InlineSingleLine(t *testing.T) {
+	cfg := newTestBamlConfig()
+	content := `client<llm> InlineCreds { provider aws-bedrock options { access_key_id "STATIC_TEST_ACCESS_KEY" secret_access_key "STATIC_TEST_SECRET_KEY" } }`
+	parseBamlFile(cfg, content)
+
+	got, ok := cfg.bedrockClientOptions["InlineCreds"]
+	if !ok {
+		t.Fatalf("inline options block must produce an entry; got map: %+v", cfg.bedrockClientOptions)
+	}
+	if got.Credentials.AccessKeyID.Literal != "STATIC_TEST_ACCESS_KEY" {
+		t.Errorf("inline AccessKeyID.Literal = %q, want STATIC_TEST_ACCESS_KEY", got.Credentials.AccessKeyID.Literal)
+	}
+	if got.Credentials.SecretAccessKey.Literal != "STATIC_TEST_SECRET_KEY" {
+		t.Errorf("inline SecretAccessKey.Literal = %q, want STATIC_TEST_SECRET_KEY", got.Credentials.SecretAccessKey.Literal)
+	}
+}

--- a/cmd/introspect/baml_parser_test.go
+++ b/cmd/introspect/baml_parser_test.go
@@ -2071,6 +2071,85 @@ func resolveBedrockOptionValueForTest(v bedrockOptionValue) (string, bool) {
 	return "", false
 }
 
+// isSetBedrockOptionValueForTest mirrors the runtime IsSet() method
+// shape emitBedrockOptionTypes generates: presence is decided by
+// Provenance alone, NOT by Resolve()'s second return. This pins the
+// declared-vs-resolved separation that the codegen relies on for
+// declared-but-env-unset credentials to enter the resolver's static
+// branch (and error there) rather than silently fall through to the
+// default AWS credential chain.
+func isSetBedrockOptionValueForTest(v bedrockOptionValue) bool {
+	return v.Provenance != ""
+}
+
+// TestBedrockOptionValue_IsSet pins the declared-vs-resolved boundary.
+// A declared env.X reference whose env var is unset at runtime must
+// still report IsSet()=true so the codegen-emitted Present flag enters
+// the resolver's static-branch validation. If a future refactor were
+// to fold IsSet into Resolve()'s ok, this test fails immediately.
+func TestBedrockOptionValue_IsSet(t *testing.T) {
+	cases := []struct {
+		name string
+		v    bedrockOptionValue
+		want bool
+	}{
+		{
+			name: "literal is declared",
+			v:    bedrockOptionValue{Literal: "x", Provenance: "literal"},
+			want: true,
+		},
+		{
+			name: "env ref is declared even when env var is unset",
+			v:    bedrockOptionValue{EnvVar: "NEVER_SET_DEFINITELY", Provenance: "env"},
+			want: true,
+		},
+		{
+			name: "empty literal is still declared (provenance != \"\")",
+			v:    bedrockOptionValue{Provenance: "literal"},
+			want: true,
+		},
+		{
+			name: "zero value is not declared",
+			v:    bedrockOptionValue{},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSetBedrockOptionValueForTest(tc.v); got != tc.want {
+				t.Errorf("IsSet(%+v) = %v, want %v", tc.v, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBedrockOptionValue_IsSetVsResolve_EnvUnset is the load-bearing
+// pin for the #263 sign-off fix. A declared env.X reference whose
+// env var is unset at runtime must report:
+//   - IsSet() == true   (the field was declared in .baml)
+//   - Resolve() == ("", false)  (the value did not resolve)
+//
+// Codegen drives Present from IsSet(), so the resolver's static branch
+// is entered (Present=true, Value=""); the existing "resolved to empty"
+// error then fires. Driving Present from Resolve()'s ok would collapse
+// declared-but-env-unset into never-declared and silently fall through
+// to the default AWS credential chain — a security-significant
+// regression. This test pins both halves of that distinction.
+func TestBedrockOptionValue_IsSetVsResolve_EnvUnset(t *testing.T) {
+	v := bedrockOptionValue{EnvVar: "BAML_REST_TEST_NEVER_SET_VAR", Provenance: "env"}
+
+	if !isSetBedrockOptionValueForTest(v) {
+		t.Error("IsSet() must be true for a declared env.X reference, regardless of env-var resolution")
+	}
+	value, ok := resolveBedrockOptionValueForTest(v)
+	if ok {
+		t.Errorf("Resolve() ok = true for unset env.X ref; want false (got value=%q)", value)
+	}
+	if value != "" {
+		t.Errorf("Resolve() value = %q for unset env.X ref; want empty", value)
+	}
+}
+
 // TestParseClientBlock_BedrockStaticCreds_Literal pins the parser
 // extension that captures literal-provenance values for the four
 // credential selector keys (#254 item 2). Asserts that all four

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -1157,12 +1157,14 @@ type bamlConfig struct {
 	// `start N`, regardless of provider.
 	roundRobinStart map[string]int
 	// bedrockClientOptions maps client name → parsed aws-bedrock
-	// options (endpoint_url + region). The parser records entries for
-	// every client whose options block declares either key (so the map
-	// can carry literal-vs-env provenance) regardless of provider; the
-	// emission step filters to provider == "aws-bedrock" so a non-bedrock
-	// client that happens to use the same option keys for an unrelated
-	// purpose can't leak into the runtime BedrockClientOptions map.
+	// options (endpoint_url, region, and the credential selectors
+	// access_key_id / secret_access_key / session_token / profile).
+	// The parser records entries for every client whose options block
+	// declares any of those keys (so the map can carry literal-vs-env
+	// provenance) regardless of provider; the emission step filters
+	// to provider == "aws-bedrock" so a non-bedrock client that
+	// happens to use the same option keys for an unrelated purpose
+	// can't leak into the runtime BedrockClientOptions map.
 	bedrockClientOptions map[string]bedrockClientOptions
 }
 
@@ -1189,11 +1191,11 @@ type bedrockClientOptions struct {
 //  2. Profile → shared-config profile load.
 //  3. Default chain (none of the above declared).
 //
-// Security note: literal values declared inline (e.g.
-// `secret_access_key "AKIA..."`) land in generated introspected.go AND
-// the compiled worker binary — that is BAML-parity behavior, documented
-// as an operator footgun. Use `env.X` to keep secret material out of
-// generated artifacts.
+// Security note: literal credential values declared inline (e.g.
+// `secret_access_key "<example-key>"`) land in generated introspected.go
+// AND the compiled worker binary — that is BAML-parity behavior,
+// documented as an operator footgun. Use `env.X` to keep secret material
+// out of generated artifacts.
 type bedrockCredentialOptions struct {
 	AccessKeyID     bedrockOptionValue
 	SecretAccessKey bedrockOptionValue
@@ -1803,11 +1805,12 @@ func parseClientBlock(cfg *bamlConfig, name string, block []string) {
 				if startVal, ok := extractRoundRobinStart(line); ok {
 					cfg.roundRobinStart[name] = startVal
 				}
-				// Capture aws-bedrock options (endpoint_url + region)
-				// at the top-level options depth. Provider filtering
-				// happens at emission time so a non-bedrock client
-				// using the same keys for an unrelated purpose can't
-				// leak into the runtime BedrockClientOptions map.
+				// Capture aws-bedrock options (endpoint_url, region,
+				// and credential selectors) at the top-level options
+				// depth. Provider filtering happens at emission time
+				// so a non-bedrock client using the same keys for an
+				// unrelated purpose can't leak into the runtime
+				// BedrockClientOptions map.
 				updateBedrockClientOption(cfg, name, line)
 			}
 			stripped := stripInlineComment(stripStringLiterals(line))
@@ -2578,11 +2581,13 @@ func generateBamlConfigVars(out *jen.File) {
 	out.Var().Id("RoundRobinCoordinator").Op("=").Qual("github.com/invakid404/baml-rest/bamlutils/buildrequest/roundrobin", "NewCoordinatorWithStarts").Call(jen.Id("RoundRobinStart"))
 
 	// BedrockOptionValue + BedrockClientOptions carry the parsed
-	// aws-bedrock client options (endpoint_url + region) that codegen
-	// reads at request-build time to override BAML v0.219's hardcoded
-	// modular Bedrock URL and pin SigV4 region. Resolution happens at
-	// runtime so env-var values reflect the worker's current
-	// environment rather than the build-time snapshot.
+	// aws-bedrock client options (endpoint_url, region, and the
+	// credential selectors access_key_id / secret_access_key /
+	// session_token / profile) that codegen reads at request-build
+	// time to override BAML v0.219's hardcoded modular Bedrock URL,
+	// pin SigV4 region, and select per-client credentials. Resolution
+	// happens at runtime so env-var values reflect the worker's
+	// current environment rather than the build-time snapshot.
 	emitBedrockOptionTypes(out)
 
 	// BedrockClientOptionsByName: keyed by client name; only aws-bedrock
@@ -2594,20 +2599,21 @@ func generateBamlConfigVars(out *jen.File) {
 	// Variable name disambiguates from the struct type
 	// `BedrockClientOptions`: Go's package namespace would otherwise
 	// reject `var BedrockClientOptions = map[string]BedrockClientOptions{}`.
-	out.Comment("BedrockClientOptionsByName maps aws-bedrock client names to their parsed endpoint_url + region options.")
-	out.Comment("Codegen looks up the resolved client name here at request-build time and dispatches to")
-	out.Comment("llmhttp.AttachBedrockAuthForClient with the resolved values.")
+	out.Comment("BedrockClientOptionsByName maps aws-bedrock client names to their parsed endpoint_url, region,")
+	out.Comment("and credential-selector options. Codegen looks up the resolved client name here at request-build")
+	out.Comment("time and dispatches to llmhttp.AttachBedrockAuthForClient with the resolved values.")
 	{
 		entries := make([]jen.Code, 0, len(cfg.bedrockClientOptions))
 		keys := make([]string, 0, len(cfg.bedrockClientOptions))
 		for k := range cfg.bedrockClientOptions {
 			// Provider filter: a non-bedrock client that happens to
-			// declare endpoint_url / region (a typo, a future
-			// provider sharing the key) must NOT leak into the runtime
-			// map — codegen looks up by client name and would wire
-			// AttachBedrockAuthForClient against a non-Bedrock URL,
-			// silently changing behaviour. Filtering here keeps the
-			// generated map honest.
+			// declare endpoint_url / region / credential keys (a typo,
+			// a future provider sharing a key name) must NOT leak into
+			// the runtime map — codegen looks up by client name and
+			// would wire AttachBedrockAuthForClient against a
+			// non-Bedrock URL, silently changing behaviour (and worse,
+			// pointing static AWS credentials at the wrong endpoint).
+			// Filtering here keeps the generated map honest.
 			if cfg.clientProvider[k] != "aws-bedrock" {
 				continue
 			}
@@ -2683,15 +2689,26 @@ func emitBedrockOptionTypes(out *jen.File) {
 		jen.Return(jen.Lit(""), jen.False()),
 	)
 
+	out.Comment("IsSet reports whether the field was declared in the .baml options block,")
+	out.Comment("irrespective of whether its value resolves to a non-empty string at runtime.")
+	out.Comment("Codegen uses IsSet to populate BedrockCredentialSelector presence flags so")
+	out.Comment("declared-but-env-unset credentials are still routed through the resolver's")
+	out.Comment("static-branch validation (where they fail with a client-scoped error) rather")
+	out.Comment("than silently falling through to the default AWS credential chain.")
+	out.Comment("Use Resolve for the value; IsSet for presence.")
+	out.Func().Params(jen.Id("v").Id("BedrockOptionValue")).Id("IsSet").Params().Bool().Block(
+		jen.Return(jen.Id("v").Dot("Provenance").Op("!=").Lit("")),
+	)
+
 	out.Comment("BedrockCredentialOptions groups the per-client aws-bedrock credential selectors parsed from .baml")
 	out.Comment("options (#254 item 2). Resolution precedence (applied by bamlutils/llmhttp.ResolveBedrockCredentials):")
 	out.Comment("  1. AccessKeyID + SecretAccessKey (+ optional SessionToken) -> static credentials.")
 	out.Comment("  2. Profile -> shared-config profile load.")
 	out.Comment("  3. Default chain (none of the above declared).")
 	out.Comment("")
-	out.Comment("SECURITY: literal values (e.g. secret_access_key \"AKIA...\") land in this generated file AND the")
-	out.Comment("compiled worker binary. That is BAML-parity behavior, documented as an operator footgun. Prefer")
-	out.Comment("env.X references for any secret material so values stay out of generated artifacts.")
+	out.Comment("SECURITY: literal credential values declared inline land in this generated file AND the compiled")
+	out.Comment("worker binary. That is BAML-parity behavior, documented as an operator footgun. Prefer env.X")
+	out.Comment("references for any secret material so values stay out of generated artifacts.")
 	out.Type().Id("BedrockCredentialOptions").Struct(
 		jen.Id("AccessKeyID").Id("BedrockOptionValue"),
 		jen.Id("SecretAccessKey").Id("BedrockOptionValue"),

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -1175,6 +1175,30 @@ type bamlConfig struct {
 type bedrockClientOptions struct {
 	EndpointURL bedrockOptionValue
 	Region      bedrockOptionValue
+	Credentials bedrockCredentialOptions
+}
+
+// bedrockCredentialOptions groups the per-client aws-bedrock credential
+// selectors (#254 item 2). Each field carries a literal-or-env
+// bedrockOptionValue resolved at request-build time. Provenance is
+// preserved so a generated literal stays a literal and an `env.X`
+// reference resolves against the worker's current environment.
+//
+// Resolution precedence (applied by bamlutils/llmhttp.ResolveBedrockCredentials):
+//  1. AccessKeyID + SecretAccessKey (+ optional SessionToken) → static.
+//  2. Profile → shared-config profile load.
+//  3. Default chain (none of the above declared).
+//
+// Security note: literal values declared inline (e.g.
+// `secret_access_key "AKIA..."`) land in generated introspected.go AND
+// the compiled worker binary — that is BAML-parity behavior, documented
+// as an operator footgun. Use `env.X` to keep secret material out of
+// generated artifacts.
+type bedrockCredentialOptions struct {
+	AccessKeyID     bedrockOptionValue
+	SecretAccessKey bedrockOptionValue
+	SessionToken    bedrockOptionValue
+	Profile         bedrockOptionValue
 }
 
 // bedrockOptionValue stores a single .baml option value with its
@@ -1480,6 +1504,9 @@ func isNestedBlockStart(line string) bool {
 // key-value statements. Sorted longest-first so that `max_delay_ms` is matched
 // before the embedded `delay_ms` substring.
 var bamlConfigKeys = []string{
+	"secret_access_key ",
+	"session_token ",
+	"access_key_id ",
 	"endpoint_url ",
 	"retry_policy ",
 	"max_delay_ms ",
@@ -1489,6 +1516,7 @@ var bamlConfigKeys = []string{
 	"provider ",
 	"delay_ms ",
 	"options ",
+	"profile ",
 	"client ",
 	"prompt ",
 	"region ",
@@ -1992,18 +2020,24 @@ func extractRoundRobinStart(line string) (int, bool) {
 	return 0, false
 }
 
-// updateBedrockClientOption extracts endpoint_url and region option
-// values from a single options-block line and merges them into the
-// per-client bedrockClientOptions entry. Each call is additive on the
-// keys actually present in `line`, so a multi-line options block whose
-// endpoint_url and region appear on separate lines accumulates both.
+// updateBedrockClientOption extracts the supported aws-bedrock option
+// values (endpoint_url, region, and the credential selectors
+// access_key_id / secret_access_key / session_token / profile) from a
+// single options-block line and merges them into the per-client
+// bedrockClientOptions entry. Each call is additive on the keys
+// actually present in `line`, so a multi-line options block whose
+// values appear on separate lines accumulates them.
 //
 // Provider filtering happens at emission, not here — see the
 // bedrockClientOptions field doc on bamlConfig for the rationale.
 func updateBedrockClientOption(cfg *bamlConfig, clientName, line string) {
 	endpoint, hasEndpoint := extractBedrockOptionValue(line, "endpoint_url")
 	region, hasRegion := extractBedrockOptionValue(line, "region")
-	if !hasEndpoint && !hasRegion {
+	accessKeyID, hasAccessKeyID := extractBedrockOptionValue(line, "access_key_id")
+	secretAccessKey, hasSecretAccessKey := extractBedrockOptionValue(line, "secret_access_key")
+	sessionToken, hasSessionToken := extractBedrockOptionValue(line, "session_token")
+	profile, hasProfile := extractBedrockOptionValue(line, "profile")
+	if !hasEndpoint && !hasRegion && !hasAccessKeyID && !hasSecretAccessKey && !hasSessionToken && !hasProfile {
 		return
 	}
 	cur := cfg.bedrockClientOptions[clientName]
@@ -2012,6 +2046,18 @@ func updateBedrockClientOption(cfg *bamlConfig, clientName, line string) {
 	}
 	if hasRegion {
 		cur.Region = region
+	}
+	if hasAccessKeyID {
+		cur.Credentials.AccessKeyID = accessKeyID
+	}
+	if hasSecretAccessKey {
+		cur.Credentials.SecretAccessKey = secretAccessKey
+	}
+	if hasSessionToken {
+		cur.Credentials.SessionToken = sessionToken
+	}
+	if hasProfile {
+		cur.Credentials.Profile = profile
 	}
 	cfg.bedrockClientOptions[clientName] = cur
 }
@@ -2573,6 +2619,12 @@ func generateBamlConfigVars(out *jen.File) {
 			entries = append(entries, jen.Lit(clientName).Op(":").Id("BedrockClientOptions").Values(jen.Dict{
 				jen.Id("EndpointURL"): bedrockOptionValueLit(opts.EndpointURL),
 				jen.Id("Region"):      bedrockOptionValueLit(opts.Region),
+				jen.Id("Credentials"): jen.Id("BedrockCredentialOptions").Values(jen.Dict{
+					jen.Id("AccessKeyID"):     bedrockOptionValueLit(opts.Credentials.AccessKeyID),
+					jen.Id("SecretAccessKey"): bedrockOptionValueLit(opts.Credentials.SecretAccessKey),
+					jen.Id("SessionToken"):    bedrockOptionValueLit(opts.Credentials.SessionToken),
+					jen.Id("Profile"):         bedrockOptionValueLit(opts.Credentials.Profile),
+				}),
 			}))
 		}
 		out.Var().Id("BedrockClientOptionsByName").Op("=").Map(jen.String()).Id("BedrockClientOptions").Values(entries...)
@@ -2631,6 +2683,22 @@ func emitBedrockOptionTypes(out *jen.File) {
 		jen.Return(jen.Lit(""), jen.False()),
 	)
 
+	out.Comment("BedrockCredentialOptions groups the per-client aws-bedrock credential selectors parsed from .baml")
+	out.Comment("options (#254 item 2). Resolution precedence (applied by bamlutils/llmhttp.ResolveBedrockCredentials):")
+	out.Comment("  1. AccessKeyID + SecretAccessKey (+ optional SessionToken) -> static credentials.")
+	out.Comment("  2. Profile -> shared-config profile load.")
+	out.Comment("  3. Default chain (none of the above declared).")
+	out.Comment("")
+	out.Comment("SECURITY: literal values (e.g. secret_access_key \"AKIA...\") land in this generated file AND the")
+	out.Comment("compiled worker binary. That is BAML-parity behavior, documented as an operator footgun. Prefer")
+	out.Comment("env.X references for any secret material so values stay out of generated artifacts.")
+	out.Type().Id("BedrockCredentialOptions").Struct(
+		jen.Id("AccessKeyID").Id("BedrockOptionValue"),
+		jen.Id("SecretAccessKey").Id("BedrockOptionValue"),
+		jen.Id("SessionToken").Id("BedrockOptionValue"),
+		jen.Id("Profile").Id("BedrockOptionValue"),
+	)
+
 	out.Comment("BedrockClientOptions carries the per-client aws-bedrock options that codegen needs at request-build time")
 	out.Comment("to override BAML's hardcoded modular Bedrock URL (BAML v0.219 hardcodes")
 	out.Comment("https://bedrock-runtime.<region>.amazonaws.com and the public Go HTTPRequest surface does not expose")
@@ -2638,5 +2706,6 @@ func emitBedrockOptionTypes(out *jen.File) {
 	out.Type().Id("BedrockClientOptions").Struct(
 		jen.Id("EndpointURL").Id("BedrockOptionValue"),
 		jen.Id("Region").Id("BedrockOptionValue"),
+		jen.Id("Credentials").Id("BedrockCredentialOptions"),
 	)
 }

--- a/introspected/introspected.go
+++ b/introspected/introspected.go
@@ -102,6 +102,22 @@ func (v BedrockOptionValue) Resolve() (string, bool) {
 	return "", false
 }
 
+// BedrockCredentialOptions groups the per-client aws-bedrock credential selectors parsed from .baml
+// options (#254 item 2). Resolution precedence (applied by bamlutils/llmhttp.ResolveBedrockCredentials):
+//  1. AccessKeyID + SecretAccessKey (+ optional SessionToken) -> static credentials.
+//  2. Profile -> shared-config profile load.
+//  3. Default chain (none of the above declared).
+//
+// SECURITY: literal values (e.g. secret_access_key "AKIA...") land in this generated file AND the
+// compiled worker binary. That is BAML-parity behavior, documented as an operator footgun. Prefer
+// env.X references for any secret material so values stay out of generated artifacts.
+type BedrockCredentialOptions struct {
+	AccessKeyID     BedrockOptionValue
+	SecretAccessKey BedrockOptionValue
+	SessionToken    BedrockOptionValue
+	Profile         BedrockOptionValue
+}
+
 // BedrockClientOptions carries the per-client aws-bedrock options that codegen needs at request-build time
 // to override BAML's hardcoded modular Bedrock URL (BAML v0.219 hardcodes
 // https://bedrock-runtime.<region>.amazonaws.com and the public Go HTTPRequest surface does not expose
@@ -109,6 +125,7 @@ func (v BedrockOptionValue) Resolve() (string, bool) {
 type BedrockClientOptions struct {
 	EndpointURL BedrockOptionValue
 	Region      BedrockOptionValue
+	Credentials BedrockCredentialOptions
 }
 
 // BedrockClientOptionsByName maps aws-bedrock client names to their parsed endpoint_url + region options.

--- a/introspected/introspected.go
+++ b/introspected/introspected.go
@@ -102,15 +102,26 @@ func (v BedrockOptionValue) Resolve() (string, bool) {
 	return "", false
 }
 
+// IsSet reports whether the field was declared in the .baml options block,
+// irrespective of whether its value resolves to a non-empty string at runtime.
+// Codegen uses IsSet to populate BedrockCredentialSelector presence flags so
+// declared-but-env-unset credentials are still routed through the resolver's
+// static-branch validation (where they fail with a client-scoped error) rather
+// than silently falling through to the default AWS credential chain.
+// Use Resolve for the value; IsSet for presence.
+func (v BedrockOptionValue) IsSet() bool {
+	return v.Provenance != ""
+}
+
 // BedrockCredentialOptions groups the per-client aws-bedrock credential selectors parsed from .baml
 // options (#254 item 2). Resolution precedence (applied by bamlutils/llmhttp.ResolveBedrockCredentials):
 //  1. AccessKeyID + SecretAccessKey (+ optional SessionToken) -> static credentials.
 //  2. Profile -> shared-config profile load.
 //  3. Default chain (none of the above declared).
 //
-// SECURITY: literal values (e.g. secret_access_key "AKIA...") land in this generated file AND the
-// compiled worker binary. That is BAML-parity behavior, documented as an operator footgun. Prefer
-// env.X references for any secret material so values stay out of generated artifacts.
+// SECURITY: literal credential values declared inline land in this generated file AND the compiled
+// worker binary. That is BAML-parity behavior, documented as an operator footgun. Prefer env.X
+// references for any secret material so values stay out of generated artifacts.
 type BedrockCredentialOptions struct {
 	AccessKeyID     BedrockOptionValue
 	SecretAccessKey BedrockOptionValue
@@ -128,9 +139,9 @@ type BedrockClientOptions struct {
 	Credentials BedrockCredentialOptions
 }
 
-// BedrockClientOptionsByName maps aws-bedrock client names to their parsed endpoint_url + region options.
-// Codegen looks up the resolved client name here at request-build time and dispatches to
-// llmhttp.AttachBedrockAuthForClient with the resolved values.
+// BedrockClientOptionsByName maps aws-bedrock client names to their parsed endpoint_url, region,
+// and credential-selector options. Codegen looks up the resolved client name here at request-build
+// time and dispatches to llmhttp.AttachBedrockAuthForClient with the resolved values.
 var BedrockClientOptionsByName = map[string]BedrockClientOptions{}
 
 // TypeBuilder type


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Implements `.baml`-declared static AWS credentials for `aws-bedrock`. Rides on the introspect-side options layer + `BedrockAuthOptions.Credentials` slot from #262. Closes `#254` item 2; umbrella tracker stays open for reasoning sig/redacted, tool-use streaming, and usage metadata.

Operators can now do:

```baml
client<llm> Bedrock {
  provider aws-bedrock
  options {
    access_key_id     env.AWS_ACCESS_KEY_ID
    secret_access_key env.AWS_SECRET_ACCESS_KEY
    session_token     env.AWS_SESSION_TOKEN  // optional
    profile           env.AWS_PROFILE
    region            "us-east-1"
  }
}
```

(literal values also supported — see security note).

## Resolution precedence

Matches BAML's own at `engine/baml-runtime/.../aws_client.rs:587-650`:
1. **Static** (`access_key_id` + `secret_access_key` + optional `session_token`) → `credentials.NewStaticCredentialsProvider`.
2. **Profile** → `config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile(name))`.
3. **Default chain** — unchanged from #262.

Static wins over profile when both configured. Default chain unchanged for clients without credential options.

## What's included

- `cmd/introspect` parser extension capturing `access_key_id`, `secret_access_key`, `session_token`, `profile` with literal-vs-`env.X` provenance.
- New nested `BedrockCredentialOptions` struct on `BedrockClientOptions`.
- `bamlutils/llmhttp.ResolveBedrockCredentials(ctx, clientName, sel)` applying the precedence above.
- `AttachBedrockAuthForClient` migrated to an options struct (`BedrockClientAuthOptions`) so future extensions don't keep growing the signature.
- Test matrix: parser/emission (8+ cases), resolver (7+ cases incl. invalid partial states), signing-end-to-end (static-vs-default sig divergence), full E2E call/stream through `httptest.NewServer`, security-pin test asserting errors never leak credential values.

## Security note

Literal `.baml` credentials are BAML-parity behavior — supported here for that reason. Literal values land in generated `introspected.go` and the compiled binary; the new `BedrockCredentialOptions` doc-comment flags this and recommends `env.X` as the safer form. No error path echoes credential values; logging hygiene preserved.

## What's NOT included (deferred to follow-ups under #254)

- Reasoning `signature` / `redactedContent` exposure (item 3).
- Tool-use streaming deltas (item 4).
- Usage metadata propagation (item 5).
- `AWS_DEFAULT_REGION` region fallback — flagged by scoping but separate scope from item 2; #262's region contract preserved as-is.

## Verification

- `go build ./...` / `go vet ./...` clean.
- `verify-framework-adapter`: 9/9. `verify-adapter-pins`: 4/4.
- `gofmt -l` clean on touched files.
- `go run ./cmd/embed && git status --porcelain` clean.

Refs #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bedrock authentication now accepts a single client auth options payload that includes endpoint, region, and per-field credential selectors (access key, secret, session token, profile); empty options fall back to the default AWS credential chain.

* **Tests**
  * Added extensive unit and end-to-end tests covering static credentials, profile loading, precedence, signing, and validation edge cases.

* **Documentation**
  * Introspection/config output now exposes credential selector fields and an IsSet() declaration-vs-resolve indicator; notes on inline-secret handling added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/263)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->