### PR TITLE
chore(release): release-prep helper script + RELEASE.md reorg + self-documenting failures (#308)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -187,14 +187,23 @@ go build ./...
 go vet ./...
 go test ./... -count=1
 (cd dynclient && GOWORK=off go test ./... -count=1)
-git status
-git commit -am "chore(release): prepare Go module versions for 0.0.N"
 ```
 
 The extra `GOWORK=off` step inside `dynclient/` verifies that the
 module also builds and tests against the rewritten requires when the
 workspace is not in play — which is the configuration downstream
 consumers will see.
+
+Then use the `git diff --cached -- <paths>` and `git commit -m
+"..." -- <paths>` lines that `release-prep.sh` printed at the end
+of Step 1 to review and commit. Those commands are the single
+source of truth for the release-prep commit shape; both restrict
+their pathspec to the rewritten go.mod files so that any unrelated
+work you happened to have staged in the same checkout is left out
+of the release commit. **Don't substitute `git commit -am ...`
+for the printed line** — `-a` would sweep up every modified
+tracked file, including any WIP the script intentionally left
+alone.
 
 ## Step 3 — Push to master
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,13 @@
 # Release Procedure
 
-> **DO NOT SKIP RELEASE-PREP.** Tagging before the first-party `require`
-> statements have been bumped to `v0.0.X` in the merged commit will cause
-> `scripts/release-go-tags.sh` to reject the Go module tags, and recovery
-> requires force-moving the product tag (already pushed and possibly already
-> attached to a GitHub Release) — see #308.
+> **DO NOT SKIP RELEASE-PREP (Step 1).** The product tag MUST be created from
+> a commit where every first-party `require` statement in the published Go
+> modules has already been rewritten to `v0.0.X`. Tagging before that point
+> causes `scripts/release-go-tags.sh` to reject the tag set, and the only
+> recovery paths are destructive (force-moving an already-pushed tag, possibly
+> already attached to a GitHub Release) or skipping the broken version
+> entirely. See [What goes wrong if you skip Step 1](#what-goes-wrong-if-you-skip-step-1)
+> and #308.
 
 This document is the maintainer-facing guide for cutting a baml-rest
 release. It covers both the existing product release (binary + Docker)
@@ -31,6 +34,11 @@ the other published nested modules at a stable version.
 
 ## Step 1 — Release-prep require rewrites
 
+**This is the first numbered step on purpose.** The product tag in
+Step 4 MUST point at a commit where this step has already landed.
+Tagging before the rewrites have merged is the failure mode #308
+captures — see [What goes wrong if you skip Step 1](#what-goes-wrong-if-you-skip-step-1).
+
 The seven published modules have first-party `require` edges between
 each other. During day-to-day development they point at
 `v0.0.0-00010101000000-000000000000` placeholders and resolve through
@@ -39,7 +47,32 @@ is cut, those placeholders must be rewritten to the actual `v0.0.N`
 that is about to be released, so that `go get` from a downstream
 consumer resolves through real tags rather than pseudo-versions.
 
-Affected files and edges:
+Run the helper:
+
+```sh
+./scripts/release-prep.sh 0.0.N
+```
+
+This:
+
+1. Validates `0.0.N` is well-formed and not already tagged.
+2. Rewrites all eleven first-party `require` edges across the five
+   published modules listed below.
+3. Runs `scripts/sync.sh` to refresh the workspace and the
+   per-adapter pin matrix.
+4. Bumps `pool/go.mod`'s first-party requires explicitly — `go work
+   sync` propagates `bamlutils` to `pool` but does not propagate
+   `workerplugin` for the same release, a quirk both #319 and #321
+   had to fix by hand.
+5. Re-validates the worktree against the same first-party-requires
+   check `scripts/release-go-tags.sh` runs at tag time, so a botched
+   prep fails BEFORE the tag exists rather than after.
+6. Leaves the changes staged but uncommitted and prints a suggested
+   commit message. The maintainer reviews and commits manually — see
+   [Step 2](#step-2--verify-and-commit).
+
+Affected files and edges (the script edits these for you; the list
+is here for reference if you need to audit the diff):
 
 - `dynclient/go.mod`
   - `adapters/common`
@@ -59,8 +92,10 @@ Affected files and edges:
 - `workerplugin/go.mod`
   - `bamlutils`
 
-Copy-pasteable rewrite (substitute the release number into `VERSION`
-before running):
+The script's behavior matches the manual rewrite that #319 and #321
+used. If you need to perform the edits by hand for any reason (e.g.
+the helper is broken on your platform), substitute the release
+number into `VERSION` and run:
 
 ```sh
 VERSION=0.0.N
@@ -91,6 +126,13 @@ VERSION=0.0.N
 (cd workerplugin && \
   go mod edit \
     -require=github.com/invakid404/baml-rest/bamlutils@v${VERSION})
+
+./scripts/sync.sh
+
+(cd pool && \
+  go mod edit \
+    -require=github.com/invakid404/baml-rest/bamlutils@v${VERSION} \
+    -require=github.com/invakid404/baml-rest/workerplugin@v${VERSION})
 ```
 
 Notes:
@@ -100,10 +142,43 @@ Notes:
   dependencies, and they keep local development ergonomic (the
   workspace builds without needing tags to exist first). Keeping
   them in the release commit is intentional.
-- **Do not rewrite the server-only `adapters/adapter_v*` modules.**
-  They are not part of the dynclient release graph and are not in
-  PR C's tag set. Their existing pins are managed by `scripts/sync.sh`
-  and the BAML pin-matrix verifier.
+- **Do not rewrite the server-only `adapters/adapter_v*` modules
+  by hand.** They are not part of the dynclient release graph and
+  are not in the published tag set. Their indirect first-party
+  requires are managed by `scripts/sync.sh` and the BAML pin-matrix
+  verifier — `release-prep.sh` invokes both for you.
+
+### What goes wrong if you skip Step 1
+
+Tagging the product version on a commit that still has stale
+first-party requires is the documented failure mode behind #308.
+The symptom and recovery cost are worth spelling out because the
+recovery is destructive:
+
+- **Symptom.** `scripts/release-go-tags.sh 0.0.N` fails Phase 1
+  validation against the freshly-pushed product tag. Every
+  first-party `require` line in the published modules is still at
+  `v0.0.<N-1>` (or further back). The script prints the offending
+  lines per module and emits a recovery hint identifying the shape
+  as "release-prep was skipped".
+- **Recovery option (a) — force-move the tag.** Create the
+  release-prep commit on master, then `git tag -f 0.0.N
+  <new-sha>` and `git push --force origin 0.0.N`. This rewrites
+  published release history: any GitHub Release attached to the
+  tag is silently re-pointed (or worse, orphaned), downstream
+  consumers who already cached the original SHA see a divergent
+  history, and any external automation watching the `0.0.*` tag
+  stream may double-fire. This option is destructive and requires
+  explicit maintainer authorization each time.
+- **Recovery option (b) — skip the version.** Land the release-prep
+  commit on master and tag `0.0.N+1` from it instead, leaving the
+  broken `0.0.N` tag in place (or deleting it cleanly before anyone
+  consumes it). This burns a version number but avoids touching
+  published history.
+
+The whole point of Step 1 being mechanical (one script invocation)
+and Step 4 having its "DO NOT tag before Step 1 has merged" guard
+is to make this failure mode unreachable in the normal flow.
 
 ## Step 2 — Verify and commit
 
@@ -130,6 +205,14 @@ git push origin master
 ```
 
 ## Step 4 — Create and push the product tag
+
+> **DO NOT tag the product version until the release-prep commit
+> from Step 1 has merged to `master`.** The Go module tag set
+> created in Step 6 must point at a commit where every first-party
+> `require` is already at `v0.0.N`. If you tag from an earlier
+> commit, Step 6 will reject the tag set and the only recoveries
+> are destructive — see
+> [What goes wrong if you skip Step 1](#what-goes-wrong-if-you-skip-step-1).
 
 ```sh
 git tag 0.0.N

--- a/scripts/release-go-tags.sh
+++ b/scripts/release-go-tags.sh
@@ -139,36 +139,30 @@ for module_path in "${required_modules[@]}"; do
         continue
     fi
     echo "  ${module_path}/go.mod"
-    release_last_failure_kind=""
+    release_last_failure_lines=""
     # Process substitution (not a pipe) so the function runs in the
-    # current shell — the failure-kind assignment relies on that.
+    # current shell — the accumulator assignment relies on that.
     if ! release_validate_module_requires "$module_path" "$expected_version" \
             < <(git show "${version}:${module_path}/go.mod"); then
         echo "ERROR: ${module_path}/go.mod has first-party requires that must be rewritten to ${expected_version} before tagging" >&2
         validation_failed=1
-        case "${release_last_failure_kind:-unknown}" in
-            stale)       stale_count=$(( stale_count + 1 )) ;;
-            pseudo)      pseudo_count=$(( pseudo_count + 1 )) ;;
-            malformed)   malformed_count=$(( malformed_count + 1 )) ;;
-            unparseable) unparseable_count=$(( unparseable_count + 1 )) ;;
-            *)           unparseable_count=$(( unparseable_count + 1 )) ;;
-        esac
-        if [ "${release_last_failure_kind:-}" = "stale" ]; then
-            # Collect every stale require's actual version so the
-            # recovery hint can confirm "they're all at v0.0.<N-1>"
-            # vs "there's a mix of stale versions".
-            while IFS= read -r stale_line; do
-                stripped="${stale_line%%//*}"
-                # shellcheck disable=SC2206
-                stale_fields=($stripped)
-                [ "${#stale_fields[@]}" -ge 2 ] || continue
-                sv="${stale_fields[1]}"
-                if [[ "$sv" =~ ^v0\.0\.[1-9][0-9]*$ ]] && [ "$sv" != "$expected_version" ]; then
-                    stale_versions+=("$sv")
-                fi
-            done < <(git show "${version}:${module_path}/go.mod" \
-                | release_extract_first_party_requires)
-        fi
+        # Tally every emitted failure line, not just the first per
+        # module. A single go.mod can mix kinds (e.g. one stale
+        # require + one pseudo-version) and the recovery hint below
+        # needs accurate per-kind counts to gate correctly.
+        while IFS=$'\t' read -r kind value; do
+            [ -n "$kind" ] || continue
+            case "$kind" in
+                stale)
+                    stale_count=$(( stale_count + 1 ))
+                    stale_versions+=("$value")
+                    ;;
+                pseudo)      pseudo_count=$(( pseudo_count + 1 )) ;;
+                malformed)   malformed_count=$(( malformed_count + 1 )) ;;
+                unparseable) unparseable_count=$(( unparseable_count + 1 )) ;;
+                *)           unparseable_count=$(( unparseable_count + 1 )) ;;
+            esac
+        done <<< "$release_last_failure_lines"
     fi
 done
 if [ "$validation_failed" -ne 0 ]; then
@@ -231,8 +225,12 @@ skipped=()
 for module_path in "${required_modules[@]}"; do
     tag="${module_path}/${expected_version}"
 
+    # Peel to the commit so an annotated tag pointing at the right
+    # release commit isn't misread as pointing at the tag-object SHA.
+    # `^{commit}` resolves both lightweight and annotated tags to a
+    # commit SHA, the same shape as $release_sha above.
     local_sha=""
-    if local_sha="$(git rev-parse --verify --quiet "refs/tags/${tag}")"; then
+    if local_sha="$(git rev-parse --verify --quiet "refs/tags/${tag}^{commit}")"; then
         :
     else
         local_sha=""
@@ -249,9 +247,21 @@ for module_path in "${required_modules[@]}"; do
 
     # `git ls-remote` exits 0 with empty stdout when the ref doesn't
     # exist, so we can't rely on the exit code alone — check stdout.
+    # We can't peel preemptively here: `git ls-remote --tags origin
+    # "refs/tags/<lightweight>^{}"` returns no row, so a naive peel
+    # would treat existing lightweight tags as missing. Instead do a
+    # raw lookup first to detect existence, then peel only when the
+    # raw SHA doesn't match — that handles annotated tags whose raw
+    # ref SHA is the tag-object SHA rather than the target commit.
     remote_line="$(git ls-remote --tags origin "refs/tags/${tag}" || true)"
     if [ -n "$remote_line" ]; then
         remote_sha="${remote_line%%[[:space:]]*}"
+        if [ "$remote_sha" != "$release_sha" ]; then
+            peeled_line="$(git ls-remote --tags origin "refs/tags/${tag}^{}" || true)"
+            if [ -n "$peeled_line" ]; then
+                remote_sha="${peeled_line%%[[:space:]]*}"
+            fi
+        fi
         if [ "$remote_sha" != "$release_sha" ]; then
             echo "ERROR: origin tag ${tag} points at ${remote_sha}, expected ${release_sha}" >&2
             exit 1

--- a/scripts/release-go-tags.sh
+++ b/scripts/release-go-tags.sh
@@ -82,31 +82,20 @@ fi
 # same way scripts/sync.sh does, so this script can be invoked from
 # anywhere without callers worrying about the working directory.
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$script_dir"
-while [ "$repo_root" != "/" ] && [ ! -d "$repo_root/.git" ] && [ ! -f "$repo_root/.git" ]; do
-    repo_root="$(dirname "$repo_root")"
-done
-if [ ! -e "$repo_root/.git" ]; then
+# shellcheck source=./release-lib.sh
+source "$script_dir/release-lib.sh"
+
+repo_root="$(release_find_repo_root "$script_dir" ".git")" || {
     echo "ERROR: no .git found above $script_dir" >&2
     exit 1
-fi
+}
 cd "$repo_root"
 
-# Required module set. Edit here if a future release adds or removes a
-# published Go module. The root module, pool, and the server-only
-# adapters/adapter_v* modules are deliberately excluded — see PR #289
-# discussion and RELEASE.md.
-required_modules=(
-    "adapters/common"
-    "bamlutils"
-    "dynclient"
-    "dynclient/baml-patched"
-    "introspected"
-    "worker"
-    "workerplugin"
-)
-
-first_party_prefix="github.com/invakid404/baml-rest"
+# Required module set + first-party prefix come from release-lib.sh
+# so the two release scripts can't drift apart on which modules are
+# in the published tag set.
+required_modules=("${release_required_modules[@]}")
+first_party_prefix="$release_first_party_prefix"
 expected_version="v${version}"
 
 # Validate that the product tag exists both locally and on origin
@@ -123,92 +112,6 @@ if ! git ls-remote --exit-code --tags origin "refs/tags/${version}" >/dev/null; 
 fi
 release_sha="$(git rev-parse "${version}^{commit}")"
 
-# validate_module_requires reads <module>/go.mod at the product tag
-# commit and emits offending require lines on stderr. Returns 0 if the
-# module is clean, 1 otherwise. The function intentionally collects all
-# bad lines for one module before returning so the operator sees every
-# fix needed in one pass rather than fixing them one error at a time.
-validate_module_requires() {
-    local module_path="$1"
-    local gomod
-    gomod="$(git show "${version}:${module_path}/go.mod")"
-
-    # Track which directive block we're in so a first-party module
-    # listed in a `replace (...)` block isn't misread as a `require`.
-    # Local `replace ../../bamlutils` directives are expected during
-    # release-prep (see RELEASE.md) and must not fail validation.
-    local first_party_lines
-    first_party_lines="$(
-        printf '%s\n' "$gomod" |
-            awk -v prefix="$first_party_prefix" '
-                function is_first_party(path) {
-                    return path == prefix || index(path, prefix "/") == 1
-                }
-                /^[[:space:]]*require[[:space:]]*\(/ { block = "require"; next }
-                /^[[:space:]]*replace[[:space:]]*\(/ { block = "replace"; next }
-                /^[[:space:]]*exclude[[:space:]]*\(/ { block = "exclude"; next }
-                /^[[:space:]]*retract[[:space:]]*\(/ { block = "retract"; next }
-                /^[[:space:]]*\)/ { block = ""; next }
-                /^[[:space:]]*require[[:space:]]+/ {
-                    line = $0
-                    sub(/^[[:space:]]*require[[:space:]]+/, "", line)
-                    split(line, fields, /[[:space:]]+/)
-                    if (is_first_party(fields[1])) print line
-                    next
-                }
-                block == "require" {
-                    line = $0
-                    sub(/^[[:space:]]*/, "", line)
-                    split(line, fields, /[[:space:]]+/)
-                    if (is_first_party(fields[1])) print line
-                }
-            '
-    )"
-
-    if [ -z "$first_party_lines" ]; then
-        return 0
-    fi
-
-    local bad=0
-    local line dep dep_version
-    while IFS= read -r line; do
-        # Strip any trailing `// indirect` (or other) comment so the
-        # version field is the last whitespace-separated token.
-        local stripped="${line%%//*}"
-        # shellcheck disable=SC2206
-        local fields=($stripped)
-        if [ "${#fields[@]}" -lt 2 ]; then
-            echo "  bad require line (cannot parse): ${line}" >&2
-            bad=1
-            continue
-        fi
-        dep="${fields[0]}"
-        dep_version="${fields[1]}"
-
-        # Pseudo-versions and any non-`v0.0.<positive-int>` require are
-        # rejected. We then narrow further to the exact `v${version}`
-        # we're releasing so a stale `v0.0.40` require during a 0.0.42
-        # cut also fails.
-        if [[ "$dep_version" == v0.0.0-* ]]; then
-            echo "  pseudo-version not allowed: ${dep} ${dep_version}" >&2
-            bad=1
-            continue
-        fi
-        if [[ ! "$dep_version" =~ ^v0\.0\.[1-9][0-9]*$ ]]; then
-            echo "  version must match v0.0.<positive-integer>: ${dep} ${dep_version}" >&2
-            bad=1
-            continue
-        fi
-        if [ "$dep_version" != "$expected_version" ]; then
-            echo "  expected ${expected_version}, got: ${dep} ${dep_version}" >&2
-            bad=1
-            continue
-        fi
-    done <<< "$first_party_lines"
-
-    return "$bad"
-}
-
 # Phase 1: validate every required module at the product-tag commit.
 # We accumulate failures so the operator sees every broken module in
 # one pass rather than re-running the script after each fix.
@@ -221,7 +124,10 @@ for module_path in "${required_modules[@]}"; do
         continue
     fi
     echo "  ${module_path}/go.mod"
-    if ! validate_module_requires "$module_path"; then
+    # Process substitution (not a pipe) so the validator runs in the
+    # current shell — required for any state it sets to persist.
+    if ! release_validate_module_requires "$module_path" "$expected_version" \
+            < <(git show "${version}:${module_path}/go.mod"); then
         echo "ERROR: ${module_path}/go.mod has first-party requires that must be rewritten to ${expected_version} before tagging" >&2
         validation_failed=1
     fi

--- a/scripts/release-go-tags.sh
+++ b/scripts/release-go-tags.sh
@@ -215,11 +215,19 @@ if [ "$validation_failed" -ne 0 ]; then
 fi
 echo "Validation OK."
 
-# Phase 2: figure out which tags need to be created / pushed.
-# `to_create` holds tags we'll create locally then push, `skipped`
-# holds tags that already point at release_sha somewhere (local or
-# remote). Anything pointing at a *different* SHA aborts immediately.
+# Phase 2: figure out which tags need to be created and / or pushed.
+# Both the local refs and origin are inspected before each tag is
+# classified so a partial-push recovery (local refs exist, origin
+# lost the tags) doesn't silently report everything as a no-op —
+# in that case the script should push the existing local tags.
+#
+#   - `to_create` — neither side has the tag; create local + push.
+#   - `to_push`   — local at release_sha, origin missing; push only.
+#   - `skipped`   — both sides at release_sha; nothing to do.
+#
+# A tag at the *wrong* SHA on either side still aborts immediately.
 to_create=()
+to_push=()
 skipped=()
 
 for module_path in "${required_modules[@]}"; do
@@ -236,13 +244,9 @@ for module_path in "${required_modules[@]}"; do
         local_sha=""
     fi
 
-    if [ -n "$local_sha" ]; then
-        if [ "$local_sha" != "$release_sha" ]; then
-            echo "ERROR: local tag ${tag} points at ${local_sha}, expected ${release_sha}" >&2
-            exit 1
-        fi
-        skipped+=("$tag")
-        continue
+    if [ -n "$local_sha" ] && [ "$local_sha" != "$release_sha" ]; then
+        echo "ERROR: local tag ${tag} points at ${local_sha}, expected ${release_sha}" >&2
+        exit 1
     fi
 
     # `git ls-remote` exits 0 with empty stdout when the ref doesn't
@@ -253,6 +257,7 @@ for module_path in "${required_modules[@]}"; do
     # raw lookup first to detect existence, then peel only when the
     # raw SHA doesn't match — that handles annotated tags whose raw
     # ref SHA is the tag-object SHA rather than the target commit.
+    remote_sha=""
     remote_line="$(git ls-remote --tags origin "refs/tags/${tag}" || true)"
     if [ -n "$remote_line" ]; then
         remote_sha="${remote_line%%[[:space:]]*}"
@@ -262,34 +267,73 @@ for module_path in "${required_modules[@]}"; do
                 remote_sha="${peeled_line%%[[:space:]]*}"
             fi
         fi
-        if [ "$remote_sha" != "$release_sha" ]; then
-            echo "ERROR: origin tag ${tag} points at ${remote_sha}, expected ${release_sha}" >&2
-            exit 1
-        fi
-        skipped+=("$tag")
-        continue
     fi
 
-    to_create+=("$tag")
+    if [ -n "$remote_sha" ] && [ "$remote_sha" != "$release_sha" ]; then
+        echo "ERROR: origin tag ${tag} points at ${remote_sha}, expected ${release_sha}" >&2
+        exit 1
+    fi
+
+    # Classify. The L✗ R✓ case (remote already at release_sha, no
+    # local ref) is treated as skipped — origin is the source of
+    # truth and the script's job here is to make origin match. A
+    # maintainer who wants the local ref can `git fetch origin
+    # --tags` themselves.
+    if [ -n "$local_sha" ] && [ -n "$remote_sha" ]; then
+        skipped+=("$tag")
+    elif [ -n "$local_sha" ] && [ -z "$remote_sha" ]; then
+        to_push+=("$tag")
+    elif [ -z "$local_sha" ] && [ -n "$remote_sha" ]; then
+        skipped+=("$tag")
+    else
+        to_create+=("$tag")
+    fi
 done
 
 # Phase 3: act (or pretend to, in dry-run).
+#
+# Tags in to_create get a local ref AND a push. Tags in to_push are
+# already at release_sha locally — only the push is missing (the
+# partial-push recovery path), so we skip the `git tag` invocation
+# and feed them straight into the same `git push origin <refs>`
+# call as anything we just created. Combining them keeps the push
+# atomic on origin's side.
 created=()
-if [ "${#to_create[@]}" -gt 0 ]; then
+push_args=()
+if [ "${#to_create[@]}" -gt 0 ] || [ "${#to_push[@]}" -gt 0 ]; then
     if $dry_run; then
         echo
-        echo "[dry-run] would create and push:"
-        for tag in "${to_create[@]}"; do
-            echo "  ${tag} -> ${release_sha}"
-        done
+        if [ "${#to_create[@]}" -gt 0 ]; then
+            echo "[dry-run] would create and push:"
+            for tag in "${to_create[@]}"; do
+                echo "  ${tag} -> ${release_sha}"
+            done
+        fi
+        if [ "${#to_push[@]}" -gt 0 ]; then
+            echo "[dry-run] would push existing local tag(s) to origin:"
+            for tag in "${to_push[@]}"; do
+                echo "  ${tag} -> ${release_sha}"
+            done
+        fi
     else
-        for tag in "${to_create[@]}"; do
-            echo "Creating ${tag} -> ${release_sha}"
-            git tag "${tag}" "${release_sha}"
-            created+=("$tag")
-        done
-        echo "Pushing ${#created[@]} tag(s) to origin..."
-        git push origin "${created[@]}"
+        if [ "${#to_create[@]}" -gt 0 ]; then
+            for tag in "${to_create[@]}"; do
+                echo "Creating ${tag} -> ${release_sha}"
+                git tag "${tag}" "${release_sha}"
+                created+=("$tag")
+                push_args+=("$tag")
+            done
+        fi
+        if [ "${#to_push[@]}" -gt 0 ]; then
+            for tag in "${to_push[@]}"; do
+                echo "Re-pushing existing local ${tag} -> ${release_sha}"
+                push_args+=("$tag")
+            done
+        fi
+        if [ "${#push_args[@]}" -gt 0 ]; then
+            echo "Pushing ${#push_args[@]} tag(s) to origin..."
+            git push origin "${push_args[@]}"
+        fi
     fi
 fi
 
@@ -308,10 +352,18 @@ if [ "${#to_create[@]}" -gt 0 ] && $dry_run; then
     echo "  would create: ${#to_create[@]}"
     for tag in "${to_create[@]}"; do echo "    ${tag}"; done
 fi
+if [ "${#to_push[@]}" -gt 0 ]; then
+    if $dry_run; then
+        echo "  would push (existing local): ${#to_push[@]}"
+    else
+        echo "  pushed (existing local): ${#to_push[@]}"
+    fi
+    for tag in "${to_push[@]}"; do echo "    ${tag}"; done
+fi
 if [ "${#skipped[@]}" -gt 0 ]; then
     echo "  skipped (already at ${release_sha}): ${#skipped[@]}"
     for tag in "${skipped[@]}"; do echo "    ${tag}"; done
 fi
-if [ "${#created[@]}" -eq 0 ] && [ "${#to_create[@]}" -eq 0 ]; then
+if [ "${#created[@]}" -eq 0 ] && [ "${#to_create[@]}" -eq 0 ] && [ "${#to_push[@]}" -eq 0 ]; then
     echo "  no-op: all ${#required_modules[@]} Go module tags already point at ${release_sha}"
 fi

--- a/scripts/release-go-tags.sh
+++ b/scripts/release-go-tags.sh
@@ -115,25 +115,108 @@ release_sha="$(git rev-parse "${version}^{commit}")"
 # Phase 1: validate every required module at the product-tag commit.
 # We accumulate failures so the operator sees every broken module in
 # one pass rather than re-running the script after each fix.
+#
+# Failure-kind tallies feed the recovery hint at the bottom of the
+# phase. The most common failure shape is "release-prep was skipped"
+# — every offending require lines up at the *previous* release tag —
+# and that case warrants a different recovery path than a one-off
+# bad require, so we surface it explicitly.
 echo "Validating release-prep state at ${version} (${release_sha})..."
 validation_failed=0
+# Per-failure-kind counters. Plain integers instead of an associative
+# array because macOS still ships bash 3.2, which lacks `declare -A`.
+stale_count=0
+pseudo_count=0
+malformed_count=0
+unparseable_count=0
+missing_count=0
+stale_versions=()
 for module_path in "${required_modules[@]}"; do
     if ! git cat-file -e "${version}:${module_path}/go.mod" 2>/dev/null; then
         echo "ERROR: product tag ${version} does not contain required module ${module_path}/go.mod" >&2
         validation_failed=1
+        missing_count=$(( missing_count + 1 ))
         continue
     fi
     echo "  ${module_path}/go.mod"
-    # Process substitution (not a pipe) so the validator runs in the
-    # current shell — required for any state it sets to persist.
+    release_last_failure_kind=""
+    # Process substitution (not a pipe) so the function runs in the
+    # current shell — the failure-kind assignment relies on that.
     if ! release_validate_module_requires "$module_path" "$expected_version" \
             < <(git show "${version}:${module_path}/go.mod"); then
         echo "ERROR: ${module_path}/go.mod has first-party requires that must be rewritten to ${expected_version} before tagging" >&2
         validation_failed=1
+        case "${release_last_failure_kind:-unknown}" in
+            stale)       stale_count=$(( stale_count + 1 )) ;;
+            pseudo)      pseudo_count=$(( pseudo_count + 1 )) ;;
+            malformed)   malformed_count=$(( malformed_count + 1 )) ;;
+            unparseable) unparseable_count=$(( unparseable_count + 1 )) ;;
+            *)           unparseable_count=$(( unparseable_count + 1 )) ;;
+        esac
+        if [ "${release_last_failure_kind:-}" = "stale" ]; then
+            # Collect every stale require's actual version so the
+            # recovery hint can confirm "they're all at v0.0.<N-1>"
+            # vs "there's a mix of stale versions".
+            while IFS= read -r stale_line; do
+                stripped="${stale_line%%//*}"
+                # shellcheck disable=SC2206
+                stale_fields=($stripped)
+                [ "${#stale_fields[@]}" -ge 2 ] || continue
+                sv="${stale_fields[1]}"
+                if [[ "$sv" =~ ^v0\.0\.[1-9][0-9]*$ ]] && [ "$sv" != "$expected_version" ]; then
+                    stale_versions+=("$sv")
+                fi
+            done < <(git show "${version}:${module_path}/go.mod" \
+                | release_extract_first_party_requires)
+        fi
     fi
 done
 if [ "$validation_failed" -ne 0 ]; then
     echo "ERROR: release-prep validation failed; fix the modules above, retag, and re-run" >&2
+
+    # Self-documenting failure: when EVERY offending line is a stale
+    # `v0.0.<previous-release>` require — the canonical
+    # "release-prep was skipped" footprint — print a tailored
+    # recovery hint instead of leaving the operator to figure out
+    # whether to force-move the tag or skip the release. A pseudo
+    # version, malformed require, or unparseable line falls through
+    # to the generic message above because the fix isn't a
+    # release-prep PR — it's a hand-fix to the offending module.
+    other_count=$(( pseudo_count + malformed_count + unparseable_count + missing_count ))
+
+    if [ "$stale_count" -gt 0 ] && [ "$other_count" -eq 0 ]; then
+        # Find the single stale version if every offending require
+        # lines up there. `sort -u` collapses duplicates.
+        uniq_stale="$(printf '%s\n' "${stale_versions[@]}" | sort -u)"
+        echo >&2
+        echo "Diagnostic: every offending require is a stale v0.0.<N> tag, not a pseudo-" >&2
+        echo "version. This is the canonical 'release-prep was skipped' shape — the" >&2
+        echo "product tag was created from a commit whose go.mods still point at the" >&2
+        echo "previous release." >&2
+        if [ "$(printf '%s\n' "$uniq_stale" | wc -l)" -eq 1 ]; then
+            echo "All offending requires point at: ${uniq_stale}" >&2
+        else
+            echo "Stale versions found across modules:" >&2
+            while IFS= read -r v; do
+                echo "  ${v}" >&2
+            done <<< "$uniq_stale"
+        fi
+        echo >&2
+        echo "Recovery options:" >&2
+        echo "  (a) Land a release-prep commit on master, then force-move ${version}:" >&2
+        echo "        ./scripts/release-prep.sh ${version}" >&2
+        echo "        # review + commit + push" >&2
+        echo "        git tag -f ${version} <release-prep-sha>" >&2
+        echo "        git push --force origin ${version}" >&2
+        echo "      This rewrites the published product tag — destructive, requires" >&2
+        echo "      explicit maintainer authorization, and any GitHub Release attached" >&2
+        echo "      to ${version} will need to be re-pointed." >&2
+        echo "  (b) Skip ${version} and prep the next release cleanly. This is the" >&2
+        echo "      safer option when ${version} hasn't yet been advertised:" >&2
+        echo "        ./scripts/release-prep.sh <next-version>" >&2
+        echo "      Then tag <next-version> from the resulting commit and re-run this" >&2
+        echo "      script with that version." >&2
+    fi
     exit 1
 fi
 echo "Validation OK."

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -1,0 +1,161 @@
+# release-lib.sh — shared helpers for scripts/release-prep.sh and
+# scripts/release-go-tags.sh. Source from another script:
+#
+#   source "$(dirname "${BASH_SOURCE[0]}")/release-lib.sh"
+#
+# The two scripts validate the same shape (first-party requires must
+# be at exactly `v${version}`) but feed it different go.mod sources:
+# release-prep.sh checks the current worktree, release-go-tags.sh
+# checks `git show <tag>:<path>/go.mod`. Keeping the awk + parsing
+# logic here means a fix to one validator can't drift away from the
+# other.
+
+# First-party module prefix and the set of published modules that
+# carry release tags. Edit here if a future release adds or removes a
+# published Go module. The root module, pool, and the server-only
+# adapters/adapter_v* modules are deliberately excluded — see PR #289
+# discussion and RELEASE.md.
+release_first_party_prefix="github.com/invakid404/baml-rest"
+release_required_modules=(
+    "adapters/common"
+    "bamlutils"
+    "dynclient"
+    "dynclient/baml-patched"
+    "introspected"
+    "worker"
+    "workerplugin"
+)
+
+# release_extract_first_party_requires
+#
+# Reads a go.mod from stdin and prints first-party `require` lines
+# (without the leading `require` keyword) to stdout.
+#
+# A first-party require inside a `replace (...)`, `exclude (...)`, or
+# `retract (...)` block is intentionally ignored — the local
+# `replace ../../bamlutils` directives present during release-prep
+# look syntactically similar to a require line and must not be
+# mistaken for one.
+release_extract_first_party_requires() {
+    awk -v prefix="$release_first_party_prefix" '
+        function is_first_party(path) {
+            return path == prefix || index(path, prefix "/") == 1
+        }
+        /^[[:space:]]*require[[:space:]]*\(/ { block = "require"; next }
+        /^[[:space:]]*replace[[:space:]]*\(/ { block = "replace"; next }
+        /^[[:space:]]*exclude[[:space:]]*\(/ { block = "exclude"; next }
+        /^[[:space:]]*retract[[:space:]]*\(/ { block = "retract"; next }
+        /^[[:space:]]*\)/ { block = ""; next }
+        /^[[:space:]]*require[[:space:]]+/ {
+            line = $0
+            sub(/^[[:space:]]*require[[:space:]]+/, "", line)
+            split(line, fields, /[[:space:]]+/)
+            if (is_first_party(fields[1])) print line
+            next
+        }
+        block == "require" {
+            line = $0
+            sub(/^[[:space:]]*/, "", line)
+            split(line, fields, /[[:space:]]+/)
+            if (is_first_party(fields[1])) print line
+        }
+    '
+}
+
+# release_validate_module_requires <module_label> <expected_version>
+#
+# Reads go.mod from stdin and validates that every first-party
+# require line is exactly <expected_version>. Pseudo-versions and any
+# non-`v0.0.<positive-int>` require fail too.
+#
+# Output:
+#   - returns 0 if clean, 1 otherwise.
+#   - on failure, emits one indented offending line per failure to
+#     stderr (no leading module label — the caller prints that once,
+#     so the operator sees every fix needed in one pass).
+#
+# On the first failed line in a module, sets the global variable
+# release_last_failure_kind to one of:
+#   - "pseudo"      — a v0.0.0-... pseudo-version require survived.
+#   - "stale"       — a clean v0.0.<N> require that points at the
+#                     wrong (most often previous) release; this is
+#                     the canonical "release-prep was skipped" shape.
+#   - "malformed"   — a require whose version doesn't even match the
+#                     v0.0.<positive-int> shape.
+#   - "unparseable" — a require line that doesn't parse.
+# Callers use this to decide what recovery hint to print.
+release_last_failure_kind=""
+
+release_validate_module_requires() {
+    local module_label="$1"
+    local expected_version="$2"
+
+    local first_party_lines
+    first_party_lines="$(release_extract_first_party_requires)"
+
+    if [ -z "$first_party_lines" ]; then
+        return 0
+    fi
+
+    local bad=0
+    local line dep dep_version stripped
+    local first_kind=""
+    while IFS= read -r line; do
+        # Strip any trailing `// indirect` (or other) comment so the
+        # version field is the last whitespace-separated token.
+        stripped="${line%%//*}"
+        # shellcheck disable=SC2206
+        local fields=($stripped)
+        if [ "${#fields[@]}" -lt 2 ]; then
+            echo "  bad require line (cannot parse): ${line}" >&2
+            [ -z "$first_kind" ] && first_kind="unparseable"
+            bad=1
+            continue
+        fi
+        dep="${fields[0]}"
+        dep_version="${fields[1]}"
+
+        if [[ "$dep_version" == v0.0.0-* ]]; then
+            echo "  pseudo-version not allowed: ${dep} ${dep_version}" >&2
+            [ -z "$first_kind" ] && first_kind="pseudo"
+            bad=1
+            continue
+        fi
+        if [[ ! "$dep_version" =~ ^v0\.0\.[1-9][0-9]*$ ]]; then
+            echo "  version must match v0.0.<positive-integer>: ${dep} ${dep_version}" >&2
+            [ -z "$first_kind" ] && first_kind="malformed"
+            bad=1
+            continue
+        fi
+        if [ "$dep_version" != "$expected_version" ]; then
+            echo "  expected ${expected_version}, got: ${dep} ${dep_version}" >&2
+            [ -z "$first_kind" ] && first_kind="stale"
+            bad=1
+            continue
+        fi
+    done <<< "$first_party_lines"
+
+    if [ "$bad" -ne 0 ]; then
+        release_last_failure_kind="$first_kind"
+    fi
+    return "$bad"
+}
+
+# release_find_repo_root <start_dir> <sentinel>
+#
+# Walks up from <start_dir> until a directory containing <sentinel>
+# is found, then prints that directory. <sentinel> is a filename or
+# directory name relative to each candidate (e.g. ".git", "go.work").
+# Prints nothing and returns 1 if no ancestor matches.
+release_find_repo_root() {
+    local dir="$1"
+    local sentinel="$2"
+    while [ "$dir" != "/" ]; do
+        if [ -e "$dir/$sentinel" ]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -74,8 +74,9 @@ release_extract_first_party_requires() {
 #     stderr (no leading module label — the caller prints that once,
 #     so the operator sees every fix needed in one pass).
 #
-# On the first failed line in a module, sets the global variable
-# release_last_failure_kind to one of:
+# For every failed line in a module, appends a record to the global
+# variable release_last_failure_lines. The accumulator is a
+# newline-delimited list of `kind<TAB>value` rows where kind is one of:
 #   - "pseudo"      — a v0.0.0-... pseudo-version require survived.
 #   - "stale"       — a clean v0.0.<N> require that points at the
 #                     wrong (most often previous) release; this is
@@ -83,8 +84,17 @@ release_extract_first_party_requires() {
 #   - "malformed"   — a require whose version doesn't even match the
 #                     v0.0.<positive-int> shape.
 #   - "unparseable" — a require line that doesn't parse.
-# Callers use this to decide what recovery hint to print.
-release_last_failure_kind=""
+# For "stale" rows, value is the offending version string (so callers
+# can collect stale_versions directly from this channel); for other
+# kinds value is the offending version (or the raw line for
+# "unparseable"), retained only as a debugging aid.
+#
+# Callers MUST reset release_last_failure_lines to "" before each
+# module so per-module classification stays clean. The accumulator
+# updates state in the current shell, so callers must run the
+# validator via process substitution / file redirection (not a pipe)
+# to keep variable assignments in scope.
+release_last_failure_lines=""
 
 release_validate_module_requires() {
     local module_label="$1"
@@ -99,7 +109,6 @@ release_validate_module_requires() {
 
     local bad=0
     local line dep dep_version stripped
-    local first_kind=""
     while IFS= read -r line; do
         # Strip any trailing `// indirect` (or other) comment so the
         # version field is the last whitespace-separated token.
@@ -108,7 +117,7 @@ release_validate_module_requires() {
         local fields=($stripped)
         if [ "${#fields[@]}" -lt 2 ]; then
             echo "  bad require line (cannot parse): ${line}" >&2
-            [ -z "$first_kind" ] && first_kind="unparseable"
+            release_last_failure_lines+=$'unparseable\t'"${line}"$'\n'
             bad=1
             continue
         fi
@@ -117,27 +126,24 @@ release_validate_module_requires() {
 
         if [[ "$dep_version" == v0.0.0-* ]]; then
             echo "  pseudo-version not allowed: ${dep} ${dep_version}" >&2
-            [ -z "$first_kind" ] && first_kind="pseudo"
+            release_last_failure_lines+=$'pseudo\t'"${dep_version}"$'\n'
             bad=1
             continue
         fi
         if [[ ! "$dep_version" =~ ^v0\.0\.[1-9][0-9]*$ ]]; then
             echo "  version must match v0.0.<positive-integer>: ${dep} ${dep_version}" >&2
-            [ -z "$first_kind" ] && first_kind="malformed"
+            release_last_failure_lines+=$'malformed\t'"${dep_version}"$'\n'
             bad=1
             continue
         fi
         if [ "$dep_version" != "$expected_version" ]; then
             echo "  expected ${expected_version}, got: ${dep} ${dep_version}" >&2
-            [ -z "$first_kind" ] && first_kind="stale"
+            release_last_failure_lines+=$'stale\t'"${dep_version}"$'\n'
             bad=1
             continue
         fi
     done <<< "$first_party_lines"
 
-    if [ "$bad" -ne 0 ]; then
-        release_last_failure_kind="$first_kind"
-    fi
     return "$bad"
 }
 

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -87,18 +87,52 @@ if git tag --list "$version" | grep -qx "$version"; then
     exit 1
 fi
 
-# Detect previous version informationally for the status output. Only
-# semver-shaped tags are considered, so accidental tags like
-# `mistake-0.0.41-rc1` don't poison the lookup. `sort -V` would treat
-# `0.0.10` as older than `0.0.2`; git's `-v:refname` understands the
-# semver ordering once we strip non-matching tags.
-prev_version="$(
-    git tag --list '[0-9]*.[0-9]*.[0-9]*' \
-        | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
-        | sort -V \
-        | tail -1 \
-        || true
-)"
+# The set of go.mod paths the script may stage at the end. The five
+# directly-edited published modules, pool, and every existing
+# adapters/adapter_v*/go.mod (which sync.sh refreshes). Resolved
+# eagerly so the same list drives both the preflight and the
+# stage-at-end pass and the two paths can't drift.
+candidate_paths=(
+    dynclient/go.mod
+    adapters/common/go.mod
+    introspected/go.mod
+    worker/go.mod
+    workerplugin/go.mod
+    pool/go.mod
+)
+shopt -s nullglob
+for dir in adapters/adapter_v*/; do
+    [ -f "${dir}go.mod" ] || continue
+    candidate_paths+=("${dir%/}/go.mod")
+done
+shopt -u nullglob
+
+# Preflight: refuse to run if any candidate path has uncommitted
+# modifications, untracked content, or staged changes. The script
+# ends by `git add`-ing these paths, so pre-existing work-in-progress
+# in one of them would get scooped into the release-prep commit by
+# accident.
+dirty_paths=()
+for path in "${candidate_paths[@]}"; do
+    if [ -n "$(git status --porcelain -- "$path")" ]; then
+        dirty_paths+=("$path")
+    fi
+done
+if [ "${#dirty_paths[@]}" -gt 0 ]; then
+    echo "ERROR: release-prep would stage paths that already have uncommitted changes:" >&2
+    for path in "${dirty_paths[@]}"; do
+        echo "    $path" >&2
+    done
+    echo "       Commit or stash those changes first; the script stages every go.mod it" >&2
+    echo "       rewrites and won't run while any of those paths are dirty." >&2
+    exit 1
+fi
+
+# Detect previous version informationally for the status output. The
+# `[0-9]*` glob excludes subdir-prefixed module tags like
+# `dynclient/v0.0.46` so only product tags rank. `--sort=-v:refname`
+# returns them in descending semver order so `head -1` is the latest.
+prev_version="$(git tag --list '[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1 || true)"
 if [ -z "$prev_version" ]; then
     echo "ERROR: no previous X.Y.Z tag found; release-prep.sh is meant for incremental releases" >&2
     echo "       — for the very first release, perform the rewrites manually per RELEASE.md" >&2
@@ -198,30 +232,43 @@ if [ "$validation_failed" -ne 0 ]; then
 fi
 echo "Validation OK."
 
-# Status summary. We do NOT commit — the maintainer still runs the
-# RELEASE.md Step 2 verification (`go build`, `go vet`, `go test`,
-# `GOWORK=off go test` inside dynclient) and then commits manually.
+# Stage the rewritten go.mod files so the maintainer's next step is
+# straight `git commit`. We do NOT commit — the maintainer still
+# runs the RELEASE.md Step 2 verification (`go build`, `go vet`,
+# `go test`, `GOWORK=off go test` inside dynclient) before
+# committing manually.
+#
+# Iterating over candidate_paths (the same list the preflight
+# verified clean) keeps the staging targeted: even if some unrelated
+# tool dirtied a file between preflight and now, we won't sweep it
+# up — only paths we knew we were going to touch get staged.
 echo
-changed=()
-while IFS= read -r line; do
-    [ -n "$line" ] && changed+=("$line")
-done < <(git -C "$repo_root" diff --name-only)
+echo "Staging release-prep changes..."
+staged_any=0
+for path in "${candidate_paths[@]}"; do
+    # Skip paths git reports as unchanged so we don't churn the
+    # index with a no-op `git add` on files where every first-party
+    # require was already at expected_version.
+    if [ -n "$(git diff --name-only -- "$path")" ]; then
+        git add -- "$path"
+        staged_any=1
+    fi
+done
 
-if [ "${#changed[@]}" -eq 0 ]; then
+if [ "$staged_any" -eq 0 ]; then
     echo "No changes — every first-party require was already at ${expected_version}."
     echo "(Run scripts/release-go-tags.sh ${version} after tagging.)"
     exit 0
 fi
 
-echo "Changed files:"
-for f in "${changed[@]}"; do
-    echo "  ${f}"
-done
+echo
+echo "Staged files:"
+git diff --cached --name-only | sed 's/^/  /'
 
 echo
 echo "Next steps (per RELEASE.md):"
 echo "  1. Verify the build:  go build ./... && go vet ./... && go test ./... -count=1"
 echo "                        (cd dynclient && GOWORK=off go test ./... -count=1)"
-echo "  2. Review the diff:   git diff"
-echo "  3. Commit:            git commit -am \"chore(release): prepare Go module versions for ${version}\""
+echo "  2. Review the diff:   git diff --cached"
+echo "  3. Commit:            git commit -m \"chore(release): prepare Go module versions for ${version}\""
 echo "  4. Push to master and continue from RELEASE.md Step 3."

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -263,12 +263,22 @@ fi
 
 echo
 echo "Staged files:"
-git diff --cached --name-only | sed 's/^/  /'
+# Scope the summary to candidate paths so any pre-existing staged
+# work the maintainer had before running release-prep isn't listed
+# under our header (and, more importantly, isn't mistaken as part
+# of the release-prep commit by a copy-paste of the commit line
+# below).
+git diff --cached --name-only -- "${candidate_paths[@]}" | sed 's/^/  /'
 
 echo
 echo "Next steps (per RELEASE.md):"
 echo "  1. Verify the build:  go build ./... && go vet ./... && go test ./... -count=1"
 echo "                        (cd dynclient && GOWORK=off go test ./... -count=1)"
-echo "  2. Review the diff:   git diff --cached"
-echo "  3. Commit:            git commit -m \"chore(release): prepare Go module versions for ${version}\""
+echo "  2. Review the diff:   git diff --cached -- ${candidate_paths[*]}"
+# The `-- <paths>` pathspec on the commit line tells git to commit
+# the working-tree content of those paths only, ignoring any
+# unrelated changes the maintainer may have staged separately. The
+# commit is safe to copy-paste even when other staged work exists.
+echo "  3. Commit:            git commit -m \"chore(release): prepare Go module versions for ${version}\" \\"
+echo "                            -- ${candidate_paths[*]}"
 echo "  4. Push to master and continue from RELEASE.md Step 3."

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# release-prep.sh — one-command release-prep for a baml-rest cut.
+#
+# Rewrites every first-party `require` line in the published Go
+# modules to `v${version}`, then runs `scripts/sync.sh` to refresh
+# the workspace + adapter pin matrix, then validates the result
+# against the same checks `scripts/release-go-tags.sh` will run at
+# tag time. The changes are left staged but uncommitted so the
+# maintainer reviews and commits manually (the verify + commit step
+# is still owned by RELEASE.md Step 2).
+#
+# This script exists because the manual release-prep — eleven hand
+# -typed `go mod edit` calls plus a `sync.sh` run plus a known
+# pool-vs-workerplugin quirk — was the step most often skipped, and
+# skipping it forces a destructive tag move to recover. See #308.
+#
+# Usage:
+#   scripts/release-prep.sh X.Y.Z
+
+usage() {
+    sed -n '/^# release-prep\.sh/,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+version=""
+for arg in "$@"; do
+    case "$arg" in
+        -h|--help) usage; exit 0 ;;
+        -*)
+            echo "ERROR: unknown flag: $arg" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            if [ -n "$version" ]; then
+                echo "ERROR: unexpected extra argument: $arg" >&2
+                usage >&2
+                exit 2
+            fi
+            version="$arg"
+            ;;
+    esac
+done
+
+if [ -z "$version" ]; then
+    echo "ERROR: missing version argument (expected X.Y.Z)" >&2
+    usage >&2
+    exit 2
+fi
+
+# Reject a leading `v` explicitly so the failure message is specific
+# rather than the generic "doesn't match X.Y.Z" complaint, matching
+# the convention release-go-tags.sh follows.
+if [[ "$version" == v* ]]; then
+    echo "ERROR: product release versions use no 'v' prefix; pass '${version#v}' instead of '${version}'" >&2
+    exit 2
+fi
+
+if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+    echo "ERROR: version must match X.Y.Z (got: '${version}')" >&2
+    exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./release-lib.sh
+source "$script_dir/release-lib.sh"
+
+repo_root="$(release_find_repo_root "$script_dir" "go.work")" || {
+    echo "ERROR: no go.work found above $script_dir" >&2
+    exit 1
+}
+cd "$repo_root"
+
+expected_version="v${version}"
+
+# Reject if the version is already a release tag — re-running this
+# script for an already-cut release silently churns module files
+# against a frozen tag, which is never what the operator wants. The
+# hint covers the two real use cases: bumping forward (next release)
+# or skipping a broken cut (cleanly prepping vN+1 after vN was
+# botched).
+if git tag --list "$version" | grep -qx "$version"; then
+    echo "ERROR: ${version} is already a release tag; this script prepares the *next* release commit" >&2
+    echo "       — to bump forward, pass the next version (e.g. the patch after ${version})" >&2
+    echo "       — to recover a botched ${version}, skip it and prep the next version cleanly" >&2
+    exit 1
+fi
+
+# Detect previous version informationally for the status output. Only
+# semver-shaped tags are considered, so accidental tags like
+# `mistake-0.0.41-rc1` don't poison the lookup. `sort -V` would treat
+# `0.0.10` as older than `0.0.2`; git's `-v:refname` understands the
+# semver ordering once we strip non-matching tags.
+prev_version="$(
+    git tag --list '[0-9]*.[0-9]*.[0-9]*' \
+        | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+        | sort -V \
+        | tail -1 \
+        || true
+)"
+if [ -z "$prev_version" ]; then
+    echo "ERROR: no previous X.Y.Z tag found; release-prep.sh is meant for incremental releases" >&2
+    echo "       — for the very first release, perform the rewrites manually per RELEASE.md" >&2
+    exit 1
+fi
+
+echo "release-prep: ${prev_version} → ${version}"
+echo
+
+# Apply the 11 explicit go mod edit rewrites across the five
+# published modules that have first-party requires. The set matches
+# RELEASE.md "Step 1 — Release-prep require rewrites" and the diffs
+# from PRs #319 and #321.
+#
+# Each module's edits are batched into a single `go mod edit` call so
+# `go.mod` is only rewritten once per module, matching the manual
+# copy-paste form in RELEASE.md.
+prefix="$release_first_party_prefix"
+
+run_edit() {
+    local module_dir="$1"
+    shift
+    local requires=()
+    local dep
+    for dep in "$@"; do
+        requires+=("-require=${prefix}/${dep}@${expected_version}")
+    done
+    echo "  ${module_dir}/go.mod"
+    (cd "$module_dir" && go mod edit "${requires[@]}")
+}
+
+echo "Rewriting first-party requires to ${expected_version}..."
+run_edit dynclient \
+    adapters/common \
+    bamlutils \
+    dynclient/baml-patched \
+    introspected \
+    worker \
+    workerplugin
+run_edit adapters/common \
+    bamlutils \
+    introspected
+run_edit introspected \
+    bamlutils
+run_edit worker \
+    bamlutils \
+    workerplugin
+run_edit workerplugin \
+    bamlutils
+
+# Run sync.sh to refresh the workspace + adapter pin matrix. This
+# propagates first-party requires to pool/go.mod and the
+# adapters/adapter_v*/go.mod files, and refreshes BAML adapter pins.
+#
+# Known quirk: `go work sync` propagates bamlutils to pool/go.mod but
+# does NOT rewrite pool's `workerplugin` require for the same
+# release. Both prior release-prep PRs (#319, #321) had to bump it
+# manually. We handle that explicitly below after sync.sh runs.
+echo
+echo "Running scripts/sync.sh..."
+"$script_dir/sync.sh"
+
+# Explicit pool bumps — workaround for the `go work sync` quirk
+# above. Doing this idempotently means an explicit edit is a no-op
+# when sync.sh already wrote the right values, so we never need to
+# branch on whether the quirk fired this run.
+echo
+echo "Pinning pool first-party requires to ${expected_version}..."
+run_edit pool \
+    bamlutils \
+    workerplugin
+
+# Final validation: every required module's first-party requires
+# must match v${version}. This is the same shape
+# scripts/release-go-tags.sh enforces against the tagged commit, run
+# here against the working tree so a botched prep fails BEFORE the
+# tag exists rather than after.
+echo
+echo "Validating release-prep state for ${expected_version}..."
+validation_failed=0
+for module_path in "${release_required_modules[@]}"; do
+    if [ ! -f "${module_path}/go.mod" ]; then
+        echo "ERROR: required module ${module_path}/go.mod is missing from the worktree" >&2
+        validation_failed=1
+        continue
+    fi
+    echo "  ${module_path}/go.mod"
+    if ! release_validate_module_requires "$module_path" "$expected_version" < "${module_path}/go.mod"; then
+        echo "ERROR: ${module_path}/go.mod still has first-party requires that don't match ${expected_version}" >&2
+        validation_failed=1
+    fi
+done
+if [ "$validation_failed" -ne 0 ]; then
+    echo
+    echo "ERROR: release-prep validation failed — fix the modules above and re-run" >&2
+    exit 1
+fi
+echo "Validation OK."
+
+# Status summary. We do NOT commit — the maintainer still runs the
+# RELEASE.md Step 2 verification (`go build`, `go vet`, `go test`,
+# `GOWORK=off go test` inside dynclient) and then commits manually.
+echo
+changed=()
+while IFS= read -r line; do
+    [ -n "$line" ] && changed+=("$line")
+done < <(git -C "$repo_root" diff --name-only)
+
+if [ "${#changed[@]}" -eq 0 ]; then
+    echo "No changes — every first-party require was already at ${expected_version}."
+    echo "(Run scripts/release-go-tags.sh ${version} after tagging.)"
+    exit 0
+fi
+
+echo "Changed files:"
+for f in "${changed[@]}"; do
+    echo "  ${f}"
+done
+
+echo
+echo "Next steps (per RELEASE.md):"
+echo "  1. Verify the build:  go build ./... && go vet ./... && go test ./... -count=1"
+echo "                        (cd dynclient && GOWORK=off go test ./... -count=1)"
+echo "  2. Review the diff:   git diff"
+echo "  3. Commit:            git commit -am \"chore(release): prepare Go module versions for ${version}\""
+echo "  4. Push to master and continue from RELEASE.md Step 3."


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes #308.

## Summary

The release-prep step (rewriting first-party requires across 5 affected `go.mod` files) is mechanical but easy to skip — and skipping it forces a destructive force-tag-move recovery on already-published release tags. We hit that failure mode once on `0.0.43`. This PR closes the gap with three coupled changes.

## What changed

### Commit 1 — `scripts/release-prep.sh` + shared validator (`a293fa9c9`)

New `scripts/release-prep.sh <version>` automates the 11 `go mod edit` rewrites + `scripts/sync.sh` sweep that we did by hand for 0.0.45 (#319) and 0.0.46 (#321). It:

- Validates version shape (`X.Y.Z`, no `v` prefix); rejects already-existing release tags.
- Auto-detects the previous version via `git tag --sort=-v:refname`.
- Runs the 11 explicit `go mod edit` rewrites across the 5 mandatory modules.
- Runs `./scripts/sync.sh` to propagate side effects.
- Handles the `go work sync` quirk for `pool/go.mod` (the `workerplugin` bump that didn't propagate automatically in #321).
- Validates all 7 published modules at the resulting tree state.
- Leaves changes STAGED — maintainer reviews and commits.

`scripts/release-lib.sh` extracts the validator so both `release-prep.sh` and `release-go-tags.sh` share the same logic.

### Commit 2 — `RELEASE.md` reorganization (`d03c10aea`)

The top-of-file DO-NOT-SKIP-RELEASE-PREP callout (added in #319) now has matching body content:

- Release-prep is **step #1** in the numbered sequence, not a sub-bullet.
- New section: "What goes wrong if you skip release-prep" — describes the symptom (validator rejection), the recovery cost (force-tag-move, rewriting published release history), and why it's worth avoiding.
- Tag-creation guard: "DO NOT tag the product version until release-prep has merged."
- The mechanical step is now `./scripts/release-prep.sh <version>` instead of 11 hand-typed `go mod edit` calls.

### Commit 3 — Self-documenting failure diagnostic in `release-go-tags.sh` (`8550b3505`)

When `release-go-tags.sh` rejects a tag, the validator now distinguishes:

- **Release-prep was skipped** (one or more first-party requires still at `vN-1` when tag claims `vN`) → reports "All offending requires point at: vN-1" + prints both recovery options (force-tag-move with destructive warning, or skip-this-version-and-prep-next).
- **Pseudo-version / unrelated broken require** → distinct classification.

So a future maintainer hitting the failure sees the recovery shape at the moment it fires, not buried in commit history.

## Test plan

Verification highlights (per the implementation):

- **`release-prep.sh` dry-run against 0.0.47**: produces the expected 9-file diff (5 mandatory + `pool/go.mod` + 3 `adapter_v*/go.mod`), matches the shape of #319 / #321 exactly; validator passes all 7 published modules.
- **Synthetic broken-tag E2E**: temporary local bare repo as fake origin, version 0.0.97 tagged at master HEAD with stale go.mods → script exits 1, diagnostic fires, both recovery options printed.
- **Guard rails**: `release-prep.sh` rejects `0.0.46` (already tagged), `nope` (malformed), `v0.0.47` (`v`-prefixed).
- **No regression**: `release-go-tags.sh --dry-run 0.0.46` still validates cleanly against current master.
- **macOS bash 3.2 compat**: avoided `declare -A`.

## Files

```
RELEASE.md                  | ~80 net
scripts/release-prep.sh     | new
scripts/release-lib.sh      | new
scripts/release-go-tags.sh  | refactored to share validator + diagnostic
```

Refs #289 (original release tagging workflow), #319 (DO-NOT-SKIP callout introduction).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated release-prep flow to update and stage first-party module versions and validate the working tree before tagging.

* **Documentation**
  * Strengthened release docs with a prominent warning about ordering, expanded step-by-step guidance, explicit validation/verification steps, failure symptoms, and recovery options.

* **Refactor**
  * Centralized release validation and repo-root discovery; improved diagnostics and hardened tag resolution and summary reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->