### PR TITLE
chore(release): release-prep for 0.0.46

### DIFF
--- a/adapters/adapter_v0_204_0/go.mod
+++ b/adapters/adapter_v0_204_0/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.45 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.45 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.46 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.46 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/adapter_v0_215_0/go.mod
+++ b/adapters/adapter_v0_215_0/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.45 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.45 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.46 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.46 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/adapter_v0_219_0/go.mod
+++ b/adapters/adapter_v0_219_0/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.45 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.45 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.46 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.46 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/adapters/common/go.mod
+++ b/adapters/common/go.mod
@@ -5,8 +5,8 @@ go 1.26.3
 require (
 	github.com/boundaryml/baml v0.204.0
 	github.com/dave/jennifer v1.7.1
-	github.com/invakid404/baml-rest/bamlutils v0.0.45
-	github.com/invakid404/baml-rest/introspected v0.0.45
+	github.com/invakid404/baml-rest/bamlutils v0.0.46
+	github.com/invakid404/baml-rest/introspected v0.0.46
 	github.com/stoewer/go-strcase v1.3.1
 )
 

--- a/dynclient/go.mod
+++ b/dynclient/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/goccy/go-json v0.10.6
 	github.com/google/uuid v1.6.0
 	github.com/gregwebs/go-recovery v0.4.1
-	github.com/invakid404/baml-rest/adapters/common v0.0.45
-	github.com/invakid404/baml-rest/bamlutils v0.0.45
-	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.45
-	github.com/invakid404/baml-rest/worker v0.0.45
-	github.com/invakid404/baml-rest/workerplugin v0.0.45
+	github.com/invakid404/baml-rest/adapters/common v0.0.46
+	github.com/invakid404/baml-rest/bamlutils v0.0.46
+	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.46
+	github.com/invakid404/baml-rest/worker v0.0.46
+	github.com/invakid404/baml-rest/workerplugin v0.0.46
 	github.com/prometheus/client_golang v1.23.2
 )
 
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.8.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.45 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.46 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect

--- a/introspected/go.mod
+++ b/introspected/go.mod
@@ -2,7 +2,7 @@ module github.com/invakid404/baml-rest/introspected
 
 go 1.26.3
 
-require github.com/invakid404/baml-rest/bamlutils v0.0.45
+require github.com/invakid404/baml-rest/bamlutils v0.0.46
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect

--- a/pool/go.mod
+++ b/pool/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/gregwebs/go-recovery v0.4.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
-	github.com/invakid404/baml-rest/bamlutils v0.0.45
-	github.com/invakid404/baml-rest/workerplugin v0.0.45
+	github.com/invakid404/baml-rest/bamlutils v0.0.46
+	github.com/invakid404/baml-rest/workerplugin v0.0.46
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1
 	google.golang.org/grpc v1.81.1

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -4,8 +4,8 @@ go 1.26.3
 
 require (
 	github.com/goccy/go-json v0.10.6
-	github.com/invakid404/baml-rest/bamlutils v0.0.45
-	github.com/invakid404/baml-rest/workerplugin v0.0.45
+	github.com/invakid404/baml-rest/bamlutils v0.0.46
+	github.com/invakid404/baml-rest/workerplugin v0.0.46
 	github.com/prometheus/client_golang v1.23.2
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )

--- a/workerplugin/go.mod
+++ b/workerplugin/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/hashicorp/go-plugin v1.8.0
-	github.com/invakid404/baml-rest/bamlutils v0.0.45
+	github.com/invakid404/baml-rest/bamlutils v0.0.46
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Release-prep for 0.0.46. Rewrites first-party `v0.0.45` requires to `v0.0.46` across the workspace go.mod files, following the same pattern as #319 (release-prep for 0.0.45).

Covers #320 (closes #314):
- Orthogonal dynclient HTTP backend options (`WithClientMode`, `WithNetHTTPClient`, `WithFastHTTPClient`).
- Unbounded default connection caps (`math.MaxInt32` for fasthttp `MaxConns`; uncapped `net/http` active + per-host idle).
- `bamlutils/llmhttp` field rename (`HTTPClient` → `NetHTTPClient`).

The DO-NOT-SKIP-RELEASE-PREP callout in `RELEASE.md` was added in #319 and remains in place — no edit needed here. README was updated as part of #320, so no doc edits required either.

## Files touched

Mandatory require rewrites:
- `dynclient/go.mod` — adapters/common, bamlutils, dynclient/baml-patched, worker, workerplugin, and indirect introspected.
- `adapters/common/go.mod` — bamlutils, introspected.
- `introspected/go.mod` — bamlutils.
- `worker/go.mod` — bamlutils, workerplugin.
- `workerplugin/go.mod` — bamlutils.

Sync side effects (produced/verified via `scripts/sync.sh`):
- `pool/go.mod` — bamlutils, workerplugin.
- `adapters/adapter_v0_204_0/go.mod` — indirect bamlutils / introspected.
- `adapters/adapter_v0_215_0/go.mod` — indirect bamlutils / introspected.
- `adapters/adapter_v0_219_0/go.mod` — indirect bamlutils / introspected.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test ./... -count=1` — all pass.
- [x] `(cd dynclient && GOWORK=off go test ./... -count=1)` — all pass.
- [x] `git status` shows only the intended release-prep files.

## Post-merge

Tag sequence handled by orchestrator (do not tag in this PR):
1. Merge PR.
2. `git tag 0.0.46 <merge-sha>` + `git push origin 0.0.46`.
3. Publish GitHub Release (auto-generated changelog).
4. `./scripts/release-go-tags.sh 0.0.46`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)