### PR TITLE
test(integration): tighten matrix-axis propagation for dedicated envs

### DIFF
--- a/integration/bridge_test.go
+++ b/integration/bridge_test.go
@@ -39,29 +39,15 @@ func TestCallBridge_ForcesStreamRequest(t *testing.T) {
 	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer setupCancel()
 
-	adapterVersion, err := testutil.GetAdapterVersionForBAML(BAMLVersion)
-	if err != nil {
-		t.Fatalf("Failed to get adapter version: %v", err)
+	opts := matrixSetupOptions()
+	opts.UseBuildRequest = true
+	opts.RuntimeEnv = map[string]string{
+		// Forces IsCallProviderSupported to return false for every
+		// provider, routing /call{,-with-raw} through the stream-
+		// accumulation bridge.
+		"BAML_REST_DISABLE_CALL_BUILD_REQUEST": "true",
 	}
-	bamlSrcPath, err := findTestdataPath()
-	if err != nil {
-		t.Fatalf("Failed to find testdata: %v", err)
-	}
-
-	env, err := testutil.Setup(setupCtx, testutil.SetupOptions{
-		BAMLSrcPath:     bamlSrcPath,
-		BAMLVersion:     BAMLVersion,
-		AdapterVersion:  adapterVersion,
-		BAMLSource:      BAMLSourcePath,
-		UseBuildRequest: true,
-		InProcess:       inProcessBuild,
-		RuntimeEnv: map[string]string{
-			// Forces IsCallProviderSupported to return false for every
-			// provider, routing /call{,-with-raw} through the stream-
-			// accumulation bridge.
-			"BAML_REST_DISABLE_CALL_BUILD_REQUEST": "true",
-		},
-	})
+	env, err := testutil.Setup(setupCtx, opts)
 	if err != nil {
 		t.Fatalf("Failed to setup dedicated env: %v", err)
 	}
@@ -280,28 +266,14 @@ func TestCallBridge_MixedChainFallsThrough(t *testing.T) {
 	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer setupCancel()
 
-	adapterVersion, err := testutil.GetAdapterVersionForBAML(BAMLVersion)
-	if err != nil {
-		t.Fatalf("Failed to get adapter version: %v", err)
+	opts := matrixSetupOptions()
+	opts.UseBuildRequest = true
+	opts.RuntimeEnv = map[string]string{
+		// Mark openai-generic as call-unsupported (but still stream-
+		// supported). Debug-tag only — no effect on release builds.
+		"BAML_REST_CALL_UNSUPPORTED_PROVIDERS": "openai-generic",
 	}
-	bamlSrcPath, err := findTestdataPath()
-	if err != nil {
-		t.Fatalf("Failed to find testdata: %v", err)
-	}
-
-	env, err := testutil.Setup(setupCtx, testutil.SetupOptions{
-		BAMLSrcPath:     bamlSrcPath,
-		BAMLVersion:     BAMLVersion,
-		AdapterVersion:  adapterVersion,
-		BAMLSource:      BAMLSourcePath,
-		UseBuildRequest: true,
-		InProcess:       inProcessBuild,
-		RuntimeEnv: map[string]string{
-			// Mark openai-generic as call-unsupported (but still stream-
-			// supported). Debug-tag only — no effect on release builds.
-			"BAML_REST_CALL_UNSUPPORTED_PROVIDERS": "openai-generic",
-		},
-	})
+	env, err := testutil.Setup(setupCtx, opts)
 	if err != nil {
 		t.Fatalf("Failed to setup dedicated env: %v", err)
 	}

--- a/integration/bridge_test.go
+++ b/integration/bridge_test.go
@@ -54,6 +54,7 @@ func TestCallBridge_ForcesStreamRequest(t *testing.T) {
 		AdapterVersion:  adapterVersion,
 		BAMLSource:      BAMLSourcePath,
 		UseBuildRequest: true,
+		InProcess:       inProcessBuild,
 		RuntimeEnv: map[string]string{
 			// Forces IsCallProviderSupported to return false for every
 			// provider, routing /call{,-with-raw} through the stream-
@@ -294,6 +295,7 @@ func TestCallBridge_MixedChainFallsThrough(t *testing.T) {
 		AdapterVersion:  adapterVersion,
 		BAMLSource:      BAMLSourcePath,
 		UseBuildRequest: true,
+		InProcess:       inProcessBuild,
 		RuntimeEnv: map[string]string{
 			// Mark openai-generic as call-unsupported (but still stream-
 			// supported). Debug-tag only — no effect on release builds.

--- a/integration/client_defaults_test.go
+++ b/integration/client_defaults_test.go
@@ -43,26 +43,11 @@ func TestClientDefaults_AllowedRoleMetadata(t *testing.T) {
 		setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
 		defer setupCancel()
 
-		adapterVersion, err := testutil.GetAdapterVersionForBAML(BAMLVersion)
-		if err != nil {
-			t.Fatalf("Failed to get adapter version: %v", err)
+		opts := matrixSetupOptions()
+		opts.RuntimeEnv = map[string]string{
+			"BAML_REST_CLIENT_DEFAULTS": `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`,
 		}
-		bamlSrcPath, err := findTestdataPath()
-		if err != nil {
-			t.Fatalf("Failed to find testdata: %v", err)
-		}
-
-		env, err := testutil.Setup(setupCtx, testutil.SetupOptions{
-			BAMLSrcPath:     bamlSrcPath,
-			BAMLVersion:     BAMLVersion,
-			AdapterVersion:  adapterVersion,
-			BAMLSource:      BAMLSourcePath,
-			UseBuildRequest: UseBuildRequest,
-			InProcess:       inProcessBuild,
-			RuntimeEnv: map[string]string{
-				"BAML_REST_CLIENT_DEFAULTS": `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`,
-			},
-		})
+		env, err := testutil.Setup(setupCtx, opts)
 		if err != nil {
 			t.Fatalf("Failed to setup dedicated env: %v", err)
 		}

--- a/integration/client_defaults_test.go
+++ b/integration/client_defaults_test.go
@@ -58,6 +58,7 @@ func TestClientDefaults_AllowedRoleMetadata(t *testing.T) {
 			AdapterVersion:  adapterVersion,
 			BAMLSource:      BAMLSourcePath,
 			UseBuildRequest: UseBuildRequest,
+			InProcess:       inProcessBuild,
 			RuntimeEnv: map[string]string{
 				"BAML_REST_CLIENT_DEFAULTS": `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`,
 			},

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -43,6 +43,30 @@ var BAMLSourcePath string
 // Set in TestMain from the BAML_REST_USE_BUILD_REQUEST env var.
 var UseBuildRequest bool
 
+// Matrix-derived setup inputs populated by TestMain before m.Run. Dedicated
+// tests read these via matrixSetupOptions so a new axis added to TestMain
+// propagates without each callsite needing to be updated.
+var (
+	bamlSrcPath    string
+	adapterVersion string
+	unaryServer    bool
+)
+
+// matrixSetupOptions returns SetupOptions pre-populated from the matrix
+// axes (build mode, unary server, build-request, BAML version) so dedicated
+// envs inherit them by default; tests override only what they pin.
+func matrixSetupOptions() testutil.SetupOptions {
+	return testutil.SetupOptions{
+		BAMLSrcPath:     bamlSrcPath,
+		BAMLVersion:     BAMLVersion,
+		AdapterVersion:  adapterVersion,
+		BAMLSource:      BAMLSourcePath,
+		UnaryServer:     unaryServer,
+		UseBuildRequest: UseBuildRequest,
+		InProcess:       inProcessBuild,
+	}
+}
+
 // ActuallyBuildRequest reports whether a request is genuinely routed through
 // the BuildRequest orchestrator given both the runtime env gate and the BAML
 // runtime version. BuildRequest requires the Request / StreamRequest APIs
@@ -142,14 +166,15 @@ func TestMain(m *testing.M) {
 	defer cancel()
 
 	// Find the testdata directory
-	bamlSrcPath, err := findTestdataPath()
+	var err error
+	bamlSrcPath, err = findTestdataPath()
 	if err != nil {
 		println("Failed to find testdata:", err.Error())
 		os.Exit(1)
 	}
 
 	// Get the appropriate adapter version
-	adapterVersion, err := testutil.GetAdapterVersionForBAML(BAMLVersion)
+	adapterVersion, err = testutil.GetAdapterVersionForBAML(BAMLVersion)
 	if err != nil {
 		println("Failed to get adapter version:", err.Error())
 		os.Exit(1)
@@ -164,9 +189,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Setup test environment
-	unaryServer := false
 	if v := os.Getenv("UNARY_SERVER"); v != "" {
-		var err error
 		unaryServer, err = strconv.ParseBool(v)
 		if err != nil {
 			println("Invalid UNARY_SERVER value:", v, "(expected true/false)")
@@ -174,15 +197,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 	UseBuildRequest = parseBoolEnv(os.Getenv("BAML_REST_USE_BUILD_REQUEST"))
-	TestEnv, err = testutil.Setup(ctx, testutil.SetupOptions{
-		BAMLSrcPath:     bamlSrcPath,
-		BAMLVersion:     BAMLVersion,
-		AdapterVersion:  adapterVersion,
-		BAMLSource:      BAMLSourcePath,
-		UnaryServer:     unaryServer,
-		UseBuildRequest: UseBuildRequest,
-		InProcess:       inProcessBuild,
-	})
+	TestEnv, err = testutil.Setup(ctx, matrixSetupOptions())
 	if err != nil {
 		println("Failed to setup test environment:", err.Error())
 		os.Exit(1)

--- a/integration/shutdown_test.go
+++ b/integration/shutdown_test.go
@@ -56,6 +56,7 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 		BAMLSource:      BAMLSourcePath,
 		UnaryServer:     unaryEnabled,
 		UseBuildRequest: UseBuildRequest,
+		InProcess:       inProcessBuild,
 	})
 	if err != nil {
 		t.Fatalf("Failed to setup dedicated shutdown env: %v", err)

--- a/integration/shutdown_test.go
+++ b/integration/shutdown_test.go
@@ -36,28 +36,7 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer setupCancel()
 
-	// Match the outer matrix leg's unary-server setting. UnaryClient is
-	// non-nil iff TestMain enabled the chi server for this run.
-	unaryEnabled := UnaryClient != nil
-
-	adapterVersion, err := testutil.GetAdapterVersionForBAML(BAMLVersion)
-	if err != nil {
-		t.Fatalf("Failed to get adapter version: %v", err)
-	}
-	bamlSrcPath, err := findTestdataPath()
-	if err != nil {
-		t.Fatalf("Failed to find testdata: %v", err)
-	}
-
-	env, err := testutil.Setup(setupCtx, testutil.SetupOptions{
-		BAMLSrcPath:     bamlSrcPath,
-		BAMLVersion:     BAMLVersion,
-		AdapterVersion:  adapterVersion,
-		BAMLSource:      BAMLSourcePath,
-		UnaryServer:     unaryEnabled,
-		UseBuildRequest: UseBuildRequest,
-		InProcess:       inProcessBuild,
-	})
+	env, err := testutil.Setup(setupCtx, matrixSetupOptions())
 	if err != nil {
 		t.Fatalf("Failed to setup dedicated shutdown env: %v", err)
 	}
@@ -81,7 +60,7 @@ func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
 	clients := []namedClient{
 		{Name: "fiber", Client: fiberClient},
 	}
-	if unaryEnabled {
+	if unaryServer {
 		clients = append(clients, namedClient{
 			Name:   "chi",
 			Client: testutil.NewBAMLRestClient(env.BAMLRestUnaryURL),


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Tightens the integration-test harness so dedicated test envs (the ones that build their own container outside the standard `TestMain` env, for isolation or scenarios like shutdown coverage) can't silently drift from the matrix's configuration.

Two commits:

1. **Fix the immediate gap** — thread \`InProcess: inProcessBuild\` through the four dedicated \`SetupOptions\` literals. Without this, on the \`-tags=integration,inprocess\` matrix the dedicated envs spun up as subprocess-mode containers, leaving those four tests without inprocess coverage.

2. **Prevent the next one** — introduce a \`matrixSetupOptions()\` helper that returns a \`SetupOptions\` pre-populated from the matrix-derived package vars (\`BAMLVersion\`, \`UseBuildRequest\`, \`unaryServer\`, \`inProcessBuild\`, etc.). Dedicated tests now start from this and override only the fields they pin. Future matrix axes will inherit into dedicated envs by construction.

## Background

The integration matrix has 3 build/runtime axes:

| Axis | Where it comes from | Affects |
|---|---|---|
| `UseBuildRequest` | `BAML_REST_USE_BUILD_REQUEST` env | Which code path the request takes |
| `UnaryServer` | `UNARY_SERVER` env | Which HTTP server is compiled in (fiber vs chi) |
| `InProcess` | `-tags=inprocess` build tag | Worker execution model (subprocess vs in-process) |

The standard `TestMain` callsite in `integration/integration_test.go` threads all three through `testutil.Setup`. The four dedicated-env callsites used to re-list each field by hand:

- `integration/bridge_test.go` — `TestCallBridge_ForcesStreamRequest`
- `integration/bridge_test.go` — `TestCallBridge_MixedChainFallsThrough`
- `integration/client_defaults_test.go` — `TestClientDefaults_AllowedRoleMetadata/positive_default_preserves_cache_control`
- `integration/shutdown_test.go` — `TestGracefulShutdownDrainsInFlightCall`

When \`InProcess\` was added to \`SetupOptions\` in #283, all four were missed. The inprocess matrix entries then silently exercised these scenarios in subprocess mode.

## After

Dedicated callsites become e.g.:

\`\`\`go
opts := matrixSetupOptions()
opts.UseBuildRequest = true  // bridge tests pin this
opts.RuntimeEnv = map[string]string{...}
env, err := testutil.Setup(setupCtx, opts)
\`\`\`

or for tests that don't need to override anything (e.g. shutdown):

\`\`\`go
env, err := testutil.Setup(setupCtx, matrixSetupOptions())
\`\`\`

The `testutil.Setup` call stays visible (so reading control flow is easy), but the boilerplate of restating every matrix axis is gone.

## No behavior change

Each test continues to get the same effective configuration it did before commit 1:
- Subprocess matrix legs: dedicated envs get `InProcess: false` (unchanged from before commit 1).
- Inprocess matrix legs: dedicated envs get `InProcess: true` (new behavior added in commit 1, preserved by commit 2).
- Bridge tests still pin `UseBuildRequest: true`.
- After the refactor, Bridge and ClientDefaults dedicated envs inherit `UnaryServer` from the matrix through `matrixSetupOptions()` (they no longer default it to `false`). These tests are HTTP-server-agnostic in their assertions — they only exercise the fiber client — so the inherited value has no observable effect on their behavior; they pass identically on both unary and non-unary matrix legs.
- Shutdown_test, which does care about fiber-vs-chi, now reads `unaryServer` directly from the package var instead of synthesizing it from `UnaryClient != nil` (semantically identical).

## Test plan

- [x] `go build ./...`
- [x] `go build -tags=inprocess ./cmd/serve`
- [x] `go vet ./...` and `go vet -tags=integration,inprocess ./integration/...`
- [x] `go build -tags=integration ./integration/...`
- [x] `go build -tags=integration,inprocess ./integration/...`
- [x] After commit 1: full CI matrix green, including all 4 `integration-tests-inprocess (*, *)` legs. Logs confirmed dedicated envs ran with `InProcess: true` and inprocess-tagged containers on the inprocess matrix entries.
- [ ] CI re-runs after commit 2 to confirm the refactor doesn't regress anything.

Refs #280.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Unified and refactored integration test environment: integration suites now use a shared, matrix-derived setup and per-test runtime settings to control routing and client-default scenarios. This improves consistency, maintainability, and reliability of call/stream routing and shutdown-related test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
