### PR TITLE
refactor(bamlutils): drop encoding/json holdouts using sonic ast

### DIFF
--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -2,11 +2,11 @@ package bamlutils
 
 import (
 	"bytes"
-	stdjson "encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/bytedance/sonic"
+	"github.com/bytedance/sonic/ast"
 	"github.com/cloudwego/gjson"
 )
 
@@ -156,7 +156,7 @@ func (m *DynamicMessage) UnmarshalJSON(data []byte) error {
 	// Use a raw type to avoid infinite recursion
 	var raw struct {
 		Role     string             `json:"role"`
-		Content  stdjson.RawMessage `json:"content"`
+		Content  sonic.NoCopyRawMessage `json:"content"`
 		Metadata *MessageMetadata   `json:"metadata,omitempty"`
 	}
 	if err := sonic.Unmarshal(data, &raw); err != nil {
@@ -376,9 +376,9 @@ func (s *DynamicOutputSchema) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	var raw struct {
-		Properties stdjson.RawMessage `json:"properties"`
-		Classes    stdjson.RawMessage `json:"classes"`
-		Enums      stdjson.RawMessage `json:"enums"`
+		Properties sonic.NoCopyRawMessage `json:"properties"`
+		Classes    sonic.NoCopyRawMessage `json:"classes"`
+		Enums      sonic.NoCopyRawMessage `json:"enums"`
 	}
 	if err := sonic.Unmarshal(data, &raw); err != nil {
 		return err
@@ -427,7 +427,7 @@ func (c *DynamicClass) UnmarshalJSON(data []byte) error {
 	var raw struct {
 		Description string             `json:"description,omitempty"`
 		Alias       string             `json:"alias,omitempty"`
-		Properties  stdjson.RawMessage `json:"properties,omitempty"`
+		Properties  sonic.NoCopyRawMessage `json:"properties,omitempty"`
 	}
 	if err := sonic.Unmarshal(data, &raw); err != nil {
 		return err
@@ -464,52 +464,45 @@ func rejectNonObject(path string, b []byte) error {
 	return fmt.Errorf("%s: must be a JSON object", path)
 }
 
-// checkUniqueTopLevelKeys token-walks the outer object and rejects any
-// duplicate key. The struct-tag unmarshal path on the receiver
-// (DynamicOutputSchema, DynamicClass) accepts duplicate top-level keys
-// with last-wins semantics, contradicting the strict-duplicate rule
-// enforced for inner schema objects via unmarshalOrderedObject. Calling
-// this before the raw-struct decode restores symmetry — both layers now
-// reject ambiguous repeats.
+// checkUniqueTopLevelKeys walks the outer object via sonic's ast.Parser
+// and rejects any duplicate key. The struct-tag unmarshal path on the
+// receiver (DynamicOutputSchema, DynamicClass) accepts duplicate
+// top-level keys with last-wins semantics, contradicting the strict-
+// duplicate rule enforced for inner schema objects via
+// unmarshalOrderedMap. Calling this before the raw-struct decode restores
+// symmetry — both layers now reject ambiguous repeats.
 //
-// Non-object inputs are left to the regular unmarshal so the caller
-// keeps producing the same shape-error it does today.
+// Non-object inputs and parse errors are deferred to the subsequent
+// sonic.Unmarshal so the caller keeps producing the same shape-error
+// it does today.
 //
-// This is one of two locked stdlib `encoding/json` token-walking sites
-// (the other is unmarshalOrderedMap). Sonic does not expose
-// Decoder.Token / json.Delim, so duplicate-key rejection over a
-// streaming token walk stays on the stdlib decoder.
+// Sonic's ast.Visitor interface uses encoding/json.Number in the number-
+// value callback signatures, so a direct visitor implementation would
+// force the encoding/json import back into the file. The Parser +
+// Properties iterator is the equivalent sonic-native streaming
+// traversal: the iterator yields pairs in source order and preserves
+// duplicates (sonic's linkedPairs pushes every pair unconditionally),
+// so the dup loop sees both occurrences.
 func checkUniqueTopLevelKeys(data []byte, path string) error {
-	dec := stdjson.NewDecoder(bytes.NewReader(data))
-	tok, err := dec.Token()
-	if err != nil {
-		return fmt.Errorf("%s: %w", path, err)
+	parser := ast.NewParser(string(data))
+	node, errP := parser.Parse()
+	if errP != 0 {
+		return nil
 	}
-	delim, ok := tok.(stdjson.Delim)
-	if !ok || delim != '{' {
+	if node.TypeSafe() != ast.V_OBJECT {
+		return nil
+	}
+	it, err := node.Properties()
+	if err != nil {
 		return nil
 	}
 	seen := make(map[string]struct{})
-	for dec.More() {
-		keyTok, err := dec.Token()
-		if err != nil {
-			return fmt.Errorf("%s: %w", path, err)
+	var pair ast.Pair
+	for it.Next(&pair) {
+		if _, dup := seen[pair.Key]; dup {
+			return fmt.Errorf("%s: duplicate key %q", path, pair.Key)
 		}
-		key, ok := keyTok.(string)
-		if !ok {
-			return fmt.Errorf("%s: expected object key", path)
-		}
-		if _, dup := seen[key]; dup {
-			return fmt.Errorf("%s: duplicate key %q", path, key)
-		}
-		seen[key] = struct{}{}
-		var raw stdjson.RawMessage
-		if err := dec.Decode(&raw); err != nil {
-			return fmt.Errorf("%s.%s: %w", path, key, err)
-		}
-	}
-	if _, err := dec.Token(); err != nil {
-		return fmt.Errorf("%s: %w", path, err)
+		seen[pair.Key] = struct{}{}
 	}
 	return nil
 }

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -155,9 +155,9 @@ type DynamicMessage struct {
 func (m *DynamicMessage) UnmarshalJSON(data []byte) error {
 	// Use a raw type to avoid infinite recursion
 	var raw struct {
-		Role     string             `json:"role"`
+		Role     string                 `json:"role"`
 		Content  sonic.NoCopyRawMessage `json:"content"`
-		Metadata *MessageMetadata   `json:"metadata,omitempty"`
+		Metadata *MessageMetadata       `json:"metadata,omitempty"`
 	}
 	if err := sonic.Unmarshal(data, &raw); err != nil {
 		return err
@@ -425,8 +425,8 @@ func (c *DynamicClass) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	var raw struct {
-		Description string             `json:"description,omitempty"`
-		Alias       string             `json:"alias,omitempty"`
+		Description string                 `json:"description,omitempty"`
+		Alias       string                 `json:"alias,omitempty"`
 		Properties  sonic.NoCopyRawMessage `json:"properties,omitempty"`
 	}
 	if err := sonic.Unmarshal(data, &raw); err != nil {

--- a/bamlutils/orderedmap.go
+++ b/bamlutils/orderedmap.go
@@ -2,13 +2,12 @@ package bamlutils
 
 import (
 	"bytes"
-	stdjson "encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"iter"
 
 	"github.com/bytedance/sonic"
+	"github.com/bytedance/sonic/ast"
 )
 
 // ErrOrderedMapDuplicateKey is the sentinel returned (wrapped in
@@ -285,39 +284,42 @@ func (m *OrderedMap[V]) UnmarshalJSON(data []byte) error {
 // dynamic.go. The optional path is prefixed to errors so callers
 // retain the existing field-qualified error text quality.
 //
-// This is one of two locked stdlib `encoding/json` token-walking sites
-// (the other is checkUniqueTopLevelKeys in dynamic.go). Sonic does not
-// expose Decoder.Token / json.Delim, so the streaming token walk that
-// preserves wire-order and rejects duplicates / trailing bytes stays on
-// the stdlib decoder. Inner value decoding hops to sonic once the raw
-// bytes for a value have been captured.
+// Walks the JSON via sonic's ast.Parser + Properties iterator: the
+// iterator yields pairs in source order and preserves duplicate keys
+// (sonic's linkedPairs stores every pushed pair without dedup), which
+// is the property needed for strict duplicate-key rejection. Per-value
+// decoding then hops back through sonic.Unmarshal on the raw substring.
+//
+// Sonic's ast.Visitor interface uses encoding/json.Number in its
+// method signatures, so a direct visitor implementation would re-pin
+// the stdlib import we are dropping; the Parser+Properties path is the
+// equivalent streaming sonic-native traversal.
 func unmarshalOrderedMap[V any](data []byte, path string) (OrderedMap[V], error) {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
 		return OrderedMap[V]{}, nil
 	}
-	dec := stdjson.NewDecoder(bytes.NewReader(data))
-	dec.UseNumber()
-	tok, err := dec.Token()
-	if err != nil {
-		return OrderedMap[V]{}, qualifyErr(path, err)
+
+	src := string(data)
+	parser := ast.NewParser(src)
+	node, errP := parser.Parse()
+	if errP != 0 {
+		return OrderedMap[V]{}, qualifyErr(path, parser.ExportError(errP))
 	}
-	if delim, ok := tok.(stdjson.Delim); !ok || delim != '{' {
+	if node.TypeSafe() != ast.V_OBJECT {
 		return OrderedMap[V]{}, fmt.Errorf("%s%sexpected object", path, sep(path))
 	}
 
+	it, err := node.Properties()
+	if err != nil {
+		return OrderedMap[V]{}, qualifyErr(path, err)
+	}
+
 	var out OrderedMap[V]
-	for dec.More() {
-		keyTok, err := dec.Token()
-		if err != nil {
-			return OrderedMap[V]{}, qualifyErr(path, err)
-		}
-		key, ok := keyTok.(string)
-		if !ok {
-			return OrderedMap[V]{}, fmt.Errorf("%s%sexpected object key", path, sep(path))
-		}
-		if out.Has(key) {
-			keyErr := &OrderedMapKeyError{Key: key, Err: ErrOrderedMapDuplicateKey}
+	var pair ast.Pair
+	for it.Next(&pair) {
+		if out.Has(pair.Key) {
+			keyErr := &OrderedMapKeyError{Key: pair.Key, Err: ErrOrderedMapDuplicateKey}
 			if path == "" {
 				return OrderedMap[V]{}, keyErr
 			}
@@ -326,33 +328,32 @@ func unmarshalOrderedMap[V any](data []byte, path string) (OrderedMap[V], error)
 			// the *OrderedMapKeyError carrier under errors.As, while
 			// preserving the existing path-qualified error prose that
 			// callers and tests assert against.
-			return OrderedMap[V]{}, fmt.Errorf("%s: duplicate key %q: %w", path, key, keyErr)
+			return OrderedMap[V]{}, fmt.Errorf("%s: duplicate key %q: %w", path, pair.Key, keyErr)
 		}
-		var rawVal stdjson.RawMessage
-		if err := dec.Decode(&rawVal); err != nil {
-			return OrderedMap[V]{}, qualifyField(path, key, err)
+		raw, rawErr := pair.Value.Raw()
+		if rawErr != nil {
+			return OrderedMap[V]{}, qualifyField(path, pair.Key, rawErr)
 		}
 		var value V
-		if err := sonic.Unmarshal(rawVal, &value); err != nil {
-			return OrderedMap[V]{}, qualifyField(path, key, err)
+		if err := sonic.Unmarshal([]byte(raw), &value); err != nil {
+			return OrderedMap[V]{}, qualifyField(path, pair.Key, err)
 		}
-		if err := out.Set(key, value); err != nil {
+		if err := out.Set(pair.Key, value); err != nil {
 			return OrderedMap[V]{}, err
 		}
 	}
-	if _, err := dec.Token(); err != nil {
-		return OrderedMap[V]{}, qualifyErr(path, err)
+
+	// Reject trailing bytes after the top-level object. sonic.Valid is
+	// strict — it returns false when non-whitespace follows the top-level
+	// value. ast.Parser produces a lazy node and doesn't surface its
+	// internal position back to the external Parser, so a manual scan
+	// from parser.Pos() doesn't work; sonic.Valid is the clean check.
+	// This preserves the strict-input contract #318 locked in (stdjson's
+	// Decoder was happy to accept `{"a":1} garbage`).
+	if !sonic.Valid(data) {
+		return OrderedMap[V]{}, qualifyErr(path, errors.New("trailing bytes after top-level object"))
 	}
-	// Reject trailing bytes after the top-level object. stdjson.Decoder
-	// is permissive about post-object data by default — `{"a":1} garbage`
-	// would otherwise be silently accepted. Strict input matches the
-	// rest of the dynamic-schema decode path (see #313).
-	if tok, err := dec.Token(); !errors.Is(err, io.EOF) {
-		if err != nil {
-			return OrderedMap[V]{}, qualifyErr(path, fmt.Errorf("trailing bytes after top-level object: %w", err))
-		}
-		return OrderedMap[V]{}, qualifyErr(path, fmt.Errorf("trailing token after top-level object: %v", tok))
-	}
+
 	return out, nil
 }
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

- Finishes the sonic migration deferred from #324/#325. The two `encoding/json` holdouts in `bamlutils` — `unmarshalOrderedMap` (orderedmap.go) and `checkUniqueTopLevelKeys` (dynamic.go) — used the stdlib `Decoder.Token()` streaming API for token-walking duplicate-key detection because sonic's `Decoder` doesn't expose `Token`/`Delim`. Both now walk via sonic's `ast.Parser` + `Properties()` iterator, which yields pairs in source order AND preserves duplicates (sonic's `linkedPairs` pushes every pair unconditionally), giving the property the strict duplicate-key rule needs.
- `ast.Visitor` was the original direction in the deferred task, but its number-value callbacks pass `encoding/json.Number`, so a direct visitor implementation would re-pin the stdlib import we are dropping. `Parser`+`Properties` is the equivalent streaming sonic-native traversal.
- `stdjson.RawMessage` usages in the schema struct decodes (and the `DynamicMessage` content-union probe) move to `sonic.NoCopyRawMessage`, sonic's own deferred-decode type. The captured bytes are read once and discarded, so the no-copy semantics are safe.
- Trailing-bytes rejection from #318 is preserved via `sonic.Valid` after iteration. `ast.Parser` returns a lazy node and doesn't surface its internal position back to the external `Parser`, so a manual scan from `parser.Pos()` doesn't work; `sonic.Valid` is the clean strict check.

`git grep 'encoding/json' bamlutils/orderedmap.go bamlutils/dynamic.go` now returns only the comment references that explain why the visitor wasn't used.

## Test plan

- [x] `go test ./bamlutils/... -count=1` — full bamlutils suite passes (includes the dup-key matrix from #313, the trailing-bytes rejection from #318, and the `errors.Is(ErrOrderedMapDuplicateKey)` sentinel detection)
- [x] `go test ./bamlutils/ -run TestOrderedMap -count=1` — OrderedMap focused suite passes
- [x] `go test ./dynclient/... -count=1` — downstream consumer passes
- [x] `go test -race ./bamlutils/... -count=1` — race-clean
- [x] `(cd dynclient && GOWORK=off go test ./... -count=1)` — standalone module passes
- [x] `git grep 'encoding/json' bamlutils/orderedmap.go bamlutils/dynamic.go` — zero non-comment matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter detection and clearer, path-qualified errors for duplicate keys and trailing data in JSON inputs.

* **Refactor**
  * Overhauled JSON parsing for more reliable behavior and consistent handling of object property order.
  * Value decoding updated for more accurate error attribution and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->