### PR TITLE
docs(readme): add dynclient install + quickstart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+## Embedding via `dynclient`
+
+The dynamic endpoints (`/call/_dynamic`, `/stream/_dynamic`, etc.) are also
+available as an in-process Go library at
+`github.com/invakid404/baml-rest/dynclient` for projects that want to call
+LLMs through baml-rest's BuildRequest pipeline without running a separate
+server.
+
+Install:
+
+```sh
+go get github.com/invakid404/baml-rest/dynclient@latest
+```
+
+Quickstart:
+
+```go
+import "github.com/invakid404/baml-rest/dynclient"
+
+c, err := dynclient.New(
+    dynclient.WithLogger(logger),
+    dynclient.WithMetricsRegistry(reg),
+)
+// c.DynamicCall(ctx, req)
+// c.DynamicStream(ctx, req)
+```
+
+See [`dynclient/`](dynclient/) for the full surface (8 options, 5 endpoint
+methods, iterator-style streaming). The patched-BAML CFFI library is
+bundled as a nested module — no separate setup required.
+
 ## Runtime configuration
 
 baml-rest reads the following environment variables at startup:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# baml-rest
+
 ## Embedding via `dynclient`
 
 The dynamic endpoints (`/call/_dynamic`, `/stream/_dynamic`, etc.) are also


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Now that the #289 sequence has shipped and v0.0.42 was just released, add a top-level README section pointing downstream consumers at the `dynclient` Go library — install command, minimal quickstart, link to the package directory for the full surface.

## What changed

One new section added at the top of `README.md`, before `## Runtime configuration`:

```
## Embedding via `dynclient`

The dynamic endpoints (...) are also available as an in-process Go library at
`github.com/invakid404/baml-rest/dynclient` for projects that want to call
LLMs through baml-rest's BuildRequest pipeline without running a separate
server.

Install:

    go get github.com/invakid404/baml-rest/dynclient@latest

Quickstart:

    import "github.com/invakid404/baml-rest/dynclient"
    ...

See `dynclient/` for the full surface.
```

Uses `@latest` rather than `@v0.0.42` so the snippet doesn't go stale every release.

## Test plan

- `README.md` renders correctly on GitHub (markdown only).
- Snippet matches the actual published `v0.0.42` API surface (verified via `go get github.com/invakid404/baml-rest/dynclient@v0.0.42` external smoke during the release).

## Files

```
README.md | 31 +++++++++++++++++++++++++++++++
1 file changed, 31 insertions(+)
```

Refs #289.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new top-level section, "Embedding via dynclient", describing an in-process Go client library for calling LLMs without running a separate server. Includes installation guidance, a minimal Go quickstart, notes on streaming/iterator usage, and a pointer to the full API reference for advanced usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->