### PR TITLE
chore(go): bump toolchain 1.26.2 → 1.26.3 (#293)

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -15,7 +15,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.3"
 
 jobs:
   # Build Linux binaries on release

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.3"
 
 jobs:
   get-versions:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.3"
 
 jobs:
   unit-tests:

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -3,7 +3,7 @@
 # Can be used as a base image for faster builds
 
 # Go version (defined once, re-declared in each stage that needs it)
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION=1.26.3
 
 # ============================================================================
 # Stage 1: Builder (native platform for fast builds with cross-compilation)

--- a/adapters/adapter_v0_204_0/go.mod
+++ b/adapters/adapter_v0_204_0/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/adapters/adapter_v0_204_0
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/boundaryml/baml v0.204.0

--- a/adapters/adapter_v0_215_0/go.mod
+++ b/adapters/adapter_v0_215_0/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/adapters/adapter_v0_215_0
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/boundaryml/baml v0.215.0

--- a/adapters/adapter_v0_219_0/go.mod
+++ b/adapters/adapter_v0_219_0/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/adapters/adapter_v0_219_0
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/boundaryml/baml v0.219.0

--- a/adapters/common/go.mod
+++ b/adapters/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/adapters/common
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/boundaryml/baml v0.204.0

--- a/bamlutils/go.mod
+++ b/bamlutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/bamlutils
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4

--- a/cmd/build/Dockerfile.tmpl
+++ b/cmd/build/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Go version (defined once, re-declared in each stage that needs it)
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION=1.26.3
 
 {{- if .bamlSource }}
 # Rust builder stage: Build BAML CFFI library and CLI from source

--- a/dynclient/go.mod
+++ b/dynclient/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/dynclient
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/enriquebris/goconcurrentqueue v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.26.2
+go 1.26.3
 
 // NOTE: ./adapters/adapter_v* and ./adapters/common are intentionally NOT
 // included in this workspace. Each adapter pins a specific

--- a/integration/mockllm/Dockerfile
+++ b/integration/mockllm/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 WORKDIR /app
 

--- a/introspected/go.mod
+++ b/introspected/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/introspected
 
-go 1.26.2
+go 1.26.3
 
 require github.com/invakid404/baml-rest/bamlutils v0.0.42
 

--- a/pool/go.mod
+++ b/pool/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/pool
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/goccy/go-json v0.10.6

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/worker
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/goccy/go-json v0.10.6

--- a/workerplugin/go.mod
+++ b/workerplugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/workerplugin
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/hashicorp/go-plugin v1.8.0


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Closes #293. Coordinated Go toolchain bump `1.26.2` → `1.26.3` across every repo-owned `go.mod`, `go.work`, and the three CI workflow `GO_VERSION` envs. `go1.26.3` was released 2026-05-07 with security and bug fixes; it's the latest stable Go 1.26.x.

## What changed (15 files, +15/-15)

**Repo-owned `go.mod` files** (11):
- `go.mod` (root)
- `adapters/adapter_v0_204_0/go.mod`
- `adapters/adapter_v0_215_0/go.mod`
- `adapters/adapter_v0_219_0/go.mod`
- `adapters/common/go.mod`
- `bamlutils/go.mod`
- `dynclient/go.mod`
- `introspected/go.mod`
- `pool/go.mod`
- `worker/go.mod`
- `workerplugin/go.mod`

**Workspace** (1):
- `go.work`

**CI** (3):
- `.github/workflows/build-and-publish.yml`
- `.github/workflows/integration-tests.yml`
- `.github/workflows/unit-tests.yml`

## Deliberately NOT touched

- `dynclient/baml-patched/go.mod` — vendored upstream BAML (stays at `go 1.24.0`).

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- `./scripts/sync.sh` ✓ (4/4 BAML pins match)
- `go test ./worker ./pool ./bamlutils/... ./dynclient/... ./workerplugin/... -count=1` ✓
- `grep -rn "1\.26\.2"` (excluding `dynclient/baml-patched`): no hits.

Closes #293.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Go toolchain from 1.26.2 → 1.26.3 across the project: modules, adapters, CI workflows (build/unit/integration), Docker builder images, and build templates to ensure consistent build environments and up-to-date toolchain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->