### PR TITLE
chore(release): cover root go.mod in release-prep + ignore first-party in Renovate

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -275,7 +275,45 @@ The full Go module tag set for release `0.0.N`:
 | `github.com/invakid404/baml-rest/worker` | `worker/v0.0.N` |
 | `github.com/invakid404/baml-rest/workerplugin` | `workerplugin/v0.0.N` |
 
-## Step 7 — External smoke test
+## Step 7 — Backfill root first-party requires
+
+```sh
+./scripts/release-prep.sh 0.0.N
+```
+
+This is the same script as Step 1, but now `0.0.N` is the latest
+product tag (just pushed in Step 4 / tagged out per-module in Step 6)
+so the script switches into **backfill mode**. Every published-module
+edit is a no-op — those `go.mod` files were already rewritten in
+Step 1 — so the only real work is a `go mod tidy` in the repo root.
+That tidy pulls root's first-party requires (and the indirect
+`dynclient/baml-patched` require + its `go.sum` entries) forward to
+the just-released module set.
+
+The tidy step has to run after Step 6 because root has no local
+`replace` for `dynclient/baml-patched` (intentional — see `go.work`'s
+inline notes on why the patched fork stays outside the workspace).
+With no replace in play, `go mod tidy` resolves baml-patched through
+the module proxy, which means the new per-module tag from Step 6
+must already be reachable. Running this step alongside Step 1, before
+the tag exists, crashes tidy with `unknown revision
+dynclient/baml-patched/v0.0.N`.
+
+Commit + push the resulting `go.mod` / `go.sum` changes as a regular
+PR — the script's "Next steps" output prints the canonical commit
+line (`chore(release): backfill root for 0.0.N`). No new product
+tag, no GitHub Release, no `release-go-tags.sh` rerun: root is
+deliberately excluded from the published tag set (see
+[Tag conventions](#tag-conventions)), so this commit just keeps
+root's own `go.mod` / `go.sum` tracking the released module set.
+
+Skipping this step is harmless for the release itself (the per-module
+tags from Step 6 are what downstream consumers resolve against), but
+it leaves root referencing the previous release and Renovate will
+open redundant first-party bump PRs to close the gap — see #330 /
+#331 against 0.0.47 for the symptom this step exists to prevent.
+
+## Step 8 — External smoke test
 
 Confirm the published Go module tags resolve cleanly for a fresh
 downstream consumer:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -311,7 +311,7 @@ Skipping this step is harmless for the release itself (the per-module
 tags from Step 6 are what downstream consumers resolve against), but
 it leaves root referencing the previous release and Renovate will
 open redundant first-party bump PRs to close the gap — see #330 /
-#331 against 0.0.47 for the symptom this step exists to prevent.
+\#331 against 0.0.47 for the symptom this step exists to prevent.
 
 ## Step 8 — External smoke test
 

--- a/go.mod
+++ b/go.mod
@@ -20,13 +20,13 @@ require (
 	github.com/invakid404/baml-rest/adapters/adapter_v0_204_0 v0.0.0-00010101000000-000000000000
 	github.com/invakid404/baml-rest/adapters/adapter_v0_215_0 v0.0.0-00010101000000-000000000000
 	github.com/invakid404/baml-rest/adapters/adapter_v0_219_0 v0.0.0-00010101000000-000000000000
-	github.com/invakid404/baml-rest/adapters/common v0.0.46
-	github.com/invakid404/baml-rest/bamlutils v0.0.46
+	github.com/invakid404/baml-rest/adapters/common v0.0.47
+	github.com/invakid404/baml-rest/bamlutils v0.0.47
 	github.com/invakid404/baml-rest/dynclient v0.0.0-00010101000000-000000000000
-	github.com/invakid404/baml-rest/introspected v0.0.46
+	github.com/invakid404/baml-rest/introspected v0.0.47
 	github.com/invakid404/baml-rest/pool v0.0.0-00010101000000-000000000000
-	github.com/invakid404/baml-rest/worker v0.0.46
-	github.com/invakid404/baml-rest/workerplugin v0.0.46
+	github.com/invakid404/baml-rest/worker v0.0.47
+	github.com/invakid404/baml-rest/workerplugin v0.0.47
 	github.com/moby/buildkit v0.30.0
 	github.com/moby/moby/api v1.54.2
 	github.com/moby/moby/client v0.4.1
@@ -112,7 +112,7 @@ require (
 	github.com/in-toto/attestation v1.1.2 // indirect
 	github.com/in-toto/in-toto-golang v0.11.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.46 // indirect
+	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.47 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,12 +78,8 @@ github.com/containerd/cgroups/v3 v3.1.3 h1:eUNflyMddm18+yrDmZPn3jI7C5hJ9ahABE5q6
 github.com/containerd/cgroups/v3 v3.1.3/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
 github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
-github.com/containerd/containerd/api v1.11.0 h1:smv4e74S/wwIx0Sj7lhwO1t3M/oi+mSzk2VXqHq8aO0=
-github.com/containerd/containerd/api v1.11.0/go.mod h1:CaQFRu+N1MtbgL6JDOJLUB1hCKESU1lD6MuTJhgtdlw=
 github.com/containerd/containerd/api v1.11.1 h1:h8nfoDW9+fNsC/9TwiAHj8B1GzXKtR4eFtkhi/X5RLU=
 github.com/containerd/containerd/api v1.11.1/go.mod h1:CaQFRu+N1MtbgL6JDOJLUB1hCKESU1lD6MuTJhgtdlw=
-github.com/containerd/containerd/v2 v2.3.0 h1:qpB5dyToxPqea1OdedyAiAnnor5wxTM+Py9nWt5CnWY=
-github.com/containerd/containerd/v2 v2.3.0/go.mod h1:+chyhxLNeqUVOcTJGgaSu/IbDGX6p3+d8AJjAaerAS8=
 github.com/containerd/containerd/v2 v2.3.1 h1:4dVXBdlvotRBlaP2TmNbY/EGc06KJrMDDUqQdxX/HOk=
 github.com/containerd/containerd/v2 v2.3.1/go.mod h1:xVoxGPWZBwwph8DF2IbDhriLKdHfjdpO0b3wFP9wQ1I=
 github.com/containerd/continuity v0.5.0 h1:7a85HZpCSs+1Zps0Ee3DPSuAWY+0SJM1JNM51nlEVDg=
@@ -124,8 +120,6 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/docker/buildx v0.34.0 h1:ivBYUNCMKMOwqCziC66p79dNkd8mv+DSrnyrY9PY9vQ=
-github.com/docker/buildx v0.34.0/go.mod h1:RG8352TWR2gg8P7uqu1ZvlSpqxUcnVvGfjqQsKpmSAY=
 github.com/docker/buildx v0.34.1 h1:gDnnCPmnbPt/5FTABZIhTlBc6kYibWNyVJzE29Mb5yM=
 github.com/docker/buildx v0.34.1/go.mod h1:RG8352TWR2gg8P7uqu1ZvlSpqxUcnVvGfjqQsKpmSAY=
 github.com/docker/cli v29.4.3+incompatible h1:u+UliYm2J/rYrIh2FqHQg32neRG8GjbvNuwQRTzGspU=
@@ -219,8 +213,8 @@ github.com/in-toto/in-toto-golang v0.11.0 h1:nfidMYBFx+E0lnmX5KUnN2Pdm8zdNKal1ay
 github.com/in-toto/in-toto-golang v0.11.0/go.mod h1:u3PjTnwFKjp5a1YCcw8SJg0G+tMeKfVoWsWeFMDCMtw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.46 h1:oHsXsz2OQjAukYSSd0WDws3T17VjDYzEIQDofAxUOqs=
-github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.46/go.mod h1:ykjc7qQ+4LAEJ9tf0+MbJ9pVwRiUiBmracb/XukpRdg=
+github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.47 h1:/DAHqQ3NuqoeC+JAwHhJ9Pas7DGMIF0UNuV/V+Z7OJM=
+github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.47/go.mod h1:ykjc7qQ+4LAEJ9tf0+MbJ9pVwRiUiBmracb/XukpRdg=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,13 @@
         "dynclient/baml-patched/go.mod"
       ],
       "enabled": false
+    },
+    {
+      "description": "First-party module versions (github.com/invakid404/baml-rest/*) are managed by scripts/release-prep.sh as part of the release flow described in RELEASE.md, not by Renovate. Renovate's bumps for these are at best redundant (matching what release-prep + go mod tidy already do) and at worst regress root go.mod between releases. See PRs #330 and #331 for the failure mode this rule prevents.",
+      "matchPackagePrefixes": [
+        "github.com/invakid404/baml-rest"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -62,11 +62,19 @@ release_extract_first_party_requires() {
     '
 }
 
-# release_validate_module_requires <module_label> <expected_version>
+# release_validate_module_requires <module_label> <expected_version> [allow_pseudo]
 #
 # Reads go.mod from stdin and validates that every first-party
 # require line is exactly <expected_version>. Pseudo-versions and any
-# non-`v0.0.<positive-int>` require fail too.
+# non-`v0.0.<positive-int>` require fail by default.
+#
+# Pass <allow_pseudo>=true to permit `v0.0.0-...` requires alongside
+# <expected_version> — used by the root validator, where modules
+# deliberately excluded from the published tag set (adapter_v*,
+# dynclient, pool — see release-lib.sh `release_required_modules` and
+# RELEASE.md) intentionally sit at pseudo-versions. The published
+# modules in `release_required_modules` always pass false because a
+# pseudo-version surviving in a published go.mod is the #308 failure.
 #
 # Output:
 #   - returns 0 if clean, 1 otherwise.
@@ -78,6 +86,11 @@ release_extract_first_party_requires() {
 # variable release_last_failure_lines. The accumulator is a
 # newline-delimited list of `kind<TAB>value` rows where kind is one of:
 #   - "pseudo"      — a v0.0.0-... pseudo-version require survived.
+#                     Emitted even when allow_pseudo=true so callers
+#                     that want to distinguish "clean release" from
+#                     "release with surviving pseudos" still can; the
+#                     return code is 0 in that case but the channel
+#                     records the lines.
 #   - "stale"       — a clean v0.0.<N> require that points at the
 #                     wrong (most often previous) release; this is
 #                     the canonical "release-prep was skipped" shape.
@@ -99,6 +112,7 @@ release_last_failure_lines=""
 release_validate_module_requires() {
     local module_label="$1"
     local expected_version="$2"
+    local allow_pseudo="${3:-false}"
 
     local first_party_lines
     first_party_lines="$(release_extract_first_party_requires)"
@@ -125,8 +139,11 @@ release_validate_module_requires() {
         dep_version="${fields[1]}"
 
         if [[ "$dep_version" == v0.0.0-* ]]; then
-            echo "  pseudo-version not allowed: ${dep} ${dep_version}" >&2
             release_last_failure_lines+=$'pseudo\t'"${dep_version}"$'\n'
+            if [ "$allow_pseudo" = true ]; then
+                continue
+            fi
+            echo "  pseudo-version not allowed: ${dep} ${dep_version}" >&2
             bad=1
             continue
         fi

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -26,6 +26,42 @@ release_required_modules=(
     "workerplugin"
 )
 
+# release_dep_allows_pseudo <full_dep_path>
+#
+# Returns 0 (true) iff <full_dep_path> is a first-party module that
+# may sit at a `v0.0.0-...` pseudo-version in root's go.mod, 1
+# otherwise. The set is the inverse of release_required_modules:
+#
+#   - <prefix>/dynclient                  — public consumer-facing
+#                                           module, published with a
+#                                           tag, but root resolves it
+#                                           through a local replace
+#                                           and the require version
+#                                           is a placeholder.
+#   - <prefix>/pool                       — workspace-only.
+#   - <prefix>/adapters/adapter_v*        — every server-only adapter
+#                                           module, also workspace-
+#                                           only.
+#
+# Note that <prefix>/dynclient/baml-patched is NOT in this set: it's
+# a published, indirectly-required module in root with no local
+# replace, so it must be at exact v${version} like the other
+# published modules. The exact-prefix match below distinguishes
+# "dynclient" from "dynclient/baml-patched".
+release_dep_allows_pseudo() {
+    local dep="$1"
+    local prefix="$release_first_party_prefix"
+    case "$dep" in
+        "${prefix}/dynclient"|"${prefix}/pool")
+            return 0
+            ;;
+        "${prefix}/adapters/adapter_v"*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
 # release_extract_first_party_requires
 #
 # Reads a go.mod from stdin and prints first-party `require` lines
@@ -69,12 +105,17 @@ release_extract_first_party_requires() {
 # non-`v0.0.<positive-int>` require fail by default.
 #
 # Pass <allow_pseudo>=true to permit `v0.0.0-...` requires alongside
-# <expected_version> — used by the root validator, where modules
-# deliberately excluded from the published tag set (adapter_v*,
-# dynclient, pool — see release-lib.sh `release_required_modules` and
-# RELEASE.md) intentionally sit at pseudo-versions. The published
-# modules in `release_required_modules` always pass false because a
-# pseudo-version surviving in a published go.mod is the #308 failure.
+# <expected_version>, but ONLY for first-party modules that
+# release_dep_allows_pseudo accepts (the workspace-only set:
+# adapter_v*, dynclient, pool). A pseudo-version for a published
+# module (anything in release_required_modules) still fails even when
+# allow_pseudo=true — those modules must always move forward to
+# exact <expected_version> at each release. The published-module
+# loop in release-prep.sh passes the default false and the root
+# validator passes true; both rely on the same per-dep gate so a
+# pseudo accidentally landing on bamlutils / common / introspected /
+# worker / workerplugin / dynclient/baml-patched in root still
+# trips validation.
 #
 # Output:
 #   - returns 0 if clean, 1 otherwise.
@@ -140,7 +181,13 @@ release_validate_module_requires() {
 
         if [[ "$dep_version" == v0.0.0-* ]]; then
             release_last_failure_lines+=$'pseudo\t'"${dep_version}"$'\n'
-            if [ "$allow_pseudo" = true ]; then
+            # allow_pseudo is the call-site gate ("any pseudo at all
+            # acceptable here?"); release_dep_allows_pseudo is the
+            # per-dep gate ("is THIS first-party module workspace-only?").
+            # Both must be true for a pseudo-version to pass. This stops
+            # an accidental pseudo on a published module (e.g. bamlutils
+            # in root) from sneaking through under allow_pseudo=true.
+            if [ "$allow_pseudo" = true ] && release_dep_allows_pseudo "$dep"; then
                 continue
             fi
             echo "  pseudo-version not allowed: ${dep} ${dep_version}" >&2

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -74,24 +74,14 @@ cd "$repo_root"
 
 expected_version="v${version}"
 
-# Reject if the version is already a release tag — re-running this
-# script for an already-cut release silently churns module files
-# against a frozen tag, which is never what the operator wants. The
-# hint covers the two real use cases: bumping forward (next release)
-# or skipping a broken cut (cleanly prepping vN+1 after vN was
-# botched).
-if git tag --list "$version" | grep -qx "$version"; then
-    echo "ERROR: ${version} is already a release tag; this script prepares the *next* release commit" >&2
-    echo "       — to bump forward, pass the next version (e.g. the patch after ${version})" >&2
-    echo "       — to recover a botched ${version}, skip it and prep the next version cleanly" >&2
-    exit 1
-fi
-
-# The set of go.mod paths the script may stage at the end. The five
-# directly-edited published modules, pool, and every existing
-# adapters/adapter_v*/go.mod (which sync.sh refreshes). Resolved
-# eagerly so the same list drives both the preflight and the
-# stage-at-end pass and the two paths can't drift.
+# The set of paths the script may stage at the end. The five
+# directly-edited published modules, pool, every existing
+# adapters/adapter_v*/go.mod (which sync.sh refreshes), and root's
+# go.mod / go.sum (which the final `go mod tidy` step rewrites to
+# pull root's first-party requires forward to the released tag set —
+# closes the gap that surfaced after 0.0.47 as Renovate PRs #330 and
+# #331). Resolved eagerly so the same list drives both the preflight
+# and the stage-at-end pass and the two paths can't drift.
 candidate_paths=(
     dynclient/go.mod
     adapters/common/go.mod
@@ -99,6 +89,8 @@ candidate_paths=(
     worker/go.mod
     workerplugin/go.mod
     pool/go.mod
+    go.mod
+    go.sum
 )
 shopt -s nullglob
 for dir in adapters/adapter_v*/; do
@@ -128,10 +120,12 @@ if [ "${#dirty_paths[@]}" -gt 0 ]; then
     exit 1
 fi
 
-# Detect previous version informationally for the status output. The
-# `[0-9]*` glob excludes subdir-prefixed module tags like
-# `dynclient/v0.0.46` so only product tags rank. `--sort=-v:refname`
-# returns them in descending semver order so `head -1` is the latest.
+# Detect the most recent product tag. The `[0-9]*` glob excludes
+# subdir-prefixed module tags like `dynclient/v0.0.46` so only product
+# tags rank. `--sort=-v:refname` returns them in descending semver
+# order so `head -1` is the latest. Computed up here (rather than just
+# before the "prev → version" banner below) so the tag-existence
+# branch below can compare against it for backfill-mode detection.
 prev_version="$(git tag --list '[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1 || true)"
 if [ -z "$prev_version" ]; then
     echo "ERROR: no previous X.Y.Z tag found; release-prep.sh is meant for incremental releases" >&2
@@ -139,7 +133,45 @@ if [ -z "$prev_version" ]; then
     exit 1
 fi
 
-echo "release-prep: ${prev_version} → ${version}"
+# Tag-existence semantics:
+# - version is not a product tag → normal forward release-prep (no
+#   message, just continue).
+# - version equals the latest product tag → backfill mode. Every
+#   published-module edit will be a no-op (modules are already at
+#   expected_version from the prior run), but the root `go mod tidy`
+#   step at the end can still pull root's first-party requires forward
+#   to match the release that already shipped. This is the path that
+#   closes the #330/#331 gap on 0.0.47 without needing a one-off
+#   maintainer script. Allow it with a NOTE so the operator sees what
+#   the script is doing.
+# - version is some older product tag → almost certainly a typo. A run
+#   here would attempt to downgrade root's first-party requires below
+#   the released set. Refuse so the operator catches the mistake
+#   before any file changes.
+backfill_mode=false
+if git tag --list "$version" | grep -qx "$version"; then
+    if [ "$version" = "$prev_version" ]; then
+        backfill_mode=true
+        echo "NOTE: ${version} is already the latest product tag — running in backfill mode."
+        echo "      Published-module edits will be no-ops (already at ${expected_version});"
+        echo "      the root \`go mod tidy\` step will pull root's first-party requires"
+        echo "      forward to ${expected_version}."
+        echo
+    else
+        echo "ERROR: ${version} is already a release tag, and not the latest one (${prev_version})." >&2
+        echo "       Running release-prep for an older tag would attempt to downgrade root's" >&2
+        echo "       first-party requires below the released set." >&2
+        echo "       — to bump forward, pass the next version after ${prev_version}" >&2
+        echo "       — to recover a botched ${version}, skip it and prep the next version cleanly" >&2
+        exit 1
+    fi
+fi
+
+if [ "$backfill_mode" = true ]; then
+    echo "release-prep: ${prev_version} (backfill)"
+else
+    echo "release-prep: ${prev_version} → ${version}"
+fi
 echo
 
 # Apply the 11 explicit go mod edit rewrites across the five
@@ -205,6 +237,22 @@ run_edit pool \
     bamlutils \
     workerplugin
 
+# Root module: tidy so root's first-party requires (and the indirect
+# dynclient/baml-patched require + its go.sum entries) move forward to
+# match the released module set. Root is deliberately excluded from
+# the published-tag set (see release-lib.sh release_required_modules),
+# but its own go.mod still references the published modules — those
+# references must move forward at each release. Skipping this step is
+# what produced Renovate PRs #330 and #331 against 0.0.47: every
+# release `go mod tidy` in root would do this organically, so Renovate
+# saw the lag and opened cosmetic-stale bumps that duplicated what
+# tidy would do anyway. Doing it here as part of release-prep keeps
+# the released tree self-consistent without needing the bot to fill
+# the gap.
+echo
+echo "Tidying root module..."
+go mod tidy
+
 # Final validation: every required module's first-party requires
 # must match v${version}. This is the same shape
 # scripts/release-go-tags.sh enforces against the tagged commit, run
@@ -225,6 +273,18 @@ for module_path in "${release_required_modules[@]}"; do
         validation_failed=1
     fi
 done
+# Root: the workspace-only modules (adapter_v*, dynclient, pool) sit
+# at pseudo-versions in root by design — they're never published with
+# a tag, and root resolves them through local `replace` directives in
+# the same go.mod. Pass allow_pseudo=true so the validator treats those
+# pseudos as clean while still catching v0.0.<N≠expected> stales for
+# the published modules root depends on (adapters/common, bamlutils,
+# introspected, worker, workerplugin, and the indirect baml-patched).
+echo "  ./go.mod (root)"
+if ! release_validate_module_requires "(root)" "$expected_version" true < go.mod; then
+    echo "ERROR: root go.mod still has first-party requires that don't match ${expected_version}" >&2
+    validation_failed=1
+fi
 if [ "$validation_failed" -ne 0 ]; then
     echo
     echo "ERROR: release-prep validation failed — fix the modules above and re-run" >&2

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -14,7 +14,10 @@ set -euo pipefail
 # This script exists because the manual release-prep — eleven hand
 # -typed `go mod edit` calls plus a `sync.sh` run plus a known
 # pool-vs-workerplugin quirk — was the step most often skipped, and
-# skipping it forces a destructive tag move to recover. See #308.
+# skipping it forces a destructive tag move to recover (the product
+# tag has to be force-moved to a fresh commit, which rewrites
+# already-published release history). RELEASE.md captures the full
+# failure-mode taxonomy under "What goes wrong if you skip Step 1".
 #
 # Usage:
 #   scripts/release-prep.sh X.Y.Z
@@ -79,8 +82,9 @@ expected_version="v${version}"
 # adapters/adapter_v*/go.mod (which sync.sh refreshes), and root's
 # go.mod / go.sum (which the final `go mod tidy` step rewrites to
 # pull root's first-party requires forward to the released tag set —
-# closes the gap that surfaced after 0.0.47 as Renovate PRs #330 and
-# #331). Resolved eagerly so the same list drives both the preflight
+# without this, root's go.mod drifts behind every release and the
+# Renovate bot opens redundant first-party bump PRs to close the gap
+# instead). Resolved eagerly so the same list drives both the preflight
 # and the stage-at-end pass and the two paths can't drift.
 candidate_paths=(
     dynclient/go.mod
@@ -175,10 +179,10 @@ fi
 #   published-module edit will be a no-op (modules are already at
 #   expected_version from the prior run), but the root `go mod tidy`
 #   step at the end can still pull root's first-party requires forward
-#   to match the release that already shipped. This is the path that
-#   closed the #330/#331 gap on 0.0.47 without needing a one-off
-#   maintainer script. Allow it with a NOTE so the operator sees what
-#   the script is doing.
+#   to match the release that already shipped. This is the post-Step-6
+#   rerun path that updates root once the per-module tags reach the
+#   module proxy — no separate maintainer script required. Allow it
+#   with a NOTE so the operator sees what the script is doing.
 backfill_mode=false
 if [ "$version" = "$prev_version" ]; then
     backfill_mode=true
@@ -198,8 +202,8 @@ echo
 
 # Apply the 11 explicit go mod edit rewrites across the five
 # published modules that have first-party requires. The set matches
-# RELEASE.md "Step 1 — Release-prep require rewrites" and the diffs
-# from PRs #319 and #321.
+# the manual copy-paste form documented under RELEASE.md "Step 1 —
+# Release-prep require rewrites".
 #
 # Each module's edits are batched into a single `go mod edit` call so
 # `go.mod` is only rewritten once per module, matching the manual
@@ -243,8 +247,8 @@ run_edit workerplugin \
 #
 # Known quirk: `go work sync` propagates bamlutils to pool/go.mod but
 # does NOT rewrite pool's `workerplugin` require for the same
-# release. Both prior release-prep PRs (#319, #321) had to bump it
-# manually. We handle that explicitly below after sync.sh runs.
+# release. We handle that explicitly below after sync.sh runs so the
+# automation matches the manual procedure that's worked in practice.
 echo
 echo "Running scripts/sync.sh..."
 "$script_dir/sync.sh"
@@ -264,19 +268,20 @@ run_edit pool \
 # match the released module set. Root is deliberately excluded from
 # the published-tag set (see release-lib.sh release_required_modules),
 # but its own go.mod still references the published modules — those
-# references must move forward at each release. Skipping this step is
-# what produced Renovate PRs #330 and #331 against 0.0.47: every
-# release `go mod tidy` in root would do this organically, so Renovate
-# saw the lag and opened cosmetic-stale bumps that duplicated what
-# tidy would do anyway. Doing it here as part of release-prep keeps
-# the released tree self-consistent without needing the bot to fill
-# the gap.
+# references must move forward at each release. Without this step,
+# every release `go mod tidy` in root would do the bump organically
+# (eventually), and Renovate sees the lag in the meantime and opens
+# redundant first-party bump PRs that duplicate what tidy produces
+# anyway. Doing it here as part of release-prep keeps the released
+# tree self-consistent and lets the Renovate config disable first-
+# party deps without losing anything.
 #
 # Backfill-mode-only: this step is gated on backfill_mode because
 # tidy needs the new product tag to exist on the module proxy. Root
-# has no local replace for dynclient/baml-patched (intentional, see
-# go.work and PR #335 thread), so a forward-mode run for an unreleased
-# version would crash here with "unknown revision
+# has no local replace for dynclient/baml-patched (intentional —
+# go.work's inline notes explain why the patched fork stays outside
+# the workspace), so a forward-mode run for an unreleased version
+# would crash here with "unknown revision
 # dynclient/baml-patched/v0.0.X". The canonical flow is forward prep
 # (this step skipped) → tag → release-go-tags → re-run release-prep
 # in backfill mode (this step fires) → commit root. The "Next steps"

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -363,7 +363,20 @@ done
 
 if [ "$staged_any" -eq 0 ]; then
     echo "No changes — every first-party require was already at ${expected_version}."
-    echo "(Run scripts/release-go-tags.sh ${version} after tagging.)"
+    # The post-`No changes` hint depends on where in the release flow
+    # the operator is. In forward mode, the only reason this branch
+    # fires is that someone already landed the Step 1 rewrites
+    # manually (or via a previous run) — they still need to push +
+    # tag + release-go-tags. In backfill mode, "no changes" means root
+    # is already current with the released module set (e.g. the
+    # operator ran backfill twice, or root was tidied out of band);
+    # there's nothing left to do for this release.
+    if [ "$backfill_mode" = true ]; then
+        echo "(Backfill is a no-op — root already tracks ${expected_version}; nothing to commit.)"
+    else
+        echo "(Run scripts/release-go-tags.sh ${version} after tagging,"
+        echo " then re-run scripts/release-prep.sh ${version} for the Step 7 root backfill.)"
+    fi
     exit 0
 fi
 
@@ -376,8 +389,24 @@ echo "Staged files:"
 # below).
 git diff --cached --name-only -- "${candidate_paths[@]}" | sed 's/^/  /'
 
+# Next-steps guidance — split by mode because forward and backfill
+# land in different places in the release flow:
+# - Forward prep is the Step 1 commit; the next chapter is RELEASE.md
+#   Steps 3-6 (push to master, tag, release-go-tags). The forward
+#   output also points at Step 7 so the operator knows the post-tag
+#   backfill rerun is a real step, not a workaround.
+# - Backfill prep is the Step 7 commit; tags already exist, no further
+#   release-go-tags pass, no GitHub Release to publish. The maintainer
+#   just commits + pushes via a regular PR. The commit-message shape
+#   differs (`backfill root for ${version}` vs `prepare Go module
+#   versions for ${version}`) so it's clear in `git log` which
+#   release-prep run produced the commit.
 echo
-echo "Next steps (per RELEASE.md):"
+if [ "$backfill_mode" = true ]; then
+    echo "Next steps (RELEASE.md Step 7 — post-tag root backfill):"
+else
+    echo "Next steps (RELEASE.md Step 1 — forward release-prep):"
+fi
 echo "  1. Verify the build:  go build ./... && go vet ./... && go test ./... -count=1"
 echo "                        (cd dynclient && GOWORK=off go test ./... -count=1)"
 echo "  2. Review the diff:   git diff --cached -- ${candidate_paths[*]}"
@@ -385,10 +414,16 @@ echo "  2. Review the diff:   git diff --cached -- ${candidate_paths[*]}"
 # the working-tree content of those paths only, ignoring any
 # unrelated changes the maintainer may have staged separately. The
 # commit is safe to copy-paste even when other staged work exists.
-echo "  3. Commit:            git commit -m \"chore(release): prepare Go module versions for ${version}\" \\"
-echo "                            -- ${candidate_paths[*]}"
-echo "  4. Push to master and continue from RELEASE.md Step 3."
-if [ "$backfill_mode" != true ]; then
+if [ "$backfill_mode" = true ]; then
+    echo "  3. Commit:            git commit -m \"chore(release): backfill root for ${version}\" \\"
+    echo "                            -- ${candidate_paths[*]}"
+    echo "  4. Push to master via a regular PR. No new tag, no GitHub Release —"
+    echo "     root is excluded from the published tag set (see RELEASE.md Tag conventions),"
+    echo "     so this commit just keeps root's go.mod / go.sum tracking the released set."
+else
+    echo "  3. Commit:            git commit -m \"chore(release): prepare Go module versions for ${version}\" \\"
+    echo "                            -- ${candidate_paths[*]}"
+    echo "  4. Push to master and continue from RELEASE.md Step 3."
     # The root tidy step was skipped in forward mode (it needs the
     # new product tag on the module proxy). After tagging in Steps 4
     # / 6 of RELEASE.md, re-running this script picks up backfill
@@ -398,6 +433,7 @@ if [ "$backfill_mode" != true ]; then
     # context.
     echo
     echo "  After Step 6 (release-go-tags.sh ${version}), re-run \`scripts/release-prep.sh ${version}\`"
-    echo "  to backfill root's first-party requires. That second run executes \`go mod tidy\` in"
-    echo "  the repo root, which needs the new product tag to be reachable on the module proxy."
+    echo "  per RELEASE.md Step 7 to backfill root's first-party requires. That second run"
+    echo "  executes \`go mod tidy\` in the repo root, which needs the new product tag to be"
+    echo "  reachable on the module proxy."
 fi

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -124,8 +124,8 @@ fi
 # subdir-prefixed module tags like `dynclient/v0.0.46` so only product
 # tags rank. `--sort=-v:refname` returns them in descending semver
 # order so `head -1` is the latest. Computed up here (rather than just
-# before the "prev → version" banner below) so the tag-existence
-# branch below can compare against it for backfill-mode detection.
+# before the "prev → version" banner below) so the ordering check
+# and backfill-mode detection below can compare against it.
 prev_version="$(git tag --list '[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1 || true)"
 if [ -z "$prev_version" ]; then
     echo "ERROR: no previous X.Y.Z tag found; release-prep.sh is meant for incremental releases" >&2
@@ -133,38 +133,60 @@ if [ -z "$prev_version" ]; then
     exit 1
 fi
 
-# Tag-existence semantics:
-# - version is not a product tag → normal forward release-prep (no
-#   message, just continue).
+# Bash 3.2-compatible "a < b" comparison for X.Y.Z semver. Used by the
+# ordering check below; we can't lean on `sort -V` because macOS BSD
+# sort doesn't ship it. `10#$x` forces decimal so a leading zero
+# anywhere in the version (already caught by the earlier shape
+# regex, but defense-in-depth) doesn't trigger octal interpretation.
+semver_lt() {
+    local a_major a_minor a_patch b_major b_minor b_patch
+    IFS=. read -r a_major a_minor a_patch <<< "$1"
+    IFS=. read -r b_major b_minor b_patch <<< "$2"
+
+    if [ $((10#$a_major)) -lt $((10#$b_major)) ]; then return 0; fi
+    if [ $((10#$a_major)) -gt $((10#$b_major)) ]; then return 1; fi
+    if [ $((10#$a_minor)) -lt $((10#$b_minor)) ]; then return 0; fi
+    if [ $((10#$a_minor)) -gt $((10#$b_minor)) ]; then return 1; fi
+    [ $((10#$a_patch)) -lt $((10#$b_patch)) ]
+}
+
+# Ordering check: refuse if version is older than the latest product
+# tag, regardless of whether the older tag exists in the local clone.
+# Without this, a typo like `release-prep.sh 0.0.45` in a shallow or
+# tag-pruned clone (where 0.0.45 isn't fetched) would slip past the
+# tag-existence branch below and proceed to downgrade root's
+# first-party requires. The semver comparison fires first so the
+# operator gets a single clear error, not whatever cascade `go mod
+# tidy` would produce against the wrong version.
+if semver_lt "$version" "$prev_version"; then
+    echo "ERROR: ${version} is older than the latest product tag (${prev_version})." >&2
+    echo "       Running release-prep for an older version would attempt to downgrade root's" >&2
+    echo "       first-party requires below the released set." >&2
+    echo "       — to bump forward, pass the next version after ${prev_version}" >&2
+    echo "       — to recover a botched ${version}, skip it and prep the next version cleanly" >&2
+    exit 1
+fi
+
+# Tag-existence semantics, simplified now that semver_lt above already
+# rejected version < prev_version:
+# - version > prev_version → normal forward release-prep (no message,
+#   just continue).
 # - version equals the latest product tag → backfill mode. Every
 #   published-module edit will be a no-op (modules are already at
 #   expected_version from the prior run), but the root `go mod tidy`
 #   step at the end can still pull root's first-party requires forward
 #   to match the release that already shipped. This is the path that
-#   closes the #330/#331 gap on 0.0.47 without needing a one-off
+#   closed the #330/#331 gap on 0.0.47 without needing a one-off
 #   maintainer script. Allow it with a NOTE so the operator sees what
 #   the script is doing.
-# - version is some older product tag → almost certainly a typo. A run
-#   here would attempt to downgrade root's first-party requires below
-#   the released set. Refuse so the operator catches the mistake
-#   before any file changes.
 backfill_mode=false
-if git tag --list "$version" | grep -qx "$version"; then
-    if [ "$version" = "$prev_version" ]; then
-        backfill_mode=true
-        echo "NOTE: ${version} is already the latest product tag — running in backfill mode."
-        echo "      Published-module edits will be no-ops (already at ${expected_version});"
-        echo "      the root \`go mod tidy\` step will pull root's first-party requires"
-        echo "      forward to ${expected_version}."
-        echo
-    else
-        echo "ERROR: ${version} is already a release tag, and not the latest one (${prev_version})." >&2
-        echo "       Running release-prep for an older tag would attempt to downgrade root's" >&2
-        echo "       first-party requires below the released set." >&2
-        echo "       — to bump forward, pass the next version after ${prev_version}" >&2
-        echo "       — to recover a botched ${version}, skip it and prep the next version cleanly" >&2
-        exit 1
-    fi
+if [ "$version" = "$prev_version" ]; then
+    backfill_mode=true
+    echo "NOTE: ${version} is already the latest product tag — running in backfill mode."
+    echo "      Published-module edits will be no-ops (already at ${expected_version});"
+    echo "      the root \`go mod tidy\` step will pull root's first-party requires"
+    echo "      forward to ${expected_version}."
+    echo
 fi
 
 if [ "$backfill_mode" = true ]; then
@@ -249,9 +271,21 @@ run_edit pool \
 # tidy would do anyway. Doing it here as part of release-prep keeps
 # the released tree self-consistent without needing the bot to fill
 # the gap.
-echo
-echo "Tidying root module..."
-go mod tidy
+#
+# Backfill-mode-only: this step is gated on backfill_mode because
+# tidy needs the new product tag to exist on the module proxy. Root
+# has no local replace for dynclient/baml-patched (intentional, see
+# go.work and PR #335 thread), so a forward-mode run for an unreleased
+# version would crash here with "unknown revision
+# dynclient/baml-patched/v0.0.X". The canonical flow is forward prep
+# (this step skipped) → tag → release-go-tags → re-run release-prep
+# in backfill mode (this step fires) → commit root. The "Next steps"
+# output in forward mode below points the operator at the re-run.
+if [ "$backfill_mode" = true ]; then
+    echo
+    echo "Tidying root module..."
+    go mod tidy
+fi
 
 # Final validation: every required module's first-party requires
 # must match v${version}. This is the same shape
@@ -280,10 +314,22 @@ done
 # pseudos as clean while still catching v0.0.<N≠expected> stales for
 # the published modules root depends on (adapters/common, bamlutils,
 # introspected, worker, workerplugin, and the indirect baml-patched).
-echo "  ./go.mod (root)"
-if ! release_validate_module_requires "(root)" "$expected_version" true < go.mod; then
-    echo "ERROR: root go.mod still has first-party requires that don't match ${expected_version}" >&2
-    validation_failed=1
+#
+# Gated on backfill_mode for the same reason as the tidy step above:
+# in forward mode root intentionally stays at the previous release
+# (the tidy step that would advance it is skipped), so a forward
+# validation against the new expected_version would report every
+# root first-party require as "stale" — a false-positive specific
+# to the forward flow. Backfill mode does run tidy first, so the
+# validation here is meaningful: it catches anything tidy left
+# behind (notably, a pseudo-version sneaking onto a published
+# module in root, which release_dep_allows_pseudo now rejects).
+if [ "$backfill_mode" = true ]; then
+    echo "  ./go.mod (root)"
+    if ! release_validate_module_requires "(root)" "$expected_version" true < go.mod; then
+        echo "ERROR: root go.mod still has first-party requires that don't match ${expected_version}" >&2
+        validation_failed=1
+    fi
 fi
 if [ "$validation_failed" -ne 0 ]; then
     echo
@@ -342,3 +388,16 @@ echo "  2. Review the diff:   git diff --cached -- ${candidate_paths[*]}"
 echo "  3. Commit:            git commit -m \"chore(release): prepare Go module versions for ${version}\" \\"
 echo "                            -- ${candidate_paths[*]}"
 echo "  4. Push to master and continue from RELEASE.md Step 3."
+if [ "$backfill_mode" != true ]; then
+    # The root tidy step was skipped in forward mode (it needs the
+    # new product tag on the module proxy). After tagging in Steps 4
+    # / 6 of RELEASE.md, re-running this script picks up backfill
+    # mode and produces the root go.mod / go.sum bump as a separate
+    # commit on top of the release-go-tags work. Surface that here so
+    # the operator doesn't have to remember the two-phase flow from
+    # context.
+    echo
+    echo "  After Step 6 (release-go-tags.sh ${version}), re-run \`scripts/release-prep.sh ${version}\`"
+    echo "  to backfill root's first-party requires. That second run executes \`go mod tidy\` in"
+    echo "  the repo root, which needs the new product tag to be reachable on the module proxy."
+fi


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Three commits that close the release-prep gap surfaced post-0.0.47 as Renovate PRs #330 and #331 (both opened bundled `v0.0.46 → v0.0.47` bumps across six first-party requires in root `go.mod`, each scoped to a single first-party module by their title).

1. **`chore(release): extend release-prep.sh to cover root go.mod / go.sum`** — release-prep.sh now runs `go mod tidy` in the repo root after the published-module + pool edits, and validates root alongside the seven published modules (with `allow_pseudo=true` so workspace-only `adapter_v0_*` / `dynclient` / `pool` pseudo-version requires stay clean). Adds a backfill mode that lets the script run when the requested version equals the latest product tag — needed for this PR to apply the new step against 0.0.47 (already tagged), and useful any time root drifts from the released set.
2. **`chore(deps): ignore first-party modules in renovate.json`** — `matchPackagePrefixes: ["github.com/invakid404/baml-rest"]`, `enabled: false`. First-party versions are release-prep-managed; Renovate has no business second-guessing them.
3. **`chore(release): bump root first-party requires to v0.0.47`** — the actual backfill: `./scripts/release-prep.sh 0.0.47` produced exactly `go.mod` + `go.sum` changes (every published module was already at `v0.0.47` from #327). Bumps the six first-party requires in root and refreshes `dynclient/baml-patched` go.sum hashes for v0.0.47. Also drops three stale `go.sum` entries (containerd/api v1.11.0, containerd/v2 v2.3.0, docker/buildx v0.34.0) that merged Renovate PRs #326 and #311 left behind — incidental cleanup that `go mod tidy` does for free.

## Why this matters

Root is deliberately excluded from the published tag set (see `release-lib.sh` `release_required_modules` and RELEASE.md PR #289 rationale), but its own `go.mod` still references the published modules — `go mod tidy` will pull those forward to the latest tag organically. Skipping that as part of release-prep is what made #330/#331 possible: Renovate saw the lag and opened bumps that duplicated what tidy would do anyway. Doing it inside release-prep keeps the released tree self-consistent and lets us tell Renovate to stay out of first-party deps without losing anything.

The `dynclient/baml-patched` indirect require in root is the load-bearing case — no local `replace` in root, real `go.sum` hash — and it was sitting stale at v0.0.46 on master until this PR.

## What lands where

| File | What changes |
| --- | --- |
| `scripts/release-prep.sh` | Adds `go.mod` + `go.sum` to candidate paths, restructures the tag-existence guard into normal/backfill/older-tag branches, runs `go mod tidy` in root after the pool bumps, and validates root in the final loop. |
| `scripts/release-lib.sh` | `release_validate_module_requires` gains a third `allow_pseudo` parameter (default `false`, preserves existing behavior for the published-module loop). |
| `renovate.json` | New `matchPackagePrefixes` rule disabling first-party bumps repo-wide. |
| `go.mod`, `go.sum` | One-time 0.0.47 backfill. |

## Supersedes

- #330 (`fix(deps): update module github.com/invakid404/baml-rest/adapters/common to v0.0.47`)
- #331 (`fix(deps): update module github.com/invakid404/baml-rest/bamlutils to v0.0.47`)

Both produce the same six-require root bump as a bundled side effect of their stated single-module scope; they'll be closed as superseded after this lands.

## Test plan

- [x] `bash -n scripts/release-prep.sh` + `scripts/release-lib.sh` — syntax clean.
- [x] `python3 -m json.tool < renovate.json` — JSON valid.
- [x] `./scripts/release-prep.sh 0.0.47` from current master — runs in backfill mode, only stages `go.mod` + `go.sum`, all validators pass.
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test ./... -count=1` — all pass.
- [x] `(cd dynclient && GOWORK=off go test ./... -count=1)` — all pass.
- [ ] After merge, close #330 and #331 as superseded.
- [ ] Confirm Renovate doesn't re-open them on its next scheduled run (the `matchPackagePrefixes` rule should suppress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped several internal module dependency versions to align released tags.
  * Release scripts: added support for permitted pseudo-versions, updated validation to optionally allow them while still recording occurrences, and introduced mode-aware output.
  * Strengthened release workflow with semver checks, a backfill mode, root manifest staging, and conditional tidy/validation to support safe backfills.
  * Disabled automated dependency updates for first‑party modules in the dependency manager config.

* **Documentation**
  * Added a release step documenting the backfill root first‑party requires flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->