### PR TITLE
fix(codegen): deterministic dynamic output_format ordering (#309)

### DIFF
--- a/adapters/common/codegen/codegen_dynamic_types.go
+++ b/adapters/common/codegen/codegen_dynamic_types.go
@@ -49,21 +49,26 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			jen.Id("classBuilderCache").Op(":=").Make(jen.Map(jen.String()).Qual(introspectedPkg, "DynamicClassBuilder")),
 			jen.Line(),
 			// Phase 1: Create all enum shells (for NEW enums only, with values since we have builder)
-			jen.For(jen.List(jen.Id("name"), jen.Id("enum")).Op(":=").Range().Id("dt").Dot("Enums")).Block(
+			// Iterate sorted keys so TypeBuilder population order is deterministic: Go map
+			// iteration is intentionally randomised, and BAML preserves the order it receives,
+			// so unsorted ranging produces non-deterministic rendered output_format text.
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("dt").Dot("Enums"))).Block(
+				jen.Id("enum").Op(":=").Id("dt").Dot("Enums").Index(jen.Id("name")),
 				jen.If(jen.Id("err").Op(":=").Id("createEnumShell").Call(jen.Id("tb"), jen.Id("name"), jen.Id("enum"), jen.Id("typeCache")), jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("enum %q: %w"), jen.Id("name"), jen.Id("err"))),
 				),
 			),
 			jen.Line(),
 			// Phase 2: Add values to EXISTING enums
-			jen.For(jen.List(jen.Id("name"), jen.Id("enum")).Op(":=").Range().Id("dt").Dot("Enums")).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("dt").Dot("Enums"))).Block(
+				jen.Id("enum").Op(":=").Id("dt").Dot("Enums").Index(jen.Id("name")),
 				jen.If(jen.Id("err").Op(":=").Id("addEnumValues").Call(jen.Id("tb"), jen.Id("name"), jen.Id("enum"), jen.Id("typeCache")), jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("enum %q values: %w"), jen.Id("name"), jen.Id("err"))),
 				),
 			),
 			jen.Line(),
 			// Phase 3: Create all NEW class shells (no properties yet - just register the type)
-			jen.For(jen.List(jen.Id("name"), jen.Id("_")).Op(":=").Range().Id("dt").Dot("Classes")).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("dt").Dot("Classes"))).Block(
 				jen.If(jen.Id("err").Op(":=").Id("createClassShell").Call(jen.Id("tb"), jen.Id("name"), jen.Id("typeCache"), jen.Id("classBuilderCache")), jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("class %q: %w"), jen.Id("name"), jen.Id("err"))),
 				),
@@ -71,14 +76,16 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			jen.Line(),
 			// Phase 4a: Add properties to NEW classes only (from classBuilderCache)
 			// These classes only have primitive types or reference other new classes
-			jen.For(jen.List(jen.Id("name"), jen.Id("class")).Op(":=").Range().Id("dt").Dot("Classes")).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("dt").Dot("Classes"))).Block(
+				jen.Id("class").Op(":=").Id("dt").Dot("Classes").Index(jen.Id("name")),
 				jen.If(jen.Id("err").Op(":=").Id("addNewClassProperties").Call(jen.Id("tb"), jen.Id("name"), jen.Id("class"), jen.Id("typeCache"), jen.Id("classBuilderCache")), jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("class %q properties: %w"), jen.Id("name"), jen.Id("err"))),
 				),
 			),
 			jen.Line(),
 			// Phase 4b: Cache types for all NEW classes (now that properties are added)
-			jen.For(jen.List(jen.Id("name"), jen.Id("cb")).Op(":=").Range().Id("classBuilderCache")).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("classBuilderCache"))).Block(
+				jen.Id("cb").Op(":=").Id("classBuilderCache").Index(jen.Id("name")),
 				jen.List(jen.Id("typ"), jen.Id("err")).Op(":=").Id("cb").Dot("Type").Call(),
 				jen.If(jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("class %q type: %w"), jen.Id("name"), jen.Id("err"))),
@@ -87,12 +94,28 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			),
 			jen.Line(),
 			// Phase 4c: Add properties to EXISTING dynamic classes (refs can now be resolved)
-			jen.For(jen.List(jen.Id("name"), jen.Id("class")).Op(":=").Range().Id("dt").Dot("Classes")).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("dt").Dot("Classes"))).Block(
+				jen.Id("class").Op(":=").Id("dt").Dot("Classes").Index(jen.Id("name")),
 				jen.If(jen.Id("err").Op(":=").Id("addExistingClassProperties").Call(jen.Id("tb"), jen.Id("name"), jen.Id("class"), jen.Id("typeCache"), jen.Id("classBuilderCache")), jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("class %q properties: %w"), jen.Id("name"), jen.Id("err"))),
 				),
 			),
 			jen.Return(jen.Nil()),
+		)
+
+	// Generate sortedMapKeys helper - returns map keys sorted alphabetically.
+	// Used by applyDynamicTypes to make TypeBuilder population deterministic.
+	out.Func().Id("sortedMapKeys").
+		Types(jen.Id("V").Any()).
+		Params(jen.Id("m").Map(jen.String()).Id("V")).
+		Index().String().
+		Block(
+			jen.Id("keys").Op(":=").Make(jen.Index().String(), jen.Lit(0), jen.Len(jen.Id("m"))),
+			jen.For(jen.Id("k").Op(":=").Range().Id("m")).Block(
+				jen.Id("keys").Op("=").Append(jen.Id("keys"), jen.Id("k")),
+			),
+			jen.Qual("slices", "Sort").Call(jen.Id("keys")),
+			jen.Return(jen.Id("keys")),
 		)
 
 	// Generate createEnumShell helper - creates enum with values (new) or skips existing
@@ -234,7 +257,8 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			),
 			jen.Line(),
 			// Add properties to the new class builder
-			jen.For(jen.List(jen.Id("propName"), jen.Id("prop")).Op(":=").Range().Id("class").Dot("Properties")).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("propName")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("class").Dot("Properties"))).Block(
+				jen.Id("prop").Op(":=").Id("class").Dot("Properties").Index(jen.Id("propName")),
 				jen.List(jen.Id("typ"), jen.Id("err")).Op(":=").Id("resolvePropertyType").Call(jen.Id("tb"), jen.Id("prop"), jen.Id("typeCache"), jen.Id("classBuilderCache")),
 				jen.If(jen.Id("err").Op("!=").Nil()).Block(
 					// Skip unresolved refs - they may reference existing types in baml_src
@@ -286,7 +310,8 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			),
 			jen.Line(),
 			// Add properties to the existing class builder
-			jen.For(jen.List(jen.Id("propName"), jen.Id("prop")).Op(":=").Range().Id("class").Dot("Properties")).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("propName")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("class").Dot("Properties"))).Block(
+				jen.Id("prop").Op(":=").Id("class").Dot("Properties").Index(jen.Id("propName")),
 				jen.List(jen.Id("typ"), jen.Id("err")).Op(":=").Id("resolvePropertyType").Call(jen.Id("tb"), jen.Id("prop"), jen.Id("typeCache"), jen.Id("classBuilderCache")),
 				jen.If(jen.Id("err").Op("!=").Nil()).Block(
 					// Skip unresolved refs - they may reference types in baml_src

--- a/dynclient/internal/generated/adapter.go
+++ b/dynclient/internal/generated/adapter.go
@@ -1055,31 +1055,35 @@ func applyDynamicTypes(tb *introspected.TypeBuilder, dt *bamlutils.DynamicTypes)
 	typeCache := make(map[string]introspected.Type)
 	classBuilderCache := make(map[string]introspected.DynamicClassBuilder)
 
-	for name, enum := range dt.Enums {
+	for _, name := range sortedMapKeys(dt.Enums) {
+		enum := dt.Enums[name]
 		if err := createEnumShell(tb, name, enum, typeCache); err != nil {
 			return fmt.Errorf("enum %q: %w", name, err)
 		}
 	}
 
-	for name, enum := range dt.Enums {
+	for _, name := range sortedMapKeys(dt.Enums) {
+		enum := dt.Enums[name]
 		if err := addEnumValues(tb, name, enum, typeCache); err != nil {
 			return fmt.Errorf("enum %q values: %w", name, err)
 		}
 	}
 
-	for name, _ := range dt.Classes {
+	for _, name := range sortedMapKeys(dt.Classes) {
 		if err := createClassShell(tb, name, typeCache, classBuilderCache); err != nil {
 			return fmt.Errorf("class %q: %w", name, err)
 		}
 	}
 
-	for name, class := range dt.Classes {
+	for _, name := range sortedMapKeys(dt.Classes) {
+		class := dt.Classes[name]
 		if err := addNewClassProperties(tb, name, class, typeCache, classBuilderCache); err != nil {
 			return fmt.Errorf("class %q properties: %w", name, err)
 		}
 	}
 
-	for name, cb := range classBuilderCache {
+	for _, name := range sortedMapKeys(classBuilderCache) {
+		cb := classBuilderCache[name]
 		typ, err := cb.Type()
 		if err != nil {
 			return fmt.Errorf("class %q type: %w", name, err)
@@ -1087,12 +1091,21 @@ func applyDynamicTypes(tb *introspected.TypeBuilder, dt *bamlutils.DynamicTypes)
 		typeCache[name] = typ
 	}
 
-	for name, class := range dt.Classes {
+	for _, name := range sortedMapKeys(dt.Classes) {
+		class := dt.Classes[name]
 		if err := addExistingClassProperties(tb, name, class, typeCache, classBuilderCache); err != nil {
 			return fmt.Errorf("class %q properties: %w", name, err)
 		}
 	}
 	return nil
+}
+func sortedMapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
 }
 func createEnumShell(tb *introspected.TypeBuilder, name string, enum *bamlutils.DynamicEnum, typeCache map[string]introspected.Type) error {
 	if introspected.EnumExists(name) {
@@ -1176,7 +1189,8 @@ func addNewClassProperties(tb *introspected.TypeBuilder, name string, class *bam
 		return nil
 	}
 
-	for propName, prop := range class.Properties {
+	for _, propName := range sortedMapKeys(class.Properties) {
+		prop := class.Properties[propName]
 		typ, err := resolvePropertyType(tb, prop, typeCache, classBuilderCache)
 		if err != nil {
 			if strings.Contains(err.Error(), "unresolved reference") {
@@ -1207,7 +1221,8 @@ func addExistingClassProperties(tb *introspected.TypeBuilder, name string, class
 		return fmt.Errorf("get class builder: %w", err)
 	}
 
-	for propName, prop := range class.Properties {
+	for _, propName := range sortedMapKeys(class.Properties) {
+		prop := class.Properties[propName]
 		typ, err := resolvePropertyType(tb, prop, typeCache, classBuilderCache)
 		if err != nil {
 			if strings.Contains(err.Error(), "unresolved reference") {

--- a/integration/dynamic_output_format_order_test.go
+++ b/integration/dynamic_output_format_order_test.go
@@ -1,0 +1,202 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// TestDynamicOutputFormatOrderStable pins #309: identical /call/_dynamic
+// requests must render byte-identical upstream prompts, so prompt caching
+// stays warm across repeats of the same schema. The Go map literals below
+// are intentionally non-alphabetical, so the codegen's sorted TypeBuilder
+// population path has to do real work for the hash to converge.
+func TestDynamicOutputFormatOrderStable(t *testing.T) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		t.Skip("dynamic endpoints require BAML >= 0.215.0")
+	}
+	if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+		t.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
+	}
+
+	scenarioID := "test-dynamic-output-format-order"
+	opts := setupNonStreamingScenario(t, scenarioID, `{
+  "alpha": 1,
+  "bravo": "b",
+  "charlie": {"city": "Sofia", "street": "Main", "zip": "1000"},
+  "delta": "d",
+  "echo": true,
+  "foxtrot": "ACTIVE",
+  "golf": {"alpha": 7, "preference": "HIGH", "status": "PENDING", "zulu": "z"},
+  "hotel": ["x", "y"]
+}`)
+
+	systemText := "Return only JSON matching the requested schema."
+	userText := "Build a sample record."
+
+	req := testutil.DynamicRequest{
+		Messages: []testutil.DynamicMessage{
+			{
+				Role: "system",
+				Content: []testutil.DynamicContentPart{
+					{Type: "text", Text: strPtr(systemText)},
+					{Type: "output_format"},
+				},
+			},
+			{Role: "user", Content: userText},
+		},
+		ClientRegistry: opts.ClientRegistry,
+		OutputSchema: &testutil.DynamicOutputSchema{
+			Properties: map[string]*testutil.DynamicProperty{
+				"delta":   {Type: "string"},
+				"alpha":   {Type: "int"},
+				"hotel":   {Type: "list", Items: &testutil.DynamicTypeSpec{Type: "string"}},
+				"charlie": {Ref: "Address"},
+				"bravo":   {Type: "string"},
+				"foxtrot": {Ref: "Status"},
+				"echo":    {Type: "bool"},
+				"golf":    {Ref: "Profile"},
+			},
+			Classes: map[string]*testutil.DynamicClass{
+				"Profile": {
+					Properties: map[string]*testutil.DynamicProperty{
+						"zulu":       {Type: "string"},
+						"alpha":      {Type: "int"},
+						"status":     {Ref: "Status"},
+						"preference": {Ref: "Preference"},
+					},
+				},
+				"Address": {
+					Properties: map[string]*testutil.DynamicProperty{
+						"zip":    {Type: "string"},
+						"city":   {Type: "string"},
+						"street": {Type: "string"},
+					},
+				},
+			},
+			Enums: map[string]*testutil.DynamicEnum{
+				"Status": {
+					Values: []*testutil.DynamicEnumValue{
+						{Name: "PENDING"},
+						{Name: "ACTIVE"},
+						{Name: "ARCHIVED"},
+					},
+				},
+				"Preference": {
+					Values: []*testutil.DynamicEnumValue{
+						{Name: "LOW"},
+						{Name: "MEDIUM"},
+						{Name: "HIGH"},
+					},
+				},
+			},
+		},
+	}
+
+	const iterations = 50
+	hashCounts := make(map[string]int, 2)
+	samples := make(map[string]string, 2)
+
+	for i := 0; i < iterations; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+		resp, err := BAMLClient.DynamicCall(ctx, req)
+		if err != nil {
+			cancel()
+			t.Fatalf("iteration %d: DynamicCall failed: %v", i, err)
+		}
+		if resp.StatusCode != 200 {
+			cancel()
+			t.Fatalf("iteration %d: expected status 200, got %d: %s", i, resp.StatusCode, resp.Error)
+		}
+
+		capturedBody, err := MockClient.GetLastRequest(ctx, scenarioID)
+		if err != nil {
+			cancel()
+			t.Fatalf("iteration %d: failed to get last request: %v", i, err)
+		}
+		cancel()
+
+		prompt, err := extractFirstMessageText(capturedBody)
+		if err != nil {
+			t.Fatalf("iteration %d: %v\ncaptured body: %s", i, err, string(capturedBody))
+		}
+
+		sum := sha256.Sum256([]byte(prompt))
+		key := hex.EncodeToString(sum[:])
+		hashCounts[key]++
+		if _, ok := samples[key]; !ok {
+			samples[key] = prompt
+		}
+	}
+
+	if len(hashCounts) != 1 {
+		t.Errorf("expected exactly 1 unique prompt hash across %d iterations, got %d", iterations, len(hashCounts))
+		shown := 0
+		for key, count := range hashCounts {
+			t.Logf("hash %s: %d iterations", key, count)
+			if shown < 2 {
+				t.Logf("sample for %s:\n%s", key, samples[key])
+				shown++
+			}
+		}
+	}
+}
+
+// extractFirstMessageText pulls the first chat message's text content out of
+// an OpenAI-compatible mock-LLM capture body. The captured body's first
+// message is either a plain string or an array of content parts; either way
+// we return the concatenated text, since that is what feeds the rendered
+// output_format block we are pinning.
+func extractFirstMessageText(body []byte) (string, error) {
+	var captured map[string]any
+	if err := json.Unmarshal(body, &captured); err != nil {
+		return "", fmt.Errorf("unmarshal captured body: %w", err)
+	}
+
+	messagesAny, ok := captured["messages"]
+	if !ok {
+		return "", fmt.Errorf("captured body missing 'messages' field")
+	}
+	messages, ok := messagesAny.([]any)
+	if !ok || len(messages) == 0 {
+		return "", fmt.Errorf("captured body 'messages' is not a non-empty array: %T", messagesAny)
+	}
+
+	first, ok := messages[0].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("messages[0] is not an object: %T", messages[0])
+	}
+	content, ok := first["content"]
+	if !ok {
+		return "", fmt.Errorf("messages[0] missing 'content' field")
+	}
+
+	switch c := content.(type) {
+	case string:
+		return c, nil
+	case []any:
+		var combined string
+		for _, partAny := range c {
+			part, ok := partAny.(map[string]any)
+			if !ok {
+				continue
+			}
+			if text, ok := part["text"].(string); ok {
+				combined += text
+			}
+		}
+		return combined, nil
+	default:
+		return "", fmt.Errorf("messages[0].content has unexpected shape: %T", content)
+	}
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes #309.

## Summary

Reporter (a colleague consuming baml-rest in production) found that repeated identical `/call/_dynamic` requests produced different rendered `ctx.output_format` text. Same inputs, different prompts. Prompt caching broken.

Root cause: baml-rest's generated adapter ranges `map[string]...` fields when populating BAML's TypeBuilder. Go map iteration order is intentionally unstable. BAML deterministically renders the (unstable) insertion order it received → byte-unstable system prompts.

BAML core is innocent — it uses `IndexMap` and renders in call order. The fix lives entirely on the baml-rest side.

## What changed

### Commit 1 — `fix(codegen): sort dynamic schema map keys before TypeBuilder population (#309)` (`0ef91a877`)

`adapters/common/codegen/codegen_dynamic_types.go` (the codegen source) + `dynclient/internal/generated/adapter.go` (regen mirror).

- New unexported helper `sortedMapKeys[V any](m map[string]V) []string` emitted into the adapter output (uses `slices.Sort`).
- Six map-range sites in the dynamic-types-application path now iterate sorted keys:
  - `dt.Enums` × 2 (enum shells + value-update phase)
  - `dt.Classes` × 2 (class shells + existing-class phase)
  - `classBuilderCache` × 1 (type-cache walk — not user-visible, canonicalized for consistency)
  - `class.Properties` × 2 (`addNewClassProperties` + `addExistingClassProperties`)
- Sliced/caller-controlled order **preserved**: `enum.Values`, `oneOf`, message arrays, content-part arrays. Those are intentionally caller-ordered.

Codegen-source fix → regenerate via `cmd/regenerate-dynclient` (gate from #299 still passes).

### Commit 2 — `test(integration): pin dynamic output_format byte-stability (#309)` (`b27ec1a24`)

`integration/dynamic_output_format_order_test.go`. Sends 50 identical `/call/_dynamic` requests against the mockllm container with a schema that deliberately uses non-alphabetical Go map literal order. Hashes the captured upstream body's system message. Asserts exactly one unique hash across all 50.

The schema fixture has 8+ top-level properties, two nested classes (each with 3-5 properties), two enums with values. That's enough surface area for the un-sorted-map path to randomly permute on every call.

## Bug-revert sanity check

Verified locally: reverting commit 1 (codegen source + regenerated adapter) made the test FAIL with **23 unique hashes across 50 iterations**. Restoring commit 1 → test passes with 1 unique hash (6.37s).

Sample of the failure hashes from the reverted run:

```
hash b0d54c52... 8 iterations
hash 94df6e1f... 5 iterations
hash 83883e0f... 5 iterations
hash 0ce6fb5e... 3 iterations
hash d34e5100... 3 iterations
hash bb160290... 3 iterations
[... 17 more, mostly 1-2 iterations each ...]
```

The captured BAML prompt log on the reverted run also shows the schema rendered with non-alphabetical, randomized property ordering (e.g. `charlie, delta, echo, foxtrot, golf, hotel, alpha, bravo`), confirming this is exactly the bug from #309.

## Why sort vs preserve-input-order

We picked **sorted keys** over preserve-input-order because:

1. **Cross-language consistency** — the same logical schema sent from different consumer languages (Python `dict`, JS object, Go map) produces the same prompt. Without sorting, prompt caching is sensitive to whatever JSON serializer order the client happened to use.
2. **Smaller scope** — sort-before-range is one helper + 6 call-site changes. Preserve-input-order would require a custom ordered-map JSON decoder + plumbing it through the JSON boundary into the worker.
3. **Maintainer call** — schema field ordering CAN matter for LLM behavior (some users tune it deliberately), so preserve-input-order should ship as an explicit opt-in flag in a follow-up rather than as an unconditional default change.

Follow-up tracker (preserve-input-order opt-in) will be filed after this lands.

## Affected paths

- `/call/_dynamic`, `/call-with-raw/_dynamic`, `/stream/_dynamic`, `/stream-with-raw/_dynamic`, `/parse/_dynamic`
- Public `dynclient` package (aliases `bamlutils.DynamicInput` + uses the same generated adapter path)
- Anywhere `ctx.output_format` placeholder / `{"type": "output_format"}` content part is used by the caller

Not affected:
- Static-template BAML functions
- Caller message-array / content-part / `enum.Values` / `oneOf` ordering (caller-controlled, preserved)

## Files

```
adapters/common/codegen/codegen_dynamic_types.go |  41 ++++-
dynclient/internal/generated/adapter.go          |  31 +++-
integration/dynamic_output_format_order_test.go  | 202 +++++++++++++++++++++++
3 files changed, 258 insertions(+), 16 deletions(-)
```

## Test plan

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./bamlutils/... -count=1` ✓
- `go test -tags=integration ./integration/mockllm -count=1` ✓
- `go test -tags=integration -v -count=1 -p 1 -timeout 15m ./integration -run TestDynamicOutputFormatOrder` ✓
- `./scripts/sync.sh` ✓ (4/4 BAML pins match)
- `cmd/regenerate-dynclient` ✓ (idempotent — the regen gate from #299 still passes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic code generation for dynamic types, ensuring consistent and reproducible output across multiple runs.

* **Tests**
  * Added integration test to verify deterministic generation of dynamic content output across repeated executions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->