### PR TITLE
fix(renovate): exclude dynclient/baml-patched/go.mod from updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,13 @@
         "adapters/**/go.mod"
       ],
       "enabled": false
+    },
+    {
+      "description": "dynclient/baml-patched/go.mod is regen-managed: cmd/regenerate-dynclient copies the file verbatim from upstream BAML's go.mod (see cmd/hacks/hacks/patched_module.go writePatchedGoMod). Any Renovate bump here is reverted by the cmd/regenerate-dynclient fresh-tree gate in CI.",
+      "matchFileNames": [
+        "dynclient/baml-patched/go.mod"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

`cmd/regenerate-dynclient` regenerates `dynclient/baml-patched/` by copying upstream BAML's `go.mod` verbatim (see `cmd/hacks/hacks/patched_module.go` `writePatchedGoMod`). Any Renovate-driven bump in that file is reverted by the `cmd/regenerate-dynclient` fresh-tree gate in `.github/workflows/unit-tests.yml`, so those PRs can never pass CI.

PR #303 (`google.golang.org/protobuf` v1.36.6 → v1.36.11) is the latest casualty. Disable Renovate for that single file so the bot stops opening unmergeable PRs against it.

## Why this single file and not the whole directory

`dynclient/baml-patched/go.mod` is the only Renovate-managed manifest under that directory; `go.sum` is derived. Targeting the manifest matches the existing `adapters/**/go.mod` exclusion pattern in this config.

## Test plan

- [ ] After merge, close #303.
- [ ] Confirm Renovate doesn't re-open #303 on its next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to optimize build automation for internal processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->