### PR TITLE
feat(introspect): error on declared-empty access_key_id/secret_access_key for aws-bedrock (#268)

### DIFF
--- a/cmd/introspect/baml_validation_errors_test.go
+++ b/cmd/introspect/baml_validation_errors_test.go
@@ -11,16 +11,21 @@ import (
 // cases for the per-client Bedrock-key validation surfaced by the
 // production walker. The negative cases exercise upstream BAML's
 // "region cannot be empty" error (aws_bedrock.rs:256-261) for declared
-// `region ""` literals on aws-bedrock clients. The regression-net cases
-// guard against accidentally tightening behaviour for other Bedrock
-// keys (endpoint_url) or for non-Bedrock clients that happen to use the
-// same key name. See cmd/introspect/main.go's bamlValueBedrockOption
-// helper and the per-client provider-gating two-pass walk in
-// processBAMLClientBlock.
+// `region ""` literals on aws-bedrock clients, plus the parse-time
+// rejection of declared-empty `access_key_id` / `secret_access_key`
+// literals (#268: upstream BAML accepts them and signs with literally
+// empty SigV4 creds, AWS then rejects at request time — failing at
+// parse time is the friendlier operator signal). The regression-net
+// cases guard against accidentally tightening behaviour for keys that
+// remain empty-as-absent (endpoint_url, session_token, profile) or for
+// non-Bedrock clients that happen to use the same key name. See
+// cmd/introspect/main.go's bamlValueBedrockOption helper and the
+// per-client provider-gating two-pass walk in processBAMLClientBlock.
 var bamlValidationErrorCases = []struct {
-	name    string
-	src     string
-	wantErr []string // substrings the accumulated error message must contain; empty/nil → expect no errors
+	name         string
+	src          string
+	wantErr      []string // substrings the accumulated error message must contain; empty/nil → expect no errors
+	wantErrCount int      // expected number of accumulated validationErrors; defaults to 1 when wantErr is non-empty
 }{
 	{
 		name: "BedrockRegionEmptyLiteralErrors",
@@ -71,6 +76,108 @@ client<llm> EndpointOnly {
 `,
 		wantErr: nil,
 	},
+	{
+		name: "BedrockAccessKeyIDEmptyLiteralErrors",
+		src: `
+client<llm> EmptyAKID {
+    provider aws-bedrock
+    options {
+        access_key_id ""
+        secret_access_key "STATIC_TEST_SECRET"
+        region "us-east-1"
+    }
+}
+`,
+		wantErr: []string{`EmptyAKID`, `access_key_id`, `cannot be empty`},
+	},
+	{
+		name: "BedrockAccessKeyIDEmptyLiteralErrors_OptionsBeforeProvider",
+		src: `
+client<llm> EmptyAKID {
+    options {
+        access_key_id ""
+        secret_access_key "STATIC_TEST_SECRET"
+        region "us-east-1"
+    }
+    provider aws-bedrock
+}
+`,
+		wantErr: []string{`EmptyAKID`, `access_key_id`, `cannot be empty`},
+	},
+	{
+		name: "BedrockSecretAccessKeyEmptyLiteralErrors",
+		src: `
+client<llm> EmptySecret {
+    provider aws-bedrock
+    options {
+        access_key_id "STATIC_TEST_ACCESS_KEY"
+        secret_access_key ""
+        region "us-east-1"
+    }
+}
+`,
+		wantErr: []string{`EmptySecret`, `secret_access_key`, `cannot be empty`},
+	},
+	{
+		name: "BedrockBothAccessKeyAndSecretEmptyErrors",
+		src: `
+client<llm> EmptyBoth {
+    provider aws-bedrock
+    options {
+        access_key_id ""
+        secret_access_key ""
+        region "us-east-1"
+    }
+}
+`,
+		// Both empty fields must each surface as a distinct
+		// accumulated validation error — pin that the walker
+		// doesn't short-circuit after the first error within
+		// one client block.
+		wantErr:      []string{`EmptyBoth`, `access_key_id`, `secret_access_key`, `cannot be empty`},
+		wantErrCount: 2,
+	},
+	{
+		name: "BedrockSessionTokenEmptyLiteral_NoError",
+		src: `
+client<llm> EmptySessionToken {
+    provider aws-bedrock
+    options {
+        access_key_id "STATIC_TEST_ACCESS_KEY"
+        secret_access_key "STATIC_TEST_SECRET"
+        session_token ""
+        region "us-east-1"
+    }
+}
+`,
+		wantErr: nil,
+	},
+	{
+		name: "BedrockProfileEmptyLiteral_NoError",
+		src: `
+client<llm> EmptyProfile {
+    provider aws-bedrock
+    options {
+        profile ""
+        region "us-east-1"
+    }
+}
+`,
+		wantErr: nil,
+	},
+	{
+		name: "AccessKeyIDEmptyLiteralOnNonBedrockClient_NoError",
+		src: `
+client<llm> Other {
+    provider openai
+    options {
+        access_key_id ""
+        secret_access_key ""
+    }
+}
+`,
+		wantErr: nil,
+	},
 }
 
 func TestBamlValidationErrors(t *testing.T) {
@@ -90,11 +197,22 @@ func TestBamlValidationErrors(t *testing.T) {
 				return
 			}
 
-			if len(cfg.validationErrors) != 1 {
-				t.Fatalf("want 1 validation error, got %d: %v",
-					len(cfg.validationErrors), cfg.validationErrors)
+			wantCount := tc.wantErrCount
+			if wantCount == 0 {
+				wantCount = 1
 			}
-			got := cfg.validationErrors[0].Message()
+			if len(cfg.validationErrors) != wantCount {
+				t.Fatalf("want %d validation error(s), got %d: %v",
+					wantCount, len(cfg.validationErrors), cfg.validationErrors)
+			}
+			// Combine all accumulated messages — substring assertions
+			// span the multi-error case where each key produces its
+			// own validation error within the same client block.
+			parts := make([]string, len(cfg.validationErrors))
+			for i, e := range cfg.validationErrors {
+				parts[i] = e.Message()
+			}
+			got := strings.Join(parts, "\n")
 			for _, want := range tc.wantErr {
 				if !strings.Contains(got, want) {
 					t.Errorf("validation error %q missing substring %q", got, want)
@@ -102,10 +220,11 @@ func TestBamlValidationErrors(t *testing.T) {
 			}
 			// Pin the no-value-leak invariant: validation messages
 			// must mention the field name + client name without
-			// echoing the configured value. For the region cases
-			// the configured value is `""`, so the literal `""`
-			// substring is a sentinel for accidental value-echoing.
-			// Same shape as #263's no-secret-leak credential checks.
+			// echoing the configured value. For the empty-literal
+			// cases the configured value is `""`, so the literal
+			// `""` substring is a sentinel for accidental
+			// value-echoing. Same shape as #263's no-secret-leak
+			// credential checks.
 			for _, leaky := range []string{`""`, `value=`, `got=`} {
 				if strings.Contains(got, leaky) {
 					t.Errorf("validation error must not echo configured value; found %q in %q",

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -1731,14 +1731,27 @@ func bamlValueStrategyList(v *bamlparser.Value) []string {
 // anything else with a non-empty string representation becomes
 // Provenance=literal (Literal=that string).
 //
-// For `region` on aws-bedrock clients, a declared-empty literal returns
-// (zero, false, validationError) — the empty literal is invalid per
-// upstream BAML semantics (engine/baml-lib/llm-client/src/clients
-// /aws_bedrock.rs:256-261, "region cannot be empty"). For all other
-// key/provider combinations, an empty literal continues to return
-// (zero, false, nil) — the historical empty-as-absent behaviour
-// preserved for parity with upstream's own resolver behaviour and for
-// non-Bedrock clients that happen to use the same option keys.
+// For aws-bedrock clients, a declared-empty literal on one of the
+// validated keys returns (zero, false, validationError):
+//   - `region` — invalid per upstream BAML semantics (engine/baml-lib
+//     /llm-client/src/clients/aws_bedrock.rs:256-261, "region cannot be
+//     empty"); upstream errors directly.
+//   - `access_key_id` / `secret_access_key` — upstream BAML accepts the
+//     empty literal and signs the actual Bedrock request with literally
+//     empty SigV4 credentials (Credential=/<date>/<region>/bedrock/
+//     aws4_request), so AWS rejects at request time with a confusing
+//     AWS-side error. Failing at parse time gives operators the
+//     clearest signal ("you wrote an empty access_key_id, fix your
+//     .baml") rather than letting the silent skip fall through to the
+//     default credential chain and accidentally "work" with ambient
+//     env creds. See #268 for the per-key actual-BAML-behaviour
+//     verification.
+//
+// Other keys (`session_token`, `profile`, `endpoint_url`) continue to
+// return (zero, false, nil) on empty literals — equivalent to upstream
+// BAML's effective behaviour (session_token/endpoint_url collapse to
+// None; profile routes to the default credential chain), and preserved
+// for non-Bedrock clients that happen to use the same option keys.
 //
 // The error is returned as *bamlValidationError (nil-means-no-error) to
 // keep the helper's hot path branch-light.
@@ -1757,11 +1770,26 @@ func bamlValueBedrockOption(clientName, key string, isBedrockClient bool, v *bam
 		return bedrockOptionValue{}, false, nil
 	}
 	if s == "" {
-		if key == "region" && isBedrockClient {
-			return bedrockOptionValue{}, false, &bamlValidationError{
-				Client: clientName,
-				Key:    key,
-				Reason: "region cannot be empty",
+		if isBedrockClient {
+			switch key {
+			case "region":
+				return bedrockOptionValue{}, false, &bamlValidationError{
+					Client: clientName,
+					Key:    key,
+					Reason: "region cannot be empty",
+				}
+			case "access_key_id":
+				return bedrockOptionValue{}, false, &bamlValidationError{
+					Client: clientName,
+					Key:    key,
+					Reason: "access_key_id cannot be empty",
+				}
+			case "secret_access_key":
+				return bedrockOptionValue{}, false, &bamlValidationError{
+					Client: clientName,
+					Key:    key,
+					Reason: "secret_access_key cannot be empty",
+				}
 			}
 		}
 		return bedrockOptionValue{}, false, nil

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -1171,11 +1171,13 @@ type bamlConfig struct {
 	// validationErrors accumulates config-validation errors discovered
 	// during walking. Generation fails (log.Fatalf at the start of
 	// generateBamlConfigVars) if non-empty so that a misconfigured
-	// project — for example aws-bedrock client with declared-empty
-	// `region ""` — cannot silently produce an introspected.go that
-	// would fail later at request-build time. Mirrors upstream BAML's
-	// semantic-validation errors (engine/baml-lib/llm-client/src/clients
-	// /aws_bedrock.rs:256-261 "region cannot be empty").
+	// project — for example an aws-bedrock client with a declared-empty
+	// bedrock option like `region ""`, `access_key_id ""`, or
+	// `secret_access_key ""` — cannot silently produce an introspected.go
+	// that would later either fail at request-build time (region) or
+	// silently fall through to the default credential chain and mask
+	// the config bug (credentials). See bamlValueBedrockOption for the
+	// per-key rationale and the corresponding upstream-BAML behaviours.
 	validationErrors []bamlValidationError
 }
 
@@ -1472,7 +1474,8 @@ func processBAMLFile(cfg *bamlConfig, f *bamlparser.File) {
 // duplicate `provider` fields), then walk fields in source order to
 // apply side effects with correct provider-gated validation. The
 // final-provider pre-pass is needed because options can appear before
-// provider in the same block, and Bedrock-key validation (region "")
+// provider in the same block, and Bedrock-key validation
+// (declared-empty `region`, `access_key_id`, `secret_access_key`)
 // must only fire when the final provider is aws-bedrock.
 func processBAMLClientBlock(cfg *bamlConfig, c *bamlparser.ClientBlock) {
 	name := c.Name
@@ -1517,11 +1520,11 @@ func processBAMLClientBlock(cfg *bamlConfig, c *bamlparser.ClientBlock) {
 //
 // isBedrockClient is the per-client gate computed by
 // processBAMLClientBlock's first pass; it controls whether
-// declared-empty Bedrock-key literals (currently: `region ""`) are
-// rejected as validation errors. A non-Bedrock client with the same
-// option keys is recorded into bedrockClientOptions for parser fidelity
-// (codegen filters by provider) and is NEVER subject to the empty-region
-// validation.
+// declared-empty Bedrock-key literals (currently: `region`,
+// `access_key_id`, `secret_access_key`) are rejected as validation
+// errors. A non-Bedrock client with the same option keys is recorded
+// into bedrockClientOptions for parser fidelity (codegen filters by
+// provider) and is NEVER subject to the empty-literal validation.
 func processBAMLOptionsBlock(cfg *bamlConfig, name string, isBedrockClient bool, opts *bamlparser.Block) {
 	for _, f := range opts.Fields {
 		switch f.Key {
@@ -1916,12 +1919,14 @@ func generateBamlConfigVars(out *jen.File) {
 	cfg := parseBamlSourceDir("baml_src")
 
 	// Stop generation if the walker accumulated any semantic-validation
-	// errors (e.g. aws-bedrock `region ""`). log.Fatalf prevents
-	// out.Save from running so introspected.go is not written with a
-	// half-resolved config that would fail downstream at request-build
-	// time with a confusing region-resolution error. Matches the
-	// existing panic-on-Save-error posture for fatal generation
-	// failures elsewhere in this file.
+	// errors (e.g. an aws-bedrock client with a declared-empty bedrock
+	// option like `region`, `access_key_id`, or `secret_access_key`).
+	// log.Fatalf prevents out.Save from running so introspected.go is
+	// not written with a half-resolved config that would later either
+	// fail at request-build time (region) or silently fall through to
+	// the default credential chain and mask the config bug
+	// (credentials). Matches the existing panic-on-Save-error posture
+	// for fatal generation failures elsewhere in this file.
 	if len(cfg.validationErrors) > 0 {
 		msgs := make([]string, 0, len(cfg.validationErrors))
 		for _, e := range cfg.validationErrors {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Extends the validation-error pattern from PR #276 (region) to two more Bedrock credential keys: declared-empty `access_key_id ""` and `secret_access_key ""` now produce a validation error and fail generation, instead of silently treating the field as absent.

Refs #268. Investigation at https://github.com/invakid404/baml-rest/issues/268#issuecomment-4450779076 (region + adjacent quirks audit) and definitive BAML-behavior verification at `/tmp/codex-i268-baml-actual-behavior-v1.md` (in-tree, posted on the PR conversation).

## Why now

Per Codex's actual-BAML-compiler verification:

- BAML **accepts** `access_key_id ""` + `secret_access_key ""` and signs the actual Bedrock request with literally empty credentials (`Authorization: AWS4-HMAC-SHA256 Credential=/20260514/us-east-1/bedrock/aws4_request, ...`). AWS rejects at request time with a confusing AWS-side error.
- baml-rest previously silently dropped the empty literal, falling through to the default credential chain. With ambient env creds (`AWS_ACCESS_KEY_ID` etc.), our config-driven build accidentally "works" while BAML's generated client would fail — a real silent runtime divergence that masks the config bug.

Failing at parse time gives operators the clearest signal: "you wrote an empty `access_key_id`, fix your `.baml`".

## What's preserved

- `session_token ""` — BAML collapses to `None`; equivalent to our skip.
- `profile ""` — BAML routes through default credential chain; equivalent to our skip.
- `endpoint_url ""` — BAML resolves to `None`; equivalent to our skip (intentional, per #268 item 4).
- `region ""` — already handled by PR #276.

## What's added

- `bamlValueBedrockOption` now errors on declared-empty `access_key_id` and `secret_access_key` for `aws-bedrock` clients (same per-key error pattern as region).
- 7 new validation-error test cases:
  - `BedrockAccessKeyIDEmptyLiteralErrors`
  - `BedrockAccessKeyIDEmptyLiteralErrors_OptionsBeforeProvider` (field-order tolerance)
  - `BedrockSecretAccessKeyEmptyLiteralErrors`
  - `BedrockBothAccessKeyAndSecretEmptyErrors` (pins multi-error accumulation)
  - `BedrockSessionTokenEmptyLiteral_NoError` (regression net)
  - `BedrockProfileEmptyLiteral_NoError` (regression net)
  - `AccessKeyIDEmptyLiteralOnNonBedrockClient_NoError` (provider gating)

## Verification

- 77 existing golden fixtures pass byte-identical.
- 33 standalone bamlparser tests + 14 KEEP introspect tests + retry-warning regression + contract test pass unchanged.
- All 11 validation-error cases pass (4 existing + 7 new).
- `verify-framework-adapter` 6/6 + `verify-adapter-pins` 4/4 green.
- Generated `introspected.go` byte-identical (no current `baml_src` file uses these keys with empty literals).

Refs #268.

Test plan:
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./bamlutils/bamlparser -count=1
- [x] go test ./cmd/introspect -count=1
- [x] go test ./...
- [x] GOWORK=off adapters/common go test ./...
- [x] go run ./cmd/verify-framework-adapter (6/6)
- [x] go run ./cmd/verify-adapter-pins (4/4)
- [x] ./scripts/sync.sh + go.mod/go.sum unchanged
- [x] gofmt -l cmd/introspect/ (clean)
- [x] go run ./cmd/embed (no extra changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now rejects empty AWS Bedrock credential fields (access key ID, secret access key) and reports per-field errors for clearer failure messages.

* **Tests**
  * Expanded coverage for Bedrock validation with multiple error expectations, added edge cases (credential combos, no-error cases), and improved multi-error assertion logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/277)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->