### PR TITLE
refactor(bamlparser): convert to idiomatic participle grammar (#265 PR 1.5)

### DIFF
--- a/bamlutils/bamlparser/ast.go
+++ b/bamlutils/bamlparser/ast.go
@@ -37,13 +37,17 @@ type Item struct {
 
 // GeneratorBlock corresponds to `generator Name { key value ... }`.
 //
-// The closing `}` is optional in the grammar to match the prior parser's
-// lenient handling of brace-missing inputs (an inline `// ... }` line
-// comment elides the closing brace because the comment lexer rule
-// consumes everything up to the next newline, including the trailing `}`).
+// Parsing is implemented via Parseable in bamlparser.go so the body
+// shares parseBlockFieldsUntilClose with Block — the prior declarative
+// `"{" @@* "}"?` grammar terminated the body at the first non-Ident
+// token, regressing the prior hand-rolled parser's "skip garbage,
+// keep parsing later fields" semantics. The closing `}` is also
+// optional to preserve lenient handling of brace-eating inline
+// comments (an inline `// ... }` consumes the trailing `}` because
+// the comment lexer rule runs to EOL/EOF).
 type GeneratorBlock struct {
-	Name   string   `"generator" @Ident`
-	Fields []*Field `( "{" @@* "}"? )?`
+	Name   string
+	Fields []*Field
 }
 
 // ClientBlock corresponds to `client[<type>] Name { key value ... }`.
@@ -76,12 +80,14 @@ type FunctionBlock struct {
 	Fields []*Field
 }
 
-// RetryPolicyBlock corresponds to `retry_policy Name { ... }`. The closing
-// `}` is optional for the same brace-eating-comment reason described on
-// GeneratorBlock.
+// RetryPolicyBlock corresponds to `retry_policy Name { ... }`.
+//
+// Parsing is implemented via Parseable in bamlparser.go so the body
+// shares parseBlockFieldsUntilClose with Block and GeneratorBlock for
+// the skip-garbage-token loop. See GeneratorBlock for the rationale.
 type RetryPolicyBlock struct {
-	Name   string   `"retry_policy" @Ident`
-	Fields []*Field `( "{" @@* "}"? )?`
+	Name   string
+	Fields []*Field
 }
 
 // TemplateBlock corresponds to `template_string Name(...) #"..."#` and the
@@ -128,15 +134,17 @@ type TypeAlias struct {
 // Other captures metadata for a top-level construct that doesn't match any
 // recognised declaration shape. Keyword is the leading token's value —
 // either the identifier text when the item began with a word, or the raw
-// token value when it began with punctuation. Any following balanced block
-// is consumed and not retained; Other is metadata-only so semantic walkers
-// can skip unknown declarations while preserving source order, mirroring
-// the line-by-line introspect parser's behaviour of ignoring any line
-// that isn't a known prefix.
+// token value when it began with punctuation. If the leading token is an
+// identifier AND the very next token is `{`, the balanced block that
+// follows is consumed and not retained. Punctuation-led tokens (a stray
+// `}`, `]`, `)`, `@`, etc.) consume just the single token so an unrelated
+// trailing block is not accidentally swallowed. Other is metadata-only so
+// semantic walkers can skip unknown declarations while preserving source
+// order, mirroring the line-by-line introspect parser's behaviour of
+// ignoring any line that isn't a known prefix.
 //
 // Parsing is implemented via Parseable in bamlparser.go because Other is
-// the catch-all alternative: it consumes one token plus, if immediately
-// followed by `{`, a balanced brace block, with no further structure.
+// the catch-all alternative.
 type Other struct {
 	Keyword string
 }

--- a/bamlutils/bamlparser/ast.go
+++ b/bamlutils/bamlparser/ast.go
@@ -167,8 +167,14 @@ type Field struct {
 // parse. Consumers that need a verbatim copy of an unknown block body
 // should read it directly from the source bytes; the AST is designed
 // around the recognised-shape contract.
+//
+// Parsing is implemented via Parseable in bamlparser.go because the
+// declarative `"{" @@* "}"?` form terminated the block early on the first
+// non-Ident token and let the rest of the block leak to the outer scope,
+// regressing the prior parser's "skip garbage, keep parsing later fields"
+// semantics.
 type Block struct {
-	Fields []*Field `"{" @@* "}"?`
+	Fields []*Field
 }
 
 // Value carries a parsed right-hand-side. Exactly one of the typed pointers

--- a/bamlutils/bamlparser/ast.go
+++ b/bamlutils/bamlparser/ast.go
@@ -5,7 +5,7 @@ package bamlparser
 // rest (Other items capture unknown or unsupported top-level shapes so the
 // parser tolerates the full upstream BAML surface without erroring).
 type File struct {
-	Items []*Item
+	Items []*Item `@@*`
 }
 
 // Item is a single top-level declaration. Exactly one of the typed pointers
@@ -20,21 +20,30 @@ type File struct {
 // → Other. Those nodes carry the declaration keyword/name only; the
 // brace body or expression right-hand-side is consumed during parsing
 // and not retained on the AST.
+//
+// The alternative order is load-bearing: keyword-shaped declarations are
+// tried first, with Other last as the catch-all so unknown punctuation /
+// stray identifiers don't get swallowed by a more specific arm.
 type Item struct {
-	Generator   *GeneratorBlock
-	Client      *ClientBlock
-	Function    *FunctionBlock
-	RetryPolicy *RetryPolicyBlock
-	Template    *TemplateBlock
-	TypeBlock   *TypeBlock
-	TypeAlias   *TypeAlias
-	Other       *Other
+	Generator   *GeneratorBlock   `  @@`
+	Client      *ClientBlock      `| @@`
+	Function    *FunctionBlock    `| @@`
+	RetryPolicy *RetryPolicyBlock `| @@`
+	Template    *TemplateBlock    `| @@`
+	TypeBlock   *TypeBlock        `| @@`
+	TypeAlias   *TypeAlias        `| @@`
+	Other       *Other            `| @@`
 }
 
 // GeneratorBlock corresponds to `generator Name { key value ... }`.
+//
+// The closing `}` is optional in the grammar to match the prior parser's
+// lenient handling of brace-missing inputs (an inline `// ... }` line
+// comment elides the closing brace because the comment lexer rule
+// consumes everything up to the next newline, including the trailing `}`).
 type GeneratorBlock struct {
-	Name   string
-	Fields []*Field
+	Name   string   `"generator" @Ident`
+	Fields []*Field `( "{" @@* "}"? )?`
 }
 
 // ClientBlock corresponds to `client[<type>] Name { key value ... }`.
@@ -43,6 +52,10 @@ type GeneratorBlock struct {
 // parameter. Preserving the raw form lets the introspect-side walker keep its
 // current client<llm>-only gate without losing the ability to see plain
 // `client Name { ... }` blocks for future widening.
+//
+// Grammar-tag form would force a public field reorder (the source order is
+// `client <TypeParam>? Name`, struct order is `Name, TypeParam, Fields`),
+// so the parsing is implemented via Parseable in bamlparser.go.
 type ClientBlock struct {
 	Name      string
 	TypeParam string
@@ -53,21 +66,33 @@ type ClientBlock struct {
 // declared name is preserved; the signature between the parentheses and the
 // return type are discarded by the parser because no downstream consumer in
 // baml-rest depends on them.
+//
+// Parsing is implemented via Parseable in bamlparser.go because grammar
+// tags cannot express the same-line `(` requirement that distinguishes
+// signed functions from unsigned function declarations (the latter drop
+// to Item.Other to match the introspect line-walker's posture).
 type FunctionBlock struct {
 	Name   string
 	Fields []*Field
 }
 
-// RetryPolicyBlock corresponds to `retry_policy Name { ... }`.
+// RetryPolicyBlock corresponds to `retry_policy Name { ... }`. The closing
+// `}` is optional for the same brace-eating-comment reason described on
+// GeneratorBlock.
 type RetryPolicyBlock struct {
-	Name   string
-	Fields []*Field
+	Name   string   `"retry_policy" @Ident`
+	Fields []*Field `( "{" @@* "}"? )?`
 }
 
 // TemplateBlock corresponds to `template_string Name(...) #"..."#` and the
 // `template_string Name { ... }` form. The body is intentionally not parsed;
 // callers either ignore TemplateBlock entirely (introspect's posture today)
 // or read Name for documentation/index purposes.
+//
+// Parsing is implemented via Parseable in bamlparser.go because the body
+// is discarded — there is no AST field to hold the parsed parameter list
+// or body — and the body alternates between a raw string token and a
+// balanced brace block.
 type TemplateBlock struct {
 	Name string
 }
@@ -79,6 +104,10 @@ type TemplateBlock struct {
 // differentiate; Name carries the declaration name. The brace body is
 // consumed during parsing and not retained; consumers that need a
 // verbatim copy must read the source bytes directly.
+//
+// Parsing is implemented via Parseable in bamlparser.go because the body
+// is discarded — there is no AST field to hold the captured fields, so
+// declarative tags cannot express the metadata-only contract.
 type TypeBlock struct {
 	Keyword string
 	Name    string
@@ -87,6 +116,11 @@ type TypeBlock struct {
 // TypeAlias corresponds to `type Name = expression`. Name carries the alias
 // name; the right-hand-side expression is consumed during parsing and not
 // retained on the AST.
+//
+// Parsing is implemented via Parseable in bamlparser.go: the right-hand
+// side is line-position-terminated (continues until the next line begins
+// with a top-level keyword), which grammar tags cannot express without
+// keeping newline tokens in the grammar.
 type TypeAlias struct {
 	Name string
 }
@@ -99,6 +133,10 @@ type TypeAlias struct {
 // can skip unknown declarations while preserving source order, mirroring
 // the line-by-line introspect parser's behaviour of ignoring any line
 // that isn't a known prefix.
+//
+// Parsing is implemented via Parseable in bamlparser.go because Other is
+// the catch-all alternative: it consumes one token plus, if immediately
+// followed by `{`, a balanced brace block, with no further structure.
 type Other struct {
 	Keyword string
 }
@@ -112,9 +150,9 @@ type Other struct {
 // The parser does not look up Key against a schema; it captures every key it
 // sees so the semantic walker can decide what to do per-block-type.
 type Field struct {
-	Key   string
-	Value *Value
-	Block *Block
+	Key   string `@Ident`
+	Value *Value `(   @@`
+	Block *Block `  | @@ )?`
 }
 
 // Block is a brace-delimited body containing zero or more fields. Fields are
@@ -130,7 +168,7 @@ type Field struct {
 // should read it directly from the source bytes; the AST is designed
 // around the recognised-shape contract.
 type Block struct {
-	Fields []*Field
+	Fields []*Field `"{" @@* "}"?`
 }
 
 // Value carries a parsed right-hand-side. Exactly one of the typed pointers
@@ -180,11 +218,16 @@ type Block struct {
 // Value.Map-vs-Field.Block for what is, in practice, the same shape.
 // Future consumers that need value-position map literals (e.g. on the
 // right-hand side of `=`) should extend Value rather than reshape Block.
+//
+// Grammar tags capture the raw token values (delimiters included); the
+// surrounding quotes / raw delimiters / `env.` prefix are stripped by
+// normalizeValue after participle returns so the AST contract matches
+// the prior hand-rolled parser byte-for-byte.
 type Value struct {
-	Literal *string
-	EnvRef  *string
-	Ident   *string
-	Number  *string
-	Raw     *string
-	List    []*Value
+	Literal *string  `  @String`
+	EnvRef  *string  `| @EnvRef`
+	Ident   *string  `| @Ident`
+	Number  *string  `| @Number`
+	Raw     *string  `| @RawString`
+	List    []*Value `| "[" ( @@ ","? )* "]"`
 }

--- a/bamlutils/bamlparser/bamlparser.go
+++ b/bamlutils/bamlparser/bamlparser.go
@@ -22,14 +22,16 @@
 // converting AST values to concrete config.
 //
 // Implementation: a participle-built parser drives the top-level grammar
-// declaratively via struct tags on the AST nodes; seven irregular shapes
-// (ClientBlock, FunctionBlock, TemplateBlock, TypeBlock, TypeAlias, Other,
-// Block) supply narrow Parseable hooks for behaviour that grammar tags
-// cannot express cleanly (field-order mismatch, same-line `(` requirement
-// after `function`, metadata-only body skipping, catch-all token
-// consumption, garbage-token-skip-inside-block). Post-parse normalisation
-// strips string / env-ref / raw-string delimiters so the AST contract
-// matches the prior hand-rolled parser byte-for-byte.
+// declaratively via struct tags on the AST nodes; nine irregular shapes
+// (GeneratorBlock, ClientBlock, FunctionBlock, RetryPolicyBlock,
+// TemplateBlock, TypeBlock, TypeAlias, Other, Block) supply narrow
+// Parseable hooks for behaviour that grammar tags cannot express cleanly
+// (field-order mismatch, same-line `(` requirement after `function`,
+// metadata-only body skipping, catch-all token consumption, and the
+// garbage-token-skip-inside-block loop that all four block-body-bearing
+// keyword nodes share via parseBlockFieldsUntilClose). Post-parse
+// normalisation strips string / env-ref / raw-string delimiters so the
+// AST contract matches the prior hand-rolled parser byte-for-byte.
 package bamlparser
 
 import (
@@ -156,6 +158,49 @@ func ParseFile(path string) (*File, error) {
 // -----------------------------------------------------------------------
 // Parseable hooks for the irregular nodes.
 // -----------------------------------------------------------------------
+
+// Parse implements participle.Parseable for GeneratorBlock. Matches the
+// literal `generator` token, the required name (Ident), and an optional
+// brace body whose fields are iterated via parseBlockFieldsUntilClose —
+// the same helper Block.Parse uses, so a top-level generator body
+// tolerates un-Field-shaped tokens with the same skip-and-continue
+// semantics. A pure `( "{" @@* "}"? )?` grammar terminated the body at
+// the first non-Ident token and leaked the rest to file scope.
+func (g *GeneratorBlock) Parse(lex *lexer.PeekingLexer) error {
+	if !peekIdentLiteral(lex, "generator") {
+		return participle.NextMatch
+	}
+	lex.Next() // consume "generator"
+
+	if t := lex.Peek(); t.Type == identType {
+		g.Name = lex.Next().Value
+	}
+	if peekPunct(lex, "{") {
+		lex.Next()
+		g.Fields = parseBlockFieldsUntilClose(lex)
+	}
+	return nil
+}
+
+// Parse implements participle.Parseable for RetryPolicyBlock. Mirrors
+// GeneratorBlock.Parse — body iteration goes through
+// parseBlockFieldsUntilClose so the skip-garbage-token semantics match
+// the prior parser exactly.
+func (r *RetryPolicyBlock) Parse(lex *lexer.PeekingLexer) error {
+	if !peekIdentLiteral(lex, "retry_policy") {
+		return participle.NextMatch
+	}
+	lex.Next() // consume "retry_policy"
+
+	if t := lex.Peek(); t.Type == identType {
+		r.Name = lex.Next().Value
+	}
+	if peekPunct(lex, "{") {
+		lex.Next()
+		r.Fields = parseBlockFieldsUntilClose(lex)
+	}
+	return nil
+}
 
 // Parse implements participle.Parseable for ClientBlock. The grammar order
 // is `client <TypeParam>? Name { Fields }`, but the struct's field order is
@@ -335,41 +380,57 @@ func (o *Other) Parse(lex *lexer.PeekingLexer) error {
 	return nil
 }
 
-// Parse implements participle.Parseable for Block. The block body is parsed
-// imperatively so the loop between fields can skip un-Field-shaped tokens
-// (matching the prior hand-rolled parseField's "advance one token, keep
-// looping" semantics). A purely declarative `"{" @@* "}"?` grammar would
-// terminate the block at the first non-Ident token and leak the rest of
-// the body to the outer scope — caught by Codex's sign-off on PR #270.
-//
-// Individual Field parsing stays declarative: each iteration delegates to
-// fieldSubParser, so the `@Ident (Value | Block)?` grammar lives on the
-// Field type itself. The loop's only responsibility is brace-bounded
-// iteration plus garbage-token skip.
-//
-// Missing-close-brace handling matches the prior parser: reaching EOF
-// before `}` is not an error (the explicit brace-eating-comment fixture
-// and bare-`{ key value` cases both depend on this).
+// Parse implements participle.Parseable for Block. Matches the opening
+// `{`, delegates body iteration to parseBlockFieldsUntilClose, and returns
+// NextMatch when the next token isn't `{` so the outer alternation can try
+// other arms. Block.Parse itself is intentionally thin: all the
+// skip-garbage-token semantics live in the shared helper so GeneratorBlock
+// and RetryPolicyBlock get the same behaviour for their top-level bodies.
 func (b *Block) Parse(lex *lexer.PeekingLexer) error {
 	if !peekPunct(lex, "{") {
 		return participle.NextMatch
 	}
 	lex.Next() // consume "{"
+	b.Fields = parseBlockFieldsUntilClose(lex)
+	return nil
+}
+
+// parseBlockFieldsUntilClose iterates field declarations from inside an
+// already-opened brace body until it reaches the matching `}` or EOF.
+// Mirrors the prior hand-rolled parseField's "advance one token, keep
+// looping" tolerance for un-Field-shaped tokens — a purely declarative
+// `@@* "}"?` grammar terminated the block at the first non-Ident token
+// and leaked the rest of the body to the outer scope (caught by Codex
+// across both rounds of PR #270 sign-off).
+//
+// Behaviour invariants preserved from the prior parser:
+//
+//   - At the matching `}`: consume it and return.
+//   - At EOF before `}`: return cleanly without erroring. The explicit
+//     brace-eating-comment fixture and the bare-`{ key value` case both
+//     rely on this.
+//   - Each iteration delegates Field parsing to fieldSubParser so the
+//     `@Ident (Value | Block)?` grammar stays declarative on the Field
+//     type itself. On Field-NextMatch (un-Field-shaped position), the
+//     lexer is rolled back to the pre-attempt checkpoint (so partial
+//     consumption doesn't compound with the one-token advance) and the
+//     loop advances one token before retrying.
+//
+// The caller is expected to have already consumed the opening `{`.
+func parseBlockFieldsUntilClose(lex *lexer.PeekingLexer) []*Field {
+	var fields []*Field
 	for {
 		t := lex.Peek()
 		if t.EOF() {
-			return nil
+			return fields
 		}
 		if isPunctTok(t, "}") {
 			lex.Next()
-			return nil
+			return fields
 		}
 		cp := lex.MakeCheckpoint()
 		f, err := fieldSubParser.ParseFromLexer(lex, participle.AllowTrailing(true))
 		if err != nil || f == nil {
-			// Field didn't match here; restore lex to its pre-attempt
-			// position so the sub-parser's partial consumption (if any)
-			// doesn't compound with the one-token advance below.
 			lex.LoadCheckpoint(cp)
 			lex.Next()
 			continue
@@ -380,7 +441,7 @@ func (b *Block) Parse(lex *lexer.PeekingLexer) error {
 			lex.Next()
 			continue
 		}
-		b.Fields = append(b.Fields, f)
+		fields = append(fields, f)
 	}
 }
 

--- a/bamlutils/bamlparser/bamlparser.go
+++ b/bamlutils/bamlparser/bamlparser.go
@@ -80,9 +80,13 @@ var bamlLexer = lexer.MustSimple([]lexer.SimpleRule{
 })
 
 // bamlParser is the participle-built parser that drives the File grammar.
-// Grammar tags on File / Item / GeneratorBlock / RetryPolicyBlock / Block /
-// Field / Value declare the parts of the surface participle can handle
-// directly; the Parseable hooks defined below cover the rest.
+// Grammar tags on File, Item, Field, and Value declare the parts of the
+// surface participle can handle directly. Body-bearing block types
+// (Block, GeneratorBlock, RetryPolicyBlock, ClientBlock, FunctionBlock,
+// TemplateBlock, TypeBlock, TypeAlias, Other) are Parseable hooks
+// instead, because field-body iteration needs to leniently skip
+// un-Field-shaped tokens and metadata-only nodes need balanced-skip
+// over content the grammar otherwise can't express.
 var bamlParser = participle.MustBuild[File](
 	participle.Lexer(bamlLexer),
 	participle.Elide(tokComment, tokWS),
@@ -92,8 +96,10 @@ var bamlParser = participle.MustBuild[File](
 // ClientBlock and FunctionBlock delegate brace-body parsing to this
 // sub-parser, which in turn invokes Block.Parse (since Block is itself
 // Parseable). The indirection keeps brace-body parsing routed through a
-// single Block.Parse implementation regardless of whether the body is
-// being parsed from a top-level keyword block or a nested Field.Block.
+// single Block.Parse implementation for client/function/nested-Field
+// bodies. GeneratorBlock and RetryPolicyBlock call parseBlockFieldsUntilClose
+// directly rather than going through blockSubParser — both routes converge
+// on the same skip-garbage helper regardless.
 var blockSubParser = participle.MustBuild[Block](
 	participle.Lexer(bamlLexer),
 	participle.Elide(tokComment, tokWS),

--- a/bamlutils/bamlparser/bamlparser.go
+++ b/bamlutils/bamlparser/bamlparser.go
@@ -22,13 +22,14 @@
 // converting AST values to concrete config.
 //
 // Implementation: a participle-built parser drives the top-level grammar
-// declaratively via struct tags on the AST nodes; five irregular shapes
-// (ClientBlock, FunctionBlock, TemplateBlock, TypeBlock, TypeAlias, Other)
-// supply narrow Parseable hooks for behaviour that grammar tags cannot
-// express cleanly (field-order mismatch, same-line `(` requirement after
-// `function`, metadata-only body skipping, catch-all token consumption).
-// Post-parse normalisation strips string / env-ref / raw-string delimiters
-// so the AST contract matches the prior hand-rolled parser byte-for-byte.
+// declaratively via struct tags on the AST nodes; seven irregular shapes
+// (ClientBlock, FunctionBlock, TemplateBlock, TypeBlock, TypeAlias, Other,
+// Block) supply narrow Parseable hooks for behaviour that grammar tags
+// cannot express cleanly (field-order mismatch, same-line `(` requirement
+// after `function`, metadata-only body skipping, catch-all token
+// consumption, garbage-token-skip-inside-block). Post-parse normalisation
+// strips string / env-ref / raw-string delimiters so the AST contract
+// matches the prior hand-rolled parser byte-for-byte.
 package bamlparser
 
 import (
@@ -87,10 +88,23 @@ var bamlParser = participle.MustBuild[File](
 
 // blockSubParser parses just a Block body. The Parseable hooks for
 // ClientBlock and FunctionBlock delegate brace-body parsing to this
-// sub-parser so the inside-block grammar stays declarative (defined on
-// Block / Field / Value via struct tags) without duplicating its
-// implementation inside the custom Parse methods.
+// sub-parser, which in turn invokes Block.Parse (since Block is itself
+// Parseable). The indirection keeps brace-body parsing routed through a
+// single Block.Parse implementation regardless of whether the body is
+// being parsed from a top-level keyword block or a nested Field.Block.
 var blockSubParser = participle.MustBuild[Block](
+	participle.Lexer(bamlLexer),
+	participle.Elide(tokComment, tokWS),
+)
+
+// fieldSubParser parses a single Field. Block.Parse uses it to consume one
+// Field at a time so the inside-block grammar (`Field = @Ident (Value |
+// Block)?` on the AST type) stays declarative, while Block.Parse retains
+// imperative control over what happens between fields — specifically, the
+// "skip an un-Field-shaped token and keep going" behaviour that the prior
+// hand-rolled parser provided and that the previous declarative `@@*`
+// grammar lost.
+var fieldSubParser = participle.MustBuild[Field](
 	participle.Lexer(bamlLexer),
 	participle.Elide(tokComment, tokWS),
 )
@@ -303,8 +317,11 @@ func (ta *TypeAlias) Parse(lex *lexer.PeekingLexer) error {
 
 // Parse implements participle.Parseable for Other, the catch-all alternative.
 // Consumes exactly one token (capturing its value as Keyword) and, if the
-// next token is `{`, the balanced body that follows. Returns NextMatch at
-// EOF so the outer Items repetition terminates cleanly.
+// leading token is an identifier and is immediately followed by `{`, the
+// balanced block body that follows. Punctuation-led Others consume just the
+// single token — matching the prior parser's behaviour so a stray `}` does
+// not gobble a subsequent valid block. Returns NextMatch at EOF so the
+// outer Items repetition terminates cleanly.
 func (o *Other) Parse(lex *lexer.PeekingLexer) error {
 	t := lex.Peek()
 	if t.EOF() {
@@ -312,13 +329,59 @@ func (o *Other) Parse(lex *lexer.PeekingLexer) error {
 	}
 	tok := lex.Next()
 	o.Keyword = tok.Value
-	// Only Ident-led items trigger balanced-block skipping, mirroring the
-	// prior parser's behaviour: punctuation-led Others consume just the
-	// single token so a stray `}` doesn't gobble a subsequent valid block.
 	if tok.Type == identType && peekPunct(lex, "{") {
 		skipBalanced(lex, "{", "}")
 	}
 	return nil
+}
+
+// Parse implements participle.Parseable for Block. The block body is parsed
+// imperatively so the loop between fields can skip un-Field-shaped tokens
+// (matching the prior hand-rolled parseField's "advance one token, keep
+// looping" semantics). A purely declarative `"{" @@* "}"?` grammar would
+// terminate the block at the first non-Ident token and leak the rest of
+// the body to the outer scope — caught by Codex's sign-off on PR #270.
+//
+// Individual Field parsing stays declarative: each iteration delegates to
+// fieldSubParser, so the `@Ident (Value | Block)?` grammar lives on the
+// Field type itself. The loop's only responsibility is brace-bounded
+// iteration plus garbage-token skip.
+//
+// Missing-close-brace handling matches the prior parser: reaching EOF
+// before `}` is not an error (the explicit brace-eating-comment fixture
+// and bare-`{ key value` cases both depend on this).
+func (b *Block) Parse(lex *lexer.PeekingLexer) error {
+	if !peekPunct(lex, "{") {
+		return participle.NextMatch
+	}
+	lex.Next() // consume "{"
+	for {
+		t := lex.Peek()
+		if t.EOF() {
+			return nil
+		}
+		if isPunctTok(t, "}") {
+			lex.Next()
+			return nil
+		}
+		cp := lex.MakeCheckpoint()
+		f, err := fieldSubParser.ParseFromLexer(lex, participle.AllowTrailing(true))
+		if err != nil || f == nil {
+			// Field didn't match here; restore lex to its pre-attempt
+			// position so the sub-parser's partial consumption (if any)
+			// doesn't compound with the one-token advance below.
+			lex.LoadCheckpoint(cp)
+			lex.Next()
+			continue
+		}
+		// Defensive against a degenerate sub-parser success that
+		// consumed nothing — would otherwise infinite-loop.
+		if lex.RawCursor() == cp.RawCursor() {
+			lex.Next()
+			continue
+		}
+		b.Fields = append(b.Fields, f)
+	}
 }
 
 // -----------------------------------------------------------------------

--- a/bamlutils/bamlparser/bamlparser.go
+++ b/bamlutils/bamlparser/bamlparser.go
@@ -20,17 +20,28 @@
 // stripped but no escape processing is applied, mirroring the existing
 // introspect helpers; semantic consumers apply their own normalisation when
 // converting AST values to concrete config.
+//
+// Implementation: a participle-built parser drives the top-level grammar
+// declaratively via struct tags on the AST nodes; five irregular shapes
+// (ClientBlock, FunctionBlock, TemplateBlock, TypeBlock, TypeAlias, Other)
+// supply narrow Parseable hooks for behaviour that grammar tags cannot
+// express cleanly (field-order mismatch, same-line `(` requirement after
+// `function`, metadata-only body skipping, catch-all token consumption).
+// Post-parse normalisation strips string / env-ref / raw-string delimiters
+// so the AST contract matches the prior hand-rolled parser byte-for-byte.
 package bamlparser
 
 import (
 	"io"
 	"os"
+	"strings"
 
+	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
 )
 
 // Token kinds emitted by the lexer. Comment and Whitespace tokens are
-// produced for completeness and filtered out by the parser before grammar
+// produced for completeness and elided by the parser before grammar
 // dispatch — keeping them in the lexer rules preserves position information
 // for tokens that follow them.
 const (
@@ -65,15 +76,43 @@ var bamlLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: tokOther, Pattern: `.`},
 })
 
+// bamlParser is the participle-built parser that drives the File grammar.
+// Grammar tags on File / Item / GeneratorBlock / RetryPolicyBlock / Block /
+// Field / Value declare the parts of the surface participle can handle
+// directly; the Parseable hooks defined below cover the rest.
+var bamlParser = participle.MustBuild[File](
+	participle.Lexer(bamlLexer),
+	participle.Elide(tokComment, tokWS),
+)
+
+// blockSubParser parses just a Block body. The Parseable hooks for
+// ClientBlock and FunctionBlock delegate brace-body parsing to this
+// sub-parser so the inside-block grammar stays declarative (defined on
+// Block / Field / Value via struct tags) without duplicating its
+// implementation inside the custom Parse methods.
+var blockSubParser = participle.MustBuild[Block](
+	participle.Lexer(bamlLexer),
+	participle.Elide(tokComment, tokWS),
+)
+
+// identType / punctType / rawStringType cache the token type IDs for the
+// kinds the Parseable hooks inspect. Looked up once at init via the lexer's
+// Symbols() table.
+var (
+	identType     = bamlLexer.Symbols()[tokIdent]
+	punctType     = bamlLexer.Symbols()[tokPunct]
+	rawStringType = bamlLexer.Symbols()[tokRawString]
+)
+
 // ParseBytes parses a .baml document from a byte slice. filename is used for
 // error messages only — it does not need to refer to an existing file.
 func ParseBytes(filename string, data []byte) (*File, error) {
-	tokens, err := tokenize(filename, data)
+	f, err := bamlParser.ParseBytes(filename, data)
 	if err != nil {
 		return nil, err
 	}
-	p := &parser{tokens: tokens}
-	return p.parseFile()
+	normalizeFile(f)
+	return f, nil
 }
 
 // ParseString is a convenience wrapper around ParseBytes.
@@ -100,257 +139,243 @@ func ParseFile(path string) (*File, error) {
 	return ParseBytes(path, data)
 }
 
-// tokenize runs the lexer and returns a slice of significant tokens
-// (comments and whitespace dropped). Position information is preserved on
-// each token via the participle lexer.Token Pos field; the parser uses
-// Pos.Line to detect line boundaries when skipping type aliases.
-func tokenize(filename string, data []byte) ([]lexer.Token, error) {
-	def, err := bamlLexer.LexString(filename, string(data))
-	if err != nil {
-		return nil, err
+// -----------------------------------------------------------------------
+// Parseable hooks for the irregular nodes.
+// -----------------------------------------------------------------------
+
+// Parse implements participle.Parseable for ClientBlock. The grammar order
+// is `client <TypeParam>? Name { Fields }`, but the struct's field order is
+// `Name, TypeParam, Fields`; pure grammar tags would force a public field
+// reorder. The hook matches the literal `client` token, the optional
+// `< Ident >` type parameter, the required name, and an optional brace
+// body parsed via blockSubParser.
+func (c *ClientBlock) Parse(lex *lexer.PeekingLexer) error {
+	if !peekIdentLiteral(lex, "client") {
+		return participle.NextMatch
 	}
-	var out []lexer.Token
-	for {
-		tok, err := def.Next()
-		if err != nil {
-			return nil, err
+	lex.Next() // consume "client"
+
+	if peekPunct(lex, "<") {
+		lex.Next()
+		if t := lex.Peek(); t.Type == identType {
+			c.TypeParam = lex.Next().Value
 		}
-		if tok.EOF() {
-			out = append(out, tok)
+		if peekPunct(lex, ">") {
+			lex.Next()
+		}
+	}
+
+	if t := lex.Peek(); t.Type == identType {
+		c.Name = lex.Next().Value
+	}
+
+	if peekPunct(lex, "{") {
+		blk, err := blockSubParser.ParseFromLexer(lex, participle.AllowTrailing(true))
+		if err != nil {
+			return err
+		}
+		c.Fields = blk.Fields
+	}
+	return nil
+}
+
+// Parse implements participle.Parseable for FunctionBlock. Mirrors the prior
+// hand-rolled parser's same-line `(` requirement: a function declaration
+// captured as FunctionBlock must have `(` on the same source line as the
+// `function` keyword. Declarations missing the parenthesised signature drop
+// to Item.Other (this hook returns NextMatch so the catch-all consumes the
+// keyword + balanced body), matching the introspect line-walker's posture.
+func (fn *FunctionBlock) Parse(lex *lexer.PeekingLexer) error {
+	if !peekIdentLiteral(lex, "function") {
+		return participle.NextMatch
+	}
+	functionTok := lex.Next() // consume "function"
+
+	name := ""
+	if t := lex.Peek(); t.Type == identType {
+		name = lex.Next().Value
+	}
+
+	// Scan tokens up to (but not consuming) the opening `{` or EOF,
+	// recording whether `(` appeared on the same source line as the
+	// `function` keyword.
+	sawParenSameLine := false
+	for {
+		t := lex.Peek()
+		if t.EOF() || isPunctTok(t, "{") {
 			break
 		}
-		switch tok.Type {
-		case bamlLexer.Symbols()[tokComment],
-			bamlLexer.Symbols()[tokWS]:
-			continue
-		}
-		out = append(out, tok)
-	}
-	return out, nil
-}
-
-// parser is a hand-rolled walker over the token stream produced by the
-// participle lexer. Hand-rolling the walker (rather than expressing the full
-// grammar in participle struct tags) keeps the permissive-skip behaviour for
-// unknown top-level constructs simple — participle's strict alternation
-// would require modelling every upstream BAML shape to avoid parse errors.
-type parser struct {
-	tokens []lexer.Token
-	pos    int
-}
-
-func (p *parser) peek() lexer.Token { return p.tokens[p.pos] }
-func (p *parser) advance() lexer.Token {
-	t := p.tokens[p.pos]
-	if !t.EOF() {
-		p.pos++
-	}
-	return t
-}
-func (p *parser) eof() bool { return p.peek().EOF() }
-
-func (p *parser) typeOf(name string) lexer.TokenType {
-	return bamlLexer.Symbols()[name]
-}
-
-func (p *parser) isPunct(t lexer.Token, ch string) bool {
-	return t.Type == p.typeOf(tokPunct) && t.Value == ch
-}
-
-func (p *parser) parseFile() (*File, error) {
-	file := &File{}
-	for !p.eof() {
-		item, err := p.parseTopLevelItem()
-		if err != nil {
-			return nil, err
-		}
-		if item != nil {
-			file.Items = append(file.Items, item)
-		}
-	}
-	return file, nil
-}
-
-// parseTopLevelItem dispatches based on the first identifier of a top-level
-// declaration. Any non-identifier first token (a stray `}` from a malformed
-// file, raw punctuation at file scope) is consumed as an Other so the
-// parser never gets stuck.
-func (p *parser) parseTopLevelItem() (*Item, error) {
-	tok := p.peek()
-	if tok.EOF() {
-		return nil, nil
-	}
-	if tok.Type != p.typeOf(tokIdent) {
-		// Unknown leading token at file scope: consume it and emit
-		// Other so the walker advances. Real BAML never produces this
-		// shape, but a future syntax extension might.
-		p.advance()
-		return &Item{Other: &Other{Keyword: tok.Value}}, nil
-	}
-	keyword := tok.Value
-	switch keyword {
-	case "generator":
-		return p.parseGeneratorItem()
-	case "client":
-		return p.parseClientItem()
-	case "function":
-		return p.parseFunctionItem()
-	case "retry_policy":
-		return p.parseRetryPolicyItem()
-	case "template_string":
-		return p.parseTemplateItem()
-	case "class", "enum", "test":
-		return p.parseTypeBlockItem()
-	case "type":
-		return p.parseTypeAliasItem()
-	default:
-		// Permissive: unknown top-level identifier. Skip a balanced
-		// block if one follows, otherwise scan to the next top-level
-		// boundary so we don't loop.
-		p.advance()
-		p.skipBalancedBlockIfPresent()
-		return &Item{Other: &Other{Keyword: keyword}}, nil
-	}
-}
-
-func (p *parser) parseGeneratorItem() (*Item, error) {
-	p.advance() // consume "generator"
-	name := p.expectIdentValue()
-	fields, err := p.parseBlockBody()
-	if err != nil {
-		return nil, err
-	}
-	return &Item{Generator: &GeneratorBlock{Name: name, Fields: fields}}, nil
-}
-
-func (p *parser) parseClientItem() (*Item, error) {
-	p.advance() // consume "client"
-	typeParam := ""
-	// Optional type parameter: <ident>
-	if p.isPunct(p.peek(), "<") {
-		p.advance()
-		if p.peek().Type == p.typeOf(tokIdent) {
-			typeParam = p.advance().Value
-		}
-		if p.isPunct(p.peek(), ">") {
-			p.advance()
-		}
-	}
-	name := p.expectIdentValue()
-	fields, err := p.parseBlockBody()
-	if err != nil {
-		return nil, err
-	}
-	return &Item{Client: &ClientBlock{Name: name, TypeParam: typeParam, Fields: fields}}, nil
-}
-
-// parseFunctionItem captures the function name and the body. The signature
-// (parameter list and return type) between the function name and the body's
-// opening brace is consumed without recording: no downstream consumer in
-// baml-rest reads it.
-//
-// A function declaration must contain `(` on the same line as the leading
-// `function` keyword for the block to be captured — declarations missing a
-// parameter list are skipped (the body is consumed opaquely) so the parser
-// stays bug-for-bug compatible with the introspect line-walker's
-// extractFunctionName helper, which only recognises a function name when
-// the parenthesis appears on the same source line.
-func (p *parser) parseFunctionItem() (*Item, error) {
-	functionTok := p.advance() // consume "function"
-	name := p.expectIdentValue()
-	sawParenSameLine := false
-	for !p.eof() && !p.isPunct(p.peek(), "{") {
-		t := p.peek()
-		if t.Pos.Line == functionTok.Pos.Line && p.isPunct(t, "(") {
+		if isPunctTok(t, "(") && t.Pos.Line == functionTok.Pos.Line {
 			sawParenSameLine = true
 		}
-		p.advance()
+		lex.Next()
 	}
 	if name == "" || !sawParenSameLine {
-		p.skipBalancedBlockIfPresent()
-		return &Item{Other: &Other{Keyword: "function"}}, nil
+		// Unsigned function declaration: return NextMatch so Item.Other
+		// catches the leading `function` token and any following balanced
+		// body. The branch's lexer state is discarded by participle.
+		return participle.NextMatch
 	}
-	fields, err := p.parseBlockBody()
-	if err != nil {
-		return nil, err
+
+	if peekPunct(lex, "{") {
+		blk, err := blockSubParser.ParseFromLexer(lex, participle.AllowTrailing(true))
+		if err != nil {
+			return err
+		}
+		fn.Fields = blk.Fields
 	}
-	return &Item{Function: &FunctionBlock{Name: name, Fields: fields}}, nil
+	fn.Name = name
+	return nil
 }
 
-func (p *parser) parseRetryPolicyItem() (*Item, error) {
-	p.advance() // consume "retry_policy"
-	name := p.expectIdentValue()
-	fields, err := p.parseBlockBody()
-	if err != nil {
-		return nil, err
+// Parse implements participle.Parseable for TemplateBlock. Matches
+// `template_string Name? (params)? ( #"..."# | { ... } )`. The body is
+// metadata-only: only Name is retained.
+func (tb *TemplateBlock) Parse(lex *lexer.PeekingLexer) error {
+	if !peekIdentLiteral(lex, "template_string") {
+		return participle.NextMatch
 	}
-	return &Item{RetryPolicy: &RetryPolicyBlock{Name: name, Fields: fields}}, nil
+	lex.Next() // consume "template_string"
+
+	if t := lex.Peek(); t.Type == identType {
+		tb.Name = lex.Next().Value
+	}
+	if peekPunct(lex, "(") {
+		skipBalanced(lex, "(", ")")
+	}
+	if t := lex.Peek(); t.Type == rawStringType {
+		lex.Next()
+	} else if peekPunct(lex, "{") {
+		skipBalanced(lex, "{", "}")
+	}
+	return nil
 }
 
-// parseTemplateItem captures the template's name; its body is intentionally
-// not parsed — the body is either a raw-string expression
-// (`template_string Name(args) #"..."#`) or a block with arbitrary content
-// that no introspect consumer reads.
-func (p *parser) parseTemplateItem() (*Item, error) {
-	p.advance() // consume "template_string"
-	name := ""
-	if p.peek().Type == p.typeOf(tokIdent) {
-		name = p.advance().Value
+// Parse implements participle.Parseable for TypeBlock. Matches
+// `(class | enum | test) Name? { ... }`. The body is discarded.
+func (tb *TypeBlock) Parse(lex *lexer.PeekingLexer) error {
+	t := lex.Peek()
+	if t.EOF() || t.Type != identType {
+		return participle.NextMatch
 	}
-	// Skip the optional parameter list `(...)`.
-	if p.isPunct(p.peek(), "(") {
-		p.skipBalanced("(", ")")
+	switch t.Value {
+	case "class", "enum", "test":
+	default:
+		return participle.NextMatch
 	}
-	// The body is either a raw string token (no braces) or a block.
-	if p.peek().Type == p.typeOf(tokRawString) {
-		p.advance()
-	} else if p.isPunct(p.peek(), "{") {
-		p.skipBalanced("{", "}")
+	tb.Keyword = lex.Next().Value
+
+	if t := lex.Peek(); t.Type == identType {
+		tb.Name = lex.Next().Value
 	}
-	return &Item{Template: &TemplateBlock{Name: name}}, nil
+	if peekPunct(lex, "{") {
+		skipBalanced(lex, "{", "}")
+	}
+	return nil
 }
 
-// parseTypeBlockItem captures `class Name { ... }`, `enum Name { ... }` and
-// `test Name { ... }`. The body is skipped — no introspect-side consumer
-// reads class/enum/test fields.
-func (p *parser) parseTypeBlockItem() (*Item, error) {
-	keyword := p.advance().Value
-	name := ""
-	if p.peek().Type == p.typeOf(tokIdent) {
-		name = p.advance().Value
+// Parse implements participle.Parseable for TypeAlias. Matches
+// `type Name? <rhs...>` where the right-hand side runs until EOF or the
+// first top-level keyword on a later line — mirroring the prior parser's
+// line-position-terminated alias scan exactly.
+func (ta *TypeAlias) Parse(lex *lexer.PeekingLexer) error {
+	if !peekIdentLiteral(lex, "type") {
+		return participle.NextMatch
 	}
-	if p.isPunct(p.peek(), "{") {
-		p.skipBalanced("{", "}")
-	}
-	return &Item{TypeBlock: &TypeBlock{Keyword: keyword, Name: name}}, nil
-}
+	startTok := lex.Next() // consume "type"
+	startLine := startTok.Pos.Line
 
-// parseTypeAliasItem captures `type Name = expression`. Type aliases have no
-// trailing braces; they're newline-terminated by convention. Skip to the
-// start of the next line that begins a top-level construct so we don't
-// over-consume the rest of the file.
-func (p *parser) parseTypeAliasItem() (*Item, error) {
-	startLine := p.peek().Pos.Line
-	p.advance() // consume "type"
-	name := ""
-	if p.peek().Type == p.typeOf(tokIdent) {
-		name = p.advance().Value
+	if t := lex.Peek(); t.Type == identType {
+		ta.Name = lex.Next().Value
 	}
-	// Consume the `=` and the expression that follows. The expression
-	// continues until the next top-level identifier on a new line OR
-	// end-of-file. Identifiers like `int`, `string`, `map`, etc. inside
-	// the expression do not trigger a top-level boundary because they
-	// stay on the same line as the `=`.
-	for !p.eof() {
-		t := p.peek()
-		if t.Pos.Line != startLine && t.Type == p.typeOf(tokIdent) && isTopLevelKeyword(t.Value) {
+	for {
+		t := lex.Peek()
+		if t.EOF() {
 			break
 		}
-		p.advance()
+		if t.Pos.Line != startLine && t.Type == identType && isTopLevelKeyword(t.Value) {
+			break
+		}
+		lex.Next()
 	}
-	return &Item{TypeAlias: &TypeAlias{Name: name}}, nil
+	return nil
 }
 
+// Parse implements participle.Parseable for Other, the catch-all alternative.
+// Consumes exactly one token (capturing its value as Keyword) and, if the
+// next token is `{`, the balanced body that follows. Returns NextMatch at
+// EOF so the outer Items repetition terminates cleanly.
+func (o *Other) Parse(lex *lexer.PeekingLexer) error {
+	t := lex.Peek()
+	if t.EOF() {
+		return participle.NextMatch
+	}
+	tok := lex.Next()
+	o.Keyword = tok.Value
+	// Only Ident-led items trigger balanced-block skipping, mirroring the
+	// prior parser's behaviour: punctuation-led Others consume just the
+	// single token so a stray `}` doesn't gobble a subsequent valid block.
+	if tok.Type == identType && peekPunct(lex, "{") {
+		skipBalanced(lex, "{", "}")
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------
+// Helpers shared by Parseable hooks.
+// -----------------------------------------------------------------------
+
+// peekIdentLiteral reports whether the next non-elided token is an Ident
+// with the given value. Returns false at EOF.
+func peekIdentLiteral(lex *lexer.PeekingLexer, value string) bool {
+	t := lex.Peek()
+	if t.EOF() {
+		return false
+	}
+	return t.Type == identType && t.Value == value
+}
+
+// peekPunct reports whether the next non-elided token is a Punct with the
+// given value. Returns false at EOF.
+func peekPunct(lex *lexer.PeekingLexer, value string) bool {
+	t := lex.Peek()
+	if t.EOF() {
+		return false
+	}
+	return isPunctTok(t, value)
+}
+
+// isPunctTok reports whether t is a Punct token with the given value.
+func isPunctTok(t *lexer.Token, value string) bool {
+	return t.Type == punctType && t.Value == value
+}
+
+// skipBalanced consumes the opener token at the lexer's current position
+// (which must match open) and then advances until the matching close token
+// is consumed, tracking brace depth. No-op when the next token is not the
+// opener.
+func skipBalanced(lex *lexer.PeekingLexer, open, close string) {
+	if !peekPunct(lex, open) {
+		return
+	}
+	lex.Next() // consume opener
+	depth := 1
+	for depth > 0 {
+		t := lex.Next()
+		if t.EOF() {
+			return
+		}
+		if isPunctTok(t, open) {
+			depth++
+		} else if isPunctTok(t, close) {
+			depth--
+		}
+	}
+}
+
+// isTopLevelKeyword reports whether s is one of the keywords that introduces
+// a top-level declaration. Used by TypeAlias.Parse to terminate its RHS
+// scan when the next line begins with a known top-level construct.
 func isTopLevelKeyword(s string) bool {
 	switch s {
 	case "generator", "client", "function", "retry_policy",
@@ -360,164 +385,63 @@ func isTopLevelKeyword(s string) bool {
 	return false
 }
 
-// expectIdentValue consumes the next token if it is an identifier and
-// returns its value; otherwise it returns the empty string without
-// advancing. The parser intentionally tolerates missing names so a malformed
-// block doesn't abort parsing of the rest of the file.
-func (p *parser) expectIdentValue() string {
-	if p.peek().Type == p.typeOf(tokIdent) {
-		return p.advance().Value
+// -----------------------------------------------------------------------
+// Post-parse normalisation.
+// -----------------------------------------------------------------------
+
+// normalizeFile strips token delimiters from captured scalar values so the
+// public AST contract matches the prior hand-rolled parser byte-for-byte:
+// String literals retain only the bytes between the quotes, EnvRef values
+// drop the leading `env.` prefix, RawString values drop the `#"` / `"#`
+// delimiters. No escape processing is applied.
+func normalizeFile(f *File) {
+	for _, item := range f.Items {
+		normalizeItem(item)
 	}
-	return ""
 }
 
-// parseBlockBody parses a `{ ... }` body. If the next token is not `{`, an
-// empty slice is returned and no tokens are consumed — the caller is
-// responsible for emitting the relevant AST node.
-func (p *parser) parseBlockBody() ([]*Field, error) {
-	if !p.isPunct(p.peek(), "{") {
-		return nil, nil
+func normalizeItem(it *Item) {
+	switch {
+	case it.Generator != nil:
+		normalizeFields(it.Generator.Fields)
+	case it.Client != nil:
+		normalizeFields(it.Client.Fields)
+	case it.Function != nil:
+		normalizeFields(it.Function.Fields)
+	case it.RetryPolicy != nil:
+		normalizeFields(it.RetryPolicy.Fields)
 	}
-	p.advance() // consume "{"
-	var fields []*Field
-	for !p.eof() && !p.isPunct(p.peek(), "}") {
-		f, err := p.parseField()
-		if err != nil {
-			return nil, err
-		}
-		if f != nil {
-			fields = append(fields, f)
-		}
-	}
-	if p.isPunct(p.peek(), "}") {
-		p.advance()
-	}
-	return fields, nil
 }
 
-// parseField parses one `key value` or `key { ... }` entry. Returns nil
-// silently when the next token doesn't begin a recognisable field (e.g.
-// stray punctuation), advancing one token so the loop makes progress.
-func (p *parser) parseField() (*Field, error) {
-	tok := p.peek()
-	if tok.Type != p.typeOf(tokIdent) {
-		// Unrecognised field-leading token; consume it to make
-		// progress without erroring. Real .baml files don't produce
-		// this shape inside a recognised block body.
-		p.advance()
-		return nil, nil
-	}
-	key := p.advance().Value
-	// Block-shaped field: `key { ... }`
-	if p.isPunct(p.peek(), "{") {
-		nested, err := p.parseBlockBody()
-		if err != nil {
-			return nil, err
+func normalizeFields(fields []*Field) {
+	for _, f := range fields {
+		if f.Value != nil {
+			normalizeValue(f.Value)
 		}
-		return &Field{Key: key, Block: &Block{Fields: nested}}, nil
+		if f.Block != nil {
+			normalizeFields(f.Block.Fields)
+		}
 	}
-	// Value-shaped field: `key value`.
-	v, err := p.parseValue()
-	if err != nil {
-		return nil, err
-	}
-	return &Field{Key: key, Value: v}, nil
 }
 
-// parseValue parses a single right-hand-side value: literal string, raw
-// string, env reference, identifier, number, or list. Returns nil when the
-// next token doesn't begin a value (e.g. immediately followed by `}` for a
-// keyword-only field like `prompt #"..."#` after a missing inner value);
-// the caller decides whether nil is acceptable.
-func (p *parser) parseValue() (*Value, error) {
-	tok := p.peek()
-	switch tok.Type {
-	case p.typeOf(tokString):
-		p.advance()
-		lit := stripStringQuotes(tok.Value)
-		return &Value{Literal: &lit}, nil
-	case p.typeOf(tokRawString):
-		p.advance()
-		raw := stripRawString(tok.Value)
-		return &Value{Raw: &raw}, nil
-	case p.typeOf(tokEnvRef):
-		p.advance()
-		name := tok.Value[len("env."):]
-		return &Value{EnvRef: &name}, nil
-	case p.typeOf(tokNumber):
-		p.advance()
-		num := tok.Value
-		return &Value{Number: &num}, nil
-	case p.typeOf(tokIdent):
-		p.advance()
-		ident := tok.Value
-		return &Value{Ident: &ident}, nil
-	}
-	if p.isPunct(tok, "[") {
-		return p.parseList()
-	}
-	return nil, nil
-}
-
-// parseList parses a `[ ... ]` literal. Elements are separated by commas
-// and/or whitespace (BAML accepts both; whitespace alone matches the
-// introspect parser's whitespace-splitting strategy list semantics).
-func (p *parser) parseList() (*Value, error) {
-	p.advance() // consume "["
-	var elems []*Value
-	for !p.eof() && !p.isPunct(p.peek(), "]") {
-		// Skip stray commas between elements.
-		if p.isPunct(p.peek(), ",") {
-			p.advance()
-			continue
-		}
-		v, err := p.parseValue()
-		if err != nil {
-			return nil, err
-		}
-		if v == nil {
-			// Defensive: unrecognised token inside list. Advance
-			// so the loop makes progress.
-			p.advance()
-			continue
-		}
-		elems = append(elems, v)
-	}
-	if p.isPunct(p.peek(), "]") {
-		p.advance()
-	}
-	return &Value{List: elems}, nil
-}
-
-// skipBalanced consumes tokens until the brace / bracket / paren count
-// returns to zero. Used to skip opaque block bodies in TypeBlock,
-// TemplateBlock, and the catch-all Other path. Assumes the next token is
-// the opener.
-func (p *parser) skipBalanced(open, close string) {
-	if !p.isPunct(p.peek(), open) {
+func normalizeValue(v *Value) {
+	if v == nil {
 		return
 	}
-	p.advance() // consume opener
-	depth := 1
-	for !p.eof() && depth > 0 {
-		t := p.advance()
-		if p.isPunctValue(t, open) {
-			depth++
-		} else if p.isPunctValue(t, close) {
-			depth--
-		}
+	if v.Literal != nil {
+		s := stripStringQuotes(*v.Literal)
+		v.Literal = &s
 	}
-}
-
-func (p *parser) isPunctValue(t lexer.Token, ch string) bool {
-	return t.Type == p.typeOf(tokPunct) && t.Value == ch
-}
-
-// skipBalancedBlockIfPresent consumes a `{ ... }` block immediately
-// following the current position. No-op when the next token isn't `{`.
-func (p *parser) skipBalancedBlockIfPresent() {
-	if p.isPunct(p.peek(), "{") {
-		p.skipBalanced("{", "}")
+	if v.EnvRef != nil {
+		s := strings.TrimPrefix(*v.EnvRef, "env.")
+		v.EnvRef = &s
+	}
+	if v.Raw != nil {
+		s := stripRawString(*v.Raw)
+		v.Raw = &s
+	}
+	for _, e := range v.List {
+		normalizeValue(e)
 	}
 }
 

--- a/bamlutils/bamlparser/bamlparser_test.go
+++ b/bamlutils/bamlparser/bamlparser_test.go
@@ -649,3 +649,90 @@ function F(x: string) -> string {
 		t.Errorf("expected baml-fallback ident, got %q", *a.Fields[0].Value.Ident)
 	}
 }
+
+// TestParse_MalformedNestedTokenAtStartSkipped pins that an un-Field-shaped
+// token at the start of a brace body is skipped and the subsequent fields
+// parse normally — mirroring the prior hand-rolled parseField's
+// non-ident-skip-and-continue behaviour. Caught by Codex's sign-off on
+// PR #270: the previous declarative `"{" @@* "}"?` Block grammar
+// terminated the block at `@` and leaked the rest of the body to the outer
+// scope.
+func TestParse_MalformedNestedTokenAtStartSkipped(t *testing.T) {
+	src := `client<llm> X { @ provider openai }`
+	f := mustParse(t, src)
+	c := findClient(f, "X")
+	if c == nil {
+		t.Fatalf("client X missing; items: %+v", f.Items)
+	}
+	if len(c.Fields) != 1 {
+		t.Fatalf("want 1 field, got %d: %+v", len(c.Fields), c.Fields)
+	}
+	prov := fieldByKey(c.Fields, "provider")
+	if prov == nil || prov.Value == nil || prov.Value.Ident == nil || *prov.Value.Ident != "openai" {
+		t.Errorf("provider missing/wrong: %+v", prov)
+	}
+}
+
+// TestParse_MalformedNestedTokenBetweenFieldsSkipped pins that a garbage
+// token between two well-formed fields does not terminate the block — the
+// `@` is skipped and `retry_policy Fast` is captured as the second field.
+//
+// Note: this is intentionally a standalone parser test rather than a parity
+// case because the production line-based parser's splitInlineStatements
+// includes the trailing `@` in the preceding field's value (so its
+// clientProvider["X"] is "openai @", not "openai"). The bamlparser
+// AST walker drops stray non-Ident tokens, matching the prior PR #269
+// standalone bamlparser. That divergence between line-based and AST
+// parsers on garbage input pre-dates PR 1.5 and is out of scope for
+// the parity invariant.
+func TestParse_MalformedNestedTokenBetweenFieldsSkipped(t *testing.T) {
+	src := `client<llm> X { provider openai @ retry_policy Fast }`
+	f := mustParse(t, src)
+	c := findClient(f, "X")
+	if c == nil {
+		t.Fatalf("client X missing; items: %+v", f.Items)
+	}
+	if len(c.Fields) != 2 {
+		t.Fatalf("want 2 fields, got %d: %+v", len(c.Fields), c.Fields)
+	}
+	prov := fieldByKey(c.Fields, "provider")
+	if prov == nil || prov.Value == nil || prov.Value.Ident == nil || *prov.Value.Ident != "openai" {
+		t.Errorf("provider missing/wrong: %+v", prov)
+	}
+	rp := fieldByKey(c.Fields, "retry_policy")
+	if rp == nil || rp.Value == nil || rp.Value.Ident == nil || *rp.Value.Ident != "Fast" {
+		t.Errorf("retry_policy missing/wrong: %+v", rp)
+	}
+	// Crucially: nothing leaks to top level. The previous declarative
+	// `@@* "}"?` Block grammar produced a spurious top-level Item from
+	// the leaked `retry_policy Fast` tokens.
+	for _, it := range f.Items {
+		if it.RetryPolicy != nil {
+			t.Errorf("retry_policy leaked to top level: %+v", it.RetryPolicy)
+		}
+	}
+}
+
+// TestParse_MalformedNestedTokenSequenceSkipped pins that consecutive
+// garbage tokens (`@ !`) between two fields are all skipped — the loop's
+// "advance one token and re-try Field" invariant must hold even when the
+// stray-token run is longer than one.
+func TestParse_MalformedNestedTokenSequenceSkipped(t *testing.T) {
+	src := `client<llm> X { provider openai @ ! retry_policy Fast }`
+	f := mustParse(t, src)
+	c := findClient(f, "X")
+	if c == nil {
+		t.Fatalf("client X missing; items: %+v", f.Items)
+	}
+	if len(c.Fields) != 2 {
+		t.Fatalf("want 2 fields, got %d: %+v", len(c.Fields), c.Fields)
+	}
+	prov := fieldByKey(c.Fields, "provider")
+	if prov == nil || prov.Value == nil || prov.Value.Ident == nil || *prov.Value.Ident != "openai" {
+		t.Errorf("provider missing/wrong: %+v", prov)
+	}
+	rp := fieldByKey(c.Fields, "retry_policy")
+	if rp == nil || rp.Value == nil || rp.Value.Ident == nil || *rp.Value.Ident != "Fast" {
+		t.Errorf("retry_policy missing/wrong: %+v", rp)
+	}
+}

--- a/bamlutils/bamlparser/bamlparser_test.go
+++ b/bamlutils/bamlparser/bamlparser_test.go
@@ -736,3 +736,90 @@ func TestParse_MalformedNestedTokenSequenceSkipped(t *testing.T) {
 		t.Errorf("retry_policy missing/wrong: %+v", rp)
 	}
 }
+
+// TestParse_GeneratorMalformedNestedTokenAtStartSkipped pins the
+// skip-garbage-token semantics for GeneratorBlock bodies. The prior
+// declarative `( "{" @@* "}"? )?` grammar terminated the body at the
+// leading `@` and leaked the rest to file scope. The fix routes the
+// generator body through the same parseBlockFieldsUntilClose helper
+// that Block / RetryPolicy / Client / Function bodies use.
+func TestParse_GeneratorMalformedNestedTokenAtStartSkipped(t *testing.T) {
+	src := `generator g { @ version "1.0.0" }`
+	f := mustParse(t, src)
+	g := findGenerator(f, "g")
+	if g == nil {
+		t.Fatalf("generator g missing; items: %+v", f.Items)
+	}
+	if len(g.Fields) != 1 {
+		t.Fatalf("want 1 field, got %d: %+v", len(g.Fields), g.Fields)
+	}
+	ver := fieldByKey(g.Fields, "version")
+	if ver == nil || ver.Value == nil || ver.Value.Literal == nil || *ver.Value.Literal != "1.0.0" {
+		t.Errorf("version missing/wrong: %+v", ver)
+	}
+}
+
+// TestParse_GeneratorMalformedNestedTokenBetweenFieldsSkipped pins that a
+// garbage token between two well-formed generator fields does not
+// terminate the body early.
+func TestParse_GeneratorMalformedNestedTokenBetweenFieldsSkipped(t *testing.T) {
+	src := `generator g { version "1.0.0" @ output_type "rest/go" }`
+	f := mustParse(t, src)
+	g := findGenerator(f, "g")
+	if g == nil {
+		t.Fatalf("generator g missing; items: %+v", f.Items)
+	}
+	if len(g.Fields) != 2 {
+		t.Fatalf("want 2 fields, got %d: %+v", len(g.Fields), g.Fields)
+	}
+	ver := fieldByKey(g.Fields, "version")
+	if ver == nil || ver.Value == nil || ver.Value.Literal == nil || *ver.Value.Literal != "1.0.0" {
+		t.Errorf("version missing/wrong: %+v", ver)
+	}
+	ot := fieldByKey(g.Fields, "output_type")
+	if ot == nil || ot.Value == nil || ot.Value.Literal == nil || *ot.Value.Literal != "rest/go" {
+		t.Errorf("output_type missing/wrong: %+v", ot)
+	}
+}
+
+// TestParse_RetryPolicyMalformedNestedTokenAtStartSkipped pins the
+// skip-garbage-token semantics for RetryPolicyBlock bodies. Same rationale
+// as TestParse_GeneratorMalformedNestedTokenAtStartSkipped.
+func TestParse_RetryPolicyMalformedNestedTokenAtStartSkipped(t *testing.T) {
+	src := `retry_policy R { @ max_retries 3 }`
+	f := mustParse(t, src)
+	rp := findRetryPolicy(f, "R")
+	if rp == nil {
+		t.Fatalf("retry_policy R missing; items: %+v", f.Items)
+	}
+	if len(rp.Fields) != 1 {
+		t.Fatalf("want 1 field, got %d: %+v", len(rp.Fields), rp.Fields)
+	}
+	mr := fieldByKey(rp.Fields, "max_retries")
+	if mr == nil || mr.Value == nil || mr.Value.Number == nil || *mr.Value.Number != "3" {
+		t.Errorf("max_retries missing/wrong: %+v", mr)
+	}
+}
+
+// TestParse_RetryPolicyMalformedNestedTokenBetweenFieldsSkipped pins that
+// a garbage token between two well-formed retry_policy fields does not
+// terminate the body early.
+func TestParse_RetryPolicyMalformedNestedTokenBetweenFieldsSkipped(t *testing.T) {
+	src := `retry_policy R { max_retries 3 @ delay_ms 100 }`
+	f := mustParse(t, src)
+	rp := findRetryPolicy(f, "R")
+	if rp == nil {
+		t.Fatalf("retry_policy R missing; items: %+v", f.Items)
+	}
+	if len(rp.Fields) != 2 {
+		t.Fatalf("want 2 fields, got %d: %+v", len(rp.Fields), rp.Fields)
+	}
+	mr := fieldByKey(rp.Fields, "max_retries")
+	if mr == nil || mr.Value == nil || mr.Value.Number == nil || *mr.Value.Number != "3" {
+		t.Errorf("max_retries missing/wrong: %+v", mr)
+	}
+	dm := fieldByKey(rp.Fields, "delay_ms")
+	if dm == nil || dm.Value == nil || dm.Value.Number == nil || *dm.Value.Number != "100" {
+		t.Errorf("delay_ms missing/wrong: %+v", dm)
+	}
+}

--- a/cmd/introspect/baml_parser_parity_test.go
+++ b/cmd/introspect/baml_parser_parity_test.go
@@ -1244,6 +1244,32 @@ function Foo(x: string) -> string {
 }
 `,
 		},
+		// Pin the "skip garbage tokens inside a block, keep parsing later
+		// fields" semantics that the prior hand-rolled parser provided
+		// via parseField's non-ident bail-and-advance fallback
+		// (master:bamlutils/bamlparser/bamlparser.go:398-408 pre-refactor).
+		// Caught by Codex's sign-off on PR #270: the declarative
+		// `"{" @@* "}"?` Block grammar terminated the body at the first
+		// non-Ident token and leaked the rest of the body to the outer
+		// scope as `Other` items.
+		//
+		// Only the leading-garbage shape is pinned at the parity level —
+		// both parsers happen to drop the leading `@` cleanly. The
+		// between-fields-garbage shapes (`provider openai @
+		// retry_policy ...`) inherently diverge between the production
+		// line-based parser and the bamlparser AST walker (the production
+		// parser's `splitInlineStatements` keyword-boundary split
+		// includes the trailing `@` in the preceding field's value,
+		// producing `provider="openai @"`; the bamlparser drops the
+		// stray token instead). That divergence pre-dates PR 1.5; the
+		// bamlparser side of it is pinned in the standalone parser
+		// tests (TestParse_MalformedNestedTokenBetweenFieldsSkipped /
+		// TestParse_MalformedNestedTokenSequenceSkipped in
+		// bamlutils/bamlparser/bamlparser_test.go) rather than here.
+		{
+			name: "MalformedNestedTokenAtStart",
+			src:  `client<llm> X { @ provider openai }`,
+		},
 	}
 }
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Refactor of `bamlutils/bamlparser` from hand-rolled recursive descent (538 LOC in `bamlparser.go`) to idiomatic participle: declarative grammar via struct tags on the AST + narrow `Parseable` escape hatches for the irregular shapes tags can't cleanly express. PR 1.5 in the #265 sequence — slots between PR 1 (just merged) and PR 2 (production switch, not yet started).

Refs #265. Umbrella stays open until PR 4.

## What's changed

- `bamlutils/bamlparser/ast.go` — added grammar tags to `File`, `Item`, `GeneratorBlock`, `RetryPolicyBlock`, `Field`, `Value`. Generator / RetryPolicy block bodies tolerate a missing closing `}` (preserves the prior parser's lenient handling of brace-eating inline comments where `// ... }` consumes the `}` because the comment rule runs to EOL/EOF).
- `bamlutils/bamlparser/bamlparser.go` — `participle.MustBuild[File]` as the single parser entrypoint; small `blockSubParser` + `fieldSubParser` keep brace-body parsing routed through the declarative Field/Value grammar; narrow `Parseable` implementations for `ClientBlock`, `FunctionBlock`, `TemplateBlock`, `TypeBlock`, `TypeAlias`, `Other`, and `Block`; post-parse normalization for delimiter stripping. Hand-rolled `parser` struct + 13 recursive-descent methods deleted.
- Sign-off fix: `Block` is now Parseable so the inside-block loop can skip un-Field-shaped tokens between fields (matching the prior `parseField` non-ident bail-and-advance). Previously the declarative `"{" @@* "}"?` grammar terminated the block at the first non-Ident token and leaked the rest to the outer scope.

## Why `Parseable` and not pure tags everywhere

`participle.Union[T]` requires interface-typed fields, but the public AST uses concrete struct pointer-variant fields (`Item`, `Value`). Under the "AST shape stays externally identical" constraint (production consumers in PR 2 depend on the exact field names/types), `Union` isn't viable. The right idiom is pointer-field alternation in struct tags — same pattern `bamlutils/versions.go` already uses.

The 7 `Parseable` hooks cover specific irregularities tags can't express:
- `ClientBlock` — `client <TypeParam>? Name` grammar order vs `Name, TypeParam, Fields` struct order
- `FunctionBlock` — same-line `(` requirement after `function` keyword
- `TemplateBlock` / `TypeBlock` / `TypeAlias` — metadata-only nodes with body discarded
- `Other` — catch-all consuming 1 token + optional balanced block (Ident-led only)
- `Block` — brace-bounded loop with garbage-token skip between fields; inside-block `Field = @Ident (Value | Block)?` grammar stays declarative on the AST type itself

## What's preserved

Every documented behavior quirk from PR #269 stays exactly:
- function-without-parens → `Item.Other`
- bare `env.X` → `EnvRef`; quoted `"env.X"` → `Literal`
- `Field.Block` (not `Value.Map`) is the map representation
- compact one-line forms parse without separators
- case-sensitive keyword matching
- duplicate-key last-wins, source-order preservation
- brace-eating `//` comments tolerated (missing `}` treated leniently)
- garbage tokens inside a brace body are skipped, later fields still parsed

## What's verified

- All standalone parser tests in `bamlutils/bamlparser/bamlparser_test.go` (29 functions including 3 regression tests pinning the garbage-token-skip fix) pass green.
- All 66 parity cases in `cmd/introspect/baml_parser_parity_test.go` (65 original + 1 regression case `MalformedNestedTokenAtStart`) pass with `knownParityDivergences` still empty and the fail-fast guard intact.
- `verify-framework-adapter` 6/6; `verify-adapter-pins` 4/4.
- No production code changes (`cmd/introspect/main.go`, `bamlutils/versions.go`, `cmd/introspect/baml_parser_test.go` untouched).

The other two regression shapes (`provider openai @ retry_policy ...` and the multi-token-garbage variant) inherently diverge between the production line-based parser and the bamlparser AST walker — production's `splitInlineStatements` concatenates trailing punctuation into the preceding field's value, while bamlparser drops stray non-Ident tokens. That divergence pre-dates PR 1.5; pinning it via parity would require `knownParityDivergences` entries (violating the invariant), so those two shapes are pinned via standalone parser tests instead.

Refs #265.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced the hand-written BAML walker with a grammar-driven parser and parse hooks; preserves prior parsing outputs via normalization.

* **Bug Fixes**
  * Robustly skips malformed/stray tokens inside brace-bodied blocks so they no longer leak into top-level items.

* **Tests**
  * Added unit tests and a parity fixture to validate consistent handling of malformed nested tokens across parsers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/270)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->