### PR TITLE
chore(release): release-prep for 0.0.45

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,10 @@
 # Release Procedure
 
-> **DO NOT SKIP RELEASE-PREP.** Tagging before the first-party `v0.0.X` requires
-> are in the merged commit will cause `scripts/release-go-tags.sh` to reject the
-> Go module tags, and recovery requires force-moving the product tag (already
-> pushed and possibly already attached to a GitHub Release) — see #308.
+> **DO NOT SKIP RELEASE-PREP.** Tagging before the first-party `require`
+> statements have been bumped to `v0.0.X` in the merged commit will cause
+> `scripts/release-go-tags.sh` to reject the Go module tags, and recovery
+> requires force-moving the product tag (already pushed and possibly already
+> attached to a GitHub Release) — see #308.
 
 This document is the maintainer-facing guide for cutting a baml-rest
 release. It covers both the existing product release (binary + Docker)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # Release Procedure
 
+> **DO NOT SKIP RELEASE-PREP.** Tagging before the first-party `v0.0.X` requires
+> are in the merged commit will cause `scripts/release-go-tags.sh` to reject the
+> Go module tags, and recovery requires force-moving the product tag (already
+> pushed and possibly already attached to a GitHub Release) — see #308.
+
 This document is the maintainer-facing guide for cutting a baml-rest
 release. It covers both the existing product release (binary + Docker)
 and the additive subdir-prefixed Go module tags that let downstream

--- a/adapters/adapter_v0_204_0/go.mod
+++ b/adapters/adapter_v0_204_0/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.44 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.44 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.45 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.45 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/adapter_v0_215_0/go.mod
+++ b/adapters/adapter_v0_215_0/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.44 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.44 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.45 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.45 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/adapter_v0_219_0/go.mod
+++ b/adapters/adapter_v0_219_0/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.44 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.44 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.45 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.45 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/common/go.mod
+++ b/adapters/common/go.mod
@@ -5,8 +5,8 @@ go 1.26.3
 require (
 	github.com/boundaryml/baml v0.204.0
 	github.com/dave/jennifer v1.7.1
-	github.com/invakid404/baml-rest/bamlutils v0.0.44
-	github.com/invakid404/baml-rest/introspected v0.0.44
+	github.com/invakid404/baml-rest/bamlutils v0.0.45
+	github.com/invakid404/baml-rest/introspected v0.0.45
 	github.com/stoewer/go-strcase v1.3.1
 )
 

--- a/dynclient/go.mod
+++ b/dynclient/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/goccy/go-json v0.10.6
 	github.com/google/uuid v1.6.0
 	github.com/gregwebs/go-recovery v0.4.1
-	github.com/invakid404/baml-rest/adapters/common v0.0.44
-	github.com/invakid404/baml-rest/bamlutils v0.0.44
-	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.44
-	github.com/invakid404/baml-rest/worker v0.0.44
-	github.com/invakid404/baml-rest/workerplugin v0.0.44
+	github.com/invakid404/baml-rest/adapters/common v0.0.45
+	github.com/invakid404/baml-rest/bamlutils v0.0.45
+	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.45
+	github.com/invakid404/baml-rest/worker v0.0.45
+	github.com/invakid404/baml-rest/workerplugin v0.0.45
 	github.com/prometheus/client_golang v1.23.2
 )
 
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.8.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.44 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.45 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect

--- a/introspected/go.mod
+++ b/introspected/go.mod
@@ -2,7 +2,7 @@ module github.com/invakid404/baml-rest/introspected
 
 go 1.26.3
 
-require github.com/invakid404/baml-rest/bamlutils v0.0.44
+require github.com/invakid404/baml-rest/bamlutils v0.0.45
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect

--- a/pool/go.mod
+++ b/pool/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/gregwebs/go-recovery v0.4.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
-	github.com/invakid404/baml-rest/bamlutils v0.0.44
-	github.com/invakid404/baml-rest/workerplugin v0.0.44
+	github.com/invakid404/baml-rest/bamlutils v0.0.45
+	github.com/invakid404/baml-rest/workerplugin v0.0.45
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1
 	google.golang.org/grpc v1.81.1

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -4,8 +4,8 @@ go 1.26.3
 
 require (
 	github.com/goccy/go-json v0.10.6
-	github.com/invakid404/baml-rest/bamlutils v0.0.44
-	github.com/invakid404/baml-rest/workerplugin v0.0.44
+	github.com/invakid404/baml-rest/bamlutils v0.0.45
+	github.com/invakid404/baml-rest/workerplugin v0.0.45
 	github.com/prometheus/client_golang v1.23.2
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )

--- a/workerplugin/go.mod
+++ b/workerplugin/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/hashicorp/go-plugin v1.8.0
-	github.com/invakid404/baml-rest/bamlutils v0.0.44
+	github.com/invakid404/baml-rest/bamlutils v0.0.45
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Release-prep for the `0.0.45` cut — rewrites first-party `require` edges from `v0.0.44` to `v0.0.45` across the published Go modules so `scripts/release-go-tags.sh 0.0.45` will accept the subdir tags after the product tag is pushed.

Covers two feature merges that should land on the same release boundary:

- #313 / #315 — opt-in `preserve_schema_order` for `output_schema`.
- #316 / #317 — server-level default for `preserve_schema_order` (introduces the `bool` → `*bool` tri-state on the public Go API).

Held together so the public Go API transition lands in a single release.

## What's in this PR

- First-party require rewrites (`v0.0.44` → `v0.0.45`):
  - `dynclient/go.mod` — `adapters/common`, `bamlutils`, `dynclient/baml-patched`, `worker`, `workerplugin`, indirect `introspected`.
  - `adapters/common/go.mod` — `bamlutils`, `introspected`.
  - `introspected/go.mod` — `bamlutils`.
  - `worker/go.mod` — `bamlutils`, `workerplugin`.
  - `workerplugin/go.mod` — `bamlutils`.
- Sync-driven side effects (produced by `./scripts/sync.sh`, matching the #296 and #312 pattern):
  - `pool/go.mod` — `bamlutils`, `workerplugin`.
  - `adapters/adapter_v0_204_0/go.mod`, `adapters/adapter_v0_215_0/go.mod`, `adapters/adapter_v0_219_0/go.mod` — indirect `bamlutils` / `introspected`.
- `RELEASE.md`: top-of-file `DO NOT SKIP RELEASE-PREP` callout that pays down the exact gap that caused #308 (tag-before-release-prep) and points at the force-move recovery cost.

No production-code changes; only `go.mod` require updates plus a `RELEASE.md` callout.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `(cd dynclient && GOWORK=off go test ./... -count=1)`
- [x] `./scripts/sync.sh --check-pins-only` (clean before and after)
- [x] `git status` shows only the intended release-prep files before commit
- [ ] CI green on this PR before merging

After this merges, the orchestrator handles the tag sequence: product tag `0.0.45` at the merge SHA, the GitHub Release, then `./scripts/release-go-tags.sh 0.0.45` for the seven subdir Go module tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an explicit maintainer warning and expanded release-prep guidance in the release documentation.

* **Chores**
  * Bumped several internal module dependency versions across adapters and components to align versions and ensure consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->