### PR TITLE
feat(serve): server-level preserve_schema_order default (#316)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ baml-rest reads the following environment variables at startup:
   v1 recognizes `allowed_role_metadata` only. See
   [bamlutils/clientdefaults](bamlutils/clientdefaults/clientdefaults.go) for
   the merge contract, supported opt-outs, and supported-version caveats.
+- `BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT` — when truthy
+  (`1`/`true`/`yes`/`on`), dynamic requests that omit or set
+  `preserve_schema_order: null` inherit `true`, so the rendered
+  `output_format` follows the JSON key order captured from `output_schema`.
+  Per-request `preserve_schema_order: true` or `false` always wins. Default
+  unset/false keeps the alphabetical ordering introduced for deterministic
+  prompts.
 - `BAML_LOG` — BAML internal log level (`debug`, `info`, `warn`, `error`).
 
 ## In-process build mode

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -557,11 +557,11 @@ type DynamicInput struct {
 	Messages       []DynamicMessage     `json:"messages"`
 	ClientRegistry *ClientRegistry      `json:"client_registry"`
 	OutputSchema   *DynamicOutputSchema `json:"output_schema"`
-	// PreserveSchemaOrder is a tri-state opt-in for #316: nil means
-	// "inherit the server default" (BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT
-	// on the serve host), while a non-nil pointer wins over any server
-	// default. JSON null decodes to nil through standard Go pointer
-	// unmarshal behavior, matching the absent/inherit semantics.
+	// PreserveSchemaOrder is a tri-state opt-in: nil means "inherit the
+	// server default" (BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT on the
+	// serve host), while a non-nil pointer wins over any server default.
+	// JSON null decodes to nil through standard Go pointer unmarshal
+	// behavior, matching the absent/inherit semantics.
 	PreserveSchemaOrder *bool `json:"preserve_schema_order,omitempty"`
 }
 

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -554,10 +554,21 @@ func unmarshalOrderedObject[V any](data []byte, path string) (map[string]V, []st
 
 // DynamicInput is the request body for dynamic endpoints
 type DynamicInput struct {
-	Messages            []DynamicMessage     `json:"messages"`
-	ClientRegistry      *ClientRegistry      `json:"client_registry"`
-	OutputSchema        *DynamicOutputSchema `json:"output_schema"`
-	PreserveSchemaOrder bool                 `json:"preserve_schema_order,omitempty"`
+	Messages       []DynamicMessage     `json:"messages"`
+	ClientRegistry *ClientRegistry      `json:"client_registry"`
+	OutputSchema   *DynamicOutputSchema `json:"output_schema"`
+	// PreserveSchemaOrder is a tri-state opt-in for #316: nil means
+	// "inherit the server default" (BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT
+	// on the serve host), while a non-nil pointer wins over any server
+	// default. JSON null decodes to nil through standard Go pointer
+	// unmarshal behavior, matching the absent/inherit semantics.
+	PreserveSchemaOrder *bool `json:"preserve_schema_order,omitempty"`
+}
+
+// preserveSchemaOrderEnabled resolves the *bool tri-state to a concrete
+// boolean for internal use. nil and *false both mean "do not preserve".
+func preserveSchemaOrderEnabled(p *bool) bool {
+	return p != nil && *p
 }
 
 // Validate checks that required fields are present
@@ -574,7 +585,7 @@ func (d *DynamicInput) Validate() error {
 	if err := validateReservedClassNames(d.OutputSchema); err != nil {
 		return err
 	}
-	if d.PreserveSchemaOrder {
+	if preserveSchemaOrderEnabled(d.PreserveSchemaOrder) {
 		if err := validatePreserveSchemaOrder(d.OutputSchema); err != nil {
 			return err
 		}
@@ -693,7 +704,7 @@ func (d *DynamicInput) ToWorkerInput() ([]byte, error) {
 		Classes: classes,
 		Enums:   d.OutputSchema.Enums,
 	}
-	if d.PreserveSchemaOrder {
+	if preserveSchemaOrderEnabled(d.PreserveSchemaOrder) {
 		dynamicTypes.PreserveOrder = true
 		dynamicTypes.Order = dynamicTypesOrderFromOutputSchema(d.OutputSchema)
 	}
@@ -712,9 +723,12 @@ func (d *DynamicInput) ToWorkerInput() ([]byte, error) {
 
 // DynamicParseInput is the request body for dynamic parse endpoint
 type DynamicParseInput struct {
-	Raw                 string               `json:"raw"`
-	OutputSchema        *DynamicOutputSchema `json:"output_schema"`
-	PreserveSchemaOrder bool                 `json:"preserve_schema_order,omitempty"`
+	Raw          string               `json:"raw"`
+	OutputSchema *DynamicOutputSchema `json:"output_schema"`
+	// PreserveSchemaOrder mirrors DynamicInput.PreserveSchemaOrder —
+	// nil inherits the server default, non-nil wins. See that field's
+	// doc comment for the full tri-state contract.
+	PreserveSchemaOrder *bool `json:"preserve_schema_order,omitempty"`
 }
 
 // Validate checks that required fields are present for parse
@@ -728,7 +742,7 @@ func (d *DynamicParseInput) Validate() error {
 	if err := validateReservedClassNames(d.OutputSchema); err != nil {
 		return err
 	}
-	if d.PreserveSchemaOrder {
+	if preserveSchemaOrderEnabled(d.PreserveSchemaOrder) {
 		if err := validatePreserveSchemaOrder(d.OutputSchema); err != nil {
 			return err
 		}
@@ -760,7 +774,7 @@ func (d *DynamicParseInput) ToWorkerInput() ([]byte, error) {
 		Classes: classes,
 		Enums:   d.OutputSchema.Enums,
 	}
-	if d.PreserveSchemaOrder {
+	if preserveSchemaOrderEnabled(d.PreserveSchemaOrder) {
 		dynamicTypes.PreserveOrder = true
 		dynamicTypes.Order = dynamicTypesOrderFromOutputSchema(d.OutputSchema)
 	}

--- a/bamlutils/dynamic_test.go
+++ b/bamlutils/dynamic_test.go
@@ -585,9 +585,9 @@ func TestDynamicParseInput_Validate_RejectsPreserveOrderWithoutOrderMetadata(t *
 	}
 }
 
-// TestDynamicInput_Validate_PreserveSchemaOrderTriState pins the #316
-// *bool contract on the DynamicInput call path. nil and *false both
-// behave like "no opt-in" — preserve-order validation is skipped, so a
+// TestDynamicInput_Validate_PreserveSchemaOrderTriState pins the *bool
+// contract on the DynamicInput call path. nil and *false both behave
+// like "no opt-in" — preserve-order validation is skipped, so a
 // multi-key schema with no captured order metadata still passes. Only
 // *true engages validatePreserveSchemaOrder. The JSON `null` row
 // exercises Go's stdlib pointer unmarshal (a `null` literal decodes a

--- a/bamlutils/dynamic_test.go
+++ b/bamlutils/dynamic_test.go
@@ -499,7 +499,7 @@ func TestDynamicInput_Validate_RejectsPreserveOrderWithoutOrderMetadata(t *testi
 					"E2": {Values: []*DynamicEnumValue{{Name: "B"}}},
 				},
 			},
-			PreserveSchemaOrder: true,
+			PreserveSchemaOrder: boolPtr(true),
 		}
 	}
 
@@ -573,7 +573,7 @@ func TestDynamicParseInput_Validate_RejectsPreserveOrderWithoutOrderMetadata(t *
 				"bravo": {Type: "int"},
 			},
 		},
-		PreserveSchemaOrder: true,
+		PreserveSchemaOrder: boolPtr(true),
 	}
 	err := in.Validate()
 	if err == nil || !strings.Contains(err.Error(), "output_schema.properties") {
@@ -583,6 +583,134 @@ func TestDynamicParseInput_Validate_RejectsPreserveOrderWithoutOrderMetadata(t *
 	if err := in.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
+}
+
+// TestDynamicInput_Validate_PreserveSchemaOrderTriState pins the #316
+// *bool contract on the DynamicInput call path. nil and *false both
+// behave like "no opt-in" — preserve-order validation is skipped, so a
+// multi-key schema with no captured order metadata still passes. Only
+// *true engages validatePreserveSchemaOrder. The JSON `null` row
+// exercises Go's stdlib pointer unmarshal (a `null` literal decodes a
+// *bool field back to nil), confirming we don't need a custom
+// UnmarshalJSON for the absent/inherit-default semantics.
+func TestDynamicInput_Validate_PreserveSchemaOrderTriState(t *testing.T) {
+	t.Parallel()
+	prompt := "hi"
+	primary := "TestClient"
+	provider := "anthropic"
+
+	mkInput := func(preserve *bool) *DynamicInput {
+		return &DynamicInput{
+			Messages: []DynamicMessage{{Role: "user", TextContent: &prompt}},
+			ClientRegistry: &ClientRegistry{
+				Primary: &primary,
+				Clients: []*ClientProperty{{Name: primary, Provider: provider, Options: map[string]any{"model": "m", "api_key": "k"}}},
+			},
+			OutputSchema: &DynamicOutputSchema{
+				Properties: map[string]*DynamicProperty{
+					"alpha": {Type: "string"},
+					"bravo": {Type: "int"},
+				},
+				// Intentionally no PropertiesOrder — preserve-order validation
+				// would reject this, while nil/*false must skip the check.
+			},
+			PreserveSchemaOrder: preserve,
+		}
+	}
+
+	t.Run("nil opts out", func(t *testing.T) {
+		if err := mkInput(nil).Validate(); err != nil {
+			t.Errorf("nil PreserveSchemaOrder must not trip preserve-order validation: %v", err)
+		}
+	})
+
+	t.Run("false opts out", func(t *testing.T) {
+		if err := mkInput(boolPtr(false)).Validate(); err != nil {
+			t.Errorf("*false PreserveSchemaOrder must not trip preserve-order validation: %v", err)
+		}
+	})
+
+	t.Run("true engages validation", func(t *testing.T) {
+		err := mkInput(boolPtr(true)).Validate()
+		if err == nil || !strings.Contains(err.Error(), "output_schema.properties") {
+			t.Fatalf("expected missing properties order error, got %v", err)
+		}
+	})
+
+	t.Run("JSON null decodes to nil and inherits default", func(t *testing.T) {
+		body := []byte(`{
+          "preserve_schema_order": null,
+          "messages": [{"role": "user", "content": "hi"}],
+          "client_registry": {"primary": "TestClient", "clients": [{"name": "TestClient", "provider": "anthropic", "options": {"model": "m", "api_key": "k"}}]},
+          "output_schema": {"properties": {"alpha": {"type": "string"}, "bravo": {"type": "int"}}}
+        }`)
+		var in DynamicInput
+		if err := json.Unmarshal(body, &in); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if in.PreserveSchemaOrder != nil {
+			t.Errorf("JSON null must decode *bool to nil; got %v", *in.PreserveSchemaOrder)
+		}
+		if err := in.Validate(); err != nil {
+			t.Errorf("null/absent must inherit absence: %v", err)
+		}
+	})
+}
+
+// TestDynamicParseInput_Validate_PreserveSchemaOrderTriState mirrors the
+// tri-state contract on the parse-input path.
+func TestDynamicParseInput_Validate_PreserveSchemaOrderTriState(t *testing.T) {
+	t.Parallel()
+
+	mkInput := func(preserve *bool) *DynamicParseInput {
+		return &DynamicParseInput{
+			Raw: `{"alpha":"x"}`,
+			OutputSchema: &DynamicOutputSchema{
+				Properties: map[string]*DynamicProperty{
+					"alpha": {Type: "string"},
+					"bravo": {Type: "int"},
+				},
+			},
+			PreserveSchemaOrder: preserve,
+		}
+	}
+
+	t.Run("nil opts out", func(t *testing.T) {
+		if err := mkInput(nil).Validate(); err != nil {
+			t.Errorf("nil PreserveSchemaOrder must not trip preserve-order validation: %v", err)
+		}
+	})
+
+	t.Run("false opts out", func(t *testing.T) {
+		if err := mkInput(boolPtr(false)).Validate(); err != nil {
+			t.Errorf("*false PreserveSchemaOrder must not trip preserve-order validation: %v", err)
+		}
+	})
+
+	t.Run("true engages validation", func(t *testing.T) {
+		err := mkInput(boolPtr(true)).Validate()
+		if err == nil || !strings.Contains(err.Error(), "output_schema.properties") {
+			t.Fatalf("expected missing properties order error, got %v", err)
+		}
+	})
+
+	t.Run("JSON null decodes to nil and inherits default", func(t *testing.T) {
+		body := []byte(`{
+          "preserve_schema_order": null,
+          "raw": "{\"alpha\":\"x\"}",
+          "output_schema": {"properties": {"alpha": {"type": "string"}, "bravo": {"type": "int"}}}
+        }`)
+		var in DynamicParseInput
+		if err := json.Unmarshal(body, &in); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if in.PreserveSchemaOrder != nil {
+			t.Errorf("JSON null must decode *bool to nil; got %v", *in.PreserveSchemaOrder)
+		}
+		if err := in.Validate(); err != nil {
+			t.Errorf("null/absent must inherit absence: %v", err)
+		}
+	})
 }
 
 func TestDynamicInput_ToWorkerInput_PropagatesOrder(t *testing.T) {
@@ -692,7 +820,7 @@ func TestDynamicInput_ToWorkerInput_SingleClassPropertyOrder(t *testing.T) {
 			},
 			// ClassesOrder intentionally empty — legal because Classes has one key.
 		},
-		PreserveSchemaOrder: true,
+		PreserveSchemaOrder: boolPtr(true),
 	}
 	if err := in.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)
@@ -725,6 +853,11 @@ func TestDynamicInput_ToWorkerInput_SingleClassPropertyOrder(t *testing.T) {
 		t.Errorf("order.classes: got %v want %v", classes, wantClasses)
 	}
 }
+
+// boolPtr returns a pointer to v. Used to construct the *bool tri-state
+// PreserveSchemaOrder field in tests where the Go literal `true`/`false`
+// would not be addressable inline.
+func boolPtr(v bool) *bool { return &v }
 
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -1535,11 +1535,13 @@ func generateDynamicEndpoints(schemas openapi3.Schemas, paths *openapi3.Paths, b
 	}
 
 	// preserve_schema_order is shared between the call/stream and parse
-	// input schemas: both expose the same opt-in.
-	preserveSchemaOrderDescription := "Opt-in: when true, the rendered output_format follows the JSON key " +
-		"order of output_schema.{properties,classes,enums} and each class's properties, rather than the " +
-		"alphabetical default. Multi-key maps must carry a captured order — raw-JSON callers get this for " +
-		"free; programmatic Go callers using the dynclient module must set the matching *Order slices."
+	// input schemas: both expose the same tri-state opt-in.
+	preserveSchemaOrderDescription := "Optional tri-state: true preserves the JSON key order of " +
+		"output_schema.{properties,classes,enums} and each class's properties in the rendered " +
+		"output_format, false forces the alphabetical default, and omitted/null inherits the server " +
+		"default configured by BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT. Multi-key maps must carry a " +
+		"captured order — raw-JSON callers get this for free; programmatic Go callers using the dynclient " +
+		"module must set the matching *Order slices."
 
 	// Dynamic input schema
 	dynamicInputSchemaName := "__DynamicInput__"
@@ -1566,6 +1568,7 @@ func generateDynamicEndpoints(schemas openapi3.Schemas, paths *openapi3.Paths, b
 				"preserve_schema_order": &openapi3.SchemaRef{
 					Value: &openapi3.Schema{
 						Type:        &openapi3.Types{openapi3.TypeBoolean},
+						Nullable:    true,
 						Description: preserveSchemaOrderDescription,
 					},
 				},
@@ -1593,6 +1596,7 @@ func generateDynamicEndpoints(schemas openapi3.Schemas, paths *openapi3.Paths, b
 				"preserve_schema_order": &openapi3.SchemaRef{
 					Value: &openapi3.Schema{
 						Type:        &openapi3.Types{openapi3.TypeBoolean},
+						Nullable:    true,
 						Description: preserveSchemaOrderDescription,
 					},
 				},

--- a/cmd/schema/main_test.go
+++ b/cmd/schema/main_test.go
@@ -331,6 +331,13 @@ func TestSchemaPreserveOrderExposure(t *testing.T) {
 		if slices.Contains(ref.Value.Required, "preserve_schema_order") {
 			t.Errorf("%s.required must not include preserve_schema_order (it's an opt-in)", name)
 		}
+		// Tri-state contract (#316): JSON null is accepted as the
+		// "inherit server default" sentinel, so the schema must mark
+		// the field nullable. Without Nullable=true the OpenAPI surface
+		// would lie about the wire shape.
+		if !isNullable(prop) {
+			t.Errorf("%s.preserve_schema_order: expected Nullable=true for tri-state inherit-default contract", name)
+		}
 	}
 
 	tb, ok := schemas["TypeBuilder"]

--- a/cmd/schema/main_test.go
+++ b/cmd/schema/main_test.go
@@ -331,7 +331,7 @@ func TestSchemaPreserveOrderExposure(t *testing.T) {
 		if slices.Contains(ref.Value.Required, "preserve_schema_order") {
 			t.Errorf("%s.required must not include preserve_schema_order (it's an opt-in)", name)
 		}
-		// Tri-state contract (#316): JSON null is accepted as the
+		// Tri-state contract: JSON null is accepted as the
 		// "inherit server default" sentinel, so the schema must mark
 		// the field nullable. Without Nullable=true the OpenAPI surface
 		// would lie about the wire shape.

--- a/cmd/schema/preserve_order_validator_test.go
+++ b/cmd/schema/preserve_order_validator_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/getkin/kin-openapi/routers"
+	"github.com/goccy/go-json"
+
+	baml_rest "github.com/invakid404/baml-rest"
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// TestPreserveSchemaOrderNullValidates pins that kin-openapi's runtime
+// validator accepts JSON `null` on the preserve_schema_order field of
+// both __DynamicInput__ and __DynamicParseInput__. The Nullable=true
+// flag asserted by TestSchemaPreserveOrderExposure is a static schema
+// property; without this test a future regression could keep
+// Nullable=true on the schema struct but break the actual validation
+// machinery (e.g., if kin-openapi changes how nullable interacts with
+// VisitJSON on primitive fields). Running the same JSON body through
+// the validator catches that.
+//
+// Validation runs both at the field-schema level (the tightest check
+// for the Nullable contract) and at the full-request-body level
+// through openapi3filter.ValidateRequestBody, which is the same code
+// path the production server would use if it ever wired up
+// schema-driven request validation on the dynamic endpoints.
+func TestPreserveSchemaOrderNullValidates(t *testing.T) {
+	baml_rest.InitBamlRuntime()
+
+	// Seed Methods with the dynamic sentinel so the dynamic input/
+	// parse-input schemas are registered — mirrors the harness in
+	// TestSchemaPreserveOrderExposure.
+	origMethods := baml_rest.Methods
+	t.Cleanup(func() { baml_rest.Methods = origMethods })
+	baml_rest.Methods = map[string]bamlutils.StreamingMethod{
+		bamlutils.DynamicMethodName: {
+			MakeInput:        func() any { return &SchemaPostRequiredStubInput{} },
+			MakeOutput:       func() any { return &SchemaPostRequiredStubOutput{} },
+			MakeStreamOutput: func() any { return &SchemaPostRequiredStubOutput{} },
+		},
+	}
+
+	// Marshal the in-memory schema and round-trip through the
+	// kin-openapi Loader so $ref pointers in the generated doc get
+	// resolved into populated SchemaRef.Value pointers — without this
+	// VisitJSON would error on the first unresolved ref it walks into.
+	doc := generateOpenAPISchema()
+	if doc == nil || doc.Components == nil {
+		t.Fatalf("generated schema has no components")
+	}
+	data, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal generated schema: %v", err)
+	}
+	loader := openapi3.NewLoader()
+	loaded, err := loader.LoadFromData(data)
+	if err != nil {
+		t.Fatalf("LoadFromData: %v", err)
+	}
+	if err := loaded.Validate(loader.Context); err != nil {
+		t.Fatalf("loaded schema failed validation: %v", err)
+	}
+
+	type bodyCase struct {
+		name       string
+		schemaName string
+		path       string
+		body       map[string]any
+	}
+
+	// Build minimal valid bodies with explicit JSON null on
+	// preserve_schema_order. The non-null required fields are the
+	// smallest shapes accepted by the generated schemas (one message
+	// with a string content, one client with required options, one
+	// property in output_schema). Anything beyond that risks tripping
+	// unrelated schema constraints.
+	callBody := map[string]any{
+		"preserve_schema_order": nil,
+		"messages": []any{
+			map[string]any{"role": "user", "content": "hi"},
+		},
+		"client_registry": map[string]any{
+			"primary": "TestClient",
+			"clients": []any{
+				map[string]any{
+					"name":     "TestClient",
+					"provider": "openai",
+					"options": map[string]any{
+						"model":    "gpt",
+						"api_key":  "k",
+						"base_url": "http://x",
+					},
+				},
+			},
+		},
+		"output_schema": map[string]any{
+			"properties": map[string]any{
+				"answer": map[string]any{"type": "string"},
+			},
+		},
+	}
+	parseBody := map[string]any{
+		"preserve_schema_order": nil,
+		"raw":                   `{"answer":"hi"}`,
+		"output_schema": map[string]any{
+			"properties": map[string]any{
+				"answer": map[string]any{"type": "string"},
+			},
+		},
+	}
+
+	cases := []bodyCase{
+		{name: "call", schemaName: "__DynamicInput__", path: "/call/" + bamlutils.DynamicEndpointName, body: callBody},
+		{name: "parse", schemaName: "__DynamicParseInput__", path: "/parse/" + bamlutils.DynamicEndpointName, body: parseBody},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ref, ok := loaded.Components.Schemas[tc.schemaName]
+			if !ok || ref == nil || ref.Value == nil {
+				t.Fatalf("schema %q not present in loaded doc", tc.schemaName)
+			}
+
+			// Field-level: confirm null validates against the
+			// preserve_schema_order property schema directly. This is
+			// the tightest possible check on the Nullable contract.
+			prop, ok := ref.Value.Properties["preserve_schema_order"]
+			if !ok || prop == nil || prop.Value == nil {
+				t.Fatalf("%s missing preserve_schema_order", tc.schemaName)
+			}
+			if err := prop.Value.VisitJSON(nil); err != nil {
+				t.Errorf("%s.preserve_schema_order: VisitJSON(nil) must accept null, got: %v", tc.schemaName, err)
+			}
+
+			// Full-body request validation through
+			// openapi3filter.ValidateRequestBody. This is the same
+			// code path a schema-driven HTTP middleware would run on
+			// the wire body, so it catches Nullable-handling
+			// regressions that VisitJSON-on-primitive might miss.
+			bodyBytes, err := json.Marshal(tc.body)
+			if err != nil {
+				t.Fatalf("marshal request body: %v", err)
+			}
+			pathItem := loaded.Paths.Find(tc.path)
+			if pathItem == nil || pathItem.Post == nil {
+				t.Fatalf("path %q POST operation not present in loaded doc", tc.path)
+			}
+			reqBodyRef := pathItem.Post.RequestBody
+			if reqBodyRef == nil || reqBodyRef.Value == nil {
+				t.Fatalf("path %q POST has no request body schema", tc.path)
+			}
+
+			reqURL, err := url.Parse(tc.path)
+			if err != nil {
+				t.Fatalf("parse URL: %v", err)
+			}
+			req := &http.Request{
+				Method: http.MethodPost,
+				URL:    reqURL,
+				Header: http.Header{"Content-Type": []string{"application/json"}},
+				Body:   io.NopCloser(bytes.NewReader(bodyBytes)),
+			}
+			input := &openapi3filter.RequestValidationInput{
+				Request: req,
+				Route: &routers.Route{
+					Spec:      loaded,
+					Path:      tc.path,
+					PathItem:  pathItem,
+					Method:    http.MethodPost,
+					Operation: pathItem.Post,
+				},
+				Options: &openapi3filter.Options{},
+			}
+			if err := openapi3filter.ValidateRequestBody(context.Background(), input, reqBodyRef.Value); err != nil {
+				t.Errorf("%s: ValidateRequestBody must accept body with preserve_schema_order=null, got: %v\nbody:\n%s", tc.schemaName, err, bodyBytes)
+			}
+		})
+	}
+}

--- a/cmd/serve/config.go
+++ b/cmd/serve/config.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// envPreserveSchemaOrderDefault names the server-level default switch for
+// the dynamic-endpoint preserve_schema_order opt-in (#316). When truthy,
+// dynamic requests that omit or null preserve_schema_order inherit true.
+const envPreserveSchemaOrderDefault = "BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT"
+
+// preserveSchemaOrderDefaultFromEnv resolves BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT
+// at server startup. Truthy parsing intentionally matches the
+// parseBuildRequestEnv contract over in bamlutils/buildrequest so the
+// two env vars behave identically — 1/true/yes/on (case-insensitive)
+// enable the default; every other value disables it.
+func preserveSchemaOrderDefaultFromEnv() bool {
+	return parseTruthyEnvBool(os.Getenv(envPreserveSchemaOrderDefault))
+}
+
+// parseTruthyEnvBool mirrors parseBuildRequestEnv: 1/true/yes/on after
+// lowercasing count as truthy, anything else (including empty string,
+// whitespace-padded variants, and unrecognized tokens) is falsy.
+func parseTruthyEnvBool(v string) bool {
+	switch strings.ToLower(v) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// applyPreserveSchemaOrderDefault fills in the request-level *bool
+// tri-state from the server default when the caller omitted the field
+// (or sent JSON null, which decodes to nil). A non-nil pointer is left
+// untouched so per-request true/false always wins over the server
+// default. Must be called after json.Unmarshal and before Validate so
+// validatePreserveSchemaOrder sees the resolved state.
+func applyPreserveSchemaOrderDefault(in *bamlutils.DynamicInput, defaultValue bool) {
+	if in != nil && in.PreserveSchemaOrder == nil {
+		in.PreserveSchemaOrder = &defaultValue
+	}
+}
+
+// applyParsePreserveSchemaOrderDefault mirrors applyPreserveSchemaOrderDefault
+// for the parse-input request type.
+func applyParsePreserveSchemaOrderDefault(in *bamlutils.DynamicParseInput, defaultValue bool) {
+	if in != nil && in.PreserveSchemaOrder == nil {
+		in.PreserveSchemaOrder = &defaultValue
+	}
+}

--- a/cmd/serve/config.go
+++ b/cmd/serve/config.go
@@ -8,8 +8,8 @@ import (
 )
 
 // envPreserveSchemaOrderDefault names the server-level default switch for
-// the dynamic-endpoint preserve_schema_order opt-in (#316). When truthy,
-// dynamic requests that omit or null preserve_schema_order inherit true.
+// the dynamic-endpoint preserve_schema_order opt-in. When truthy, dynamic
+// requests that omit or null preserve_schema_order inherit true.
 const envPreserveSchemaOrderDefault = "BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT"
 
 // preserveSchemaOrderDefaultFromEnv resolves BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT

--- a/cmd/serve/config_test.go
+++ b/cmd/serve/config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/invakid404/baml-rest/bamlutils"
 )
 
-// TestParseTruthyEnvBool pins #316's env-parser contract: 1/true/yes/on
+// TestParseTruthyEnvBool pins the env-parser contract: 1/true/yes/on
 // (case-insensitive) are the only truthy tokens. Mirrors the
 // parseBuildRequestEnv accept list in bamlutils/buildrequest so the two
 // server env flags share a single truthiness convention — diverging

--- a/cmd/serve/config_test.go
+++ b/cmd/serve/config_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// TestParseTruthyEnvBool pins #316's env-parser contract: 1/true/yes/on
+// (case-insensitive) are the only truthy tokens. Mirrors the
+// parseBuildRequestEnv accept list in bamlutils/buildrequest so the two
+// server env flags share a single truthiness convention — diverging
+// would surprise operators who set both vars together.
+func TestParseTruthyEnvBool(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"1", true},
+		{"true", true},
+		{"yes", true},
+		{"on", true},
+		{"TRUE", true},
+		{"Yes", true},
+		{"On", true},
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"off", false},
+		{"no", false},
+		{" true ", false}, // no whitespace trimming — mirrors parseBuildRequestEnv
+		{"truthy", false},
+		{"2", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := parseTruthyEnvBool(tc.in); got != tc.want {
+				t.Errorf("parseTruthyEnvBool(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplyPreserveSchemaOrderDefault_PreservesExplicitPerRequestChoice
+// pins the contract that the server default only fills in an absent
+// (nil) PreserveSchemaOrder. Per-request *true and *false must survive
+// the helper unchanged so callers retain the ability to override the
+// server default on either side of the boolean.
+func TestApplyPreserveSchemaOrderDefault_PreservesExplicitPerRequestChoice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil inherits true default", func(t *testing.T) {
+		in := &bamlutils.DynamicInput{}
+		applyPreserveSchemaOrderDefault(in, true)
+		if in.PreserveSchemaOrder == nil || !*in.PreserveSchemaOrder {
+			t.Errorf("nil + default=true should resolve to *true, got %v", in.PreserveSchemaOrder)
+		}
+	})
+
+	t.Run("nil inherits false default", func(t *testing.T) {
+		in := &bamlutils.DynamicInput{}
+		applyPreserveSchemaOrderDefault(in, false)
+		if in.PreserveSchemaOrder == nil || *in.PreserveSchemaOrder {
+			t.Errorf("nil + default=false should resolve to *false, got %v", in.PreserveSchemaOrder)
+		}
+	})
+
+	t.Run("explicit true wins over false default", func(t *testing.T) {
+		explicit := true
+		in := &bamlutils.DynamicInput{PreserveSchemaOrder: &explicit}
+		applyPreserveSchemaOrderDefault(in, false)
+		if in.PreserveSchemaOrder == nil || !*in.PreserveSchemaOrder {
+			t.Errorf("*true must survive default=false, got %v", in.PreserveSchemaOrder)
+		}
+	})
+
+	t.Run("explicit false wins over true default", func(t *testing.T) {
+		explicit := false
+		in := &bamlutils.DynamicInput{PreserveSchemaOrder: &explicit}
+		applyPreserveSchemaOrderDefault(in, true)
+		if in.PreserveSchemaOrder == nil || *in.PreserveSchemaOrder {
+			t.Errorf("*false must survive default=true, got %v", in.PreserveSchemaOrder)
+		}
+	})
+}
+
+// TestApplyParsePreserveSchemaOrderDefault mirrors the call-side
+// contract on the parse-input type.
+func TestApplyParsePreserveSchemaOrderDefault(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil inherits true default", func(t *testing.T) {
+		in := &bamlutils.DynamicParseInput{}
+		applyParsePreserveSchemaOrderDefault(in, true)
+		if in.PreserveSchemaOrder == nil || !*in.PreserveSchemaOrder {
+			t.Errorf("nil + default=true should resolve to *true, got %v", in.PreserveSchemaOrder)
+		}
+	})
+
+	t.Run("explicit false wins over true default", func(t *testing.T) {
+		explicit := false
+		in := &bamlutils.DynamicParseInput{PreserveSchemaOrder: &explicit}
+		applyParsePreserveSchemaOrderDefault(in, true)
+		if in.PreserveSchemaOrder == nil || *in.PreserveSchemaOrder {
+			t.Errorf("*false must survive default=true, got %v", in.PreserveSchemaOrder)
+		}
+	})
+}

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -236,6 +236,7 @@ var serveCmd = &cobra.Command{
 		// configuration the subprocess build's cmd/worker would
 		// produce on its own at process startup.
 		buildRequestConfig := buildrequest.EnvConfig()
+		preserveSchemaOrderDefault := preserveSchemaOrderDefaultFromEnv()
 		baseURLRewrites := urlrewrite.LoadDefaultRules()
 		httpClient := llmhttp.NewDefaultClientWithOptions(llmhttp.ClientOptions{
 			Mode:         llmhttp.ClientModeFromEnv(),
@@ -495,6 +496,8 @@ var serveCmd = &cobra.Command{
 						return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidJSON, nil, fiber.StatusBadRequest)
 					}
 
+					applyPreserveSchemaOrderDefault(&input, preserveSchemaOrderDefault)
+
 					if err := input.Validate(); err != nil {
 						return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidRequest, nil, fiber.StatusBadRequest)
 					}
@@ -541,7 +544,7 @@ var serveCmd = &cobra.Command{
 
 			makeDynamicStreamHandler := func(streamMode bamlutils.StreamMode) fiber.Handler {
 				return func(c fiber.Ctx) error {
-					workerInput, statusCode, code, err := parseDynamicStreamInput(c.Body())
+					workerInput, statusCode, code, err := parseDynamicStreamInput(c.Body(), preserveSchemaOrderDefault)
 					if err != nil {
 						if statusCode >= fiber.StatusInternalServerError {
 							logger.Error().Err(err).Msg("dynamic stream input parsing failed")
@@ -584,6 +587,7 @@ var serveCmd = &cobra.Command{
 				if err := json.Unmarshal(rawBody, &input); err != nil {
 					return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidJSON, nil, fiber.StatusBadRequest)
 				}
+				applyParsePreserveSchemaOrderDefault(&input, preserveSchemaOrderDefault)
 				if err := input.Validate(); err != nil {
 					return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidRequest, nil, fiber.StatusBadRequest)
 				}
@@ -616,7 +620,7 @@ var serveCmd = &cobra.Command{
 		// Optionally start the chi-based unary server on a separate port.
 		// newUnaryServer returns nil when the unaryserver build tag is absent
 		// or when --unary-port is set to 0.
-		unaryServer := newUnaryServer(logger, workerPool, methodNames, hasDynamicMethod)
+		unaryServer := newUnaryServer(logger, workerPool, methodNames, hasDynamicMethod, preserveSchemaOrderDefault)
 
 		// Start Fiber server in a goroutine.
 		serverErr := make(chan error, 1)
@@ -698,11 +702,17 @@ var serveCmd = &cobra.Command{
 // alongside the apierror.Code that classifies any failure (so callers
 // preserve machine-readable codes instead of collapsing every 4xx into
 // invalid_request). On success: code is "" and statusCode is 0.
-func parseDynamicStreamInput(rawBody []byte) (workerInput []byte, statusCode int, code apierror.Code, err error) {
+//
+// preserveSchemaOrderDefault is the server-level default for the
+// dynamic preserve_schema_order opt-in (#316). It is applied only when
+// the request omits / nulls the field; per-request true/false wins.
+func parseDynamicStreamInput(rawBody []byte, preserveSchemaOrderDefault bool) (workerInput []byte, statusCode int, code apierror.Code, err error) {
 	var input bamlutils.DynamicInput
 	if err := json.Unmarshal(rawBody, &input); err != nil {
 		return nil, fiber.StatusBadRequest, apierror.CodeInvalidJSON, fmt.Errorf("invalid JSON: %w", err)
 	}
+
+	applyPreserveSchemaOrderDefault(&input, preserveSchemaOrderDefault)
 
 	if err := input.Validate(); err != nil {
 		return nil, fiber.StatusBadRequest, apierror.CodeInvalidRequest, err

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -704,7 +704,7 @@ var serveCmd = &cobra.Command{
 // invalid_request). On success: code is "" and statusCode is 0.
 //
 // preserveSchemaOrderDefault is the server-level default for the
-// dynamic preserve_schema_order opt-in (#316). It is applied only when
+// dynamic preserve_schema_order opt-in. It is applied only when
 // the request omits / nulls the field; per-request true/false wins.
 func parseDynamicStreamInput(rawBody []byte, preserveSchemaOrderDefault bool) (workerInput []byte, statusCode int, code apierror.Code, err error) {
 	var input bamlutils.DynamicInput

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -488,25 +488,13 @@ var serveCmd = &cobra.Command{
 					ctx, cancel := context.WithCancel(c.Context())
 					defer cancel()
 
-					rawBody := c.Body()
-
-					// Parse and validate dynamic input
-					var input bamlutils.DynamicInput
-					if err := json.Unmarshal(rawBody, &input); err != nil {
-						return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidJSON, nil, fiber.StatusBadRequest)
-					}
-
-					applyPreserveSchemaOrderDefault(&input, preserveSchemaOrderDefault)
-
-					if err := input.Validate(); err != nil {
-						return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidRequest, nil, fiber.StatusBadRequest)
-					}
-
-					// Convert to internal format
-					workerInput, err := input.ToWorkerInput()
+					workerInput, statusCode, code, err := parseDynamicCallBody(c.Body(), preserveSchemaOrderDefault)
 					if err != nil {
-						logger.Error().Err(err).Msg("dynamic input conversion failed")
-						return writeFiberInternalError(c, err)
+						if statusCode >= fiber.StatusInternalServerError {
+							logger.Error().Err(err).Msg("dynamic input conversion failed")
+							return writeFiberInternalError(c, err)
+						}
+						return writeFiberJSONErrorWithCode(c, err.Error(), code, nil, statusCode)
 					}
 
 					result, err := workerPool.Call(ctx, bamlutils.DynamicMethodName, workerInput, streamMode)
@@ -544,7 +532,7 @@ var serveCmd = &cobra.Command{
 
 			makeDynamicStreamHandler := func(streamMode bamlutils.StreamMode) fiber.Handler {
 				return func(c fiber.Ctx) error {
-					workerInput, statusCode, code, err := parseDynamicStreamInput(c.Body(), preserveSchemaOrderDefault)
+					workerInput, statusCode, code, err := parseDynamicCallBody(c.Body(), preserveSchemaOrderDefault)
 					if err != nil {
 						if statusCode >= fiber.StatusInternalServerError {
 							logger.Error().Err(err).Msg("dynamic stream input parsing failed")
@@ -552,7 +540,7 @@ var serveCmd = &cobra.Command{
 							// httplogger.SetError attaches the error to the request-
 							// scoped structured log alongside the discrete logger
 							// line above. Wire shape is unchanged —
-							// parseDynamicStreamInput only returns statusCode>=500
+							// parseDynamicCallBody only returns statusCode>=500
 							// from the ToWorkerInput path, which already classifies
 							// as CodeInternalError, so the helper produces an
 							// identical envelope.
@@ -580,23 +568,13 @@ var serveCmd = &cobra.Command{
 				ctx, cancel := context.WithCancel(c.Context())
 				defer cancel()
 
-				rawBody := c.Body()
-
-				// Parse and validate dynamic parse input
-				var input bamlutils.DynamicParseInput
-				if err := json.Unmarshal(rawBody, &input); err != nil {
-					return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidJSON, nil, fiber.StatusBadRequest)
-				}
-				applyParsePreserveSchemaOrderDefault(&input, preserveSchemaOrderDefault)
-				if err := input.Validate(); err != nil {
-					return writeFiberJSONErrorWithCode(c, err.Error(), apierror.CodeInvalidRequest, nil, fiber.StatusBadRequest)
-				}
-
-				// Convert to internal format
-				workerInput, err := input.ToWorkerInput()
+				workerInput, statusCode, code, err := parseDynamicParseBody(c.Body(), preserveSchemaOrderDefault)
 				if err != nil {
-					logger.Error().Err(err).Msg("dynamic parse input conversion failed")
-					return writeFiberInternalError(c, err)
+					if statusCode >= fiber.StatusInternalServerError {
+						logger.Error().Err(err).Msg("dynamic parse input conversion failed")
+						return writeFiberInternalError(c, err)
+					}
+					return writeFiberJSONErrorWithCode(c, err.Error(), code, nil, statusCode)
 				}
 
 				result, err := workerPool.Parse(ctx, bamlutils.DynamicMethodName, workerInput)
@@ -697,22 +675,47 @@ var serveCmd = &cobra.Command{
 	},
 }
 
-// parseDynamicStreamInput parses + validates the JSON body for a
-// dynamic streaming endpoint and returns the worker-shaped input
-// alongside the apierror.Code that classifies any failure (so callers
-// preserve machine-readable codes instead of collapsing every 4xx into
-// invalid_request). On success: code is "" and statusCode is 0.
+// parseDynamicCallBody parses + validates the JSON body for any
+// dynamic call/stream endpoint (/call/_dynamic, /call-with-raw/_dynamic,
+// /stream/_dynamic, /stream-with-raw/_dynamic) and returns the
+// worker-shaped input alongside the apierror.Code that classifies any
+// failure (so callers preserve machine-readable codes instead of
+// collapsing every 4xx into invalid_request). On success: code is ""
+// and statusCode is 0.
 //
 // preserveSchemaOrderDefault is the server-level default for the
 // dynamic preserve_schema_order opt-in. It is applied only when
 // the request omits / nulls the field; per-request true/false wins.
-func parseDynamicStreamInput(rawBody []byte, preserveSchemaOrderDefault bool) (workerInput []byte, statusCode int, code apierror.Code, err error) {
+func parseDynamicCallBody(rawBody []byte, preserveSchemaOrderDefault bool) (workerInput []byte, statusCode int, code apierror.Code, err error) {
 	var input bamlutils.DynamicInput
 	if err := json.Unmarshal(rawBody, &input); err != nil {
 		return nil, fiber.StatusBadRequest, apierror.CodeInvalidJSON, fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	applyPreserveSchemaOrderDefault(&input, preserveSchemaOrderDefault)
+
+	if err := input.Validate(); err != nil {
+		return nil, fiber.StatusBadRequest, apierror.CodeInvalidRequest, err
+	}
+
+	workerInput, err = input.ToWorkerInput()
+	if err != nil {
+		return nil, fiber.StatusInternalServerError, apierror.CodeInternalError, fmt.Errorf("failed to convert input: %w", err)
+	}
+
+	return workerInput, 0, "", nil
+}
+
+// parseDynamicParseBody mirrors parseDynamicCallBody for the
+// /parse/_dynamic endpoint, decoding into the DynamicParseInput shape
+// rather than DynamicInput.
+func parseDynamicParseBody(rawBody []byte, preserveSchemaOrderDefault bool) (workerInput []byte, statusCode int, code apierror.Code, err error) {
+	var input bamlutils.DynamicParseInput
+	if err := json.Unmarshal(rawBody, &input); err != nil {
+		return nil, fiber.StatusBadRequest, apierror.CodeInvalidJSON, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	applyParsePreserveSchemaOrderDefault(&input, preserveSchemaOrderDefault)
 
 	if err := input.Validate(); err != nil {
 		return nil, fiber.StatusBadRequest, apierror.CodeInvalidRequest, err

--- a/cmd/serve/unary.go
+++ b/cmd/serve/unary.go
@@ -25,13 +25,13 @@ func init() {
 
 // newUnaryServer creates the chi-based unary HTTP server if unaryPort > 0.
 // Returns nil when the unary server is disabled.
-func newUnaryServer(logger zerolog.Logger, workerPool *pool.Pool, methodNames []string, hasDynamicMethod bool) *http.Server {
+func newUnaryServer(logger zerolog.Logger, workerPool *pool.Pool, methodNames []string, hasDynamicMethod bool, preserveSchemaOrderDefault bool) *http.Server {
 	if unaryPort <= 0 {
 		return nil
 	}
 	return &http.Server{
 		Addr:              fmt.Sprintf(":%d", unaryPort),
-		Handler:           newUnaryRouter(logger, workerPool, methodNames, hasDynamicMethod),
+		Handler:           newUnaryRouter(logger, workerPool, methodNames, hasDynamicMethod, preserveSchemaOrderDefault),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      5 * time.Minute,
@@ -48,6 +48,7 @@ func newUnaryRouter(
 	workerPool *pool.Pool,
 	methodNames []string,
 	hasDynamicMethod bool,
+	preserveSchemaOrderDefault bool,
 ) http.Handler {
 	r := chi.NewRouter()
 
@@ -95,9 +96,9 @@ func newUnaryRouter(
 
 	// Register dynamic endpoints.
 	if hasDynamicMethod {
-		r.Post(fmt.Sprintf("/call/%s", bamlutils.DynamicEndpointName), makeChiDynamicCallHandler(workerPool, bamlutils.StreamModeCall))
-		r.Post(fmt.Sprintf("/call-with-raw/%s", bamlutils.DynamicEndpointName), makeChiDynamicCallHandler(workerPool, bamlutils.StreamModeCallWithRaw))
-		r.Post(fmt.Sprintf("/parse/%s", bamlutils.DynamicEndpointName), makeChiDynamicParseHandler(workerPool))
+		r.Post(fmt.Sprintf("/call/%s", bamlutils.DynamicEndpointName), makeChiDynamicCallHandler(workerPool, bamlutils.StreamModeCall, preserveSchemaOrderDefault))
+		r.Post(fmt.Sprintf("/call-with-raw/%s", bamlutils.DynamicEndpointName), makeChiDynamicCallHandler(workerPool, bamlutils.StreamModeCallWithRaw, preserveSchemaOrderDefault))
+		r.Post(fmt.Sprintf("/parse/%s", bamlutils.DynamicEndpointName), makeChiDynamicParseHandler(workerPool, preserveSchemaOrderDefault))
 	}
 
 	return r

--- a/cmd/serve/unary_handlers.go
+++ b/cmd/serve/unary_handlers.go
@@ -22,6 +22,14 @@ type unaryCaller interface {
 	Call(ctx context.Context, methodName string, inputJSON []byte, streamMode bamlutils.StreamMode) (*workerplugin.CallResult, error)
 }
 
+// unaryParser is the parse-side analog of unaryCaller for the dynamic
+// /parse/_dynamic chi handler. Declared so tests can record the worker
+// input the handler routed without depending on *pool.Pool; *pool.Pool
+// satisfies the interface structurally via Pool.Parse.
+type unaryParser interface {
+	Parse(ctx context.Context, methodName string, inputJSON []byte) (*workerplugin.ParseResult, error)
+}
+
 // chiHeadersEmitter is the function-typed seam the chi dynamic call
 // handler uses to publish BAML observability headers from a CallResult's
 // planned/outcome JSON. Extracted so tests can substitute a counting
@@ -117,15 +125,20 @@ func makeChiParseHandler(p *pool.Pool, methodName string) http.HandlerFunc {
 	}
 }
 
-func makeChiDynamicCallHandler(p unaryCaller, streamMode bamlutils.StreamMode) http.HandlerFunc {
-	return makeChiDynamicCallHandlerWithEmitter(p, streamMode, defaultChiHeadersEmitter)
+func makeChiDynamicCallHandler(p unaryCaller, streamMode bamlutils.StreamMode, preserveSchemaOrderDefault bool) http.HandlerFunc {
+	return makeChiDynamicCallHandlerWithEmitter(p, streamMode, preserveSchemaOrderDefault, defaultChiHeadersEmitter)
 }
 
 // makeChiDynamicCallHandlerWithEmitter is the test-injectable form of
 // makeChiDynamicCallHandler. Production callers go through the
 // default-emitter wrapper above; tests pass a counting wrapper so they
 // can assert how many times the headers seam was invoked.
-func makeChiDynamicCallHandlerWithEmitter(p unaryCaller, streamMode bamlutils.StreamMode, emit chiHeadersEmitter) http.HandlerFunc {
+//
+// preserveSchemaOrderDefault is the server-level fallback for the
+// dynamic preserve_schema_order opt-in (#316). It is applied via
+// applyPreserveSchemaOrderDefault after Unmarshal and before Validate
+// so per-request true/false always wins over the server default.
+func makeChiDynamicCallHandlerWithEmitter(p unaryCaller, streamMode bamlutils.StreamMode, preserveSchemaOrderDefault bool, emit chiHeadersEmitter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithCancel(r.Context())
 		defer cancel()
@@ -141,6 +154,7 @@ func makeChiDynamicCallHandlerWithEmitter(p unaryCaller, streamMode bamlutils.St
 			writeChiJSONErrorWithCode(w, r, err.Error(), apierror.CodeInvalidJSON, nil, http.StatusBadRequest)
 			return
 		}
+		applyPreserveSchemaOrderDefault(&input, preserveSchemaOrderDefault)
 		if err := input.Validate(); err != nil {
 			writeChiJSONErrorWithCode(w, r, err.Error(), apierror.CodeInvalidRequest, nil, http.StatusBadRequest)
 			return
@@ -186,7 +200,7 @@ func makeChiDynamicCallHandlerWithEmitter(p unaryCaller, streamMode bamlutils.St
 	}
 }
 
-func makeChiDynamicParseHandler(p *pool.Pool) http.HandlerFunc {
+func makeChiDynamicParseHandler(p unaryParser, preserveSchemaOrderDefault bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithCancel(r.Context())
 		defer cancel()
@@ -202,6 +216,7 @@ func makeChiDynamicParseHandler(p *pool.Pool) http.HandlerFunc {
 			writeChiJSONErrorWithCode(w, r, err.Error(), apierror.CodeInvalidJSON, nil, http.StatusBadRequest)
 			return
 		}
+		applyParsePreserveSchemaOrderDefault(&input, preserveSchemaOrderDefault)
 		if err := input.Validate(); err != nil {
 			writeChiJSONErrorWithCode(w, r, err.Error(), apierror.CodeInvalidRequest, nil, http.StatusBadRequest)
 			return

--- a/cmd/serve/unary_handlers.go
+++ b/cmd/serve/unary_handlers.go
@@ -135,7 +135,7 @@ func makeChiDynamicCallHandler(p unaryCaller, streamMode bamlutils.StreamMode, p
 // can assert how many times the headers seam was invoked.
 //
 // preserveSchemaOrderDefault is the server-level fallback for the
-// dynamic preserve_schema_order opt-in (#316). It is applied via
+// dynamic preserve_schema_order opt-in. It is applied via
 // applyPreserveSchemaOrderDefault after Unmarshal and before Validate
 // so per-request true/false always wins over the server default.
 func makeChiDynamicCallHandlerWithEmitter(p unaryCaller, streamMode bamlutils.StreamMode, preserveSchemaOrderDefault bool, emit chiHeadersEmitter) http.HandlerFunc {

--- a/cmd/serve/unary_handlers_test.go
+++ b/cmd/serve/unary_handlers_test.go
@@ -15,13 +15,40 @@ import (
 )
 
 // fakeUnaryCaller satisfies unaryCaller and lets tests stub Pool.Call's
-// return values without spinning up a real worker pool.
+// return values without spinning up a real worker pool. Also records
+// the most recent (methodName, inputJSON, streamMode) tuple so tests
+// can assert what the handler routed to the worker layer — in
+// particular, whether the worker-bound payload preserves order.
 type fakeUnaryCaller struct {
 	result *workerplugin.CallResult
 	err    error
+
+	gotMethod     string
+	gotInputJSON  []byte
+	gotStreamMode bamlutils.StreamMode
 }
 
-func (f *fakeUnaryCaller) Call(_ context.Context, _ string, _ []byte, _ bamlutils.StreamMode) (*workerplugin.CallResult, error) {
+func (f *fakeUnaryCaller) Call(_ context.Context, methodName string, inputJSON []byte, streamMode bamlutils.StreamMode) (*workerplugin.CallResult, error) {
+	f.gotMethod = methodName
+	// Copy the slice — the caller may reuse the buffer after returning.
+	f.gotInputJSON = append([]byte(nil), inputJSON...)
+	f.gotStreamMode = streamMode
+	return f.result, f.err
+}
+
+// fakeUnaryParser satisfies unaryParser for parse-handler tests.
+// Mirrors fakeUnaryCaller's record-then-replay shape.
+type fakeUnaryParser struct {
+	result *workerplugin.ParseResult
+	err    error
+
+	gotMethod    string
+	gotInputJSON []byte
+}
+
+func (f *fakeUnaryParser) Parse(_ context.Context, methodName string, inputJSON []byte) (*workerplugin.ParseResult, error) {
+	f.gotMethod = methodName
+	f.gotInputJSON = append([]byte(nil), inputJSON...)
 	return f.result, f.err
 }
 
@@ -107,7 +134,7 @@ func TestMakeChiDynamicCallHandler_EmitsHeadersOnError(t *testing.T) {
 	}
 
 	emitter := &countingHeadersEmitter{delegate: defaultChiHeadersEmitter}
-	handler := makeChiDynamicCallHandlerWithEmitter(caller, bamlutils.StreamModeCall, emitter.emit)
+	handler := makeChiDynamicCallHandlerWithEmitter(caller, bamlutils.StreamModeCall, false, emitter.emit)
 	req := httptest.NewRequest(http.MethodPost, "/call/dynamic", bytes.NewReader(minimalDynamicInputJSON(t)))
 	rec := httptest.NewRecorder()
 	handler(rec, req)
@@ -155,7 +182,7 @@ func TestMakeChiDynamicCallHandler_EmitsHeadersOnSuccess(t *testing.T) {
 	}
 
 	emitter := &countingHeadersEmitter{delegate: defaultChiHeadersEmitter}
-	handler := makeChiDynamicCallHandlerWithEmitter(caller, bamlutils.StreamModeCall, emitter.emit)
+	handler := makeChiDynamicCallHandlerWithEmitter(caller, bamlutils.StreamModeCall, false, emitter.emit)
 	req := httptest.NewRequest(http.MethodPost, "/call/dynamic", bytes.NewReader(minimalDynamicInputJSON(t)))
 	rec := httptest.NewRecorder()
 	handler(rec, req)
@@ -188,7 +215,7 @@ func TestMakeChiDynamicCallHandler_NoMetadataNoHeaders(t *testing.T) {
 	}
 
 	emitter := &countingHeadersEmitter{delegate: defaultChiHeadersEmitter}
-	handler := makeChiDynamicCallHandlerWithEmitter(caller, bamlutils.StreamModeCall, emitter.emit)
+	handler := makeChiDynamicCallHandlerWithEmitter(caller, bamlutils.StreamModeCall, false, emitter.emit)
 	req := httptest.NewRequest(http.MethodPost, "/call/dynamic", bytes.NewReader(minimalDynamicInputJSON(t)))
 	rec := httptest.NewRecorder()
 	handler(rec, req)
@@ -204,5 +231,237 @@ func TestMakeChiDynamicCallHandler_NoMetadataNoHeaders(t *testing.T) {
 	}
 	if got := rec.Header().Get(HeaderBAMLPathReason); got != "" {
 		t.Errorf("X-BAML-Path-Reason: got %q, want empty when result is nil", got)
+	}
+}
+
+// orderedDynamicInputJSON returns a /call/_dynamic body with at least
+// two top-level properties so preserve-order behavior is observable in
+// the worker payload (single-property schemas never need an order
+// slice). Includes the requested preserve_schema_order raw fragment
+// inline so callers can probe the omitted/null/true/false matrix.
+func orderedDynamicInputJSON(preserveField string) []byte {
+	body := `{
+      ` + preserveField + `
+      "messages": [{"role": "user", "content": "go"}],
+      "client_registry": {"primary": "X", "clients": [{"name": "X", "provider": "anthropic", "options": {"model": "m", "api_key": "k"}}]},
+      "output_schema": {
+        "properties": {
+          "zulu": {"type": "string"},
+          "alpha": {"type": "string"}
+        }
+      }
+    }`
+	return []byte(body)
+}
+
+// workerPayloadPreserveOrder decodes the worker-bound JSON and reports
+// whether __baml_options__.type_builder.dynamic_types.preserve_order
+// is the boolean true. Missing keys or non-true values all read as
+// false — matches the worker's view of "no preserve-order opt-in".
+func workerPayloadPreserveOrder(t *testing.T, data []byte) bool {
+	t.Helper()
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal worker payload: %v\n%s", err, data)
+	}
+	opts, _ := decoded["__baml_options__"].(map[string]any)
+	if opts == nil {
+		return false
+	}
+	tb, _ := opts["type_builder"].(map[string]any)
+	if tb == nil {
+		return false
+	}
+	dt, _ := tb["dynamic_types"].(map[string]any)
+	if dt == nil {
+		return false
+	}
+	got, _ := dt["preserve_order"].(bool)
+	return got
+}
+
+// TestMakeChiDynamicCallHandler_PreserveSchemaOrderDefault walks the
+// #316 truth table at the chi handler boundary: server default × per-
+// request field => worker preserve_order. The handler must defer to
+// the explicit per-request value when present (true or false) and only
+// fall back to the server default when the field is absent / null.
+func TestMakeChiDynamicCallHandler_PreserveSchemaOrderDefault(t *testing.T) {
+	cases := []struct {
+		name           string
+		serverDefault  bool
+		preserveField  string // exact JSON fragment for preserve_schema_order
+		wantPreserve   bool
+	}{
+		{
+			name:          "default off, field omitted -> off",
+			serverDefault: false,
+			preserveField: ``,
+			wantPreserve:  false,
+		},
+		{
+			name:          "default off, field true -> on",
+			serverDefault: false,
+			preserveField: `"preserve_schema_order": true,`,
+			wantPreserve:  true,
+		},
+		{
+			name:          "default on, field omitted -> on",
+			serverDefault: true,
+			preserveField: ``,
+			wantPreserve:  true,
+		},
+		{
+			name:          "default on, field false -> off",
+			serverDefault: true,
+			preserveField: `"preserve_schema_order": false,`,
+			wantPreserve:  false,
+		},
+		{
+			name:          "default on, field null -> on (null is inherit)",
+			serverDefault: true,
+			preserveField: `"preserve_schema_order": null,`,
+			wantPreserve:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			caller := &fakeUnaryCaller{
+				result: &workerplugin.CallResult{Data: []byte(`{"zulu":"x","alpha":"y"}`)},
+			}
+			emitter := &countingHeadersEmitter{delegate: defaultChiHeadersEmitter}
+			handler := makeChiDynamicCallHandlerWithEmitter(caller, bamlutils.StreamModeCall, tc.serverDefault, emitter.emit)
+			req := httptest.NewRequest(http.MethodPost, "/call/_dynamic", bytes.NewReader(orderedDynamicInputJSON(tc.preserveField)))
+			rec := httptest.NewRecorder()
+			handler(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status: got %d body=%s", rec.Code, rec.Body.String())
+			}
+			if got := workerPayloadPreserveOrder(t, caller.gotInputJSON); got != tc.wantPreserve {
+				t.Errorf("preserve_order: got %v want %v\nworker payload:\n%s", got, tc.wantPreserve, caller.gotInputJSON)
+			}
+		})
+	}
+}
+
+// TestMakeChiDynamicParseHandler_PreserveSchemaOrderDefault mirrors
+// the call-side truth table on the parse handler. The fakeUnaryParser
+// records the routed worker input so the test can assert preserve_order
+// the same way as the call-side check.
+func TestMakeChiDynamicParseHandler_PreserveSchemaOrderDefault(t *testing.T) {
+	cases := []struct {
+		name          string
+		serverDefault bool
+		preserveField string
+		wantPreserve  bool
+	}{
+		{
+			name:          "default off, field omitted -> off",
+			serverDefault: false,
+			preserveField: ``,
+			wantPreserve:  false,
+		},
+		{
+			name:          "default off, field true -> on",
+			serverDefault: false,
+			preserveField: `"preserve_schema_order": true,`,
+			wantPreserve:  true,
+		},
+		{
+			name:          "default on, field omitted -> on",
+			serverDefault: true,
+			preserveField: ``,
+			wantPreserve:  true,
+		},
+		{
+			name:          "default on, field false -> off",
+			serverDefault: true,
+			preserveField: `"preserve_schema_order": false,`,
+			wantPreserve:  false,
+		},
+		{
+			name:          "default on, field null -> on (null is inherit)",
+			serverDefault: true,
+			preserveField: `"preserve_schema_order": null,`,
+			wantPreserve:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parser := &fakeUnaryParser{result: &workerplugin.ParseResult{Data: []byte(`{"zulu":"x","alpha":"y"}`)}}
+			body := []byte(`{
+              ` + tc.preserveField + `
+              "raw": "{\"zulu\":\"x\",\"alpha\":\"y\"}",
+              "output_schema": {"properties": {"zulu": {"type": "string"}, "alpha": {"type": "string"}}}
+            }`)
+			handler := makeChiDynamicParseHandler(parser, tc.serverDefault)
+			req := httptest.NewRequest(http.MethodPost, "/parse/_dynamic", bytes.NewReader(body))
+			rec := httptest.NewRecorder()
+			handler(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status: got %d body=%s", rec.Code, rec.Body.String())
+			}
+			if got := workerPayloadPreserveOrder(t, parser.gotInputJSON); got != tc.wantPreserve {
+				t.Errorf("preserve_order: got %v want %v\nworker payload:\n%s", got, tc.wantPreserve, parser.gotInputJSON)
+			}
+		})
+	}
+}
+
+// TestParseDynamicStreamInput_PreserveSchemaOrderDefault covers the
+// Fiber stream-input helper directly. parseDynamicStreamInput is the
+// only piece of Fiber-side dynamic plumbing that holds the
+// decode->default->validate->ToWorkerInput sequence in one function,
+// so testing it without a live Fiber server still exercises the
+// stream path's exact code.
+func TestParseDynamicStreamInput_PreserveSchemaOrderDefault(t *testing.T) {
+	cases := []struct {
+		name          string
+		serverDefault bool
+		preserveField string
+		wantPreserve  bool
+	}{
+		{
+			name:          "default off, field omitted -> off",
+			serverDefault: false,
+			preserveField: ``,
+			wantPreserve:  false,
+		},
+		{
+			name:          "default off, field true -> on",
+			serverDefault: false,
+			preserveField: `"preserve_schema_order": true,`,
+			wantPreserve:  true,
+		},
+		{
+			name:          "default on, field omitted -> on",
+			serverDefault: true,
+			preserveField: ``,
+			wantPreserve:  true,
+		},
+		{
+			name:          "default on, field false -> off",
+			serverDefault: true,
+			preserveField: `"preserve_schema_order": false,`,
+			wantPreserve:  false,
+		},
+		{
+			name:          "default on, field null -> on (null is inherit)",
+			serverDefault: true,
+			preserveField: `"preserve_schema_order": null,`,
+			wantPreserve:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			workerInput, statusCode, code, err := parseDynamicStreamInput(orderedDynamicInputJSON(tc.preserveField), tc.serverDefault)
+			if err != nil {
+				t.Fatalf("parseDynamicStreamInput: status=%d code=%q err=%v", statusCode, code, err)
+			}
+			if got := workerPayloadPreserveOrder(t, workerInput); got != tc.wantPreserve {
+				t.Errorf("preserve_order: got %v want %v\nworker payload:\n%s", got, tc.wantPreserve, workerInput)
+			}
+		})
 	}
 }

--- a/cmd/serve/unary_handlers_test.go
+++ b/cmd/serve/unary_handlers_test.go
@@ -281,7 +281,7 @@ func workerPayloadPreserveOrder(t *testing.T, data []byte) bool {
 }
 
 // TestMakeChiDynamicCallHandler_PreserveSchemaOrderDefault walks the
-// #316 truth table at the chi handler boundary: server default × per-
+// preserve_schema_order truth table at the chi handler boundary: server default × per-
 // request field => worker preserve_order. The handler must defer to
 // the explicit per-request value when present (true or false) and only
 // fall back to the server default when the field is absent / null.

--- a/cmd/serve/unary_handlers_test.go
+++ b/cmd/serve/unary_handlers_test.go
@@ -409,55 +409,97 @@ func TestMakeChiDynamicParseHandler_PreserveSchemaOrderDefault(t *testing.T) {
 	}
 }
 
-// TestParseDynamicStreamInput_PreserveSchemaOrderDefault covers the
-// Fiber stream-input helper directly. parseDynamicStreamInput is the
-// only piece of Fiber-side dynamic plumbing that holds the
-// decode->default->validate->ToWorkerInput sequence in one function,
-// so testing it without a live Fiber server still exercises the
-// stream path's exact code.
-func TestParseDynamicStreamInput_PreserveSchemaOrderDefault(t *testing.T) {
-	cases := []struct {
-		name          string
-		serverDefault bool
-		preserveField string
-		wantPreserve  bool
-	}{
-		{
-			name:          "default off, field omitted -> off",
-			serverDefault: false,
-			preserveField: ``,
-			wantPreserve:  false,
-		},
-		{
-			name:          "default off, field true -> on",
-			serverDefault: false,
-			preserveField: `"preserve_schema_order": true,`,
-			wantPreserve:  true,
-		},
-		{
-			name:          "default on, field omitted -> on",
-			serverDefault: true,
-			preserveField: ``,
-			wantPreserve:  true,
-		},
-		{
-			name:          "default on, field false -> off",
-			serverDefault: true,
-			preserveField: `"preserve_schema_order": false,`,
-			wantPreserve:  false,
-		},
-		{
-			name:          "default on, field null -> on (null is inherit)",
-			serverDefault: true,
-			preserveField: `"preserve_schema_order": null,`,
-			wantPreserve:  true,
-		},
-	}
-	for _, tc := range cases {
+// preserveSchemaOrderTruthTable is the shared 5-cell matrix used by
+// every Fiber/chi handler test that exercises the server-default x
+// per-request-field interaction. Defined once so the chi call/parse
+// and Fiber call/parse/stream coverage stays in lockstep — a new row
+// added here is picked up by all consumers.
+var preserveSchemaOrderTruthTable = []struct {
+	name          string
+	serverDefault bool
+	preserveField string
+	wantPreserve  bool
+}{
+	{
+		name:          "default off, field omitted -> off",
+		serverDefault: false,
+		preserveField: ``,
+		wantPreserve:  false,
+	},
+	{
+		name:          "default off, field true -> on",
+		serverDefault: false,
+		preserveField: `"preserve_schema_order": true,`,
+		wantPreserve:  true,
+	},
+	{
+		name:          "default on, field omitted -> on",
+		serverDefault: true,
+		preserveField: ``,
+		wantPreserve:  true,
+	},
+	{
+		name:          "default on, field false -> off",
+		serverDefault: true,
+		preserveField: `"preserve_schema_order": false,`,
+		wantPreserve:  false,
+	},
+	{
+		name:          "default on, field null -> on (null is inherit)",
+		serverDefault: true,
+		preserveField: `"preserve_schema_order": null,`,
+		wantPreserve:  true,
+	},
+}
+
+// orderedDynamicParseInputJSON mirrors orderedDynamicInputJSON for the
+// /parse/_dynamic body shape. At least two top-level properties so
+// preserve-order behavior is observable in the worker payload.
+func orderedDynamicParseInputJSON(preserveField string) []byte {
+	body := `{
+      ` + preserveField + `
+      "raw": "{\"zulu\":\"x\",\"alpha\":\"y\"}",
+      "output_schema": {
+        "properties": {
+          "zulu": {"type": "string"},
+          "alpha": {"type": "string"}
+        }
+      }
+    }`
+	return []byte(body)
+}
+
+// TestParseDynamicCallBody_PreserveSchemaOrderDefault covers the
+// Fiber-side decode/default/validate/ToWorkerInput helper used by both
+// /call/_dynamic and /stream/_dynamic. The Fiber call and stream
+// handlers do not own a fakeUnaryCaller-style seam, so the helper is
+// the smallest unit that captures the wire-visible behavior end-to-end
+// without spinning up a Fiber app and a worker pool.
+func TestParseDynamicCallBody_PreserveSchemaOrderDefault(t *testing.T) {
+	for _, tc := range preserveSchemaOrderTruthTable {
 		t.Run(tc.name, func(t *testing.T) {
-			workerInput, statusCode, code, err := parseDynamicStreamInput(orderedDynamicInputJSON(tc.preserveField), tc.serverDefault)
+			workerInput, statusCode, code, err := parseDynamicCallBody(orderedDynamicInputJSON(tc.preserveField), tc.serverDefault)
 			if err != nil {
-				t.Fatalf("parseDynamicStreamInput: status=%d code=%q err=%v", statusCode, code, err)
+				t.Fatalf("parseDynamicCallBody: status=%d code=%q err=%v", statusCode, code, err)
+			}
+			if got := workerPayloadPreserveOrder(t, workerInput); got != tc.wantPreserve {
+				t.Errorf("preserve_order: got %v want %v\nworker payload:\n%s", got, tc.wantPreserve, workerInput)
+			}
+		})
+	}
+}
+
+// TestParseDynamicParseBody_PreserveSchemaOrderDefault covers the
+// Fiber-side decode/default/validate/ToWorkerInput helper used by
+// /parse/_dynamic. Mirrors TestParseDynamicCallBody but routes through
+// the DynamicParseInput shape (raw + output_schema, no messages or
+// client_registry).
+func TestParseDynamicParseBody_PreserveSchemaOrderDefault(t *testing.T) {
+	for _, tc := range preserveSchemaOrderTruthTable {
+		t.Run(tc.name, func(t *testing.T) {
+			workerInput, statusCode, code, err := parseDynamicParseBody(orderedDynamicParseInputJSON(tc.preserveField), tc.serverDefault)
+			if err != nil {
+				t.Fatalf("parseDynamicParseBody: status=%d code=%q err=%v", statusCode, code, err)
 			}
 			if got := workerPayloadPreserveOrder(t, workerInput); got != tc.wantPreserve {
 				t.Errorf("preserve_order: got %v want %v\nworker payload:\n%s", got, tc.wantPreserve, workerInput)

--- a/cmd/serve/unary_handlers_test.go
+++ b/cmd/serve/unary_handlers_test.go
@@ -410,10 +410,12 @@ func TestMakeChiDynamicParseHandler_PreserveSchemaOrderDefault(t *testing.T) {
 }
 
 // preserveSchemaOrderTruthTable is the shared 5-cell matrix used by
-// every Fiber/chi handler test that exercises the server-default x
-// per-request-field interaction. Defined once so the chi call/parse
-// and Fiber call/parse/stream coverage stays in lockstep — a new row
-// added here is picked up by all consumers.
+// the Fiber helper tests that exercise the server-default x
+// per-request-field interaction. The chi call/parse handler tests
+// keep their own local case tables because they thread the truth
+// table through handler-specific setup (fake caller/parser, header
+// emitter, http.Request construction) rather than calling a helper
+// directly.
 var preserveSchemaOrderTruthTable = []struct {
 	name          string
 	serverDefault bool

--- a/cmd/serve/unary_stub.go
+++ b/cmd/serve/unary_stub.go
@@ -10,6 +10,6 @@ import (
 )
 
 // newUnaryServer is a no-op when the unaryserver build tag is not set.
-func newUnaryServer(_ zerolog.Logger, _ *pool.Pool, _ []string, _ bool) *http.Server {
+func newUnaryServer(_ zerolog.Logger, _ *pool.Pool, _ []string, _ bool, _ bool) *http.Server {
 	return nil
 }

--- a/embed.go
+++ b/embed.go
@@ -16,7 +16,7 @@ import (
 	"github.com/invakid404/baml-rest/workerplugin"
 )
 
-//go:embed LICENSE NOTICE RELEASE.md adapter.go adapters cmd/build cmd/embed cmd/hacks cmd/introspect/main.go cmd/regenerate-dynclient cmd/schema/main.go cmd/serve/debug.go cmd/serve/debug_stub.go cmd/serve/error.go cmd/serve/headers.go cmd/serve/main.go cmd/serve/openapi.json cmd/serve/streamwriter.go cmd/serve/unary.go cmd/serve/unary_handlers.go cmd/serve/unary_stub.go cmd/serve/worker cmd/serve/worker_mode.go cmd/serve/worker_mode_inprocess.go cmd/serve/worker_mode_subprocess.go cmd/verify-adapter-pins cmd/verify-framework-adapter/main.go cmd/worker embed.go go.mod go.sum go.work go.work.sum internal/apierror/error.go internal/httplogger internal/memlimit/memlimit.go internal/rootruntime internal/unsafeutil renovate.json scripts
+//go:embed LICENSE NOTICE RELEASE.md adapter.go adapters cmd/build cmd/embed cmd/hacks cmd/introspect/main.go cmd/regenerate-dynclient cmd/schema/main.go cmd/serve/config.go cmd/serve/debug.go cmd/serve/debug_stub.go cmd/serve/error.go cmd/serve/headers.go cmd/serve/main.go cmd/serve/openapi.json cmd/serve/streamwriter.go cmd/serve/unary.go cmd/serve/unary_handlers.go cmd/serve/unary_stub.go cmd/serve/worker cmd/serve/worker_mode.go cmd/serve/worker_mode_inprocess.go cmd/serve/worker_mode_subprocess.go cmd/verify-adapter-pins cmd/verify-framework-adapter/main.go cmd/worker embed.go go.mod go.sum go.work go.work.sum internal/apierror/error.go internal/httplogger internal/memlimit/memlimit.go internal/rootruntime internal/unsafeutil renovate.json scripts
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/integration/dynamic_output_format_preserve_order_test.go
+++ b/integration/dynamic_output_format_preserve_order_test.go
@@ -175,14 +175,15 @@ func TestDynamicOutputFormatPreserveSchemaOrder(t *testing.T) {
 	assertOrderIn(t, "Mailbox", prompt, "charlie: {", []string{"zip", "city", "street"})
 }
 
-// TestDynamicOutputFormatPreserveSchemaOrder_ServerDefault pins #316:
-// when the server is started with BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT
-// truthy, dynamic requests that omit preserve_schema_order must inherit
-// the default and render the output_format in JSON wire order. A
-// per-request `preserve_schema_order: false` overrides the server
-// default back to the alphabetical fallback. The test boots a
-// dedicated env (the shared TestEnv container has no such env var)
-// and exercises both legs against the same /call/_dynamic endpoint.
+// TestDynamicOutputFormatPreserveSchemaOrder_ServerDefault pins the
+// server-default behavior: when the server is started with
+// BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT truthy, dynamic requests that
+// omit preserve_schema_order must inherit the default and render the
+// output_format in JSON wire order. A per-request
+// `preserve_schema_order: false` overrides the server default back to
+// the alphabetical fallback. The test boots a dedicated env (the
+// shared TestEnv container has no such env var) and exercises both
+// legs against the same /call/_dynamic endpoint.
 func TestDynamicOutputFormatPreserveSchemaOrder_ServerDefault(t *testing.T) {
 	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
 		t.Skip("dynamic endpoints require BAML >= 0.215.0")

--- a/integration/dynamic_output_format_preserve_order_test.go
+++ b/integration/dynamic_output_format_preserve_order_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/goccy/go-json"
 	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
 )
 
 // TestDynamicOutputFormatPreserveSchemaOrder pins #313: when a caller
@@ -171,6 +173,192 @@ func TestDynamicOutputFormatPreserveSchemaOrder(t *testing.T) {
 	// charlie -> Mailbox.
 	assertOrderIn(t, "Profile", prompt, "golf: {", []string{"zulu", "alpha", "status", "preference"})
 	assertOrderIn(t, "Mailbox", prompt, "charlie: {", []string{"zip", "city", "street"})
+}
+
+// TestDynamicOutputFormatPreserveSchemaOrder_ServerDefault pins #316:
+// when the server is started with BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT
+// truthy, dynamic requests that omit preserve_schema_order must inherit
+// the default and render the output_format in JSON wire order. A
+// per-request `preserve_schema_order: false` overrides the server
+// default back to the alphabetical fallback. The test boots a
+// dedicated env (the shared TestEnv container has no such env var)
+// and exercises both legs against the same /call/_dynamic endpoint.
+func TestDynamicOutputFormatPreserveSchemaOrder_ServerDefault(t *testing.T) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		t.Skip("dynamic endpoints require BAML >= 0.215.0")
+	}
+	if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+		t.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
+	}
+
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer setupCancel()
+
+	opts := matrixSetupOptions()
+	opts.RuntimeEnv = map[string]string{
+		"BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT": "true",
+	}
+	env, err := testutil.Setup(setupCtx, opts)
+	if err != nil {
+		t.Fatalf("Failed to setup dedicated env: %v", err)
+	}
+	defer func() {
+		termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer termCancel()
+		if err := env.Terminate(termCtx); err != nil {
+			t.Logf("dedicated env Terminate: %v", err)
+		}
+	}()
+
+	mockClient := mockllm.NewClient(env.MockLLMURL)
+
+	// Helper: register a non-streaming scenario on the dedicated mock and
+	// return a ClientRegistry that targets it. The shared
+	// setupNonStreamingScenario uses TestEnv / MockClient — we need the
+	// dedicated env's clients instead.
+	registerScenario := func(t *testing.T, scenarioID, content string) *testutil.ClientRegistry {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		scenario := &mockllm.Scenario{
+			ID:             scenarioID,
+			Provider:       "openai",
+			Content:        content,
+			ChunkSize:      0,
+			InitialDelayMs: 50,
+		}
+		if err := mockClient.RegisterScenario(ctx, scenario); err != nil {
+			t.Fatalf("RegisterScenario: %v", err)
+		}
+		return testutil.CreateTestClient(env.MockLLMInternal, scenarioID)
+	}
+
+	responseContent := `{
+  "alpha": 1,
+  "bravo": "b",
+  "charlie": {"city": "Sofia", "street": "Main", "zip": "1000"},
+  "delta": "d",
+  "echo": true,
+  "foxtrot": "ACTIVE",
+  "golf": {"alpha": 7, "preference": "HIGH", "status": "PENDING", "zulu": "z"},
+  "hotel": ["x", "y"]
+}`
+
+	// Build a raw JSON request body with the same schema as the #313
+	// preserve-order test, but parameterized on the preserve_schema_order
+	// field so we can exercise omitted vs. false in the same env.
+	buildReq := func(t *testing.T, registry *testutil.ClientRegistry, preserveField string) string {
+		t.Helper()
+		registryJSON, err := json.Marshal(registry)
+		if err != nil {
+			t.Fatalf("marshal client_registry: %v", err)
+		}
+		return fmt.Sprintf(`{
+  %s
+  "messages": [
+    {
+      "role": "system",
+      "content": [
+        {"type": "text", "text": "Return only JSON matching the requested schema."},
+        {"type": "output_format"}
+      ]
+    },
+    {"role": "user", "content": "Build a sample record."}
+  ],
+  "client_registry": %s,
+  "output_schema": {
+    "properties": {
+      "delta": {"type": "string"},
+      "alpha": {"type": "int"},
+      "hotel": {"type": "list", "items": {"type": "string"}},
+      "charlie": {"ref": "Mailbox"},
+      "bravo": {"type": "string"},
+      "foxtrot": {"ref": "Status"},
+      "echo": {"type": "bool"},
+      "golf": {"ref": "Profile"}
+    },
+    "classes": {
+      "Profile": {
+        "properties": {
+          "zulu": {"type": "string"},
+          "alpha": {"type": "int"},
+          "status": {"ref": "Status"},
+          "preference": {"ref": "Preference"}
+        }
+      },
+      "Mailbox": {
+        "properties": {
+          "zip": {"type": "string"},
+          "city": {"type": "string"},
+          "street": {"type": "string"}
+        }
+      }
+    },
+    "enums": {
+      "Status": {"values": [{"name": "PENDING"}, {"name": "ACTIVE"}, {"name": "ARCHIVED"}]},
+      "Preference": {"values": [{"name": "LOW"}, {"name": "MEDIUM"}, {"name": "HIGH"}]}
+    }
+  }
+}`, preserveField, string(registryJSON))
+	}
+
+	url := fmt.Sprintf("%s/call/_dynamic", env.BAMLRestURL)
+
+	t.Run("omitted_inherits_server_default_true", func(t *testing.T) {
+		scenarioID := "test-server-default-omitted"
+		registry := registerScenario(t, scenarioID, responseContent)
+		req := buildReq(t, registry, "")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := postRaw(ctx, url, req); err != nil {
+			t.Fatalf("POST failed: %v", err)
+		}
+
+		inspectCtx, inspectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer inspectCancel()
+		capturedBody, err := mockClient.GetLastRequest(inspectCtx, scenarioID)
+		if err != nil {
+			t.Fatalf("GetLastRequest: %v", err)
+		}
+		prompt, err := extractFirstMessageText(capturedBody)
+		if err != nil {
+			t.Fatalf("extractFirstMessageText: %v\ncaptured: %s", err, string(capturedBody))
+		}
+
+		assertOrderIn(t, "top-level (wire order)", prompt, "", []string{"delta", "alpha", "hotel", "charlie", "bravo", "foxtrot", "echo", "golf"})
+		assertOrderIn(t, "Profile (wire order)", prompt, "golf: {", []string{"zulu", "alpha", "status", "preference"})
+		assertOrderIn(t, "Mailbox (wire order)", prompt, "charlie: {", []string{"zip", "city", "street"})
+	})
+
+	t.Run("explicit_false_overrides_server_default", func(t *testing.T) {
+		scenarioID := "test-server-default-explicit-false"
+		registry := registerScenario(t, scenarioID, responseContent)
+		req := buildReq(t, registry, `"preserve_schema_order": false,`)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := postRaw(ctx, url, req); err != nil {
+			t.Fatalf("POST failed: %v", err)
+		}
+
+		inspectCtx, inspectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer inspectCancel()
+		capturedBody, err := mockClient.GetLastRequest(inspectCtx, scenarioID)
+		if err != nil {
+			t.Fatalf("GetLastRequest: %v", err)
+		}
+		prompt, err := extractFirstMessageText(capturedBody)
+		if err != nil {
+			t.Fatalf("extractFirstMessageText: %v\ncaptured: %s", err, string(capturedBody))
+		}
+
+		// Alphabetical fallback — same schema, but the renderer must sort
+		// each block lexicographically.
+		assertOrderIn(t, "top-level (alphabetical)", prompt, "", []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"})
+		assertOrderIn(t, "Profile (alphabetical)", prompt, "golf: {", []string{"alpha", "preference", "status", "zulu"})
+		assertOrderIn(t, "Mailbox (alphabetical)", prompt, "charlie: {", []string{"city", "street", "zip"})
+	})
 }
 
 // assertOrderIn checks that the listed field names appear in the


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes #316.

## Summary

Follow-up to #313 (just merged). Adds a server-instance-level default for `preserve_schema_order` so operators can flip the rendered `output_format` ordering policy without per-request opt-in on every call.

Per-request explicit value still wins. Defaults remain backwards-compatible: env var unset → existing alphabetical-sort behavior.

## API shape

New env var:

```
BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT={1|true|yes|on}
```

Truthy parsing matches `BAML_REST_USE_BUILD_REQUEST` exactly.

Effective behavior:

| Server default | Request field | Result |
|---|---|---|
| off | omitted | sorted alphabetical (existing default) |
| off | `true` | preserve |
| off | `false` | sorted alphabetical |
| on | omitted | preserve |
| on | `true` | preserve |
| on | `false` | sorted alphabetical (caller opt-out) |
| on | `null` | preserve (null = absent = inherit default) |

## Design: `*bool` tri-state

`DynamicInput.PreserveSchemaOrder` and `DynamicParseInput.PreserveSchemaOrder` change from `bool` to `*bool`. Tri-state:

- JSON absent → nil → inherit server default.
- JSON `true` → `*true` → preserve.
- JSON `false` → `*false` → explicit opt-out.
- JSON `null` → nil → inherit server default (Go's default pointer-unmarshal behavior).

`omitempty` on the pointer means non-nil values always serialize; nil is omitted.

This is a breaking change for direct Go consumers of `bamlutils.DynamicInput` / `dynclient.Request`. **#313 has been held back from release for this reason** — the two changes ship together so no external consumer sees a transition.

## Out of scope

- **dynclient client-instance parity** (`WithPreserveSchemaOrderDefault`) — separate follow-up that also makes `preserve_schema_order` the default in dynclient and likely changes the dynclient types to ordered maps. Tracked separately.
- Changing the wire default. Sorted alphabetical remains the default unless the operator opts in.

## What changed

### Commit 1 — `refactor(bamlutils): convert PreserveSchemaOrder to *bool tri-state` (`bb558fb62`)

- `DynamicInput.PreserveSchemaOrder` and `DynamicParseInput.PreserveSchemaOrder`: `bool` → `*bool` with `json:"preserve_schema_order,omitempty"`.
- New `preserveSchemaOrderEnabled(p *bool) bool` helper; every internal read site (`Validate`/`ToWorkerInput` × `DynamicInput`/`DynamicParseInput`) migrated to use it.
- Worker-bound `DynamicTypes.PreserveOrder bool` is unchanged (only the public request opt-in is tri-state).
- Existing test literals migrated from `PreserveSchemaOrder: true` to `PreserveSchemaOrder: boolPtr(true)` via a tiny local helper (no new dep).
- New unit tests `TestDynamicInput_Validate_PreserveSchemaOrderTriState` + `TestDynamicParseInput_Validate_PreserveSchemaOrderTriState` cover nil / true / false / JSON null.
- OpenAPI: `preserve_schema_order` on both `__DynamicInput__` and `__DynamicParseInput__` now `Nullable: true`. `TestSchemaPreserveOrderExposure` asserts `isNullable(prop)`.

### Commit 2 — `feat(serve): BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT env var` (`69909167e`)

- New `cmd/serve/config.go` declaring `envPreserveSchemaOrderDefault` + `parseTruthyEnvBool` (matches `BAML_REST_USE_BUILD_REQUEST` truthy parsing) + `preserveSchemaOrderDefaultFromEnv()`.
- Default resolved once at startup in `cmd/serve/main.go` alongside other env-driven config.
- `applyPreserveSchemaOrderDefault(*DynamicInput, bool)` + `applyParsePreserveSchemaOrderDefault(*DynamicParseInput, bool)` helpers — no-op when the field is already non-nil.
- Defaulting applied after `json.Unmarshal` and before `Validate()` in every dynamic handler path:
  - Fiber call/parse handlers in `cmd/serve/main.go`.
  - `parseDynamicStreamInput` (signature accepts the default).
  - Chi `makeChiDynamicCallHandler` / `makeChiDynamicCallHandlerWithEmitter` / `makeChiDynamicParseHandler` (signatures accept the default).
- Worker-side: no changes (defaulting happens in the HTTP host before `ToWorkerInput`).
- New tests: `TestParseTruthyEnvBool`, `TestApply{,Parse}PreserveSchemaOrderDefault*`, chi-handler truth-table tests, `TestParseDynamicStreamInput_PreserveSchemaOrderDefault` — all 5 cells per handler.
- README: new bullet for `BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT`.
- Integration test extends `integration/dynamic_output_format_preserve_order_test.go`: starts a dedicated env via `testutil.SetupOptions.RuntimeEnv` with the var set, verifies both omitted-inherits-on and explicit-false-overrides.

### Commit 3 — `chore: scrub issue-number breadcrumbs from comments` (`36706db29`)

- Replaced `#316` references in 9 files with durable behavioral descriptions (or removed when the comment added nothing beyond the issue reference).

## Test plan

- `go vet ./bamlutils/... ./cmd/serve/... ./cmd/schema/...` ✓
- `go build ./...` and `go build -tags=unaryserver,subprocess ./...` ✓
- `go test ./bamlutils/ -count=1` ✓
- `go test ./cmd/serve/ -count=1` ✓
- `go test -tags=unaryserver ./cmd/serve/ -count=1` ✓
- `go test ./cmd/schema/ -count=1` ✓
- Integration test compiles with `go build -tags=integration ./integration/...` ✓

## Files

```
README.md                                                |  ~10
bamlutils/dynamic.go                                     |  ~40
bamlutils/dynamic_test.go                                |  ~180
cmd/schema/main.go                                       |  ~10
cmd/schema/main_test.go                                  |  ~20
cmd/serve/config.go                                      |  ~80 (new)
cmd/serve/config_test.go                                 |  ~200 (new)
cmd/serve/main.go                                        |  ~40
cmd/serve/unary.go                                       |  ~20
cmd/serve/unary_handlers.go                              |  ~30
cmd/serve/unary_handlers_test.go                         |  ~250
integration/dynamic_output_format_preserve_order_test.go |  ~120
```

Refs #313, #315.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-level default for preserve_schema_order via BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT; dynamic requests can omit/null to inherit it while explicit per-request values override.

* **Documentation**
  * README updated to document the new environment variable and tri-state (true/false/null) behavior.

* **Tests**
  * Added and expanded unit and integration tests covering tri-state handling, default resolution, and runtime output ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->