### PR TITLE
chore(release): release-prep for 0.0.42

### DIFF
--- a/adapters/adapter_v0_204_0/go.mod
+++ b/adapters/adapter_v0_204_0/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.0-00010101000000-000000000000 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.0-00010101000000-000000000000 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.42 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.42 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/adapter_v0_215_0/go.mod
+++ b/adapters/adapter_v0_215_0/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.0-00010101000000-000000000000 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.0-00010101000000-000000000000 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.42 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.42 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/adapter_v0_219_0/go.mod
+++ b/adapters/adapter_v0_219_0/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.0-00010101000000-000000000000 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.0-00010101000000-000000000000 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.42 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.42 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/common/go.mod
+++ b/adapters/common/go.mod
@@ -5,8 +5,8 @@ go 1.26.2
 require (
 	github.com/boundaryml/baml v0.204.0
 	github.com/dave/jennifer v1.7.1
-	github.com/invakid404/baml-rest/bamlutils v0.0.0-00010101000000-000000000000
-	github.com/invakid404/baml-rest/introspected v0.0.0-00010101000000-000000000000
+	github.com/invakid404/baml-rest/bamlutils v0.0.42
+	github.com/invakid404/baml-rest/introspected v0.0.42
 	github.com/stoewer/go-strcase v1.3.1
 )
 

--- a/dynclient/go.mod
+++ b/dynclient/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/goccy/go-json v0.10.6
 	github.com/google/uuid v1.6.0
 	github.com/gregwebs/go-recovery v0.4.1
-	github.com/invakid404/baml-rest/adapters/common v0.0.0-20260518112657-a042afdd4284
-	github.com/invakid404/baml-rest/bamlutils v0.0.0-20260518112657-a042afdd4284
-	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.0-20260518112657-a042afdd4284
-	github.com/invakid404/baml-rest/worker v0.0.0-20260518112657-a042afdd4284
-	github.com/invakid404/baml-rest/workerplugin v0.0.0-20260518112657-a042afdd4284
+	github.com/invakid404/baml-rest/adapters/common v0.0.42
+	github.com/invakid404/baml-rest/bamlutils v0.0.42
+	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.42
+	github.com/invakid404/baml-rest/worker v0.0.42
+	github.com/invakid404/baml-rest/workerplugin v0.0.42
 	github.com/prometheus/client_golang v1.23.2
 )
 
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.8.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.0-20260518112657-a042afdd4284 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.42 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect

--- a/go.work.sum
+++ b/go.work.sum
@@ -470,6 +470,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/boundaryml/baml v0.204.0/go.mod h1:dzmyDMNDXIVxJX75q9KTjuTUADsYSGUEbGyi76Cwkew=
 github.com/boundaryml/baml v0.219.0 h1:p1neLJaV6pvSvRtyfROD9N2E9/HOmnycVqlGn6gxPsE=
 github.com/boundaryml/baml v0.219.0/go.mod h1:dzmyDMNDXIVxJX75q9KTjuTUADsYSGUEbGyi76Cwkew=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -595,7 +596,6 @@ github.com/docker/cli v28.2.2+incompatible h1:qzx5BNUDFqlvyq4AHzdNB7gSyVTmU4cgsy
 github.com/docker/cli v28.2.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v28.3.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v29.2.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/cli v29.4.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli-docs-tool v0.10.0 h1:bOD6mKynPQgojQi3s2jgcUWGp/Ebqy1SeCr9VfKQLLU=
 github.com/docker/cli-docs-tool v0.10.0/go.mod h1:5EM5zPnT2E7yCLERZmrDA234Vwn09fzRHP4aX1qwp1U=
 github.com/docker/cli-docs-tool v0.11.0/go.mod h1:ma8BKiisUo8D6W05XEYIh3oa1UbgrZhi1nowyKFJa8Q=
@@ -646,7 +646,6 @@ github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui72
 github.com/fvbommel/sortorder v1.1.0/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
-github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
@@ -773,6 +772,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.20.1 h1:eTgx9QNYugV4DN5mz4U8hiAGTi1ybXn0TPi4Smd8du0=
@@ -944,7 +944,6 @@ github.com/moby/policy-helpers v0.0.0-20251105011237-bcaa71c99f14/go.mod h1:HJfK
 github.com/moby/policy-helpers v0.0.0-20251206004813-9fcc1a9ec5c9/go.mod h1:nJ1clNCIXZqUu3jxCkaUBpeR5bKyzzb7wmEG4xhecTI=
 github.com/moby/policy-helpers v0.0.0-20260127165209-eeebf1a0ab2b/go.mod h1:nJ1clNCIXZqUu3jxCkaUBpeR5bKyzzb7wmEG4xhecTI=
 github.com/moby/policy-helpers v0.0.0-20260211190020-824747bfdd3c/go.mod h1:2P1OGoTVIrybI4M7yhpkDpqiwOnI3yR+HnNhEyo8ovs=
-github.com/moby/policy-helpers v0.0.0-20260507153417-a39d60132186/go.mod h1:AbesLhDyQnWkhYOeG5BjDpfUWuyFlSpwv17zBGc03ag=
 github.com/moby/profiles/seccomp v0.1.0 h1:kVf1lc5ytNB1XPxEdZUVF+oPpbBYJHR50eEvPt/9k8A=
 github.com/moby/profiles/seccomp v0.1.0/go.mod h1:Kqk57vxH6/wuOc5bmqRiSXJ6iEz8Pvo3LQRkv0ytFWs=
 github.com/moby/profiles/seccomp v0.2.3/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
@@ -1065,7 +1064,6 @@ github.com/sigstore/protobuf-specs v0.5.0/go.mod h1:+gXR+38nIa2oEupqDdzg4qSBT0Os
 github.com/sigstore/rekor v1.4.3/go.mod h1:o0zgY087Q21YwohVvGwV9vK1/tliat5mfnPiVI3i75o=
 github.com/sigstore/rekor v1.5.0/go.mod h1:D7JoVCUkxwQOpPDNYeu+CE8zeBC18Y5uDo6tF8s2rcQ=
 github.com/sigstore/rekor-tiles/v2 v2.0.1/go.mod h1:Pjsbhzj5hc3MKY8FfVTYHBUHQEnP0ozC4huatu4x7OU=
-github.com/sigstore/sigstore v1.10.5/go.mod h1:k/mcVVXw3I87dYG/iCVTSW2xTrW7vPzxxGic4KqsqXs=
 github.com/sigstore/timestamp-authority/v2 v2.0.2/go.mod h1:D+wbQg8ASQzKnwBhLo7rIJD+9Zev4Ppqd4myPe8k57E=
 github.com/sigstore/timestamp-authority/v2 v2.0.3/go.mod h1:mDaHxkt3HmZYoIlwYj4QWo0RUr7VjYU52aVO5f5Qb3I=
 github.com/sigstore/timestamp-authority/v2 v2.0.6/go.mod h1:Nk5ucGBDyH0tXAIMZ0prf6xn8qfTnbJhSq+CDabYcfc=
@@ -1374,6 +1372,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
@@ -1384,7 +1383,6 @@ gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/introspected/go.mod
+++ b/introspected/go.mod
@@ -2,7 +2,7 @@ module github.com/invakid404/baml-rest/introspected
 
 go 1.26.2
 
-require github.com/invakid404/baml-rest/bamlutils v0.0.0-00010101000000-000000000000
+require github.com/invakid404/baml-rest/bamlutils v0.0.42
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect

--- a/pool/go.mod
+++ b/pool/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/gregwebs/go-recovery v0.4.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
-	github.com/invakid404/baml-rest/bamlutils v0.0.0-00010101000000-000000000000
-	github.com/invakid404/baml-rest/workerplugin v0.0.0-00010101000000-000000000000
+	github.com/invakid404/baml-rest/bamlutils v0.0.42
+	github.com/invakid404/baml-rest/workerplugin v0.0.42
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1
 	google.golang.org/grpc v1.81.1

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -4,8 +4,8 @@ go 1.26.2
 
 require (
 	github.com/goccy/go-json v0.10.6
-	github.com/invakid404/baml-rest/bamlutils v0.0.0-00010101000000-000000000000
-	github.com/invakid404/baml-rest/workerplugin v0.0.0-00010101000000-000000000000
+	github.com/invakid404/baml-rest/bamlutils v0.0.42
+	github.com/invakid404/baml-rest/workerplugin v0.0.42
 	github.com/prometheus/client_golang v1.23.2
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )

--- a/workerplugin/go.mod
+++ b/workerplugin/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/hashicorp/go-plugin v1.8.0
-	github.com/invakid404/baml-rest/bamlutils v0.0.0-00010101000000-000000000000
+	github.com/invakid404/baml-rest/bamlutils v0.0.42
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Release prep for `0.0.42`. Rewrites first-party require versions from SHA pseudo-versions / zero-placeholders to `v0.0.42` across the public dynclient graph (and the workspace-sync side effects in pool + the adapter `_v*` indirect entries) so the upcoming `0.0.42` product tag — and the subdir Go module tags `scripts/release-go-tags.sh` will create from it — produce a clean, internally consistent dependency graph for external `go get github.com/invakid404/baml-rest/dynclient@v0.0.42`.

This is the first release that exercises the #289 workflow.

## What changed

| File | Reason |
|---|---|
| `dynclient/go.mod` | Required: 6 first-party requires (adapters/common, bamlutils, dynclient/baml-patched, worker, workerplugin, introspected) |
| `adapters/common/go.mod` | Required: bamlutils, introspected |
| `introspected/go.mod` | Required: bamlutils |
| `worker/go.mod` | Required: bamlutils, workerplugin |
| `workerplugin/go.mod` | Required: bamlutils |
| `pool/go.mod` | Workspace-sync side effect (bamlutils + workerplugin) — kept consistent so pool/go.mod isn't half-updated |
| `adapters/adapter_v0_204_0/go.mod` | Workspace-sync side effect (indirect bamlutils + introspected) — same reason |
| `adapters/adapter_v0_215_0/go.mod` | Same |
| `adapters/adapter_v0_219_0/go.mod` | Same |
| `go.work.sum` | Workspace sync delta |

10 files, +23/-25.

## Deliberately NOT changed

- **Root `go.mod`** — not in the published v0.0.42 tag set (the root module's `v0.0.N` Go tag was deferred from #289 PR C). Its first-party requires are cosmetic at the local build because of `replace` directives.
- **`dynclient/baml-patched/go.mod`** — no first-party requires to rewrite. Its `dynclient/baml-patched/v0.0.42` tag is created by the script post-release regardless.

## Validation

- `go build ./...` ✓
- `go vet ./...` ✓
- `./scripts/sync.sh` ✓ (workspace + common + 3 adapters; all 4 BAML pins match)
- Manual replication of `release-go-tags.sh`'s pseudo-version validation logic against the commit: all 7 required modules PASS (no pseudo-versions, all at `v0.0.42`).

## Release sequence (post-merge)

Per `RELEASE.md`:

1. Merge this PR.
2. Create + push lightweight tag `0.0.42` at the release-prep merge commit.
3. Publish GitHub Release from `0.0.42` (this triggers `build-and-publish.yml` for the binary builds).
4. Run `./scripts/release-go-tags.sh 0.0.42` from the master checkout to create + push the 7 subdir Go module tags.
5. External `go get` smoke:

```sh
tmp=$(mktemp -d) && cd "$tmp"
go mod init smoke
GOWORK=off go get github.com/invakid404/baml-rest/dynclient@v0.0.42
GOWORK=off go list -deps github.com/invakid404/baml-rest/dynclient
```

Refs #289.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module dependencies to a consistent version across multiple packages.
  * Bumped Go toolchain version requirement to support latest compatibility standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->