### PR TITLE
docs(bamlparser): document whitespace-list looseness vs upstream BAML grammar

### DIFF
--- a/bamlutils/bamlparser/ast.go
+++ b/bamlutils/bamlparser/ast.go
@@ -219,7 +219,15 @@ type Block struct {
 //   - List:    a `[ ... ]` literal containing zero or more values. The
 //     surrounding brackets are consumed; List is the slice of element
 //     values. Element separators (commas and/or whitespace) are
-//     consumed during parsing and not preserved.
+//     consumed during parsing and not preserved. This grammar is
+//     deliberately looser than upstream BAML's, which permits only
+//     commas and newlines as separators (see upstream BAML's grammar
+//     `splitter` production). The looseness is safe to
+//     keep because baml-rest invokes the real BAML compiler against
+//     the same source as part of the build, and any bare-whitespace
+//     list such as `[A B C]` is rejected upstream as a malformed
+//     identifier reference before our walker would observe a
+//     divergent element count.
 //
 // Map-shape design choice. Upstream BAML's grammar allows a value to be a
 // map literal (e.g. config-map expressions inside `options { ... }`).


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Summary

Final closeout item on the BAML parser-parity investigation. Adds an in-code comment to `bamlutils/bamlparser/ast.go`'s `List` rule documenting that bamlparser accepts bare-whitespace-separated list elements while upstream BAML accepts only `,` / newline. No code or behavior change.

## Why preserve, not fix

baml-rest runs the actual BAML compiler against the same `.baml` source as part of the build. Any `[A B C]`-style input is rejected by BAML first as a malformed identifier reference (`error: client \`A B C\` does not exist`), so our parser's looseness never sees production input that diverges in practice. Comment exists so future readers don't mistake the looseness for a bug.

Closes #268.

Test plan:
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./bamlutils/bamlparser -count=1
- [x] go test ./cmd/introspect -count=1
- [x] gofmt -l bamlutils/bamlparser/ (clean)
- [x] go run ./cmd/embed (no extra changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified parsing behavior documentation for list element handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->