### PR TITLE
feat(dynclient,llmhttp): orthogonal backend selection + unbounded conn defaults (#314)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,20 @@ tuning option can apply in parallel.
 
 ```go
 import (
+    "net/http"
+
     "github.com/invakid404/baml-rest/bamlutils/llmhttp"
     "github.com/invakid404/baml-rest/dynclient"
 )
 
+netClient := &http.Client{
+    Transport: http.DefaultTransport.(*http.Transport).Clone(),
+}
+
 // Force net/http with a custom *http.Client:
 dynclient.New(
     dynclient.WithClientMode(llmhttp.ClientModeNetHTTP),
-    dynclient.WithNetHTTPClient(client),
+    dynclient.WithNetHTTPClient(netClient),
 )
 
 // Force net/http with the package's tuned default transport
@@ -63,7 +69,7 @@ dynclient.New(
 
 // Keep Auto mode and tune both backend families:
 dynclient.New(
-    dynclient.WithNetHTTPClient(client),
+    dynclient.WithNetHTTPClient(netClient),
     dynclient.WithFastHTTPClient(llmhttp.FastHTTPClientOptions{MaxConns: 1024}),
 )
 ```

--- a/README.md
+++ b/README.md
@@ -27,9 +27,54 @@ c, err := dynclient.New(
 // c.DynamicStream(ctx, req)
 ```
 
-See [`dynclient/`](dynclient/) for the full surface (8 options, 5 endpoint
+See [`dynclient/`](dynclient/) for the full surface (10 options, 5 endpoint
 methods, iterator-style streaming). The patched-BAML CFFI library is
 bundled as a nested module — no separate setup required.
+
+### HTTP backend selection and tuning
+
+The underlying HTTP backend (net/http vs fasthttp) is chosen by
+`WithClientMode` and tuned independently by `WithNetHTTPClient`
+(net/http only) and `WithFastHTTPClient` (fasthttp only). Selection and
+tuning are orthogonal axes: the default `llmhttp.ClientModeAuto` routes
+each origin to the appropriate backend via an ALPN probe, and either
+tuning option can apply in parallel.
+
+```go
+import (
+    "github.com/invakid404/baml-rest/bamlutils/llmhttp"
+    "github.com/invakid404/baml-rest/dynclient"
+)
+
+// Force net/http with a custom *http.Client:
+dynclient.New(
+    dynclient.WithClientMode(llmhttp.ClientModeNetHTTP),
+    dynclient.WithNetHTTPClient(client),
+)
+
+// Force net/http with the package's tuned default transport
+// (no custom client needed):
+dynclient.New(dynclient.WithClientMode(llmhttp.ClientModeNetHTTP))
+
+// Keep Auto mode and tune fasthttp routes only:
+dynclient.New(
+    dynclient.WithFastHTTPClient(llmhttp.FastHTTPClientOptions{MaxConns: 1024}),
+)
+
+// Keep Auto mode and tune both backend families:
+dynclient.New(
+    dynclient.WithNetHTTPClient(client),
+    dynclient.WithFastHTTPClient(llmhttp.FastHTTPClientOptions{MaxConns: 1024}),
+)
+```
+
+Forced modes reject tuning aimed at the unused backend — e.g.
+`WithClientMode(ClientModeNetHTTP)` combined with `WithFastHTTPClient`
+is a hard error from `New` so the misconfiguration surfaces at startup
+rather than as a silent no-op at request time.
+
+`BAML_REST_HTTP_CLIENT` (`auto`/`fasthttp`/`nethttp`) is a server/worker
+env var only; dynclient stays explicit-only and never reads it.
 
 ## Runtime configuration
 

--- a/bamlutils/llmhttp/cache.go
+++ b/bamlutils/llmhttp/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -16,6 +17,14 @@ import (
 	"github.com/valyala/fasthttp"
 	"golang.org/x/sync/singleflight"
 )
+
+// defaultFastHTTPMaxConns is the per-origin connection cap used when
+// FastHTTPClientOptions.MaxConns is zero or negative. fasthttp falls back
+// to DefaultMaxConnsPerHost = 512 on its own zero value, which throttles
+// LLM workloads that funnel many concurrent requests at a few hosts. We
+// pick math.MaxInt32 — large enough to never bound real traffic, small
+// enough to fit a Go int on every platform we support.
+const defaultFastHTTPMaxConns = math.MaxInt32
 
 // ClientMode selects how requests are dispatched between the net/http
 // and fasthttp backends. Constructed via NewClient (env-driven) or
@@ -124,17 +133,27 @@ type protocolCache struct {
 	sf        singleflight.Group
 }
 
-// newProtocolCache constructs a cache configured for the given mode. tlsConf
-// is mirrored into both the probe dialer and every per-origin HostClient so
-// that private CAs / custom verification apply consistently across
-// dispatched backends and the probe itself. A nil tlsConf is treated as the
-// default {MinVersion: TLS12}. proxyFunc determines when origins are pinned
-// to net/http for proxy traversal; a nil value disables proxy pinning
-// (tests use this to force the ALPN probe path).
-func newProtocolCache(mode clientMode, tlsConf *tls.Config, proxyFunc func(*http.Request) (*url.URL, error)) *protocolCache {
+// newProtocolCache constructs a cache configured for the given mode.
+// fastOpts.TLSConfig is mirrored into both the probe dialer and every
+// per-origin HostClient so that private CAs / custom verification apply
+// consistently across dispatched backends and the probe itself. A nil
+// fastOpts.TLSConfig is treated as the default {MinVersion: TLS12}. The
+// remaining fastOpts fields (MaxConns, MaxConnWaitTimeout,
+// MaxIdleConnDuration) propagate to every HostClient buildEntry produces.
+// proxyFunc determines when origins are pinned to net/http for proxy
+// traversal; a nil value disables proxy pinning (tests use this to force
+// the ALPN probe path).
+func newProtocolCache(mode clientMode, fastOpts FastHTTPClientOptions, proxyFunc func(*http.Request) (*url.URL, error)) *protocolCache {
+	tlsConf := fastOpts.TLSConfig
 	if tlsConf == nil {
 		tlsConf = &tls.Config{MinVersion: tls.VersionTLS12}
 	}
+
+	maxConns := fastOpts.MaxConns
+	if maxConns <= 0 {
+		maxConns = defaultFastHTTPMaxConns
+	}
+
 	c := &protocolCache{
 		mode:         mode,
 		probeTLS:     tlsConf,
@@ -145,8 +164,9 @@ func newProtocolCache(mode clientMode, tlsConf *tls.Config, proxyFunc func(*http
 			Name:                          "baml-rest-llmhttp",
 			DisableHeaderNamesNormalizing: true,
 			StreamResponseBody:            true,
-			MaxIdleConnDuration:           90 * time.Second,
-			MaxConns:                      256,
+			MaxIdleConnDuration:           fastOpts.MaxIdleConnDuration,
+			MaxConnWaitTimeout:            fastOpts.MaxConnWaitTimeout,
+			MaxConns:                      maxConns,
 			TLSConfig:                     tlsConf,
 		},
 	}
@@ -361,6 +381,7 @@ func (c *protocolCache) buildEntry(origin originURL, d decision) *hostEntry {
 		DisableHeaderNamesNormalizing: tmpl.DisableHeaderNamesNormalizing,
 		StreamResponseBody:            tmpl.StreamResponseBody,
 		MaxIdleConnDuration:           tmpl.MaxIdleConnDuration,
+		MaxConnWaitTimeout:            tmpl.MaxConnWaitTimeout,
 		MaxConns:                      tmpl.MaxConns,
 		TLSConfig:                     tmpl.TLSConfig,
 	}

--- a/bamlutils/llmhttp/cache.go
+++ b/bamlutils/llmhttp/cache.go
@@ -338,7 +338,15 @@ func (c *protocolCache) probe(origin originURL) decision {
 	}
 
 	cfg := c.probeTLS.Clone()
-	cfg.ServerName = origin.hostname
+	// Preserve a caller-supplied ServerName (FastHTTPClientOptions.TLSConfig
+	// or NewClient's injected http.Client.Transport.TLSClientConfig). The
+	// pooled and streaming HostClients use the same "fill if empty" rule,
+	// so an origin that needs a custom SNI for fasthttp would otherwise
+	// probe with the URL hostname, fail ALPN against the real server, and
+	// pin to net/http even though fasthttp was explicitly configured.
+	if cfg.ServerName == "" {
+		cfg.ServerName = origin.hostname
+	}
 	cfg.NextProtos = []string{"h2", "http/1.1"}
 
 	probeCtx, cancel := context.WithTimeout(context.Background(), c.probeTimeout)

--- a/bamlutils/llmhttp/cache_test.go
+++ b/bamlutils/llmhttp/cache_test.go
@@ -2,11 +2,14 @@ package llmhttp
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestParseOrigin(t *testing.T) {
@@ -248,5 +251,77 @@ func TestBuildEntry_FastCarriesHost(t *testing.T) {
 	net := cache.buildEntry(origin, decisionNet)
 	if net.host != nil {
 		t.Error("decisionNet entry must not allocate a HostClient")
+	}
+}
+
+// TestProbe_PreservesCallerServerName guards against the Auto-mode probe
+// clobbering a caller-supplied TLSConfig.ServerName with the URL
+// hostname. A caller that overrides SNI via
+// FastHTTPClientOptions.TLSConfig.ServerName (e.g. to talk to an LLM
+// gateway whose cert advertises a different name than the dial target)
+// must see that ServerName reach the wire during the probe — otherwise
+// the probe handshake would fail and the origin would be silently pinned
+// to net/http, defeating the configured fasthttp tuning.
+//
+// The test captures the ClientHello SNI server-side via
+// GetConfigForClient. With the fix, the wire SNI equals the caller's
+// override. Without the fix, the probe would overwrite ServerName with
+// "127.0.0.1" (the URL hostname), which Go's TLS stack strips before
+// emitting SNI — so the buggy path observes an empty SNI on the wire.
+func TestProbe_PreservesCallerServerName(t *testing.T) {
+	const callerSNI = "custom.sni.example"
+
+	sniCh := make(chan string, 1)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.TLS = &tls.Config{
+		GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+			select {
+			case sniCh <- hello.ServerName:
+			default:
+			}
+			return nil, nil
+		},
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+
+	// InsecureSkipVerify so the probe handshake completes despite the
+	// caller's ServerName not matching the test certificate's SAN — we
+	// care about what SNI hits the wire, not about cert verification.
+	tlsCfg := &tls.Config{
+		ServerName:         callerSNI,
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+	}
+	cache := newProtocolCache(modeAuto, FastHTTPClientOptions{TLSConfig: tlsCfg}, nil)
+
+	origin, err := parseOrigin("https://" + u.Host + "/")
+	if err != nil {
+		t.Fatalf("parseOrigin: %v", err)
+	}
+	if got := cache.resolve(context.Background(), origin); got == nil {
+		t.Fatal("resolve returned nil")
+	}
+
+	select {
+	case sni := <-sniCh:
+		if sni != callerSNI {
+			t.Errorf("probe sent SNI %q on the wire, want caller-supplied %q (URL hostname was %q)", sni, callerSNI, origin.hostname)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("probe did not reach the TLS server within 5s")
+	}
+
+	// The caller's TLSConfig itself must not be mutated by the probe —
+	// the clone is what gets the NextProtos / ServerName tweaks.
+	if tlsCfg.ServerName != callerSNI {
+		t.Errorf("caller's TLSConfig.ServerName mutated to %q; probe must clone before edit", tlsCfg.ServerName)
 	}
 }

--- a/bamlutils/llmhttp/cache_test.go
+++ b/bamlutils/llmhttp/cache_test.go
@@ -55,7 +55,7 @@ func TestProtocolCacheMode_HTTPAlwaysFast(t *testing.T) {
 	// Plain http:// must never probe — the cache decides "fast" immediately.
 	// The fact that the probe TLS dialer points at nothing is sufficient
 	// proof that we didn't attempt one.
-	cache := newProtocolCache(modeAuto, nil, nil)
+	cache := newProtocolCache(modeAuto, FastHTTPClientOptions{}, nil)
 	origin, err := parseOrigin("http://example.invalid/")
 	if err != nil {
 		t.Fatal(err)
@@ -70,7 +70,7 @@ func TestProtocolCacheMode_HTTPAlwaysFast(t *testing.T) {
 }
 
 func TestProtocolCacheMode_OverrideFast(t *testing.T) {
-	cache := newProtocolCache(modeFast, nil, nil)
+	cache := newProtocolCache(modeFast, FastHTTPClientOptions{}, nil)
 	origin, err := parseOrigin("https://api.openai.com/")
 	if err != nil {
 		t.Fatal(err)
@@ -85,7 +85,7 @@ func TestProtocolCacheMode_OverrideFast(t *testing.T) {
 }
 
 func TestProtocolCacheMode_OverrideNet(t *testing.T) {
-	cache := newProtocolCache(modeNet, nil, nil)
+	cache := newProtocolCache(modeNet, FastHTTPClientOptions{}, nil)
 	origin, err := parseOrigin("https://api.openai.com/")
 	if err != nil {
 		t.Fatal(err)
@@ -103,7 +103,7 @@ func TestProtocolCache_ProxyPinsNet(t *testing.T) {
 	proxy := func(req *http.Request) (*url.URL, error) {
 		return &url.URL{Scheme: "http", Host: "proxy.example:3128"}, nil
 	}
-	cache := newProtocolCache(modeAuto, nil, proxy)
+	cache := newProtocolCache(modeAuto, FastHTTPClientOptions{}, proxy)
 	origin, err := parseOrigin("https://api.openai.com/")
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +121,7 @@ func TestProtocolCache_ProxyPinsNetForHTTP(t *testing.T) {
 	proxy := func(req *http.Request) (*url.URL, error) {
 		return &url.URL{Scheme: "http", Host: "proxy.example:3128"}, nil
 	}
-	cache := newProtocolCache(modeAuto, nil, proxy)
+	cache := newProtocolCache(modeAuto, FastHTTPClientOptions{}, proxy)
 	origin, err := parseOrigin("http://internal.service/")
 	if err != nil {
 		t.Fatal(err)
@@ -137,7 +137,7 @@ func TestProtocolCache_CacheHitIsLockFree(t *testing.T) {
 	// go through singleflight or any mutex — hit the atomic map and return.
 	// We approximate this by racing many resolvers and ensuring no data
 	// races trip the race detector. The `go test -race` pass catches it.
-	cache := newProtocolCache(modeFast, nil, nil)
+	cache := newProtocolCache(modeFast, FastHTTPClientOptions{}, nil)
 	origin, err := parseOrigin("http://host/")
 	if err != nil {
 		t.Fatal(err)
@@ -168,7 +168,7 @@ func TestProtocolCache_SingleflightDedupe(t *testing.T) {
 		probes.Add(1)
 		return &url.URL{Scheme: "http", Host: "proxy:3128"}, nil
 	}
-	cache := newProtocolCache(modeAuto, nil, proxy)
+	cache := newProtocolCache(modeAuto, FastHTTPClientOptions{}, proxy)
 	origin, err := parseOrigin("https://host/")
 	if err != nil {
 		t.Fatal(err)
@@ -228,7 +228,7 @@ func TestLoadClientMode(t *testing.T) {
 // decision always ships with a non-nil HostClient (dispatcher nil-checks
 // it), while a net decision never allocates one.
 func TestBuildEntry_FastCarriesHost(t *testing.T) {
-	cache := newProtocolCache(modeAuto, nil, nil)
+	cache := newProtocolCache(modeAuto, FastHTTPClientOptions{}, nil)
 	origin, err := parseOrigin("https://x/")
 	if err != nil {
 		t.Fatalf("parseOrigin: %v", err)

--- a/bamlutils/llmhttp/fast_backend.go
+++ b/bamlutils/llmhttp/fast_backend.go
@@ -166,10 +166,18 @@ func (c *Client) executeStreamFast(ctx context.Context, req *Request, rewrittenU
 	var doErr error
 	select {
 	case <-ctx.Done():
+		// Severing the captured conn via slot.shutdown should unblock
+		// hc.Do promptly, but hand off the wait so ctx.Err() reaches
+		// the caller without blocking on Do's wind-down. Mirrors the
+		// non-streaming executeFast cleanup. Any error from the orphan
+		// Do is intentionally unsurfaced — the caller has already seen
+		// ctx.Err().
 		slot.shutdown()
-		<-doneCh
-		fasthttp.ReleaseRequest(fReq)
-		fasthttp.ReleaseResponse(fResp)
+		go func() {
+			<-doneCh
+			fasthttp.ReleaseRequest(fReq)
+			fasthttp.ReleaseResponse(fResp)
+		}()
 		return nil, ctx.Err()
 	case doErr = <-doneCh:
 	}

--- a/bamlutils/llmhttp/fast_backend.go
+++ b/bamlutils/llmhttp/fast_backend.go
@@ -405,6 +405,7 @@ func newStreamHostClient(ctx context.Context, tmpl *fasthttp.HostClient, slot *c
 		DisableHeaderNamesNormalizing: tmpl.DisableHeaderNamesNormalizing,
 		StreamResponseBody:            tmpl.StreamResponseBody,
 		MaxIdleConnDuration:           tmpl.MaxIdleConnDuration,
+		MaxConnWaitTimeout:            tmpl.MaxConnWaitTimeout,
 		MaxConns:                      tmpl.MaxConns,
 		Dial: func(addr string) (net.Conn, error) {
 			dialer := &net.Dialer{

--- a/bamlutils/llmhttp/llmhttp.go
+++ b/bamlutils/llmhttp/llmhttp.go
@@ -13,6 +13,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -122,16 +123,53 @@ type Client struct {
 	useGlobalRewriteRules bool
 }
 
+// FastHTTPClientOptions tunes the fasthttp backend. Each field affects
+// only origins that route through fasthttp — either because Mode is
+// ClientModeFastHTTP or because Auto mode resolved an origin to
+// fasthttp via the ALPN probe.
+//
+// The net/http backend is tuned via ClientOptions.NetHTTPClient: the
+// caller supplies a configured *http.Client whose Transport.* fields
+// (MaxConnsPerHost, MaxIdleConnsPerHost, etc.) apply on that path.
+type FastHTTPClientOptions struct {
+	// MaxConns is the per-origin active connection cap for fasthttp.
+	// Values <= 0 use llmhttp's effectively-unbounded default
+	// (math.MaxInt32). fasthttp's own zero value falls back to
+	// DefaultMaxConnsPerHost = 512, which is too low for LLM traffic
+	// that funnels many concurrent requests to a few hosts.
+	MaxConns int
+
+	// MaxConnWaitTimeout is copied to fasthttp.HostClient. Zero keeps
+	// fasthttp's default no-wait behaviour: when MaxConns is saturated,
+	// Do returns ErrNoFreeConns immediately rather than blocking.
+	MaxConnWaitTimeout time.Duration
+
+	// MaxIdleConnDuration is copied to fasthttp.HostClient. Zero keeps
+	// fasthttp's default (10 seconds). Higher values reduce TLS
+	// handshakes for sustained LLM traffic.
+	MaxIdleConnDuration time.Duration
+
+	// TLSConfig is used by the fasthttp backend (per-origin HostClient)
+	// and the auto-mode ALPN probe. When nil, the default
+	// {MinVersion: TLS12} applies. The net/http backend gets its TLS
+	// config from NetHTTPClient.Transport.TLSClientConfig.
+	TLSConfig *tls.Config
+}
+
 // ClientOptions configures NewClientWithOptions / NewDefaultClientWithOptions.
 // All fields are optional; the constructors apply sensible defaults
 // matching the legacy env-driven NewClient(nil) shape when the
 // corresponding field is zero.
 type ClientOptions struct {
-	// HTTPClient is the underlying *http.Client. When nil, the
-	// constructor's default is used: http.DefaultClient for
-	// NewClientWithOptions; the tuned defaultLLMTransport-backed
-	// client for NewDefaultClientWithOptions.
-	HTTPClient *http.Client
+	// NetHTTPClient is the underlying *http.Client used by the net/http
+	// backend. When nil, the constructor's default is used:
+	// http.DefaultClient for NewClientWithOptions; the tuned
+	// defaultLLMTransport-backed client for NewDefaultClientWithOptions.
+	//
+	// This field tunes only the net/http backend. The fasthttp backend
+	// is tuned via FastHTTP below; under Mode == ClientModeAuto each
+	// backend uses its own settings on the origins it serves.
+	NetHTTPClient *http.Client
 	// Mode forces a specific backend selection (Auto / FastHTTP /
 	// NetHTTP). Defaults to ClientModeAuto when zero.
 	Mode ClientMode
@@ -154,6 +192,10 @@ type ClientOptions struct {
 	// To opt into the env-driven defaults under the options
 	// constructors, pass urlrewrite.LoadDefaultRules().
 	RewriteRules []urlrewrite.Rule
+	// FastHTTP tunes the fasthttp backend. Applies when Mode is
+	// ClientModeFastHTTP or when Auto mode resolves an origin to
+	// fasthttp. Ignored entirely when Mode is ClientModeNetHTTP.
+	FastHTTP FastHTTPClientOptions
 }
 
 // NewClient creates a new LLM HTTP client with the given http.Client.
@@ -190,9 +232,15 @@ func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
+	// Legacy seam: mirror the injected http.Client's TLS config into the
+	// fasthttp/probe path so private CAs and custom verification keep
+	// working under BAML_REST_HTTP_CLIENT=fasthttp / Auto.
+	fast := FastHTTPClientOptions{
+		TLSConfig: tlsConfigFromHTTPClient(httpClient),
+	}
 	return &Client{
 		httpClient:            httpClient,
-		cache:                 newProtocolCache(loadClientMode(), tlsConfigFromHTTPClient(httpClient), proxyFuncFromHTTPClient(httpClient)),
+		cache:                 newProtocolCache(loadClientMode(), fast, proxyFuncFromHTTPClient(httpClient)),
 		useGlobalRewriteRules: true,
 	}
 }
@@ -207,31 +255,31 @@ func NewClient(httpClient *http.Client) *Client {
 // Execute / ExecuteStream / ExecuteAWSStream calls reading
 // c.rewriteRules at request time.
 //
-// HTTPClient nil falls back to http.DefaultClient (matching NewClient).
+// NetHTTPClient nil falls back to http.DefaultClient (matching NewClient).
 // For the tuned LLM transport, use NewDefaultClientWithOptions.
 func NewClientWithOptions(opts ClientOptions) *Client {
-	httpClient := opts.HTTPClient
+	httpClient := opts.NetHTTPClient
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 	return &Client{
 		httpClient:   httpClient,
-		cache:        newProtocolCache(opts.Mode, tlsConfigFromHTTPClient(httpClient), proxyFuncFromHTTPClient(httpClient)),
+		cache:        newProtocolCache(opts.Mode, opts.FastHTTP, proxyFuncFromHTTPClient(httpClient)),
 		rewriteRules: slices.Clone(opts.RewriteRules),
 	}
 }
 
 // NewDefaultClientWithOptions builds a Client whose underlying
 // *http.Client uses defaultLLMTransport — the tuned LLM-traffic
-// transport that backs the package-level DefaultClient. opts.HTTPClient
-// is ignored.
+// transport that backs the package-level DefaultClient. opts.NetHTTPClient
+// is overridden.
 //
 // Use this when constructing a per-process LLM client at startup so
 // the same connection-pool sizing the legacy DefaultClient relied on
 // applies to the new explicit client.
 func NewDefaultClientWithOptions(opts ClientOptions) *Client {
 	httpClient := &http.Client{Transport: defaultLLMTransport}
-	opts.HTTPClient = httpClient
+	opts.NetHTTPClient = httpClient
 	return NewClientWithOptions(opts)
 }
 
@@ -275,9 +323,12 @@ func proxyFuncFromHTTPClient(c *http.Client) func(*http.Request) (*url.URL, erro
 // etc.). With the default, almost every request under concurrent load creates
 // a new TCP+TLS connection (~100-300ms handshake overhead per request).
 //
-// The values below mirror http.DefaultTransport (Go 1.26) with connection
-// pool sizes raised for the LLM provider traffic pattern: many concurrent
-// requests to few hosts.
+// The caps are deliberately uncapped: MaxConnsPerHost=0 (no active limit),
+// MaxIdleConns=0 (no global idle limit), MaxIdleConnsPerHost=math.MaxInt32
+// (effectively no per-host idle limit). Worker concurrency is bounded
+// upstream by the pool size, so the transport itself does not need to
+// throttle further; an artificial cap would just queue requests behind
+// new TCP+TLS handshakes for no benefit.
 var defaultLLMTransport = &http.Transport{
 	Proxy: http.ProxyFromEnvironment,
 	DialContext: (&net.Dialer{
@@ -289,8 +340,9 @@ var defaultLLMTransport = &http.Transport{
 		MinVersion: tls.VersionTLS12,
 	},
 	TLSHandshakeTimeout:   10 * time.Second,
-	MaxIdleConns:          256,
-	MaxIdleConnsPerHost:   64,
+	MaxIdleConns:          0,
+	MaxIdleConnsPerHost:   math.MaxInt32,
+	MaxConnsPerHost:       0,
 	IdleConnTimeout:       90 * time.Second,
 	ExpectContinueTimeout: 1 * time.Second,
 }

--- a/bamlutils/llmhttp/per_client_test.go
+++ b/bamlutils/llmhttp/per_client_test.go
@@ -2,11 +2,14 @@ package llmhttp
 
 import (
 	"context"
+	"crypto/tls"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/invakid404/baml-rest/bamlutils/urlrewrite"
 )
@@ -79,6 +82,25 @@ func TestNewDefaultClientWithOptionsUsesTunedTransport(t *testing.T) {
 	}
 	if client.httpClient.Transport != defaultLLMTransport {
 		t.Errorf("expected NewDefaultClientWithOptions to install defaultLLMTransport; got %T", client.httpClient.Transport)
+	}
+
+	// The default transport must be effectively uncapped for LLM
+	// workloads (many concurrent requests to few hosts). A regression
+	// that re-introduces an artificial limit would queue requests behind
+	// new TCP+TLS handshakes — the exact bottleneck this transport was
+	// rewritten to avoid.
+	tr, ok := client.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.httpClient.Transport)
+	}
+	if tr.MaxConnsPerHost != 0 {
+		t.Errorf("MaxConnsPerHost = %d, want 0 (unlimited)", tr.MaxConnsPerHost)
+	}
+	if tr.MaxIdleConnsPerHost != math.MaxInt32 {
+		t.Errorf("MaxIdleConnsPerHost = %d, want math.MaxInt32", tr.MaxIdleConnsPerHost)
+	}
+	if tr.MaxIdleConns != 0 {
+		t.Errorf("MaxIdleConns = %d, want 0 (unlimited)", tr.MaxIdleConns)
 	}
 }
 
@@ -256,6 +278,98 @@ func TestClientWithOptionsDefensiveCopiesRewriteRules(t *testing.T) {
 	got := client.resolveRequestURL(&Request{URL: "https://upstream.example/v1/chat"})
 	if want := "http://snapshot.local:8080/v1/chat"; got != want {
 		t.Errorf("expected snapshot rule to survive caller-side mutation; got %q, want %q", got, want)
+	}
+}
+
+// TestFastHTTPDefaultMaxConnsIsUnbounded pins that an unconfigured
+// FastHTTPClientOptions resolves to math.MaxInt32, not fasthttp's own
+// DefaultMaxConnsPerHost (512). Falling back to fasthttp's default would
+// silently throttle every Auto-mode HTTP/1.1 origin under heavy load.
+func TestFastHTTPDefaultMaxConnsIsUnbounded(t *testing.T) {
+	t.Parallel()
+
+	cache := newProtocolCache(modeAuto, FastHTTPClientOptions{}, nil)
+	origin, err := parseOrigin("http://example.invalid/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := cache.resolve(context.Background(), origin)
+	if entry == nil || entry.host == nil {
+		t.Fatalf("expected fasthttp host client for http://, got %+v", entry)
+	}
+	if entry.host.MaxConns != math.MaxInt32 {
+		t.Errorf("MaxConns = %d, want math.MaxInt32 (%d)", entry.host.MaxConns, math.MaxInt32)
+	}
+}
+
+// TestFastHTTPTuningPropagates_CachedHost pins that caller-supplied
+// FastHTTPClientOptions reach the per-origin HostClient (both pooled
+// and streaming variants), so users can actually tune the fasthttp
+// backend without forking the package.
+func TestFastHTTPTuningPropagates_CachedHost(t *testing.T) {
+	t.Parallel()
+
+	opts := FastHTTPClientOptions{
+		MaxConns:            123,
+		MaxConnWaitTimeout:  7 * time.Second,
+		MaxIdleConnDuration: 11 * time.Second,
+	}
+	cache := newProtocolCache(modeFast, opts, nil)
+	origin, err := parseOrigin("http://example.invalid/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := cache.resolve(context.Background(), origin)
+	if entry == nil || entry.host == nil {
+		t.Fatalf("expected fasthttp host client, got %+v", entry)
+	}
+	if entry.host.MaxConns != 123 {
+		t.Errorf("MaxConns = %d, want 123", entry.host.MaxConns)
+	}
+	if entry.host.MaxConnWaitTimeout != 7*time.Second {
+		t.Errorf("MaxConnWaitTimeout = %v, want 7s", entry.host.MaxConnWaitTimeout)
+	}
+	if entry.host.MaxIdleConnDuration != 11*time.Second {
+		t.Errorf("MaxIdleConnDuration = %v, want 11s", entry.host.MaxIdleConnDuration)
+	}
+
+	// Streaming per-request HostClient must mirror the pooled template's
+	// tuning — otherwise streams would silently revert to fasthttp's
+	// defaults regardless of caller configuration.
+	streamHC := newStreamHostClient(context.Background(), entry.host, &captureSlot{})
+	if streamHC.MaxConns != 123 {
+		t.Errorf("stream MaxConns = %d, want 123", streamHC.MaxConns)
+	}
+	if streamHC.MaxConnWaitTimeout != 7*time.Second {
+		t.Errorf("stream MaxConnWaitTimeout = %v, want 7s", streamHC.MaxConnWaitTimeout)
+	}
+	if streamHC.MaxIdleConnDuration != 11*time.Second {
+		t.Errorf("stream MaxIdleConnDuration = %v, want 11s", streamHC.MaxIdleConnDuration)
+	}
+}
+
+// TestFastHTTPTLSConfigPropagates pins that a caller-supplied TLSConfig
+// reaches both the probe dialer and the per-origin HostClient. Without
+// this, embedding callers couldn't pin a custom CA pool or ServerName
+// for the fasthttp backend.
+func TestFastHTTPTLSConfigPropagates(t *testing.T) {
+	t.Parallel()
+
+	tlsCfg := &tls.Config{ServerName: "example.test", MinVersion: tls.VersionTLS13}
+	cache := newProtocolCache(modeFast, FastHTTPClientOptions{TLSConfig: tlsCfg}, nil)
+	if cache.probeTLS != tlsCfg {
+		t.Error("expected supplied TLSConfig to reach probeTLS")
+	}
+	origin, err := parseOrigin("https://example.invalid/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := cache.resolve(context.Background(), origin)
+	if entry == nil || entry.host == nil {
+		t.Fatalf("expected fasthttp host client, got %+v", entry)
+	}
+	if entry.host.TLSConfig != tlsCfg {
+		t.Error("expected supplied TLSConfig to reach per-origin HostClient")
 	}
 }
 

--- a/dynclient/client.go
+++ b/dynclient/client.go
@@ -74,6 +74,12 @@ func New(opts ...Option) (*Client, error) {
 // caller is responsible for any de-duplication semantics). Tests pass a
 // no-op init alongside a fake runtime so the native BAML CFFI is never
 // loaded.
+//
+// Validation runs after all options have been applied but BEFORE the
+// init callback so a misconfigured client never reaches runtime
+// initialization (which loads the native BAML library). Tests rely on
+// this ordering to assert that error paths leave the init counter at
+// zero.
 func newWithRuntime(rt worker.Runtime, init func(), opts ...Option) (*Client, error) {
 	cfg := &config{}
 	for _, opt := range opts {
@@ -83,6 +89,10 @@ func newWithRuntime(rt worker.Runtime, init func(), opts ...Option) (*Client, er
 		if err := opt(cfg); err != nil {
 			return nil, fmt.Errorf("dynclient: new client: %w", err)
 		}
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("dynclient: new client: %w", err)
 	}
 
 	if init != nil {
@@ -116,14 +126,24 @@ func newWithRuntime(rt worker.Runtime, init func(), opts ...Option) (*Client, er
 	}, nil
 }
 
-// newLLMHTTPClient builds the per-handler llmhttp.Client. Caller-supplied
-// HTTP clients are wrapped explicitly; otherwise the tuned default LLM
-// transport is used. Either path passes the configured rewrite rules so
-// outbound requests are rewritten consistently with the registry pass.
+// newLLMHTTPClient builds the per-handler llmhttp.Client. The backend
+// mode (zero is Auto) and fasthttp tuning always flow through; a
+// caller-supplied *http.Client wraps an existing instance, otherwise
+// the tuned default LLM transport is used. Either path passes the
+// configured rewrite rules so outbound requests are rewritten
+// consistently with the registry pass.
+//
+// netHTTPClientSet without a non-nil client (i.e. WithNetHTTPClient(nil))
+// preserves the default tuned transport — validation has already
+// guaranteed this combination is allowed (Auto or ClientModeNetHTTP).
 func newLLMHTTPClient(cfg *config) *llmhttp.Client {
-	opts := llmhttp.ClientOptions{RewriteRules: cfg.baseURLRewrites}
-	if cfg.httpClient != nil {
-		opts.NetHTTPClient = cfg.httpClient
+	opts := llmhttp.ClientOptions{
+		Mode:         cfg.clientMode,
+		RewriteRules: cfg.baseURLRewrites,
+		FastHTTP:     cfg.fastHTTPOptions,
+	}
+	if cfg.netHTTPClientSet && cfg.netHTTPClient != nil {
+		opts.NetHTTPClient = cfg.netHTTPClient
 		return llmhttp.NewClientWithOptions(opts)
 	}
 	return llmhttp.NewDefaultClientWithOptions(opts)

--- a/dynclient/client.go
+++ b/dynclient/client.go
@@ -123,7 +123,7 @@ func newWithRuntime(rt worker.Runtime, init func(), opts ...Option) (*Client, er
 func newLLMHTTPClient(cfg *config) *llmhttp.Client {
 	opts := llmhttp.ClientOptions{RewriteRules: cfg.baseURLRewrites}
 	if cfg.httpClient != nil {
-		opts.HTTPClient = cfg.httpClient
+		opts.NetHTTPClient = cfg.httpClient
 		return llmhttp.NewClientWithOptions(opts)
 	}
 	return llmhttp.NewDefaultClientWithOptions(opts)

--- a/dynclient/client_test.go
+++ b/dynclient/client_test.go
@@ -220,7 +220,7 @@ func TestNewAppliesOptions(t *testing.T) {
 		WithLogger(logger),
 		WithMetricsRegistry(metrics),
 		WithBaseURLRewrites(rewrites),
-		WithHTTPClient(httpClient),
+		WithNetHTTPClient(httpClient),
 		WithClientDefaults(defaults),
 		WithSharedStateStore(store),
 	)
@@ -815,3 +815,183 @@ type _ifaceCheck interface {
 }
 
 var _ _ifaceCheck = (*Client)(nil)
+
+// -- Backend option interaction tests --------------------------------
+
+// runOptionsCase exercises newWithRuntime with a counted init callback
+// and returns the resulting error. Error cases assert the init counter
+// stays at zero, proving validation rejected the configuration BEFORE
+// runtime initialization could load the native library.
+func runOptionsCase(t *testing.T, wantErr bool, opts ...Option) error {
+	t.Helper()
+	var initCalls atomic.Int64
+	rt := &fakeRuntime{}
+	_, err := newWithRuntime(rt, func() { initCalls.Add(1) }, opts...)
+	if wantErr {
+		if err == nil {
+			t.Fatalf("expected validation error, got nil")
+		}
+		if got := initCalls.Load(); got != 0 {
+			t.Errorf("init ran %d times on a rejected config; validation must run before init", got)
+		}
+		return err
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := initCalls.Load(); got != 1 {
+		t.Errorf("init ran %d times on a valid config, want 1", got)
+	}
+	return nil
+}
+
+func TestBackendOptions_ValidCombinations(t *testing.T) {
+	netClient := &http.Client{}
+	fastOpts := llmhttp.FastHTTPClientOptions{MaxConns: 64}
+
+	cases := []struct {
+		name string
+		opts []Option
+	}{
+		{"no options", nil},
+		{"fasthttp tuning only", []Option{WithFastHTTPClient(fastOpts)}},
+		{"net/http client only", []Option{WithNetHTTPClient(netClient)}},
+		{"both tunings, implicit auto", []Option{WithFastHTTPClient(fastOpts), WithNetHTTPClient(netClient)}},
+		{"explicit auto + both tunings", []Option{WithClientMode(llmhttp.ClientModeAuto), WithFastHTTPClient(fastOpts), WithNetHTTPClient(netClient)}},
+		{"forced net/http + net client", []Option{WithClientMode(llmhttp.ClientModeNetHTTP), WithNetHTTPClient(netClient)}},
+		{"forced fasthttp + fast opts", []Option{WithClientMode(llmhttp.ClientModeFastHTTP), WithFastHTTPClient(fastOpts)}},
+		// WithNetHTTPClient(nil) signals "net/http tuning requested" so
+		// validation runs, but the default tuned transport still applies.
+		{"forced net/http + nil net client", []Option{WithClientMode(llmhttp.ClientModeNetHTTP), WithNetHTTPClient(nil)}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runOptionsCase(t, false, tc.opts...)
+		})
+	}
+}
+
+func TestBackendOptions_ConflictingCombinations(t *testing.T) {
+	netClient := &http.Client{}
+	fastOpts := llmhttp.FastHTTPClientOptions{MaxConns: 64}
+
+	cases := []struct {
+		name       string
+		opts       []Option
+		mustNameA  string
+		mustNameB  string
+		mustNameC  string // optional
+		invalidEnum bool
+	}{
+		{
+			name:      "forced net/http with fasthttp tuning",
+			opts:      []Option{WithClientMode(llmhttp.ClientModeNetHTTP), WithFastHTTPClient(fastOpts)},
+			mustNameA: "WithClientMode",
+			mustNameB: "WithFastHTTPClient",
+		},
+		{
+			name:      "forced fasthttp with net/http client",
+			opts:      []Option{WithClientMode(llmhttp.ClientModeFastHTTP), WithNetHTTPClient(netClient)},
+			mustNameA: "WithClientMode",
+			mustNameB: "WithNetHTTPClient",
+		},
+		{
+			name:      "forced net/http with both tunings",
+			opts:      []Option{WithClientMode(llmhttp.ClientModeNetHTTP), WithFastHTTPClient(fastOpts), WithNetHTTPClient(netClient)},
+			mustNameA: "WithClientMode",
+			mustNameB: "WithFastHTTPClient",
+		},
+		{
+			name:      "forced fasthttp with both tunings",
+			opts:      []Option{WithClientMode(llmhttp.ClientModeFastHTTP), WithFastHTTPClient(fastOpts), WithNetHTTPClient(netClient)},
+			mustNameA: "WithClientMode",
+			mustNameB: "WithNetHTTPClient",
+		},
+		{
+			name:        "invalid client mode value",
+			opts:        []Option{WithClientMode(llmhttp.ClientMode(999))},
+			invalidEnum: true,
+		},
+		{
+			// nil counts as "net/http tuning supplied" so even nil cannot
+			// pass under ClientModeFastHTTP.
+			name:      "forced fasthttp with nil net client",
+			opts:      []Option{WithClientMode(llmhttp.ClientModeFastHTTP), WithNetHTTPClient(nil)},
+			mustNameA: "WithClientMode",
+			mustNameB: "WithNetHTTPClient",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := runOptionsCase(t, true, tc.opts...)
+			if !strings.Contains(err.Error(), "dynclient: new client") {
+				t.Errorf("error not wrapped with construction label: %v", err)
+			}
+			if tc.invalidEnum {
+				if !strings.Contains(err.Error(), "invalid llmhttp.ClientMode") {
+					t.Errorf("expected invalid-mode error text, got: %v", err)
+				}
+				return
+			}
+			for _, name := range []string{tc.mustNameA, tc.mustNameB, tc.mustNameC} {
+				if name == "" {
+					continue
+				}
+				if !strings.Contains(err.Error(), name) {
+					t.Errorf("expected error to name %q; got: %v", name, err)
+				}
+			}
+		})
+	}
+}
+
+func TestBackendOptions_LastWins(t *testing.T) {
+	netClient := &http.Client{}
+	fastOpts := llmhttp.FastHTTPClientOptions{MaxConns: 64}
+
+	// Last-wins on WithClientMode: an early NetHTTP that would conflict
+	// with WithFastHTTPClient is harmless if a later WithClientMode(Auto)
+	// overrides it.
+	runOptionsCase(t, false,
+		WithClientMode(llmhttp.ClientModeNetHTTP),
+		WithClientMode(llmhttp.ClientModeAuto),
+		WithFastHTTPClient(fastOpts),
+	)
+
+	// Last-wins on WithClientMode: FastHTTP first then NetHTTP, with
+	// WithNetHTTPClient present, is valid because the final mode is
+	// NetHTTP.
+	runOptionsCase(t, false,
+		WithClientMode(llmhttp.ClientModeFastHTTP),
+		WithClientMode(llmhttp.ClientModeNetHTTP),
+		WithNetHTTPClient(netClient),
+	)
+
+	// Last-wins on WithNetHTTPClient: two calls — the final non-nil
+	// client is what reaches the underlying llmhttp.Client.
+	clientA := &http.Client{Timeout: 1 * time.Second}
+	clientB := &http.Client{Timeout: 2 * time.Second}
+	cfg := &config{}
+	for _, opt := range []Option{WithNetHTTPClient(clientA), WithNetHTTPClient(clientB)} {
+		if err := opt(cfg); err != nil {
+			t.Fatalf("option: %v", err)
+		}
+	}
+	if cfg.netHTTPClient != clientB {
+		t.Errorf("WithNetHTTPClient is not last-wins: got %p, want %p", cfg.netHTTPClient, clientB)
+	}
+
+	// Last-wins on WithFastHTTPClient: two calls — the final options
+	// value is what reaches the cache.
+	cfg = &config{}
+	first := llmhttp.FastHTTPClientOptions{MaxConns: 10}
+	second := llmhttp.FastHTTPClientOptions{MaxConns: 20}
+	for _, opt := range []Option{WithFastHTTPClient(first), WithFastHTTPClient(second)} {
+		if err := opt(cfg); err != nil {
+			t.Fatalf("option: %v", err)
+		}
+	}
+	if cfg.fastHTTPOptions.MaxConns != 20 {
+		t.Errorf("WithFastHTTPClient is not last-wins: MaxConns = %d, want 20", cfg.fastHTTPOptions.MaxConns)
+	}
+}

--- a/dynclient/options.go
+++ b/dynclient/options.go
@@ -1,6 +1,7 @@
 package dynclient
 
 import (
+	"fmt"
 	"net/http"
 	"slices"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/bamlutils/clientdefaults"
+	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
 	"github.com/invakid404/baml-rest/bamlutils/urlrewrite"
 	"github.com/invakid404/baml-rest/workerplugin"
 )
@@ -19,14 +21,31 @@ type Option func(*config) error
 // config is the internal, mutable view of a client's configuration. It
 // is populated from Options and read once by New when wiring the
 // underlying worker handler.
+//
+// HTTP backend selection and tuning are split across three orthogonal
+// fields. clientMode (WithClientMode) selects which backend handles a
+// request. netHTTPClient (WithNetHTTPClient) tunes net/http only.
+// fastHTTPOptions (WithFastHTTPClient) tunes fasthttp only. The *Set
+// companion booleans record whether the caller invoked the
+// corresponding option at all — required so validate() can reject
+// configurations like "forced net/http with fasthttp tuning" even when
+// the tuning value would otherwise look like a zero value.
 type config struct {
 	buildRequest    bamlutils.BuildRequestConfig
 	baseURLRewrites []urlrewrite.Rule
 	logger          bamlutils.Logger
 	metrics         *prometheus.Registry
 	clientDefaults  *clientdefaults.Config
-	httpClient      *http.Client
 	sharedState     *workerplugin.SharedStateStore
+
+	clientMode    llmhttp.ClientMode
+	clientModeSet bool
+
+	netHTTPClient    *http.Client
+	netHTTPClientSet bool
+
+	fastHTTPOptions llmhttp.FastHTTPClientOptions
+	fastHTTPSet     bool
 }
 
 // WithUseBuildRequest mirrors the BAML_REST_USE_BUILD_REQUEST gate for a
@@ -95,12 +114,68 @@ func WithClientDefaults(cfg *clientdefaults.Config) Option {
 	}
 }
 
-// WithHTTPClient installs the underlying *http.Client used for outbound
-// LLM traffic on the BuildRequest path. Passing nil resets to the
-// library default and does not panic.
-func WithHTTPClient(client *http.Client) Option {
+// WithClientMode selects which HTTP backend handles outbound LLM
+// traffic. Backend selection and backend tuning are orthogonal axes:
+// this option is the only one that picks a backend. WithNetHTTPClient
+// and WithFastHTTPClient configure their respective backends without
+// implying a mode.
+//
+// The default mode (zero value) is llmhttp.ClientModeAuto, which routes
+// each origin to net/http or fasthttp based on a per-origin ALPN probe.
+// Under Auto, both backends can be tuned simultaneously and each
+// applies to the origins it actually serves.
+//
+// Forced modes reject tuning aimed at the unused backend: combining
+// ClientModeNetHTTP with WithFastHTTPClient (or ClientModeFastHTTP with
+// WithNetHTTPClient) is a hard error from New so the misconfiguration
+// surfaces at startup rather than silently no-op'ing at request time.
+// Invalid llmhttp.ClientMode values are also rejected.
+//
+// Repeated calls are last-wins.
+func WithClientMode(mode llmhttp.ClientMode) Option {
 	return func(c *config) error {
-		c.httpClient = client
+		c.clientMode = mode
+		c.clientModeSet = true
+		return nil
+	}
+}
+
+// WithNetHTTPClient supplies a custom *http.Client for the net/http
+// backend. Passing nil records that net/http tuning was requested but
+// supplies no replacement: the default tuned net/http transport (via
+// llmhttp.NewDefaultClientWithOptions) still applies. The nil case
+// still counts as "net/http tuning supplied" for validation purposes,
+// so combining WithClientMode(ClientModeFastHTTP) with
+// WithNetHTTPClient(nil) is a hard error.
+//
+// This option tunes only the net/http backend. It does not select a
+// mode; under the default Auto mode the supplied client governs
+// origins routed to net/http while fasthttp-routed origins are
+// unaffected. Use WithClientMode to force a specific backend.
+//
+// Repeated calls are last-wins.
+func WithNetHTTPClient(client *http.Client) Option {
+	return func(c *config) error {
+		c.netHTTPClient = client
+		c.netHTTPClientSet = true
+		return nil
+	}
+}
+
+// WithFastHTTPClient tunes the fasthttp backend (MaxConns,
+// MaxConnWaitTimeout, MaxIdleConnDuration, TLSConfig). The options
+// apply only to origins that route through fasthttp.
+//
+// This option tunes only the fasthttp backend. It does not select a
+// mode; under the default Auto mode the values apply to fasthttp-routed
+// origins while net/http-routed origins are unaffected. Use
+// WithClientMode to force a specific backend.
+//
+// Repeated calls are last-wins.
+func WithFastHTTPClient(opts llmhttp.FastHTTPClientOptions) Option {
+	return func(c *config) error {
+		c.fastHTTPOptions = opts
+		c.fastHTTPSet = true
 		return nil
 	}
 }
@@ -112,5 +187,50 @@ func WithSharedStateStore(store *SharedStateStore) Option {
 	return func(c *config) error {
 		c.sharedState = store
 		return nil
+	}
+}
+
+// validate enforces the interaction rules between WithClientMode,
+// WithNetHTTPClient, and WithFastHTTPClient. Selection and tuning are
+// orthogonal under Auto mode, but forced modes reject tuning for the
+// unused backend so misconfiguration surfaces at New() rather than as
+// silent no-ops at request time.
+//
+// Runs on the final config so option order doesn't matter — repeated
+// WithClientMode calls are last-wins.
+func (c *config) validate() error {
+	if c == nil {
+		return nil
+	}
+	if c.clientModeSet && !validClientMode(c.clientMode) {
+		return fmt.Errorf("WithClientMode: invalid llmhttp.ClientMode %d", c.clientMode)
+	}
+	if !c.clientModeSet || c.clientMode == llmhttp.ClientModeAuto {
+		return nil
+	}
+
+	switch c.clientMode {
+	case llmhttp.ClientModeNetHTTP:
+		if c.fastHTTPSet {
+			return fmt.Errorf("WithClientMode(llmhttp.ClientModeNetHTTP) conflicts with WithFastHTTPClient: fasthttp tuning has no effect when the backend is forced to net/http")
+		}
+	case llmhttp.ClientModeFastHTTP:
+		if c.netHTTPClientSet {
+			return fmt.Errorf("WithClientMode(llmhttp.ClientModeFastHTTP) conflicts with WithNetHTTPClient: net/http tuning has no effect when the backend is forced to fasthttp")
+		}
+	}
+	return nil
+}
+
+// validClientMode reports whether the supplied ClientMode is a known
+// enum value. The llmhttp package treats unknown raw values from env as
+// Auto, but for an explicit programmatic option a typo is a bug, not a
+// silent fallback.
+func validClientMode(mode llmhttp.ClientMode) bool {
+	switch mode {
+	case llmhttp.ClientModeAuto, llmhttp.ClientModeFastHTTP, llmhttp.ClientModeNetHTTP:
+		return true
+	default:
+		return false
 	}
 }

--- a/worker/runtime_test.go
+++ b/worker/runtime_test.go
@@ -242,8 +242,8 @@ func TestHandlerInstallsHTTPClient(t *testing.T) {
 	t.Parallel()
 
 	client := llmhttp.NewClientWithOptions(llmhttp.ClientOptions{
-		HTTPClient: &http.Client{},
-		Mode:       llmhttp.ClientModeNetHTTP,
+		NetHTTPClient: &http.Client{},
+		Mode:          llmhttp.ClientModeNetHTTP,
 	})
 
 	var captured *fakeAdapter


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes #314.

## Summary

Two coupled bugs in `dynclient`'s HTTP layer, both surfaced by Viktor:

1. **`WithHTTPClient(*http.Client)` didn't do anything for plain `http://` origins**. Auto-mode routed them to fasthttp, which silently ignored every `http.Transport` knob the caller passed. `MaxConnsPerHost`, idle pool settings, custom RoundTrippers — all bypassed.
2. **Default fasthttp `MaxConns = 256`** is a hardcoded per-origin cap. 256+ concurrent workers against a single plain-`http://` LLM proxy hit `fasthttp.ErrNoFreeConns` immediately.

Fix: rebuild dynclient's HTTP option surface around an **orthogonal selection-vs-tuning** model + raise the default caps to effectively unbounded.

## Orthogonal model

Selection and tuning are now separate axes:

- **`WithClientMode(mode)`** — selects the backend (Auto / NetHTTP / FastHTTP). Default Auto.
- **`WithNetHTTPClient(client)`** — tunes the net/http backend. Does NOT change mode.
- **`WithFastHTTPClient(opts)`** — tunes the fasthttp backend. Does NOT change mode.

This lets you keep Auto and tune both backends simultaneously (useful for mixed `http://` + `https://` workloads). It also makes the previous footgun impossible: tuning a backend you've explicitly excluded via `WithClientMode` is a hard construction error.

## Interaction matrix

| Combination | Result |
|---|---|
| `WithFastHTTPClient` + `WithNetHTTPClient` (no explicit mode) | Valid — Auto routes by origin, both backends tuned |
| `WithClientMode(Auto)` + both tuning options | Valid — same as above |
| `WithClientMode(NetHTTP)` + `WithNetHTTPClient` | Valid — net/http forced + tuned |
| `WithClientMode(FastHTTP)` + `WithFastHTTPClient` | Valid — fasthttp forced + tuned |
| `WithClientMode(NetHTTP)` + `WithFastHTTPClient` | Hard error |
| `WithClientMode(FastHTTP)` + `WithNetHTTPClient` | Hard error |
| Invalid `ClientMode` value | Hard error |
| Repeated calls within same family | Last-wins |

Validation runs in `dynclient.New` after all options are applied and **before runtime init**, so misconfigurations don't allocate the native runtime.

## Default cap changes

- **fasthttp `MaxConns`**: hardcoded `256` → `math.MaxInt32`. (fasthttp's `0` is NOT unbounded — it silently falls back to `DefaultMaxConnsPerHost = 512`; only an explicit high value gives effective unbounded.)
- **net/http transport**:
  - `MaxConnsPerHost`: `0` (no active cap; Go's "unlimited").
  - `MaxIdleConnsPerHost`: `math.MaxInt32` (overrides Go's `DefaultMaxIdleConnsPerHost = 2`).
  - `MaxIdleConns`: `0` (no global idle cap).

Net effect: Viktor's 256+ worker setup no longer hits `ErrNoFreeConns` even in Auto mode.

## Breaking changes

**Removed**:
- `dynclient.WithHTTPClient(*http.Client)`.

**Renamed**:
- `llmhttp.ClientOptions.HTTPClient` → `llmhttp.ClientOptions.NetHTTPClient`.

These shipped in `0.0.45`. The only known external consumer is Viktor (issue author). Held back from the next tagged release until consumers migrate.

### Migration

`dynclient.WithHTTPClient(client)` becomes one of:

- **Force net/http with a custom client** (mirror of old behavior, now actually working):
  ```go
  dynclient.WithClientMode(llmhttp.ClientModeNetHTTP),
  dynclient.WithNetHTTPClient(client),
  ```

- **Force net/http with the tuned default transport**:
  ```go
  dynclient.WithClientMode(llmhttp.ClientModeNetHTTP),
  ```

- **Keep Auto, raise fasthttp's cap on its origins only**:
  ```go
  dynclient.WithFastHTTPClient(llmhttp.FastHTTPClientOptions{MaxConns: 4096}),
  ```

- **Keep Auto, tune both backend families**:
  ```go
  dynclient.WithFastHTTPClient(llmhttp.FastHTTPClientOptions{...}),
  dynclient.WithNetHTTPClient(&http.Client{...}),
  ```

`BAML_REST_HTTP_CLIENT` remains a server/worker env var. dynclient is explicit-only by design.

## What changed

### Commit 1 — `feat(llmhttp): expose backend tuning options and uncap defaults` (`a2cdb91b7`)

- `bamlutils/llmhttp/llmhttp.go`: `ClientOptions.HTTPClient` → `NetHTTPClient`; new `FastHTTPClientOptions{MaxConns, MaxConnWaitTimeout, MaxIdleConnDuration, TLSConfig}` type; `ClientOptions.FastHTTP` field; `defaultLLMTransport` cap changes.
- `bamlutils/llmhttp/cache.go`: `defaultFastHTTPMaxConns = math.MaxInt32`; `newProtocolCache` accepts `FastHTTPClientOptions`; per-origin `HostClient` build copies the tunable fields.
- `bamlutils/llmhttp/fast_backend.go`: streaming per-request `HostClient` copies the same tunable fields.
- `cmd/serve/main.go`, `cmd/worker/main.go`: rename `HTTPClient` field usage; still pass `ClientModeFromEnv()` for env parity.
- Tests cover the renamed field, `FastHTTPClientOptions` propagation (cached + streaming), TLS config propagation, default cap assertions.

### Commit 2 — `feat(dynclient): add orthogonal HTTP backend options` (`b8acde8a9`)

- `dynclient/options.go`: removed `WithHTTPClient`. New `WithClientMode`, `WithNetHTTPClient`, `WithFastHTTPClient`. `config` struct switched to dedicated `*Set` flags so nil-vs-absent is distinguishable.
- `dynclient/client.go`: `config.validate()` enforces the interaction matrix; runs after options applied and before runtime init.
- Tests cover the full interaction matrix (valid + error cells), `LastWins`, and the "validation runs before init" invariant.

## Test plan

- `go build ./...` (root + dynclient module) ✓
- `go vet ./...` (root + dynclient module) ✓
- `go test ./bamlutils/llmhttp/... -count=1` ✓
- `go test -race ./bamlutils/llmhttp/... -count=1` ✓
- `go test ./cmd/serve/... -count=1` ✓
- `go test ./worker/... ./pool/... ./internal/... -count=1` ✓
- `(cd dynclient && GOWORK=off go test ./... -count=1)` ✓

Refs #314.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selectable HTTP backend with separate tuning for each backend and configurable backend-specific options exposed to clients.

* **Bug Fixes**
  * Improved connection-pool defaults for LLM workloads, preserved TLS server name during ALPN probing, and non-blocking request shutdown on cancel.

* **Documentation**
  * Expanded docs with backend selection, tuning examples, and startup validation behavior.

* **Tests**
  * Added and strengthened tests for defaults, tuning propagation, TLS/SNI behavior, and option validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->