### PR TITLE
feat(introspect): error on declared-empty `region ""` for aws-bedrock (#268)

### DIFF
--- a/cmd/introspect/baml_parser_golden_test.go
+++ b/cmd/introspect/baml_parser_golden_test.go
@@ -210,6 +210,10 @@ func TestBamlConfigGoldens(t *testing.T) {
 				t.Fatalf("no golden entry for fixture %q; rerun with -update-baml-config-goldens", tc.name)
 			}
 			cfg := runProductionParser(t, tc.src)
+			if len(cfg.validationErrors) > 0 {
+				t.Fatalf("fixture %q accumulated unexpected validation errors: %v",
+					tc.name, cfg.validationErrors)
+			}
 			got := snapshotBamlConfig(cfg)
 			if !reflect.DeepEqual(got, want) {
 				t.Fatalf("snapshot mismatch for %s\n got: %#v\nwant: %#v", tc.name, got, want)

--- a/cmd/introspect/baml_validation_errors_test.go
+++ b/cmd/introspect/baml_validation_errors_test.go
@@ -100,6 +100,18 @@ func TestBamlValidationErrors(t *testing.T) {
 					t.Errorf("validation error %q missing substring %q", got, want)
 				}
 			}
+			// Pin the no-value-leak invariant: validation messages
+			// must mention the field name + client name without
+			// echoing the configured value. For the region cases
+			// the configured value is `""`, so the literal `""`
+			// substring is a sentinel for accidental value-echoing.
+			// Same shape as #263's no-secret-leak credential checks.
+			for _, leaky := range []string{`""`, `value=`, `got=`} {
+				if strings.Contains(got, leaky) {
+					t.Errorf("validation error must not echo configured value; found %q in %q",
+						leaky, got)
+				}
+			}
 		})
 	}
 }

--- a/cmd/introspect/baml_validation_errors_test.go
+++ b/cmd/introspect/baml_validation_errors_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils/bamlparser"
+)
+
+// bamlValidationErrorCases is the table of negative + regression-net
+// cases for the per-client Bedrock-key validation surfaced by the
+// production walker. The negative cases exercise upstream BAML's
+// "region cannot be empty" error (aws_bedrock.rs:256-261) for declared
+// `region ""` literals on aws-bedrock clients. The regression-net cases
+// guard against accidentally tightening behaviour for other Bedrock
+// keys (endpoint_url) or for non-Bedrock clients that happen to use the
+// same key name. See cmd/introspect/main.go's bamlValueBedrockOption
+// helper and the per-client provider-gating two-pass walk in
+// processBAMLClientBlock.
+var bamlValidationErrorCases = []struct {
+	name    string
+	src     string
+	wantErr []string // substrings the accumulated error message must contain; empty/nil → expect no errors
+}{
+	{
+		name: "BedrockRegionEmptyLiteralErrors",
+		src: `
+client<llm> EmptyRegion {
+    provider aws-bedrock
+    options {
+        region ""
+    }
+}
+`,
+		wantErr: []string{`EmptyRegion`, `region`, `cannot be empty`},
+	},
+	{
+		name: "BedrockRegionEmptyLiteralErrors_OptionsBeforeProvider",
+		src: `
+client<llm> EmptyRegion {
+    options {
+        region ""
+    }
+    provider aws-bedrock
+}
+`,
+		wantErr: []string{`EmptyRegion`, `region`, `cannot be empty`},
+	},
+	{
+		name: "RegionEmptyLiteralOnNonBedrockClient_NoError",
+		src: `
+client<llm> Other {
+    provider openai
+    options {
+        region ""
+    }
+}
+`,
+		wantErr: nil,
+	},
+	{
+		name: "BedrockEndpointURLEmptyLiteral_NoError",
+		src: `
+client<llm> EndpointOnly {
+    provider aws-bedrock
+    options {
+        endpoint_url ""
+        region "us-east-1"
+    }
+}
+`,
+		wantErr: nil,
+	},
+}
+
+func TestBamlValidationErrors(t *testing.T) {
+	for _, tc := range bamlValidationErrorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := bamlparser.ParseString("validation.baml", tc.src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			cfg := newTestBamlConfig()
+			processBAMLFile(cfg, f)
+
+			if len(tc.wantErr) == 0 {
+				if len(cfg.validationErrors) > 0 {
+					t.Errorf("want no validation errors, got: %v", cfg.validationErrors)
+				}
+				return
+			}
+
+			if len(cfg.validationErrors) != 1 {
+				t.Fatalf("want 1 validation error, got %d: %v",
+					len(cfg.validationErrors), cfg.validationErrors)
+			}
+			got := cfg.validationErrors[0].Message()
+			for _, want := range tc.wantErr {
+				if !strings.Contains(got, want) {
+					t.Errorf("validation error %q missing substring %q", got, want)
+				}
+			}
+		})
+	}
+}

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -1168,6 +1168,30 @@ type bamlConfig struct {
 	// happens to use the same option keys for an unrelated purpose
 	// can't leak into the runtime BedrockClientOptions map.
 	bedrockClientOptions map[string]bedrockClientOptions
+	// validationErrors accumulates config-validation errors discovered
+	// during walking. Generation fails (log.Fatalf at the start of
+	// generateBamlConfigVars) if non-empty so that a misconfigured
+	// project — for example aws-bedrock client with declared-empty
+	// `region ""` — cannot silently produce an introspected.go that
+	// would fail later at request-build time. Mirrors upstream BAML's
+	// semantic-validation errors (engine/baml-lib/llm-client/src/clients
+	// /aws_bedrock.rs:256-261 "region cannot be empty").
+	validationErrors []bamlValidationError
+}
+
+// bamlValidationError captures a single semantic-validation failure
+// surfaced during client-block walking. Field-scoped and client-scoped
+// so the operator can locate the offending block at a glance.
+type bamlValidationError struct {
+	Client string
+	Key    string
+	Reason string
+}
+
+// Message formats the error for stderr / the combined generation error
+// per the existing client-scoped error patterns elsewhere in introspect.
+func (e bamlValidationError) Message() string {
+	return fmt.Sprintf("aws-bedrock: invalid %s for client %q: %s", e.Key, e.Client, e.Reason)
 }
 
 // bedrockClientOptions captures the per-client aws-bedrock options that
@@ -1443,6 +1467,13 @@ func processBAMLFile(cfg *bamlConfig, f *bamlparser.File) {
 // ordered top-level provider / retry_policy / options handling. Both
 // spellings produce identical output; the source keyword is not encoded
 // after dispatch (see processBAMLFile).
+//
+// Two-pass: first resolve the client's final provider (last-wins on
+// duplicate `provider` fields), then walk fields in source order to
+// apply side effects with correct provider-gated validation. The
+// final-provider pre-pass is needed because options can appear before
+// provider in the same block, and Bedrock-key validation (region "")
+// must only fire when the final provider is aws-bedrock.
 func processBAMLClientBlock(cfg *bamlConfig, c *bamlparser.ClientBlock) {
 	name := c.Name
 	delete(cfg.roundRobinStart, name)
@@ -1450,6 +1481,14 @@ func processBAMLClientBlock(cfg *bamlConfig, c *bamlparser.ClientBlock) {
 	delete(cfg.clientProvider, name)
 	delete(cfg.clientRetryPolicy, name)
 	delete(cfg.bedrockClientOptions, name)
+
+	finalProvider := ""
+	for _, f := range c.Fields {
+		if f.Key == "provider" && f.Value != nil {
+			finalProvider = canonicaliseProvider(bamlValueScalar(f.Value))
+		}
+	}
+	isBedrockClient := finalProvider == "aws-bedrock"
 
 	for _, f := range c.Fields {
 		switch f.Key {
@@ -1463,7 +1502,7 @@ func processBAMLClientBlock(cfg *bamlConfig, c *bamlparser.ClientBlock) {
 			}
 		case "options":
 			if f.Block != nil {
-				processBAMLOptionsBlock(cfg, name, f.Block)
+				processBAMLOptionsBlock(cfg, name, isBedrockClient, f.Block)
 			}
 		}
 	}
@@ -1475,7 +1514,15 @@ func processBAMLClientBlock(cfg *bamlConfig, c *bamlparser.ClientBlock) {
 // honoured ONLY at the immediate options depth, matching
 // extractRoundRobinStart's and updateBedrockClientOption's
 // optionsDepth == 1 guard.
-func processBAMLOptionsBlock(cfg *bamlConfig, name string, opts *bamlparser.Block) {
+//
+// isBedrockClient is the per-client gate computed by
+// processBAMLClientBlock's first pass; it controls whether
+// declared-empty Bedrock-key literals (currently: `region ""`) are
+// rejected as validation errors. A non-Bedrock client with the same
+// option keys is recorded into bedrockClientOptions for parser fidelity
+// (codegen filters by provider) and is NEVER subject to the empty-region
+// validation.
+func processBAMLOptionsBlock(cfg *bamlConfig, name string, isBedrockClient bool, opts *bamlparser.Block) {
 	for _, f := range opts.Fields {
 		switch f.Key {
 		case "strategy":
@@ -1493,7 +1540,12 @@ func processBAMLOptionsBlock(cfg *bamlConfig, name string, opts *bamlparser.Bloc
 			}
 		case "endpoint_url", "region",
 			"access_key_id", "secret_access_key", "session_token", "profile":
-			if val, ok := bamlValueBedrockOption(f.Value); ok {
+			val, ok, verr := bamlValueBedrockOption(name, f.Key, isBedrockClient, f.Value)
+			if verr != nil {
+				cfg.validationErrors = append(cfg.validationErrors, *verr)
+				continue
+			}
+			if ok {
 				cur := cfg.bedrockClientOptions[name]
 				switch f.Key {
 				case "endpoint_url":
@@ -1674,26 +1726,47 @@ func bamlValueStrategyList(v *bamlparser.Value) []string {
 	return out
 }
 
-// bamlValueBedrockOption mirrors extractBedrockOptionValue: a bare
-// `env.IDENT` becomes Provenance=env (EnvVar=IDENT); anything else with
-// a non-empty string representation becomes Provenance=literal
-// (Literal=that string). An empty literal yields ok=false so the field
-// is not recorded — matches the old line walker's empty-literal skip.
-func bamlValueBedrockOption(v *bamlparser.Value) (bedrockOptionValue, bool) {
+// bamlValueBedrockOption extracts a Bedrock option value with key-aware
+// validation. A bare `env.IDENT` becomes Provenance=env (EnvVar=IDENT);
+// anything else with a non-empty string representation becomes
+// Provenance=literal (Literal=that string).
+//
+// For `region` on aws-bedrock clients, a declared-empty literal returns
+// (zero, false, validationError) — the empty literal is invalid per
+// upstream BAML semantics (engine/baml-lib/llm-client/src/clients
+// /aws_bedrock.rs:256-261, "region cannot be empty"). For all other
+// key/provider combinations, an empty literal continues to return
+// (zero, false, nil) — the historical empty-as-absent behaviour
+// preserved for parity with upstream's own resolver behaviour and for
+// non-Bedrock clients that happen to use the same option keys.
+//
+// The error is returned as *bamlValidationError (nil-means-no-error) to
+// keep the helper's hot path branch-light.
+func bamlValueBedrockOption(clientName, key string, isBedrockClient bool, v *bamlparser.Value) (bedrockOptionValue, bool, *bamlValidationError) {
 	if v == nil {
-		return bedrockOptionValue{}, false
+		return bedrockOptionValue{}, false, nil
 	}
 	if name, ok := v.EnvName(); ok {
 		if name == "" {
-			return bedrockOptionValue{}, false
+			return bedrockOptionValue{}, false, nil
 		}
-		return bedrockOptionValue{EnvVar: name, Provenance: "env"}, true
+		return bedrockOptionValue{EnvVar: name, Provenance: "env"}, true, nil
 	}
 	s, ok := v.String()
-	if !ok || s == "" {
-		return bedrockOptionValue{}, false
+	if !ok {
+		return bedrockOptionValue{}, false, nil
 	}
-	return bedrockOptionValue{Literal: s, Provenance: "literal"}, true
+	if s == "" {
+		if key == "region" && isBedrockClient {
+			return bedrockOptionValue{}, false, &bamlValidationError{
+				Client: clientName,
+				Key:    key,
+				Reason: "region cannot be empty",
+			}
+		}
+		return bedrockOptionValue{}, false, nil
+	}
+	return bedrockOptionValue{Literal: s, Provenance: "literal"}, true, nil
 }
 
 // generateBamlConfigVars parses .baml source files and generates introspected
@@ -1813,6 +1886,22 @@ func generateBamlConfigVars(out *jen.File) {
 
 	// Parse .baml source files from baml_src/ directory
 	cfg := parseBamlSourceDir("baml_src")
+
+	// Stop generation if the walker accumulated any semantic-validation
+	// errors (e.g. aws-bedrock `region ""`). log.Fatalf prevents
+	// out.Save from running so introspected.go is not written with a
+	// half-resolved config that would fail downstream at request-build
+	// time with a confusing region-resolution error. Matches the
+	// existing panic-on-Save-error posture for fatal generation
+	// failures elsewhere in this file.
+	if len(cfg.validationErrors) > 0 {
+		msgs := make([]string, 0, len(cfg.validationErrors))
+		for _, e := range cfg.validationErrors {
+			msgs = append(msgs, e.Message())
+		}
+		log.Fatalf("introspect: %d config validation error(s):\n  %s",
+			len(cfg.validationErrors), strings.Join(msgs, "\n  "))
+	}
 
 	// Build FunctionClient: function → client name
 	out.Comment("FunctionClient maps BAML function names to their default client name")


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Aligns introspect with upstream BAML on declared-empty `region ""` for `aws-bedrock` clients. Upstream errors at `aws_bedrock.rs:256-261` ("region cannot be empty"); baml-rest previously silently dropped the declared region via uniform empty→absent handling in `bamlValueBedrockOption`. After this PR, `client<llm> X { provider aws-bedrock options { region "" } }` produces a config validation error at generation time instead of silently failing downstream during SigV4 signing.

Refs #268. Investigation at https://github.com/invakid404/baml-rest/issues/268#issuecomment-4450779076 (item flagged during the empty-Bedrock-literal investigation).

## What's preserved

- `endpoint_url ""` — parity-aligned (upstream resolves to `None`).
- Other Bedrock keys (`access_key_id`, `secret_access_key`, `session_token`, `profile`) — current empty→absent behavior. Their upstream divergences are different in shape (e.g. upstream resolves to `Some("")` rather than erroring) and tracked separately on #268.

## What changed

- `bamlConfig` gains a `validationErrors` accumulator; `generateBamlConfigVars` `log.Fatalf`s if non-empty (matches the existing panic-on-Save-error posture for fatal generation failures, prevents `out.Save` from writing `introspected.go`).
- `bamlValueBedrockOption` takes `(clientName, key, isBedrockClient, *Value)` and returns `*bamlValidationError` for declared-empty `region` on Bedrock clients.
- `processBAMLClientBlock` does a two-pass walk to resolve the final provider before validating, so field order (`options` before or after `provider`) doesn't matter.
- New `cmd/introspect/baml_validation_errors_test.go` covers: both field orders, non-Bedrock negative case (regression net), endpoint_url-stays-allowed regression net.
- `TestBamlConfigGoldens` guards that no existing success fixture accumulates validation errors (cheap regression net for future fixture additions).

## What's NOT included

- Credentials/profile empty-literal presence divergences — different upstream shape, separate #268 follow-up.
- Strategy list whitespace splitting — also separate #268 item.
- BAML pin changes, schema changes.

## Verification

- 77 existing golden fixtures pass byte-identical.
- 33 standalone bamlparser tests + 14 KEEP introspect tests + retry-warning regression test all pass unchanged.
- 4 new validation-error test cases pass.
- `verify-framework-adapter` 6/6 + `verify-adapter-pins` 4/4 green.
- Generated `introspected.go` byte-identical (no current `baml_src` file has `region ""`).
- Manual regression: a temp `baml_src/` with `region ""` on an aws-bedrock client correctly fails generation with `aws-bedrock: invalid region for client "BadRegion": region cannot be empty`, and `introspected/introspected.go` is not written.

Refs #268.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added semantic validation for AWS Bedrock client options during BAML parsing; code generation stops when validation errors are found.

* **Bug Fixes**
  * Empty `region` for AWS Bedrock clients is now reported as a validation error; non-Bedrock cases remain unaffected.

* **Tests**
  * Added table-driven tests for BAML validation error scenarios and tightened golden-test behavior to catch validation errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/276)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->