### PR TITLE
refactor(worker): extract handler into internal/worker package (#280)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,39 +1,25 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"os"
-	"runtime"
-	"runtime/debug"
-	"runtime/pprof"
-	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/hashicorp/go-hclog"
 	goplugin "github.com/hashicorp/go-plugin"
-	baml_rest "github.com/invakid404/baml-rest"
+	"google.golang.org/grpc"
+
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/bamlutils/buildrequest"
-	"github.com/invakid404/baml-rest/bamlutils/clientdefaults"
-	"github.com/invakid404/baml-rest/bamlutils/urlrewrite"
-	"github.com/invakid404/baml-rest/internal/apierror"
 	"github.com/invakid404/baml-rest/internal/memlimit"
+	"github.com/invakid404/baml-rest/internal/worker"
 	"github.com/invakid404/baml-rest/workerplugin"
 	pb "github.com/invakid404/baml-rest/workerplugin/proto"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 )
 
 func main() {
-	// Initialize BAML runtime - this loads the shared library
-	baml_rest.InitBamlRuntime()
+	// Initialize BAML runtime - this loads the shared library.
+	worker.InitRuntime()
 
 	// Create hclog logger for go-plugin communication.
 	// Logs are routed back to the main process via go-plugin's protocol.
@@ -42,11 +28,6 @@ func main() {
 		Output:     os.Stderr,
 		JSONFormat: true,
 	})
-	// Expose the logger to package-level helpers (roundRobinAdvancerFor)
-	// that need to surface handshake-level diagnostics. Set before Serve
-	// starts dispatching RPCs so the first request's helper call sees a
-	// non-nil value.
-	workerLogger = logger
 
 	// Load deployment-wide ClientRegistry defaults. A parse failure here is
 	// fatal by design: the worker exits non-zero, go-plugin's handshake
@@ -56,13 +37,12 @@ func main() {
 	// logger.Error (hclog-structured JSON on stderr) is the only channel
 	// go-plugin preserves; fmt.Fprintln / log.Fatal output would be demoted
 	// to debug or dropped entirely by the plugin host.
-	var err error
-	workerClientDefaults, err = clientdefaults.Load()
+	clientDefaults, err := worker.LoadClientDefaults()
 	if err != nil {
 		logger.Error("invalid BAML_REST_CLIENT_DEFAULTS", "err", err.Error())
 		os.Exit(1)
 	}
-	if workerClientDefaults.HasKey("allowed_role_metadata") && buildrequest.UseBuildRequest() {
+	if clientDefaults.HasKey("allowed_role_metadata") && buildrequest.UseBuildRequest() {
 		logger.Warn(
 			"BAML_REST_CLIENT_DEFAULTS sets allowed_role_metadata but " +
 				"BAML_REST_USE_BUILD_REQUEST=true; message-level metadata " +
@@ -97,21 +77,24 @@ func main() {
 		}
 	}
 
-	// Set up Prometheus metrics registry for this worker
-	metricsReg := prometheus.NewRegistry()
-	metricsReg.MustRegister(
-		collectors.NewGoCollector(),
-		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
-	)
+	handler, err := worker.New(worker.Config{
+		Logger:         logger,
+		Metrics:        worker.NewMetricsRegistry(),
+		ClientDefaults: clientDefaults,
+	})
+	if err != nil {
+		logger.Error("failed to construct worker handler", "err", err.Error())
+		os.Exit(1)
+	}
 
-	workerPlugin := &workerplugin.WorkerPlugin{Impl: &workerImpl{metricsReg: metricsReg, logger: logger}}
+	workerPlugin := &workerplugin.WorkerPlugin{Impl: handler}
 	// Install the AttachSharedState callback *before* handing the plugin
 	// to go-plugin. The host calls AttachSharedState once during
 	// handshake; without a handler the RPC fails fast (see
 	// workerplugin/grpc.go) and worker startup fails — there is no
 	// silent fallback to the in-process Coordinator on this path.
 	workerPlugin.SetAttachSharedStateHandler(func(_ context.Context, client pb.SharedStateClient) error {
-		sharedStateClient.Store(&client)
+		handler.SetSharedStateHook(grpcSharedStateHook{client: client})
 		return nil
 	})
 
@@ -128,594 +111,16 @@ func main() {
 	})
 }
 
-// sharedStateClient is the process-scoped handle the host installs via
-// AttachSharedState. Workers read it per-request to build a RemoteAdvancer
-// that delegates round-robin counter updates to the host's SharedStateStore.
-//
-// atomic.Pointer keeps the common read path lock-free: the host writes
-// once at handshake, every request reads. A nil pointer (unset / attach
-// never happened) is legal — callers treat it as "no shared state, use
-// the in-process coordinator".
-var sharedStateClient atomic.Pointer[pb.SharedStateClient]
-
-// workerLogger is the hclog logger set in main() and read from the
-// per-request helpers that need to log outside the workerImpl receiver
-// (e.g. roundRobinAdvancerFor). Set exactly once before goplugin.Serve
-// starts dispatching RPCs.
-var workerLogger hclog.Logger
-
-// noSharedStateWarnOnce ensures the "no shared state attached" warning
-// fires exactly once per process lifetime. Pool-managed workers always
-// attach during handshake; a nil client here means either a handshake
-// regression or a standalone test harness running the worker without
-// shared state. The one-shot warn surfaces the first case to operators
-// without spamming the log on every request.
-var noSharedStateWarnOnce sync.Once
-
-// missingRequestIDWarnOnce fires once per process when SharedState is
-// attached but the inbound context carries no request id. Pool-managed
-// callers (CallStream / Parse) always install a UUID before invoking
-// the worker, so this case is reachable only from standalone /
-// non-pool harnesses that wired SharedState without threading
-// request ids. The host-side SharedStateStore.FetchAdd intentionally
-// bypasses idempotency caching when operationID == "", so retries
-// would advance the counter twice — falling back to the in-process
-// coordinator preserves "same logical request observes the same
-// rotation" instead.
-var missingRequestIDWarnOnce sync.Once
-
-// roundRobinAdvancerFor returns the Advancer the generated dispatch path
-// should use for this request. When a shared-state client is attached
-// AND the inbound context carries a non-empty request id it builds a
-// request-scoped RemoteAdvancer keyed on that id; otherwise it returns
-// nil so orchestrator.ResolveEffectiveClient falls back to the
-// package-level Coordinator compiled into introspected.
-func roundRobinAdvancerFor(ctx context.Context) bamlutils.RoundRobinAdvancer {
-	clientPtr := sharedStateClient.Load()
-	if clientPtr == nil {
-		noSharedStateWarnOnce.Do(func() {
-			if workerLogger != nil {
-				workerLogger.Warn(
-					"round-robin falling back to in-process coordinator; " +
-						"host did not complete AttachSharedState handshake. " +
-						"Pool-managed workers should always attach — this " +
-						"usually indicates a broken handshake or a standalone " +
-						"test harness. baml-roundrobin rotations will be " +
-						"per-worker instead of pool-wide for the rest of " +
-						"this process's lifetime.")
-			}
-		})
-		return nil
-	}
-	requestID := workerplugin.RequestIDFromContext(ctx)
-	if requestID == "" {
-		missingRequestIDWarnOnce.Do(func() {
-			if workerLogger != nil {
-				workerLogger.Warn(
-					"round-robin falling back to in-process coordinator; " +
-						"SharedState is attached but the inbound context " +
-						"carries no request id. SharedStateStore.FetchAdd " +
-						"bypasses its idempotency cache for empty operation " +
-						"ids, so retries of the same logical request would " +
-						"advance the counter twice. Pool-managed callers " +
-						"always install a UUID — this usually indicates a " +
-						"standalone / non-pool harness that wired SharedState " +
-						"without threading request ids.")
-			}
-		})
-		return nil
-	}
-	return workerplugin.NewRemoteAdvancer(ctx, *clientPtr, requestID)
+// grpcSharedStateHook adapts the brokered pb.SharedStateClient to the
+// worker package's SharedStateHook seam. Lives in cmd/worker rather
+// than internal/worker so the protobuf/gRPC client type does not leak
+// into the handler package; the wire layer continues to use
+// workerplugin.NewRemoteAdvancer so request handling stays
+// byte-identical to the pre-extraction subprocess build.
+type grpcSharedStateHook struct {
+	client pb.SharedStateClient
 }
 
-// defaultDrainLeakThreshold is how long a drain goroutine waits before logging
-// a warning that the producer has not closed its result channel. This does NOT
-// add a hard timeout — the drain still waits for close — but alerts operators
-// to a likely leak so they can investigate the misbehaving adapter.
-const defaultDrainLeakThreshold = 30 * time.Second
-
-// drainLeakThreshold stores the current threshold in nanoseconds. Tests can
-// override it via setDrainLeakThreshold. The atomic avoids data races between
-// test goroutines and drain goroutines from earlier tests.
-var drainLeakThresholdNs atomic.Int64
-
-func init() {
-	drainLeakThresholdNs.Store(int64(defaultDrainLeakThreshold))
-}
-
-func getDrainLeakThreshold() time.Duration {
-	return time.Duration(drainLeakThresholdNs.Load())
-}
-
-func setDrainLeakThreshold(d time.Duration) {
-	drainLeakThresholdNs.Store(int64(d))
-}
-
-// activeDrainGoroutines tracks how many drain goroutines are currently running.
-// Exported for operational monitoring (e.g. Prometheus gauge, debug endpoint).
-var activeDrainGoroutines atomic.Int64
-
-// ActiveDrainGoroutines returns the number of drain goroutines currently
-// waiting for a producer to close its result channel.
-func ActiveDrainGoroutines() int64 {
-	return activeDrainGoroutines.Load()
-}
-
-// workerClientDefaults holds deployment-wide ClientRegistry option defaults
-// parsed from BAML_REST_CLIENT_DEFAULTS at worker startup. Always non-nil
-// after main() runs; Apply is a no-op when no options were configured.
-var workerClientDefaults *clientdefaults.Config
-
-// workerImpl implements the workerplugin.Worker interface
-type workerImpl struct {
-	metricsReg *prometheus.Registry
-	logger     bamlutils.Logger
-}
-
-// workerBamlOptions wraps the options for JSON parsing
-type workerBamlOptions struct {
-	Options *bamlutils.BamlOptions `json:"__baml_options__,omitempty"`
-}
-
-func (o *workerBamlOptions) apply(adapter bamlutils.Adapter) error {
-	if o.Options == nil {
-		return nil
-	}
-
-	if o.Options.ClientRegistry != nil {
-		// Apply URL rewrite rules to custom client base_url options
-		if rules := urlrewrite.GlobalRules(); len(rules) > 0 {
-			rewriteClientBaseURLs(o.Options.ClientRegistry, rules)
-		}
-		// Merge deployment-wide defaults *after* URL rewrites (so injected
-		// values aren't accidentally URL-rewritten) and *before*
-		// SetClientRegistry (so BAML sees the merged options).
-		workerClientDefaults.Apply(o.Options.ClientRegistry)
-		if err := adapter.SetClientRegistry(o.Options.ClientRegistry); err != nil {
-			return fmt.Errorf("failed to set client registry: %w", err)
-		}
-	}
-
-	if o.Options.TypeBuilder != nil {
-		if err := adapter.SetTypeBuilder(o.Options.TypeBuilder); err != nil {
-			return fmt.Errorf("failed to set type builder: %w", err)
-		}
-	}
-
-	if o.Options.Retry != nil {
-		adapter.SetRetryConfig(o.Options.Retry)
-	}
-
-	// Always pass IncludeReasoning through (even when false) so the
-	// adapter reflects an explicit per-request choice. Default value
-	// leaves the structured reasoning channel empty.
-	adapter.SetIncludeReasoning(o.Options.IncludeReasoning)
-
-	return nil
-}
-
-// rewriteClientBaseURLs applies URL rewrite rules to the base_url option
-// of each client in the registry. This allows remapping external URLs
-// (e.g., https://llm.mandel.ai) to internal URLs (e.g., http://litellm:4000)
-// for custom clients passed via __baml_options__.
-func rewriteClientBaseURLs(registry *bamlutils.ClientRegistry, rules []urlrewrite.Rule) {
-	for _, client := range registry.Clients {
-		if client == nil || client.Options == nil {
-			continue
-		}
-		baseURL, ok := client.Options["base_url"]
-		if !ok {
-			continue
-		}
-		urlStr, ok := baseURL.(string)
-		if !ok || urlStr == "" {
-			continue
-		}
-		rewritten := urlrewrite.ApplyToURL(urlStr, rules)
-		if rewritten != urlStr {
-			client.Options["base_url"] = rewritten
-		}
-	}
-}
-
-func (w *workerImpl) CallStream(ctx context.Context, methodName string, inputJSON []byte, streamMode bamlutils.StreamMode) (<-chan *workerplugin.StreamResult, error) {
-	method, ok := baml_rest.Methods[methodName]
-	if !ok {
-		return nil, fmt.Errorf("method %q not found", methodName)
-	}
-
-	// Parse input — the typed input struct ignores unknown fields like __baml_options__
-	input := method.MakeInput()
-	if err := json.Unmarshal(inputJSON, input); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal input: %w", err)
-	}
-
-	// Parse options separately — only extracts __baml_options__ field.
-	// This is a second pass over the same JSON. A single-pass approach would
-	// require a combined struct, but the input type is generated per-method
-	// and not known at compile time. The cost is minor for typical payloads.
-	var options workerBamlOptions
-	if err := json.Unmarshal(inputJSON, &options); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal options: %w", err)
-	}
-
-	// Create adapter and apply options
-	adapter := baml_rest.MakeAdapter(ctx)
-	adapter.SetLogger(w.logger)
-	adapter.SetStreamMode(streamMode)
-	// Install a per-request round-robin Advancer that delegates to the
-	// host-side SharedState store. Safe to call unconditionally: returns
-	// nil when no shared-state client is attached, and the adapter treats
-	// nil as "fall back to the introspected default Coordinator".
-	adapter.SetRoundRobinAdvancer(roundRobinAdvancerFor(ctx))
-	if err := options.apply(adapter); err != nil {
-		return nil, fmt.Errorf("failed to apply options: %w", err)
-	}
-
-	// Execute the method
-	resultChan, err := method.Impl(adapter, input)
-	if err != nil {
-		return nil, fmt.Errorf("failed to call method: %w", err)
-	}
-
-	return bridgeStreamResults(ctx, resultChan, w.logger), nil
-}
-
-// bridgeStreamResults converts adapter stream results into plugin stream results
-// while respecting cancellation both before reading upstream and before sending
-// downstream.
-func bridgeStreamResults(ctx context.Context, resultChan <-chan bamlutils.StreamResult, logger bamlutils.Logger) <-chan *workerplugin.StreamResult {
-	out := make(chan *workerplugin.StreamResult)
-	go func() {
-		defer close(out)
-		for {
-			select {
-			case <-ctx.Done():
-				go drainStreamResults(resultChan, logger)
-				return
-			default:
-			}
-
-			var (
-				result bamlutils.StreamResult
-				ok     bool
-			)
-
-			select {
-			case <-ctx.Done():
-				go drainStreamResults(resultChan, logger)
-				return
-			case result, ok = <-resultChan:
-				if !ok {
-					return
-				}
-			}
-
-			pluginResult := workerplugin.GetStreamResult()
-			pluginResult.Reset = result.Reset()
-
-			switch result.Kind() {
-			case bamlutils.StreamResultKindError:
-				pluginResult.Kind = workerplugin.StreamResultKindError
-				pluginResult.Error = result.Error()
-				// Classify typed BuildRequest / transport surfaces into a
-				// worker-facing apierror.Code (parse_error / provider_error)
-				// so the host's classifyWorkerError forwards it verbatim
-				// instead of defaulting to worker_error. classifyBAMLError
-				// returns ("", nil) for unrecognized errors, leaving
-				// pluginResult.ErrorCode at its zero value for host-side
-				// fallback.
-				//
-				// mergeRawDetail attaches the accumulator's text (per #256)
-				// to details regardless of classification arm: parse_error,
-				// provider_error, and unclassified errors all carry
-				// details.raw when result.Raw() is non-empty. Unclassified
-				// errors keep their empty worker code but gain details.raw
-				// via the host's worker_error fallback path. Empty raw
-				// leaves details untouched (omitempty contract).
-				code, details := classifyBAMLError(result.Error())
-				details = mergeRawDetail(details, result.Raw())
-				if code != "" {
-					pluginResult.ErrorCode = code
-				}
-				if details != nil {
-					pluginResult.ErrorDetails = details
-				}
-			case bamlutils.StreamResultKindStream:
-				pluginResult.Kind = workerplugin.StreamResultKindStream
-				// Reset-only stream results intentionally carry no payload. If we
-				// marshal nil here, it becomes JSON `null`, which downstream would
-				// publish as a bogus partial frame in addition to the reset event.
-				// Raw and reasoning stay at their zero values for reset-only
-				// frames — the orchestrator clears the accumulators downstream.
-				if !(result.Reset() && result.Stream() == nil) {
-					data, err := json.Marshal(result.Stream())
-					if err != nil {
-						// Marshal failed: reclassify as an error frame. Raw/
-						// reasoning must stay unset — leaking stale values
-						// from the doomed stream frame onto an error frame
-						// would publish accumulated bytes alongside an error
-						// the client cannot pair them with. Assigning raw/
-						// reasoning only on the success branch below
-						// guarantees this invariant.
-						pluginResult.Kind = workerplugin.StreamResultKindError
-						pluginResult.Error = fmt.Errorf("failed to marshal stream result: %w", err)
-						pluginResult.ErrorCode = string(apierror.CodeInternalError)
-					} else {
-						pluginResult.Data = data
-						pluginResult.Raw = result.Raw()
-						pluginResult.Reasoning = result.Reasoning()
-					}
-				}
-			case bamlutils.StreamResultKindFinal:
-				data, err := json.Marshal(result.Final())
-				if err != nil {
-					pluginResult.Kind = workerplugin.StreamResultKindError
-					pluginResult.Error = fmt.Errorf("failed to marshal final result: %w", err)
-					pluginResult.ErrorCode = string(apierror.CodeInternalError)
-				} else {
-					pluginResult.Kind = workerplugin.StreamResultKindFinal
-					pluginResult.Data = data
-					pluginResult.Raw = result.Raw()
-					pluginResult.Reasoning = result.Reasoning()
-				}
-			case bamlutils.StreamResultKindHeartbeat:
-				pluginResult.Kind = workerplugin.StreamResultKindHeartbeat
-			case bamlutils.StreamResultKindMetadata:
-				md := result.Metadata()
-				if md == nil {
-					// An orchestrator bug — drop the event rather than crashing the stream.
-					pluginResult.Kind = workerplugin.StreamResultKindError
-					pluginResult.Error = fmt.Errorf("metadata result without payload")
-					pluginResult.ErrorCode = string(apierror.CodeInternalError)
-					break
-				}
-				data, err := json.Marshal(md)
-				if err != nil {
-					pluginResult.Kind = workerplugin.StreamResultKindError
-					pluginResult.Error = fmt.Errorf("failed to marshal metadata result: %w", err)
-					pluginResult.ErrorCode = string(apierror.CodeInternalError)
-				} else {
-					pluginResult.Kind = workerplugin.StreamResultKindMetadata
-					pluginResult.Data = data
-				}
-			}
-
-			// Release the adapter's output struct back to its pool
-			result.Release()
-
-			select {
-			case out <- pluginResult:
-			case <-ctx.Done():
-				// Release the plugin result we couldn't send
-				workerplugin.ReleaseStreamResult(pluginResult)
-				go drainStreamResults(resultChan, logger)
-				return
-			}
-		}
-	}()
-
-	return out
-}
-
-// drainStreamResults consumes and releases remaining results from the BAML
-// adapter's stream channel after the bridge goroutine exits due to context
-// cancellation. Each result holds native (Rust) memory via Release(); failing
-// to drain leaves those resources leaked and can block the producer goroutine
-// on an unbuffered send.
-//
-// The function drains until the channel is closed (i.e. the producer finishes).
-// There is intentionally no hard timeout: a timeout would cause the drain
-// goroutine to exit while the producer is still alive, stranding unreleased
-// native results and blocking the producer on its next send.
-//
-// However, if the producer has not closed the channel after drainLeakThreshold
-// (default 30s), a warning is logged so operators can investigate. The drain
-// goroutine is also tracked in activeDrainGoroutines for monitoring.
-func drainStreamResults(resultChan <-chan bamlutils.StreamResult, logger bamlutils.Logger) {
-	activeDrainGoroutines.Add(1)
-	defer activeDrainGoroutines.Add(-1)
-
-	// Start a background timer that fires a warning if the drain takes
-	// too long. The done channel signals the timer goroutine to exit
-	// when the drain completes before the threshold.
-	threshold := getDrainLeakThreshold()
-	done := make(chan struct{})
-	timer := time.NewTimer(threshold)
-	go func() {
-		select {
-		case <-timer.C:
-			active := activeDrainGoroutines.Load()
-			if logger != nil {
-				logger.Warn("drain goroutine still waiting for producer to close result channel",
-					"waited", threshold.String(),
-					"active_drain_goroutines", active,
-				)
-			}
-		case <-done:
-		}
-	}()
-
-	for result := range resultChan {
-		result.Release()
-	}
-
-	timer.Stop()
-	close(done)
-}
-
-func (w *workerImpl) Health(ctx context.Context) (bool, error) {
-	return true, nil
-}
-
-func (w *workerImpl) GetMetrics(ctx context.Context) ([][]byte, error) {
-	mfs, err := w.metricsReg.Gather()
-	if err != nil {
-		return nil, fmt.Errorf("failed to gather metrics: %w", err)
-	}
-
-	result := make([][]byte, 0, len(mfs))
-	for _, mf := range mfs {
-		data, err := proto.Marshal(mf)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal metric family %s: %w", mf.GetName(), err)
-		}
-		result = append(result, data)
-	}
-	return result, nil
-}
-
-func (w *workerImpl) TriggerGC(ctx context.Context) (*workerplugin.GCResult, error) {
-	// Capture memory stats before GC
-	var memBefore runtime.MemStats
-	runtime.ReadMemStats(&memBefore)
-
-	// Force garbage collection
-	runtime.GC()
-
-	// Aggressively release memory to OS
-	debug.FreeOSMemory()
-
-	// Capture memory stats after GC
-	var memAfter runtime.MemStats
-	runtime.ReadMemStats(&memAfter)
-
-	return &workerplugin.GCResult{
-		HeapAllocBefore: memBefore.HeapAlloc,
-		HeapAllocAfter:  memAfter.HeapAlloc,
-		HeapReleased:    memAfter.HeapReleased - memBefore.HeapReleased,
-	}, nil
-}
-
-func (w *workerImpl) GetGoroutines(ctx context.Context, filter string) (*workerplugin.GoroutinesResult, error) {
-	// Capture goroutine profile with full stacks
-	var buf bytes.Buffer
-	if err := pprof.Lookup("goroutine").WriteTo(&buf, 2); err != nil {
-		return nil, fmt.Errorf("failed to capture goroutine profile: %w", err)
-	}
-
-	stacks := buf.String()
-	totalCount := int32(runtime.NumGoroutine())
-
-	result := &workerplugin.GoroutinesResult{
-		TotalCount: totalCount,
-	}
-
-	// Parse include and exclude patterns (patterns prefixed with - are exclusions)
-	var includePatterns, excludePatterns []string
-	if filter != "" {
-		for _, pattern := range strings.Split(filter, ",") {
-			pattern = strings.TrimSpace(pattern)
-			if pattern == "" {
-				continue
-			}
-			if strings.HasPrefix(pattern, "-") {
-				excludePatterns = append(excludePatterns, strings.ToLower(strings.TrimPrefix(pattern, "-")))
-			} else {
-				includePatterns = append(includePatterns, strings.ToLower(pattern))
-			}
-		}
-	}
-
-	// If include patterns provided, count matching goroutines (case-insensitive)
-	if len(includePatterns) > 0 {
-		goroutineStacks := strings.Split(stacks, "goroutine ")
-		for _, stack := range goroutineStacks {
-			if stack == "" {
-				continue
-			}
-			stackLower := strings.ToLower(stack)
-
-			// Check if stack matches any include pattern
-			matched := false
-			for _, pattern := range includePatterns {
-				if strings.Contains(stackLower, pattern) {
-					matched = true
-					break
-				}
-			}
-			if !matched {
-				continue
-			}
-
-			// Check if stack matches any exclude pattern
-			excluded := false
-			for _, pattern := range excludePatterns {
-				if strings.Contains(stackLower, pattern) {
-					excluded = true
-					break
-				}
-			}
-			if excluded {
-				continue
-			}
-
-			result.MatchCount++
-			// Truncate for readability
-			if len(stack) > 1000 {
-				stack = stack[:1000] + "..."
-			}
-			result.MatchedStacks = append(result.MatchedStacks, "goroutine "+stack)
-		}
-	}
-
-	return result, nil
-}
-
-// workerParseInput wraps the input for parse requests
-type workerParseInput struct {
-	Raw     string                 `json:"raw"`
-	Options *bamlutils.BamlOptions `json:"__baml_options__,omitempty"`
-}
-
-func (w *workerImpl) Parse(ctx context.Context, methodName string, inputJSON []byte) (*workerplugin.ParseResult, error) {
-	method, ok := baml_rest.ParseMethods[methodName]
-	if !ok {
-		return nil, fmt.Errorf("parse method %q not found", methodName)
-	}
-
-	// Parse input
-	var input workerParseInput
-	if err := json.Unmarshal(inputJSON, &input); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal input: %w", err)
-	}
-
-	if input.Raw == "" {
-		return nil, fmt.Errorf("missing required field 'raw'")
-	}
-
-	// Create adapter and apply options
-	adapter := baml_rest.MakeAdapter(ctx)
-	adapter.SetLogger(w.logger)
-	if input.Options != nil {
-		opts := workerBamlOptions{Options: input.Options}
-		if err := opts.apply(adapter); err != nil {
-			return nil, fmt.Errorf("failed to apply options: %w", err)
-		}
-	}
-
-	// Call the parse method
-	result, err := method.Impl(adapter, input.Raw)
-	if err != nil {
-		// Wrap with any typed classification so the gRPC layer's
-		// errors.As against GetCode()/GetDetails() picks it up
-		// (workerplugin/grpc.go:220+). The /parse host endpoint also
-		// has a fallback rewrite from worker_error to parse_error, so
-		// leaving the code empty is safe; wrapping just lets typed
-		// surfaces (e.g. an underlying *llmhttp.HTTPError surfaced
-		// through a BAML adapter that propagates the wrap chain) land
-		// as the more specific code.
-		if code, details := classifyBAMLError(err); code != "" {
-			return nil, workerplugin.NewErrorWithMetadata(err, "", code, details)
-		}
-		return nil, err
-	}
-
-	// Marshal the result to JSON
-	data, err := json.Marshal(result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal parse result: %w", err)
-	}
-
-	return &workerplugin.ParseResult{Data: data}, nil
+func (h grpcSharedStateHook) NewRoundRobinAdvancer(ctx context.Context, requestID string) bamlutils.RoundRobinAdvancer {
+	return workerplugin.NewRemoteAdvancer(ctx, h.client, requestID)
 }

--- a/embed.go
+++ b/embed.go
@@ -15,7 +15,7 @@ import (
 	"github.com/invakid404/baml-rest/workerplugin"
 )
 
-//go:embed adapter.go adapters cmd/build cmd/embed cmd/hacks cmd/introspect/main.go cmd/schema/main.go cmd/serve/debug.go cmd/serve/debug_stub.go cmd/serve/error.go cmd/serve/headers.go cmd/serve/main.go cmd/serve/openapi.json cmd/serve/streamwriter.go cmd/serve/unary.go cmd/serve/unary_handlers.go cmd/serve/unary_stub.go cmd/serve/worker cmd/verify-adapter-pins cmd/verify-framework-adapter/main.go cmd/worker/error_classify.go cmd/worker/main.go embed.go go.mod go.sum go.work go.work.sum internal/apierror/error.go internal/httplogger internal/memlimit/memlimit.go internal/unsafeutil renovate.json scripts
+//go:embed adapter.go adapters cmd/build cmd/embed cmd/hacks cmd/introspect/main.go cmd/schema/main.go cmd/serve/debug.go cmd/serve/debug_stub.go cmd/serve/error.go cmd/serve/headers.go cmd/serve/main.go cmd/serve/openapi.json cmd/serve/streamwriter.go cmd/serve/unary.go cmd/serve/unary_handlers.go cmd/serve/unary_stub.go cmd/serve/worker cmd/verify-adapter-pins cmd/verify-framework-adapter/main.go cmd/worker embed.go go.mod go.sum go.work go.work.sum internal/apierror/error.go internal/httplogger internal/memlimit/memlimit.go internal/unsafeutil internal/worker/admin.go internal/worker/defaults.go internal/worker/errors.go internal/worker/handler.go internal/worker/metrics.go internal/worker/options.go internal/worker/parse.go internal/worker/runtime.go internal/worker/sharedstate.go internal/worker/stream.go renovate.json scripts
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/internal/worker/admin.go
+++ b/internal/worker/admin.go
@@ -103,8 +103,11 @@ func (h *Handler) GetGoroutines(ctx context.Context, filter string) (*workerplug
 		}
 	}
 
-	// If include patterns provided, count matching goroutines (case-insensitive)
-	if len(includePatterns) > 0 {
+	// If any patterns were parsed, count matching goroutines
+	// (case-insensitive). An empty includePatterns set means "match all
+	// stacks before applying exclusions", so exclude-only filters like
+	// "-runtime." still run the exclude loop instead of short-circuiting.
+	if len(includePatterns) > 0 || len(excludePatterns) > 0 {
 		goroutineStacks := strings.Split(stacks, "goroutine ")
 		for _, stack := range goroutineStacks {
 			if stack == "" {
@@ -112,8 +115,10 @@ func (h *Handler) GetGoroutines(ctx context.Context, filter string) (*workerplug
 			}
 			stackLower := strings.ToLower(stack)
 
-			// Check if stack matches any include pattern
-			matched := false
+			// Check if stack matches any include pattern. With no include
+			// patterns, the default is "match" so the exclude pass below
+			// still filters down from the full goroutine set.
+			matched := len(includePatterns) == 0
 			for _, pattern := range includePatterns {
 				if strings.Contains(stackLower, pattern) {
 					matched = true

--- a/internal/worker/admin.go
+++ b/internal/worker/admin.go
@@ -1,0 +1,139 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"runtime/pprof"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/invakid404/baml-rest/workerplugin"
+)
+
+// GetMetrics returns the worker process Prometheus metrics, serialized
+// as MetricFamily proto bytes so the host can wire them into its own
+// /metrics endpoint without re-collecting.
+func (h *Handler) GetMetrics(ctx context.Context) ([][]byte, error) {
+	mfs, err := h.metricsReg.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("failed to gather metrics: %w", err)
+	}
+
+	result := make([][]byte, 0, len(mfs))
+	for _, mf := range mfs {
+		data, err := proto.Marshal(mf)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal metric family %s: %w", mf.GetName(), err)
+		}
+		result = append(result, data)
+	}
+	return result, nil
+}
+
+// TriggerGC forces a Go garbage collection and releases unused heap
+// memory back to the OS, returning the before/after heap snapshot so
+// the host can surface the effectiveness of the GC.
+func (h *Handler) TriggerGC(ctx context.Context) (*workerplugin.GCResult, error) {
+	// Capture memory stats before GC
+	var memBefore runtime.MemStats
+	runtime.ReadMemStats(&memBefore)
+
+	// Force garbage collection
+	runtime.GC()
+
+	// Aggressively release memory to OS
+	debug.FreeOSMemory()
+
+	// Capture memory stats after GC
+	var memAfter runtime.MemStats
+	runtime.ReadMemStats(&memAfter)
+
+	return &workerplugin.GCResult{
+		HeapAllocBefore: memBefore.HeapAlloc,
+		HeapAllocAfter:  memAfter.HeapAlloc,
+		HeapReleased:    memAfter.HeapReleased - memBefore.HeapReleased,
+	}, nil
+}
+
+// GetGoroutines returns the worker process goroutine profile, optionally
+// filtered by a comma-separated include/exclude pattern list. Patterns
+// prefixed with `-` are exclusions; others are inclusions. Matching is
+// case-insensitive substring against each goroutine's stack.
+func (h *Handler) GetGoroutines(ctx context.Context, filter string) (*workerplugin.GoroutinesResult, error) {
+	// Capture goroutine profile with full stacks
+	var buf bytes.Buffer
+	if err := pprof.Lookup("goroutine").WriteTo(&buf, 2); err != nil {
+		return nil, fmt.Errorf("failed to capture goroutine profile: %w", err)
+	}
+
+	stacks := buf.String()
+	totalCount := int32(runtime.NumGoroutine())
+
+	result := &workerplugin.GoroutinesResult{
+		TotalCount: totalCount,
+	}
+
+	// Parse include and exclude patterns (patterns prefixed with - are exclusions)
+	var includePatterns, excludePatterns []string
+	if filter != "" {
+		for _, pattern := range strings.Split(filter, ",") {
+			pattern = strings.TrimSpace(pattern)
+			if pattern == "" {
+				continue
+			}
+			if strings.HasPrefix(pattern, "-") {
+				excludePatterns = append(excludePatterns, strings.ToLower(strings.TrimPrefix(pattern, "-")))
+			} else {
+				includePatterns = append(includePatterns, strings.ToLower(pattern))
+			}
+		}
+	}
+
+	// If include patterns provided, count matching goroutines (case-insensitive)
+	if len(includePatterns) > 0 {
+		goroutineStacks := strings.Split(stacks, "goroutine ")
+		for _, stack := range goroutineStacks {
+			if stack == "" {
+				continue
+			}
+			stackLower := strings.ToLower(stack)
+
+			// Check if stack matches any include pattern
+			matched := false
+			for _, pattern := range includePatterns {
+				if strings.Contains(stackLower, pattern) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+
+			// Check if stack matches any exclude pattern
+			excluded := false
+			for _, pattern := range excludePatterns {
+				if strings.Contains(stackLower, pattern) {
+					excluded = true
+					break
+				}
+			}
+			if excluded {
+				continue
+			}
+
+			result.MatchCount++
+			// Truncate for readability
+			if len(stack) > 1000 {
+				stack = stack[:1000] + "..."
+			}
+			result.MatchedStacks = append(result.MatchedStacks, "goroutine "+stack)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/worker/admin.go
+++ b/internal/worker/admin.go
@@ -52,10 +52,23 @@ func (h *Handler) TriggerGC(ctx context.Context) (*workerplugin.GCResult, error)
 	var memAfter runtime.MemStats
 	runtime.ReadMemStats(&memAfter)
 
+	// runtime.MemStats.HeapReleased is *current* bytes returned to the OS,
+	// not a cumulative counter — it can decrease between snapshots when the
+	// runtime reacquires previously-released memory. A naive subtraction
+	// underflows the uint64 delta to ~18 EB in that case. Clamp to zero so
+	// metrics/logs report a sane "no bytes released" rather than a wildly
+	// wrong magnitude. workerplugin.GCResult.HeapReleased and its protobuf
+	// are uint64 by wire contract, so saturating clamp here rather than
+	// widening the field is the in-scope fix.
+	var heapReleased uint64
+	if memAfter.HeapReleased >= memBefore.HeapReleased {
+		heapReleased = memAfter.HeapReleased - memBefore.HeapReleased
+	}
+
 	return &workerplugin.GCResult{
 		HeapAllocBefore: memBefore.HeapAlloc,
 		HeapAllocAfter:  memAfter.HeapAlloc,
-		HeapReleased:    memAfter.HeapReleased - memBefore.HeapReleased,
+		HeapReleased:    heapReleased,
 	}, nil
 }
 

--- a/internal/worker/admin.go
+++ b/internal/worker/admin.go
@@ -52,14 +52,11 @@ func (h *Handler) TriggerGC(ctx context.Context) (*workerplugin.GCResult, error)
 	var memAfter runtime.MemStats
 	runtime.ReadMemStats(&memAfter)
 
-	// runtime.MemStats.HeapReleased is *current* bytes returned to the OS,
-	// not a cumulative counter — it can decrease between snapshots when the
-	// runtime reacquires previously-released memory. A naive subtraction
-	// underflows the uint64 delta to ~18 EB in that case. Clamp to zero so
-	// metrics/logs report a sane "no bytes released" rather than a wildly
-	// wrong magnitude. workerplugin.GCResult.HeapReleased and its protobuf
-	// are uint64 by wire contract, so saturating clamp here rather than
-	// widening the field is the in-scope fix.
+	// HeapReleased is current bytes returned to the OS, not a cumulative
+	// counter — it can decrease between snapshots when the runtime
+	// reacquires previously-released memory. A naive uint64 subtraction
+	// would underflow to ~18 EB in that case; clamp to zero so metrics
+	// and logs report "no bytes released" instead.
 	var heapReleased uint64
 	if memAfter.HeapReleased >= memBefore.HeapReleased {
 		heapReleased = memAfter.HeapReleased - memBefore.HeapReleased

--- a/internal/worker/admin.go
+++ b/internal/worker/admin.go
@@ -96,7 +96,11 @@ func (h *Handler) GetGoroutines(ctx context.Context, filter string) (*workerplug
 				continue
 			}
 			if strings.HasPrefix(pattern, "-") {
-				excludePatterns = append(excludePatterns, strings.ToLower(strings.TrimPrefix(pattern, "-")))
+				exclude := strings.ToLower(strings.TrimPrefix(pattern, "-"))
+				if exclude == "" {
+					continue
+				}
+				excludePatterns = append(excludePatterns, exclude)
 			} else {
 				includePatterns = append(includePatterns, strings.ToLower(pattern))
 			}

--- a/internal/worker/admin_test.go
+++ b/internal/worker/admin_test.go
@@ -1,0 +1,86 @@
+package worker
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestGetGoroutinesFilterBranches exercises the goroutine-filter
+// branches (empty / include-only / exclude-only / no-op exclude) against
+// the live test-runner goroutines. The fictitious sentinel pattern is
+// chosen so it cannot appear in any real stack, which makes the
+// exclude-only assertion symmetric to the include-only one.
+func TestGetGoroutinesFilterBranches(t *testing.T) {
+	// Not parallel: reads the live goroutine profile, and other parallel
+	// tests in the package spawn drain goroutines that would race with
+	// the include-pattern count.
+
+	const sentinel = "baml-rest-pr280-filter-sentinel-xyz"
+
+	h, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx := context.Background()
+
+	t.Run("empty filter returns no matched stacks", func(t *testing.T) {
+		got, err := h.GetGoroutines(ctx, "")
+		if err != nil {
+			t.Fatalf("GetGoroutines: %v", err)
+		}
+		if got.TotalCount <= 0 {
+			t.Fatalf("TotalCount: got %d, want > 0", got.TotalCount)
+		}
+		if got.MatchCount != 0 || len(got.MatchedStacks) != 0 {
+			t.Fatalf("empty filter must return no matched stacks; got MatchCount=%d, len(MatchedStacks)=%d",
+				got.MatchCount, len(got.MatchedStacks))
+		}
+	})
+
+	t.Run("include-only fictitious pattern matches nothing", func(t *testing.T) {
+		got, err := h.GetGoroutines(ctx, sentinel)
+		if err != nil {
+			t.Fatalf("GetGoroutines: %v", err)
+		}
+		if got.MatchCount != 0 || len(got.MatchedStacks) != 0 {
+			t.Fatalf("sentinel include must match no stacks; got MatchCount=%d, MatchedStacks=%v",
+				got.MatchCount, got.MatchedStacks)
+		}
+	})
+
+	t.Run("exclude-only fictitious pattern matches every stack", func(t *testing.T) {
+		got, err := h.GetGoroutines(ctx, "-"+sentinel)
+		if err != nil {
+			t.Fatalf("GetGoroutines: %v", err)
+		}
+		// The sentinel cannot appear in any real stack, so an exclude-only
+		// filter must return at least one matched stack. Before the fix
+		// the outer gate short-circuited on empty includePatterns and
+		// MatchCount was zero.
+		if got.MatchCount == 0 || len(got.MatchedStacks) == 0 {
+			t.Fatalf("exclude-only filter returned zero matched stacks; want > 0")
+		}
+		// And none of the returned stacks should contain the sentinel
+		// (vacuously true, but pins the exclude pass actually runs).
+		for _, stack := range got.MatchedStacks {
+			if strings.Contains(strings.ToLower(stack), sentinel) {
+				t.Errorf("matched stack contains the excluded sentinel: %q", stack)
+			}
+		}
+	})
+
+	t.Run("include-only testing pattern hits the test runner", func(t *testing.T) {
+		// "testing." appears in every Go test process (the test runner
+		// goroutine itself), so an include-only filter on it must
+		// surface at least one stack. Guards against an over-eager fix
+		// that broke the include path.
+		got, err := h.GetGoroutines(ctx, "testing.")
+		if err != nil {
+			t.Fatalf("GetGoroutines: %v", err)
+		}
+		if got.MatchCount == 0 || len(got.MatchedStacks) == 0 {
+			t.Fatalf("include filter for 'testing.' returned zero matches; expected the test runner stack")
+		}
+	})
+}

--- a/internal/worker/admin_test.go
+++ b/internal/worker/admin_test.go
@@ -70,6 +70,46 @@ func TestGetGoroutinesFilterBranches(t *testing.T) {
 		}
 	})
 
+	t.Run("bare dash exclude token returns no matched stacks", func(t *testing.T) {
+		// A "-" token strips to an empty exclude pattern. Without the
+		// empty-guard, strings.Contains(stack, "") matches every stack
+		// and the goroutine set is silently dropped. The dropped pattern
+		// leaves the parsed set empty, so the outer gate returns no
+		// stacks — same shape as filter="".
+		got, err := h.GetGoroutines(ctx, "-")
+		if err != nil {
+			t.Fatalf("GetGoroutines: %v", err)
+		}
+		if got.MatchCount != 0 || len(got.MatchedStacks) != 0 {
+			t.Fatalf("filter=\"-\" must drop the empty exclude and return no matched stacks; got MatchCount=%d, len(MatchedStacks)=%d",
+				got.MatchCount, len(got.MatchedStacks))
+		}
+	})
+
+	t.Run("multiple empty exclude tokens collapse to no-op", func(t *testing.T) {
+		got, err := h.GetGoroutines(ctx, "-,-,-")
+		if err != nil {
+			t.Fatalf("GetGoroutines: %v", err)
+		}
+		if got.MatchCount != 0 || len(got.MatchedStacks) != 0 {
+			t.Fatalf("filter=\"-,-,-\" must drop all empty excludes and return no matched stacks; got MatchCount=%d, len(MatchedStacks)=%d",
+				got.MatchCount, len(got.MatchedStacks))
+		}
+	})
+
+	t.Run("empty exclude alongside real include still applies include", func(t *testing.T) {
+		// Sanity check: dropping the bare-dash exclude must not affect
+		// adjacent include patterns. "testing." reliably hits the test
+		// runner stack, so the include side should still produce matches.
+		got, err := h.GetGoroutines(ctx, "testing.,-")
+		if err != nil {
+			t.Fatalf("GetGoroutines: %v", err)
+		}
+		if got.MatchCount == 0 || len(got.MatchedStacks) == 0 {
+			t.Fatalf("real include alongside empty exclude must still match stacks; got MatchCount=%d", got.MatchCount)
+		}
+	})
+
 	t.Run("include-only testing pattern hits the test runner", func(t *testing.T) {
 		// "testing." appears in every Go test process (the test runner
 		// goroutine itself), so an include-only filter on it must

--- a/internal/worker/defaults.go
+++ b/internal/worker/defaults.go
@@ -1,0 +1,15 @@
+package worker
+
+import (
+	"github.com/invakid404/baml-rest/bamlutils/clientdefaults"
+)
+
+// LoadClientDefaults parses the deployment-wide ClientRegistry option
+// defaults from BAML_REST_CLIENT_DEFAULTS. Thin wrapper around
+// clientdefaults.Load so cmd/worker (and future in-process callers) hit
+// the same entry point. The caller decides what to do on error — the
+// subprocess binary treats it as fatal, but that policy lives in
+// cmd/worker rather than here.
+func LoadClientDefaults() (*clientdefaults.Config, error) {
+	return clientdefaults.Load()
+}

--- a/internal/worker/errors.go
+++ b/internal/worker/errors.go
@@ -1,4 +1,4 @@
-package main
+package worker
 
 import (
 	"errors"

--- a/internal/worker/errors_test.go
+++ b/internal/worker/errors_test.go
@@ -1,4 +1,4 @@
-package main
+package worker
 
 import (
 	"encoding/json"

--- a/internal/worker/handler.go
+++ b/internal/worker/handler.go
@@ -1,0 +1,127 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/goccy/go-json"
+	"github.com/prometheus/client_golang/prometheus"
+
+	baml_rest "github.com/invakid404/baml-rest"
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/clientdefaults"
+	"github.com/invakid404/baml-rest/workerplugin"
+)
+
+// Config carries the construction-time dependencies for a Handler. Any
+// field may be left at its zero value:
+//
+//   - Logger nil: bridge/drain paths and the round-robin warnings become
+//     silent for that handler instance.
+//   - Metrics nil: New constructs a default registry with the same Go +
+//     process collectors NewMetricsRegistry would have produced.
+//   - ClientDefaults nil: BAML_REST_CLIENT_DEFAULTS overrides aren't
+//     applied. clientdefaults.Config.Apply is nil-safe.
+//   - SharedState nil: the handler logs the existing once-per-process
+//     warning the first time a request tries to use round-robin shared
+//     state, then falls back to the in-process Coordinator.
+type Config struct {
+	Logger         bamlutils.Logger
+	Metrics        *prometheus.Registry
+	ClientDefaults *clientdefaults.Config
+	SharedState    SharedStateHook
+}
+
+// Handler is the worker-side request handler extracted from
+// cmd/worker/main.go. It satisfies workerplugin.Worker so the subprocess
+// binary can hand it to goplugin.Serve without wrapping. Process-global
+// state from the previous package-main layout (client defaults,
+// shared-state client, logger, warning sync.Once values) now lives on
+// the Handler so the type is constructible without hidden initialization.
+type Handler struct {
+	logger         bamlutils.Logger
+	metricsReg     *prometheus.Registry
+	clientDefaults *clientdefaults.Config
+
+	sharedStateHook hookStorage
+
+	noSharedStateWarnOnce    sync.Once
+	missingRequestIDWarnOnce sync.Once
+}
+
+// Compile-time assertion that Handler satisfies the wire interface.
+// Catches signature drift between workerplugin.Worker and Handler at
+// build time rather than at first plugin handshake.
+var _ workerplugin.Worker = (*Handler)(nil)
+
+// New constructs a Handler from the supplied configuration. See Config
+// for the nil-tolerance contract.
+func New(cfg Config) (*Handler, error) {
+	metricsReg := cfg.Metrics
+	if metricsReg == nil {
+		metricsReg = NewMetricsRegistry()
+	}
+	h := &Handler{
+		logger:         cfg.Logger,
+		metricsReg:     metricsReg,
+		clientDefaults: cfg.ClientDefaults,
+	}
+	if cfg.SharedState != nil {
+		h.SetSharedStateHook(cfg.SharedState)
+	}
+	return h, nil
+}
+
+// CallStream executes a streaming BAML method and bridges its results
+// onto the worker plugin's stream channel.
+func (h *Handler) CallStream(ctx context.Context, methodName string, inputJSON []byte, streamMode bamlutils.StreamMode) (<-chan *workerplugin.StreamResult, error) {
+	method, ok := baml_rest.Methods[methodName]
+	if !ok {
+		return nil, fmt.Errorf("method %q not found", methodName)
+	}
+
+	// Parse input — the typed input struct ignores unknown fields like __baml_options__
+	input := method.MakeInput()
+	if err := json.Unmarshal(inputJSON, input); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal input: %w", err)
+	}
+
+	// Parse options separately — only extracts __baml_options__ field.
+	// This is a second pass over the same JSON. A single-pass approach would
+	// require a combined struct, but the input type is generated per-method
+	// and not known at compile time. The cost is minor for typical payloads.
+	var options workerBamlOptions
+	if err := json.Unmarshal(inputJSON, &options); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal options: %w", err)
+	}
+
+	// Create adapter and apply options
+	adapter := baml_rest.MakeAdapter(ctx)
+	adapter.SetLogger(h.logger)
+	adapter.SetStreamMode(streamMode)
+	// Install a per-request round-robin Advancer that delegates to the
+	// host-side SharedState store. Safe to call unconditionally: returns
+	// nil when no shared-state hook is attached, and the adapter treats
+	// nil as "fall back to the introspected default Coordinator".
+	adapter.SetRoundRobinAdvancer(h.roundRobinAdvancerFor(ctx))
+	if err := options.apply(adapter, h.clientDefaults); err != nil {
+		return nil, fmt.Errorf("failed to apply options: %w", err)
+	}
+
+	// Execute the method
+	resultChan, err := method.Impl(adapter, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call method: %w", err)
+	}
+
+	return bridgeStreamResults(ctx, resultChan, h.logger), nil
+}
+
+// Health is part of the workerplugin.Worker interface — the host calls
+// it as a liveness probe. Always returns (true, nil) today; the
+// subprocess process model treats a non-responsive handler the same as
+// a crashed worker.
+func (h *Handler) Health(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/internal/worker/metrics.go
+++ b/internal/worker/metrics.go
@@ -1,0 +1,19 @@
+package worker
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+)
+
+// NewMetricsRegistry returns a fresh Prometheus registry pre-populated
+// with the Go runtime + process collectors. The default subprocess worker
+// reads metrics from this registry via GetMetrics; keeping construction
+// here means in-process callers don't need to mirror the collector list.
+func NewMetricsRegistry() *prometheus.Registry {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+	)
+	return reg
+}

--- a/internal/worker/options.go
+++ b/internal/worker/options.go
@@ -1,0 +1,79 @@
+package worker
+
+import (
+	"fmt"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/clientdefaults"
+	"github.com/invakid404/baml-rest/bamlutils/urlrewrite"
+)
+
+// workerBamlOptions wraps the options for JSON parsing.
+type workerBamlOptions struct {
+	Options *bamlutils.BamlOptions `json:"__baml_options__,omitempty"`
+}
+
+// apply installs the request-level option overrides on adapter. The
+// deployment-wide client defaults are passed in so the handler owns the
+// merged config rather than reaching into a package global. Nil defaults
+// is fine — clientdefaults.Config.Apply is nil-safe.
+func (o *workerBamlOptions) apply(adapter bamlutils.Adapter, defaults *clientdefaults.Config) error {
+	if o.Options == nil {
+		return nil
+	}
+
+	if o.Options.ClientRegistry != nil {
+		// Apply URL rewrite rules to custom client base_url options
+		if rules := urlrewrite.GlobalRules(); len(rules) > 0 {
+			rewriteClientBaseURLs(o.Options.ClientRegistry, rules)
+		}
+		// Merge deployment-wide defaults *after* URL rewrites (so injected
+		// values aren't accidentally URL-rewritten) and *before*
+		// SetClientRegistry (so BAML sees the merged options).
+		defaults.Apply(o.Options.ClientRegistry)
+		if err := adapter.SetClientRegistry(o.Options.ClientRegistry); err != nil {
+			return fmt.Errorf("failed to set client registry: %w", err)
+		}
+	}
+
+	if o.Options.TypeBuilder != nil {
+		if err := adapter.SetTypeBuilder(o.Options.TypeBuilder); err != nil {
+			return fmt.Errorf("failed to set type builder: %w", err)
+		}
+	}
+
+	if o.Options.Retry != nil {
+		adapter.SetRetryConfig(o.Options.Retry)
+	}
+
+	// Always pass IncludeReasoning through (even when false) so the
+	// adapter reflects an explicit per-request choice. Default value
+	// leaves the structured reasoning channel empty.
+	adapter.SetIncludeReasoning(o.Options.IncludeReasoning)
+
+	return nil
+}
+
+// rewriteClientBaseURLs applies URL rewrite rules to the base_url option
+// of each client in the registry. This allows remapping external URLs
+// (e.g., https://llm.mandel.ai) to internal URLs (e.g., http://litellm:4000)
+// for custom clients passed via __baml_options__.
+func rewriteClientBaseURLs(registry *bamlutils.ClientRegistry, rules []urlrewrite.Rule) {
+	for _, client := range registry.Clients {
+		if client == nil || client.Options == nil {
+			continue
+		}
+		baseURL, ok := client.Options["base_url"]
+		if !ok {
+			continue
+		}
+		urlStr, ok := baseURL.(string)
+		if !ok || urlStr == "" {
+			continue
+		}
+		rewritten := urlrewrite.ApplyToURL(urlStr, rules)
+		if rewritten != urlStr {
+			client.Options["base_url"] = rewritten
+		}
+	}
+}

--- a/internal/worker/parse.go
+++ b/internal/worker/parse.go
@@ -1,0 +1,74 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/goccy/go-json"
+
+	baml_rest "github.com/invakid404/baml-rest"
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/workerplugin"
+)
+
+// workerParseInput wraps the input for parse requests.
+type workerParseInput struct {
+	Raw     string                 `json:"raw"`
+	Options *bamlutils.BamlOptions `json:"__baml_options__,omitempty"`
+}
+
+// Parse executes a BAML parse method against a raw response string.
+// Parse intentionally does not thread a round-robin advancer — parsing
+// is a local CPU operation and never dispatches against a baml-roundrobin
+// client.
+func (h *Handler) Parse(ctx context.Context, methodName string, inputJSON []byte) (*workerplugin.ParseResult, error) {
+	method, ok := baml_rest.ParseMethods[methodName]
+	if !ok {
+		return nil, fmt.Errorf("parse method %q not found", methodName)
+	}
+
+	// Parse input
+	var input workerParseInput
+	if err := json.Unmarshal(inputJSON, &input); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal input: %w", err)
+	}
+
+	if input.Raw == "" {
+		return nil, fmt.Errorf("missing required field 'raw'")
+	}
+
+	// Create adapter and apply options
+	adapter := baml_rest.MakeAdapter(ctx)
+	adapter.SetLogger(h.logger)
+	if input.Options != nil {
+		opts := workerBamlOptions{Options: input.Options}
+		if err := opts.apply(adapter, h.clientDefaults); err != nil {
+			return nil, fmt.Errorf("failed to apply options: %w", err)
+		}
+	}
+
+	// Call the parse method
+	result, err := method.Impl(adapter, input.Raw)
+	if err != nil {
+		// Wrap with any typed classification so the gRPC layer's
+		// errors.As against GetCode()/GetDetails() picks it up
+		// (workerplugin/grpc.go:220+). The /parse host endpoint also
+		// has a fallback rewrite from worker_error to parse_error, so
+		// leaving the code empty is safe; wrapping just lets typed
+		// surfaces (e.g. an underlying *llmhttp.HTTPError surfaced
+		// through a BAML adapter that propagates the wrap chain) land
+		// as the more specific code.
+		if code, details := classifyBAMLError(err); code != "" {
+			return nil, workerplugin.NewErrorWithMetadata(err, "", code, details)
+		}
+		return nil, err
+	}
+
+	// Marshal the result to JSON
+	data, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal parse result: %w", err)
+	}
+
+	return &workerplugin.ParseResult{Data: data}, nil
+}

--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -1,0 +1,14 @@
+package worker
+
+import (
+	baml_rest "github.com/invakid404/baml-rest"
+)
+
+// InitRuntime initializes the BAML runtime by loading the shared library.
+// Thin wrapper over the generated baml_rest.InitBamlRuntime so callers in
+// cmd/worker (subprocess binary) and future in-process callers can hit the
+// same entry point. Callers decide when to invoke it — New does not call it
+// implicitly so startup ordering stays explicit.
+func InitRuntime() {
+	baml_rest.InitBamlRuntime()
+}

--- a/internal/worker/sharedstate.go
+++ b/internal/worker/sharedstate.go
@@ -1,0 +1,148 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/workerplugin"
+)
+
+// SharedStateHook is the worker-facing seam that produces a per-request
+// round-robin advancer. The default subprocess binary wraps the existing
+// pb.SharedStateClient (which talks to the host over the go-plugin broker
+// socket); future in-process callers will plug in a non-gRPC adapter that
+// calls SharedStateStore.FetchAdd directly.
+//
+// The shape is intentionally narrow — Advance is the only round-robin
+// operation the handler needs, and DropScope remains the pool's
+// responsibility. Returning a *bamlutils.RoundRobinAdvancer rather than
+// the underlying client keeps protobuf/gRPC types out of internal/worker.
+type SharedStateHook interface {
+	// NewRoundRobinAdvancer returns the Advancer the generated dispatch
+	// path should use for the given request. Implementations may return
+	// nil to signal "no advancer for this request"; callers treat nil as
+	// fall-through to the introspected default Coordinator.
+	NewRoundRobinAdvancer(ctx context.Context, requestID string) bamlutils.RoundRobinAdvancer
+}
+
+// FetchAddStore is the minimal store-side surface a direct-call
+// SharedStateHook needs. *workerplugin.SharedStateStore satisfies this
+// without importing protobuf or gRPC types into internal/worker.
+type FetchAddStore interface {
+	FetchAdd(key string, delta uint64, operationID string) uint64
+}
+
+// NewStoreSharedStateHook returns a SharedStateHook backed by an
+// in-memory FetchAdd store. Used by future in-process builds where the
+// worker shares the host's SharedStateStore directly rather than going
+// through the brokered gRPC client. The default subprocess binary does
+// not invoke this — the wire layer continues to use
+// workerplugin.NewRemoteAdvancer via the cmd/worker grpcSharedStateHook
+// wrapper, preserving byte-identical IPC behavior.
+func NewStoreSharedStateHook(store FetchAddStore) SharedStateHook {
+	return &storeSharedStateHook{store: store}
+}
+
+type storeSharedStateHook struct {
+	store FetchAddStore
+}
+
+func (h *storeSharedStateHook) NewRoundRobinAdvancer(_ context.Context, requestID string) bamlutils.RoundRobinAdvancer {
+	return &storeRoundRobinAdvancer{store: h.store, operationID: requestID}
+}
+
+// storeRoundRobinAdvancer is the direct-call counterpart to
+// workerplugin.RemoteAdvancer: it advances counters by calling
+// SharedStateStore.FetchAdd in-process rather than over gRPC. The
+// timeout machinery RemoteAdvancer needs for the brokered RPC is
+// unnecessary here — FetchAdd is an atomic in-memory operation.
+type storeRoundRobinAdvancer struct {
+	store       FetchAddStore
+	operationID string
+}
+
+func (a *storeRoundRobinAdvancer) Advance(clientName string, childCount int) (int, error) {
+	if childCount <= 0 {
+		return 0, nil
+	}
+	if a == nil || a.store == nil {
+		// A nil store here is a wiring bug — return an error rather than
+		// silently downgrading to per-worker rotation.
+		return 0, fmt.Errorf("round-robin shared-state hook has no store")
+	}
+	prev := a.store.FetchAdd(clientName, 1, a.operationID)
+	return int(prev % uint64(childCount)), nil
+}
+
+// sharedStateHookHolder wraps the interface value so atomic.Pointer can
+// store concrete types that differ between subprocess (grpcSharedStateHook)
+// and direct-call (storeSharedStateHook) builds. atomic.Value would panic on
+// the second Store with a different concrete type.
+type sharedStateHookHolder struct {
+	hook SharedStateHook
+}
+
+// SetSharedStateHook installs the per-request advancer factory. The
+// subprocess binary calls this from the AttachSharedState callback
+// after handshake; tests and in-process callers can call it any time
+// before the first request lands. Passing nil clears the hook.
+func (h *Handler) SetSharedStateHook(hook SharedStateHook) {
+	if hook == nil {
+		h.sharedStateHook.Store(nil)
+		return
+	}
+	h.sharedStateHook.Store(&sharedStateHookHolder{hook: hook})
+}
+
+// roundRobinAdvancerFor returns the Advancer the generated dispatch path
+// should use for this request. When a shared-state hook is installed AND
+// the inbound context carries a non-empty request id it builds a
+// request-scoped advancer via the hook; otherwise it returns nil so
+// orchestrator.ResolveEffectiveClient falls back to the package-level
+// Coordinator compiled into introspected.
+func (h *Handler) roundRobinAdvancerFor(ctx context.Context) bamlutils.RoundRobinAdvancer {
+	holder := h.sharedStateHook.Load()
+	if holder == nil || holder.hook == nil {
+		h.noSharedStateWarnOnce.Do(func() {
+			if h.logger != nil {
+				h.logger.Warn(
+					"round-robin falling back to in-process coordinator; " +
+						"host did not complete AttachSharedState handshake. " +
+						"Pool-managed workers should always attach — this " +
+						"usually indicates a broken handshake or a standalone " +
+						"test harness. baml-roundrobin rotations will be " +
+						"per-worker instead of pool-wide for the rest of " +
+						"this process's lifetime.")
+			}
+		})
+		return nil
+	}
+	requestID := workerplugin.RequestIDFromContext(ctx)
+	if requestID == "" {
+		h.missingRequestIDWarnOnce.Do(func() {
+			if h.logger != nil {
+				h.logger.Warn(
+					"round-robin falling back to in-process coordinator; " +
+						"SharedState is attached but the inbound context " +
+						"carries no request id. SharedStateStore.FetchAdd " +
+						"bypasses its idempotency cache for empty operation " +
+						"ids, so retries of the same logical request would " +
+						"advance the counter twice. Pool-managed callers " +
+						"always install a UUID — this usually indicates a " +
+						"standalone / non-pool harness that wired SharedState " +
+						"without threading request ids.")
+			}
+		})
+		return nil
+	}
+	return holder.hook.NewRoundRobinAdvancer(ctx, requestID)
+}
+
+// hookStorage is the atomic field type for a Handler's shared-state
+// hook slot. Encapsulated so callers can swap implementations without
+// re-deriving the holder pattern.
+type hookStorage struct {
+	atomic.Pointer[sharedStateHookHolder]
+}

--- a/internal/worker/sharedstate.go
+++ b/internal/worker/sharedstate.go
@@ -17,7 +17,7 @@ import (
 //
 // The shape is intentionally narrow — Advance is the only round-robin
 // operation the handler needs, and DropScope remains the pool's
-// responsibility. Returning a *bamlutils.RoundRobinAdvancer rather than
+// responsibility. Returning a bamlutils.RoundRobinAdvancer rather than
 // the underlying client keeps protobuf/gRPC types out of internal/worker.
 type SharedStateHook interface {
 	// NewRoundRobinAdvancer returns the Advancer the generated dispatch

--- a/internal/worker/sharedstate_test.go
+++ b/internal/worker/sharedstate_test.go
@@ -1,0 +1,190 @@
+package worker
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/workerplugin"
+)
+
+// fakeSharedStateHook is a test double that records calls to
+// NewRoundRobinAdvancer and returns a fixed sentinel advancer so the
+// assertions can verify the handler's wiring without depending on
+// the gRPC RemoteAdvancer or an in-memory store.
+type fakeSharedStateHook struct {
+	calls       atomic.Int64
+	lastReqID   atomic.Value // string
+	returnValue bamlutils.RoundRobinAdvancer
+}
+
+func (f *fakeSharedStateHook) NewRoundRobinAdvancer(_ context.Context, requestID string) bamlutils.RoundRobinAdvancer {
+	f.calls.Add(1)
+	f.lastReqID.Store(requestID)
+	return f.returnValue
+}
+
+// stubAdvancer is a sentinel RoundRobinAdvancer the fake hook can
+// return so equality assertions on the handler's output work even
+// though bamlutils.RoundRobinAdvancer is an interface.
+type stubAdvancer struct{}
+
+func (stubAdvancer) Advance(string, int) (int, error) { return 0, nil }
+
+// TestHandlerSharedStateHook_UsesRequestID asserts that
+// roundRobinAdvancerFor delegates to the installed hook when the
+// inbound context carries a non-empty request id. This is the load-
+// bearing seam: subprocess builds wire grpcSharedStateHook through
+// here, and PR 2's in-process build will swap in a direct-call store
+// adapter — both depend on the request id being threaded through.
+func TestHandlerSharedStateHook_UsesRequestID(t *testing.T) {
+	t.Parallel()
+
+	expected := stubAdvancer{}
+	hook := &fakeSharedStateHook{returnValue: expected}
+	h, err := New(Config{SharedState: hook})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	const reqID = "test-request-id"
+	ctx := workerplugin.WithRequestID(context.Background(), reqID)
+
+	got := h.roundRobinAdvancerFor(ctx)
+	if got != expected {
+		t.Fatalf("advancer: got %#v, want %#v", got, expected)
+	}
+	if calls := hook.calls.Load(); calls != 1 {
+		t.Fatalf("hook calls: got %d, want 1", calls)
+	}
+	if id, _ := hook.lastReqID.Load().(string); id != reqID {
+		t.Fatalf("hook saw request id %q, want %q", id, reqID)
+	}
+}
+
+// TestHandlerSharedStateHook_MissingRequestIDFallsBack asserts that
+// roundRobinAdvancerFor returns nil (and does NOT call the hook) when
+// the inbound context has no request id installed. SharedStateStore's
+// idempotency cache bypasses empty operation ids — falling back to the
+// in-process Coordinator preserves "same logical request observes the
+// same rotation".
+func TestHandlerSharedStateHook_MissingRequestIDFallsBack(t *testing.T) {
+	t.Parallel()
+
+	hook := &fakeSharedStateHook{returnValue: stubAdvancer{}}
+	h, err := New(Config{SharedState: hook})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	got := h.roundRobinAdvancerFor(context.Background())
+	if got != nil {
+		t.Fatalf("advancer: got %#v, want nil (no request id should bypass the hook)", got)
+	}
+	if calls := hook.calls.Load(); calls != 0 {
+		t.Fatalf("hook calls: got %d, want 0 (missing request id must not invoke the hook)", calls)
+	}
+}
+
+// TestHandlerSharedStateHook_NilHookFallsBack covers the "no hook
+// attached" branch — the handler must return nil without panicking,
+// which is the same fall-through behavior the subprocess binary
+// observed before AttachSharedState completed (and what standalone
+// test harnesses see throughout their run).
+func TestHandlerSharedStateHook_NilHookFallsBack(t *testing.T) {
+	t.Parallel()
+
+	h, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := workerplugin.WithRequestID(context.Background(), "req-id")
+	got := h.roundRobinAdvancerFor(ctx)
+	if got != nil {
+		t.Fatalf("advancer: got %#v, want nil (no hook installed)", got)
+	}
+}
+
+// fakeFetchAddStore records FetchAdd invocations and returns
+// caller-controlled previous values. Used to verify
+// storeRoundRobinAdvancer forwards keys, deltas, and operation ids
+// without depending on the real SharedStateStore.
+type fakeFetchAddStore struct {
+	mu         atomic.Int64 // monotonic call counter doubles as "next return"
+	lastKey    atomic.Value // string
+	lastDelta  atomic.Uint64
+	lastOpID   atomic.Value // string
+	nextReturn uint64       // value returned by FetchAdd
+}
+
+func (s *fakeFetchAddStore) FetchAdd(key string, delta uint64, operationID string) uint64 {
+	s.mu.Add(1)
+	s.lastKey.Store(key)
+	s.lastDelta.Store(delta)
+	s.lastOpID.Store(operationID)
+	return s.nextReturn
+}
+
+// TestStoreSharedStateHook_AdvanceUsesFetchAddIdempotency asserts that
+// the direct-call adapter forwards the operation id to FetchAdd
+// (idempotency cache key on the store side) and applies the modulus
+// locally, matching workerplugin.RemoteAdvancer's contract. PR 2's
+// in-process build relies on this surface — without operation id
+// forwarding, retries of the same logical request would re-advance
+// the counter.
+func TestStoreSharedStateHook_AdvanceUsesFetchAddIdempotency(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeFetchAddStore{nextReturn: 7}
+	hook := NewStoreSharedStateHook(store)
+	const reqID = "op-uuid-xyz"
+
+	advancer := hook.NewRoundRobinAdvancer(context.Background(), reqID)
+	if advancer == nil {
+		t.Fatal("NewRoundRobinAdvancer returned nil")
+	}
+
+	// 7 % 3 = 1; verifies modulo math runs on the worker side.
+	idx, err := advancer.Advance("client-a", 3)
+	if err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if idx != 1 {
+		t.Fatalf("Advance: got %d, want 1 (7 mod 3)", idx)
+	}
+
+	if key, _ := store.lastKey.Load().(string); key != "client-a" {
+		t.Fatalf("FetchAdd key: got %q, want client-a", key)
+	}
+	if delta := store.lastDelta.Load(); delta != 1 {
+		t.Fatalf("FetchAdd delta: got %d, want 1", delta)
+	}
+	if id, _ := store.lastOpID.Load().(string); id != reqID {
+		t.Fatalf("FetchAdd operation id: got %q, want %q (must forward request id for SharedStateStore idempotency)", id, reqID)
+	}
+}
+
+// TestStoreSharedStateHook_AdvanceZeroChildCount mirrors the existing
+// RemoteAdvancer contract: childCount <= 0 short-circuits to (0, nil)
+// without touching the store, so an introspected client with zero
+// configured children doesn't generate a FetchAdd RPC.
+func TestStoreSharedStateHook_AdvanceZeroChildCount(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeFetchAddStore{nextReturn: 99}
+	hook := NewStoreSharedStateHook(store)
+	advancer := hook.NewRoundRobinAdvancer(context.Background(), "req-id")
+
+	idx, err := advancer.Advance("client-a", 0)
+	if err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if idx != 0 {
+		t.Fatalf("Advance: got %d, want 0", idx)
+	}
+	if calls := store.mu.Load(); calls != 0 {
+		t.Fatalf("store FetchAdd calls: got %d, want 0 (childCount=0 must not touch the store)", calls)
+	}
+}

--- a/internal/worker/sharedstate_test.go
+++ b/internal/worker/sharedstate_test.go
@@ -36,7 +36,7 @@ func (stubAdvancer) Advance(string, int) (int, error) { return 0, nil }
 // roundRobinAdvancerFor delegates to the installed hook when the
 // inbound context carries a non-empty request id. This is the load-
 // bearing seam: subprocess builds wire grpcSharedStateHook through
-// here, and PR 2's in-process build will swap in a direct-call store
+// here, and the in-process build swaps in a direct-call store
 // adapter — both depend on the request id being threaded through.
 func TestHandlerSharedStateHook_UsesRequestID(t *testing.T) {
 	t.Parallel()
@@ -130,7 +130,7 @@ func (s *fakeFetchAddStore) FetchAdd(key string, delta uint64, operationID strin
 // TestStoreSharedStateHook_AdvanceUsesFetchAddIdempotency asserts that
 // the direct-call adapter forwards the operation id to FetchAdd
 // (idempotency cache key on the store side) and applies the modulus
-// locally, matching workerplugin.RemoteAdvancer's contract. PR 2's
+// locally, matching workerplugin.RemoteAdvancer's contract. The
 // in-process build relies on this surface — without operation id
 // forwarding, retries of the same logical request would re-advance
 // the counter.

--- a/internal/worker/sharedstate_test.go
+++ b/internal/worker/sharedstate_test.go
@@ -35,9 +35,9 @@ func (stubAdvancer) Advance(string, int) (int, error) { return 0, nil }
 // TestHandlerSharedStateHook_UsesRequestID asserts that
 // roundRobinAdvancerFor delegates to the installed hook when the
 // inbound context carries a non-empty request id. This is the load-
-// bearing seam: subprocess builds wire grpcSharedStateHook through
-// here, and the in-process build swaps in a direct-call store
-// adapter — both depend on the request id being threaded through.
+// bearing seam between request handling and shared-state operations;
+// hook implementations depend on the request id being threaded
+// through to make per-request operations addressable.
 func TestHandlerSharedStateHook_UsesRequestID(t *testing.T) {
 	t.Parallel()
 
@@ -129,11 +129,10 @@ func (s *fakeFetchAddStore) FetchAdd(key string, delta uint64, operationID strin
 
 // TestStoreSharedStateHook_AdvanceUsesFetchAddIdempotency asserts that
 // the direct-call adapter forwards the operation id to FetchAdd
-// (idempotency cache key on the store side) and applies the modulus
-// locally, matching workerplugin.RemoteAdvancer's contract. The
-// in-process build relies on this surface — without operation id
-// forwarding, retries of the same logical request would re-advance
-// the counter.
+// (the idempotency cache key on the store side) and applies the
+// modulus locally, matching workerplugin.RemoteAdvancer's contract.
+// Without operation id forwarding, retries of the same logical
+// request would re-advance the counter.
 func TestStoreSharedStateHook_AdvanceUsesFetchAddIdempotency(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/stream.go
+++ b/internal/worker/stream.go
@@ -1,0 +1,230 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/goccy/go-json"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/apierror"
+	"github.com/invakid404/baml-rest/workerplugin"
+)
+
+// defaultDrainLeakThreshold is how long a drain goroutine waits before logging
+// a warning that the producer has not closed its result channel. This does NOT
+// add a hard timeout — the drain still waits for close — but alerts operators
+// to a likely leak so they can investigate the misbehaving adapter.
+const defaultDrainLeakThreshold = 30 * time.Second
+
+// drainLeakThreshold stores the current threshold in nanoseconds. Tests can
+// override it via setDrainLeakThreshold. The atomic avoids data races between
+// test goroutines and drain goroutines from earlier tests.
+var drainLeakThresholdNs atomic.Int64
+
+func init() {
+	drainLeakThresholdNs.Store(int64(defaultDrainLeakThreshold))
+}
+
+func getDrainLeakThreshold() time.Duration {
+	return time.Duration(drainLeakThresholdNs.Load())
+}
+
+func setDrainLeakThreshold(d time.Duration) {
+	drainLeakThresholdNs.Store(int64(d))
+}
+
+// activeDrainGoroutines tracks how many drain goroutines are currently running.
+// Exported for operational monitoring (e.g. Prometheus gauge, debug endpoint).
+var activeDrainGoroutines atomic.Int64
+
+// ActiveDrainGoroutines returns the number of drain goroutines currently
+// waiting for a producer to close its result channel.
+func ActiveDrainGoroutines() int64 {
+	return activeDrainGoroutines.Load()
+}
+
+// bridgeStreamResults converts adapter stream results into plugin stream results
+// while respecting cancellation both before reading upstream and before sending
+// downstream.
+func bridgeStreamResults(ctx context.Context, resultChan <-chan bamlutils.StreamResult, logger bamlutils.Logger) <-chan *workerplugin.StreamResult {
+	out := make(chan *workerplugin.StreamResult)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-ctx.Done():
+				go drainStreamResults(resultChan, logger)
+				return
+			default:
+			}
+
+			var (
+				result bamlutils.StreamResult
+				ok     bool
+			)
+
+			select {
+			case <-ctx.Done():
+				go drainStreamResults(resultChan, logger)
+				return
+			case result, ok = <-resultChan:
+				if !ok {
+					return
+				}
+			}
+
+			pluginResult := workerplugin.GetStreamResult()
+			pluginResult.Reset = result.Reset()
+
+			switch result.Kind() {
+			case bamlutils.StreamResultKindError:
+				pluginResult.Kind = workerplugin.StreamResultKindError
+				pluginResult.Error = result.Error()
+				// Classify typed BuildRequest / transport surfaces into a
+				// worker-facing apierror.Code (parse_error / provider_error)
+				// so the host's classifyWorkerError forwards it verbatim
+				// instead of defaulting to worker_error. classifyBAMLError
+				// returns ("", nil) for unrecognized errors, leaving
+				// pluginResult.ErrorCode at its zero value for host-side
+				// fallback.
+				//
+				// mergeRawDetail attaches the accumulator's text (per #256)
+				// to details regardless of classification arm: parse_error,
+				// provider_error, and unclassified errors all carry
+				// details.raw when result.Raw() is non-empty. Unclassified
+				// errors keep their empty worker code but gain details.raw
+				// via the host's worker_error fallback path. Empty raw
+				// leaves details untouched (omitempty contract).
+				code, details := classifyBAMLError(result.Error())
+				details = mergeRawDetail(details, result.Raw())
+				if code != "" {
+					pluginResult.ErrorCode = code
+				}
+				if details != nil {
+					pluginResult.ErrorDetails = details
+				}
+			case bamlutils.StreamResultKindStream:
+				pluginResult.Kind = workerplugin.StreamResultKindStream
+				// Reset-only stream results intentionally carry no payload. If we
+				// marshal nil here, it becomes JSON `null`, which downstream would
+				// publish as a bogus partial frame in addition to the reset event.
+				// Raw and reasoning stay at their zero values for reset-only
+				// frames — the orchestrator clears the accumulators downstream.
+				if !(result.Reset() && result.Stream() == nil) {
+					data, err := json.Marshal(result.Stream())
+					if err != nil {
+						// Marshal failed: reclassify as an error frame. Raw/
+						// reasoning must stay unset — leaking stale values
+						// from the doomed stream frame onto an error frame
+						// would publish accumulated bytes alongside an error
+						// the client cannot pair them with. Assigning raw/
+						// reasoning only on the success branch below
+						// guarantees this invariant.
+						pluginResult.Kind = workerplugin.StreamResultKindError
+						pluginResult.Error = fmt.Errorf("failed to marshal stream result: %w", err)
+						pluginResult.ErrorCode = string(apierror.CodeInternalError)
+					} else {
+						pluginResult.Data = data
+						pluginResult.Raw = result.Raw()
+						pluginResult.Reasoning = result.Reasoning()
+					}
+				}
+			case bamlutils.StreamResultKindFinal:
+				data, err := json.Marshal(result.Final())
+				if err != nil {
+					pluginResult.Kind = workerplugin.StreamResultKindError
+					pluginResult.Error = fmt.Errorf("failed to marshal final result: %w", err)
+					pluginResult.ErrorCode = string(apierror.CodeInternalError)
+				} else {
+					pluginResult.Kind = workerplugin.StreamResultKindFinal
+					pluginResult.Data = data
+					pluginResult.Raw = result.Raw()
+					pluginResult.Reasoning = result.Reasoning()
+				}
+			case bamlutils.StreamResultKindHeartbeat:
+				pluginResult.Kind = workerplugin.StreamResultKindHeartbeat
+			case bamlutils.StreamResultKindMetadata:
+				md := result.Metadata()
+				if md == nil {
+					// An orchestrator bug — drop the event rather than crashing the stream.
+					pluginResult.Kind = workerplugin.StreamResultKindError
+					pluginResult.Error = fmt.Errorf("metadata result without payload")
+					pluginResult.ErrorCode = string(apierror.CodeInternalError)
+					break
+				}
+				data, err := json.Marshal(md)
+				if err != nil {
+					pluginResult.Kind = workerplugin.StreamResultKindError
+					pluginResult.Error = fmt.Errorf("failed to marshal metadata result: %w", err)
+					pluginResult.ErrorCode = string(apierror.CodeInternalError)
+				} else {
+					pluginResult.Kind = workerplugin.StreamResultKindMetadata
+					pluginResult.Data = data
+				}
+			}
+
+			// Release the adapter's output struct back to its pool
+			result.Release()
+
+			select {
+			case out <- pluginResult:
+			case <-ctx.Done():
+				// Release the plugin result we couldn't send
+				workerplugin.ReleaseStreamResult(pluginResult)
+				go drainStreamResults(resultChan, logger)
+				return
+			}
+		}
+	}()
+
+	return out
+}
+
+// drainStreamResults consumes and releases remaining results from the BAML
+// adapter's stream channel after the bridge goroutine exits due to context
+// cancellation. Each result holds native (Rust) memory via Release(); failing
+// to drain leaves those resources leaked and can block the producer goroutine
+// on an unbuffered send.
+//
+// The function drains until the channel is closed (i.e. the producer finishes).
+// There is intentionally no hard timeout: a timeout would cause the drain
+// goroutine to exit while the producer is still alive, stranding unreleased
+// native results and blocking the producer on its next send.
+//
+// However, if the producer has not closed the channel after drainLeakThreshold
+// (default 30s), a warning is logged so operators can investigate. The drain
+// goroutine is also tracked in activeDrainGoroutines for monitoring.
+func drainStreamResults(resultChan <-chan bamlutils.StreamResult, logger bamlutils.Logger) {
+	activeDrainGoroutines.Add(1)
+	defer activeDrainGoroutines.Add(-1)
+
+	// Start a background timer that fires a warning if the drain takes
+	// too long. The done channel signals the timer goroutine to exit
+	// when the drain completes before the threshold.
+	threshold := getDrainLeakThreshold()
+	done := make(chan struct{})
+	timer := time.NewTimer(threshold)
+	go func() {
+		select {
+		case <-timer.C:
+			active := activeDrainGoroutines.Load()
+			if logger != nil {
+				logger.Warn("drain goroutine still waiting for producer to close result channel",
+					"waited", threshold.String(),
+					"active_drain_goroutines", active,
+				)
+			}
+		case <-done:
+		}
+	}()
+
+	for result := range resultChan {
+		result.Release()
+	}
+
+	timer.Stop()
+	close(done)
+}

--- a/internal/worker/stream_test.go
+++ b/internal/worker/stream_test.go
@@ -1,4 +1,4 @@
-package main
+package worker
 
 import (
 	"context"


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

This is **PR 1 of 3** in the in-process build-flag sequence tracked at #280. Pure refactor with **no behavior change in the default subprocess build**. Moves the worker request handler out of `cmd/worker/` (`package main`, not importable) into a new `internal/worker` package as a `Handler` type satisfying `workerplugin.Worker`.

- `cmd/worker/main.go` shrinks from ~720 LOC to ~120 LOC of thin go-plugin glue: init runtime, load defaults, build handler, serve.
- Process-global state (`workerClientDefaults`, `sharedStateClient` atomic pointer, `workerLogger`, warning `sync.Once` values) moves to `Handler` fields so the handler is constructible without hidden package-global mutation.
- Introduces a small `SharedStateHook` interface seam so PR 2 can swap the brokered gRPC client for a direct-call store adapter without touching the handler.

## What moves vs what stays

**Moves to `internal/worker/`:**
- `workerImpl` → exported `Handler`. Methods (`CallStream`, `Health`, `GetMetrics`, `TriggerGC`, `GetGoroutines`, `Parse`) preserved.
- Stream bridging + drain (`bridgeStreamResults`, `drainStreamResults`, `ActiveDrainGoroutines`, drain leak threshold helpers).
- Error classification (`classifyBAMLError`, `mergeRawDetail`, legacy envelope helpers).
- Option parsing/URL rewrite (`workerBamlOptions.apply`, `rewriteClientBaseURLs`).
- Round-robin advancer plumbing (`roundRobinAdvancerFor` → method on `Handler`).
- `worker.InitRuntime`, `worker.LoadClientDefaults`, `worker.NewMetricsRegistry` helpers.
- Existing test files renamed in place: `cmd/worker/main_test.go` → `internal/worker/stream_test.go`; `cmd/worker/error_classify_test.go` → `internal/worker/errors_test.go` (git detects as ~99% rename). Test package stays `worker` to keep unexported access.

**Stays in `cmd/worker/main.go`:**
- `func main()` — go-plugin entry point.
- hclog logger construction (go-plugin-specific).
- `BAML_REST_CLIENT_DEFAULTS` fatal handling + the `allowed_role_metadata`/BuildRequest startup warning (binary-policy, not handler logic).
- RSS monitor wiring tied to `GOMEMLIMIT` (process-lifecycle, subprocess-specific — in-process semantics deferred to PR 2/3).
- `workerplugin.WorkerPlugin` construction and `goplugin.Serve(...)`.
- `grpcSharedStateHook` — a tiny adapter that wraps the brokered `pb.SharedStateClient` and produces a `*workerplugin.RemoteAdvancer` per request. Lives in `cmd/worker` so the gRPC/protobuf client type does not leak into `internal/worker`.

Full scoping audit (per-symbol move plan, risk analysis): the audit drove the file layout and surface API; nothing in this PR deviates from it.

## Locked-in design choices

- **Package:** `internal/worker` (internal — no public-API guarantees, only `cmd/worker` and future in-process callers import it).
- **`SharedStateHook` interface:** `NewRoundRobinAdvancer(ctx, requestID) bamlutils.RoundRobinAdvancer`. Narrow on purpose — `DropScope` stays the pool's responsibility, and returning the advancer (rather than the underlying client) keeps protobuf/gRPC out of `internal/worker`.
- **`FetchAddStore` + `NewStoreSharedStateHook` included:** a small direct-call adapter that satisfies `SharedStateHook` from any `FetchAdd(key, delta, opID)` store. `*workerplugin.SharedStateStore` already matches this shape. Unused by the subprocess build → no behavior change in PR 1, but it locks the seam PR 2 will consume.
- **No build tag in PR 1.** `//go:build inprocess` is PR 2 work.
- **No `recover()` hardening in PR 1.** Direct-call panic recovery is PR 3 work.

## Behavior preservation

- IPC wire layer (`workerplugin/*`) is **untouched**: same handshake, same protobuf, same `workerplugin.Worker` interface, same `workerplugin.NewRemoteAdvancer`, same gRPC server options.
- `cmd/serve/*` and `pool/*` are **untouched**.
- `//go:embed worker` in `cmd/serve` continues to work identically (the binary still builds from `cmd/worker`).
- Warning scope (`noSharedStateWarnOnce`, `missingRequestIDWarnOnce`): once-per-handler instead of once-per-process. Subprocess has exactly one handler per process, so operator-visible behavior is unchanged.
- Metric collector set + labels are identical (`NewMetricsRegistry` registers the same Go + Process collectors).

## What's deferred

- **PR 2:** `//go:build inprocess` build tag, `cmd/serve/main.go` embed splitting, direct-construction wiring through `pool` (or factory injection), in-process use of `SharedStateStore` without gRPC.
- **PR 3:** direct-call `recover()` hardening, `--pool-size` no-op + warn in in-process builds, in-process metric naming cleanup, in-process memory/RSS policy, operator docs about crash-isolation loss.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/worker ./internal/worker -count=1` — all moved tests pass under the new package
- [x] `go test ./workerplugin -count=1`
- [x] `go test ./pool -count=1`
- [x] `go test ./bamlutils/... -count=1`
- [x] `go test ./cmd/introspect -count=1`
- [x] `go test -race ./internal/worker -count=1`
- [x] `gofmt -l` on all changed files clean
- [x] `go run ./cmd/embed` produces the expected `embed.go` update (drops `cmd/worker/error_classify.go`, adds `internal/worker/*` files); idempotent on re-run.
- [x] `./scripts/sync.sh` — no go.mod/go.sum drift
- [x] `go run ./cmd/verify-framework-adapter` — 6/6 green
- [x] `go run ./cmd/verify-adapter-pins` — 4/4 green
- [x] `go test -tags=integration ./integration/... -run='^$'` compiles cleanly (full run skipped locally — IPC layer is byte-identical so the refactor is safe by construction)
- [x] New focused tests for the seam:
  - `TestHandlerSharedStateHook_UsesRequestID` — fake hook + request id in ctx → hook called with the id.
  - `TestHandlerSharedStateHook_MissingRequestIDFallsBack` — fake hook, no request id → hook never invoked, advancer nil.
  - `TestHandlerSharedStateHook_NilHookFallsBack` — no hook installed → nil advancer (legacy fall-through path).
  - `TestStoreSharedStateHook_AdvanceUsesFetchAddIdempotency` — fake `FetchAddStore` → modulo math + operation id forwarding correct.
  - `TestStoreSharedStateHook_AdvanceZeroChildCount` — `childCount<=0` short-circuits without touching the store.

Refs #280.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Worker startup and internals reorganized into a dedicated worker component; embedded assets updated.

* **New Features**
  * Admin endpoints: metrics export, on‑demand GC, and goroutine capture with filtering.
  * Centralized client-defaults and per-request options; pluggable shared-state advancer for pool round‑robin.
  * Safer streaming: improved bridging, draining, and error classification to reduce leaks.

* **Tests**
  * Added unit tests for shared-state, streaming, and admin goroutine filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->