### PR TITLE
chore(release): subdir Go module tagging workflow (#289 PR C)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,209 @@
+# Release Procedure
+
+This document is the maintainer-facing guide for cutting a baml-rest
+release. It covers both the existing product release (binary + Docker)
+and the additive subdir-prefixed Go module tags that let downstream
+Go consumers import `github.com/invakid404/baml-rest/dynclient` and
+the other published nested modules at a stable version.
+
+## Tag conventions
+
+- Product release tags are `0.0.N`, with **no `v` prefix**. This
+  matches every prior release in `git tag -l` and the existing GitHub
+  release flow.
+- Do **not** change the product tag scheme. Renaming product tags to
+  `v0.0.N` would orphan every prior release and break any
+  external automation that watches the `0.0.*` tag stream.
+- Go module tags are **additive**, subdir-prefixed tags like
+  `dynclient/v0.0.N`. They follow Go's nested-module convention
+  (subdir prefix + a `v`-prefixed semver) so `go get` can resolve the
+  nested modules without conflating them with the product tag.
+- The Go module tag set is exactly the seven modules listed under
+  [Step 6](#step-6--create-go-module-tags). The repo root, `pool`,
+  and the server-only `adapters/adapter_v*` modules are deliberately
+  excluded — see PR #289 for the rationale.
+
+## Step 1 — Release-prep require rewrites
+
+The seven published modules have first-party `require` edges between
+each other. During day-to-day development they point at
+`v0.0.0-00010101000000-000000000000` placeholders and resolve through
+local `replace` directives in each `go.mod`. Before the product tag
+is cut, those placeholders must be rewritten to the actual `v0.0.N`
+that is about to be released, so that `go get` from a downstream
+consumer resolves through real tags rather than pseudo-versions.
+
+Affected files and edges:
+
+- `dynclient/go.mod`
+  - `adapters/common`
+  - `bamlutils`
+  - `dynclient/baml-patched`
+  - `introspected`
+  - `worker`
+  - `workerplugin`
+- `adapters/common/go.mod`
+  - `bamlutils`
+  - `introspected`
+- `introspected/go.mod`
+  - `bamlutils`
+- `worker/go.mod`
+  - `bamlutils`
+  - `workerplugin`
+- `workerplugin/go.mod`
+  - `bamlutils`
+
+Copy-pasteable rewrite (substitute the release number into `VERSION`
+before running):
+
+```sh
+VERSION=0.0.N
+
+(cd dynclient && \
+  go mod edit \
+    -require=github.com/invakid404/baml-rest/adapters/common@v${VERSION} \
+    -require=github.com/invakid404/baml-rest/bamlutils@v${VERSION} \
+    -require=github.com/invakid404/baml-rest/dynclient/baml-patched@v${VERSION} \
+    -require=github.com/invakid404/baml-rest/introspected@v${VERSION} \
+    -require=github.com/invakid404/baml-rest/worker@v${VERSION} \
+    -require=github.com/invakid404/baml-rest/workerplugin@v${VERSION})
+
+(cd adapters/common && \
+  go mod edit \
+    -require=github.com/invakid404/baml-rest/bamlutils@v${VERSION} \
+    -require=github.com/invakid404/baml-rest/introspected@v${VERSION})
+
+(cd introspected && \
+  go mod edit \
+    -require=github.com/invakid404/baml-rest/bamlutils@v${VERSION})
+
+(cd worker && \
+  go mod edit \
+    -require=github.com/invakid404/baml-rest/bamlutils@v${VERSION} \
+    -require=github.com/invakid404/baml-rest/workerplugin@v${VERSION})
+
+(cd workerplugin && \
+  go mod edit \
+    -require=github.com/invakid404/baml-rest/bamlutils@v${VERSION})
+```
+
+Notes:
+
+- **Do not remove the local `replace` directives.** They are ignored
+  by downstream consumers when these modules are imported as
+  dependencies, and they keep local development ergonomic (the
+  workspace builds without needing tags to exist first). Keeping
+  them in the release commit is intentional.
+- **Do not rewrite the server-only `adapters/adapter_v*` modules.**
+  They are not part of the dynclient release graph and are not in
+  PR C's tag set. Their existing pins are managed by `scripts/sync.sh`
+  and the BAML pin-matrix verifier.
+
+## Step 2 — Verify and commit
+
+```sh
+go build ./...
+go vet ./...
+go test ./... -count=1
+(cd dynclient && GOWORK=off go test ./... -count=1)
+git status
+git commit -am "chore(release): prepare Go module versions for 0.0.N"
+```
+
+The extra `GOWORK=off` step inside `dynclient/` verifies that the
+module also builds and tests against the rewritten requires when the
+workspace is not in play — which is the configuration downstream
+consumers will see.
+
+## Step 3 — Push to master
+
+Push the release-prep commit:
+
+```sh
+git push origin master
+```
+
+## Step 4 — Create and push the product tag
+
+```sh
+git tag 0.0.N
+git push origin 0.0.N
+```
+
+This is the canonical product release tag. The release-go-tags script
+in Step 6 refuses to run until this tag exists both locally and on
+`origin`.
+
+## Step 5 — Publish the GitHub Release
+
+Publish a GitHub Release from tag `0.0.N`. This preserves the
+existing binary and Docker image release flow — none of that pipeline
+is changed by the Go module tags added in this document.
+
+## Step 6 — Create Go module tags
+
+```sh
+./scripts/release-go-tags.sh 0.0.N
+```
+
+The script:
+
+1. Validates that `0.0.N` exists locally and on `origin`.
+2. Reads each of the seven module `go.mod` files **at the product-tag
+   commit** (not the current worktree) and confirms every first-party
+   require is exactly `v0.0.N`. Pseudo-versions (`v0.0.0-…`) and any
+   `v0.0.<positive-int>` value that does not match the release fail
+   validation with the module path and offending require lines.
+3. For each of the seven module paths, creates the local Go module
+   tag pointing at the product-tag commit and pushes them together to
+   `origin`.
+
+The script is idempotent: tags that already exist at the right SHA
+(locally or on `origin`) are skipped; tags that exist at a different
+SHA fail loudly. Re-running after a partial push is safe.
+
+`--dry-run` validates and prints the tags that would be created and
+pushed without touching any refs.
+
+The full Go module tag set for release `0.0.N`:
+
+| Module | Tag |
+| --- | --- |
+| `github.com/invakid404/baml-rest/adapters/common` | `adapters/common/v0.0.N` |
+| `github.com/invakid404/baml-rest/bamlutils` | `bamlutils/v0.0.N` |
+| `github.com/invakid404/baml-rest/dynclient` | `dynclient/v0.0.N` |
+| `github.com/invakid404/baml-rest/dynclient/baml-patched` | `dynclient/baml-patched/v0.0.N` |
+| `github.com/invakid404/baml-rest/introspected` | `introspected/v0.0.N` |
+| `github.com/invakid404/baml-rest/worker` | `worker/v0.0.N` |
+| `github.com/invakid404/baml-rest/workerplugin` | `workerplugin/v0.0.N` |
+
+## Step 7 — External smoke test
+
+Confirm the published Go module tags resolve cleanly for a fresh
+downstream consumer:
+
+```sh
+tmp=$(mktemp -d)
+cd "$tmp"
+go mod init smoke
+GOWORK=off go get github.com/invakid404/baml-rest/dynclient@v0.0.N
+GOWORK=off go list -deps github.com/invakid404/baml-rest/dynclient
+```
+
+The `GOWORK=off` is important — without it, a stray
+`~/go.work` covering this repo would resolve `dynclient` through
+the local workspace instead of through the just-published tag, and
+the smoke test would silently pass even if the tag chain were broken.
+
+## Consuming dynclient
+
+Downstream Go consumers add dynclient with:
+
+```sh
+go get github.com/invakid404/baml-rest/dynclient@v0.0.N
+```
+
+The other six published modules (`adapters/common`, `bamlutils`,
+`dynclient/baml-patched`, `introspected`, `worker`, `workerplugin`)
+are tagged together so that anything reachable from `dynclient`'s
+require graph resolves at the same release.

--- a/scripts/release-go-tags.sh
+++ b/scripts/release-go-tags.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# release-go-tags.sh — create the subdir-prefixed Go module tags for a
+# product release.
+#
+# The product release tag is `X.Y.Z` (no `v` prefix) and is created and
+# pushed by hand as part of the normal release flow (see RELEASE.md).
+# This script is the second step: it walks the set of nested Go modules
+# that we publish, validates that the product-tag commit is in a clean
+# release-prep state, and then creates and pushes the matching
+# subdir-prefixed Go module tags, for example:
+#
+#   dynclient/vX.Y.Z
+#   bamlutils/vX.Y.Z
+#   ...
+#
+# Validation runs against the product-tag commit (NOT the current
+# worktree). Each required module's go.mod is read with
+# `git show <tag>:<path>/go.mod`. Every first-party require
+# (github.com/invakid404/baml-rest/...) must already point at
+# `v${version}`. Pseudo-versions (`v0.0.0-...`) and any
+# non-`v0.0.<positive-integer>` require are rejected so we never tag a
+# commit whose modules would resolve through stale pseudo-versions.
+#
+# Tag creation is idempotent: tags that already exist at the right SHA
+# (locally or on origin) are skipped; tags that exist at a different
+# SHA fail loudly.
+#
+# Usage:
+#   scripts/release-go-tags.sh [--dry-run] X.Y.Z
+#
+# --dry-run validates the product-tag commit and prints the tags that
+# would be created and pushed without touching local or remote refs.
+
+usage() {
+    sed -n '/^# release-go-tags\.sh/,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+dry_run=false
+version=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) dry_run=true ;;
+        -h|--help) usage; exit 0 ;;
+        -*)
+            echo "ERROR: unknown flag: $arg" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            if [ -n "$version" ]; then
+                echo "ERROR: unexpected extra argument: $arg" >&2
+                usage >&2
+                exit 2
+            fi
+            version="$arg"
+            ;;
+    esac
+done
+
+if [ -z "$version" ]; then
+    echo "ERROR: missing version argument (expected X.Y.Z)" >&2
+    usage >&2
+    exit 2
+fi
+
+# Reject a leading `v` explicitly so the failure message is specific
+# rather than the generic "doesn't match X.Y.Z" complaint.
+if [[ "$version" == v* ]]; then
+    echo "ERROR: product release tags use no 'v' prefix; pass '${version#v}' instead of '${version}'" >&2
+    exit 2
+fi
+
+if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+    echo "ERROR: version must match X.Y.Z (got: '${version}')" >&2
+    exit 2
+fi
+
+# Walk up from the script's own location to find the repo root, the
+# same way scripts/sync.sh does, so this script can be invoked from
+# anywhere without callers worrying about the working directory.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$script_dir"
+while [ "$repo_root" != "/" ] && [ ! -d "$repo_root/.git" ] && [ ! -f "$repo_root/.git" ]; do
+    repo_root="$(dirname "$repo_root")"
+done
+if [ ! -e "$repo_root/.git" ]; then
+    echo "ERROR: no .git found above $script_dir" >&2
+    exit 1
+fi
+cd "$repo_root"
+
+# Required module set. Edit here if a future release adds or removes a
+# published Go module. The root module, pool, and the server-only
+# adapters/adapter_v* modules are deliberately excluded — see PR #289
+# discussion and RELEASE.md.
+required_modules=(
+    "adapters/common"
+    "bamlutils"
+    "dynclient"
+    "dynclient/baml-patched"
+    "introspected"
+    "worker"
+    "workerplugin"
+)
+
+first_party_prefix="github.com/invakid404/baml-rest"
+expected_version="v${version}"
+
+# Validate that the product tag exists both locally and on origin
+# before doing anything else. The local check resolves the SHA; the
+# remote check makes sure we don't push module tags that point at a
+# commit nobody else can fetch.
+if ! git rev-parse --verify --quiet "${version}^{commit}" >/dev/null; then
+    echo "ERROR: product tag '${version}' does not exist locally; create and push it first (see RELEASE.md)" >&2
+    exit 1
+fi
+if ! git ls-remote --exit-code --tags origin "refs/tags/${version}" >/dev/null; then
+    echo "ERROR: product tag '${version}' is not on origin; push it first (see RELEASE.md)" >&2
+    exit 1
+fi
+release_sha="$(git rev-parse "${version}^{commit}")"
+
+# validate_module_requires reads <module>/go.mod at the product tag
+# commit and emits offending require lines on stderr. Returns 0 if the
+# module is clean, 1 otherwise. The function intentionally collects all
+# bad lines for one module before returning so the operator sees every
+# fix needed in one pass rather than fixing them one error at a time.
+validate_module_requires() {
+    local module_path="$1"
+    local gomod
+    gomod="$(git show "${version}:${module_path}/go.mod")"
+
+    # Track which directive block we're in so a first-party module
+    # listed in a `replace (...)` block isn't misread as a `require`.
+    # Local `replace ../../bamlutils` directives are expected during
+    # release-prep (see RELEASE.md) and must not fail validation.
+    local first_party_lines
+    first_party_lines="$(
+        printf '%s\n' "$gomod" |
+            awk '
+                /^[[:space:]]*require[[:space:]]*\(/ { block = "require"; next }
+                /^[[:space:]]*replace[[:space:]]*\(/ { block = "replace"; next }
+                /^[[:space:]]*exclude[[:space:]]*\(/ { block = "exclude"; next }
+                /^[[:space:]]*retract[[:space:]]*\(/ { block = "retract"; next }
+                /^[[:space:]]*\)/ { block = ""; next }
+                /^[[:space:]]*require[[:space:]]+github\.com\/invakid404\/baml-rest/ {
+                    sub(/^[[:space:]]*require[[:space:]]+/, "")
+                    print
+                    next
+                }
+                block == "require" && /^[[:space:]]*github\.com\/invakid404\/baml-rest/ {
+                    sub(/^[[:space:]]*/, "")
+                    print
+                }
+            '
+    )"
+
+    if [ -z "$first_party_lines" ]; then
+        return 0
+    fi
+
+    local bad=0
+    local line dep dep_version
+    while IFS= read -r line; do
+        # Strip any trailing `// indirect` (or other) comment so the
+        # version field is the last whitespace-separated token.
+        local stripped="${line%%//*}"
+        # shellcheck disable=SC2206
+        local fields=($stripped)
+        if [ "${#fields[@]}" -lt 2 ]; then
+            echo "  bad require line (cannot parse): ${line}" >&2
+            bad=1
+            continue
+        fi
+        dep="${fields[0]}"
+        dep_version="${fields[1]}"
+
+        # Pseudo-versions and any non-`v0.0.<positive-int>` require are
+        # rejected. We then narrow further to the exact `v${version}`
+        # we're releasing so a stale `v0.0.40` require during a 0.0.42
+        # cut also fails.
+        if [[ "$dep_version" == v0.0.0-* ]]; then
+            echo "  pseudo-version not allowed: ${dep} ${dep_version}" >&2
+            bad=1
+            continue
+        fi
+        if [[ ! "$dep_version" =~ ^v0\.0\.[1-9][0-9]*$ ]]; then
+            echo "  version must match v0.0.<positive-integer>: ${dep} ${dep_version}" >&2
+            bad=1
+            continue
+        fi
+        if [ "$dep_version" != "$expected_version" ]; then
+            echo "  expected ${expected_version}, got: ${dep} ${dep_version}" >&2
+            bad=1
+            continue
+        fi
+    done <<< "$first_party_lines"
+
+    return "$bad"
+}
+
+# Phase 1: validate every required module at the product-tag commit.
+# We accumulate failures so the operator sees every broken module in
+# one pass rather than re-running the script after each fix.
+echo "Validating release-prep state at ${version} (${release_sha})..."
+validation_failed=0
+for module_path in "${required_modules[@]}"; do
+    if ! git cat-file -e "${version}:${module_path}/go.mod" 2>/dev/null; then
+        echo "ERROR: product tag ${version} does not contain required module ${module_path}/go.mod" >&2
+        validation_failed=1
+        continue
+    fi
+    echo "  ${module_path}/go.mod"
+    if ! validate_module_requires "$module_path"; then
+        echo "ERROR: ${module_path}/go.mod has first-party requires that must be rewritten to ${expected_version} before tagging" >&2
+        validation_failed=1
+    fi
+done
+if [ "$validation_failed" -ne 0 ]; then
+    echo "ERROR: release-prep validation failed; fix the modules above, retag, and re-run" >&2
+    exit 1
+fi
+echo "Validation OK."
+
+# Phase 2: figure out which tags need to be created / pushed.
+# `to_create` holds tags we'll create locally then push, `skipped`
+# holds tags that already point at release_sha somewhere (local or
+# remote). Anything pointing at a *different* SHA aborts immediately.
+to_create=()
+skipped=()
+
+for module_path in "${required_modules[@]}"; do
+    tag="${module_path}/${expected_version}"
+
+    local_sha=""
+    if local_sha="$(git rev-parse --verify --quiet "refs/tags/${tag}")"; then
+        :
+    else
+        local_sha=""
+    fi
+
+    if [ -n "$local_sha" ]; then
+        if [ "$local_sha" != "$release_sha" ]; then
+            echo "ERROR: local tag ${tag} points at ${local_sha}, expected ${release_sha}" >&2
+            exit 1
+        fi
+        skipped+=("$tag")
+        continue
+    fi
+
+    # `git ls-remote` exits 0 with empty stdout when the ref doesn't
+    # exist, so we can't rely on the exit code alone — check stdout.
+    remote_line="$(git ls-remote --tags origin "refs/tags/${tag}" || true)"
+    if [ -n "$remote_line" ]; then
+        remote_sha="${remote_line%%[[:space:]]*}"
+        if [ "$remote_sha" != "$release_sha" ]; then
+            echo "ERROR: origin tag ${tag} points at ${remote_sha}, expected ${release_sha}" >&2
+            exit 1
+        fi
+        skipped+=("$tag")
+        continue
+    fi
+
+    to_create+=("$tag")
+done
+
+# Phase 3: act (or pretend to, in dry-run).
+created=()
+if [ "${#to_create[@]}" -gt 0 ]; then
+    if $dry_run; then
+        echo
+        echo "[dry-run] would create and push:"
+        for tag in "${to_create[@]}"; do
+            echo "  ${tag} -> ${release_sha}"
+        done
+    else
+        for tag in "${to_create[@]}"; do
+            echo "Creating ${tag} -> ${release_sha}"
+            git tag "${tag}" "${release_sha}"
+            created+=("$tag")
+        done
+        echo "Pushing ${#created[@]} tag(s) to origin..."
+        git push origin "${created[@]}"
+    fi
+fi
+
+# Final summary.
+echo
+echo "Summary:"
+echo "  product tag: ${version} (${release_sha})"
+if $dry_run; then
+    echo "  mode: dry-run (no tags created or pushed)"
+fi
+if [ "${#created[@]}" -gt 0 ]; then
+    echo "  created: ${#created[@]}"
+    for tag in "${created[@]}"; do echo "    ${tag}"; done
+fi
+if [ "${#to_create[@]}" -gt 0 ] && $dry_run; then
+    echo "  would create: ${#to_create[@]}"
+    for tag in "${to_create[@]}"; do echo "    ${tag}"; done
+fi
+if [ "${#skipped[@]}" -gt 0 ]; then
+    echo "  skipped (already at ${release_sha}): ${#skipped[@]}"
+    for tag in "${skipped[@]}"; do echo "    ${tag}"; done
+fi
+if [ "${#created[@]}" -eq 0 ] && [ "${#to_create[@]}" -eq 0 ]; then
+    echo "  no-op: all 7 Go module tags already point at ${release_sha}"
+fi

--- a/scripts/release-go-tags.sh
+++ b/scripts/release-go-tags.sh
@@ -140,20 +140,27 @@ validate_module_requires() {
     local first_party_lines
     first_party_lines="$(
         printf '%s\n' "$gomod" |
-            awk '
+            awk -v prefix="$first_party_prefix" '
+                function is_first_party(path) {
+                    return path == prefix || index(path, prefix "/") == 1
+                }
                 /^[[:space:]]*require[[:space:]]*\(/ { block = "require"; next }
                 /^[[:space:]]*replace[[:space:]]*\(/ { block = "replace"; next }
                 /^[[:space:]]*exclude[[:space:]]*\(/ { block = "exclude"; next }
                 /^[[:space:]]*retract[[:space:]]*\(/ { block = "retract"; next }
                 /^[[:space:]]*\)/ { block = ""; next }
-                /^[[:space:]]*require[[:space:]]+github\.com\/invakid404\/baml-rest/ {
-                    sub(/^[[:space:]]*require[[:space:]]+/, "")
-                    print
+                /^[[:space:]]*require[[:space:]]+/ {
+                    line = $0
+                    sub(/^[[:space:]]*require[[:space:]]+/, "", line)
+                    split(line, fields, /[[:space:]]+/)
+                    if (is_first_party(fields[1])) print line
                     next
                 }
-                block == "require" && /^[[:space:]]*github\.com\/invakid404\/baml-rest/ {
-                    sub(/^[[:space:]]*/, "")
-                    print
+                block == "require" {
+                    line = $0
+                    sub(/^[[:space:]]*/, "", line)
+                    split(line, fields, /[[:space:]]+/)
+                    if (is_first_party(fields[1])) print line
                 }
             '
     )"
@@ -307,5 +314,5 @@ if [ "${#skipped[@]}" -gt 0 ]; then
     for tag in "${skipped[@]}"; do echo "    ${tag}"; done
 fi
 if [ "${#created[@]}" -eq 0 ] && [ "${#to_create[@]}" -eq 0 ]; then
-    echo "  no-op: all 7 Go module tags already point at ${release_sha}"
+    echo "  no-op: all ${#required_modules[@]} Go module tags already point at ${release_sha}"
 fi


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

PR C of the #289 sequence — the **release tooling**. Adds `scripts/release-go-tags.sh` plus `RELEASE.md` so future releases can produce subdir-prefixed Go module tags (`dynclient/v0.0.N`, `worker/v0.0.N`, etc.) alongside the existing product tags (`0.0.N`).

**This PR creates no actual tags.** The script is the artifact; tags happen at release time.

## What this unlocks

After PR A (worker module lift) and PR B (dynclient module split), external `go get github.com/invakid404/baml-rest/dynclient` works via SHA pseudo-versions. PR C lets downstream consumers pin a real semver:

```sh
go get github.com/invakid404/baml-rest/dynclient@v0.0.N
```

## The 7-tag set

Per release, the script creates these subdir-prefixed Go module tags at the product-tag commit:

```
adapters/common/v0.0.N
bamlutils/v0.0.N
dynclient/v0.0.N
dynclient/baml-patched/v0.0.N
introspected/v0.0.N
worker/v0.0.N
workerplugin/v0.0.N
```

Excluded by design:
- Root module `v0.0.N` — deferred until there's a use case for external root consumption.
- Adapter `_v*` modules (`adapter_v0_204_0`, etc.) — server-only build modules, not in the dynclient consumer graph.

## The release-prep gotcha

`dynclient/go.mod` and the other public-graph `go.mod`s currently reference first-party deps via SHA pseudo-versions. Tagging at the current state would resolve, but consumers would pull pseudo-version siblings instead of a clean `v0.0.N` release set. So every release needs a pre-tag rewrite step.

`release-go-tags.sh` enforces this with **validation only** (no auto-rewrite): it reads each public-graph `go.mod` at the product-tag commit (via `git show <tag>:<path>/go.mod`) and fails loudly if any first-party require still uses a pseudo-version or placeholder. `RELEASE.md` documents the manual `go mod edit -require=...` commands.

## Script behavior summary

- **Usage**: `./scripts/release-go-tags.sh [--dry-run] X.Y.Z`
- **Validates**:
  - Argument shape (`X.Y.Z`, no `v` prefix).
  - Product tag exists.
  - All 7 module `go.mod` files exist at the product-tag commit.
  - No pseudo-versions or placeholders remain in first-party `require` lines.
- **Idempotency**:
  - Tag already at the same SHA → skip + report.
  - Tag at a different SHA → fail loudly.
- **Pushes** all created tags together in one `git push origin <tags...>` call.

## Validation paths verified locally (all 4 passing)

1. **Negative path** — `./scripts/release-go-tags.sh --dry-run 0.0.41` correctly fails: that tag predates PR B's modular layout (no `dynclient/go.mod`, no `worker/go.mod`), and the existing modules still have pseudo-version requires.
2. **Positive path** — synthesized `0.0.42` in a temp bare-clone with all first-party requires rewritten to `v0.0.42`. Validation passes; script reports 7 tags to create.
3. **Idempotency** — pre-existing tag at the same SHA → 6 to create, 1 skipped.
4. **Conflict** — local tag at a different SHA → loud failure, no tags created.

(Synthesized scenarios all in throwaway sandboxes; no actual tags left in any repo.)

## Files

```
RELEASE.md                 | 209 ++++++++++++++++++++++++++++++
scripts/release-go-tags.sh | 311 +++++++++++++++++++++++++++++++++++++++++++++
2 files changed, 520 insertions(+)
```

No `go.mod`, README, or CI changes. No actual tags created.

## Deviation from impl brief

The brief's recommended awk pattern to find first-party requires (`/^[[:space:]]*github[.]com\/invakid404\/baml-rest(\/|[[:space:]])/`) would also match lines inside `replace (...)` blocks (e.g. `github.com/invakid404/baml-rest/bamlutils => ../../bamlutils`). Since local replace directives are legitimate in release-prep state, Claude added block tracking so only lines inside `require (...)` (or single-line `require ...`) are validated. Verified by both the negative-path test (#0.0.41) and a synthesized positive-path test in a temp clone.

## Future follow-ups (out of scope)

- CI `workflow_dispatch` smoke job that runs the external `go get` against a tagged release. Needs public tags to exist before it can be meaningful — added after the first release ships.
- Pre-existing `dynclient/baml-patched/{go.mod, go.sum}` regen drift on master. Doesn't block tagging (tag the committed state as-is). Worth a separate small PR.

Refs #289.
Closes #289.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a maintainer-facing release guide describing tagging conventions, release verification steps, consumer install guidance, and a downstream smoke-test procedure.

* **Chores**
  * Added release tooling that validates release-prep state, supports dry-run validation, and creates/pushes module tags to automate publishing and ensure consistent dependency resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->