### PR TITLE
refactor(introspect): switch parseBamlSourceDir to bamlparser (#265 PR 2)

### DIFF
--- a/cmd/introspect/baml_parser_parity_test.go
+++ b/cmd/introspect/baml_parser_parity_test.go
@@ -3,14 +3,14 @@
 // This file is the load-bearing safety mechanism for the BAML parser
 // unification refactor: it feeds every fixture the existing line-based
 // parser handles (plus a hand-built edge-case table) through BOTH the
-// existing parser and the new shared bamlutils/bamlparser-based AST walker,
-// then asserts the two produce byte-identical *bamlConfig values.
+// existing parser and the new shared bamlutils/bamlparser-based AST
+// walker, then asserts the two produce byte-identical *bamlConfig
+// values.
 //
-// The AST walker (`parityProcessFile` and friends below) is intentionally
-// scoped to this test file — production code still calls parseBamlFile in
-// main.go. The walker exists here so the parity assertion is meaningful
-// today; a subsequent PR promotes it into production after this parity
-// surface is green.
+// As of #265 PR 2, the AST walker lives in production code
+// (processBAMLFile + friends in main.go) and runNewParser below calls
+// it directly — so this harness verifies the EXACT production
+// implementation rather than a test-local copy.
 //
 // The knownParityDivergences list is expected to remain EMPTY: any
 // divergence surfaced by this test is either a correctness issue in the
@@ -22,8 +22,6 @@ package main
 import (
 	"reflect"
 	"sort"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/invakid404/baml-rest/bamlutils/bamlparser"
@@ -53,9 +51,10 @@ func runOldParser(src string) *bamlConfig {
 	return cfg
 }
 
-// runNewParser builds a fresh *bamlConfig and runs the new AST-based
-// walker (parityProcessFile) + enrichShorthandClientProviders. Output is
-// structurally compatible with runOldParser.
+// runNewParser builds a fresh *bamlConfig and runs the production AST
+// walker (processBAMLFile) + enrichShorthandClientProviders. By calling
+// the actual production walker (rather than a test-local copy), this
+// harness verifies the exact production implementation.
 func runNewParser(t *testing.T, src string) *bamlConfig {
 	t.Helper()
 	f, err := bamlparser.ParseString("parity.baml", src)
@@ -63,282 +62,9 @@ func runNewParser(t *testing.T, src string) *bamlConfig {
 		t.Fatalf("new parser failed: %v", err)
 	}
 	cfg := newTestBamlConfig()
-	parityProcessFile(cfg, f)
+	processBAMLFile(cfg, f)
 	enrichShorthandClientProviders(cfg)
 	return cfg
-}
-
-// parityProcessFile dispatches over the new parser's top-level items in
-// source order. Only client<llm>, function (with parenthesised signature),
-// and retry_policy blocks contribute to *bamlConfig — every other top-level
-// shape is intentionally ignored, mirroring parseBamlFile in main.go.
-func parityProcessFile(cfg *bamlConfig, f *bamlparser.File) {
-	for _, it := range f.Items {
-		switch {
-		case it.Client != nil && it.Client.TypeParam == "llm" && it.Client.Name != "":
-			parityProcessClient(cfg, it.Client)
-		case it.Function != nil && it.Function.Name != "":
-			parityProcessFunction(cfg, it.Function)
-		case it.RetryPolicy != nil && it.RetryPolicy.Name != "":
-			parityProcessRetryPolicy(cfg, it.RetryPolicy)
-		}
-	}
-}
-
-// parityProcessClient walks a parsed client block, mirroring
-// parseClientBlock's behavior: stale-state cleanup, ordered field
-// processing, options-block dive for strategy / start / Bedrock keys.
-func parityProcessClient(cfg *bamlConfig, c *bamlparser.ClientBlock) {
-	name := c.Name
-	delete(cfg.roundRobinStart, name)
-	delete(cfg.fallbackChains, name)
-	delete(cfg.clientProvider, name)
-	delete(cfg.clientRetryPolicy, name)
-	delete(cfg.bedrockClientOptions, name)
-
-	for _, f := range c.Fields {
-		switch f.Key {
-		case "provider":
-			if f.Value != nil {
-				cfg.clientProvider[name] = canonicaliseProvider(asScalarString(f.Value))
-			}
-		case "retry_policy":
-			if f.Value != nil {
-				cfg.clientRetryPolicy[name] = asScalarString(f.Value)
-			}
-		case "options":
-			if f.Block != nil {
-				parityProcessOptions(cfg, name, f.Block)
-			}
-		}
-	}
-}
-
-// parityProcessOptions walks an options block. Strategy is captured at any
-// depth (matching the old parser's depth-agnostic strategy extraction);
-// start and Bedrock keys are only honoured at the top level of the
-// options block (depth == 1), matching extractRoundRobinStart's and
-// updateBedrockClientOption's guard.
-func parityProcessOptions(cfg *bamlConfig, name string, opts *bamlparser.Block) {
-	for _, f := range opts.Fields {
-		switch f.Key {
-		case "strategy":
-			if f.Value != nil && f.Value.List != nil {
-				chain := parityStrategyList(f.Value)
-				if len(chain) > 0 {
-					cfg.fallbackChains[name] = chain
-				}
-			}
-		case "start":
-			if f.Value != nil && f.Value.Number != nil {
-				if n, err := strconv.ParseInt(*f.Value.Number, 10, 32); err == nil {
-					cfg.roundRobinStart[name] = int(n)
-				}
-			}
-		case "endpoint_url", "region",
-			"access_key_id", "secret_access_key", "session_token", "profile":
-			if val, ok := parityBedrockOptionValue(f.Value); ok {
-				cur := cfg.bedrockClientOptions[name]
-				switch f.Key {
-				case "endpoint_url":
-					cur.EndpointURL = val
-				case "region":
-					cur.Region = val
-				case "access_key_id":
-					cur.Credentials.AccessKeyID = val
-				case "secret_access_key":
-					cur.Credentials.SecretAccessKey = val
-				case "session_token":
-					cur.Credentials.SessionToken = val
-				case "profile":
-					cur.Credentials.Profile = val
-				}
-				cfg.bedrockClientOptions[name] = cur
-			}
-		}
-		// Strategy at any nested depth: recurse into block-shaped option
-		// fields and capture a strategy list if present. The old parser's
-		// in-options strategy extraction is not depth-gated (see Codex's
-		// scoping doc Q1) so the AST walker mirrors that posture.
-		if f.Block != nil {
-			parityProcessOptionsStrategyRecursive(cfg, name, f.Block)
-		}
-	}
-}
-
-func parityProcessOptionsStrategyRecursive(cfg *bamlConfig, name string, blk *bamlparser.Block) {
-	for _, f := range blk.Fields {
-		if f.Key == "strategy" && f.Value != nil && f.Value.List != nil {
-			chain := parityStrategyList(f.Value)
-			if len(chain) > 0 {
-				cfg.fallbackChains[name] = chain
-			}
-		}
-		if f.Block != nil {
-			parityProcessOptionsStrategyRecursive(cfg, name, f.Block)
-		}
-	}
-}
-
-// parityStrategyList converts a List Value to a slice of client names,
-// matching parseStrategyList's whitespace/comma splitting and quote
-// stripping.
-func parityStrategyList(v *bamlparser.Value) []string {
-	if v == nil || v.List == nil {
-		return nil
-	}
-	var out []string
-	for _, e := range v.List {
-		s, ok := e.String()
-		if !ok {
-			continue
-		}
-		s = strings.TrimSpace(s)
-		if s != "" {
-			out = append(out, s)
-		}
-	}
-	return out
-}
-
-// parityBedrockOptionValue mirrors extractBedrockOptionValue: a bare
-// env.IDENT becomes Provenance=env (EnvVar=IDENT); anything else with a
-// non-empty string representation becomes Provenance=literal (Literal=that
-// string). An empty literal yields ok=false so the field is not recorded.
-func parityBedrockOptionValue(v *bamlparser.Value) (bedrockOptionValue, bool) {
-	if v == nil {
-		return bedrockOptionValue{}, false
-	}
-	if name, ok := v.EnvName(); ok {
-		if name == "" {
-			return bedrockOptionValue{}, false
-		}
-		return bedrockOptionValue{EnvVar: name, Provenance: "env"}, true
-	}
-	s, ok := v.String()
-	if !ok || s == "" {
-		return bedrockOptionValue{}, false
-	}
-	return bedrockOptionValue{Literal: s, Provenance: "literal"}, true
-}
-
-// parityProcessFunction walks a function block, capturing the top-level
-// `client VALUE` field. Matches parseFunctionBlock — every other field is
-// ignored (prompt body is a Raw value or a nested block, options are
-// ignored).
-//
-// Last-wins on duplicates: the production loop at
-// cmd/introspect/main.go:2143-2174 keeps scanning every top-level line in
-// the function body, so a later `client` field overwrites an earlier one.
-// The walker iterates all matching fields rather than stopping at the
-// first, mirroring that semantics exactly.
-func parityProcessFunction(cfg *bamlConfig, fn *bamlparser.FunctionBlock) {
-	for _, f := range fn.Fields {
-		if f.Key != "client" || f.Value == nil {
-			continue
-		}
-		cfg.functionClient[fn.Name] = asScalarString(f.Value)
-	}
-}
-
-// parityProcessRetryPolicy walks a retry_policy block. Direct top-level
-// fields (max_retries, type, delay_ms, multiplier, max_delay_ms) are
-// applied first; nested `strategy { ... }` fields override them, matching
-// the old expandStrategyBlock + allLines append precedence.
-func parityProcessRetryPolicy(cfg *bamlConfig, r *bamlparser.RetryPolicyBlock) {
-	p := parsedRetryPolicy{}
-	apply := func(key string, v *bamlparser.Value) {
-		switch key {
-		case "max_retries":
-			if n, ok := atoiValue(v); ok {
-				p.maxRetries = n
-			}
-		case "type":
-			p.strategy = asScalarString(v)
-		case "delay_ms":
-			if n, ok := atoiValue(v); ok {
-				p.delayMs = n
-			}
-		case "multiplier":
-			if fl, ok := parseFloatValue(v); ok {
-				p.multiplier = fl
-			}
-		case "max_delay_ms":
-			if n, ok := atoiValue(v); ok {
-				p.maxDelayMs = n
-			}
-		}
-	}
-	// Pass 1: direct top-level fields (excluding nested blocks).
-	for _, f := range r.Fields {
-		if f.Block != nil {
-			continue
-		}
-		apply(f.Key, f.Value)
-	}
-	// Pass 2: nested strategy block — overrides direct values, mirroring
-	// the old parser's allLines = expanded + strategyLines precedence.
-	for _, f := range r.Fields {
-		if f.Key != "strategy" || f.Block == nil {
-			continue
-		}
-		for _, sf := range f.Block.Fields {
-			apply(sf.Key, sf.Value)
-		}
-	}
-	cfg.retryPolicies[r.Name] = p
-}
-
-// asScalarString reconstructs the string the old parser would have seen
-// after cleanBamlValue: quotes stripped from a Literal, env.X reassembled
-// for an EnvRef so semantic consumers see the same "env.X" lexeme the
-// line-based parser produced.
-func asScalarString(v *bamlparser.Value) string {
-	if v == nil {
-		return ""
-	}
-	switch {
-	case v.IsLiteral():
-		s, _ := v.LiteralValue()
-		return s
-	case v.IsIdent():
-		s, _ := v.IdentValue()
-		return s
-	case v.IsNumber():
-		s, _ := v.NumberValue()
-		return s
-	case v.IsRaw():
-		s, _ := v.RawValue()
-		return s
-	case v.IsEnvRef():
-		name, _ := v.EnvName()
-		return "env." + name
-	}
-	return ""
-}
-
-func atoiValue(v *bamlparser.Value) (int, bool) {
-	s := asScalarString(v)
-	if s == "" {
-		return 0, false
-	}
-	n, err := strconv.Atoi(s)
-	if err != nil {
-		return 0, false
-	}
-	return n, true
-}
-
-func parseFloatValue(v *bamlparser.Value) (float64, bool) {
-	s := asScalarString(v)
-	if s == "" {
-		return 0, false
-	}
-	f, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0, false
-	}
-	return f, true
 }
 
 // ----------------------------------------------------------------------------

--- a/cmd/introspect/baml_parser_parity_test.go
+++ b/cmd/introspect/baml_parser_parity_test.go
@@ -954,9 +954,9 @@ client<llm> QuotedEnvBedrock {
 		// function block resolve last-wins. The old parser's
 		// parseFunctionBlock (cmd/introspect/main.go:2143-2174) keeps
 		// scanning every line and overwrites functionClient[name] on
-		// each `client VALUE` match. The walker fix at
-		// parityProcessFunction (this file, above) removed an early
-		// `break` to mirror that semantics.
+		// each `client VALUE` match. The production processBAMLFunctionBlock
+		// walker in main.go iterates every top-level `client` field for
+		// the same last-wins semantics.
 		{
 			name: "DuplicateFunctionClientLastWins",
 			src: `

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 
 	"github.com/dave/jennifer/jen"
+
+	"github.com/invakid404/baml-rest/bamlutils/bamlparser"
 )
 
 const (
@@ -1252,7 +1254,15 @@ func parseBamlSourceDir(dir string) *bamlConfig {
 		if readErr != nil {
 			return nil // skip unreadable files
 		}
-		parseBamlFile(cfg, string(data))
+		file, parseErr := bamlparser.ParseBytes(path, data)
+		if parseErr != nil {
+			// The new parser is intentionally permissive (Codex scoping Q2/Q6);
+			// any real-world parse error is a parser bug to be fixed by adding
+			// a fixture rather than swallowing here. Match the old line walker's
+			// silent-on-unreadable posture so generation stays best-effort.
+			return nil
+		}
+		processBAMLFile(cfg, file)
 		return nil
 	})
 	if err != nil {
@@ -2260,6 +2270,281 @@ func parseRetryPolicyBlock(cfg *bamlConfig, name string, block []string) {
 		}
 	}
 	cfg.retryPolicies[name] = p
+}
+
+// processBAMLFile dispatches the parsed AST's top-level items in source
+// order, mirroring parseBamlFile's top-level top-down posture: only
+// client<llm>, function (with named signature), and retry_policy blocks
+// contribute to *bamlConfig. Every other top-level shape — generators,
+// classes, enums, type aliases, template_strings, tests, plain `client`
+// blocks without the <llm> type param — is intentionally ignored.
+func processBAMLFile(cfg *bamlConfig, f *bamlparser.File) {
+	for _, it := range f.Items {
+		switch {
+		case it.Client != nil && it.Client.TypeParam == "llm" && it.Client.Name != "":
+			processBAMLClientBlock(cfg, it.Client)
+		case it.Function != nil && it.Function.Name != "":
+			processBAMLFunctionBlock(cfg, it.Function)
+		case it.RetryPolicy != nil && it.RetryPolicy.Name != "":
+			processBAMLRetryPolicyBlock(cfg, it.RetryPolicy)
+		}
+	}
+}
+
+// processBAMLClientBlock walks a parsed client<llm> block, mirroring
+// parseClientBlock's behaviour: stale-state cleanup for the client name,
+// ordered top-level provider / retry_policy / options handling.
+func processBAMLClientBlock(cfg *bamlConfig, c *bamlparser.ClientBlock) {
+	name := c.Name
+	delete(cfg.roundRobinStart, name)
+	delete(cfg.fallbackChains, name)
+	delete(cfg.clientProvider, name)
+	delete(cfg.clientRetryPolicy, name)
+	delete(cfg.bedrockClientOptions, name)
+
+	for _, f := range c.Fields {
+		switch f.Key {
+		case "provider":
+			if f.Value != nil {
+				cfg.clientProvider[name] = canonicaliseProvider(bamlValueScalar(f.Value))
+			}
+		case "retry_policy":
+			if f.Value != nil {
+				cfg.clientRetryPolicy[name] = bamlValueScalar(f.Value)
+			}
+		case "options":
+			if f.Block != nil {
+				processBAMLOptionsBlock(cfg, name, f.Block)
+			}
+		}
+	}
+}
+
+// processBAMLOptionsBlock walks an options block. Strategy is captured
+// at ANY depth (matching the old parser's depth-agnostic strategy
+// extraction in extractStrategyStatement); start and Bedrock keys are
+// honoured ONLY at the immediate options depth, matching
+// extractRoundRobinStart's and updateBedrockClientOption's
+// optionsDepth == 1 guard.
+func processBAMLOptionsBlock(cfg *bamlConfig, name string, opts *bamlparser.Block) {
+	for _, f := range opts.Fields {
+		switch f.Key {
+		case "strategy":
+			if f.Value != nil && f.Value.List != nil {
+				chain := bamlValueStrategyList(f.Value)
+				if len(chain) > 0 {
+					cfg.fallbackChains[name] = chain
+				}
+			}
+		case "start":
+			if f.Value != nil && f.Value.Number != nil {
+				if n, err := strconv.ParseInt(*f.Value.Number, 10, 32); err == nil {
+					cfg.roundRobinStart[name] = int(n)
+				}
+			}
+		case "endpoint_url", "region",
+			"access_key_id", "secret_access_key", "session_token", "profile":
+			if val, ok := bamlValueBedrockOption(f.Value); ok {
+				cur := cfg.bedrockClientOptions[name]
+				switch f.Key {
+				case "endpoint_url":
+					cur.EndpointURL = val
+				case "region":
+					cur.Region = val
+				case "access_key_id":
+					cur.Credentials.AccessKeyID = val
+				case "secret_access_key":
+					cur.Credentials.SecretAccessKey = val
+				case "session_token":
+					cur.Credentials.SessionToken = val
+				case "profile":
+					cur.Credentials.Profile = val
+				}
+				cfg.bedrockClientOptions[name] = cur
+			}
+		}
+		if f.Block != nil {
+			processBAMLOptionsStrategyRecursive(cfg, name, f.Block)
+		}
+	}
+}
+
+// processBAMLOptionsStrategyRecursive walks block-valued option fields
+// looking for nested `strategy [...]` lists. Only strategy is captured;
+// `start` and Bedrock keys are gated to depth==1 by the caller.
+func processBAMLOptionsStrategyRecursive(cfg *bamlConfig, name string, blk *bamlparser.Block) {
+	for _, f := range blk.Fields {
+		if f.Key == "strategy" && f.Value != nil && f.Value.List != nil {
+			chain := bamlValueStrategyList(f.Value)
+			if len(chain) > 0 {
+				cfg.fallbackChains[name] = chain
+			}
+		}
+		if f.Block != nil {
+			processBAMLOptionsStrategyRecursive(cfg, name, f.Block)
+		}
+	}
+}
+
+// processBAMLFunctionBlock walks a function block, capturing every
+// top-level `client VALUE` field. Last-wins on duplicates: the old
+// parseFunctionBlock loop scans every line and overwrites
+// functionClient[name] on each `client VALUE` match, so the walker
+// iterates all matching fields rather than stopping at the first.
+func processBAMLFunctionBlock(cfg *bamlConfig, fn *bamlparser.FunctionBlock) {
+	for _, f := range fn.Fields {
+		if f.Key != "client" || f.Value == nil {
+			continue
+		}
+		cfg.functionClient[fn.Name] = bamlValueScalar(f.Value)
+	}
+}
+
+// processBAMLRetryPolicyBlock walks a retry_policy block. Direct
+// top-level fields (max_retries, type, delay_ms, multiplier,
+// max_delay_ms) are applied first; nested `strategy { ... }` fields
+// override them, mirroring the old expandStrategyBlock + allLines
+// append precedence (strategy nested values win).
+//
+// Production-only behaviour preserved here: stderr warnings for invalid
+// numeric values on max_retries / delay_ms / multiplier / max_delay_ms.
+// The parity harness compares *bamlConfig and cannot observe stderr, so
+// the warning emission is verified by inspection rather than by parity.
+// The warning strings match parseRetryPolicyBlock byte-for-byte so
+// anyone grep'ing logs for the old warning text still finds it.
+func processBAMLRetryPolicyBlock(cfg *bamlConfig, r *bamlparser.RetryPolicyBlock) {
+	p := parsedRetryPolicy{}
+	apply := func(key string, v *bamlparser.Value) {
+		switch key {
+		case "max_retries":
+			if v == nil {
+				return
+			}
+			if n, err := strconv.Atoi(bamlValueScalar(v)); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: invalid max_retries value in retry_policy %s: %v\n", r.Name, err)
+			} else {
+				p.maxRetries = n
+			}
+		case "type":
+			p.strategy = bamlValueScalar(v)
+		case "delay_ms":
+			if v == nil {
+				return
+			}
+			if n, err := strconv.Atoi(bamlValueScalar(v)); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: invalid delay_ms value in retry_policy %s: %v\n", r.Name, err)
+			} else {
+				p.delayMs = n
+			}
+		case "multiplier":
+			if v == nil {
+				return
+			}
+			if fl, err := strconv.ParseFloat(bamlValueScalar(v), 64); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: invalid multiplier value in retry_policy %s: %v\n", r.Name, err)
+			} else {
+				p.multiplier = fl
+			}
+		case "max_delay_ms":
+			if v == nil {
+				return
+			}
+			if n, err := strconv.Atoi(bamlValueScalar(v)); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: invalid max_delay_ms value in retry_policy %s: %v\n", r.Name, err)
+			} else {
+				p.maxDelayMs = n
+			}
+		}
+	}
+	// Pass 1: direct top-level fields (excluding nested blocks).
+	for _, f := range r.Fields {
+		if f.Block != nil {
+			continue
+		}
+		apply(f.Key, f.Value)
+	}
+	// Pass 2: nested strategy block — overrides direct values, mirroring
+	// the old parser's allLines = expanded + strategyLines precedence.
+	for _, f := range r.Fields {
+		if f.Key != "strategy" || f.Block == nil {
+			continue
+		}
+		for _, sf := range f.Block.Fields {
+			apply(sf.Key, sf.Value)
+		}
+	}
+	cfg.retryPolicies[r.Name] = p
+}
+
+// bamlValueScalar reconstructs the string the old parser would have
+// produced from a Value after cleanBamlValue: quotes stripped from a
+// Literal, env.X reassembled for an EnvRef so downstream consumers see
+// the same "env.X" lexeme the line-based parser produced.
+func bamlValueScalar(v *bamlparser.Value) string {
+	if v == nil {
+		return ""
+	}
+	switch {
+	case v.IsLiteral():
+		s, _ := v.LiteralValue()
+		return s
+	case v.IsIdent():
+		s, _ := v.IdentValue()
+		return s
+	case v.IsNumber():
+		s, _ := v.NumberValue()
+		return s
+	case v.IsRaw():
+		s, _ := v.RawValue()
+		return s
+	case v.IsEnvRef():
+		name, _ := v.EnvName()
+		return "env." + name
+	}
+	return ""
+}
+
+// bamlValueStrategyList converts a List Value into a slice of client
+// names, mirroring parseStrategyList's whitespace/comma splitting and
+// quote stripping (the latter handled inside Value.String for literals).
+func bamlValueStrategyList(v *bamlparser.Value) []string {
+	if v == nil || v.List == nil {
+		return nil
+	}
+	var out []string
+	for _, e := range v.List {
+		s, ok := e.String()
+		if !ok {
+			continue
+		}
+		s = strings.TrimSpace(s)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// bamlValueBedrockOption mirrors extractBedrockOptionValue: a bare
+// `env.IDENT` becomes Provenance=env (EnvVar=IDENT); anything else with
+// a non-empty string representation becomes Provenance=literal
+// (Literal=that string). An empty literal yields ok=false so the field
+// is not recorded — matches the old line walker's empty-literal skip.
+func bamlValueBedrockOption(v *bamlparser.Value) (bedrockOptionValue, bool) {
+	if v == nil {
+		return bedrockOptionValue{}, false
+	}
+	if name, ok := v.EnvName(); ok {
+		if name == "" {
+			return bedrockOptionValue{}, false
+		}
+		return bedrockOptionValue{EnvVar: name, Provenance: "env"}, true
+	}
+	s, ok := v.String()
+	if !ok || s == "" {
+		return bedrockOptionValue{}, false
+	}
+	return bedrockOptionValue{Literal: s, Provenance: "literal"}, true
 }
 
 // generateBamlConfigVars parses .baml source files and generates introspected


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

PR 2 of the #265 sequence. Production switch: `cmd/introspect/main.go`'s `parseBamlSourceDir` now uses `bamlparser.ParseBytes` + the promoted `processBAMLFile` walker instead of the old line-based `parseBamlFile`. The old parser helpers all remain callable for the parity harness and the existing old-helper test suite — PR 3 of the sequence deletes them.

Refs #265. Umbrella stays open until PR 4.

## What's changed

- Promoted the AST walker from `cmd/introspect/baml_parser_parity_test.go` (test-only) to `cmd/introspect/main.go` (production) with production names: `processBAMLFile` + walker family (`processBAMLClientBlock`, `processBAMLOptionsBlock`, `processBAMLFunctionBlock`, `processBAMLRetryPolicyBlock`) + value helpers (`bamlValueScalar`, `bamlValueStrategyList`, `bamlValueBedrockOption`).
- `parseBamlSourceDir` switches to the new parser/walker. Pipeline order preserved: parse → walk → `enrichShorthandClientProviders` (single pass after all files).
- Parity test's `runNewParser` now calls production `processBAMLFile` directly. The duplicated `parityProcess*` walker is removed from the test file.
- Production-only behavior preserved: stderr warnings for invalid retry-policy numeric fields (`max_retries`, `delay_ms`, `multiplier`, `max_delay_ms`). The parity harness compares `bamlConfig` and cannot see stderr, so the warning emission is preserved by inspection — warning strings match `parseRetryPolicyBlock` byte-for-byte.

## What stays for PR 3

All old parser helpers remain callable (`parseBamlFile`, `stripStringLiterals`, `stripInlineComment`, `stripBamlQuotes`, `cleanBamlValue`, `splitInlineStatements`, `expandBlockLines`, `collectBlock`, `bamlConfigKeys`, `parseClientBlock`, `extractStrategyStatement`, `extractRoundRobinStart`, `updateBedrockClientOption`, `extractBedrockOptionValue`, `parseStrategyList`, `parseFunctionBlock`, `expandStrategyBlock`, `parseRetryPolicyBlock`). PR 3 deletes them and retargets `baml_parser_test.go`.

## Verification

- 66 parity cases pass with `knownParityDivergences` empty + fail-fast guard intact.
- 33 standalone `bamlutils/bamlparser` tests pass unchanged.
- `cmd/introspect/baml_parser_test.go` tests pass unchanged (exercise the still-alive old helpers).
- Generated `introspected.go` byte-identical (`go run ./cmd/embed && git status --porcelain` shows only the two PR-edited files).
- `verify-framework-adapter` 6/6, `verify-adapter-pins` 4/4 green.
- `./scripts/sync.sh` clean; `gofmt` on changed files clean; `go vet ./...` clean.
- Empirical retry-warning sanity check (temp test): all four warning strings fire from `processBAMLRetryPolicyBlock` on a fixture with invalid `max_retries`/`delay_ms`/`multiplier`/`max_delay_ms` values.

Refs #265.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched BAML parsing to a structured parser for more robust, accurate parsing.
  * Updated parity tests to exercise the production parser implementation and removed the duplicate test-local walker.
  * Introspection now performs best-effort generation when encountering parse issues to avoid blocking output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/271)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->