### PR TITLE
feat(introspect): consume plain `client Name {}` blocks (#268)

### DIFF
--- a/cmd/introspect/baml_parser_fixtures_test.go
+++ b/cmd/introspect/baml_parser_fixtures_test.go
@@ -830,21 +830,15 @@ function Shortcut(x: string) -> string {
 
 		// ---- Additional Q1 parity gaps ----
 		//
-		// Pin that a plain `client Name { ... }` block (no <llm> type
-		// param) is parsed by the grammar but excluded by the walker's
-		// TypeParam == "llm" gate — preserves introspect's `client<llm>`-only
-		// consumption posture. #268 may widen this to consume plain
-		// `client` blocks; until then, the gate is part of the contract.
-		//
-		// The Foo block deliberately contains only fields whose keys
-		// are NOT top-level dispatch keywords (`client`, `function`,
-		// `retry_policy`). Pre-PR-3 the line-based parser had a
-		// greedy outer-scope re-scan quirk that would consume an inner
-		// `retry_policy NAME` as a top-level declaration; that quirk
-		// is gone with the line parser, but the fixture keeps the
-		// minimal shape so it isolates the TypeParam gate cleanly.
+		// Pin that the walker's client-dispatch gate accepts BOTH
+		// `client<llm> Name { ... }` (TypeParam == "llm") AND plain
+		// `client Name { ... }` (TypeParam == ""), aligning with upstream
+		// BAML. Upstream grammar's CLIENT_KEYWORD rule
+		// (engine/baml-lib/ast/src/parser/datamodel.pest) accepts both
+		// spellings and dispatches both through the same visit_client
+		// path without distinguishing the source keyword. Refs #268.
 		{
-			name: "PlainClientWithoutLLMIgnored",
+			name: "PlainClientConsumedSameAsLLMTyped",
 			src: `
 client Foo {
     provider openai
@@ -853,6 +847,43 @@ client Foo {
 client<llm> Bar {
     provider anthropic
     retry_policy Slow
+}
+`,
+		},
+		// Pin duplicate-name last-wins when the same client name is
+		// declared with BOTH a plain `client` and a `client<llm>` keyword
+		// in the same source. processBAMLClientBlock deletes stale per-
+		// client state before re-populating, so the textually later
+		// declaration overwrites the earlier one regardless of spelling.
+		// Plain `client Foo` first, `client<llm> Foo` second: the <llm>
+		// variant wins.
+		{
+			name: "DuplicateClientPlainAndLLMTypedLastWins",
+			src: `
+client Foo {
+    provider openai
+}
+
+client<llm> Foo {
+    provider anthropic
+    retry_policy Slow
+}
+`,
+		},
+		// Mirror of DuplicateClientPlainAndLLMTypedLastWins with the
+		// source order reversed: `client<llm> Foo` first, plain
+		// `client Foo` second. The plain variant wins, pinning that the
+		// last-wins rule is symmetric and not biased by spelling.
+		{
+			name: "DuplicateClientLLMTypedThenPlainLastWins",
+			src: `
+client<llm> Foo {
+    provider anthropic
+    retry_policy Slow
+}
+
+client Foo {
+    provider openai
 }
 `,
 		},

--- a/cmd/introspect/baml_parser_golden_data_test.go
+++ b/cmd/introspect/baml_parser_golden_data_test.go
@@ -437,6 +437,30 @@ var bamlConfigGoldens = map[string]bamlConfigSnapshot{
 		RoundRobinStart:      map[string]int{},
 		BedrockClientOptions: map[string]bedrockClientOptionsSnapshot{},
 	},
+	"DuplicateClientLLMTypedThenPlainLastWins": {
+		ClientProvider: map[string]string{
+			"Foo": "openai",
+		},
+		ClientRetryPolicy:    map[string]string{},
+		FunctionClient:       map[string]string{},
+		RetryPolicies:        map[string]retryPolicySnapshot{},
+		FallbackChains:       map[string][]string{},
+		RoundRobinStart:      map[string]int{},
+		BedrockClientOptions: map[string]bedrockClientOptionsSnapshot{},
+	},
+	"DuplicateClientPlainAndLLMTypedLastWins": {
+		ClientProvider: map[string]string{
+			"Foo": "anthropic",
+		},
+		ClientRetryPolicy: map[string]string{
+			"Foo": "Slow",
+		},
+		FunctionClient:       map[string]string{},
+		RetryPolicies:        map[string]retryPolicySnapshot{},
+		FallbackChains:       map[string][]string{},
+		RoundRobinStart:      map[string]int{},
+		BedrockClientOptions: map[string]bedrockClientOptionsSnapshot{},
+	},
 	"DuplicateClientStaleClearing_BedrockCreds": {
 		ClientProvider: map[string]string{
 			"CredsBedrock": "aws-bedrock",
@@ -867,9 +891,10 @@ var bamlConfigGoldens = map[string]bamlConfigSnapshot{
 		RoundRobinStart:      map[string]int{},
 		BedrockClientOptions: map[string]bedrockClientOptionsSnapshot{},
 	},
-	"PlainClientWithoutLLMIgnored": {
+	"PlainClientConsumedSameAsLLMTyped": {
 		ClientProvider: map[string]string{
 			"Bar": "anthropic",
+			"Foo": "openai",
 		},
 		ClientRetryPolicy: map[string]string{
 			"Bar": "Slow",

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -1408,14 +1408,26 @@ func isKnownShorthandProvider(p string) bool {
 
 // processBAMLFile dispatches the parsed AST's top-level items in source
 // order, mirroring parseBamlFile's top-level top-down posture: only
-// client<llm>, function (with named signature), and retry_policy blocks
-// contribute to *bamlConfig. Every other top-level shape — generators,
-// classes, enums, type aliases, template_strings, tests, plain `client`
-// blocks without the <llm> type param — is intentionally ignored.
+// client (both `client<llm> Name { ... }` and plain `client Name { ... }`),
+// function (with named signature), and retry_policy blocks contribute to
+// *bamlConfig. Every other top-level shape — generators, classes, enums,
+// type aliases, template_strings, tests, and clients with an unknown
+// non-empty TypeParam — is intentionally ignored.
+//
+// Consume both `client<llm> Foo { ... }` and plain `client Foo { ... }`:
+// upstream BAML's grammar accepts both spellings (CLIENT_KEYWORD =
+// "client<llm>" | "client" in engine/baml-lib/ast/src/parser/datamodel.pest)
+// and the parser-database walks them through the same visit_client path
+// without distinguishing the source keyword (engine/baml-lib/parser-database
+// /src/types/mod.rs visit_client). Our walker has no LLM-specific behavior
+// gated on TypeParam after dispatch, so both spellings produce the same
+// *bamlConfig shape. Refs #268. Future non-LLM type params (e.g. a
+// hypothetical `client<openapi> Foo`) are intentionally NOT accepted here
+// — we have no semantics for them yet.
 func processBAMLFile(cfg *bamlConfig, f *bamlparser.File) {
 	for _, it := range f.Items {
 		switch {
-		case it.Client != nil && it.Client.TypeParam == "llm" && it.Client.Name != "":
+		case it.Client != nil && (it.Client.TypeParam == "llm" || it.Client.TypeParam == "") && it.Client.Name != "":
 			processBAMLClientBlock(cfg, it.Client)
 		case it.Function != nil && it.Function.Name != "":
 			processBAMLFunctionBlock(cfg, it.Function)
@@ -1425,9 +1437,12 @@ func processBAMLFile(cfg *bamlConfig, f *bamlparser.File) {
 	}
 }
 
-// processBAMLClientBlock walks a parsed client<llm> block, mirroring
+// processBAMLClientBlock walks a parsed client block — either
+// `client<llm> Name { ... }` or plain `client Name { ... }` — mirroring
 // parseClientBlock's behaviour: stale-state cleanup for the client name,
-// ordered top-level provider / retry_policy / options handling.
+// ordered top-level provider / retry_policy / options handling. Both
+// spellings produce identical output; the source keyword is not encoded
+// after dispatch (see processBAMLFile).
 func processBAMLClientBlock(cfg *bamlConfig, c *bamlparser.ClientBlock) {
 	name := c.Name
 	delete(cfg.roundRobinStart, name)


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Aligns introspect's walker with upstream BAML: plain `client Name { ... }` blocks (no `<llm>` type parameter) are now consumed identically to `client<llm> Name { ... }` blocks. Upstream accepts both spellings and dispatches them through the same `visit_client` path; baml-rest's walker previously gated on `TypeParam == "llm"`, silently dropping plain clients even though the parser captured them.

Refs #268. Item 1 of the #268 parity tracker; full investigation at https://github.com/invakid404/baml-rest/issues/268#issuecomment-4450655407 (4-row decision matrix) and follow-up at https://github.com/invakid404/baml-rest/issues/268#issuecomment-4450779076 (closure decisions + region quirk addition).

## What changed

- `cmd/introspect/main.go::processBAMLFile`: widened the client gate to accept `TypeParam == ""` (plain) in addition to `TypeParam == "llm"`. Comment updated to document the upstream alignment.
- Parity fixture `PlainClientWithoutLLMIgnored` → renamed to `PlainClientConsumedSameAsLLMTyped`; golden regenerated to reflect that plain `client Foo` now contributes `Foo` → `provider: openai` to the result.
- Added 2 new parity fixtures pinning the duplicate-name last-wins case for mixed plain/`<llm>` declarations (plain first; `<llm>` first).

## Behavior change

A `.baml` file containing:

```baml
client Foo { provider openai }
```

previously contributed nothing to introspect's `bamlConfig`. After this PR, it contributes `Foo` → `provider: openai`. This matches upstream BAML (the parser-database doesn't distinguish the source keyword spelling).

Risk: minimal. Plain clients are upstream-canonical; if any operator had `client Foo { ... }` in their `.baml` files, it was almost certainly intended to be consumed.

## Verification

- 33 bamlparser tests + golden corpus (renamed fixture + 2 new fixtures) + retry-warning regression test pass.
- KEEP-listed tests in `baml_parser_test.go` pass unchanged.
- `verify-framework-adapter` 6/6 + `verify-adapter-pins` 4/4 green.
- Generated `introspected.go` byte-identical.

Refs #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parser now uniformly processes both client declaration syntaxes consistently.

* **Tests**
  * Added test cases for client declaration parity and duplicate client resolution precedence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/275)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->