### PR TITLE
feat(dynclient): opt-in preserve_schema_order for output_schema (#313)

### DIFF
--- a/adapters/common/codegen/codegen_dynamic_types.go
+++ b/adapters/common/codegen/codegen_dynamic_types.go
@@ -47,12 +47,17 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			// Create caches
 			jen.Id("typeCache").Op(":=").Make(jen.Map(jen.String()).Add(typeAlias)),
 			jen.Id("classBuilderCache").Op(":=").Make(jen.Map(jen.String()).Qual(introspectedPkg, "DynamicClassBuilder")),
+			// preserveOrder and order drive schemaMapKeys: when both are
+			// set, TypeBuilder population follows the caller's wire order;
+			// otherwise the canonical sorted fallback applies.
+			jen.Id("preserveOrder").Op(":=").Id("dt").Dot("PreserveOrder"),
+			jen.Id("order").Op(":=").Id("dt").Dot("Order"),
 			jen.Line(),
 			// Phase 1: Create all enum shells (for NEW enums only, with values since we have builder)
 			// Iterate sorted keys so TypeBuilder population order is deterministic: Go map
 			// iteration is intentionally randomised, and BAML preserves the order it receives,
 			// so unsorted ranging produces non-deterministic rendered output_format text.
-			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("dt").Dot("Enums"))).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("schemaMapKeys").Call(jen.Id("dt").Dot("Enums"), jen.Id("enumOrder").Call(jen.Id("order")), jen.Id("preserveOrder"))).Block(
 				jen.Id("enum").Op(":=").Id("dt").Dot("Enums").Index(jen.Id("name")),
 				jen.If(jen.Id("err").Op(":=").Id("createEnumShell").Call(jen.Id("tb"), jen.Id("name"), jen.Id("enum"), jen.Id("typeCache")), jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("enum %q: %w"), jen.Id("name"), jen.Id("err"))),
@@ -60,7 +65,7 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			),
 			jen.Line(),
 			// Phase 2: Add values to EXISTING enums
-			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("dt").Dot("Enums"))).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("schemaMapKeys").Call(jen.Id("dt").Dot("Enums"), jen.Id("enumOrder").Call(jen.Id("order")), jen.Id("preserveOrder"))).Block(
 				jen.Id("enum").Op(":=").Id("dt").Dot("Enums").Index(jen.Id("name")),
 				jen.If(jen.Id("err").Op(":=").Id("addEnumValues").Call(jen.Id("tb"), jen.Id("name"), jen.Id("enum"), jen.Id("typeCache")), jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("enum %q values: %w"), jen.Id("name"), jen.Id("err"))),
@@ -68,7 +73,7 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			),
 			jen.Line(),
 			// Phase 3: Create all NEW class shells (no properties yet - just register the type)
-			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("dt").Dot("Classes"))).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("schemaMapKeys").Call(jen.Id("dt").Dot("Classes"), jen.Id("classOrder").Call(jen.Id("order")), jen.Id("preserveOrder"))).Block(
 				jen.If(jen.Id("err").Op(":=").Id("createClassShell").Call(jen.Id("tb"), jen.Id("name"), jen.Id("typeCache"), jen.Id("classBuilderCache")), jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("class %q: %w"), jen.Id("name"), jen.Id("err"))),
 				),
@@ -76,15 +81,15 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			jen.Line(),
 			// Phase 4a: Add properties to NEW classes only (from classBuilderCache)
 			// These classes only have primitive types or reference other new classes
-			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("dt").Dot("Classes"))).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("schemaMapKeys").Call(jen.Id("dt").Dot("Classes"), jen.Id("classOrder").Call(jen.Id("order")), jen.Id("preserveOrder"))).Block(
 				jen.Id("class").Op(":=").Id("dt").Dot("Classes").Index(jen.Id("name")),
-				jen.If(jen.Id("err").Op(":=").Id("addNewClassProperties").Call(jen.Id("tb"), jen.Id("name"), jen.Id("class"), jen.Id("typeCache"), jen.Id("classBuilderCache")), jen.Id("err").Op("!=").Nil()).Block(
+				jen.If(jen.Id("err").Op(":=").Id("addNewClassProperties").Call(jen.Id("tb"), jen.Id("name"), jen.Id("class"), jen.Id("typeCache"), jen.Id("classBuilderCache"), jen.Id("order"), jen.Id("preserveOrder")), jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("class %q properties: %w"), jen.Id("name"), jen.Id("err"))),
 				),
 			),
 			jen.Line(),
 			// Phase 4b: Cache types for all NEW classes (now that properties are added)
-			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("classBuilderCache"))).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("schemaMapKeys").Call(jen.Id("classBuilderCache"), jen.Id("classOrder").Call(jen.Id("order")), jen.Id("preserveOrder"))).Block(
 				jen.Id("cb").Op(":=").Id("classBuilderCache").Index(jen.Id("name")),
 				jen.List(jen.Id("typ"), jen.Id("err")).Op(":=").Id("cb").Dot("Type").Call(),
 				jen.If(jen.Id("err").Op("!=").Nil()).Block(
@@ -94,9 +99,9 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			),
 			jen.Line(),
 			// Phase 4c: Add properties to EXISTING dynamic classes (refs can now be resolved)
-			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("dt").Dot("Classes"))).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("name")).Op(":=").Range().Id("schemaMapKeys").Call(jen.Id("dt").Dot("Classes"), jen.Id("classOrder").Call(jen.Id("order")), jen.Id("preserveOrder"))).Block(
 				jen.Id("class").Op(":=").Id("dt").Dot("Classes").Index(jen.Id("name")),
-				jen.If(jen.Id("err").Op(":=").Id("addExistingClassProperties").Call(jen.Id("tb"), jen.Id("name"), jen.Id("class"), jen.Id("typeCache"), jen.Id("classBuilderCache")), jen.Id("err").Op("!=").Nil()).Block(
+				jen.If(jen.Id("err").Op(":=").Id("addExistingClassProperties").Call(jen.Id("tb"), jen.Id("name"), jen.Id("class"), jen.Id("typeCache"), jen.Id("classBuilderCache"), jen.Id("order"), jen.Id("preserveOrder")), jen.Id("err").Op("!=").Nil()).Block(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("class %q properties: %w"), jen.Id("name"), jen.Id("err"))),
 				),
 			),
@@ -104,7 +109,8 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 		)
 
 	// Generate sortedMapKeys helper - returns map keys sorted alphabetically.
-	// Used by applyDynamicTypes to make TypeBuilder population deterministic.
+	// Used as the canonical fallback by schemaMapKeys when preserve_order
+	// is off or no explicit order slice is supplied for a dimension.
 	out.Func().Id("sortedMapKeys").
 		Types(jen.Id("V").Any()).
 		Params(jen.Id("m").Map(jen.String()).Id("V")).
@@ -116,6 +122,75 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			),
 			jen.Qual("slices", "Sort").Call(jen.Id("keys")),
 			jen.Return(jen.Id("keys")),
+		)
+
+	// schemaMapKeys: order-aware key list. When preserve is true and a
+	// non-empty order slice was supplied, return keys in that order
+	// (intersected with the live map, dropping unknown names). Keys
+	// absent from the order slice are appended in sorted order so the
+	// caller's partial ordering still drives deterministic placement
+	// for everything they listed. When preserve is false or no order
+	// is supplied, fall back to sortedMapKeys.
+	out.Func().Id("schemaMapKeys").
+		Types(jen.Id("V").Any()).
+		Params(
+			jen.Id("m").Map(jen.String()).Id("V"),
+			jen.Id("order").Index().String(),
+			jen.Id("preserve").Bool(),
+		).
+		Index().String().
+		Block(
+			jen.If(jen.Op("!").Id("preserve").Op("||").Len(jen.Id("order")).Op("==").Lit(0)).Block(
+				jen.Return(jen.Id("sortedMapKeys").Call(jen.Id("m"))),
+			),
+			jen.Id("keys").Op(":=").Make(jen.Index().String(), jen.Lit(0), jen.Len(jen.Id("m"))),
+			jen.Id("seen").Op(":=").Make(jen.Map(jen.String()).Struct(), jen.Len(jen.Id("order"))),
+			jen.For(jen.List(jen.Id("_"), jen.Id("k")).Op(":=").Range().Id("order")).Block(
+				jen.If(jen.List(jen.Id("_"), jen.Id("ok")).Op(":=").Id("m").Index(jen.Id("k")), jen.Op("!").Id("ok")).Block(
+					jen.Continue(),
+				),
+				jen.If(jen.List(jen.Id("_"), jen.Id("dup")).Op(":=").Id("seen").Index(jen.Id("k")), jen.Id("dup")).Block(
+					jen.Continue(),
+				),
+				jen.Id("seen").Index(jen.Id("k")).Op("=").Struct().Values(),
+				jen.Id("keys").Op("=").Append(jen.Id("keys"), jen.Id("k")),
+			),
+			jen.For(jen.List(jen.Id("_"), jen.Id("k")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("m"))).Block(
+				jen.If(jen.List(jen.Id("_"), jen.Id("ok")).Op(":=").Id("seen").Index(jen.Id("k")), jen.Op("!").Id("ok")).Block(
+					jen.Id("keys").Op("=").Append(jen.Id("keys"), jen.Id("k")),
+				),
+			),
+			jen.Return(jen.Id("keys")),
+		)
+
+	// enumOrder/classOrder/propertyOrder are nil-safe accessors into
+	// *DynamicTypesOrder so schemaMapKeys callers can pass an explicit
+	// order slice without rechecking the parent for nil.
+	out.Func().Id("enumOrder").
+		Params(jen.Id("o").Op("*").Qual(pkgs.InterfacesPkg, "DynamicTypesOrder")).
+		Index().String().
+		Block(
+			jen.If(jen.Id("o").Op("==").Nil()).Block(jen.Return(jen.Nil())),
+			jen.Return(jen.Id("o").Dot("Enums")),
+		)
+
+	out.Func().Id("classOrder").
+		Params(jen.Id("o").Op("*").Qual(pkgs.InterfacesPkg, "DynamicTypesOrder")).
+		Index().String().
+		Block(
+			jen.If(jen.Id("o").Op("==").Nil()).Block(jen.Return(jen.Nil())),
+			jen.Return(jen.Id("o").Dot("Classes")),
+		)
+
+	out.Func().Id("propertyOrder").
+		Params(
+			jen.Id("o").Op("*").Qual(pkgs.InterfacesPkg, "DynamicTypesOrder"),
+			jen.Id("className").String(),
+		).
+		Index().String().
+		Block(
+			jen.If(jen.Id("o").Op("==").Nil().Op("||").Id("o").Dot("Properties").Op("==").Nil()).Block(jen.Return(jen.Nil())),
+			jen.Return(jen.Id("o").Dot("Properties").Index(jen.Id("className"))),
 		)
 
 	// Generate createEnumShell helper - creates enum with values (new) or skips existing
@@ -246,6 +321,8 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			jen.Id("class").Op("*").Qual(pkgs.InterfacesPkg, "DynamicClass"),
 			jen.Id("typeCache").Map(jen.String()).Add(typeAlias),
 			jen.Id("classBuilderCache").Map(jen.String()).Qual(introspectedPkg, "DynamicClassBuilder"),
+			jen.Id("order").Op("*").Qual(pkgs.InterfacesPkg, "DynamicTypesOrder"),
+			jen.Id("preserveOrder").Bool(),
 		).
 		Error().
 		Block(
@@ -257,7 +334,7 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			),
 			jen.Line(),
 			// Add properties to the new class builder
-			jen.For(jen.List(jen.Id("_"), jen.Id("propName")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("class").Dot("Properties"))).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("propName")).Op(":=").Range().Id("schemaMapKeys").Call(jen.Id("class").Dot("Properties"), jen.Id("propertyOrder").Call(jen.Id("order"), jen.Id("name")), jen.Id("preserveOrder"))).Block(
 				jen.Id("prop").Op(":=").Id("class").Dot("Properties").Index(jen.Id("propName")),
 				jen.List(jen.Id("typ"), jen.Id("err")).Op(":=").Id("resolvePropertyType").Call(jen.Id("tb"), jen.Id("prop"), jen.Id("typeCache"), jen.Id("classBuilderCache")),
 				jen.If(jen.Id("err").Op("!=").Nil()).Block(
@@ -288,6 +365,8 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			jen.Id("class").Op("*").Qual(pkgs.InterfacesPkg, "DynamicClass"),
 			jen.Id("typeCache").Map(jen.String()).Add(typeAlias),
 			jen.Id("classBuilderCache").Map(jen.String()).Qual(introspectedPkg, "DynamicClassBuilder"),
+			jen.Id("order").Op("*").Qual(pkgs.InterfacesPkg, "DynamicTypesOrder"),
+			jen.Id("preserveOrder").Bool(),
 		).
 		Error().
 		Block(
@@ -310,7 +389,7 @@ func generateApplyDynamicTypes(out *jen.File, pkgs PackageConfig) {
 			),
 			jen.Line(),
 			// Add properties to the existing class builder
-			jen.For(jen.List(jen.Id("_"), jen.Id("propName")).Op(":=").Range().Id("sortedMapKeys").Call(jen.Id("class").Dot("Properties"))).Block(
+			jen.For(jen.List(jen.Id("_"), jen.Id("propName")).Op(":=").Range().Id("schemaMapKeys").Call(jen.Id("class").Dot("Properties"), jen.Id("propertyOrder").Call(jen.Id("order"), jen.Id("name")), jen.Id("preserveOrder"))).Block(
 				jen.Id("prop").Op(":=").Id("class").Dot("Properties").Index(jen.Id("propName")),
 				jen.List(jen.Id("typ"), jen.Id("err")).Op(":=").Id("resolvePropertyType").Call(jen.Id("tb"), jen.Id("prop"), jen.Id("typeCache"), jen.Id("classBuilderCache")),
 				jen.If(jen.Id("err").Op("!=").Nil()).Block(

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -1,6 +1,8 @@
 package bamlutils
 
 import (
+	"bytes"
+	encjson "encoding/json"
 	"fmt"
 	"strings"
 
@@ -336,13 +338,148 @@ type DynamicOutputSchema struct {
 	Classes map[string]*DynamicClass `json:"classes,omitempty"`
 	// Enums defines enum types that can be referenced via ref (optional)
 	Enums map[string]*DynamicEnum `json:"enums,omitempty"`
+
+	// PropertiesOrder records the insertion order of Properties as it
+	// appeared on the JSON wire. Populated by UnmarshalJSON for raw-JSON
+	// callers; Go callers that set PreserveSchemaOrder must fill this
+	// slice explicitly (Go map literals do not carry order).
+	PropertiesOrder []string `json:"-"`
+	// ClassesOrder mirrors PropertiesOrder for the Classes map.
+	ClassesOrder []string `json:"-"`
+	// EnumsOrder mirrors PropertiesOrder for the Enums map.
+	EnumsOrder []string `json:"-"`
+}
+
+// UnmarshalJSON decodes a DynamicOutputSchema while capturing the JSON
+// key insertion order of properties/classes/enums into the matching
+// *Order slices. Duplicate keys in any of these objects are rejected
+// with a path-qualified error.
+//
+// Implementation note: this uses encoding/json's streaming decoder to
+// read tokens in source order; goccy/go-json's Decoder.Token is API-
+// compatible but its behaviour around RawMessage decoding inside a
+// streaming token loop has historically diverged. encoding/json is
+// only used here for the ordered top-level scan — nested values are
+// still decoded through json.Unmarshal which routes through goccy.
+func (s *DynamicOutputSchema) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Properties json.RawMessage `json:"properties"`
+		Classes    json.RawMessage `json:"classes"`
+		Enums      json.RawMessage `json:"enums"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if isJSONObject(raw.Properties) {
+		props, order, err := unmarshalOrderedObject[*DynamicProperty](raw.Properties, "output_schema.properties")
+		if err != nil {
+			return err
+		}
+		s.Properties = props
+		s.PropertiesOrder = order
+	}
+	if isJSONObject(raw.Classes) {
+		classes, order, err := unmarshalOrderedObject[*DynamicClass](raw.Classes, "output_schema.classes")
+		if err != nil {
+			return err
+		}
+		s.Classes = classes
+		s.ClassesOrder = order
+	}
+	if isJSONObject(raw.Enums) {
+		enums, order, err := unmarshalOrderedObject[*DynamicEnum](raw.Enums, "output_schema.enums")
+		if err != nil {
+			return err
+		}
+		s.Enums = enums
+		s.EnumsOrder = order
+	}
+	return nil
+}
+
+// UnmarshalJSON decodes a DynamicClass while capturing the JSON key
+// insertion order of its properties object into PropertiesOrder. The
+// description and alias fields decode through the normal route.
+// Duplicate property keys are rejected.
+func (c *DynamicClass) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Description string          `json:"description,omitempty"`
+		Alias       string          `json:"alias,omitempty"`
+		Properties  json.RawMessage `json:"properties,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	c.Description = raw.Description
+	c.Alias = raw.Alias
+	if isJSONObject(raw.Properties) {
+		props, order, err := unmarshalOrderedObject[*DynamicProperty](raw.Properties, "class.properties")
+		if err != nil {
+			return err
+		}
+		c.Properties = props
+		c.PropertiesOrder = order
+	}
+	return nil
+}
+
+func isJSONObject(b []byte) bool {
+	t := bytes.TrimSpace(b)
+	return len(t) > 0 && t[0] == '{'
+}
+
+// unmarshalOrderedObject decodes a JSON object into a map[string]V while
+// recording the appearance order of keys. Duplicate keys produce a
+// path-qualified error so callers cannot smuggle in ambiguous schemas.
+func unmarshalOrderedObject[V any](data []byte, path string) (map[string]V, []string, error) {
+	dec := encjson.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if delim, ok := tok.(encjson.Delim); !ok || delim != '{' {
+		return nil, nil, fmt.Errorf("%s: expected object", path)
+	}
+
+	values := make(map[string]V)
+	order := make([]string, 0)
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s: %w", path, err)
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, nil, fmt.Errorf("%s: expected object key", path)
+		}
+		if _, exists := values[key]; exists {
+			return nil, nil, fmt.Errorf("%s: duplicate key %q", path, key)
+		}
+		var rawVal encjson.RawMessage
+		if err := dec.Decode(&rawVal); err != nil {
+			return nil, nil, fmt.Errorf("%s.%s: %w", path, key, err)
+		}
+		var value V
+		if err := json.Unmarshal(rawVal, &value); err != nil {
+			return nil, nil, fmt.Errorf("%s.%s: %w", path, key, err)
+		}
+		values[key] = value
+		order = append(order, key)
+	}
+	if _, err := dec.Token(); err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return values, order, nil
 }
 
 // DynamicInput is the request body for dynamic endpoints
 type DynamicInput struct {
-	Messages       []DynamicMessage     `json:"messages"`
-	ClientRegistry *ClientRegistry      `json:"client_registry"`
-	OutputSchema   *DynamicOutputSchema `json:"output_schema"`
+	Messages            []DynamicMessage     `json:"messages"`
+	ClientRegistry      *ClientRegistry      `json:"client_registry"`
+	OutputSchema        *DynamicOutputSchema `json:"output_schema"`
+	PreserveSchemaOrder bool                 `json:"preserve_schema_order,omitempty"`
 }
 
 // Validate checks that required fields are present
@@ -355,6 +492,11 @@ func (d *DynamicInput) Validate() error {
 	}
 	if d.OutputSchema == nil || len(d.OutputSchema.Properties) == 0 {
 		return fmt.Errorf("output_schema with at least one property is required")
+	}
+	if d.PreserveSchemaOrder {
+		if err := validatePreserveSchemaOrder(d.OutputSchema); err != nil {
+			return err
+		}
 	}
 	for i, m := range d.Messages {
 		if m.Role == "" {
@@ -383,17 +525,82 @@ func (d *DynamicInput) Validate() error {
 	return nil
 }
 
+// validatePreserveSchemaOrder enforces the contract that
+// PreserveSchemaOrder=true requires explicit order metadata for every
+// multi-key first-party map in the schema. Raw JSON callers get this
+// automatically through DynamicOutputSchema.UnmarshalJSON; Go callers
+// must set the *Order slices themselves because map literals do not
+// carry order. Also catches duplicate or unknown names in order slices.
+func validatePreserveSchemaOrder(s *DynamicOutputSchema) error {
+	if s == nil {
+		return nil
+	}
+	if len(s.Properties) >= 2 && len(s.PropertiesOrder) == 0 {
+		return fmt.Errorf("preserve_schema_order=true but output_schema.properties has no captured order; send the request via JSON or set OutputSchema.PropertiesOrder explicitly")
+	}
+	if err := checkOrderSlice("output_schema.properties", s.PropertiesOrder, mapKeySet(s.Properties)); err != nil {
+		return err
+	}
+	if len(s.Classes) >= 2 && len(s.ClassesOrder) == 0 {
+		return fmt.Errorf("preserve_schema_order=true but output_schema.classes has no captured order; send the request via JSON or set OutputSchema.ClassesOrder explicitly")
+	}
+	if err := checkOrderSlice("output_schema.classes", s.ClassesOrder, mapKeySet(s.Classes)); err != nil {
+		return err
+	}
+	if len(s.Enums) >= 2 && len(s.EnumsOrder) == 0 {
+		return fmt.Errorf("preserve_schema_order=true but output_schema.enums has no captured order; send the request via JSON or set OutputSchema.EnumsOrder explicitly")
+	}
+	if err := checkOrderSlice("output_schema.enums", s.EnumsOrder, mapKeySet(s.Enums)); err != nil {
+		return err
+	}
+	for name, cls := range s.Classes {
+		if cls == nil {
+			continue
+		}
+		path := fmt.Sprintf("output_schema.classes[%q].properties", name)
+		if len(cls.Properties) >= 2 && len(cls.PropertiesOrder) == 0 {
+			return fmt.Errorf("preserve_schema_order=true but %s has no captured order; send the request via JSON or set DynamicClass.PropertiesOrder explicitly", path)
+		}
+		if err := checkOrderSlice(path, cls.PropertiesOrder, mapKeySet(cls.Properties)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mapKeySet[V any](m map[string]V) map[string]struct{} {
+	set := make(map[string]struct{}, len(m))
+	for k := range m {
+		set[k] = struct{}{}
+	}
+	return set
+}
+
+func checkOrderSlice(path string, order []string, known map[string]struct{}) error {
+	if len(order) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(order))
+	for _, name := range order {
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("%s order: duplicate name %q", path, name)
+		}
+		seen[name] = struct{}{}
+		if _, ok := known[name]; !ok {
+			return fmt.Errorf("%s order: unknown name %q", path, name)
+		}
+	}
+	for name := range known {
+		if _, ok := seen[name]; !ok {
+			return fmt.Errorf("%s order: missing name %q", path, name)
+		}
+	}
+	return nil
+}
+
 // ToWorkerInput converts to the internal format for worker processing
 func (d *DynamicInput) ToWorkerInput() ([]byte, error) {
-	// Build classes map: start with user-defined classes, then add the output class
-	classes := make(map[string]*DynamicClass)
-	for name, class := range d.OutputSchema.Classes {
-		classes[name] = class
-	}
-	// Add the output class with the top-level properties
-	classes["Baml_Rest_DynamicOutput"] = &DynamicClass{
-		Properties: d.OutputSchema.Properties,
-	}
+	classes := buildWorkerClassMap(d.OutputSchema)
 
 	// Convert messages to internal format
 	internalMessages := make([]internalMessage, 0, len(d.Messages))
@@ -401,15 +608,21 @@ func (d *DynamicInput) ToWorkerInput() ([]byte, error) {
 		internalMessages = append(internalMessages, m.toInternalMessage())
 	}
 
+	dynamicTypes := &DynamicTypes{
+		Classes: classes,
+		Enums:   d.OutputSchema.Enums,
+	}
+	if d.PreserveSchemaOrder {
+		dynamicTypes.PreserveOrder = true
+		dynamicTypes.Order = dynamicTypesOrderFromOutputSchema(d.OutputSchema)
+	}
+
 	internal := map[string]any{
 		"messages": internalMessages,
 		"__baml_options__": &BamlOptions{
 			ClientRegistry: d.ClientRegistry,
 			TypeBuilder: &TypeBuilder{
-				DynamicTypes: &DynamicTypes{
-					Classes: classes,
-					Enums:   d.OutputSchema.Enums,
-				},
+				DynamicTypes: dynamicTypes,
 			},
 		},
 	}
@@ -418,8 +631,9 @@ func (d *DynamicInput) ToWorkerInput() ([]byte, error) {
 
 // DynamicParseInput is the request body for dynamic parse endpoint
 type DynamicParseInput struct {
-	Raw          string               `json:"raw"`
-	OutputSchema *DynamicOutputSchema `json:"output_schema"`
+	Raw                 string               `json:"raw"`
+	OutputSchema        *DynamicOutputSchema `json:"output_schema"`
+	PreserveSchemaOrder bool                 `json:"preserve_schema_order,omitempty"`
 }
 
 // Validate checks that required fields are present for parse
@@ -430,33 +644,80 @@ func (d *DynamicParseInput) Validate() error {
 	if d.OutputSchema == nil || len(d.OutputSchema.Properties) == 0 {
 		return fmt.Errorf("output_schema with at least one property is required")
 	}
+	if d.PreserveSchemaOrder {
+		if err := validatePreserveSchemaOrder(d.OutputSchema); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
 // ToWorkerInput converts to the internal format for worker processing
 func (d *DynamicParseInput) ToWorkerInput() ([]byte, error) {
-	// Build classes map: start with user-defined classes, then add the output class
-	classes := make(map[string]*DynamicClass)
-	for name, class := range d.OutputSchema.Classes {
-		classes[name] = class
+	classes := buildWorkerClassMap(d.OutputSchema)
+
+	dynamicTypes := &DynamicTypes{
+		Classes: classes,
+		Enums:   d.OutputSchema.Enums,
 	}
-	// Add the output class with the top-level properties
-	classes["Baml_Rest_DynamicOutput"] = &DynamicClass{
-		Properties: d.OutputSchema.Properties,
+	if d.PreserveSchemaOrder {
+		dynamicTypes.PreserveOrder = true
+		dynamicTypes.Order = dynamicTypesOrderFromOutputSchema(d.OutputSchema)
 	}
 
 	internal := map[string]any{
 		"raw": d.Raw,
 		"__baml_options__": &BamlOptions{
 			TypeBuilder: &TypeBuilder{
-				DynamicTypes: &DynamicTypes{
-					Classes: classes,
-					Enums:   d.OutputSchema.Enums,
-				},
+				DynamicTypes: dynamicTypes,
 			},
 		},
 	}
 	return json.Marshal(internal)
+}
+
+// dynamicOutputClassName is the synthetic class name baml-rest assigns
+// to the top-level dynamic output. Surfaced as a constant so codegen
+// and the order helper agree on where the synthetic class lives in the
+// preserved class order.
+const dynamicOutputClassName = "Baml_Rest_DynamicOutput"
+
+// buildWorkerClassMap collects user-defined classes and injects the
+// synthetic Baml_Rest_DynamicOutput class whose Properties mirror the
+// top-level output_schema.properties.
+func buildWorkerClassMap(schema *DynamicOutputSchema) map[string]*DynamicClass {
+	classes := make(map[string]*DynamicClass)
+	for name, class := range schema.Classes {
+		classes[name] = class
+	}
+	classes[dynamicOutputClassName] = &DynamicClass{
+		Properties:      schema.Properties,
+		PropertiesOrder: append([]string(nil), schema.PropertiesOrder...),
+	}
+	return classes
+}
+
+// dynamicTypesOrderFromOutputSchema assembles the DynamicTypesOrder
+// shipped across the worker boundary when PreserveSchemaOrder=true.
+// The synthetic Baml_Rest_DynamicOutput class is placed first in
+// Classes per the Q3 contract; user classes follow in the order the
+// caller supplied. Per-class property orders are copied from
+// DynamicClass.PropertiesOrder when present.
+func dynamicTypesOrderFromOutputSchema(schema *DynamicOutputSchema) *DynamicTypesOrder {
+	order := &DynamicTypesOrder{
+		Classes:    make([]string, 0, 1+len(schema.ClassesOrder)),
+		Enums:      append([]string(nil), schema.EnumsOrder...),
+		Properties: make(map[string][]string),
+	}
+	order.Classes = append(order.Classes, dynamicOutputClassName)
+	order.Classes = append(order.Classes, schema.ClassesOrder...)
+	order.Properties[dynamicOutputClassName] = append([]string(nil), schema.PropertiesOrder...)
+	for _, className := range schema.ClassesOrder {
+		if cls := schema.Classes[className]; cls != nil {
+			order.Properties[className] = append([]string(nil), cls.PropertiesOrder...)
+		}
+	}
+	return order
 }
 
 // FlattenDynamicOutput extracts the DynamicProperties field from a dynamic endpoint response.

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -372,6 +372,9 @@ func (s *DynamicOutputSchema) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	if err := rejectNonObject("output_schema.properties", raw.Properties); err != nil {
+		return err
+	}
 	if isJSONObject(raw.Properties) {
 		props, order, err := unmarshalOrderedObject[*DynamicProperty](raw.Properties, "output_schema.properties")
 		if err != nil {
@@ -380,6 +383,9 @@ func (s *DynamicOutputSchema) UnmarshalJSON(data []byte) error {
 		s.Properties = props
 		s.PropertiesOrder = order
 	}
+	if err := rejectNonObject("output_schema.classes", raw.Classes); err != nil {
+		return err
+	}
 	if isJSONObject(raw.Classes) {
 		classes, order, err := unmarshalOrderedObject[*DynamicClass](raw.Classes, "output_schema.classes")
 		if err != nil {
@@ -387,6 +393,9 @@ func (s *DynamicOutputSchema) UnmarshalJSON(data []byte) error {
 		}
 		s.Classes = classes
 		s.ClassesOrder = order
+	}
+	if err := rejectNonObject("output_schema.enums", raw.Enums); err != nil {
+		return err
 	}
 	if isJSONObject(raw.Enums) {
 		enums, order, err := unmarshalOrderedObject[*DynamicEnum](raw.Enums, "output_schema.enums")
@@ -414,6 +423,9 @@ func (c *DynamicClass) UnmarshalJSON(data []byte) error {
 	}
 	c.Description = raw.Description
 	c.Alias = raw.Alias
+	if err := rejectNonObject("class.properties", raw.Properties); err != nil {
+		return err
+	}
 	if isJSONObject(raw.Properties) {
 		props, order, err := unmarshalOrderedObject[*DynamicProperty](raw.Properties, "class.properties")
 		if err != nil {
@@ -428,6 +440,18 @@ func (c *DynamicClass) UnmarshalJSON(data []byte) error {
 func isJSONObject(b []byte) bool {
 	t := bytes.TrimSpace(b)
 	return len(t) > 0 && t[0] == '{'
+}
+
+// rejectNonObject returns a path-qualified error when b carries a
+// present-but-not-object JSON value. Absent (empty RawMessage) and
+// explicit null are accepted to match standard map decoding (an
+// absent key or null is the conventional nil-map sentinel).
+func rejectNonObject(path string, b []byte) error {
+	t := bytes.TrimSpace(b)
+	if len(t) == 0 || bytes.Equal(t, []byte("null")) || t[0] == '{' {
+		return nil
+	}
+	return fmt.Errorf("%s: must be a JSON object", path)
 }
 
 // unmarshalOrderedObject decodes a JSON object into a map[string]V while

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -362,6 +362,9 @@ func (s *DynamicOutputSchema) UnmarshalJSON(data []byte) error {
 	// stale maps/order slices leaking across decode calls when the
 	// new payload omits or nulls a section.
 	*s = DynamicOutputSchema{}
+	if err := checkUniqueTopLevelKeys(data, "output_schema"); err != nil {
+		return err
+	}
 	var raw struct {
 		Properties json.RawMessage `json:"properties"`
 		Classes    json.RawMessage `json:"classes"`
@@ -415,6 +418,9 @@ func (c *DynamicClass) UnmarshalJSON(data []byte) error {
 	// Reset on reuse — see DynamicOutputSchema.UnmarshalJSON for
 	// rationale. The struct is wholly decoded from input.
 	*c = DynamicClass{}
+	if err := checkUniqueTopLevelKeys(data, "class"); err != nil {
+		return err
+	}
 	var raw struct {
 		Description string          `json:"description,omitempty"`
 		Alias       string          `json:"alias,omitempty"`
@@ -454,6 +460,51 @@ func rejectNonObject(path string, b []byte) error {
 		return nil
 	}
 	return fmt.Errorf("%s: must be a JSON object", path)
+}
+
+// checkUniqueTopLevelKeys token-walks the outer object and rejects any
+// duplicate key. The struct-tag unmarshal path on the receiver
+// (DynamicOutputSchema, DynamicClass) accepts duplicate top-level keys
+// with last-wins semantics, contradicting the strict-duplicate rule
+// enforced for inner schema objects via unmarshalOrderedObject. Calling
+// this before the raw-struct decode restores symmetry — both layers now
+// reject ambiguous repeats.
+//
+// Non-object inputs are left to the regular unmarshal so the caller
+// keeps producing the same shape-error it does today.
+func checkUniqueTopLevelKeys(data []byte, path string) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != '{' {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return fmt.Errorf("%s: expected object key", path)
+		}
+		if _, dup := seen[key]; dup {
+			return fmt.Errorf("%s: duplicate key %q", path, key)
+		}
+		seen[key] = struct{}{}
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return fmt.Errorf("%s.%s: %w", path, key, err)
+		}
+	}
+	if _, err := dec.Token(); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return nil
 }
 
 // unmarshalOrderedObject decodes a JSON object into a map[string]V while

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -761,39 +761,60 @@ func buildWorkerClassMap(schema *DynamicOutputSchema) map[string]*DynamicClass {
 // DynamicClass.PropertiesOrder when present.
 func dynamicTypesOrderFromOutputSchema(schema *DynamicOutputSchema) *DynamicTypesOrder {
 	order := &DynamicTypesOrder{
-		Classes:    make([]string, 0, 1+len(schema.ClassesOrder)),
-		Enums:      append([]string(nil), schema.EnumsOrder...),
+		Classes:    make([]string, 0, 1+len(schema.Classes)),
+		Enums:      make([]string, 0, len(schema.Enums)),
 		Properties: make(map[string][]string),
 	}
 	order.Classes = append(order.Classes, dynamicOutputClassName)
 	order.Classes = append(order.Classes, schema.ClassesOrder...)
 	order.Properties[dynamicOutputClassName] = append([]string(nil), schema.PropertiesOrder...)
 
-	seen := make(map[string]struct{}, len(schema.Classes))
+	seenClasses := map[string]struct{}{dynamicOutputClassName: {}}
 	for _, className := range schema.ClassesOrder {
 		if cls := schema.Classes[className]; cls != nil {
 			order.Properties[className] = append([]string(nil), cls.PropertiesOrder...)
 		}
-		seen[className] = struct{}{}
+		seenClasses[className] = struct{}{}
 	}
 	// Cover classes absent from ClassesOrder. Single-class schemas
 	// can legally have empty ClassesOrder while still carrying a
-	// multi-key Properties order on the class — without this pass
-	// that nested order would be dropped on the wire. Sort the
-	// remaining names so the worker payload stays deterministic.
-	remaining := make([]string, 0, len(schema.Classes))
+	// multi-key Properties order on the class. The worker-side
+	// DynamicTypes.Validate also requires Order.Classes to cover
+	// every entry in dt.Classes (which always includes the synthetic
+	// top-level class), so we fill in remaining user classes here
+	// rather than leaving the order incomplete.
+	remainingClasses := make([]string, 0, len(schema.Classes))
 	for className := range schema.Classes {
-		if _, ok := seen[className]; ok {
+		if _, ok := seenClasses[className]; ok {
 			continue
 		}
-		remaining = append(remaining, className)
+		remainingClasses = append(remainingClasses, className)
 	}
-	slices.Sort(remaining)
-	for _, className := range remaining {
+	slices.Sort(remainingClasses)
+	for _, className := range remainingClasses {
+		order.Classes = append(order.Classes, className)
 		if cls := schema.Classes[className]; cls != nil {
 			order.Properties[className] = append([]string(nil), cls.PropertiesOrder...)
 		}
 	}
+
+	// Enums mirror the Classes pattern: fill in any names missing
+	// from EnumsOrder so direct DynamicTypes validation downstream
+	// sees a complete cover.
+	order.Enums = append(order.Enums, schema.EnumsOrder...)
+	seenEnums := make(map[string]struct{}, len(schema.EnumsOrder))
+	for _, n := range schema.EnumsOrder {
+		seenEnums[n] = struct{}{}
+	}
+	remainingEnums := make([]string, 0, len(schema.Enums))
+	for enumName := range schema.Enums {
+		if _, ok := seenEnums[enumName]; ok {
+			continue
+		}
+		remainingEnums = append(remainingEnums, enumName)
+	}
+	slices.Sort(remainingEnums)
+	order.Enums = append(order.Enums, remainingEnums...)
 	return order
 }
 

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	encjson "encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/goccy/go-json"
@@ -712,7 +713,28 @@ func dynamicTypesOrderFromOutputSchema(schema *DynamicOutputSchema) *DynamicType
 	order.Classes = append(order.Classes, dynamicOutputClassName)
 	order.Classes = append(order.Classes, schema.ClassesOrder...)
 	order.Properties[dynamicOutputClassName] = append([]string(nil), schema.PropertiesOrder...)
+
+	seen := make(map[string]struct{}, len(schema.Classes))
 	for _, className := range schema.ClassesOrder {
+		if cls := schema.Classes[className]; cls != nil {
+			order.Properties[className] = append([]string(nil), cls.PropertiesOrder...)
+		}
+		seen[className] = struct{}{}
+	}
+	// Cover classes absent from ClassesOrder. Single-class schemas
+	// can legally have empty ClassesOrder while still carrying a
+	// multi-key Properties order on the class — without this pass
+	// that nested order would be dropped on the wire. Sort the
+	// remaining names so the worker payload stays deterministic.
+	remaining := make([]string, 0, len(schema.Classes))
+	for className := range schema.Classes {
+		if _, ok := seen[className]; ok {
+			continue
+		}
+		remaining = append(remaining, className)
+	}
+	slices.Sort(remaining)
+	for _, className := range remaining {
 		if cls := schema.Classes[className]; cls != nil {
 			order.Properties[className] = append([]string(nil), cls.PropertiesOrder...)
 		}

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -363,6 +363,12 @@ type DynamicOutputSchema struct {
 // only used here for the ordered top-level scan — nested values are
 // still decoded through json.Unmarshal which routes through goccy.
 func (s *DynamicOutputSchema) UnmarshalJSON(data []byte) error {
+	// Reset on reuse: json.Unmarshal into a previously-populated
+	// receiver is valid Go usage, and the wire shape carries no
+	// caller-managed state we'd need to merge. Zeroing here avoids
+	// stale maps/order slices leaking across decode calls when the
+	// new payload omits or nulls a section.
+	*s = DynamicOutputSchema{}
 	var raw struct {
 		Properties json.RawMessage `json:"properties"`
 		Classes    json.RawMessage `json:"classes"`
@@ -413,6 +419,9 @@ func (s *DynamicOutputSchema) UnmarshalJSON(data []byte) error {
 // description and alias fields decode through the normal route.
 // Duplicate property keys are rejected.
 func (c *DynamicClass) UnmarshalJSON(data []byte) error {
+	// Reset on reuse — see DynamicOutputSchema.UnmarshalJSON for
+	// rationale. The struct is wholly decoded from input.
+	*c = DynamicClass{}
 	var raw struct {
 		Description string          `json:"description,omitempty"`
 		Alias       string          `json:"alias,omitempty"`
@@ -517,6 +526,9 @@ func (d *DynamicInput) Validate() error {
 	}
 	if d.OutputSchema == nil || len(d.OutputSchema.Properties) == 0 {
 		return fmt.Errorf("output_schema with at least one property is required")
+	}
+	if err := validateReservedClassNames(d.OutputSchema); err != nil {
+		return err
 	}
 	if d.PreserveSchemaOrder {
 		if err := validatePreserveSchemaOrder(d.OutputSchema); err != nil {
@@ -669,10 +681,29 @@ func (d *DynamicParseInput) Validate() error {
 	if d.OutputSchema == nil || len(d.OutputSchema.Properties) == 0 {
 		return fmt.Errorf("output_schema with at least one property is required")
 	}
+	if err := validateReservedClassNames(d.OutputSchema); err != nil {
+		return err
+	}
 	if d.PreserveSchemaOrder {
 		if err := validatePreserveSchemaOrder(d.OutputSchema); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// validateReservedClassNames rejects user-supplied class names that
+// collide with synthetic names baml-rest writes into the worker
+// payload. buildWorkerClassMap unconditionally overwrites the entry
+// at dynamicOutputClassName with the synthetic top-level class, so
+// without this guard a user class with that exact name would be
+// silently dropped.
+func validateReservedClassNames(s *DynamicOutputSchema) error {
+	if s == nil {
+		return nil
+	}
+	if _, ok := s.Classes[dynamicOutputClassName]; ok {
+		return fmt.Errorf("output_schema.classes: %q is reserved by baml-rest", dynamicOutputClassName)
 	}
 	return nil
 }

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -2,7 +2,6 @@ package bamlutils
 
 import (
 	"bytes"
-	encjson "encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -354,14 +353,8 @@ type DynamicOutputSchema struct {
 // UnmarshalJSON decodes a DynamicOutputSchema while capturing the JSON
 // key insertion order of properties/classes/enums into the matching
 // *Order slices. Duplicate keys in any of these objects are rejected
-// with a path-qualified error.
-//
-// Implementation note: this uses encoding/json's streaming decoder to
-// read tokens in source order; goccy/go-json's Decoder.Token is API-
-// compatible but its behaviour around RawMessage decoding inside a
-// streaming token loop has historically diverged. encoding/json is
-// only used here for the ordered top-level scan — nested values are
-// still decoded through json.Unmarshal which routes through goccy.
+// with a path-qualified error. The ordered scan and nested decode both
+// route through goccy/go-json for consistency with the rest of bamlutils.
 func (s *DynamicOutputSchema) UnmarshalJSON(data []byte) error {
 	// Reset on reuse: json.Unmarshal into a previously-populated
 	// receiver is valid Go usage, and the wire shape carries no
@@ -467,13 +460,13 @@ func rejectNonObject(path string, b []byte) error {
 // recording the appearance order of keys. Duplicate keys produce a
 // path-qualified error so callers cannot smuggle in ambiguous schemas.
 func unmarshalOrderedObject[V any](data []byte, path string) (map[string]V, []string, error) {
-	dec := encjson.NewDecoder(bytes.NewReader(data))
+	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
 	tok, err := dec.Token()
 	if err != nil {
 		return nil, nil, fmt.Errorf("%s: %w", path, err)
 	}
-	if delim, ok := tok.(encjson.Delim); !ok || delim != '{' {
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
 		return nil, nil, fmt.Errorf("%s: expected object", path)
 	}
 
@@ -491,7 +484,7 @@ func unmarshalOrderedObject[V any](data []byte, path string) (map[string]V, []st
 		if _, exists := values[key]; exists {
 			return nil, nil, fmt.Errorf("%s: duplicate key %q", path, key)
 		}
-		var rawVal encjson.RawMessage
+		var rawVal json.RawMessage
 		if err := dec.Decode(&rawVal); err != nil {
 			return nil, nil, fmt.Errorf("%s.%s: %w", path, key, err)
 		}

--- a/bamlutils/dynamic_test.go
+++ b/bamlutils/dynamic_test.go
@@ -110,9 +110,15 @@ func TestDynamicOutputSchema_UnmarshalJSON_RejectsNonObject(t *testing.T) {
 		{name: "properties as bool", body: `{"properties":true}`, want: `output_schema.properties: must be a JSON object`},
 		{name: "classes as array", body: `{"properties":{"x":{"type":"string"}},"classes":[]}`, want: `output_schema.classes: must be a JSON object`},
 		{name: "classes as string", body: `{"properties":{"x":{"type":"string"}},"classes":"x"}`, want: `output_schema.classes: must be a JSON object`},
+		{name: "classes as number", body: `{"properties":{"x":{"type":"string"}},"classes":42}`, want: `output_schema.classes: must be a JSON object`},
+		{name: "classes as bool", body: `{"properties":{"x":{"type":"string"}},"classes":true}`, want: `output_schema.classes: must be a JSON object`},
 		{name: "enums as array", body: `{"properties":{"x":{"type":"string"}},"enums":[]}`, want: `output_schema.enums: must be a JSON object`},
+		{name: "enums as string", body: `{"properties":{"x":{"type":"string"}},"enums":"x"}`, want: `output_schema.enums: must be a JSON object`},
 		{name: "enums as number", body: `{"properties":{"x":{"type":"string"}},"enums":7}`, want: `output_schema.enums: must be a JSON object`},
+		{name: "enums as bool", body: `{"properties":{"x":{"type":"string"}},"enums":false}`, want: `output_schema.enums: must be a JSON object`},
 		{name: "class properties as array", body: `{"properties":{"x":{"type":"string"}},"classes":{"C":{"properties":[]}}}`, want: `class.properties: must be a JSON object`},
+		{name: "class properties as string", body: `{"properties":{"x":{"type":"string"}},"classes":{"C":{"properties":"x"}}}`, want: `class.properties: must be a JSON object`},
+		{name: "class properties as number", body: `{"properties":{"x":{"type":"string"}},"classes":{"C":{"properties":9}}}`, want: `class.properties: must be a JSON object`},
 		{name: "class properties as bool", body: `{"properties":{"x":{"type":"string"}},"classes":{"C":{"properties":false}}}`, want: `class.properties: must be a JSON object`},
 	}
 	for _, tc := range cases {

--- a/bamlutils/dynamic_test.go
+++ b/bamlutils/dynamic_test.go
@@ -96,6 +96,85 @@ func TestDynamicOutputSchema_UnmarshalJSON_RejectsDuplicateKey(t *testing.T) {
 	}
 }
 
+func TestDynamicOutputSchema_UnmarshalJSON_RejectsNonObject(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "properties as array", body: `{"properties":[]}`, want: `output_schema.properties: must be a JSON object`},
+		{name: "properties as string", body: `{"properties":"x"}`, want: `output_schema.properties: must be a JSON object`},
+		{name: "properties as number", body: `{"properties":123}`, want: `output_schema.properties: must be a JSON object`},
+		{name: "properties as bool", body: `{"properties":true}`, want: `output_schema.properties: must be a JSON object`},
+		{name: "classes as array", body: `{"properties":{"x":{"type":"string"}},"classes":[]}`, want: `output_schema.classes: must be a JSON object`},
+		{name: "classes as string", body: `{"properties":{"x":{"type":"string"}},"classes":"x"}`, want: `output_schema.classes: must be a JSON object`},
+		{name: "enums as array", body: `{"properties":{"x":{"type":"string"}},"enums":[]}`, want: `output_schema.enums: must be a JSON object`},
+		{name: "enums as number", body: `{"properties":{"x":{"type":"string"}},"enums":7}`, want: `output_schema.enums: must be a JSON object`},
+		{name: "class properties as array", body: `{"properties":{"x":{"type":"string"}},"classes":{"C":{"properties":[]}}}`, want: `class.properties: must be a JSON object`},
+		{name: "class properties as bool", body: `{"properties":{"x":{"type":"string"}},"classes":{"C":{"properties":false}}}`, want: `class.properties: must be a JSON object`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s DynamicOutputSchema
+			err := json.Unmarshal([]byte(tc.body), &s)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestDynamicOutputSchema_UnmarshalJSON_AcceptsNull pins the
+// nil-map convention: null on any schema-object field is accepted
+// and leaves the corresponding map / order slice nil, so callers can
+// explicitly opt out of classes or enums via `null` without tripping
+// the non-object guard.
+func TestDynamicOutputSchema_UnmarshalJSON_AcceptsNull(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{
+      "properties": null,
+      "classes": null,
+      "enums": null
+    }`)
+	var s DynamicOutputSchema
+	if err := json.Unmarshal(body, &s); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if s.Properties != nil {
+		t.Errorf("Properties: got %v want nil", s.Properties)
+	}
+	if s.Classes != nil {
+		t.Errorf("Classes: got %v want nil", s.Classes)
+	}
+	if s.Enums != nil {
+		t.Errorf("Enums: got %v want nil", s.Enums)
+	}
+	if len(s.PropertiesOrder) != 0 || len(s.ClassesOrder) != 0 || len(s.EnumsOrder) != 0 {
+		t.Errorf("order slices should be empty; got props=%v classes=%v enums=%v", s.PropertiesOrder, s.ClassesOrder, s.EnumsOrder)
+	}
+
+	// Nested null on a class's properties is also accepted.
+	nested := []byte(`{
+      "properties": {"x": {"type": "string"}},
+      "classes": {"C": {"properties": null}}
+    }`)
+	var s2 DynamicOutputSchema
+	if err := json.Unmarshal(nested, &s2); err != nil {
+		t.Fatalf("Unmarshal nested: %v", err)
+	}
+	if s2.Classes["C"].Properties != nil {
+		t.Errorf("class C properties: got %v want nil", s2.Classes["C"].Properties)
+	}
+	if len(s2.Classes["C"].PropertiesOrder) != 0 {
+		t.Errorf("class C PropertiesOrder: got %v want empty", s2.Classes["C"].PropertiesOrder)
+	}
+}
+
 func TestDynamicInput_Validate_RejectsPreserveOrderWithoutOrderMetadata(t *testing.T) {
 	t.Parallel()
 	prompt := "hi"

--- a/bamlutils/dynamic_test.go
+++ b/bamlutils/dynamic_test.go
@@ -8,6 +8,308 @@ import (
 	"github.com/goccy/go-json"
 )
 
+// TestDynamicOutputSchema_UnmarshalJSON_CapturesOrder pins #313: raw
+// JSON callers of /call/_dynamic should get the wire-order of
+// properties/classes/enums and nested class properties captured into
+// the matching *Order slices, so the worker boundary can ship the
+// order across to TypeBuilder population without a round-trip through
+// Go map iteration.
+func TestDynamicOutputSchema_UnmarshalJSON_CapturesOrder(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{
+      "properties": {
+        "delta": {"type": "string"},
+        "alpha": {"type": "int"},
+        "charlie": {"ref": "Address"},
+        "bravo": {"type": "string"}
+      },
+      "classes": {
+        "Profile": {"properties": {"zulu": {"type": "string"}, "alpha": {"type": "int"}}},
+        "Address": {"properties": {"zip": {"type": "string"}, "city": {"type": "string"}, "street": {"type": "string"}}}
+      },
+      "enums": {
+        "Status": {"values": [{"name": "PENDING"}, {"name": "ACTIVE"}]},
+        "Preference": {"values": [{"name": "LOW"}, {"name": "HIGH"}]}
+      }
+    }`)
+	var s DynamicOutputSchema
+	if err := json.Unmarshal(body, &s); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got, want := s.PropertiesOrder, []string{"delta", "alpha", "charlie", "bravo"}; !equalStrings(got, want) {
+		t.Errorf("PropertiesOrder: got %v want %v", got, want)
+	}
+	if got, want := s.ClassesOrder, []string{"Profile", "Address"}; !equalStrings(got, want) {
+		t.Errorf("ClassesOrder: got %v want %v", got, want)
+	}
+	if got, want := s.EnumsOrder, []string{"Status", "Preference"}; !equalStrings(got, want) {
+		t.Errorf("EnumsOrder: got %v want %v", got, want)
+	}
+	if got, want := s.Classes["Profile"].PropertiesOrder, []string{"zulu", "alpha"}; !equalStrings(got, want) {
+		t.Errorf("Profile.PropertiesOrder: got %v want %v", got, want)
+	}
+	if got, want := s.Classes["Address"].PropertiesOrder, []string{"zip", "city", "street"}; !equalStrings(got, want) {
+		t.Errorf("Address.PropertiesOrder: got %v want %v", got, want)
+	}
+}
+
+func TestDynamicOutputSchema_UnmarshalJSON_RejectsDuplicateKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "duplicate property",
+			body: `{"properties":{"a":{"type":"string"},"a":{"type":"int"}}}`,
+			want: `output_schema.properties: duplicate key "a"`,
+		},
+		{
+			name: "duplicate class",
+			body: `{"properties":{"x":{"type":"string"}},"classes":{"C":{"properties":{}},"C":{"properties":{}}}}`,
+			want: `output_schema.classes: duplicate key "C"`,
+		},
+		{
+			name: "duplicate enum",
+			body: `{"properties":{"x":{"type":"string"}},"enums":{"E":{"values":[{"name":"A"}]},"E":{"values":[{"name":"B"}]}}}`,
+			want: `output_schema.enums: duplicate key "E"`,
+		},
+		{
+			name: "duplicate nested class property",
+			body: `{"properties":{"x":{"type":"string"}},"classes":{"C":{"properties":{"a":{"type":"string"},"a":{"type":"int"}}}}}`,
+			want: `class.properties: duplicate key "a"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s DynamicOutputSchema
+			err := json.Unmarshal([]byte(tc.body), &s)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestDynamicInput_Validate_RejectsPreserveOrderWithoutOrderMetadata(t *testing.T) {
+	t.Parallel()
+	prompt := "hi"
+	primary := "TestClient"
+	provider := "anthropic"
+
+	mkInput := func() *DynamicInput {
+		return &DynamicInput{
+			Messages: []DynamicMessage{{Role: "user", TextContent: &prompt}},
+			ClientRegistry: &ClientRegistry{
+				Primary: &primary,
+				Clients: []*ClientProperty{{Name: primary, Provider: provider, Options: map[string]any{"model": "x", "api_key": "k"}}},
+			},
+			OutputSchema: &DynamicOutputSchema{
+				Properties: map[string]*DynamicProperty{
+					"alpha": {Type: "string"},
+					"bravo": {Type: "int"},
+				},
+				Classes: map[string]*DynamicClass{
+					"C1": {Properties: map[string]*DynamicProperty{"p": {Type: "string"}}},
+					"C2": {Properties: map[string]*DynamicProperty{"q": {Type: "string"}}},
+				},
+				Enums: map[string]*DynamicEnum{
+					"E1": {Values: []*DynamicEnumValue{{Name: "A"}}},
+					"E2": {Values: []*DynamicEnumValue{{Name: "B"}}},
+				},
+			},
+			PreserveSchemaOrder: true,
+		}
+	}
+
+	t.Run("missing properties order", func(t *testing.T) {
+		in := mkInput()
+		err := in.Validate()
+		if err == nil || !strings.Contains(err.Error(), "output_schema.properties") {
+			t.Fatalf("expected missing properties order, got %v", err)
+		}
+	})
+
+	t.Run("missing classes order", func(t *testing.T) {
+		in := mkInput()
+		in.OutputSchema.PropertiesOrder = []string{"alpha", "bravo"}
+		err := in.Validate()
+		if err == nil || !strings.Contains(err.Error(), "output_schema.classes") {
+			t.Fatalf("expected missing classes order, got %v", err)
+		}
+	})
+
+	t.Run("missing enums order", func(t *testing.T) {
+		in := mkInput()
+		in.OutputSchema.PropertiesOrder = []string{"alpha", "bravo"}
+		in.OutputSchema.ClassesOrder = []string{"C1", "C2"}
+		err := in.Validate()
+		if err == nil || !strings.Contains(err.Error(), "output_schema.enums") {
+			t.Fatalf("expected missing enums order, got %v", err)
+		}
+	})
+
+	t.Run("positive with all order set", func(t *testing.T) {
+		in := mkInput()
+		in.OutputSchema.PropertiesOrder = []string{"alpha", "bravo"}
+		in.OutputSchema.ClassesOrder = []string{"C1", "C2"}
+		in.OutputSchema.EnumsOrder = []string{"E1", "E2"}
+		// Nested classes carry only 1 property — order required when len>=2,
+		// so single-property classes need no order. Set anyway for clarity.
+		in.OutputSchema.Classes["C1"].PropertiesOrder = []string{"p"}
+		in.OutputSchema.Classes["C2"].PropertiesOrder = []string{"q"}
+		if err := in.Validate(); err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+	})
+
+	t.Run("duplicate order entry rejected", func(t *testing.T) {
+		in := mkInput()
+		in.OutputSchema.PropertiesOrder = []string{"alpha", "alpha"}
+		err := in.Validate()
+		if err == nil || !strings.Contains(err.Error(), "duplicate") {
+			t.Fatalf("expected duplicate error, got %v", err)
+		}
+	})
+
+	t.Run("unknown order entry rejected", func(t *testing.T) {
+		in := mkInput()
+		in.OutputSchema.PropertiesOrder = []string{"alpha", "zzz"}
+		err := in.Validate()
+		if err == nil || !strings.Contains(err.Error(), "unknown") {
+			t.Fatalf("expected unknown error, got %v", err)
+		}
+	})
+}
+
+func TestDynamicParseInput_Validate_RejectsPreserveOrderWithoutOrderMetadata(t *testing.T) {
+	t.Parallel()
+	in := &DynamicParseInput{
+		Raw: "{\"alpha\":\"x\"}",
+		OutputSchema: &DynamicOutputSchema{
+			Properties: map[string]*DynamicProperty{
+				"alpha": {Type: "string"},
+				"bravo": {Type: "int"},
+			},
+		},
+		PreserveSchemaOrder: true,
+	}
+	err := in.Validate()
+	if err == nil || !strings.Contains(err.Error(), "output_schema.properties") {
+		t.Fatalf("expected missing properties order error, got %v", err)
+	}
+	in.OutputSchema.PropertiesOrder = []string{"alpha", "bravo"}
+	if err := in.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestDynamicInput_ToWorkerInput_PropagatesOrder(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{
+      "preserve_schema_order": true,
+      "messages": [{"role": "user", "content": "go"}],
+      "client_registry": {"primary": "X", "clients": [{"name": "X", "provider": "anthropic", "retry_policy": null, "options": {"model": "m", "api_key": "k"}}]},
+      "output_schema": {
+        "properties": {
+          "delta": {"type": "string"},
+          "alpha": {"type": "int"},
+          "charlie": {"ref": "Address"}
+        },
+        "classes": {
+          "Profile": {"properties": {"zulu": {"type": "string"}, "alpha": {"type": "int"}}},
+          "Address": {"properties": {"zip": {"type": "string"}, "city": {"type": "string"}}}
+        },
+        "enums": {
+          "Status": {"values": [{"name": "PENDING"}, {"name": "ACTIVE"}]},
+          "Preference": {"values": [{"name": "LOW"}, {"name": "HIGH"}]}
+        }
+      }
+    }`)
+	var in DynamicInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if err := in.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	data, err := in.ToWorkerInput()
+	if err != nil {
+		t.Fatalf("ToWorkerInput: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal worker payload: %v\n%s", err, data)
+	}
+	opts := decoded["__baml_options__"].(map[string]any)
+	tb := opts["type_builder"].(map[string]any)
+	dt := tb["dynamic_types"].(map[string]any)
+	if got := dt["preserve_order"]; got != true {
+		t.Errorf("preserve_order: got %v want true", got)
+	}
+	order := dt["order"].(map[string]any)
+	classes := toStringSlice(t, order["classes"])
+	wantClasses := []string{"Baml_Rest_DynamicOutput", "Profile", "Address"}
+	if !equalStrings(classes, wantClasses) {
+		t.Errorf("order.classes: got %v want %v", classes, wantClasses)
+	}
+	enums := toStringSlice(t, order["enums"])
+	wantEnums := []string{"Status", "Preference"}
+	if !equalStrings(enums, wantEnums) {
+		t.Errorf("order.enums: got %v want %v", enums, wantEnums)
+	}
+	props := order["properties"].(map[string]any)
+	dynOut := toStringSlice(t, props["Baml_Rest_DynamicOutput"])
+	wantDynOut := []string{"delta", "alpha", "charlie"}
+	if !equalStrings(dynOut, wantDynOut) {
+		t.Errorf("order.properties.Baml_Rest_DynamicOutput: got %v want %v", dynOut, wantDynOut)
+	}
+	profile := toStringSlice(t, props["Profile"])
+	wantProfile := []string{"zulu", "alpha"}
+	if !equalStrings(profile, wantProfile) {
+		t.Errorf("order.properties.Profile: got %v want %v", profile, wantProfile)
+	}
+	address := toStringSlice(t, props["Address"])
+	wantAddress := []string{"zip", "city"}
+	if !equalStrings(address, wantAddress) {
+		t.Errorf("order.properties.Address: got %v want %v", address, wantAddress)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func toStringSlice(t *testing.T, v any) []string {
+	t.Helper()
+	arr, ok := v.([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", v)
+	}
+	out := make([]string, 0, len(arr))
+	for _, x := range arr {
+		s, ok := x.(string)
+		if !ok {
+			t.Fatalf("expected string, got %T", x)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
 // TestDynamicInput_ToWorkerInput_CacheControlBridge pins the bridge from
 // the public CacheControl{Type: ...} shape to the generated dynamic BAML
 // input's `cache_control.cache_type` shape. The previous wire reused the

--- a/bamlutils/dynamic_test.go
+++ b/bamlutils/dynamic_test.go
@@ -181,6 +181,139 @@ func TestDynamicOutputSchema_UnmarshalJSON_AcceptsNull(t *testing.T) {
 	}
 }
 
+// TestDynamicOutputSchema_UnmarshalJSON_ResetsOnReuse pins that
+// decoding into an already-populated receiver clears stale maps and
+// *Order slices, instead of merging or retaining the previous values.
+// json.Unmarshal into a non-zero target is valid Go usage; the prior
+// implementation silently kept stale fields when the new payload
+// omitted or nulled a section.
+func TestDynamicOutputSchema_UnmarshalJSON_ResetsOnReuse(t *testing.T) {
+	t.Parallel()
+	first := []byte(`{
+      "properties": {"a": {"type": "string"}, "b": {"type": "int"}},
+      "classes": {"C": {"properties": {"p": {"type": "string"}, "q": {"type": "int"}}}},
+      "enums": {"E": {"values": [{"name": "A"}]}}
+    }`)
+	var s DynamicOutputSchema
+	if err := json.Unmarshal(first, &s); err != nil {
+		t.Fatalf("first Unmarshal: %v", err)
+	}
+	if len(s.Properties) == 0 || len(s.Classes) == 0 || len(s.Enums) == 0 {
+		t.Fatalf("first decode left maps empty: %+v", s)
+	}
+
+	// Empty object — every section absent. Reuse must clear all
+	// previously populated fields.
+	if err := json.Unmarshal([]byte(`{}`), &s); err != nil {
+		t.Fatalf("reuse Unmarshal {}: %v", err)
+	}
+	if s.Properties != nil || s.Classes != nil || s.Enums != nil {
+		t.Errorf("maps not cleared after empty reuse: %+v", s)
+	}
+	if len(s.PropertiesOrder) != 0 || len(s.ClassesOrder) != 0 || len(s.EnumsOrder) != 0 {
+		t.Errorf("order slices not cleared after empty reuse: props=%v classes=%v enums=%v", s.PropertiesOrder, s.ClassesOrder, s.EnumsOrder)
+	}
+
+	// Re-populate then null every section. null is accepted as the
+	// nil-map sentinel, so the same clearing contract applies.
+	if err := json.Unmarshal(first, &s); err != nil {
+		t.Fatalf("re-populate Unmarshal: %v", err)
+	}
+	if err := json.Unmarshal([]byte(`{"properties":null,"classes":null,"enums":null}`), &s); err != nil {
+		t.Fatalf("reuse Unmarshal null: %v", err)
+	}
+	if s.Properties != nil || s.Classes != nil || s.Enums != nil {
+		t.Errorf("maps not cleared after null reuse: %+v", s)
+	}
+	if len(s.PropertiesOrder) != 0 || len(s.ClassesOrder) != 0 || len(s.EnumsOrder) != 0 {
+		t.Errorf("order slices not cleared after null reuse: props=%v classes=%v enums=%v", s.PropertiesOrder, s.ClassesOrder, s.EnumsOrder)
+	}
+}
+
+// TestDynamicClass_UnmarshalJSON_ResetsOnReuse mirrors the
+// DynamicOutputSchema reuse-reset contract on the nested class type.
+func TestDynamicClass_UnmarshalJSON_ResetsOnReuse(t *testing.T) {
+	t.Parallel()
+	first := []byte(`{"description": "old", "alias": "old-alias", "properties": {"p": {"type": "string"}, "q": {"type": "int"}}}`)
+	var c DynamicClass
+	if err := json.Unmarshal(first, &c); err != nil {
+		t.Fatalf("first Unmarshal: %v", err)
+	}
+	if c.Description == "" || c.Alias == "" || len(c.Properties) == 0 || len(c.PropertiesOrder) == 0 {
+		t.Fatalf("first decode left fields empty: %+v", c)
+	}
+	if err := json.Unmarshal([]byte(`{}`), &c); err != nil {
+		t.Fatalf("reuse Unmarshal: %v", err)
+	}
+	if c.Description != "" || c.Alias != "" || c.Properties != nil || len(c.PropertiesOrder) != 0 {
+		t.Errorf("fields not cleared after empty reuse: %+v", c)
+	}
+}
+
+// TestDynamicInput_Validate_RejectsReservedClassName pins that a
+// user class named Baml_Rest_DynamicOutput is rejected at validation
+// rather than silently overwritten by buildWorkerClassMap. The name
+// is the synthetic top-level class baml-rest writes into the worker
+// payload.
+func TestDynamicInput_Validate_RejectsReservedClassName(t *testing.T) {
+	t.Parallel()
+	prompt := "hi"
+	primary := "TestClient"
+	provider := "anthropic"
+	in := &DynamicInput{
+		Messages: []DynamicMessage{{Role: "user", TextContent: &prompt}},
+		ClientRegistry: &ClientRegistry{
+			Primary: &primary,
+			Clients: []*ClientProperty{{Name: primary, Provider: provider, Options: map[string]any{"model": "m", "api_key": "k"}}},
+		},
+		OutputSchema: &DynamicOutputSchema{
+			Properties: map[string]*DynamicProperty{"x": {Type: "string"}},
+			Classes: map[string]*DynamicClass{
+				"Baml_Rest_DynamicOutput": {
+					Properties: map[string]*DynamicProperty{"sneaky": {Type: "string"}},
+				},
+			},
+		},
+	}
+	err := in.Validate()
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "reserved") {
+		t.Errorf("error %q should mention 'reserved'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "Baml_Rest_DynamicOutput") {
+		t.Errorf("error %q should name the reserved class", err.Error())
+	}
+}
+
+// TestDynamicParseInput_Validate_RejectsReservedClassName mirrors
+// the reserved-name validation on the parse-input path.
+func TestDynamicParseInput_Validate_RejectsReservedClassName(t *testing.T) {
+	t.Parallel()
+	in := &DynamicParseInput{
+		Raw: `{"x":"y"}`,
+		OutputSchema: &DynamicOutputSchema{
+			Properties: map[string]*DynamicProperty{"x": {Type: "string"}},
+			Classes: map[string]*DynamicClass{
+				"Baml_Rest_DynamicOutput": {
+					Properties: map[string]*DynamicProperty{"sneaky": {Type: "string"}},
+				},
+			},
+		},
+	}
+	err := in.Validate()
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "reserved") {
+		t.Errorf("error %q should mention 'reserved'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "Baml_Rest_DynamicOutput") {
+		t.Errorf("error %q should name the reserved class", err.Error())
+	}
+}
+
 func TestDynamicInput_Validate_RejectsPreserveOrderWithoutOrderMetadata(t *testing.T) {
 	t.Parallel()
 	prompt := "hi"

--- a/bamlutils/dynamic_test.go
+++ b/bamlutils/dynamic_test.go
@@ -53,6 +53,68 @@ func TestDynamicOutputSchema_UnmarshalJSON_CapturesOrder(t *testing.T) {
 	}
 }
 
+// TestUnmarshalOrderedObject_NestedRawMessage pins the goccy/go-json
+// streaming-decoder contract that the order-capture path depends on:
+// Token() must surface object delimiters and string keys, and a
+// subsequent Decode(&json.RawMessage) on the value position must hand
+// back the raw bytes of nested objects/arrays/primitives intact so the
+// downstream goccy Unmarshal can decode them. Exercised through
+// DynamicOutputSchema.UnmarshalJSON since unmarshalOrderedObject is
+// package-private; if goccy ever diverges from stdlib here the order
+// capture would silently break and this test should fail first.
+func TestUnmarshalOrderedObject_NestedRawMessage(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{
+      "properties": {
+        "obj": {"type": "list", "items": {"type": "string"}},
+        "lit": {"type": "literal_int", "value": 42},
+        "ref": {"ref": "Other"},
+        "primitive": {"type": "string"}
+      },
+      "classes": {
+        "Other": {"description": "nested with array of values", "properties": {"a": {"type": "string"}}}
+      }
+    }`)
+	var s DynamicOutputSchema
+	if err := json.Unmarshal(body, &s); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got, want := s.PropertiesOrder, []string{"obj", "lit", "ref", "primitive"}; !equalStrings(got, want) {
+		t.Errorf("PropertiesOrder: got %v want %v", got, want)
+	}
+
+	// Nested object value: items must round-trip through the goccy
+	// Decode(&RawMessage) -> json.Unmarshal path.
+	objProp := s.Properties["obj"]
+	if objProp == nil || objProp.Type != "list" || objProp.Items == nil || objProp.Items.Type != "string" {
+		t.Errorf("nested list property lost its items spec: %+v", objProp)
+	}
+
+	// Literal value (a JSON number) round-trips as expected. Goccy's
+	// streaming decoder accepts UseNumber on the outer scan, but the
+	// inner Decode(&RawMessage) -> Unmarshal must still surface the
+	// value through the DynamicProperty.Value any field.
+	litProp := s.Properties["lit"]
+	if litProp == nil || litProp.Type != "literal_int" || litProp.Value == nil {
+		t.Errorf("literal_int property missing value: %+v", litProp)
+	}
+
+	// Ref-only property: the inner Decode shouldn't strip the ref key.
+	refProp := s.Properties["ref"]
+	if refProp == nil || refProp.Ref != "Other" {
+		t.Errorf("ref property dropped: %+v", refProp)
+	}
+
+	// Nested class round-trips with description + ordered properties.
+	other := s.Classes["Other"]
+	if other == nil || other.Description != "nested with array of values" {
+		t.Errorf("nested class lost description: %+v", other)
+	}
+	if got, want := other.PropertiesOrder, []string{"a"}; !equalStrings(got, want) {
+		t.Errorf("nested class PropertiesOrder: got %v want %v", got, want)
+	}
+}
+
 func TestDynamicOutputSchema_UnmarshalJSON_RejectsDuplicateKey(t *testing.T) {
 	t.Parallel()
 

--- a/bamlutils/dynamic_test.go
+++ b/bamlutils/dynamic_test.go
@@ -281,6 +281,66 @@ func TestDynamicInput_ToWorkerInput_PropagatesOrder(t *testing.T) {
 	}
 }
 
+// TestDynamicInput_ToWorkerInput_SingleClassPropertyOrder pins the
+// reachable single-class case: validation legally allows empty
+// ClassesOrder when there is exactly one class, so the worker-bound
+// DynamicTypesOrder.Properties[<className>] must still carry that
+// class's PropertiesOrder. Earlier code only copied per-class order
+// for names listed in ClassesOrder, silently dropping nested order
+// on single-class schemas.
+func TestDynamicInput_ToWorkerInput_SingleClassPropertyOrder(t *testing.T) {
+	t.Parallel()
+	primary := "TestClient"
+	provider := "anthropic"
+	greeting := "go"
+	in := &DynamicInput{
+		Messages: []DynamicMessage{{Role: "user", TextContent: &greeting}},
+		ClientRegistry: &ClientRegistry{
+			Primary: &primary,
+			Clients: []*ClientProperty{{Name: primary, Provider: provider, Options: map[string]any{"model": "m", "api_key": "k"}}},
+		},
+		OutputSchema: &DynamicOutputSchema{
+			Properties: map[string]*DynamicProperty{
+				"only": {Ref: "Solo"},
+			},
+			PropertiesOrder: []string{"only"},
+			Classes: map[string]*DynamicClass{
+				"Solo": {
+					Properties: map[string]*DynamicProperty{
+						"zulu":  {Type: "string"},
+						"alpha": {Type: "int"},
+						"mike":  {Type: "bool"},
+					},
+					PropertiesOrder: []string{"zulu", "alpha", "mike"},
+				},
+			},
+			// ClassesOrder intentionally empty — legal because Classes has one key.
+		},
+		PreserveSchemaOrder: true,
+	}
+	if err := in.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	data, err := in.ToWorkerInput()
+	if err != nil {
+		t.Fatalf("ToWorkerInput: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal worker payload: %v\n%s", err, data)
+	}
+	opts := decoded["__baml_options__"].(map[string]any)
+	tb := opts["type_builder"].(map[string]any)
+	dt := tb["dynamic_types"].(map[string]any)
+	order := dt["order"].(map[string]any)
+	props := order["properties"].(map[string]any)
+	got := toStringSlice(t, props["Solo"])
+	want := []string{"zulu", "alpha", "mike"}
+	if !equalStrings(got, want) {
+		t.Errorf("order.properties.Solo: got %v want %v", got, want)
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/bamlutils/dynamic_test.go
+++ b/bamlutils/dynamic_test.go
@@ -158,6 +158,102 @@ func TestDynamicOutputSchema_UnmarshalJSON_RejectsDuplicateKey(t *testing.T) {
 	}
 }
 
+// TestDynamicOutputSchema_UnmarshalJSON_RejectsDuplicateTopLevelKey
+// pins the strict-duplicate rule at the OUTER level of the schema
+// payload. The inner schema objects (properties/classes/enums) already
+// reject duplicate keys via the token-walking unmarshalOrderedObject
+// path; the struct-tag decode on the outer object would silently
+// accept last-wins, so the pre-check helper restores symmetry.
+func TestDynamicOutputSchema_UnmarshalJSON_RejectsDuplicateTopLevelKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "duplicate outer properties",
+			body: `{"properties":{"a":{"type":"string"}},"properties":{"b":{"type":"int"}}}`,
+			want: `output_schema: duplicate key "properties"`,
+		},
+		{
+			name: "duplicate outer classes",
+			body: `{"properties":{"x":{"type":"string"}},"classes":{"A":{"properties":{}}},"classes":{"B":{"properties":{}}}}`,
+			want: `output_schema: duplicate key "classes"`,
+		},
+		{
+			name: "duplicate outer enums",
+			body: `{"properties":{"x":{"type":"string"}},"enums":{"E1":{"values":[{"name":"A"}]}},"enums":{"E2":{"values":[{"name":"B"}]}}}`,
+			want: `output_schema: duplicate key "enums"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s DynamicOutputSchema
+			err := json.Unmarshal([]byte(tc.body), &s)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestDynamicClass_UnmarshalJSON_RejectsDuplicateTopLevelKey pins the
+// same outer-level duplicate-key rejection on the nested class type.
+// description/alias/properties are all rejected — the helper is
+// strict-all rather than allow-listed.
+func TestDynamicClass_UnmarshalJSON_RejectsDuplicateTopLevelKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "duplicate properties",
+			body: `{"properties":{"a":{"type":"string"}},"properties":{"b":{"type":"int"}}}`,
+			want: `class: duplicate key "properties"`,
+		},
+		{
+			name: "duplicate alias",
+			body: `{"alias":"first","alias":"second","properties":{"a":{"type":"string"}}}`,
+			want: `class: duplicate key "alias"`,
+		},
+		{
+			name: "duplicate description",
+			body: `{"description":"first","description":"second","properties":{"a":{"type":"string"}}}`,
+			want: `class: duplicate key "description"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var c DynamicClass
+			err := json.Unmarshal([]byte(tc.body), &c)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+
+	// Negative control — a well-formed class still parses cleanly.
+	body := []byte(`{"description":"only","alias":"once","properties":{"p":{"type":"string"}}}`)
+	var c DynamicClass
+	if err := json.Unmarshal(body, &c); err != nil {
+		t.Errorf("well-formed class rejected: %v", err)
+	}
+	if c.Description != "only" || c.Alias != "once" || len(c.Properties) != 1 {
+		t.Errorf("well-formed class decoded incorrectly: %+v", c)
+	}
+}
+
 func TestDynamicOutputSchema_UnmarshalJSON_RejectsNonObject(t *testing.T) {
 	t.Parallel()
 

--- a/bamlutils/dynamic_test.go
+++ b/bamlutils/dynamic_test.go
@@ -557,6 +557,15 @@ func TestDynamicInput_ToWorkerInput_SingleClassPropertyOrder(t *testing.T) {
 	if !equalStrings(got, want) {
 		t.Errorf("order.properties.Solo: got %v want %v", got, want)
 	}
+	// Order.Classes must also cover the user class (single-class case
+	// where ClassesOrder was legally empty). dt.Classes carries the
+	// synthetic + user class on the worker side, so the worker-side
+	// DynamicTypes.Validate requires both names in Order.Classes.
+	classes := toStringSlice(t, order["classes"])
+	wantClasses := []string{"Baml_Rest_DynamicOutput", "Solo"}
+	if !equalStrings(classes, wantClasses) {
+		t.Errorf("order.classes: got %v want %v", classes, wantClasses)
+	}
 }
 
 func equalStrings(a, b []string) bool {

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -647,6 +647,29 @@ func (b *TypeBuilder) Add(input string) {
 type DynamicTypes struct {
 	Classes map[string]*DynamicClass `json:"classes,omitempty"`
 	Enums   map[string]*DynamicEnum  `json:"enums,omitempty"`
+
+	// PreserveOrder, when true, instructs the codegen-emitted
+	// applyDynamicTypes to populate TypeBuilder following the explicit
+	// Order metadata instead of sorting map keys alphabetically. Set by
+	// the public dynamic endpoints when their caller opts in via
+	// DynamicInput.PreserveSchemaOrder.
+	PreserveOrder bool `json:"preserve_order,omitempty"`
+	// Order carries the desired population order for Classes, Enums,
+	// and per-class Properties when PreserveOrder is true. nil or
+	// empty slices fall back to alphabetical sorting for that
+	// dimension via the schemaMapKeys helper.
+	Order *DynamicTypesOrder `json:"order,omitempty"`
+}
+
+// DynamicTypesOrder is the cross-boundary order payload that captures
+// the schema's first-party map insertion order. Classes lists the
+// synthetic Baml_Rest_DynamicOutput class first followed by user
+// classes; Enums lists user enums; Properties maps each class name
+// to its per-property order.
+type DynamicTypesOrder struct {
+	Classes    []string            `json:"classes,omitempty"`
+	Enums      []string            `json:"enums,omitempty"`
+	Properties map[string][]string `json:"properties,omitempty"`
 }
 
 // maxTypeDepth is the maximum nesting depth for type references.
@@ -810,6 +833,11 @@ type DynamicClass struct {
 	Description string                      `json:"description,omitempty"`
 	Alias       string                      `json:"alias,omitempty"`
 	Properties  map[string]*DynamicProperty `json:"properties,omitempty"`
+	// PropertiesOrder records the JSON wire order of Properties for
+	// preserve_schema_order callers. Populated by DynamicClass.UnmarshalJSON;
+	// Go callers must set it explicitly when constructing the class
+	// programmatically.
+	PropertiesOrder []string `json:"-"`
 }
 
 // DynamicProperty defines a property on a class.

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
 )
@@ -722,6 +723,112 @@ func (dt *DynamicTypes) Validate() error {
 		}
 	}
 
+	if dt.PreserveOrder {
+		if err := dt.validatePreserveOrder(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validatePreserveOrder enforces the same locked contract that the
+// public DynamicInput/DynamicParseInput validators enforce at the HTTP
+// boundary, but on the worker-bound DynamicTypes shape itself. Direct
+// `__baml_options__.type_builder.dynamic_types` callers bypass the
+// input validators; without this pass they could set PreserveOrder=true
+// with missing or malformed Order metadata and silently fall back to
+// the sorted iteration in the generated schemaMapKeys helper.
+//
+// Mirrors validatePreserveSchemaOrder in dynamic.go: each multi-key
+// map dimension (Classes, Enums, per-class Properties) requires a
+// non-empty matching order slice with no duplicates, no unknown names,
+// and full coverage of the map's keys.
+func (dt *DynamicTypes) validatePreserveOrder() error {
+	var orderClasses, orderEnums []string
+	var orderProps map[string][]string
+	if dt.Order != nil {
+		orderClasses = dt.Order.Classes
+		orderEnums = dt.Order.Enums
+		orderProps = dt.Order.Properties
+	}
+
+	classKeys := make(map[string]struct{}, len(dt.Classes))
+	for n := range dt.Classes {
+		classKeys[n] = struct{}{}
+	}
+	if len(dt.Classes) >= 2 && len(orderClasses) == 0 {
+		return fmt.Errorf("dynamic_types.preserve_order=true but classes has no captured order")
+	}
+	if err := checkDynamicTypesOrderSlice("dynamic_types.classes", orderClasses, classKeys); err != nil {
+		return err
+	}
+
+	enumKeys := make(map[string]struct{}, len(dt.Enums))
+	for n := range dt.Enums {
+		enumKeys[n] = struct{}{}
+	}
+	if len(dt.Enums) >= 2 && len(orderEnums) == 0 {
+		return fmt.Errorf("dynamic_types.preserve_order=true but enums has no captured order")
+	}
+	if err := checkDynamicTypesOrderSlice("dynamic_types.enums", orderEnums, enumKeys); err != nil {
+		return err
+	}
+
+	// Iterate per-class property order in deterministic (sorted) order
+	// so error messages are stable across runs.
+	classNames := make([]string, 0, len(dt.Classes))
+	for name := range dt.Classes {
+		classNames = append(classNames, name)
+	}
+	sort.Strings(classNames)
+	for _, className := range classNames {
+		cls := dt.Classes[className]
+		if cls == nil {
+			continue
+		}
+		path := fmt.Sprintf("dynamic_types.classes[%q].properties", className)
+		var classOrder []string
+		if orderProps != nil {
+			classOrder = orderProps[className]
+		}
+		propKeys := make(map[string]struct{}, len(cls.Properties))
+		for n := range cls.Properties {
+			propKeys[n] = struct{}{}
+		}
+		if len(cls.Properties) >= 2 && len(classOrder) == 0 {
+			return fmt.Errorf("dynamic_types.preserve_order=true but %s has no captured order", path)
+		}
+		if err := checkDynamicTypesOrderSlice(path, classOrder, propKeys); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkDynamicTypesOrderSlice mirrors checkOrderSlice in dynamic.go
+// (kept local here to avoid a package-level cycle and to keep the
+// worker-side validator self-contained). Reports the first duplicate,
+// unknown, or missing name as a path-qualified error.
+func checkDynamicTypesOrderSlice(path string, order []string, known map[string]struct{}) error {
+	if len(order) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(order))
+	for _, name := range order {
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("%s order: duplicate name %q", path, name)
+		}
+		seen[name] = struct{}{}
+		if _, ok := known[name]; !ok {
+			return fmt.Errorf("%s order: unknown name %q", path, name)
+		}
+	}
+	for name := range known {
+		if _, ok := seen[name]; !ok {
+			return fmt.Errorf("%s order: missing name %q", path, name)
+		}
+	}
 	return nil
 }
 

--- a/bamlutils/interfaces_test.go
+++ b/bamlutils/interfaces_test.go
@@ -1242,6 +1242,30 @@ func TestDynamicTypes_Validate(t *testing.T) {
 			wantErr: `dynamic_types.enums order: missing name "E2"`,
 		},
 		{
+			name: "preserve_order with duplicate enum entry",
+			dt: &DynamicTypes{
+				Enums: map[string]*DynamicEnum{
+					"E1": {Values: []*DynamicEnumValue{{Name: "A"}}},
+					"E2": {Values: []*DynamicEnumValue{{Name: "B"}}},
+				},
+				PreserveOrder: true,
+				Order:         &DynamicTypesOrder{Enums: []string{"E1", "E1", "E2"}},
+			},
+			wantErr: `dynamic_types.enums order: duplicate name "E1"`,
+		},
+		{
+			name: "preserve_order with unknown enum entry",
+			dt: &DynamicTypes{
+				Enums: map[string]*DynamicEnum{
+					"E1": {Values: []*DynamicEnumValue{{Name: "A"}}},
+					"E2": {Values: []*DynamicEnumValue{{Name: "B"}}},
+				},
+				PreserveOrder: true,
+				Order:         &DynamicTypesOrder{Enums: []string{"E1", "E2", "Z"}},
+			},
+			wantErr: `dynamic_types.enums order: unknown name "Z"`,
+		},
+		{
 			name: "preserve_order with no per-class property order on multi-key class",
 			dt: &DynamicTypes{
 				Classes: map[string]*DynamicClass{
@@ -1265,6 +1289,34 @@ func TestDynamicTypes_Validate(t *testing.T) {
 				},
 			},
 			wantErr: `dynamic_types.classes["A"].properties order: unknown name "zzz"`,
+		},
+		{
+			name: "preserve_order with duplicate nested property entry",
+			dt: &DynamicTypes{
+				Classes: map[string]*DynamicClass{
+					"A": {Properties: map[string]*DynamicProperty{"p": {Type: "string"}, "q": {Type: "int"}}},
+				},
+				PreserveOrder: true,
+				Order: &DynamicTypesOrder{
+					Classes:    []string{"A"},
+					Properties: map[string][]string{"A": {"p", "p", "q"}},
+				},
+			},
+			wantErr: `dynamic_types.classes["A"].properties order: duplicate name "p"`,
+		},
+		{
+			name: "preserve_order with missing nested property entry",
+			dt: &DynamicTypes{
+				Classes: map[string]*DynamicClass{
+					"A": {Properties: map[string]*DynamicProperty{"p": {Type: "string"}, "q": {Type: "int"}}},
+				},
+				PreserveOrder: true,
+				Order: &DynamicTypesOrder{
+					Classes:    []string{"A"},
+					Properties: map[string][]string{"A": {"p"}},
+				},
+			},
+			wantErr: `dynamic_types.classes["A"].properties order: missing name "q"`,
 		},
 		{
 			name: "preserve_order accepts complete order across all dimensions",

--- a/bamlutils/interfaces_test.go
+++ b/bamlutils/interfaces_test.go
@@ -1171,6 +1171,134 @@ func TestDynamicTypes_Validate(t *testing.T) {
 			},
 			wantErr: "",
 		},
+		{
+			name: "preserve_order with no order and multi-key classes",
+			dt: &DynamicTypes{
+				Classes: map[string]*DynamicClass{
+					"A": {Properties: map[string]*DynamicProperty{"p": {Type: "string"}}},
+					"B": {Properties: map[string]*DynamicProperty{"q": {Type: "string"}}},
+				},
+				PreserveOrder: true,
+			},
+			wantErr: "classes has no captured order",
+		},
+		{
+			name: "preserve_order with incomplete classes order",
+			dt: &DynamicTypes{
+				Classes: map[string]*DynamicClass{
+					"A": {Properties: map[string]*DynamicProperty{"p": {Type: "string"}}},
+					"B": {Properties: map[string]*DynamicProperty{"q": {Type: "string"}}},
+				},
+				PreserveOrder: true,
+				Order:         &DynamicTypesOrder{Classes: []string{"A"}},
+			},
+			wantErr: `dynamic_types.classes order: missing name "B"`,
+		},
+		{
+			name: "preserve_order with duplicate class entry",
+			dt: &DynamicTypes{
+				Classes: map[string]*DynamicClass{
+					"A": {Properties: map[string]*DynamicProperty{"p": {Type: "string"}}},
+					"B": {Properties: map[string]*DynamicProperty{"q": {Type: "string"}}},
+				},
+				PreserveOrder: true,
+				Order:         &DynamicTypesOrder{Classes: []string{"A", "A", "B"}},
+			},
+			wantErr: `dynamic_types.classes order: duplicate name "A"`,
+		},
+		{
+			name: "preserve_order with unknown class entry",
+			dt: &DynamicTypes{
+				Classes: map[string]*DynamicClass{
+					"A": {Properties: map[string]*DynamicProperty{"p": {Type: "string"}}},
+					"B": {Properties: map[string]*DynamicProperty{"q": {Type: "string"}}},
+				},
+				PreserveOrder: true,
+				Order:         &DynamicTypesOrder{Classes: []string{"A", "B", "Z"}},
+			},
+			wantErr: `dynamic_types.classes order: unknown name "Z"`,
+		},
+		{
+			name: "preserve_order with no order and multi-key enums",
+			dt: &DynamicTypes{
+				Enums: map[string]*DynamicEnum{
+					"E1": {Values: []*DynamicEnumValue{{Name: "A"}}},
+					"E2": {Values: []*DynamicEnumValue{{Name: "B"}}},
+				},
+				PreserveOrder: true,
+			},
+			wantErr: "enums has no captured order",
+		},
+		{
+			name: "preserve_order with incomplete enums order",
+			dt: &DynamicTypes{
+				Enums: map[string]*DynamicEnum{
+					"E1": {Values: []*DynamicEnumValue{{Name: "A"}}},
+					"E2": {Values: []*DynamicEnumValue{{Name: "B"}}},
+				},
+				PreserveOrder: true,
+				Order:         &DynamicTypesOrder{Enums: []string{"E1"}},
+			},
+			wantErr: `dynamic_types.enums order: missing name "E2"`,
+		},
+		{
+			name: "preserve_order with no per-class property order on multi-key class",
+			dt: &DynamicTypes{
+				Classes: map[string]*DynamicClass{
+					"A": {Properties: map[string]*DynamicProperty{"p": {Type: "string"}, "q": {Type: "int"}}},
+				},
+				PreserveOrder: true,
+				Order:         &DynamicTypesOrder{Classes: []string{"A"}},
+			},
+			wantErr: `dynamic_types.classes["A"].properties has no captured order`,
+		},
+		{
+			name: "preserve_order with unknown nested property name",
+			dt: &DynamicTypes{
+				Classes: map[string]*DynamicClass{
+					"A": {Properties: map[string]*DynamicProperty{"p": {Type: "string"}, "q": {Type: "int"}}},
+				},
+				PreserveOrder: true,
+				Order: &DynamicTypesOrder{
+					Classes:    []string{"A"},
+					Properties: map[string][]string{"A": {"p", "q", "zzz"}},
+				},
+			},
+			wantErr: `dynamic_types.classes["A"].properties order: unknown name "zzz"`,
+		},
+		{
+			name: "preserve_order accepts complete order across all dimensions",
+			dt: &DynamicTypes{
+				Classes: map[string]*DynamicClass{
+					"A": {Properties: map[string]*DynamicProperty{"p": {Type: "string"}, "q": {Type: "int"}}},
+					"B": {Properties: map[string]*DynamicProperty{"r": {Type: "string"}}},
+				},
+				Enums: map[string]*DynamicEnum{
+					"E1": {Values: []*DynamicEnumValue{{Name: "A"}}},
+					"E2": {Values: []*DynamicEnumValue{{Name: "B"}}},
+				},
+				PreserveOrder: true,
+				Order: &DynamicTypesOrder{
+					Classes: []string{"A", "B"},
+					Enums:   []string{"E1", "E2"},
+					Properties: map[string][]string{
+						"A": {"p", "q"},
+						// B has a single property — order optional.
+					},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "preserve_order with single-key classes and no order is allowed",
+			dt: &DynamicTypes{
+				Classes: map[string]*DynamicClass{
+					"Solo": {Properties: map[string]*DynamicProperty{"only": {Type: "string"}}},
+				},
+				PreserveOrder: true,
+			},
+			wantErr: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -986,6 +986,65 @@ func generateOpenAPISchema() *openapi3.T {
 									},
 								},
 							},
+							"preserve_order": &openapi3.SchemaRef{
+								Value: &openapi3.Schema{
+									Type: &openapi3.Types{openapi3.TypeBoolean},
+									Description: "Opt-in: when true, TypeBuilder population follows the explicit 'order' " +
+										"metadata rather than alphabetical key sorting. Direct callers must supply a " +
+										"complete 'order' covering every multi-key map (classes, enums, per-class " +
+										"properties); incomplete order is rejected by validation.",
+								},
+							},
+							"order": &openapi3.SchemaRef{
+								Value: &openapi3.Schema{
+									Type: &openapi3.Types{openapi3.TypeObject},
+									Description: "Explicit class/enum/property population order, consumed when " +
+										"preserve_order is true.",
+									Nullable: true,
+									Properties: openapi3.Schemas{
+										"classes": &openapi3.SchemaRef{
+											Value: &openapi3.Schema{
+												Type:        &openapi3.Types{openapi3.TypeArray},
+												Description: "Class names in the order they should be populated.",
+												Items: &openapi3.SchemaRef{
+													Value: &openapi3.Schema{
+														Type: &openapi3.Types{openapi3.TypeString},
+													},
+												},
+											},
+										},
+										"enums": &openapi3.SchemaRef{
+											Value: &openapi3.Schema{
+												Type:        &openapi3.Types{openapi3.TypeArray},
+												Description: "Enum names in the order they should be populated.",
+												Items: &openapi3.SchemaRef{
+													Value: &openapi3.Schema{
+														Type: &openapi3.Types{openapi3.TypeString},
+													},
+												},
+											},
+										},
+										"properties": &openapi3.SchemaRef{
+											Value: &openapi3.Schema{
+												Type:        &openapi3.Types{openapi3.TypeObject},
+												Description: "Map of class name to the order its properties should be populated in.",
+												AdditionalProperties: openapi3.AdditionalProperties{
+													Schema: &openapi3.SchemaRef{
+														Value: &openapi3.Schema{
+															Type: &openapi3.Types{openapi3.TypeArray},
+															Items: &openapi3.SchemaRef{
+																Value: &openapi3.Schema{
+																	Type: &openapi3.Types{openapi3.TypeString},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				}
@@ -1475,6 +1534,13 @@ func generateDynamicEndpoints(schemas openapi3.Schemas, paths *openapi3.Paths, b
 		},
 	}
 
+	// preserve_schema_order is shared between the call/stream and parse
+	// input schemas: both expose the same opt-in.
+	preserveSchemaOrderDescription := "Opt-in: when true, the rendered output_format follows the JSON key " +
+		"order of output_schema.{properties,classes,enums} and each class's properties, rather than the " +
+		"alphabetical default. Multi-key maps must carry a captured order — raw-JSON callers get this for " +
+		"free; programmatic Go callers using the dynclient module must set the matching *Order slices."
+
 	// Dynamic input schema
 	dynamicInputSchemaName := "__DynamicInput__"
 	schemas[dynamicInputSchemaName] = &openapi3.SchemaRef{
@@ -1497,6 +1563,12 @@ func generateDynamicEndpoints(schemas openapi3.Schemas, paths *openapi3.Paths, b
 				"output_schema": &openapi3.SchemaRef{
 					Ref: fmt.Sprintf("#/components/schemas/%s", outputSchemaSchemaName),
 				},
+				"preserve_schema_order": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type:        &openapi3.Types{openapi3.TypeBoolean},
+						Description: preserveSchemaOrderDescription,
+					},
+				},
 			},
 			Required: []string{"messages", "client_registry", "output_schema"},
 		},
@@ -1517,6 +1589,12 @@ func generateDynamicEndpoints(schemas openapi3.Schemas, paths *openapi3.Paths, b
 				},
 				"output_schema": &openapi3.SchemaRef{
 					Ref: fmt.Sprintf("#/components/schemas/%s", outputSchemaSchemaName),
+				},
+				"preserve_schema_order": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type:        &openapi3.Types{openapi3.TypeBoolean},
+						Description: preserveSchemaOrderDescription,
+					},
 				},
 			},
 			Required: []string{"raw", "output_schema"},

--- a/cmd/schema/main_test.go
+++ b/cmd/schema/main_test.go
@@ -285,3 +285,107 @@ func isNullable(ref *openapi3.SchemaRef) bool {
 	}
 	return false
 }
+
+// TestSchemaPreserveOrderExposure pins #313: the public OpenAPI surface
+// must surface the preserve-order opt-in on both __DynamicInput__ and
+// __DynamicParseInput__, and the worker-bound TypeBuilder.dynamic_types
+// shape must expose the matching preserve_order/order keys so generated
+// clients can use the feature.
+func TestSchemaPreserveOrderExposure(t *testing.T) {
+	baml_rest.InitBamlRuntime()
+
+	// The dynamic-input/parse schemas are only registered when Methods
+	// carries the dynamic-method sentinel — mirror the seeding done by
+	// TestPostRequestBodyRequired so this test exercises the dynamic
+	// codepath.
+	origMethods := baml_rest.Methods
+	t.Cleanup(func() { baml_rest.Methods = origMethods })
+	baml_rest.Methods = map[string]bamlutils.StreamingMethod{
+		bamlutils.DynamicMethodName: {
+			MakeInput:        func() any { return &SchemaPostRequiredStubInput{} },
+			MakeOutput:       func() any { return &SchemaPostRequiredStubOutput{} },
+			MakeStreamOutput: func() any { return &SchemaPostRequiredStubOutput{} },
+		},
+	}
+
+	doc := generateOpenAPISchema()
+	if doc == nil || doc.Components == nil {
+		t.Fatalf("generated schema has no components")
+	}
+	schemas := doc.Components.Schemas
+
+	for _, name := range []string{"__DynamicInput__", "__DynamicParseInput__"} {
+		ref, ok := schemas[name]
+		if !ok || ref == nil || ref.Value == nil {
+			t.Fatalf("schema %q not registered", name)
+		}
+		prop, ok := ref.Value.Properties["preserve_schema_order"]
+		if !ok || prop == nil || prop.Value == nil {
+			t.Errorf("%s.properties missing preserve_schema_order", name)
+			continue
+		}
+		if !prop.Value.Type.Is(openapi3.TypeBoolean) {
+			t.Errorf("%s.preserve_schema_order: expected boolean, got %v", name, prop.Value.Type)
+		}
+		// Opt-in: must not be in required.
+		if slices.Contains(ref.Value.Required, "preserve_schema_order") {
+			t.Errorf("%s.required must not include preserve_schema_order (it's an opt-in)", name)
+		}
+	}
+
+	tb, ok := schemas["TypeBuilder"]
+	if !ok || tb == nil || tb.Value == nil {
+		t.Fatalf("TypeBuilder schema not registered")
+	}
+	dt, ok := tb.Value.Properties["dynamic_types"]
+	if !ok || dt == nil || dt.Value == nil {
+		t.Fatalf("TypeBuilder.dynamic_types not present")
+	}
+
+	preserveOrder, ok := dt.Value.Properties["preserve_order"]
+	if !ok || preserveOrder == nil || preserveOrder.Value == nil {
+		t.Errorf("dynamic_types missing preserve_order")
+	} else if !preserveOrder.Value.Type.Is(openapi3.TypeBoolean) {
+		t.Errorf("dynamic_types.preserve_order expected boolean, got %v", preserveOrder.Value.Type)
+	}
+
+	order, ok := dt.Value.Properties["order"]
+	if !ok || order == nil || order.Value == nil {
+		t.Fatalf("dynamic_types missing order")
+	}
+	if !order.Value.Type.Is(openapi3.TypeObject) {
+		t.Errorf("dynamic_types.order expected object, got %v", order.Value.Type)
+	}
+	// classes/enums are string arrays; properties is map<string, []string>.
+	for _, sub := range []string{"classes", "enums"} {
+		p, ok := order.Value.Properties[sub]
+		if !ok || p == nil || p.Value == nil {
+			t.Errorf("dynamic_types.order missing %q", sub)
+			continue
+		}
+		if !p.Value.Type.Is(openapi3.TypeArray) {
+			t.Errorf("dynamic_types.order.%s expected array, got %v", sub, p.Value.Type)
+			continue
+		}
+		if p.Value.Items == nil || p.Value.Items.Value == nil || !p.Value.Items.Value.Type.Is(openapi3.TypeString) {
+			t.Errorf("dynamic_types.order.%s items expected string", sub)
+		}
+	}
+	props, ok := order.Value.Properties["properties"]
+	if !ok || props == nil || props.Value == nil {
+		t.Fatalf("dynamic_types.order missing properties")
+	}
+	if !props.Value.Type.Is(openapi3.TypeObject) {
+		t.Errorf("dynamic_types.order.properties expected object, got %v", props.Value.Type)
+	}
+	addl := props.Value.AdditionalProperties.Schema
+	if addl == nil || addl.Value == nil {
+		t.Fatalf("dynamic_types.order.properties missing additionalProperties schema")
+	}
+	if !addl.Value.Type.Is(openapi3.TypeArray) {
+		t.Errorf("dynamic_types.order.properties additionalProperties expected array, got %v", addl.Value.Type)
+	}
+	if addl.Value.Items == nil || addl.Value.Items.Value == nil || !addl.Value.Items.Value.Type.Is(openapi3.TypeString) {
+		t.Errorf("dynamic_types.order.properties additionalProperties items expected string")
+	}
+}

--- a/dynclient/internal/generated/adapter.go
+++ b/dynclient/internal/generated/adapter.go
@@ -1054,35 +1054,37 @@ func applyDynamicTypes(tb *introspected.TypeBuilder, dt *bamlutils.DynamicTypes)
 	}
 	typeCache := make(map[string]introspected.Type)
 	classBuilderCache := make(map[string]introspected.DynamicClassBuilder)
+	preserveOrder := dt.PreserveOrder
+	order := dt.Order
 
-	for _, name := range sortedMapKeys(dt.Enums) {
+	for _, name := range schemaMapKeys(dt.Enums, enumOrder(order), preserveOrder) {
 		enum := dt.Enums[name]
 		if err := createEnumShell(tb, name, enum, typeCache); err != nil {
 			return fmt.Errorf("enum %q: %w", name, err)
 		}
 	}
 
-	for _, name := range sortedMapKeys(dt.Enums) {
+	for _, name := range schemaMapKeys(dt.Enums, enumOrder(order), preserveOrder) {
 		enum := dt.Enums[name]
 		if err := addEnumValues(tb, name, enum, typeCache); err != nil {
 			return fmt.Errorf("enum %q values: %w", name, err)
 		}
 	}
 
-	for _, name := range sortedMapKeys(dt.Classes) {
+	for _, name := range schemaMapKeys(dt.Classes, classOrder(order), preserveOrder) {
 		if err := createClassShell(tb, name, typeCache, classBuilderCache); err != nil {
 			return fmt.Errorf("class %q: %w", name, err)
 		}
 	}
 
-	for _, name := range sortedMapKeys(dt.Classes) {
+	for _, name := range schemaMapKeys(dt.Classes, classOrder(order), preserveOrder) {
 		class := dt.Classes[name]
-		if err := addNewClassProperties(tb, name, class, typeCache, classBuilderCache); err != nil {
+		if err := addNewClassProperties(tb, name, class, typeCache, classBuilderCache, order, preserveOrder); err != nil {
 			return fmt.Errorf("class %q properties: %w", name, err)
 		}
 	}
 
-	for _, name := range sortedMapKeys(classBuilderCache) {
+	for _, name := range schemaMapKeys(classBuilderCache, classOrder(order), preserveOrder) {
 		cb := classBuilderCache[name]
 		typ, err := cb.Type()
 		if err != nil {
@@ -1091,9 +1093,9 @@ func applyDynamicTypes(tb *introspected.TypeBuilder, dt *bamlutils.DynamicTypes)
 		typeCache[name] = typ
 	}
 
-	for _, name := range sortedMapKeys(dt.Classes) {
+	for _, name := range schemaMapKeys(dt.Classes, classOrder(order), preserveOrder) {
 		class := dt.Classes[name]
-		if err := addExistingClassProperties(tb, name, class, typeCache, classBuilderCache); err != nil {
+		if err := addExistingClassProperties(tb, name, class, typeCache, classBuilderCache, order, preserveOrder); err != nil {
 			return fmt.Errorf("class %q properties: %w", name, err)
 		}
 	}
@@ -1106,6 +1108,47 @@ func sortedMapKeys[V any](m map[string]V) []string {
 	}
 	slices.Sort(keys)
 	return keys
+}
+func schemaMapKeys[V any](m map[string]V, order []string, preserve bool) []string {
+	if !preserve || len(order) == 0 {
+		return sortedMapKeys(m)
+	}
+	keys := make([]string, 0, len(m))
+	seen := make(map[string]struct{}, len(order))
+	for _, k := range order {
+		if _, ok := m[k]; !ok {
+			continue
+		}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		keys = append(keys, k)
+	}
+	for _, k := range sortedMapKeys(m) {
+		if _, ok := seen[k]; !ok {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+func enumOrder(o *bamlutils.DynamicTypesOrder) []string {
+	if o == nil {
+		return nil
+	}
+	return o.Enums
+}
+func classOrder(o *bamlutils.DynamicTypesOrder) []string {
+	if o == nil {
+		return nil
+	}
+	return o.Classes
+}
+func propertyOrder(o *bamlutils.DynamicTypesOrder, className string) []string {
+	if o == nil || o.Properties == nil {
+		return nil
+	}
+	return o.Properties[className]
 }
 func createEnumShell(tb *introspected.TypeBuilder, name string, enum *bamlutils.DynamicEnum, typeCache map[string]introspected.Type) error {
 	if introspected.EnumExists(name) {
@@ -1183,13 +1226,13 @@ func createClassShell(tb *introspected.TypeBuilder, name string, typeCache map[s
 	classBuilderCache[name] = cb
 	return nil
 }
-func addNewClassProperties(tb *introspected.TypeBuilder, name string, class *bamlutils.DynamicClass, typeCache map[string]introspected.Type, classBuilderCache map[string]introspected.DynamicClassBuilder) error {
+func addNewClassProperties(tb *introspected.TypeBuilder, name string, class *bamlutils.DynamicClass, typeCache map[string]introspected.Type, classBuilderCache map[string]introspected.DynamicClassBuilder, order *bamlutils.DynamicTypesOrder, preserveOrder bool) error {
 	cb, ok := classBuilderCache[name]
 	if !ok {
 		return nil
 	}
 
-	for _, propName := range sortedMapKeys(class.Properties) {
+	for _, propName := range schemaMapKeys(class.Properties, propertyOrder(order, name), preserveOrder) {
 		prop := class.Properties[propName]
 		typ, err := resolvePropertyType(tb, prop, typeCache, classBuilderCache)
 		if err != nil {
@@ -1206,7 +1249,7 @@ func addNewClassProperties(tb *introspected.TypeBuilder, name string, class *bam
 	}
 	return nil
 }
-func addExistingClassProperties(tb *introspected.TypeBuilder, name string, class *bamlutils.DynamicClass, typeCache map[string]introspected.Type, classBuilderCache map[string]introspected.DynamicClassBuilder) error {
+func addExistingClassProperties(tb *introspected.TypeBuilder, name string, class *bamlutils.DynamicClass, typeCache map[string]introspected.Type, classBuilderCache map[string]introspected.DynamicClassBuilder, order *bamlutils.DynamicTypesOrder, preserveOrder bool) error {
 	if _, ok := classBuilderCache[name]; ok {
 		return nil
 	}
@@ -1221,7 +1264,7 @@ func addExistingClassProperties(tb *introspected.TypeBuilder, name string, class
 		return fmt.Errorf("get class builder: %w", err)
 	}
 
-	for _, propName := range sortedMapKeys(class.Properties) {
+	for _, propName := range schemaMapKeys(class.Properties, propertyOrder(order, name), preserveOrder) {
 		prop := class.Properties[propName]
 		typ, err := resolvePropertyType(tb, prop, typeCache, classBuilderCache)
 		if err != nil {

--- a/integration/dynamic_output_format_preserve_order_test.go
+++ b/integration/dynamic_output_format_preserve_order_test.go
@@ -200,7 +200,7 @@ func assertOrderIn(t *testing.T, label, prompt, anchor string, names []string) {
 	}
 	indices := make([]int, len(names))
 	for i, name := range names {
-		idx := strings.Index(window, name)
+		idx := fieldTokenIndex(window, name)
 		if idx < 0 {
 			t.Errorf("%s: name %q not found in window", label, name)
 			t.Logf("window:\n%s\nfull prompt:\n%s", window, prompt)
@@ -217,6 +217,26 @@ func assertOrderIn(t *testing.T, label, prompt, anchor string, names []string) {
 	}
 }
 
+// fieldTokenIndex returns the lowest index at which name appears as a
+// field-key token in window, i.e. either `name:` (unquoted, as the
+// BAML output_format renderer emits) or `"name":` (quoted, as a JSON
+// payload would). Returns -1 if neither form is present. Searching
+// for the token rather than the bare name avoids matching incidental
+// text in descriptions, sibling field names, or value renderings.
+func fieldTokenIndex(window, name string) int {
+	candidates := []string{
+		fmt.Sprintf("%q:", name),
+		fmt.Sprintf("%s:", name),
+	}
+	best := -1
+	for _, token := range candidates {
+		if idx := strings.Index(window, token); idx >= 0 && (best < 0 || idx < best) {
+			best = idx
+		}
+	}
+	return best
+}
+
 func postRaw(ctx context.Context, url, body string) error {
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader([]byte(body)))
 	if err != nil {
@@ -228,7 +248,13 @@ func postRaw(ctx context.Context, url, body string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		if len(respBody) > 0 {
+			return fmt.Errorf("read response body: %w (partial body: %s)", readErr, string(respBody))
+		}
+		return fmt.Errorf("read response body: %w", readErr)
+	}
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("status %d: %s", resp.StatusCode, string(respBody))
 	}

--- a/integration/dynamic_output_format_preserve_order_test.go
+++ b/integration/dynamic_output_format_preserve_order_test.go
@@ -28,6 +28,14 @@ import (
 // The request body is built as a raw JSON string so the JSON object
 // order capture path is exercised end-to-end. Go map literals would
 // not carry order and would defeat the whole invariant.
+//
+// The nested class is named "Mailbox" rather than "Address" because
+// integration/baml_src/types.baml already declares a static (non-@@dynamic)
+// `class Address`. When a dynamic schema reuses that name, the generated
+// applyDynamicTypes short-circuits via ClassExists("Address") and the
+// static class's source order wins for that class — masking the
+// order-fidelity invariant we're trying to pin here. Mailbox sidesteps
+// the collision and exercises the user-defined-class path cleanly.
 func TestDynamicOutputFormatPreserveSchemaOrder(t *testing.T) {
 	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
 		t.Skip("dynamic endpoints require BAML >= 0.215.0")

--- a/integration/dynamic_output_format_preserve_order_test.go
+++ b/integration/dynamic_output_format_preserve_order_test.go
@@ -1,0 +1,228 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// TestDynamicOutputFormatPreserveSchemaOrder pins #313: when a caller
+// opts into preserve_schema_order, identical raw-JSON requests must
+// (1) render byte-identical upstream prompts across repeats (stability,
+// to keep prompt caching warm) and (2) follow the JSON wire order of
+// properties/classes/enums and per-class properties rather than the
+// alphabetical fallback (order fidelity).
+//
+// The request body is built as a raw JSON string so the JSON object
+// order capture path is exercised end-to-end. Go map literals would
+// not carry order and would defeat the whole invariant.
+func TestDynamicOutputFormatPreserveSchemaOrder(t *testing.T) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		t.Skip("dynamic endpoints require BAML >= 0.215.0")
+	}
+	if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+		t.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
+	}
+
+	scenarioID := "test-dynamic-output-format-preserve-order"
+	opts := setupNonStreamingScenario(t, scenarioID, `{
+  "alpha": 1,
+  "bravo": "b",
+  "charlie": {"city": "Sofia", "street": "Main", "zip": "1000"},
+  "delta": "d",
+  "echo": true,
+  "foxtrot": "ACTIVE",
+  "golf": {"alpha": 7, "preference": "HIGH", "status": "PENDING", "zulu": "z"},
+  "hotel": ["x", "y"]
+}`)
+
+	registryJSON, err := json.Marshal(opts.ClientRegistry)
+	if err != nil {
+		t.Fatalf("marshal client_registry: %v", err)
+	}
+
+	rawReq := fmt.Sprintf(`{
+  "preserve_schema_order": true,
+  "messages": [
+    {
+      "role": "system",
+      "content": [
+        {"type": "text", "text": "Return only JSON matching the requested schema."},
+        {"type": "output_format"}
+      ]
+    },
+    {"role": "user", "content": "Build a sample record."}
+  ],
+  "client_registry": %s,
+  "output_schema": {
+    "properties": {
+      "delta": {"type": "string"},
+      "alpha": {"type": "int"},
+      "hotel": {"type": "list", "items": {"type": "string"}},
+      "charlie": {"ref": "Mailbox"},
+      "bravo": {"type": "string"},
+      "foxtrot": {"ref": "Status"},
+      "echo": {"type": "bool"},
+      "golf": {"ref": "Profile"}
+    },
+    "classes": {
+      "Profile": {
+        "properties": {
+          "zulu": {"type": "string"},
+          "alpha": {"type": "int"},
+          "status": {"ref": "Status"},
+          "preference": {"ref": "Preference"}
+        }
+      },
+      "Mailbox": {
+        "properties": {
+          "zip": {"type": "string"},
+          "city": {"type": "string"},
+          "street": {"type": "string"}
+        }
+      }
+    },
+    "enums": {
+      "Status": {"values": [{"name": "PENDING"}, {"name": "ACTIVE"}, {"name": "ARCHIVED"}]},
+      "Preference": {"values": [{"name": "LOW"}, {"name": "MEDIUM"}, {"name": "HIGH"}]}
+    }
+  }
+}`, string(registryJSON))
+
+	const iterations = 50
+	hashCounts := make(map[string]int, 2)
+	samples := make(map[string]string, 2)
+
+	url := fmt.Sprintf("%s/call/_dynamic", TestEnv.BAMLRestURL)
+
+	for i := 0; i < iterations; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+		if err := postRaw(ctx, url, rawReq); err != nil {
+			cancel()
+			t.Fatalf("iteration %d: POST failed: %v", i, err)
+		}
+
+		capturedBody, err := MockClient.GetLastRequest(ctx, scenarioID)
+		if err != nil {
+			cancel()
+			t.Fatalf("iteration %d: failed to get last request: %v", i, err)
+		}
+		cancel()
+
+		prompt, err := extractFirstMessageText(capturedBody)
+		if err != nil {
+			t.Fatalf("iteration %d: %v\ncaptured body: %s", i, err, string(capturedBody))
+		}
+
+		sum := sha256.Sum256([]byte(prompt))
+		key := hex.EncodeToString(sum[:])
+		hashCounts[key]++
+		if _, ok := samples[key]; !ok {
+			samples[key] = prompt
+		}
+	}
+
+	if len(hashCounts) != 1 {
+		t.Errorf("expected exactly 1 unique prompt hash across %d iterations, got %d", iterations, len(hashCounts))
+		shown := 0
+		for key, count := range hashCounts {
+			t.Logf("hash %s: %d iterations", key, count)
+			if shown < 2 {
+				t.Logf("sample for %s:\n%s", key, samples[key])
+				shown++
+			}
+		}
+	}
+
+	// Pick one sample for order-fidelity assertions. With stability
+	// passing the choice is arbitrary; with stability failing we still
+	// want to surface what the renderer produced.
+	var prompt string
+	for _, s := range samples {
+		prompt = s
+		break
+	}
+
+	assertOrderIn(t, "top-level", prompt, "", []string{"delta", "alpha", "hotel", "charlie", "bravo", "foxtrot", "echo", "golf"})
+	// Nested classes share property names with the top level (alpha is in
+	// both top-level and Profile), so scan within the block opened by the
+	// referencing field rather than the full prompt. golf -> Profile,
+	// charlie -> Mailbox.
+	assertOrderIn(t, "Profile", prompt, "golf: {", []string{"zulu", "alpha", "status", "preference"})
+	assertOrderIn(t, "Mailbox", prompt, "charlie: {", []string{"zip", "city", "street"})
+}
+
+// assertOrderIn checks that the listed field names appear in the
+// declared order within the prompt window starting at anchor and
+// ending at the matching closing brace. anchor="" scans the whole
+// prompt. Order is checked via the first occurrence of each name
+// inside the window; matching is good enough because each rendered
+// class block lists each property exactly once.
+func assertOrderIn(t *testing.T, label, prompt, anchor string, names []string) {
+	t.Helper()
+	window := prompt
+	if anchor != "" {
+		start := strings.Index(prompt, anchor)
+		if start < 0 {
+			t.Errorf("%s: anchor %q not found", label, anchor)
+			t.Logf("prompt:\n%s", prompt)
+			return
+		}
+		rest := prompt[start+len(anchor):]
+		end := strings.Index(rest, "}")
+		if end < 0 {
+			t.Errorf("%s: closing brace not found after anchor %q", label, anchor)
+			t.Logf("prompt:\n%s", prompt)
+			return
+		}
+		window = rest[:end]
+	}
+	indices := make([]int, len(names))
+	for i, name := range names {
+		idx := strings.Index(window, name)
+		if idx < 0 {
+			t.Errorf("%s: name %q not found in window", label, name)
+			t.Logf("window:\n%s\nfull prompt:\n%s", window, prompt)
+			return
+		}
+		indices[i] = idx
+	}
+	for i := 1; i < len(indices); i++ {
+		if indices[i] <= indices[i-1] {
+			t.Errorf("%s: %q (at %d) must appear after %q (at %d) within window", label, names[i], indices[i], names[i-1], indices[i-1])
+			t.Logf("window:\n%s\nfull prompt:\n%s", window, prompt)
+			return
+		}
+	}
+}
+
+func postRaw(ctx context.Context, url, body string) error {
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader([]byte(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("status %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes #313.

## Summary

Follow-up to #309. Adds an opt-in `preserve_schema_order` flag so callers who deliberately tune their dynamic schema field order can keep it through the BAML TypeBuilder population path instead of getting alphabetical sort.

**Default behavior is unchanged.** #309's sorted-alphabetical is still what callers get unless they explicitly set `preserve_schema_order: true`.

## API shape

Per-request top-level flag on both call and parse paths:

```json
{
  "messages": [...],
  "client_registry": {...},
  "output_schema": {
    "properties": {"delta": ..., "alpha": ..., "hotel": ...},
    "classes": {...},
    "enums": {...}
  },
  "preserve_schema_order": true
}
```

When the flag is true, the rendered `ctx.output_format` follows the JSON object key order of the request body — `delta` before `alpha` before `hotel` in the example above. Same behavior available through `dynclient.Request{PreserveSchemaOrder: true}` for Go consumers (but they have to populate the `*Order` slices on `OutputSchema`/`DynamicClass` themselves; validation rejects the flag-without-order shape — see Q2 below).

OpenAPI schema exposes the new fields on both `__DynamicInput__` and `__DynamicParseInput__`, plus the low-level `TypeBuilder.dynamic_types` replacement gets `preserve_order` and the nested `order` object (`classes []string`, `enums []string`, `properties map[string][]string`).

## Locked design decisions

Five questions surfaced during scoping. All five locked to the strict/explicit choice:

1. **Duplicate JSON keys**: `UnmarshalJSON` rejects with `output_schema.<field>: duplicate key %q` — at every nesting level (top-level outer keys, properties/classes/enums maps, and nested class properties). Caller intent is ambiguous and standard map unmarshal can't represent both entries.
2. **Programmatic Go callers with `PreserveSchemaOrder=true` but no `*Order` slices**: `Validate()` fails with `preserve_schema_order=true but output_schema.properties has no captured order; send the request via JSON or set OutputSchema.PropertiesOrder explicitly`. Silent fallback to sort would undermine the opt-in.
3. **Synthetic `Baml_Rest_DynamicOutput` class placement**: FIRST in the class order, before user classes. Top-level output class is the logical root.
4. **`DynamicParseInput` symmetry**: yes, opt-in applies to parse too for TypeBuilder consistency.
5. **Direct `DynamicTypes` callers (low-level `__baml_options__`)**: yes, fields added; callers must provide complete `order` metadata when `preserve_order` is true — enforced by `DynamicTypes.Validate()` at the adapter boundary so the contract holds for callers who bypass the public input validators.

## What changed

### Core feature

- **`feat(bamlutils): capture dynamic output_schema order`** (`09e232c`) — `*Order []string` fields on `DynamicOutputSchema` and `DynamicClass` (json:"-"), custom `UnmarshalJSON` token-walks raw JSON to capture object-key order, rejects duplicate keys. `PreserveSchemaOrder bool` on both `DynamicInput` and `DynamicParseInput`. `Validate()` rejects preserve+no-order combos. `DynamicTypes` (worker-facing) gains `PreserveOrder` + `Order *DynamicTypesOrder`. Synthetic `Baml_Rest_DynamicOutput` always first.
- **`fix(codegen): honor preserve_schema_order in TypeBuilder population`** (`513a3c4`) — generated `schemaMapKeys[V any](m, order, preserve)` uses captured order when set, then sorted-alphabetical for any missing keys. Each #309 `sortedMapKeys` call site swapped to the new helper. Nil-safe order accessors emitted (`enumOrder`, `classOrder`, `propertyOrder`).
- **`test(integration): pin preserve_schema_order output_format rendering`** (`2836c9e` + `cf5a9ae`) — 50-iteration regression asserts stability (1 unique upstream-body hash) AND order fidelity (rendered prompt follows declared order). The existing `TestDynamicOutputFormatOrderStable` (#309 default-regression) is left untouched.

### Strict-input behavior (CR-driven hardening)

- **`fix(bamlutils): propagate single-class property order + tighten test helpers`** (`92cdc56`) — `dynamicTypesOrderFromOutputSchema` was dropping nested class property order in single-class schemas (empty `ClassesOrder` is legal for single-class shapes). Fix iterates ALL classes, ClassesOrder names first, then sorted remaining. Also tightens `assertOrderIn` to look for `"name":` / `name:` field tokens instead of substring matching, and stops `postRaw` from swallowing `io.ReadAll` errors.
- **`fix(bamlutils): reject non-object JSON for output_schema fields`** (`b10b1df` + `f819112`) — `UnmarshalJSON` was silently accepting `output_schema.properties: []` / `123` / `"x"` / `true` (the field stayed nil). Now rejects any non-null, non-object value with a path-qualified error. Null and absent stay accepted. Full 4×4 negative matrix covers all four schema-object paths × all four malformed types.
- **`fix(bamlutils): reset UnmarshalJSON state + reject reserved class name`** (`2df405a`) — `*s = DynamicOutputSchema{}` / `*c = DynamicClass{}` at the top of each custom UnmarshalJSON so reuse-into-populated-struct doesn't retain stale maps/order. Also: `Validate()` now rejects schemas where `Classes["Baml_Rest_DynamicOutput"]` is set (previously a silent overwrite in `buildWorkerClassMap`); enforced on both `DynamicInput.Validate()` and `DynamicParseInput.Validate()` via shared `validateReservedClassNames`.
- **`fix(bamlutils): validate DynamicTypes.PreserveOrder requires complete order metadata`** (`c612e44` + `10c4f26`) — `DynamicTypes.Validate()` now enforces the locked low-level contract (missing/duplicate/unknown/incomplete order metadata for classes, enums, per-class properties). Generated adapter already calls `dt.Validate()` before TypeBuilder population, so direct `__baml_options__.type_builder.dynamic_types` callers are caught before any `schemaMapKeys` sorted fallback can run.
- **`fix(bamlutils): reject duplicate top-level keys in custom UnmarshalJSON`** (`1015fae`) — outer object decode (`json.Unmarshal(data, &raw)`) was silently last-wins on duplicate outer keys, inconsistent with the inner-level strict rejection. New `checkUniqueTopLevelKeys` token-walks the outer object before raw struct decode, rejecting `output_schema: duplicate key "properties"` / `class: duplicate key "alias"` etc.

### Schema + plumbing

- **`fix(schema): expose preserve_schema_order + DynamicTypes.preserve_order/order in OpenAPI`** (`5ef2597`) — generated clients can now use the new flag. `TestSchemaPreserveOrderExposure` pins all three surfaces (call, parse, low-level dynamic_types).
- **`refactor(bamlutils): migrate dynamic.go from encoding/json to goccy/go-json`** (`1fecfae`) — `dynamic.go` was the only `encoding/json` holdout in `bamlutils/`; goccy exposes a stdlib-compatible streaming API (`NewDecoder` / `Token` / `Delim` / `RawMessage`), so the swap is mechanical. `TestUnmarshalOrderedObject_NestedRawMessage` pins `Token()` + `Decode(&json.RawMessage)` parity.

### Note on the `Mailbox` class name in the integration test

The fixture uses a nested class named `Mailbox`, not `Address`. Reason: `integration/baml_src/types.baml` declares a static (non-`@@dynamic`) `Address` class with its own property order. `applyDynamicTypes` short-circuits via `ClassExists("Address")` when a dynamic schema reuses that name, so the static class's order would silently win for that class only. The dynamic order capture still flows correctly into the worker; the resolution short-circuit happens later in the adapter. Documented inline in the test file (`cf5a9ae`).

## Bug-revert sanity check

Both directions verified locally:

1. **Revert ONLY the codegen conditional** (commit `513a3c4`'s adapter changes) → preserve-order test FAILS order fidelity with specific position diagnostics (e.g. `"alpha" at 85 must appear after "delta" at 189 within window`). Stability invariant still holds.
2. **Revert ONLY the order-capture path** (commit `09e232c`'s `*Order` fields + custom unmarshal) → request rejected at the boundary with the Q2 validation error.

Restoring both → test passes.

## Test plan

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./bamlutils/... -count=1` ✓ (60+ unit tests including order capture, duplicate-key rejection at every level, non-object rejection, reset-on-reuse, reserved class name, preserve_schema_order validation, `DynamicTypes.Validate` worker-side contract, goccy parity)
- `go test ./cmd/schema -count=1` ✓ (includes `TestSchemaPreserveOrderExposure`)
- `go test -tags=integration ./integration/mockllm -count=1` ✓
- `go test -tags=integration ./integration -run TestDynamicOutputFormat` ✓ (both `TestDynamicOutputFormatOrderStable` and `TestDynamicOutputFormatPreserveSchemaOrder`)
- `./scripts/sync.sh` ✓ (4/4 BAML pins match)
- `cmd/regenerate-dynclient` ✓ (idempotent — #299 gate passes)

## Files

```
 adapters/common/codegen/codegen_dynamic_types.go         | 101 ++-
 bamlutils/dynamic.go                                     | 461 ++++++++++-
 bamlutils/dynamic_test.go                                | 747 +++++++++++++++++++
 bamlutils/interfaces.go                                  | 135 ++++
 bamlutils/interfaces_test.go                             | 180 ++++
 cmd/schema/main.go                                       |  78 +++
 cmd/schema/main_test.go                                  | 104 +++
 dynclient/internal/generated/adapter.go                  |  67 +-
 integration/dynamic_output_format_preserve_order_test.go | 262 ++++++++
 9 files changed, 2083 insertions(+), 52 deletions(-)
```

Refs #309 (which introduced the sorted-default behavior this PR opt-ins out of).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in preserve_schema_order: capture and propagate JSON schema field order (properties, classes, enums) end-to-end so prompts and outputs retain requested ordering.

* **Bug Fixes / Validation**
  * Validation now rejects duplicate, non-object, unknown, or incomplete order metadata and blocks use of a reserved synthetic class name.

* **Tests**
  * Added unit and integration tests for order capture, validation, propagation, and stable prompt/output ordering.

* **Documentation**
  * OpenAPI/schema now exposes preserve_schema_order and ordering controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
