### PR TITLE
chore(release): release-prep for 0.0.44

### DIFF
--- a/adapters/adapter_v0_204_0/go.mod
+++ b/adapters/adapter_v0_204_0/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.43 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.43 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.44 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.44 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/adapter_v0_215_0/go.mod
+++ b/adapters/adapter_v0_215_0/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.43 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.43 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.44 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.44 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/adapter_v0_219_0/go.mod
+++ b/adapters/adapter_v0_219_0/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.43 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.43 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.44 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.44 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/common/go.mod
+++ b/adapters/common/go.mod
@@ -5,8 +5,8 @@ go 1.26.3
 require (
 	github.com/boundaryml/baml v0.204.0
 	github.com/dave/jennifer v1.7.1
-	github.com/invakid404/baml-rest/bamlutils v0.0.43
-	github.com/invakid404/baml-rest/introspected v0.0.43
+	github.com/invakid404/baml-rest/bamlutils v0.0.44
+	github.com/invakid404/baml-rest/introspected v0.0.44
 	github.com/stoewer/go-strcase v1.3.1
 )
 

--- a/dynclient/go.mod
+++ b/dynclient/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/goccy/go-json v0.10.6
 	github.com/google/uuid v1.6.0
 	github.com/gregwebs/go-recovery v0.4.1
-	github.com/invakid404/baml-rest/adapters/common v0.0.43
-	github.com/invakid404/baml-rest/bamlutils v0.0.43
-	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.43
-	github.com/invakid404/baml-rest/worker v0.0.43
-	github.com/invakid404/baml-rest/workerplugin v0.0.43
+	github.com/invakid404/baml-rest/adapters/common v0.0.44
+	github.com/invakid404/baml-rest/bamlutils v0.0.44
+	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.44
+	github.com/invakid404/baml-rest/worker v0.0.44
+	github.com/invakid404/baml-rest/workerplugin v0.0.44
 	github.com/prometheus/client_golang v1.23.2
 )
 
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.8.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.43 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.44 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect

--- a/introspected/go.mod
+++ b/introspected/go.mod
@@ -2,7 +2,7 @@ module github.com/invakid404/baml-rest/introspected
 
 go 1.26.3
 
-require github.com/invakid404/baml-rest/bamlutils v0.0.43
+require github.com/invakid404/baml-rest/bamlutils v0.0.44
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect

--- a/pool/go.mod
+++ b/pool/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/gregwebs/go-recovery v0.4.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
-	github.com/invakid404/baml-rest/bamlutils v0.0.43
-	github.com/invakid404/baml-rest/workerplugin v0.0.43
+	github.com/invakid404/baml-rest/bamlutils v0.0.44
+	github.com/invakid404/baml-rest/workerplugin v0.0.44
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1
 	google.golang.org/grpc v1.81.1

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -4,8 +4,8 @@ go 1.26.3
 
 require (
 	github.com/goccy/go-json v0.10.6
-	github.com/invakid404/baml-rest/bamlutils v0.0.43
-	github.com/invakid404/baml-rest/workerplugin v0.0.43
+	github.com/invakid404/baml-rest/bamlutils v0.0.44
+	github.com/invakid404/baml-rest/workerplugin v0.0.44
 	github.com/prometheus/client_golang v1.23.2
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )

--- a/workerplugin/go.mod
+++ b/workerplugin/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/hashicorp/go-plugin v1.8.0
-	github.com/invakid404/baml-rest/bamlutils v0.0.43
+	github.com/invakid404/baml-rest/bamlutils v0.0.44
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Release-prep for `0.0.44`. Rewrites first-party require versions from `v0.0.43` to `v0.0.44` across the 5 affected `go.mod` files (plus the workspace-sync side effects in `pool/` and the adapter `_v*` indirects) so the upcoming `0.0.44` product tag — and the subdir Go module tags `scripts/release-go-tags.sh` will create from it — produce a clean, internally consistent dependency graph for external `go get github.com/invakid404/baml-rest/dynclient@v0.0.44`.

Doing release-prep pre-tag this time. Last release (`0.0.43`) tagged before release-prep, which required force-moving the published tag — a non-trivial recovery. This PR avoids that by sequencing prep → merge → tag → release → script.

## What changed

| File | Reason |
|---|---|
| `dynclient/go.mod` | Required: 6 first-party requires |
| `adapters/common/go.mod` | Required: bamlutils, introspected |
| `introspected/go.mod` | Required: bamlutils |
| `worker/go.mod` | Required: bamlutils, workerplugin |
| `workerplugin/go.mod` | Required: bamlutils |
| `pool/go.mod` | Workspace-sync side effect (bamlutils + workerplugin) — kept consistent |
| `adapters/adapter_v0_{204,215,219}_0/go.mod` | Workspace-sync side effect (indirect bamlutils + introspected) |

9 files, +20/-20.

## Deliberately NOT changed

- **Root `go.mod`** — not in the published `v0.0.N` tag set. Its first-party requires are cosmetic at the local build because of `replace` directives.
- **`dynclient/baml-patched/go.mod`** — no first-party requires to rewrite.

## Validation

- `go build ./...` ✓
- `go vet ./...` ✓
- `./scripts/sync.sh` ✓ (workspace + common + 3 adapters; 4/4 BAML pins match)
- Manual replication of `release-go-tags.sh`'s pseudo-version check against the staged tree: all 7 required modules PASS (no pseudo-versions, all at `v0.0.44`).

## Release sequence (post-merge)

Per `RELEASE.md`:

1. Merge this PR.
2. Create + push lightweight tag `0.0.44` at the merge commit (no `v` prefix).
3. Publish GitHub Release from `0.0.44` (this triggers the binary build via `build-and-publish.yml`).
4. Run `./scripts/release-go-tags.sh 0.0.44` from a master checkout to create + push the 7 subdir Go module tags.
5. External `go get` smoke:

```sh
tmp=$(mktemp -d) && cd "$tmp"
go mod init smoke
GOWORK=off go get github.com/invakid404/baml-rest/dynclient@v0.0.44
GOWORK=off go list -deps github.com/invakid404/baml-rest/dynclient
```

Refs #289.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module dependencies across the codebase to the latest compatible versions, enhancing system stability and ensuring consistency between all components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->