### PR TITLE
perf: pool memory across SSE scanner, stream frames, and dynamic conversion

### DIFF
--- a/.embedignore
+++ b/.embedignore
@@ -25,3 +25,11 @@ integration
 # discovered module — only per-adapter modules have an
 # adapter/adapter.go to begin with.
 **/adapter/adapter.go
+
+# Codegen test scaffolding (codegen/internal/fixtures and any
+# future siblings). These are non-test .go files because the
+# compile-matrix test's temp module must `go build` against real
+# type declarations — `_test.go` files are invisible to `go build`
+# — but they are NOT part of the published codegen artifact and
+# must not be bundled into the server binary's embed.FS.
+codegen/internal

--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -207,6 +207,11 @@ type generator struct {
 	supportsWithClient   bool
 	mirrors              *mirrorStructTracker
 	emittedUnwrapHelpers map[string]bool
+	// slicePools dedupes pooled-slice helper emission across all method
+	// preambles + nested struct conversions. Lifetime is per-file: every
+	// pooled inner type encountered during emission lazily lands one
+	// sync.Pool + get/put helper trio via tracker.ensure.
+	slicePools *slicePoolTracker
 }
 
 func newGenerator(opts Options) *generator {
@@ -222,6 +227,7 @@ func newGenerator(opts Options) *generator {
 		supportsWithClient:   resolved.SupportsWithClient,
 		mirrors:              newMirrorStructTracker(),
 		emittedUnwrapHelpers: make(map[string]bool),
+		slicePools:           newSlicePoolTracker(resolved.Packages),
 	}
 }
 

--- a/adapters/common/codegen/codegen_buildrequest.go
+++ b/adapters/common/codegen/codegen_buildrequest.go
@@ -606,9 +606,15 @@ func (me *methodEmitter) emitBuildRequest() {
 			jen.Id("__httpClient").Op("=").Id("__c"),
 		),
 
-		jen.Go().Func().Params().Block(
-			jen.Defer().Close(jen.Id("out")),
-			jen.Qual("github.com/gregwebs/go-recovery", "GoHandler").Call(
+		jen.Go().Func().Params().BlockFunc(func(grp *jen.Group) {
+			grp.Defer().Close(jen.Id("out"))
+			if me.hasReleaseConverted {
+				// Retry closures captured by RunStreamOrchestration
+				// outlive the outer function, so the converted slice
+				// release belongs inside the orchestration goroutine.
+				grp.Defer().Id("__releaseConverted").Call()
+			}
+			grp.Qual("github.com/gregwebs/go-recovery", "GoHandler").Call(
 				jen.Func().Params(jen.Id("err").Error()).Block(
 					jen.Id("__errR").Op(":=").Id("newResultFn").Call(
 						jen.Qual(g.pkgs.InterfacesPkg, "StreamResultKindError"),
@@ -633,8 +639,8 @@ func (me *methodEmitter) emitBuildRequest() {
 						jen.Id("newResultFn"),
 					)),
 				),
-			),
-		).Call(),
+			)
+		}).Call(),
 		jen.Return(jen.Nil()),
 	)
 
@@ -878,9 +884,15 @@ func (me *methodEmitter) emitBuildCallRequest() {
 		),
 
 		// Run in goroutine with panic recovery
-		jen.Go().Func().Params().Block(
-			jen.Defer().Close(jen.Id("out")),
-			jen.Qual("github.com/gregwebs/go-recovery", "GoHandler").Call(
+		jen.Go().Func().Params().BlockFunc(func(grp *jen.Group) {
+			grp.Defer().Close(jen.Id("out"))
+			if me.hasReleaseConverted {
+				// Retry closures captured by RunCallOrchestration
+				// outlive the outer function, so the converted slice
+				// release belongs inside the orchestration goroutine.
+				grp.Defer().Id("__releaseConverted").Call()
+			}
+			grp.Qual("github.com/gregwebs/go-recovery", "GoHandler").Call(
 				jen.Func().Params(jen.Id("err").Error()).Block(
 					jen.Id("__errR").Op(":=").Id("newResultFn").Call(
 						jen.Qual(g.pkgs.InterfacesPkg, "StreamResultKindError"),
@@ -905,8 +917,8 @@ func (me *methodEmitter) emitBuildCallRequest() {
 						jen.Id("newResultFn"),
 					)),
 				),
-			),
-		).Call(),
+			)
+		}).Call(),
 		jen.Return(jen.Nil()),
 	)
 

--- a/adapters/common/codegen/codegen_legacy_stream.go
+++ b/adapters/common/codegen/codegen_legacy_stream.go
@@ -148,6 +148,13 @@ func (me *methodEmitter) emitLegacyStream() {
 	// runtime strategy-parent overrides are visible to BAML.
 	noRawBody := me.makeLegacyPreamble()
 
+	// runNoRawOrchestration runs the BAML stream synchronously, so a
+	// top-level defer releases pooled conversion slices once the call
+	// returns (whether by completion, error, or panic).
+	if me.hasReleaseConverted {
+		noRawBody = append(noRawBody, jen.Defer().Id("__releaseConverted").Call())
+	}
+
 	// Delegate to shared orchestration helper - supplies per-method closures
 	noRawBody = append(noRawBody,
 		jen.Return(jen.Id("runNoRawOrchestration").Call(
@@ -466,6 +473,12 @@ func (me *methodEmitter) emitLegacyStream() {
 	// Same legacy-view rationale as _noRaw.
 	var fullBody []jen.Code
 	fullBody = append(fullBody, me.makeLegacyPreamble()...)
+	if me.hasReleaseConverted {
+		// runFullOrchestration runs synchronously; defer release at
+		// the top of the function covers normal completion, errors,
+		// and panics. Mirror of the _noRaw shape above.
+		fullBody = append(fullBody, jen.Defer().Id("__releaseConverted").Call())
+	}
 
 	// Delegate to shared full orchestration helper with per-method closures
 	fullBody = append(fullBody,

--- a/adapters/common/codegen/codegen_legacy_stream.go
+++ b/adapters/common/codegen/codegen_legacy_stream.go
@@ -148,11 +148,14 @@ func (me *methodEmitter) emitLegacyStream() {
 	// runtime strategy-parent overrides are visible to BAML.
 	noRawBody := me.makeLegacyPreamble()
 
-	// runNoRawOrchestration runs the BAML stream synchronously, so a
-	// top-level defer releases pooled conversion slices once the call
-	// returns (whether by completion, error, or panic).
+	// runNoRawOrchestration spawns its own goroutine and returns
+	// immediately. The body closure below is what actually consumes
+	// __struct_messages, and it runs inside that orchestration
+	// goroutine — so the pooled-slice release MUST live inside the
+	// body closure, not at the outer function level (where the defer
+	// would fire before the orchestrator even read the slice).
 	if me.hasReleaseConverted {
-		noRawBody = append(noRawBody, jen.Defer().Id("__releaseConverted").Call())
+		noRawGoroutineBody = append([]jen.Code{jen.Defer().Id("__releaseConverted").Call()}, noRawGoroutineBody...)
 	}
 
 	// Delegate to shared orchestration helper - supplies per-method closures
@@ -474,10 +477,14 @@ func (me *methodEmitter) emitLegacyStream() {
 	var fullBody []jen.Code
 	fullBody = append(fullBody, me.makeLegacyPreamble()...)
 	if me.hasReleaseConverted {
-		// runFullOrchestration runs synchronously; defer release at
-		// the top of the function covers normal completion, errors,
-		// and panics. Mirror of the _noRaw shape above.
-		fullBody = append(fullBody, jen.Defer().Id("__releaseConverted").Call())
+		// runFullOrchestration spawns its own goroutines and returns
+		// immediately. driveStream is the only callback that touches
+		// __struct_messages, and it runs inside the orchestrator
+		// goroutine — so the pooled-slice release MUST live inside
+		// driveStream's body, not at the outer function level (where
+		// the defer would fire before the orchestrator even started
+		// the stream). Mirror of the _noRaw fix.
+		driveStreamBody = append([]jen.Code{jen.Defer().Id("__releaseConverted").Call()}, driveStreamBody...)
 	}
 
 	// Delegate to shared full orchestration helper with per-method closures

--- a/adapters/common/codegen/codegen_methods.go
+++ b/adapters/common/codegen/codegen_methods.go
@@ -451,85 +451,118 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 			preamble = append(preamble, mediaConversionCode(convertedVar, fieldName, paramType, mediaKind, me.g.pkgs)...)
 		}
 
-		// Pass 1: discover which struct-media params route through the
-		// slice pool so the dispatch can hoist a single
-		// `__releaseConverted` closure that aggregates every per-param
-		// cleanup. Without this hoist, two or more pooled params would
-		// emit two `__releaseConverted := func() { ... }` lines in the
-		// same scope and the generated file would not compile.
-		type pooledSliceParam struct {
-			smp             structMediaParam
-			fieldName       string
-			convertedVar    string
-			messagesPtrName string
-			ownedNestedName string
-			outerPool       *slicePoolNames
-			innerPool       *slicePoolNames
-			innerNestedElem reflect.Type
+		// Pass 1: discover per-param pooling intent so the dispatch can
+		// hoist a single `__releaseConverted` closure that aggregates
+		// every per-param cleanup. Two distinct facets feed this:
+		//
+		//   - outerPool: this param is `[]ClassWithMedia` with value
+		//     elements; the outer slice routes through the slice pool.
+		//   - needsOwnedNested: the converter for this param's inner
+		//     mirror type takes the `ownedNested *[]func()` param
+		//     (either directly pools a `*[]Struct` field, or
+		//     transitively calls another converter that does). The
+		//     dispatch must materialize a per-param closure slice and
+		//     drain it in the release.
+		//
+		// Both facets are independent: a `*MessageWithMedia` param has
+		// no outer pool but its converter may still take ownedNested
+		// (the F1 shape from cold review). Without a per-param
+		// `__ownedNested_<name>` slice the non-pooled call site
+		// couldn't pass the third argument the converter requires.
+		type structMediaParamInfo struct {
+			smp              structMediaParam
+			fieldName        string
+			convertedVar     string
+			messagesPtrName  string
+			ownedNestedName  string
+			outerPool        *slicePoolNames
+			needsOwnedNested bool
 		}
-		var pooledSlices []pooledSliceParam
+		unwrapInner := func(t reflect.Type) reflect.Type {
+			for t.Kind() == reflect.Ptr || t.Kind() == reflect.Slice {
+				t = t.Elem()
+			}
+			return t
+		}
+		var paramInfos []structMediaParamInfo
 		for _, smp := range me.structMediaParams {
-			if smp.paramType.Kind() != reflect.Slice {
-				continue
-			}
-			elemType := smp.paramType.Elem()
-			if elemType.Kind() == reflect.Ptr {
-				// Pointer-element slices fall through to the legacy
-				// `make([]*T, n)` path; pooling those would also need
-				// per-element nil clearing and the inner ownedNested
-				// type would not match.
-				continue
-			}
-			if me.g.slicePools == nil {
-				continue
-			}
-			outerPool := me.g.slicePools.ensure(me.g.out, elemType, 1024)
-			innerNestedElem := me.g.mirrors.convertOwnedNestedFor(elemType)
-			var innerPool *slicePoolNames
-			if innerNestedElem != nil {
-				innerPool = me.g.slicePools.ensure(me.g.out, innerNestedElem, 256)
-			}
-			pooledSlices = append(pooledSlices, pooledSliceParam{
+			info := structMediaParamInfo{
 				smp:             smp,
 				fieldName:       strcase.UpperCamelCase(smp.paramName),
 				convertedVar:    "__struct_" + smp.paramName,
 				messagesPtrName: "__messagesPtr_" + smp.paramName,
 				ownedNestedName: "__ownedNested_" + smp.paramName,
-				outerPool:       outerPool,
-				innerPool:       innerPool,
-				innerNestedElem: innerNestedElem,
-			})
+			}
+			// Outer-pool eligibility: only `[]ValueStruct` shapes
+			// (slice with value-type elements). Pointer-element slices
+			// and ptr/direct struct params fall through the existing
+			// non-pooled emission.
+			if smp.paramType.Kind() == reflect.Slice &&
+				smp.paramType.Elem().Kind() != reflect.Ptr &&
+				me.g.slicePools != nil {
+				info.outerPool = me.g.slicePools.ensure(me.g.out, smp.paramType.Elem(), 1024)
+			}
+			// ownedNested propagation: query the inner BAML type's
+			// converter. Works uniformly across [], *[], *, and
+			// direct param shapes because unwrapInner strips every
+			// leading ptr/slice layer.
+			if me.g.mirrors != nil {
+				info.needsOwnedNested = me.g.mirrors.convertNeedsOwnedNestedFor(unwrapInner(smp.paramType))
+			}
+			paramInfos = append(paramInfos, info)
 		}
 
-		// Phase A — emit the per-pooled-param outer-slice checkout +
-		// ownedNested declaration so every referenced variable exists
-		// before the hoisted release closure captures it.
-		for _, p := range pooledSlices {
-			preamble = append(preamble,
-				jen.Id(p.messagesPtrName).Op(":=").Id(p.outerPool.getFunc).Call(jen.Len(jen.Id("input").Dot(p.fieldName))),
-				jen.Op("*").Id(p.messagesPtrName).Op("=").Parens(jen.Op("*").Id(p.messagesPtrName)).Index(jen.Empty(), jen.Len(jen.Id("input").Dot(p.fieldName))),
-				jen.Id(p.convertedVar).Op(":=").Op("*").Id(p.messagesPtrName),
-			)
-			if p.innerNestedElem != nil {
+		// Phase A — declare per-param resources so every variable the
+		// hoisted release closure references exists by the time it
+		// captures them. Outer-pool checkout and ownedNested slice
+		// declarations both land here; the per-param fill loop in
+		// Phase B is non-declarative and just consumes what Phase A
+		// set up.
+		anyReleaseResource := false
+		for _, p := range paramInfos {
+			if p.outerPool != nil {
 				preamble = append(preamble,
-					jen.Var().Id(p.ownedNestedName).Index().Op("*").Index().Add(parseReflectType(p.innerNestedElem).statement),
+					jen.Id(p.messagesPtrName).Op(":=").Id(p.outerPool.getFunc).Call(jen.Len(jen.Id("input").Dot(p.fieldName))),
+					jen.Op("*").Id(p.messagesPtrName).Op("=").Parens(jen.Op("*").Id(p.messagesPtrName)).Index(jen.Empty(), jen.Len(jen.Id("input").Dot(p.fieldName))),
+					jen.Id(p.convertedVar).Op(":=").Op("*").Id(p.messagesPtrName),
 				)
+				anyReleaseResource = true
+			}
+			if p.needsOwnedNested {
+				preamble = append(preamble,
+					jen.Var().Id(p.ownedNestedName).Index().Func().Params(),
+				)
+				anyReleaseResource = true
 			}
 		}
 		// Phase B — hoist a single `__releaseConverted` closure that
-		// drains every per-param ownedNested list and puts every outer
-		// slice back. Dispatch-site emitters defer this closure exactly
-		// once (inside the orchestration goroutine for async paths,
+		// invokes every release closure each per-param ownedNested
+		// slice accumulated and then puts every outer pool slice back.
+		// Dispatch-site emitters defer this closure exactly once
+		// (inside the orchestration goroutine for async paths,
 		// inside the body callback for legacy paths).
-		if len(pooledSlices) > 0 {
+		if anyReleaseResource {
 			var releaseBody []jen.Code
-			for _, p := range pooledSlices {
-				if p.innerPool != nil {
-					releaseBody = append(releaseBody,
-						jen.For(jen.List(jen.Id("_"), jen.Id("__partsPtr")).Op(":=").Range().Id(p.ownedNestedName)).Block(
-							jen.Id(p.innerPool.putFunc).Call(jen.Id("__partsPtr")),
-						),
-					)
+			// Drain release closures first so the pooled inner slices
+			// are zeroed + returned before the outer pool slice's
+			// `put` zeroes the message slots that pointed at them.
+			// (Order within drain doesn't matter functionally — every
+			// closure operates on a disjoint pointer — but draining
+			// innermost-to-outermost mirrors the original allocation
+			// order and reads more naturally.)
+			for _, p := range paramInfos {
+				if !p.needsOwnedNested {
+					continue
+				}
+				releaseBody = append(releaseBody,
+					jen.For(jen.List(jen.Id("_"), jen.Id("__release")).Op(":=").Range().Id(p.ownedNestedName)).Block(
+						jen.Id("__release").Call(),
+					),
+				)
+			}
+			for _, p := range paramInfos {
+				if p.outerPool == nil {
+					continue
 				}
 				releaseBody = append(releaseBody,
 					jen.Id(p.outerPool.putFunc).Call(jen.Id(p.messagesPtrName)),
@@ -542,11 +575,11 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 		}
 
 		// Build a lookup so the per-param emission below can detect
-		// which params are pooled without re-running the cap/type
-		// checks.
-		pooledByName := map[string]pooledSliceParam{}
-		for _, p := range pooledSlices {
-			pooledByName[p.smp.paramName] = p
+		// which params are pooled / need ownedNested without re-
+		// running the type checks.
+		infoByName := map[string]structMediaParamInfo{}
+		for _, p := range paramInfos {
+			infoByName[p.smp.paramName] = p
 		}
 
 		// releaseThenReturnError prepends `__releaseConverted()` to a
@@ -583,12 +616,24 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 			isPtr := smp.paramType.Kind() == reflect.Ptr
 			isSlice := smp.paramType.Kind() == reflect.Slice
 
+			info := infoByName[smp.paramName]
+
+			// buildConvertArgs threads `&__ownedNested_<name>` into
+			// the call when the inner converter takes it. Shared by
+			// every branch so call sites and the converter signature
+			// stay in sync regardless of the param's outer wrapping.
+			buildConvertArgs := func(vArg jen.Code) []jen.Code {
+				args := []jen.Code{jen.Id("adapter"), vArg}
+				if info.needsOwnedNested {
+					args = append(args, jen.Op("&").Id(info.ownedNestedName))
+				}
+				return args
+			}
+
 			if isSlice {
 				// []ClassWithMedia -> iterate and convert each element
 				elemType := smp.paramType.Elem()
 				elemIsPtr := elemType.Kind() == reflect.Ptr
-
-				pooled, isPooled := pooledByName[smp.paramName]
 
 				// Determine how to pass the element to the conversion function
 				var vArg jen.Code
@@ -596,11 +641,6 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 					vArg = jen.Id("__v") // already *Mirror, pass directly
 				} else {
 					vArg = jen.Op("&").Id("__v") // Mirror, take address
-				}
-
-				convertArgs := []jen.Code{jen.Id("adapter"), vArg}
-				if isPooled && pooled.innerNestedElem != nil {
-					convertArgs = append(convertArgs, jen.Op("&").Id(pooled.ownedNestedName))
 				}
 
 				errReturnStmts := releaseThenReturnError(
@@ -612,7 +652,7 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 				)
 
 				convBlock := []jen.Code{
-					jen.List(jen.Id("__converted"), jen.Id(errVar)).Op(":=").Id(smp.convertFunc).Call(convertArgs...),
+					jen.List(jen.Id("__converted"), jen.Id(errVar)).Op(":=").Id(smp.convertFunc).Call(buildConvertArgs(vArg)...),
 					jen.If(jen.Id(errVar).Op("!=").Nil()).Block(errReturnStmts...),
 					func() jen.Code {
 						if elemIsPtr {
@@ -632,9 +672,9 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 					loopBody = convBlock
 				}
 
-				if isPooled {
-					// Pooled outer slice + ownedNested were already
-					// declared above. Just emit the fill loop here.
+				if info.outerPool != nil {
+					// Pooled outer slice was already declared in Phase
+					// A. Just emit the fill loop here.
 					preamble = append(preamble,
 						jen.For(jen.List(jen.Id("__i"), jen.Id("__v")).Op(":=").Range().Id("input").Dot(fieldName)).Block(loopBody...),
 					)
@@ -662,10 +702,7 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 					}
 
 					innerConvBlock := []jen.Code{
-						jen.List(jen.Id("__converted"), jen.Id(errVar)).Op(":=").Id(smp.convertFunc).Call(
-							jen.Id("adapter"),
-							vArg,
-						),
+						jen.List(jen.Id("__converted"), jen.Id(errVar)).Op(":=").Id(smp.convertFunc).Call(buildConvertArgs(vArg)...),
 						jen.If(jen.Id(errVar).Op("!=").Nil()).Block(releaseThenReturnError(
 							jen.Return(jen.Qual("fmt", "Errorf").Call(
 								jen.Lit(smp.paramName+"[%d]: %w"),
@@ -707,8 +744,7 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 						jen.Var().Id(convertedVar).Add(parseReflectType(smp.paramType).statement),
 						jen.If(jen.Id("input").Dot(fieldName).Op("!=").Nil()).Block(
 							jen.List(jen.Id("__converted"), jen.Id(errVar)).Op(":=").Id(smp.convertFunc).Call(
-								jen.Id("adapter"),
-								jen.Id("input").Dot(fieldName), // already *Mirror, pass directly
+								buildConvertArgs(jen.Id("input").Dot(fieldName))..., // already *Mirror, pass directly
 							),
 							jen.If(jen.Id(errVar).Op("!=").Nil()).Block(releaseThenReturnError(
 								jen.Return(jen.Qual("fmt", "Errorf").Call(
@@ -724,8 +760,7 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 				// Direct: ClassWithMedia -> take address and convert
 				preamble = append(preamble,
 					jen.List(jen.Id(convertedVar), jen.Id(errVar)).Op(":=").Id(smp.convertFunc).Call(
-						jen.Id("adapter"),
-						jen.Op("&").Id("input").Dot(fieldName),
+						buildConvertArgs(jen.Op("&").Id("input").Dot(fieldName))...,
 					),
 					jen.If(jen.Id(errVar).Op("!=").Nil()).Block(releaseThenReturnError(
 						jen.Return(jen.Qual("fmt", "Errorf").Call(

--- a/adapters/common/codegen/codegen_methods.go
+++ b/adapters/common/codegen/codegen_methods.go
@@ -451,6 +451,104 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 			preamble = append(preamble, mediaConversionCode(convertedVar, fieldName, paramType, mediaKind, me.g.pkgs)...)
 		}
 
+		// Pass 1: discover which struct-media params route through the
+		// slice pool so the dispatch can hoist a single
+		// `__releaseConverted` closure that aggregates every per-param
+		// cleanup. Without this hoist, two or more pooled params would
+		// emit two `__releaseConverted := func() { ... }` lines in the
+		// same scope and the generated file would not compile.
+		type pooledSliceParam struct {
+			smp             structMediaParam
+			fieldName       string
+			convertedVar    string
+			messagesPtrName string
+			ownedNestedName string
+			outerPool       *slicePoolNames
+			innerPool       *slicePoolNames
+			innerNestedElem reflect.Type
+		}
+		var pooledSlices []pooledSliceParam
+		for _, smp := range me.structMediaParams {
+			if smp.paramType.Kind() != reflect.Slice {
+				continue
+			}
+			elemType := smp.paramType.Elem()
+			if elemType.Kind() == reflect.Ptr {
+				// Pointer-element slices fall through to the legacy
+				// `make([]*T, n)` path; pooling those would also need
+				// per-element nil clearing and the inner ownedNested
+				// type would not match.
+				continue
+			}
+			if me.g.slicePools == nil {
+				continue
+			}
+			outerPool := me.g.slicePools.ensure(me.g.out, elemType, 1024)
+			innerNestedElem := me.g.mirrors.convertOwnedNestedFor(elemType)
+			var innerPool *slicePoolNames
+			if innerNestedElem != nil {
+				innerPool = me.g.slicePools.ensure(me.g.out, innerNestedElem, 256)
+			}
+			pooledSlices = append(pooledSlices, pooledSliceParam{
+				smp:             smp,
+				fieldName:       strcase.UpperCamelCase(smp.paramName),
+				convertedVar:    "__struct_" + smp.paramName,
+				messagesPtrName: "__messagesPtr_" + smp.paramName,
+				ownedNestedName: "__ownedNested_" + smp.paramName,
+				outerPool:       outerPool,
+				innerPool:       innerPool,
+				innerNestedElem: innerNestedElem,
+			})
+		}
+
+		// Phase A — emit the per-pooled-param outer-slice checkout +
+		// ownedNested declaration so every referenced variable exists
+		// before the hoisted release closure captures it.
+		for _, p := range pooledSlices {
+			preamble = append(preamble,
+				jen.Id(p.messagesPtrName).Op(":=").Id(p.outerPool.getFunc).Call(jen.Len(jen.Id("input").Dot(p.fieldName))),
+				jen.Op("*").Id(p.messagesPtrName).Op("=").Parens(jen.Op("*").Id(p.messagesPtrName)).Index(jen.Empty(), jen.Len(jen.Id("input").Dot(p.fieldName))),
+				jen.Id(p.convertedVar).Op(":=").Op("*").Id(p.messagesPtrName),
+			)
+			if p.innerNestedElem != nil {
+				preamble = append(preamble,
+					jen.Var().Id(p.ownedNestedName).Index().Op("*").Index().Add(parseReflectType(p.innerNestedElem).statement),
+				)
+			}
+		}
+		// Phase B — hoist a single `__releaseConverted` closure that
+		// drains every per-param ownedNested list and puts every outer
+		// slice back. Dispatch-site emitters defer this closure exactly
+		// once (inside the orchestration goroutine for async paths,
+		// inside the body callback for legacy paths).
+		if len(pooledSlices) > 0 {
+			var releaseBody []jen.Code
+			for _, p := range pooledSlices {
+				if p.innerPool != nil {
+					releaseBody = append(releaseBody,
+						jen.For(jen.List(jen.Id("_"), jen.Id("__partsPtr")).Op(":=").Range().Id(p.ownedNestedName)).Block(
+							jen.Id(p.innerPool.putFunc).Call(jen.Id("__partsPtr")),
+						),
+					)
+				}
+				releaseBody = append(releaseBody,
+					jen.Id(p.outerPool.putFunc).Call(jen.Id(p.messagesPtrName)),
+				)
+			}
+			preamble = append(preamble,
+				jen.Id("__releaseConverted").Op(":=").Func().Params().Block(releaseBody...),
+			)
+			me.hasReleaseConverted = true
+		}
+
+		// Build a lookup so the per-param emission below can detect
+		// which params are pooled without re-running the cap/type
+		// checks.
+		pooledByName := map[string]pooledSliceParam{}
+		for _, p := range pooledSlices {
+			pooledByName[p.smp.paramName] = p
+		}
+
 		// Generate struct conversion code for params with nested media.
 		// Must handle direct, pointer, and slice wrapping of the struct param.
 		for _, smp := range me.structMediaParams {
@@ -466,23 +564,7 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 				elemType := smp.paramType.Elem()
 				elemIsPtr := elemType.Kind() == reflect.Ptr
 
-				// Pool the outer slice when the element type is a value
-				// struct. Pointer-element slices ([]*ClassWithMedia) are
-				// rare and skipped — pooling those would also require
-				// nil-clearing per element, which the current shape does
-				// not exercise.
-				var outerPool *slicePoolNames
-				if me.g.slicePools != nil && !elemIsPtr {
-					outerPool = me.g.slicePools.ensure(me.g.out, elemType, 1024)
-				}
-
-				// Detect the convert function's ownedNested contract so
-				// the dispatch site sets up + threads through the
-				// matching `*[]*[]InnerT` variable.
-				var innerNestedElem reflect.Type
-				if outerPool != nil {
-					innerNestedElem = me.g.mirrors.convertOwnedNestedFor(elemType)
-				}
+				pooled, isPooled := pooledByName[smp.paramName]
 
 				// Determine how to pass the element to the conversion function
 				var vArg jen.Code
@@ -493,12 +575,12 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 				}
 
 				convertArgs := []jen.Code{jen.Id("adapter"), vArg}
-				if innerNestedElem != nil {
-					convertArgs = append(convertArgs, jen.Op("&").Id("__ownedNested"))
+				if isPooled && pooled.innerNestedElem != nil {
+					convertArgs = append(convertArgs, jen.Op("&").Id(pooled.ownedNestedName))
 				}
 
 				errReturnStmts := []jen.Code{}
-				if outerPool != nil {
+				if isPooled {
 					errReturnStmts = append(errReturnStmts, jen.Id("__releaseConverted").Call())
 				}
 				errReturnStmts = append(errReturnStmts,
@@ -530,37 +612,12 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 					loopBody = convBlock
 				}
 
-				if outerPool != nil {
-					messagesPtrName := "__messagesPtr_" + smp.paramName
-					releaseBody := []jen.Code{}
-					if innerNestedElem != nil {
-						innerPool := me.g.slicePools.ensure(me.g.out, innerNestedElem, 256)
-						releaseBody = append(releaseBody,
-							jen.For(jen.List(jen.Id("_"), jen.Id("__partsPtr")).Op(":=").Range().Id("__ownedNested")).Block(
-								jen.Id(innerPool.putFunc).Call(jen.Id("__partsPtr")),
-							),
-						)
-					}
-					releaseBody = append(releaseBody,
-						jen.Id(outerPool.putFunc).Call(jen.Id(messagesPtrName)),
-					)
-
-					preambleAdd := []jen.Code{
-						jen.Id(messagesPtrName).Op(":=").Id(outerPool.getFunc).Call(jen.Len(jen.Id("input").Dot(fieldName))),
-						jen.Op("*").Id(messagesPtrName).Op("=").Parens(jen.Op("*").Id(messagesPtrName)).Index(jen.Empty(), jen.Len(jen.Id("input").Dot(fieldName))),
-						jen.Id(convertedVar).Op(":=").Op("*").Id(messagesPtrName),
-					}
-					if innerNestedElem != nil {
-						preambleAdd = append(preambleAdd,
-							jen.Var().Id("__ownedNested").Index().Op("*").Index().Add(parseReflectType(innerNestedElem).statement),
-						)
-					}
-					preambleAdd = append(preambleAdd,
-						jen.Id("__releaseConverted").Op(":=").Func().Params().Block(releaseBody...),
+				if isPooled {
+					// Pooled outer slice + ownedNested were already
+					// declared above. Just emit the fill loop here.
+					preamble = append(preamble,
 						jen.For(jen.List(jen.Id("__i"), jen.Id("__v")).Op(":=").Range().Id("input").Dot(fieldName)).Block(loopBody...),
 					)
-					preamble = append(preamble, preambleAdd...)
-					me.hasReleaseConverted = true
 				} else {
 					preamble = append(preamble,
 						jen.Id(convertedVar).Op(":=").Make(

--- a/adapters/common/codegen/codegen_methods.go
+++ b/adapters/common/codegen/codegen_methods.go
@@ -506,7 +506,7 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 			// converter. Works uniformly across [], *[], *, and
 			// direct param shapes because unwrapInner strips every
 			// leading ptr/slice layer.
-			if me.g.mirrors != nil {
+			if me.g.mirrors != nil && me.g.slicePools != nil {
 				info.needsOwnedNested = me.g.mirrors.convertNeedsOwnedNestedFor(unwrapInner(smp.paramType))
 			}
 			paramInfos = append(paramInfos, info)
@@ -847,7 +847,9 @@ func (g *generator) emitMethods() []methodOut {
 	// Without this pass, mutually-recursive media-bearing structs
 	// emit Go code where an outer signature has 3 params while a
 	// callee's call site is 2-arg — the file doesn't compile.
-	g.precomputeOwnedNestedNeeds(methodNames)
+	if g.slicePools != nil {
+		g.precomputeOwnedNestedNeeds(methodNames)
+	}
 
 	for _, methodName := range methodNames {
 		args := g.intro.SyncMethods[methodName]

--- a/adapters/common/codegen/codegen_methods.go
+++ b/adapters/common/codegen/codegen_methods.go
@@ -549,6 +549,30 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 			pooledByName[p.smp.paramName] = p
 		}
 
+		// releaseThenReturnError prepends `__releaseConverted()` to a
+		// Phase-B conversion-error return when any pooled resources
+		// were allocated upstream in Phase A. Without this, a non-
+		// pooled sibling param's conversion failure (e.g. a `*C` field
+		// after a pooled `[]C` was checked out) leaks the pooled outer
+		// slice and every owned nested slice for the lifetime of the
+		// program: the `defer __releaseConverted()` placements live
+		// inside body callbacks / goroutines that never start when the
+		// outer dispatch function returns the conversion error
+		// directly, so the defer cannot cover this path.
+		//
+		// Only call sites EMITTED IN PHASE B should route through this
+		// helper. Errors raised before Phase A (raw-input assertion,
+		// direct media-typed param conversion) happen before any pool
+		// checkout and must NOT call __releaseConverted (which would
+		// reference an undeclared identifier and fail to compile when
+		// hasReleaseConverted is false too).
+		releaseThenReturnError := func(returnStmt jen.Code) []jen.Code {
+			if me.hasReleaseConverted {
+				return []jen.Code{jen.Id("__releaseConverted").Call(), returnStmt}
+			}
+			return []jen.Code{returnStmt}
+		}
+
 		// Generate struct conversion code for params with nested media.
 		// Must handle direct, pointer, and slice wrapping of the struct param.
 		for _, smp := range me.structMediaParams {
@@ -579,11 +603,7 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 					convertArgs = append(convertArgs, jen.Op("&").Id(pooled.ownedNestedName))
 				}
 
-				errReturnStmts := []jen.Code{}
-				if isPooled {
-					errReturnStmts = append(errReturnStmts, jen.Id("__releaseConverted").Call())
-				}
-				errReturnStmts = append(errReturnStmts,
+				errReturnStmts := releaseThenReturnError(
 					jen.Return(jen.Qual("fmt", "Errorf").Call(
 						jen.Lit(smp.paramName+"[%d]: %w"),
 						jen.Id("__i"),
@@ -646,13 +666,13 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 							jen.Id("adapter"),
 							vArg,
 						),
-						jen.If(jen.Id(errVar).Op("!=").Nil()).Block(
+						jen.If(jen.Id(errVar).Op("!=").Nil()).Block(releaseThenReturnError(
 							jen.Return(jen.Qual("fmt", "Errorf").Call(
 								jen.Lit(smp.paramName+"[%d]: %w"),
 								jen.Id("__i"),
 								jen.Id(errVar),
 							)),
-						),
+						)...),
 						func() jen.Code {
 							if elemIsPtr {
 								return jen.Id("__ptrSlice").Index(jen.Id("__i")).Op("=").Op("&").Id("__converted")
@@ -690,12 +710,12 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 								jen.Id("adapter"),
 								jen.Id("input").Dot(fieldName), // already *Mirror, pass directly
 							),
-							jen.If(jen.Id(errVar).Op("!=").Nil()).Block(
+							jen.If(jen.Id(errVar).Op("!=").Nil()).Block(releaseThenReturnError(
 								jen.Return(jen.Qual("fmt", "Errorf").Call(
 									jen.Lit(smp.paramName+": %w"),
 									jen.Id(errVar),
 								)),
-							),
+							)...),
 							jen.Id(convertedVar).Op("=").Op("&").Id("__converted"),
 						),
 					)
@@ -707,12 +727,12 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 						jen.Id("adapter"),
 						jen.Op("&").Id("input").Dot(fieldName),
 					),
-					jen.If(jen.Id(errVar).Op("!=").Nil()).Block(
+					jen.If(jen.Id(errVar).Op("!=").Nil()).Block(releaseThenReturnError(
 						jen.Return(jen.Qual("fmt", "Errorf").Call(
 							jen.Lit(smp.paramName+": %w"),
 							jen.Id(errVar),
 						)),
-					),
+					)...),
 				)
 			}
 		}

--- a/adapters/common/codegen/codegen_methods.go
+++ b/adapters/common/codegen/codegen_methods.go
@@ -65,6 +65,14 @@ type methodEmitter struct {
 	fullMethodName             string
 	buildRequestMethodName     string
 	buildCallRequestMethodName string
+
+	// hasReleaseConverted is set by makePreambleWithArgs when the
+	// preamble emits a __releaseConverted closure (i.e., this method
+	// has slice params routed through the slice pool). Dispatch-site
+	// emitters consult it to place `defer __releaseConverted()` either
+	// in the outer body (sync paths) or inside the orchestration
+	// goroutine (BuildRequest/BuildCallRequest).
+	hasReleaseConverted bool
 }
 
 // newMethodEmitter validates the method's reflect signature and (on
@@ -155,7 +163,7 @@ func (me *methodEmitter) emitInputAndOutputStructs() {
 			fieldType = jen.Id(strcase.UpperCamelCase(paramName)).Add(mediaFieldType(paramType, g.pkgs.InterfacesPkg))
 		} else if structContainsMedia(paramType, g.pkgs) {
 			// Struct param containing nested media: use mirror struct
-			mirrorName := g.mirrors.ensureMirrorStruct(out, paramType, g.pkgs)
+			mirrorName := g.mirrors.ensureMirrorStruct(out, paramType, g.pkgs, g.slicePools)
 			fieldType = jen.Id(strcase.UpperCamelCase(paramName)).Add(mirrorFieldType(paramType, mirrorName))
 
 			// Unwrap to get the inner type for the convert function name
@@ -458,6 +466,24 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 				elemType := smp.paramType.Elem()
 				elemIsPtr := elemType.Kind() == reflect.Ptr
 
+				// Pool the outer slice when the element type is a value
+				// struct. Pointer-element slices ([]*ClassWithMedia) are
+				// rare and skipped — pooling those would also require
+				// nil-clearing per element, which the current shape does
+				// not exercise.
+				var outerPool *slicePoolNames
+				if me.g.slicePools != nil && !elemIsPtr {
+					outerPool = me.g.slicePools.ensure(me.g.out, elemType, 1024)
+				}
+
+				// Detect the convert function's ownedNested contract so
+				// the dispatch site sets up + threads through the
+				// matching `*[]*[]InnerT` variable.
+				var innerNestedElem reflect.Type
+				if outerPool != nil {
+					innerNestedElem = me.g.mirrors.convertOwnedNestedFor(elemType)
+				}
+
 				// Determine how to pass the element to the conversion function
 				var vArg jen.Code
 				if elemIsPtr {
@@ -466,18 +492,26 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 					vArg = jen.Op("&").Id("__v") // Mirror, take address
 				}
 
+				convertArgs := []jen.Code{jen.Id("adapter"), vArg}
+				if innerNestedElem != nil {
+					convertArgs = append(convertArgs, jen.Op("&").Id("__ownedNested"))
+				}
+
+				errReturnStmts := []jen.Code{}
+				if outerPool != nil {
+					errReturnStmts = append(errReturnStmts, jen.Id("__releaseConverted").Call())
+				}
+				errReturnStmts = append(errReturnStmts,
+					jen.Return(jen.Qual("fmt", "Errorf").Call(
+						jen.Lit(smp.paramName+"[%d]: %w"),
+						jen.Id("__i"),
+						jen.Id(errVar),
+					)),
+				)
+
 				convBlock := []jen.Code{
-					jen.List(jen.Id("__converted"), jen.Id(errVar)).Op(":=").Id(smp.convertFunc).Call(
-						jen.Id("adapter"),
-						vArg,
-					),
-					jen.If(jen.Id(errVar).Op("!=").Nil()).Block(
-						jen.Return(jen.Qual("fmt", "Errorf").Call(
-							jen.Lit(smp.paramName+"[%d]: %w"),
-							jen.Id("__i"),
-							jen.Id(errVar),
-						)),
-					),
+					jen.List(jen.Id("__converted"), jen.Id(errVar)).Op(":=").Id(smp.convertFunc).Call(convertArgs...),
+					jen.If(jen.Id(errVar).Op("!=").Nil()).Block(errReturnStmts...),
 					func() jen.Code {
 						if elemIsPtr {
 							return jen.Id(convertedVar).Index(jen.Id("__i")).Op("=").Op("&").Id("__converted")
@@ -496,13 +530,46 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 					loopBody = convBlock
 				}
 
-				preamble = append(preamble,
-					jen.Id(convertedVar).Op(":=").Make(
-						jen.Add(parseReflectType(smp.paramType).statement),
-						jen.Len(jen.Id("input").Dot(fieldName)),
-					),
-					jen.For(jen.List(jen.Id("__i"), jen.Id("__v")).Op(":=").Range().Id("input").Dot(fieldName)).Block(loopBody...),
-				)
+				if outerPool != nil {
+					messagesPtrName := "__messagesPtr_" + smp.paramName
+					releaseBody := []jen.Code{}
+					if innerNestedElem != nil {
+						innerPool := me.g.slicePools.ensure(me.g.out, innerNestedElem, 256)
+						releaseBody = append(releaseBody,
+							jen.For(jen.List(jen.Id("_"), jen.Id("__partsPtr")).Op(":=").Range().Id("__ownedNested")).Block(
+								jen.Id(innerPool.putFunc).Call(jen.Id("__partsPtr")),
+							),
+						)
+					}
+					releaseBody = append(releaseBody,
+						jen.Id(outerPool.putFunc).Call(jen.Id(messagesPtrName)),
+					)
+
+					preambleAdd := []jen.Code{
+						jen.Id(messagesPtrName).Op(":=").Id(outerPool.getFunc).Call(jen.Len(jen.Id("input").Dot(fieldName))),
+						jen.Op("*").Id(messagesPtrName).Op("=").Parens(jen.Op("*").Id(messagesPtrName)).Index(jen.Empty(), jen.Len(jen.Id("input").Dot(fieldName))),
+						jen.Id(convertedVar).Op(":=").Op("*").Id(messagesPtrName),
+					}
+					if innerNestedElem != nil {
+						preambleAdd = append(preambleAdd,
+							jen.Var().Id("__ownedNested").Index().Op("*").Index().Add(parseReflectType(innerNestedElem).statement),
+						)
+					}
+					preambleAdd = append(preambleAdd,
+						jen.Id("__releaseConverted").Op(":=").Func().Params().Block(releaseBody...),
+						jen.For(jen.List(jen.Id("__i"), jen.Id("__v")).Op(":=").Range().Id("input").Dot(fieldName)).Block(loopBody...),
+					)
+					preamble = append(preamble, preambleAdd...)
+					me.hasReleaseConverted = true
+				} else {
+					preamble = append(preamble,
+						jen.Id(convertedVar).Op(":=").Make(
+							jen.Add(parseReflectType(smp.paramType).statement),
+							jen.Len(jen.Id("input").Dot(fieldName)),
+						),
+						jen.For(jen.List(jen.Id("__i"), jen.Id("__v")).Op(":=").Range().Id("input").Dot(fieldName)).Block(loopBody...),
+					)
+				}
 			} else if isPtr {
 				innerAfterPtr := smp.paramType.Elem()
 				if innerAfterPtr.Kind() == reflect.Slice {

--- a/adapters/common/codegen/codegen_methods.go
+++ b/adapters/common/codegen/codegen_methods.go
@@ -839,6 +839,16 @@ func (g *generator) emitMethods() []methodOut {
 	}
 	slices.Sort(methodNames)
 
+	// Precompute the `convertNeedsOwnedNested` transitive closure
+	// over every struct-media type reachable from any sync-method
+	// param. Must run before the per-method emit loop below so
+	// nested converter call sites query the FINAL flag value
+	// rather than racing with recursive ensureMirrorStruct calls.
+	// Without this pass, mutually-recursive media-bearing structs
+	// emit Go code where an outer signature has 3 params while a
+	// callee's call site is 2-arg — the file doesn't compile.
+	g.precomputeOwnedNestedNeeds(methodNames)
+
 	for _, methodName := range methodNames {
 		args := g.intro.SyncMethods[methodName]
 		me, ok := g.newMethodEmitter(methodName, args)
@@ -854,6 +864,40 @@ func (g *generator) emitMethods() []methodOut {
 	}
 
 	return methods
+}
+
+// precomputeOwnedNestedNeeds collects every struct-media param type
+// across all sync methods and feeds them to
+// mirrorStructTracker.precomputeOwnedNestedNeeds, populating the
+// `convertNeedsOwnedNested` map for every reachable struct-media
+// type before any converter body is emitted. See the tracker
+// method's doc comment for the cycle-handling rationale.
+func (g *generator) precomputeOwnedNestedNeeds(methodNames []string) {
+	if g.mirrors == nil {
+		return
+	}
+	var roots []reflect.Type
+	for _, methodName := range methodNames {
+		fn, ok := g.intro.SyncFuncs[methodName]
+		if !ok {
+			continue
+		}
+		ft := reflect.TypeOf(fn)
+		if ft == nil || ft.Kind() != reflect.Func {
+			continue
+		}
+		// Sync funcs are `func(ctx, args..., opts...)`. Skip the
+		// leading ctx and the trailing variadic opts slot — only
+		// the middle slots can be struct-media params.
+		for paramIdx := 1; paramIdx < ft.NumIn()-1; paramIdx++ {
+			paramType := ft.In(paramIdx)
+			if !structContainsMedia(paramType, g.pkgs) {
+				continue
+			}
+			roots = append(roots, paramType)
+		}
+	}
+	g.mirrors.precomputeOwnedNestedNeeds(roots, g.pkgs)
 }
 
 // emitMethodsMap emits the package-level Methods variable mapping

--- a/adapters/common/codegen/codegen_reflect.go
+++ b/adapters/common/codegen/codegen_reflect.go
@@ -116,31 +116,37 @@ func structContainsMediaVisited(typ reflect.Type, visited map[reflect.Type]bool,
 // Maps the original BAML type name to the generated mirror struct name.
 type mirrorStructTracker struct {
 	generated map[reflect.Type]string // baml type -> mirror struct name
-	// convertOwnedNested records the inner BAML element type that a
-	// convert function pushes into its `ownedNested` parameter (for
-	// `*[]Struct` fields routed through a slice pool). Populated lazily
-	// by nestedStructConversion via the generator's slicePoolTracker.
-	// Keyed by the outer BAML type whose convert function carries the
-	// extra parameter. Empty means the convert function uses the legacy
-	// 2-arg signature.
-	convertOwnedNested map[reflect.Type]reflect.Type
+	// convertNeedsOwnedNested records which mirror converters take
+	// the third `ownedNested *[]func()` parameter — either because the
+	// converter directly pools a `*[]Struct` field, or because it
+	// transitively calls another converter that takes the parameter.
+	//
+	// The `*[]func()` (closure-context) shape lets a single propagated
+	// slice carry release closures for every pooled nested type at any
+	// depth — distinct nested element types append distinct closures,
+	// the outer dispatch drains them uniformly. The earlier `*[]*[]T`
+	// shape forced a single inner element type per converter and could
+	// not propagate through nested converter calls without per-type
+	// parameter explosion.
+	convertNeedsOwnedNested map[reflect.Type]bool
 }
 
 func newMirrorStructTracker() *mirrorStructTracker {
 	return &mirrorStructTracker{
-		generated:          make(map[reflect.Type]string),
-		convertOwnedNested: make(map[reflect.Type]reflect.Type),
+		generated:               make(map[reflect.Type]string),
+		convertNeedsOwnedNested: make(map[reflect.Type]bool),
 	}
 }
 
-// convertOwnedNestedFor returns the inner BAML element type that
-// convert<Mirror> for `outer` threads through its ownedNested param,
-// or nil if the convert function uses the legacy 2-arg signature.
-func (m *mirrorStructTracker) convertOwnedNestedFor(outer reflect.Type) reflect.Type {
+// convertNeedsOwnedNestedFor reports whether convert<Mirror> for
+// `outer` takes the `ownedNested *[]func()` parameter. Call sites
+// (dispatch top-level + nested helpers) consult this to thread the
+// matching slice through.
+func (m *mirrorStructTracker) convertNeedsOwnedNestedFor(outer reflect.Type) bool {
 	if m == nil {
-		return nil
+		return false
 	}
-	return m.convertOwnedNested[outer]
+	return m.convertNeedsOwnedNested[outer]
 }
 
 // mirrorInputName returns the name for a mirror input struct.
@@ -227,17 +233,84 @@ func (m *mirrorStructTracker) ensureMirrorStruct(out *jen.File, typ reflect.Type
 // to the real BAML struct, handling media field conversion.
 //
 // pools is the per-file slice pool tracker. When non-nil, `*[]Struct`
-// fields route through the pool helpers and the emitted function gains
-// an extra `ownedNested *[]*[]<innerElem>` parameter that the dispatch
-// caller releases after BAML consumes the converted slice.
+// value-element fields route through the pool helpers and the emitted
+// function gains an extra `ownedNested *[]func()` parameter — a slice
+// of release closures the dispatch caller drains after BAML consumes
+// the converted value. The closure-context shape (versus the earlier
+// `*[]*[]T` typed-pointer shape) lets a single propagated parameter
+// carry release closures for arbitrarily many distinct pooled nested
+// types at any depth: each pooled-nested branch captures its own
+// `put<X>Slice` call in a closure and appends it; the outer release
+// loop invokes them uniformly.
+//
+// A converter takes the `ownedNested` parameter when EITHER:
+//
+//  1. It directly pools at least one `*[]Struct` field with value
+//     elements (registering a release closure during conversion).
+//  2. It transitively calls another converter that takes the parameter
+//     (in which case it must thread its own `ownedNested` through so
+//     the inner converter's appended closures bubble up to the outer
+//     dispatch's drain).
+//
+// Because ensureMirrorStruct generates nested converters before the
+// outer (depth-first), `convertNeedsOwnedNestedFor` returns the correct
+// answer for any nested call site by the time the outer converter is
+// emitted.
 func (m *mirrorStructTracker) generateConversionFunc(out *jen.File, bamlType reflect.Type, mirrorName string, pkgs PackageConfig, pools *slicePoolTracker) {
 	funcName := "convert" + mirrorName
 	bamlTypeExpr := parseReflectType(bamlType).statement
 
+	// Pre-walk fields to decide whether this converter needs the
+	// `ownedNested` parameter — both directly (any pooled `*[]Struct`
+	// value-element field) and transitively (any nested converter that
+	// already takes it). Detection must happen before body emission so
+	// nestedStructConversion knows whether the closure it's appending
+	// to actually exists.
+	needsOwnedNested := false
+	for field := range bamlType.Fields() {
+		if !field.IsExported() {
+			continue
+		}
+		if _, isMedia := isMediaReflectType(field.Type, pkgs); isMedia {
+			continue
+		}
+		fieldInner := field.Type
+		for fieldInner.Kind() == reflect.Ptr || fieldInner.Kind() == reflect.Slice {
+			fieldInner = fieldInner.Elem()
+		}
+		if fieldInner.Kind() != reflect.Struct || !structContainsMedia(field.Type, pkgs) {
+			continue
+		}
+		// Direct pool: a `*[]Struct` value-element field this
+		// converter will route through the slice pool.
+		if pools != nil &&
+			field.Type.Kind() == reflect.Ptr &&
+			field.Type.Elem().Kind() == reflect.Slice &&
+			field.Type.Elem().Elem().Kind() != reflect.Ptr {
+			needsOwnedNested = true
+			break
+		}
+		// Transitive: the nested converter for the inner mirror type
+		// already takes `ownedNested`, so the call site must thread
+		// ours through.
+		if m.convertNeedsOwnedNestedFor(fieldInner) {
+			needsOwnedNested = true
+			break
+		}
+	}
+
+	if needsOwnedNested {
+		// Record the contract before emitting the body so any
+		// recursive ensureMirrorStruct callers see the up-to-date
+		// answer for this type. (In practice this matters only for
+		// hypothetical cycle-bearing schemas; the dynamic adapter
+		// has no such cycle today.)
+		m.convertNeedsOwnedNested[bamlType] = true
+	}
+
 	var bodyCode []jen.Code
 	bodyCode = append(bodyCode, jen.Var().Id("result").Add(bamlTypeExpr.Clone()))
 
-	var pooledInner reflect.Type
 	for field := range bamlType.Fields() {
 		if !field.IsExported() {
 			continue
@@ -254,29 +327,6 @@ func (m *mirrorStructTracker) generateConversionFunc(out *jen.File, bamlType ref
 				fieldInner = fieldInner.Elem()
 			}
 			if fieldInner.Kind() == reflect.Struct && structContainsMedia(field.Type, pkgs) {
-				// Detect the inner-slice-of-struct case before recursing
-				// so we can thread the pool helpers through. Only pools
-				// a single inner type per convert function — multiple
-				// distinct `*[]Struct` fields per outer type would need
-				// per-type ownedNested params, which the dynamic adapter
-				// shape does not currently require.
-				//
-				// Pointer-element slices (`*[]*T`) are skipped: the pool
-				// would have to produce `*[]*T`, but the convert
-				// function's ownedNested parameter is typed as
-				// `*[]*[]T` (value-element slices) — mixing them would
-				// generate a compile-time type mismatch. Pointer-element
-				// slices fall through to the legacy `make` path inside
-				// nestedStructConversion, which has the symmetric guard.
-				if pools != nil &&
-					field.Type.Kind() == reflect.Ptr &&
-					field.Type.Elem().Kind() == reflect.Slice &&
-					field.Type.Elem().Elem().Kind() != reflect.Ptr {
-					innerElem := field.Type.Elem().Elem()
-					if pooledInner == nil {
-						pooledInner = innerElem
-					}
-				}
 				bodyCode = append(bodyCode, nestedStructConversion(fieldName, srcExpr, field.Type, m, pools, out)...)
 			} else {
 				// Direct copy
@@ -291,11 +341,8 @@ func (m *mirrorStructTracker) generateConversionFunc(out *jen.File, bamlType ref
 		jen.Id("adapter").Qual(pkgs.InterfacesPkg, "Adapter"),
 		jen.Id("input").Op("*").Id(mirrorName),
 	}
-	if pooledInner != nil {
-		// Record the contract so dispatch-site emitters know to pass
-		// the matching `&ownedNested` and to set up the typed slice.
-		m.convertOwnedNested[bamlType] = pooledInner
-		params = append(params, jen.Id("ownedNested").Op("*").Index().Op("*").Index().Add(parseReflectType(pooledInner).statement))
+	if needsOwnedNested {
+		params = append(params, jen.Id("ownedNested").Op("*").Index().Func().Params())
 	}
 
 	out.Func().Id(funcName).
@@ -496,12 +543,18 @@ func mediaFieldConversion(fieldName string, srcExpr *jen.Statement, fieldType re
 // nestedStructConversion generates code to convert a nested mirror struct field
 // to the real BAML struct via its conversion function. Handles ptr/slice wrapping.
 //
-// pools (optional) wires the `*[]Struct` branch through a shared slice
-// pool — the parts slice is checked out via the generated getter, the
-// pointer is appended to the enclosing convert function's
-// `ownedNested` parameter, and the dispatch site releases it after
-// BAML consumes the converted value. Passing nil keeps the legacy
-// `make([]T, n)` shape.
+// pools (optional) wires the `*[]Struct` value-element branch through
+// a shared slice pool — the parts slice is checked out via the
+// generated getter, a release closure that `put`s the slice back is
+// appended to the enclosing convert function's `ownedNested
+// *[]func()` parameter, and the dispatch site invokes the closures
+// after BAML consumes the converted value. Passing nil keeps the
+// legacy `make([]T, n)` shape.
+//
+// Every converter call inside the body threads `ownedNested` through
+// when the called converter takes it. This lets a single propagated
+// `*[]func()` slice carry release closures across arbitrarily nested
+// converters and arbitrarily many distinct pooled element types.
 func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType reflect.Type, tracker *mirrorStructTracker, pools *slicePoolTracker, out *jen.File) []jen.Code {
 	isPtr := fieldType.Kind() == reflect.Ptr
 	isSlice := fieldType.Kind() == reflect.Slice
@@ -511,6 +564,18 @@ func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType 
 		innerType = innerType.Elem()
 	}
 	convertFunc := "convert" + mirrorInputName(innerType)
+	innerNeedsOwnedNested := tracker.convertNeedsOwnedNestedFor(innerType)
+
+	// buildConvertCall threads `ownedNested` into the convert<Inner>
+	// call when the inner converter takes it. Sits at the head of the
+	// var-args list so every branch builds the call the same way.
+	buildConvertCall := func(vArg jen.Code) *jen.Statement {
+		callArgs := []jen.Code{jen.Id("adapter"), vArg}
+		if innerNeedsOwnedNested {
+			callArgs = append(callArgs, jen.Id("ownedNested"))
+		}
+		return jen.List(jen.Id("__converted"), jen.Id("__err")).Op(":=").Id(convertFunc).Call(callArgs...)
+	}
 
 	if isSlice {
 		elemType := fieldType.Elem()
@@ -526,10 +591,7 @@ func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType 
 		}
 
 		conversionBlock := []jen.Code{
-			jen.List(jen.Id("__converted"), jen.Id("__err")).Op(":=").Id(convertFunc).Call(
-				jen.Id("adapter"),
-				vArg,
-			),
+			buildConvertCall(vArg),
 			jen.If(jen.Id("__err").Op("!=").Nil()).Block(
 				jen.Return(jen.Id("result"), jen.Qual("fmt", "Errorf").Call(
 					jen.Lit(fieldName+"[%d]: %w"),
@@ -579,10 +641,7 @@ func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType 
 			}
 
 			innerConvBlock := []jen.Code{
-				jen.List(jen.Id("__converted"), jen.Id("__err")).Op(":=").Id(convertFunc).Call(
-					jen.Id("adapter"),
-					vArg,
-				),
+				buildConvertCall(vArg),
 				jen.If(jen.Id("__err").Op("!=").Nil()).Block(
 					jen.Return(jen.Id("result"), jen.Qual("fmt", "Errorf").Call(
 						jen.Lit(fieldName+"[%d]: %w"),
@@ -608,14 +667,14 @@ func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType 
 				innerLoopBody = innerConvBlock
 			}
 
-			// Only pool when the inner slice element is a value type:
-			// the convert function's `ownedNested *[]*[]T` parameter is
-			// typed against value elements, and feeding it `*[]*T`
-			// would generate a compile-time type mismatch. The detection
-			// branch in generateConversionFunc has the symmetric guard;
-			// keeping them in sync means pointer-element slices fall
-			// through to the legacy `make` path here without setting
-			// `convertOwnedNested` upstream.
+			// Only pool when the inner slice element is a value type.
+			// Pointer-element slices (`*[]*T`) fall through to the
+			// legacy `make` path because pooling them would have to
+			// nil-clear per element and the dispatch site never
+			// promised a pool for that shape. The closure-context
+			// `ownedNested` parameter accepts arbitrary release
+			// closures, so distinct pooled inner types coexist; only
+			// the element-shape mismatch still gates the pool branch.
 			if pools != nil && out != nil && !elemIsPtr {
 				poolNames := pools.ensure(out, elemType, 256)
 				return []jen.Code{
@@ -623,9 +682,16 @@ func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType 
 						jen.Id("__partsPtr").Op(":=").Id(poolNames.getFunc).Call(
 							jen.Len(jen.Op("*").Add(srcExpr.Clone())),
 						),
+						// Append a release closure capturing this
+						// branch's specific pool helper + pointer.
+						// Distinct nested types append distinct
+						// closures; the outer dispatch drains them
+						// uniformly without knowing the inner types.
 						jen.Op("*").Id("ownedNested").Op("=").Append(
 							jen.Op("*").Id("ownedNested"),
-							jen.Id("__partsPtr"),
+							jen.Func().Params().Block(
+								jen.Id(poolNames.putFunc).Call(jen.Id("__partsPtr")),
+							),
 						),
 						jen.Op("*").Id("__partsPtr").Op("=").Parens(jen.Op("*").Id("__partsPtr")).Index(
 							jen.Empty(),
@@ -652,10 +718,7 @@ func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType 
 		// *Struct (optional single nested struct with media)
 		return []jen.Code{
 			jen.If(srcExpr.Clone().Op("!=").Nil()).Block(
-				jen.List(jen.Id("__converted"), jen.Id("__err")).Op(":=").Id(convertFunc).Call(
-					jen.Id("adapter"),
-					srcExpr.Clone(),
-				),
+				buildConvertCall(srcExpr.Clone()),
 				jen.If(jen.Id("__err").Op("!=").Nil()).Block(
 					jen.Return(jen.Id("result"), jen.Qual("fmt", "Errorf").Call(
 						jen.Lit(fieldName+": %w"),
@@ -670,10 +733,7 @@ func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType 
 	// Direct
 	return []jen.Code{
 		jen.Block(
-			jen.List(jen.Id("__converted"), jen.Id("__err")).Op(":=").Id(convertFunc).Call(
-				jen.Id("adapter"),
-				jen.Op("&").Add(srcExpr.Clone()),
-			),
+			buildConvertCall(jen.Op("&").Add(srcExpr.Clone())),
 			jen.If(jen.Id("__err").Op("!=").Nil()).Block(
 				jen.Return(jen.Id("result"), jen.Qual("fmt", "Errorf").Call(
 					jen.Lit(fieldName+": %w"),

--- a/adapters/common/codegen/codegen_reflect.go
+++ b/adapters/common/codegen/codegen_reflect.go
@@ -260,11 +260,19 @@ func (m *mirrorStructTracker) generateConversionFunc(out *jen.File, bamlType ref
 				// distinct `*[]Struct` fields per outer type would need
 				// per-type ownedNested params, which the dynamic adapter
 				// shape does not currently require.
-				if pools != nil && field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Slice {
+				//
+				// Pointer-element slices (`*[]*T`) are skipped: the pool
+				// would have to produce `*[]*T`, but the convert
+				// function's ownedNested parameter is typed as
+				// `*[]*[]T` (value-element slices) — mixing them would
+				// generate a compile-time type mismatch. Pointer-element
+				// slices fall through to the legacy `make` path inside
+				// nestedStructConversion, which has the symmetric guard.
+				if pools != nil &&
+					field.Type.Kind() == reflect.Ptr &&
+					field.Type.Elem().Kind() == reflect.Slice &&
+					field.Type.Elem().Elem().Kind() != reflect.Ptr {
 					innerElem := field.Type.Elem().Elem()
-					if innerElem.Kind() == reflect.Ptr {
-						innerElem = innerElem.Elem()
-					}
 					if pooledInner == nil {
 						pooledInner = innerElem
 					}
@@ -600,7 +608,15 @@ func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType 
 				innerLoopBody = innerConvBlock
 			}
 
-			if pools != nil && out != nil {
+			// Only pool when the inner slice element is a value type:
+			// the convert function's `ownedNested *[]*[]T` parameter is
+			// typed against value elements, and feeding it `*[]*T`
+			// would generate a compile-time type mismatch. The detection
+			// branch in generateConversionFunc has the symmetric guard;
+			// keeping them in sync means pointer-element slices fall
+			// through to the legacy `make` path here without setting
+			// `convertOwnedNested` upstream.
+			if pools != nil && out != nil && !elemIsPtr {
 				poolNames := pools.ensure(out, elemType, 256)
 				return []jen.Code{
 					jen.If(srcExpr.Clone().Op("!=").Nil()).Block(

--- a/adapters/common/codegen/codegen_reflect.go
+++ b/adapters/common/codegen/codegen_reflect.go
@@ -116,10 +116,31 @@ func structContainsMediaVisited(typ reflect.Type, visited map[reflect.Type]bool,
 // Maps the original BAML type name to the generated mirror struct name.
 type mirrorStructTracker struct {
 	generated map[reflect.Type]string // baml type -> mirror struct name
+	// convertOwnedNested records the inner BAML element type that a
+	// convert function pushes into its `ownedNested` parameter (for
+	// `*[]Struct` fields routed through a slice pool). Populated lazily
+	// by nestedStructConversion via the generator's slicePoolTracker.
+	// Keyed by the outer BAML type whose convert function carries the
+	// extra parameter. Empty means the convert function uses the legacy
+	// 2-arg signature.
+	convertOwnedNested map[reflect.Type]reflect.Type
 }
 
 func newMirrorStructTracker() *mirrorStructTracker {
-	return &mirrorStructTracker{generated: make(map[reflect.Type]string)}
+	return &mirrorStructTracker{
+		generated:          make(map[reflect.Type]string),
+		convertOwnedNested: make(map[reflect.Type]reflect.Type),
+	}
+}
+
+// convertOwnedNestedFor returns the inner BAML element type that
+// convert<Mirror> for `outer` threads through its ownedNested param,
+// or nil if the convert function uses the legacy 2-arg signature.
+func (m *mirrorStructTracker) convertOwnedNestedFor(outer reflect.Type) reflect.Type {
+	if m == nil {
+		return nil
+	}
+	return m.convertOwnedNested[outer]
 }
 
 // mirrorInputName returns the name for a mirror input struct.
@@ -129,7 +150,11 @@ func mirrorInputName(typ reflect.Type) string {
 
 // ensureMirrorStruct generates a mirror struct and conversion function for a BAML struct
 // that contains media fields. Returns the mirror struct name. Skips generation if already done.
-func (m *mirrorStructTracker) ensureMirrorStruct(out *jen.File, typ reflect.Type, pkgs PackageConfig) string {
+//
+// `pools` (optional) wires slice-pool helpers into nested `*[]Struct`
+// conversions and the convert function signature. Pass nil for adapters
+// that should not opt into pooling.
+func (m *mirrorStructTracker) ensureMirrorStruct(out *jen.File, typ reflect.Type, pkgs PackageConfig, pools *slicePoolTracker) string {
 	// Unwrap pointer/slice to get to the struct
 	inner := typ
 	for inner.Kind() == reflect.Ptr || inner.Kind() == reflect.Slice {
@@ -153,7 +178,7 @@ func (m *mirrorStructTracker) ensureMirrorStruct(out *jen.File, typ reflect.Type
 			fieldInner = fieldInner.Elem()
 		}
 		if fieldInner.Kind() == reflect.Struct && structContainsMedia(field.Type, pkgs) {
-			m.ensureMirrorStruct(out, field.Type, pkgs)
+			m.ensureMirrorStruct(out, field.Type, pkgs, pools)
 		}
 	}
 
@@ -193,20 +218,26 @@ func (m *mirrorStructTracker) ensureMirrorStruct(out *jen.File, typ reflect.Type
 	out.Type().Id(mirrorName).Struct(fields...)
 
 	// Generate the conversion function: convert<MirrorName>(adapter, input) -> (bamlType, error)
-	m.generateConversionFunc(out, inner, mirrorName, pkgs)
+	m.generateConversionFunc(out, inner, mirrorName, pkgs, pools)
 
 	return mirrorName
 }
 
 // generateConversionFunc generates a function that converts a mirror input struct
 // to the real BAML struct, handling media field conversion.
-func (m *mirrorStructTracker) generateConversionFunc(out *jen.File, bamlType reflect.Type, mirrorName string, pkgs PackageConfig) {
+//
+// pools is the per-file slice pool tracker. When non-nil, `*[]Struct`
+// fields route through the pool helpers and the emitted function gains
+// an extra `ownedNested *[]*[]<innerElem>` parameter that the dispatch
+// caller releases after BAML consumes the converted slice.
+func (m *mirrorStructTracker) generateConversionFunc(out *jen.File, bamlType reflect.Type, mirrorName string, pkgs PackageConfig, pools *slicePoolTracker) {
 	funcName := "convert" + mirrorName
 	bamlTypeExpr := parseReflectType(bamlType).statement
 
 	var bodyCode []jen.Code
 	bodyCode = append(bodyCode, jen.Var().Id("result").Add(bamlTypeExpr.Clone()))
 
+	var pooledInner reflect.Type
 	for field := range bamlType.Fields() {
 		if !field.IsExported() {
 			continue
@@ -223,7 +254,22 @@ func (m *mirrorStructTracker) generateConversionFunc(out *jen.File, bamlType ref
 				fieldInner = fieldInner.Elem()
 			}
 			if fieldInner.Kind() == reflect.Struct && structContainsMedia(field.Type, pkgs) {
-				bodyCode = append(bodyCode, nestedStructConversion(fieldName, srcExpr, field.Type, m)...)
+				// Detect the inner-slice-of-struct case before recursing
+				// so we can thread the pool helpers through. Only pools
+				// a single inner type per convert function — multiple
+				// distinct `*[]Struct` fields per outer type would need
+				// per-type ownedNested params, which the dynamic adapter
+				// shape does not currently require.
+				if pools != nil && field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Slice {
+					innerElem := field.Type.Elem().Elem()
+					if innerElem.Kind() == reflect.Ptr {
+						innerElem = innerElem.Elem()
+					}
+					if pooledInner == nil {
+						pooledInner = innerElem
+					}
+				}
+				bodyCode = append(bodyCode, nestedStructConversion(fieldName, srcExpr, field.Type, m, pools, out)...)
 			} else {
 				// Direct copy
 				bodyCode = append(bodyCode, jen.Id("result").Dot(fieldName).Op("=").Add(srcExpr.Clone()))
@@ -233,11 +279,19 @@ func (m *mirrorStructTracker) generateConversionFunc(out *jen.File, bamlType ref
 
 	bodyCode = append(bodyCode, jen.Return(jen.Id("result"), jen.Nil()))
 
+	params := []jen.Code{
+		jen.Id("adapter").Qual(pkgs.InterfacesPkg, "Adapter"),
+		jen.Id("input").Op("*").Id(mirrorName),
+	}
+	if pooledInner != nil {
+		// Record the contract so dispatch-site emitters know to pass
+		// the matching `&ownedNested` and to set up the typed slice.
+		m.convertOwnedNested[bamlType] = pooledInner
+		params = append(params, jen.Id("ownedNested").Op("*").Index().Op("*").Index().Add(parseReflectType(pooledInner).statement))
+	}
+
 	out.Func().Id(funcName).
-		Params(
-			jen.Id("adapter").Qual(pkgs.InterfacesPkg, "Adapter"),
-			jen.Id("input").Op("*").Id(mirrorName),
-		).
+		Params(params...).
 		Params(bamlTypeExpr.Clone(), jen.Error()).
 		Block(bodyCode...)
 }
@@ -433,7 +487,14 @@ func mediaFieldConversion(fieldName string, srcExpr *jen.Statement, fieldType re
 
 // nestedStructConversion generates code to convert a nested mirror struct field
 // to the real BAML struct via its conversion function. Handles ptr/slice wrapping.
-func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType reflect.Type, tracker *mirrorStructTracker) []jen.Code {
+//
+// pools (optional) wires the `*[]Struct` branch through a shared slice
+// pool — the parts slice is checked out via the generated getter, the
+// pointer is appended to the enclosing convert function's
+// `ownedNested` parameter, and the dispatch site releases it after
+// BAML consumes the converted value. Passing nil keeps the legacy
+// `make([]T, n)` shape.
+func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType reflect.Type, tracker *mirrorStructTracker, pools *slicePoolTracker, out *jen.File) []jen.Code {
 	isPtr := fieldType.Kind() == reflect.Ptr
 	isSlice := fieldType.Kind() == reflect.Slice
 
@@ -539,6 +600,27 @@ func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType 
 				innerLoopBody = innerConvBlock
 			}
 
+			if pools != nil && out != nil {
+				poolNames := pools.ensure(out, elemType, 256)
+				return []jen.Code{
+					jen.If(srcExpr.Clone().Op("!=").Nil()).Block(
+						jen.Id("__partsPtr").Op(":=").Id(poolNames.getFunc).Call(
+							jen.Len(jen.Op("*").Add(srcExpr.Clone())),
+						),
+						jen.Op("*").Id("ownedNested").Op("=").Append(
+							jen.Op("*").Id("ownedNested"),
+							jen.Id("__partsPtr"),
+						),
+						jen.Op("*").Id("__partsPtr").Op("=").Parens(jen.Op("*").Id("__partsPtr")).Index(
+							jen.Empty(),
+							jen.Len(jen.Op("*").Add(srcExpr.Clone())),
+						),
+						jen.Id("__ptrSlice").Op(":=").Op("*").Id("__partsPtr"),
+						jen.For(jen.List(jen.Id("__i"), jen.Id("__v")).Op(":=").Range().Op("*").Add(srcExpr.Clone())).Block(innerLoopBody...),
+						jen.Id("result").Dot(fieldName).Op("=").Op("&").Id("__ptrSlice"),
+					),
+				}
+			}
 			return []jen.Code{
 				jen.If(srcExpr.Clone().Op("!=").Nil()).Block(
 					jen.Id("__ptrSlice").Op(":=").Make(

--- a/adapters/common/codegen/codegen_reflect.go
+++ b/adapters/common/codegen/codegen_reflect.go
@@ -400,8 +400,8 @@ func (m *mirrorStructTracker) generateConversionFunc(out *jen.File, bamlType ref
 	// error. The precompute pass guarantees every reachable type's
 	// flag is final before any body emission runs.
 	//
-	// When `pools` is nil the legacy non-pooling path applies; the
-	// precompute would have left the map empty in that case too.
+	// When `pools` is nil the legacy non-pooling path applies and
+	// neither signatures nor call sites thread ownedNested.
 	needsOwnedNested := pools != nil && m.convertNeedsOwnedNested[bamlType]
 
 	var bodyCode []jen.Code
@@ -660,7 +660,7 @@ func nestedStructConversion(fieldName string, srcExpr *jen.Statement, fieldType 
 		innerType = innerType.Elem()
 	}
 	convertFunc := "convert" + mirrorInputName(innerType)
-	innerNeedsOwnedNested := tracker.convertNeedsOwnedNestedFor(innerType)
+	innerNeedsOwnedNested := pools != nil && tracker.convertNeedsOwnedNestedFor(innerType)
 
 	// buildConvertCall threads `ownedNested` into the convert<Inner>
 	// call when the inner converter takes it. Sits at the head of the

--- a/adapters/common/codegen/codegen_reflect.go
+++ b/adapters/common/codegen/codegen_reflect.go
@@ -149,6 +149,136 @@ func (m *mirrorStructTracker) convertNeedsOwnedNestedFor(outer reflect.Type) boo
 	return m.convertNeedsOwnedNested[outer]
 }
 
+// precomputeOwnedNestedNeeds walks the struct-media type graph
+// reachable from `roots` and populates `convertNeedsOwnedNested`
+// for every reachable type via fixpoint iteration. Must run before
+// any `generateConversionFunc` call so nested converter call sites
+// query the final transitive value instead of a partial answer
+// frozen mid-emission.
+//
+// Why a separate pass: `ensureMirrorStruct` marks each type as
+// "generated" before recursing into its fields. For cycles like
+// `A.B *B; B.A *A`, B's body emission completes BEFORE A finishes
+// its own analysis — so B's nestedStructConversion call site for
+// the A field used to snapshot the pre-fixpoint
+// (`convertNeedsOwnedNested[A] == false`) answer, while A's
+// converter signature later gained the third parameter once its
+// own pre-walk set the flag. The rendered Go is then internally
+// inconsistent: B's call site is 2-arg, A's signature is 3-arg →
+// compile error.
+//
+// The precompute resolves this by computing the transitive closure
+// up front. The fixpoint converges because the lattice is finite
+// (one bit per type, monotonically rising true), so each round
+// either flips at least one bit or terminates.
+func (m *mirrorStructTracker) precomputeOwnedNestedNeeds(roots []reflect.Type, pkgs PackageConfig) {
+	if m == nil {
+		return
+	}
+
+	// Walk every struct-media type reachable from the roots so the
+	// fixpoint loop iterates the full graph and not just the
+	// subset emitted so far. Cycle detection is via `visited`; the
+	// recursion descends into ptr/slice element types because
+	// those are the wrapping shapes struct-media fields take.
+	visited := map[reflect.Type]bool{}
+	var types []reflect.Type
+	var walk func(t reflect.Type)
+	walk = func(t reflect.Type) {
+		for t.Kind() == reflect.Ptr || t.Kind() == reflect.Slice {
+			t = t.Elem()
+		}
+		if t.Kind() != reflect.Struct {
+			return
+		}
+		if !structContainsMedia(t, pkgs) {
+			return
+		}
+		if visited[t] {
+			return
+		}
+		visited[t] = true
+		types = append(types, t)
+		for field := range t.Fields() {
+			if !field.IsExported() {
+				continue
+			}
+			if _, isMedia := isMediaReflectType(field.Type, pkgs); isMedia {
+				continue
+			}
+			walk(field.Type)
+		}
+	}
+	for _, root := range roots {
+		walk(root)
+	}
+
+	// Seed: any reachable type that DIRECTLY pools (has a
+	// `*[]Struct` value-element field whose inner struct contains
+	// media) needs `ownedNested` outright. This mirrors
+	// nestedStructConversion's `*[]Struct` value-element branch
+	// gating.
+	for _, t := range types {
+		if m.convertNeedsOwnedNested[t] {
+			continue
+		}
+		for field := range t.Fields() {
+			if !field.IsExported() {
+				continue
+			}
+			ft := field.Type
+			if _, isMedia := isMediaReflectType(ft, pkgs); isMedia {
+				continue
+			}
+			if ft.Kind() != reflect.Ptr || ft.Elem().Kind() != reflect.Slice || ft.Elem().Elem().Kind() == reflect.Ptr {
+				continue
+			}
+			inner := ft.Elem().Elem()
+			if inner.Kind() != reflect.Struct || !structContainsMedia(ft, pkgs) {
+				continue
+			}
+			m.convertNeedsOwnedNested[t] = true
+			break
+		}
+	}
+
+	// Fixpoint: propagate from callees to callers. If T calls
+	// convert<N> and N needs ownedNested, T must accept and
+	// thread the same parameter through.
+	for {
+		changed := false
+		for _, t := range types {
+			if m.convertNeedsOwnedNested[t] {
+				continue
+			}
+			for field := range t.Fields() {
+				if !field.IsExported() {
+					continue
+				}
+				ft := field.Type
+				if _, isMedia := isMediaReflectType(ft, pkgs); isMedia {
+					continue
+				}
+				inner := ft
+				for inner.Kind() == reflect.Ptr || inner.Kind() == reflect.Slice {
+					inner = inner.Elem()
+				}
+				if inner.Kind() != reflect.Struct || !structContainsMedia(ft, pkgs) {
+					continue
+				}
+				if m.convertNeedsOwnedNested[inner] {
+					m.convertNeedsOwnedNested[t] = true
+					changed = true
+					break
+				}
+			}
+		}
+		if !changed {
+			return
+		}
+	}
+}
+
 // mirrorInputName returns the name for a mirror input struct.
 func mirrorInputName(typ reflect.Type) string {
 	return typ.Name() + "MediaInput"
@@ -260,53 +390,19 @@ func (m *mirrorStructTracker) generateConversionFunc(out *jen.File, bamlType ref
 	funcName := "convert" + mirrorName
 	bamlTypeExpr := parseReflectType(bamlType).statement
 
-	// Pre-walk fields to decide whether this converter needs the
-	// `ownedNested` parameter — both directly (any pooled `*[]Struct`
-	// value-element field) and transitively (any nested converter that
-	// already takes it). Detection must happen before body emission so
-	// nestedStructConversion knows whether the closure it's appending
-	// to actually exists.
-	needsOwnedNested := false
-	for field := range bamlType.Fields() {
-		if !field.IsExported() {
-			continue
-		}
-		if _, isMedia := isMediaReflectType(field.Type, pkgs); isMedia {
-			continue
-		}
-		fieldInner := field.Type
-		for fieldInner.Kind() == reflect.Ptr || fieldInner.Kind() == reflect.Slice {
-			fieldInner = fieldInner.Elem()
-		}
-		if fieldInner.Kind() != reflect.Struct || !structContainsMedia(field.Type, pkgs) {
-			continue
-		}
-		// Direct pool: a `*[]Struct` value-element field this
-		// converter will route through the slice pool.
-		if pools != nil &&
-			field.Type.Kind() == reflect.Ptr &&
-			field.Type.Elem().Kind() == reflect.Slice &&
-			field.Type.Elem().Elem().Kind() != reflect.Ptr {
-			needsOwnedNested = true
-			break
-		}
-		// Transitive: the nested converter for the inner mirror type
-		// already takes `ownedNested`, so the call site must thread
-		// ours through.
-		if m.convertNeedsOwnedNestedFor(fieldInner) {
-			needsOwnedNested = true
-			break
-		}
-	}
-
-	if needsOwnedNested {
-		// Record the contract before emitting the body so any
-		// recursive ensureMirrorStruct callers see the up-to-date
-		// answer for this type. (In practice this matters only for
-		// hypothetical cycle-bearing schemas; the dynamic adapter
-		// has no such cycle today.)
-		m.convertNeedsOwnedNested[bamlType] = true
-	}
+	// `needsOwnedNested` is the precomputed transitive answer from
+	// `precomputeOwnedNestedNeeds`. Earlier revisions of this code
+	// re-derived the flag inline mid-emission, which races with
+	// recursive `ensureMirrorStruct` callers: for cycles like
+	// `A.B *B; B.A *A` where A directly pools, B's emission
+	// would complete before A set its own flag, so B's call site
+	// for A was 2-arg while A's signature ended up 3-arg → compile
+	// error. The precompute pass guarantees every reachable type's
+	// flag is final before any body emission runs.
+	//
+	// When `pools` is nil the legacy non-pooling path applies; the
+	// precompute would have left the map empty in that case too.
+	needsOwnedNested := pools != nil && m.convertNeedsOwnedNested[bamlType]
 
 	var bodyCode []jen.Code
 	bodyCode = append(bodyCode, jen.Var().Id("result").Add(bamlTypeExpr.Clone()))

--- a/adapters/common/codegen/codegen_slice_pool.go
+++ b/adapters/common/codegen/codegen_slice_pool.go
@@ -1,0 +1,140 @@
+package codegen
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/dave/jennifer/jen"
+)
+
+// slicePoolNames captures the symbol names emitted for a single pooled
+// slice type. Tracked centrally so emitters and call sites stay in
+// lockstep; one entry covers `[]T` where T is the unwrapped BAML
+// struct type (e.g. types.Baml_Rest_Message).
+type slicePoolNames struct {
+	poolVar   string
+	getFunc   string
+	putFunc   string
+	elemQual  *jen.Statement
+	elemRefl  reflect.Type
+	maxCap    int
+	emittedAt int
+}
+
+// slicePoolTracker dedupes per-file pool emission for each pooled
+// inner type. The lifecycle is:
+//
+//  1. emitter encounters a slice-of-struct conversion that benefits
+//     from pooling and calls `ensure`, which lazily emits the
+//     `sync.Pool` variable + `get/put` helpers into `out`.
+//  2. emitter consumers (nested struct conversion, slice-param
+//     preamble) read the returned names to assemble call-site code.
+//
+// Names are deterministic functions of the unwrapped BAML type name so
+// repeat encounters reuse the same helpers across the file.
+type slicePoolTracker struct {
+	mu       sync.Mutex
+	entries  map[reflect.Type]*slicePoolNames
+	emitOrd  int
+	pkgs     PackageConfig
+	jenSync  string
+}
+
+func newSlicePoolTracker(pkgs PackageConfig) *slicePoolTracker {
+	return &slicePoolTracker{
+		entries: make(map[reflect.Type]*slicePoolNames),
+		pkgs:    pkgs,
+		jenSync: "sync",
+	}
+}
+
+// ensure registers `elemType` for pooling with the supplied retention
+// cap. On the first call for a given type, it emits the pool variable
+// + get/put helpers into `out`. Subsequent calls are no-ops returning
+// the same names. `maxCap` lower bounds at 1 — non-positive values are
+// clamped so a misconfiguration cannot disable the cap check entirely.
+func (t *slicePoolTracker) ensure(out *jen.File, elemType reflect.Type, maxCap int) *slicePoolNames {
+	if elemType == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if existing, ok := t.entries[elemType]; ok {
+		return existing
+	}
+
+	if maxCap < 1 {
+		maxCap = 1
+	}
+
+	baseName := slicePoolBaseName(elemType)
+	names := &slicePoolNames{
+		poolVar:   baseName + "SlicePool",
+		getFunc:   "get" + baseName + "Slice",
+		putFunc:   "put" + baseName + "Slice",
+		elemQual:  parseReflectType(elemType).statement,
+		elemRefl:  elemType,
+		maxCap:    maxCap,
+		emittedAt: t.emitOrd,
+	}
+	t.emitOrd++
+	t.entries[elemType] = names
+
+	// var <pool> sync.Pool
+	out.Var().Id(names.poolVar).Qual(t.jenSync, "Pool")
+
+	// func get<Name>Slice(n int) *[]Elem { ... }
+	out.Func().Id(names.getFunc).
+		Params(jen.Id("n").Int()).
+		Op("*").Index().Add(names.elemQual.Clone()).
+		Block(
+			jen.If(jen.Id("v").Op(":=").Id(names.poolVar).Dot("Get").Call(), jen.Id("v").Op("!=").Nil()).Block(
+				jen.Id("sp").Op(":=").Id("v").Assert(jen.Op("*").Index().Add(names.elemQual.Clone())),
+				jen.If(jen.Cap(jen.Op("*").Id("sp")).Op(">=").Id("n")).Block(
+					jen.Op("*").Id("sp").Op("=").Parens(jen.Op("*").Id("sp")).Index(jen.Empty(), jen.Lit(0)),
+					jen.Return(jen.Id("sp")),
+				),
+			),
+			jen.Id("s").Op(":=").Make(jen.Index().Add(names.elemQual.Clone()), jen.Lit(0), jen.Id("n")),
+			jen.Return(jen.Op("&").Id("s")),
+		)
+
+	// func put<Name>Slice(sp *[]Elem) { ... }
+	out.Func().Id(names.putFunc).
+		Params(jen.Id("sp").Op("*").Index().Add(names.elemQual.Clone())).
+		Block(
+			jen.If(jen.Id("sp").Op("==").Nil()).Block(jen.Return()),
+			jen.If(jen.Cap(jen.Op("*").Id("sp")).Op(">").Lit(maxCap)).Block(jen.Return()),
+			jen.Id("used").Op(":=").Parens(jen.Op("*").Id("sp")).Index(jen.Lit(0), jen.Len(jen.Op("*").Id("sp")), jen.Cap(jen.Op("*").Id("sp"))),
+			jen.For(jen.Id("i").Op(":=").Range().Id("used")).Block(
+				jen.Id("used").Index(jen.Id("i")).Op("=").Add(names.elemQual.Clone()).Values(),
+			),
+			jen.Op("*").Id("sp").Op("=").Parens(jen.Op("*").Id("sp")).Index(jen.Empty(), jen.Lit(0)),
+			jen.Id(names.poolVar).Dot("Put").Call(jen.Id("sp")),
+		)
+
+	return names
+}
+
+func slicePoolBaseName(t reflect.Type) string {
+	name := t.Name()
+	if name == "" {
+		// Fall back to a sanitized full string when the type has no
+		// declared name (anonymous types should not reach here in the
+		// generated paths, but guard so the codegen does not panic).
+		name = "Anon"
+	}
+	return lowerFirst(name)
+}
+
+func lowerFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	if r[0] >= 'A' && r[0] <= 'Z' {
+		r[0] = r[0] + ('a' - 'A')
+	}
+	return string(r)
+}

--- a/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
@@ -95,6 +95,28 @@ func emitMatrix(t *testing.T) (*jen.File, []matrixCell) {
 	tracker := newMirrorStructTracker()
 	pools := newSlicePoolTracker(pkgs)
 
+	// Precompute the convertNeedsOwnedNested transitive closure
+	// across every reachable struct-media type the matrix exercises.
+	// Mirrors what `generator.emitMethods` does at the head of the
+	// real generator pipeline. Without this, the per-cell
+	// `ensureMirrorStruct` calls would race with one another and
+	// nested call sites could snapshot a stale `false`.
+	var precomputeRoots []reflect.Type
+	for _, shape := range []struct{ ty reflect.Type }{
+		{reflect.TypeOf(fixtures.MessageA{})},
+		{reflect.TypeOf(fixtures.MessageB{})},
+		{reflect.TypeOf(fixtures.MessageC{})},
+		{reflect.TypeOf(fixtures.ClassA{})},
+		{reflect.TypeOf(fixtures.ClassB{})},
+		{reflect.TypeOf(fixtures.ClassC{})},
+		{reflect.TypeOf(fixtures.OtherA{})},
+		{reflect.TypeOf(fixtures.OtherB{})},
+		{reflect.TypeOf(fixtures.OtherC{})},
+	} {
+		precomputeRoots = append(precomputeRoots, shape.ty)
+	}
+	tracker.precomputeOwnedNestedNeeds(precomputeRoots, pkgs)
+
 	// nestedShapes enumerates the 3 nested-field configurations the
 	// matrix crosses. The fixture struct families (MessageA /
 	// MessageB / MessageC + Class<X> / Other<X> siblings) capture
@@ -277,6 +299,17 @@ func emitMatrix(t *testing.T) (*jen.File, []matrixCell) {
 		}
 	}
 
+	// Mutually-recursive cycle cell. Drives ensureMirrorStruct
+	// against `CycleA` (which references `*CycleB`, which references
+	// `*CycleA` — a cycle) and emits a dispatch function that
+	// converts a `CycleA` slice. Without the two-pass precompute,
+	// the inner-body emission for CycleB would snapshot
+	// convertNeedsOwnedNestedFor(CycleA) == false (because A is
+	// mid-generation) and the call site there would be 2-arg
+	// against A's eventual 3-arg signature. Adding this cell to
+	// the same compile target so the build error surfaces here.
+	emitCycleCell(t, out, tracker, pools, pkgs, &cells)
+
 	// The rendered file's preamble references `makeOptionsFromAdapter`
 	// (which the real generator emits elsewhere). Provide a stub so
 	// `go build` resolves it.
@@ -286,6 +319,63 @@ func emitMatrix(t *testing.T) (*jen.File, []matrixCell) {
 		Block(jen.Return(jen.Nil(), jen.Nil()))
 
 	return out, cells
+}
+
+// emitCycleCell adds the mutually-recursive cycle regression cell
+// to the matrix. CycleA references *CycleB and pools its Parts
+// slice; CycleB references *CycleA. The precompute pass must mark
+// both A and B as needing ownedNested before any body emission, or
+// the rendered file will not compile (B's call site to convertA
+// will be 2-arg while convertA's signature is 3-arg).
+func emitCycleCell(t *testing.T, out *jen.File, tracker *mirrorStructTracker, pools *slicePoolTracker, pkgs PackageConfig, cells *[]matrixCell) {
+	t.Helper()
+	cycleAType := reflect.TypeOf(fixtures.CycleA{})
+	cycleBType := reflect.TypeOf(fixtures.CycleB{})
+	tracker.precomputeOwnedNestedNeeds([]reflect.Type{cycleAType, cycleBType}, pkgs)
+
+	// Both ends of the cycle must end up flagged. CycleA pools
+	// directly; CycleB transitively calls convertA so it must
+	// thread the parameter through.
+	if !tracker.convertNeedsOwnedNestedFor(cycleAType) {
+		t.Fatal("cycle fixture invariant: CycleA must need ownedNested (it directly pools)")
+	}
+	if !tracker.convertNeedsOwnedNestedFor(cycleBType) {
+		t.Fatal("cycle fixture invariant: CycleB must need ownedNested (transitive via *CycleA call site)")
+	}
+
+	mirrorName := tracker.ensureMirrorStruct(out, cycleAType, pkgs, pools)
+	paramType := reflect.SliceOf(cycleAType)
+	smps := []structMediaParam{{
+		paramName:   "cycles",
+		mirrorName:  mirrorName,
+		convertFunc: "convert" + mirrorName,
+		paramType:   paramType,
+	}}
+	cellName := "cell_cycle_mutually_recursive"
+	me := newSyntheticMethodEmitter(out, tracker, pools, pkgs, cellName, smps, []reflect.Type{paramType})
+	preamble := me.makePreambleWithArgs("makeOptionsFromAdapter")
+	tail := []jen.Code{
+		jen.Id("_").Op("=").Id("options"),
+		jen.Id("_").Op("=").Id("__struct_cycles"),
+		jen.Return(jen.Nil()),
+	}
+	body := append([]jen.Code{}, preamble...)
+	body = append(body, tail...)
+
+	dispatchName := cellName + "_dispatch"
+	out.Func().Id(dispatchName).
+		Params(
+			jen.Id("adapter").Qual(pkgs.InterfacesPkg, "Adapter"),
+			jen.Id("rawInput").Any(),
+		).
+		Error().
+		Block(body...)
+
+	*cells = append(*cells, matrixCell{
+		name:                   cellName,
+		dispatchFunc:           dispatchName,
+		expectReleaseConverted: true,
+	})
 }
 
 // newSyntheticMethodEmitter constructs a minimal methodEmitter that
@@ -557,4 +647,3 @@ func writeFile(t *testing.T, path, content string) {
 		t.Fatalf("write %s: %v", path, err)
 	}
 }
-

--- a/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
@@ -1,0 +1,560 @@
+package codegen
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/dave/jennifer/jen"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/internal/fixtures"
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// TestCompileMatrix is the "broad" complement to the targeted F1 / F2
+// / F3 regression pins. The targeted tests assert specific textual
+// fragments. This one drives the real generator path
+// (ensureMirrorStruct + makePreambleWithArgs) for a matrix of
+// legitimate BAML signature shapes, writes the rendered output to a
+// temp Go module, and shells out to `go build` to type-check it.
+// That catches every class of compile-level bug the rendered output
+// can grow — including future variants we haven't pre-enumerated.
+//
+// Per the meta-analysis driving this test: the existing codegen
+// tests verify rendered-source fragments but never type-check the
+// output. That gap let five generator-contract bugs slip through
+// review. This test directly closes it.
+//
+// The matrix crosses 7 top-level param shapes with 3 nested field
+// shapes (21 cells). Each cell emits one synthetic `cell_<N>_*`
+// dispatch function into a shared file; we run `go build` against
+// the file once (per the brief's batching note) and rely on the
+// type checker to surface mismatches anywhere in the matrix. A
+// follow-up AST scan asserts no `__releaseConverted` is emitted in
+// the single-non-pooled cell, which `go build` alone wouldn't catch
+// (an unnecessary closure would still compile).
+func TestCompileMatrix(t *testing.T) {
+	t.Parallel()
+
+	// Skip when `go` is not on PATH (the subprocess compile step
+	// needs it). In CI Go is always present; in offline / sandbox
+	// shells this avoids a noisy failure unrelated to the contract
+	// under test.
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go binary not on PATH: %v", err)
+	}
+
+	out, cells := emitMatrix(t)
+	rendered := out.GoString()
+
+	tmp := t.TempDir()
+	writeTempModule(t, tmp, rendered)
+	runGoBuild(t, tmp)
+
+	parsed, fset := parseRendered(t, rendered)
+	assertNoReleaseConvertedInNonPooledCell(t, parsed, fset, cells)
+}
+
+// matrixCell records the shape under test and the name of the
+// dispatch function the matrix emitter wrote into the shared file.
+// AST assertions look up cells by `dispatchFunc`; subprocess
+// `go build` does not need the metadata.
+type matrixCell struct {
+	name                  string
+	dispatchFunc          string
+	expectReleaseConverted bool
+}
+
+// emitMatrix walks the 7-top × 3-nested matrix, drives the real
+// generator path for each cell, and returns the shared rendered
+// file plus the per-cell metadata the AST checks consume. The file
+// uses the `matrix` package name; `runGoBuild` writes it to a temp
+// module that imports bamlutils + fixtures via replace directives.
+func emitMatrix(t *testing.T) (*jen.File, []matrixCell) {
+	t.Helper()
+
+	pkgs := DefaultPackageConfig()
+	// Point BamlPkg at the fixtures package so `isMediaReflectType`
+	// resolves `Image` as a BAML media type. Without this the
+	// fixture structs would not be detected as media-bearing and
+	// the matrix would not exercise ensureMirrorStruct at all.
+	pkgs.BamlPkg = reflect.TypeOf(fixtures.Image{}).PkgPath()
+	pkgs.OutputPkg = "github.com/invakid404/baml-rest/adapters/common/codegen/matrixtest"
+	pkgs.OutputPkgName = "matrix"
+
+	out := jen.NewFilePathName(pkgs.OutputPkg, pkgs.OutputPkgName)
+	tracker := newMirrorStructTracker()
+	pools := newSlicePoolTracker(pkgs)
+
+	// nestedShapes enumerates the 3 nested-field configurations the
+	// matrix crosses. The fixture struct families (MessageA /
+	// MessageB / MessageC + Class<X> / Other<X> siblings) capture
+	// the three shapes:
+	//
+	//   a — `Parts *[]ContentPart` (value-element pooled, the
+	//       closure-context happy path)
+	//   b — `Parts *[]*ContentPart` (pointer-element fallback to
+	//       the legacy `make` path; converter doesn't take
+	//       ownedNested)
+	//   c — `Parts *[]Content; Tools *[]Tool` (two distinct pooled
+	//       types per converter — the F2 multi-pool shape)
+	nestedShapes := []struct {
+		name      string
+		messageTy reflect.Type
+		classTy   reflect.Type
+		otherTy   reflect.Type
+	}{
+		{name: "a_value_elem", messageTy: reflect.TypeOf(fixtures.MessageA{}), classTy: reflect.TypeOf(fixtures.ClassA{}), otherTy: reflect.TypeOf(fixtures.OtherA{})},
+		{name: "b_ptr_elem", messageTy: reflect.TypeOf(fixtures.MessageB{}), classTy: reflect.TypeOf(fixtures.ClassB{}), otherTy: reflect.TypeOf(fixtures.OtherB{})},
+		{name: "c_two_pooled_types", messageTy: reflect.TypeOf(fixtures.MessageC{}), classTy: reflect.TypeOf(fixtures.ClassC{}), otherTy: reflect.TypeOf(fixtures.OtherC{})},
+	}
+
+	// topShapes enumerates the 7 top-level signature shapes per the
+	// brief. Each shape is described by a builder that, given the
+	// per-nested-shape fixture types, returns the structMediaParam
+	// list to feed into the synthetic methodEmitter.
+	type paramSpec struct {
+		name string
+		ty   reflect.Type
+	}
+	topShapes := []struct {
+		name           string
+		expectRelease  bool
+		buildParams    func(messageTy, classTy, otherTy reflect.Type) []paramSpec
+	}{
+		{
+			name:          "1_pooled_baseline",
+			expectRelease: true,
+			buildParams: func(messageTy, _, _ reflect.Type) []paramSpec {
+				return []paramSpec{{name: "messages", ty: reflect.SliceOf(messageTy)}}
+			},
+		},
+		{
+			name:          "2_two_pooled_params",
+			expectRelease: true,
+			buildParams: func(messageTy, classTy, _ reflect.Type) []paramSpec {
+				return []paramSpec{
+					{name: "messages", ty: reflect.SliceOf(messageTy)},
+					{name: "classes", ty: reflect.SliceOf(classTy)},
+				}
+			},
+		},
+		{
+			name:          "3_pooled_plus_slice_of_ptr",
+			expectRelease: true,
+			buildParams: func(messageTy, _, otherTy reflect.Type) []paramSpec {
+				return []paramSpec{
+					{name: "messages", ty: reflect.SliceOf(messageTy)},
+					{name: "extra", ty: reflect.SliceOf(reflect.PointerTo(otherTy))},
+				}
+			},
+		},
+		{
+			name:          "4_pooled_plus_ptr_to_slice",
+			expectRelease: true,
+			buildParams: func(messageTy, _, otherTy reflect.Type) []paramSpec {
+				return []paramSpec{
+					{name: "messages", ty: reflect.SliceOf(messageTy)},
+					{name: "extra", ty: reflect.PointerTo(reflect.SliceOf(otherTy))},
+				}
+			},
+		},
+		{
+			name:          "5_pooled_plus_ptr",
+			expectRelease: true,
+			buildParams: func(messageTy, _, otherTy reflect.Type) []paramSpec {
+				return []paramSpec{
+					{name: "messages", ty: reflect.SliceOf(messageTy)},
+					{name: "extra", ty: reflect.PointerTo(otherTy)},
+				}
+			},
+		},
+		{
+			name:          "6_pooled_plus_direct",
+			expectRelease: true,
+			buildParams: func(messageTy, _, otherTy reflect.Type) []paramSpec {
+				return []paramSpec{
+					{name: "messages", ty: reflect.SliceOf(messageTy)},
+					{name: "extra", ty: otherTy},
+				}
+			},
+		},
+		{
+			name:          "7_single_non_pooled_ptr",
+			// Whether the cell emits __releaseConverted depends on
+			// whether `*Other<Shape>`'s converter takes ownedNested.
+			// For nested shapes a and c the converter pools, so it
+			// takes ownedNested → the dispatch hoists
+			// __releaseConverted (to drain the closures).
+			// For nested shape b the converter does NOT pool
+			// (pointer-element fallback) → no ownedNested → no
+			// __releaseConverted. The per-cell expectation is
+			// computed below.
+			expectRelease: false,
+			buildParams: func(_, _, otherTy reflect.Type) []paramSpec {
+				return []paramSpec{{name: "extra", ty: reflect.PointerTo(otherTy)}}
+			},
+		},
+	}
+
+	var cells []matrixCell
+	for topIdx, top := range topShapes {
+		for nestedIdx, nested := range nestedShapes {
+			cellIdx := topIdx*len(nestedShapes) + nestedIdx
+			cellName := fmt.Sprintf("cell_%02d_%s_%s", cellIdx, top.name, nested.name)
+
+			params := top.buildParams(nested.messageTy, nested.classTy, nested.otherTy)
+
+			// Ensure mirror structs for every struct-media param.
+			// This populates `tracker.convertNeedsOwnedNested` so
+			// the makePreambleWithArgs call below sees the
+			// up-to-date contract.
+			smps := make([]structMediaParam, 0, len(params))
+			paramTypes := make([]reflect.Type, 0, len(params))
+			for _, p := range params {
+				mirrorName := tracker.ensureMirrorStruct(out, p.ty, pkgs, pools)
+				smps = append(smps, structMediaParam{
+					paramName:   p.name,
+					mirrorName:  mirrorName,
+					convertFunc: "convert" + mirrorName,
+					paramType:   p.ty,
+				})
+				paramTypes = append(paramTypes, p.ty)
+			}
+
+			me := newSyntheticMethodEmitter(out, tracker, pools, pkgs, cellName, smps, paramTypes)
+			preamble := me.makePreambleWithArgs("makeOptionsFromAdapter")
+			// Silence `declared and not used` for the preamble's
+			// locals (options, __struct_<name>, etc.). In the real
+			// codegen these flow into legacy-stream / BuildRequest
+			// emission downstream; the matrix only exercises the
+			// preamble, so we tack on a `_ = options` plus a
+			// `_ = __struct_<name>` per pooled param.
+			tail := []jen.Code{jen.Id("_").Op("=").Id("options")}
+			for _, smp := range smps {
+				tail = append(tail, jen.Id("_").Op("=").Id("__struct_"+smp.paramName))
+			}
+			tail = append(tail, jen.Return(jen.Nil()))
+			body := append([]jen.Code{}, preamble...)
+			body = append(body, tail...)
+			// Wrap the preamble in a dispatch function so the
+			// rendered file declares a callable function `go build`
+			// can type-check. The signature mirrors what the real
+			// codegen emits at dispatch sites (adapter, rawInput,
+			// error return).
+			dispatchName := cellName + "_dispatch"
+			out.Func().Id(dispatchName).
+				Params(
+					jen.Id("adapter").Qual(pkgs.InterfacesPkg, "Adapter"),
+					jen.Id("rawInput").Any(),
+				).
+				Error().
+				Block(body...)
+
+			// Compute per-cell expectReleaseConverted. For the
+			// single-non-pooled top shape, it's true only when the
+			// `*Other` converter itself takes ownedNested (nested
+			// shapes a and c).
+			expect := top.expectRelease
+			if top.name == "7_single_non_pooled_ptr" {
+				expect = tracker.convertNeedsOwnedNestedFor(nested.otherTy)
+			}
+
+			cells = append(cells, matrixCell{
+				name:                   cellName,
+				dispatchFunc:           dispatchName,
+				expectReleaseConverted: expect,
+			})
+		}
+	}
+
+	// The rendered file's preamble references `makeOptionsFromAdapter`
+	// (which the real generator emits elsewhere). Provide a stub so
+	// `go build` resolves it.
+	out.Func().Id("makeOptionsFromAdapter").
+		Params(jen.Id("adapter").Qual(pkgs.InterfacesPkg, "Adapter")).
+		Params(jen.Index().Any(), jen.Error()).
+		Block(jen.Return(jen.Nil(), jen.Nil()))
+
+	return out, cells
+}
+
+// newSyntheticMethodEmitter constructs a minimal methodEmitter that
+// makePreambleWithArgs can run against — only the fields the preamble
+// path touches need to be set. structMediaParamSet is rebuilt here
+// because the public newMethodEmitter wouldn't accept synthetic
+// inputs cleanly.
+func newSyntheticMethodEmitter(
+	out *jen.File,
+	tracker *mirrorStructTracker,
+	pools *slicePoolTracker,
+	pkgs PackageConfig,
+	cellName string,
+	smps []structMediaParam,
+	paramTypes []reflect.Type,
+) *methodEmitter {
+	g := &generator{
+		opts:                 Options{SupportsWithClient: true, Packages: pkgs, Introspection: RootIntrospection()},
+		pkgs:                 pkgs,
+		intro:                RootIntrospection(),
+		out:                  out,
+		supportsWithClient:   true,
+		mirrors:              tracker,
+		emittedUnwrapHelpers: map[string]bool{},
+		slicePools:           pools,
+	}
+	args := make([]string, 0, len(smps))
+	for _, smp := range smps {
+		args = append(args, smp.paramName)
+	}
+	me := &methodEmitter{
+		g:                 g,
+		methodName:        cellName,
+		args:              args,
+		syncFuncType:      synthSyncFuncType(paramTypes),
+		methodMediaParams: map[string]bamlutils.MediaKind{},
+		structMediaParams: smps,
+		inputStructName:   cellName + "Input",
+	}
+	me.structMediaParamSet = make(map[string]bool, len(smps))
+	for _, smp := range smps {
+		me.structMediaParamSet[smp.paramName] = true
+	}
+	// Declare the synthetic input struct that
+	// `rawInput.(*<InputStruct>)` type-asserts to. Fields use the
+	// MIRROR type (not the original BAML type) because the real
+	// codegen emits the JSON-decoded shape there — the convert
+	// function takes `*<Mirror>`, so the loop's `&__v` must produce
+	// a `*<Mirror>` pointer too. Using the BAML type here was the
+	// source of "cannot use &__v ... as *<Mirror>" errors during
+	// matrix bring-up.
+	var fields []jen.Code
+	for _, smp := range smps {
+		fields = append(fields, jen.Id(upperCamelForMatrix(smp.paramName)).Add(mirrorFieldType(smp.paramType, smp.mirrorName)))
+	}
+	out.Type().Id(me.inputStructName).Struct(fields...)
+	return me
+}
+
+// upperCamelForMatrix mirrors the strcase.UpperCamelCase the codegen
+// uses for input-struct field names. Inlined to avoid an extra dep
+// here.
+func upperCamelForMatrix(s string) string {
+	if s == "" {
+		return s
+	}
+	parts := strings.Split(s, "_")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, "")
+}
+
+// writeTempModule lays out a self-contained Go module under `dir`
+// that compiles the rendered file against bamlutils + the fixtures
+// package via replace directives. The temp module reuses
+// adapters/common's go.mod + go.sum verbatim — that module already
+// pins every transitive dep bamlutils needs — and rewrites the
+// module path / replace directives to point at the local sources.
+// Without inheriting the transitive-dep pins `go build` would
+// complain "updates to go.mod needed" and refuse to proceed without
+// network access.
+func writeTempModule(t *testing.T, dir, rendered string) {
+	t.Helper()
+
+	bamlutilsAbs := absRepoPath(t, "bamlutils")
+	introspectedAbs := absRepoPath(t, "introspected")
+	fixturesAbs := absRepoPath(t, "adapters/common/codegen/internal/fixtures")
+	commonAbs := absRepoPath(t, "adapters/common")
+
+	_ = fixturesAbs // fixtures is a sub-package of adapters/common; the adapters/common replace below covers it
+
+	commonModBytes, err := os.ReadFile(filepath.Join(commonAbs, "go.mod"))
+	if err != nil {
+		t.Fatalf("read adapters/common go.mod: %v", err)
+	}
+	commonMod := string(commonModBytes)
+
+	// Rewrite the module path so the temp module is a standalone
+	// build target (`matrixtest`). Replace the original
+	// first-party replaces (which used `../../...` relative paths)
+	// with absolute paths so the temp dir's CWD doesn't matter.
+	// Declare the temp module under the adapters/common/codegen
+	// import-path prefix so the matrix file can import
+	// `.../codegen/internal/fixtures` — Go's `internal/`
+	// visibility rule allows that from any package whose path is
+	// rooted at the same parent (`adapters/common/codegen/`).
+	// Any module path outside that prefix would be rejected as a
+	// cross-tree internal import.
+	rewritten := strings.Replace(
+		commonMod,
+		"module github.com/invakid404/baml-rest/adapters/common",
+		"module github.com/invakid404/baml-rest/adapters/common/codegen/matrixtest",
+		1,
+	)
+	rewritten = strings.Replace(
+		rewritten,
+		"github.com/invakid404/baml-rest/bamlutils => ../../bamlutils",
+		"github.com/invakid404/baml-rest/bamlutils => "+bamlutilsAbs,
+		1,
+	)
+	rewritten = strings.Replace(
+		rewritten,
+		"github.com/invakid404/baml-rest/introspected => ../../introspected",
+		"github.com/invakid404/baml-rest/introspected => "+introspectedAbs,
+		1,
+	)
+	// Add a require + replace for the adapters/common module so the
+	// rendered file's fixtures import (a sub-package of
+	// adapters/common) resolves to the local source tree.
+	rewritten += "\nrequire github.com/invakid404/baml-rest/adapters/common v0.0.0-00010101000000-000000000000\n"
+	rewritten += "\nreplace github.com/invakid404/baml-rest/adapters/common => " + commonAbs + "\n"
+	writeFile(t, filepath.Join(dir, "go.mod"), rewritten)
+
+	// Reuse adapters/common's go.sum verbatim so transitive
+	// dep hashes don't trip the "module verification" gate.
+	commonSum, err := os.ReadFile(filepath.Join(commonAbs, "go.sum"))
+	if err != nil {
+		t.Fatalf("read adapters/common go.sum: %v", err)
+	}
+	writeFile(t, filepath.Join(dir, "go.sum"), string(commonSum))
+
+	writeFile(t, filepath.Join(dir, "matrix.go"), rendered)
+}
+
+// runGoBuild shells out to `go build ./...` in `dir`. The matrix is
+// rendered into a single file, so a single build invocation
+// type-checks every cell in one shot. Any failure (undeclared
+// identifier, arg-count mismatch, type mismatch) surfaces as a
+// build error.
+func runGoBuild(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("go", "build", "./...")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("matrix temp module failed to compile (the rendered codegen output type-checks against bamlutils + fixtures):\n%s\nerror: %v", out, err)
+	}
+}
+
+// parseRendered re-parses the rendered file in-process so the AST
+// scan in `assertNoReleaseConvertedInNonPooledCell` can look at the
+// emitter's exact textual output rather than reading the temp file
+// from disk.
+func parseRendered(t *testing.T, rendered string) (*ast.File, *token.FileSet) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "matrix.go", rendered, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("rendered matrix file fails to parse: %v\n--- rendered ---\n%s", err, rendered)
+	}
+	return f, fset
+}
+
+// assertNoReleaseConvertedInNonPooledCell complements `go build` by
+// catching the failure mode where a cell that should NOT emit
+// `__releaseConverted` does so anyway. The compiler would accept an
+// unused closure; only an AST scan catches the over-emit.
+//
+// We iterate per-cell, find the cell's dispatch function in the
+// parsed AST, and assert the presence or absence of `__releaseConverted`
+// against the cell's expectReleaseConverted flag.
+func assertNoReleaseConvertedInNonPooledCell(t *testing.T, parsed *ast.File, fset *token.FileSet, cells []matrixCell) {
+	t.Helper()
+
+	funcByName := map[string]*ast.FuncDecl{}
+	for _, decl := range parsed.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		funcByName[fd.Name.Name] = fd
+	}
+
+	// Sort cells for deterministic iteration order — test output
+	// orders by cell index so failures point at a stable cell.
+	sorted := append([]matrixCell(nil), cells...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].name < sorted[j].name })
+
+	for _, cell := range sorted {
+		fd, ok := funcByName[cell.dispatchFunc]
+		if !ok {
+			t.Errorf("cell %q: dispatch function %q missing from rendered AST", cell.name, cell.dispatchFunc)
+			continue
+		}
+		hasRelease := dispatchHasReleaseConverted(fd)
+		switch {
+		case cell.expectReleaseConverted && !hasRelease:
+			t.Errorf("cell %q: expected __releaseConverted closure in %s (a pooled param or ownedNested-needing converter is present) but the dispatch did not emit one",
+				cell.name, cell.dispatchFunc)
+		case !cell.expectReleaseConverted && hasRelease:
+			t.Errorf("cell %q: dispatch %s emitted __releaseConverted but the cell has no pooled resources and no converter that takes ownedNested",
+				cell.name, cell.dispatchFunc)
+		}
+	}
+}
+
+// dispatchHasReleaseConverted returns true if the function body
+// contains a `__releaseConverted := func() { ... }` assignment.
+func dispatchHasReleaseConverted(fd *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fd, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || assign.Tok != token.DEFINE {
+			return true
+		}
+		for _, lhs := range assign.Lhs {
+			id, ok := lhs.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			if id.Name == "__releaseConverted" {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// absRepoPath returns the absolute path to a repo-relative directory.
+// Used to wire the temp module's go.mod replaces against the real
+// bamlutils + fixtures source trees.
+func absRepoPath(t *testing.T, rel string) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not resolve test file path via runtime.Caller")
+	}
+	// Walk up from adapters/common/codegen/<this file> to the repo
+	// root, then descend into the requested rel path.
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	return filepath.Join(repoRoot, rel)
+}
+
+// writeFile is a t.Helper wrapper that fails the test on write error
+// rather than ignoring it.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+

--- a/adapters/common/codegen/codegen_slice_pool_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_test.go
@@ -1,6 +1,8 @@
 package codegen
 
 import (
+	"go/parser"
+	"go/token"
 	"reflect"
 	"strings"
 	"testing"
@@ -83,8 +85,6 @@ func newPooledMethodEmitter(t *testing.T, paramNames []string) (*methodEmitter, 
 		reflect.TypeOf(testMessageElemA{}),
 		reflect.TypeOf(testMessageElemB{}),
 	}
-	innerElem := reflect.TypeOf(testContentPartElem{})
-
 	var smps []structMediaParam
 	var paramTypes []reflect.Type
 	for i, name := range paramNames {
@@ -97,7 +97,10 @@ func newPooledMethodEmitter(t *testing.T, paramNames []string) (*methodEmitter, 
 			paramType:   sliceType,
 		})
 		paramTypes = append(paramTypes, sliceType)
-		g.mirrors.convertOwnedNested[elem] = innerElem
+		// Pre-populate the closure-context contract so the dispatch
+		// site emits the `&__ownedNested_<name>` 3rd arg without
+		// first generating the inner converter.
+		g.mirrors.convertNeedsOwnedNested[elem] = true
 	}
 
 	me := &methodEmitter{
@@ -275,8 +278,7 @@ func newMixedMethodEmitter(t *testing.T, nonPooledKind string) *methodEmitter {
 	}
 
 	pooledElem := reflect.TypeOf(testMessageElemA{})
-	innerElem := reflect.TypeOf(testContentPartElem{})
-	g.mirrors.convertOwnedNested[pooledElem] = innerElem
+	g.mirrors.convertNeedsOwnedNested[pooledElem] = true
 	pooledType := reflect.SliceOf(pooledElem)
 
 	nonPooledStruct := reflect.TypeOf(nonPooledMessageElem{})
@@ -480,11 +482,267 @@ func TestGenerateConversionFunc_PointerElementSliceSkipsPool(t *testing.T) {
 		t.Errorf("pointer-element slice must NOT trigger a slice-pool emission for the inner element; rendered:\n%s", rendered)
 	}
 
-	// 4. convertOwnedNested must be unset for the outer type so the
-	// dispatch site does not try to pass `&__ownedNested_*` into a
-	// convert call that has no matching parameter.
-	if got := tracker.convertOwnedNestedFor(outerType); got != nil {
-		t.Errorf("convertOwnedNestedFor(%v) = %v, want nil — pointer-element nested slices must NOT register an ownedNested contract",
-			outerType, got)
+	// 4. convertNeedsOwnedNested must be unset for the outer type so
+	// the dispatch site does not try to pass `&__ownedNested_*` into
+	// a convert call that has no matching parameter.
+	if got := tracker.convertNeedsOwnedNestedFor(outerType); got {
+		t.Errorf("convertNeedsOwnedNestedFor(%v) = true, want false — pointer-element nested slices must NOT register an ownedNested contract",
+			outerType)
+	}
+}
+
+// =====================================================================
+// F1/F2 cold-review regression tests (closure-context ownedNested).
+// =====================================================================
+
+// f1MessageWithMedia is the cold-review F1 shape: a struct-media param
+// with shape `*MessageWithMedia` (single pointer-to-struct, non-pooled
+// at the top level) whose mirror's `Parts *[]ContentPart` field IS
+// pooled. The dispatch top-level call site must pass the third
+// `ownedNested` argument so the inner converter's signature matches.
+// Pre-fix the call site emitted 2-arg, the converter emitted 3-param,
+// and the file failed to compile.
+type f1ContentPart struct {
+	Text *string
+	Img  *Image
+}
+
+type f1MessageWithMedia struct {
+	Role  string
+	Parts *[]f1ContentPart
+}
+
+// f1OuterWrapper has a direct nested struct field whose converter
+// needs `ownedNested`. Used to assert nested helpers also thread the
+// argument through.
+type f1OuterWrapper struct {
+	Inner f1MessageWithMedia
+}
+
+// TestPreambleThreadsOwnedNestedThroughNonPooledCallSites pins F1:
+// every top-level dispatch call site whose target converter takes the
+// closure-context `ownedNested` parameter must pass `&__ownedNested_<name>`
+// as the third argument — including the non-pooled `*[]C`, `*C`,
+// direct `C`, and `[]*C` shapes that pre-fix emitted 2-arg calls.
+//
+// We exercise the F1 brief's `*MessageWithMedia` shape: a single
+// pointer-to-struct param whose inner converter requires
+// `ownedNested *[]func()` because the inner struct has a pooled
+// `*[]ContentPart` field. The rendered preamble must declare
+// `var __ownedNested_<name> []func()` and the converter call must
+// include `&__ownedNested_<name>` as its third arg.
+func TestPreambleThreadsOwnedNestedThroughNonPooledCallSites(t *testing.T) {
+	t.Parallel()
+
+	pkgs := DefaultPackageConfig()
+	// Point BamlPkg at this test package so `Image` (declared above)
+	// is recognized as a BAML media type by `isMediaReflectType`,
+	// which routes f1ContentPart through structContainsMedia.
+	pkgs.BamlPkg = reflect.TypeOf(Image{}).PkgPath()
+
+	g := &generator{
+		opts:                 Options{SupportsWithClient: true, Packages: pkgs, Introspection: RootIntrospection()},
+		pkgs:                 pkgs,
+		intro:                RootIntrospection(),
+		out:                  common.MakeFile(),
+		supportsWithClient:   true,
+		mirrors:              newMirrorStructTracker(),
+		emittedUnwrapHelpers: map[string]bool{},
+		slicePools:           newSlicePoolTracker(pkgs),
+	}
+
+	// Generate the mirror struct + converter for the outer type. The
+	// recursive ensureMirrorStruct call walks fields, sees the inner
+	// `*[]ContentPart` pooled slice, and registers the outer
+	// converter as needing `ownedNested *[]func()`.
+	outerType := reflect.TypeOf(f1MessageWithMedia{})
+	mirrorName := g.mirrors.ensureMirrorStruct(g.out, outerType, pkgs, g.slicePools)
+	if !g.mirrors.convertNeedsOwnedNestedFor(outerType) {
+		t.Fatalf("fixture invariant: convertNeedsOwnedNestedFor(%v) must be true after ensureMirrorStruct — otherwise the dispatch site under test has nothing to thread", outerType)
+	}
+
+	// Set up a methodEmitter whose single struct-media param is
+	// `*f1MessageWithMedia`, the F1 failing shape.
+	paramType := reflect.PointerTo(outerType)
+	convertFunc := "convert" + mirrorName
+	me := &methodEmitter{
+		g:            g,
+		methodName:   "TestMethod",
+		args:         []string{"extra"},
+		syncFuncType: synthSyncFuncType([]reflect.Type{paramType}),
+		structMediaParams: []structMediaParam{{
+			paramName:   "extra",
+			mirrorName:  mirrorName,
+			convertFunc: convertFunc,
+			paramType:   paramType,
+		}},
+		methodMediaParams: map[string]bamlutils.MediaKind{},
+		inputStructName:   "TestMethodInput",
+	}
+	me.structMediaParamSet = map[string]bool{"extra": true}
+
+	preamble := me.makePreambleWithArgs("makeOptionsFromAdapter")
+	out := common.MakeFile()
+	out.Func().Id("preambleHarness").Params().Block(preamble...)
+	rendered := out.GoString()
+
+	// 1. The dispatch must declare a per-param closure slice so the
+	// converter has somewhere to deposit its release closures.
+	if !strings.Contains(rendered, "var __ownedNested_extra []func()") {
+		t.Errorf("expected `var __ownedNested_extra []func()` declaration in dispatch preamble; rendered:\n%s", rendered)
+	}
+
+	// 2. The call site for the non-pooled `*Mirror` shape must pass
+	// `&__ownedNested_extra` as the third argument. Pre-fix the
+	// dispatch emitted only `(adapter, input.Extra)` and the file
+	// did not compile.
+	wantCall := convertFunc + "(adapter, input.Extra, &__ownedNested_extra)"
+	if !strings.Contains(rendered, wantCall) {
+		t.Errorf("expected non-pooled call site %q in dispatch preamble; rendered:\n%s", wantCall, rendered)
+	}
+
+	// 3. The hoisted release closure must drain the per-param
+	// closure slice — the F1 fix's reason for existence.
+	if !strings.Contains(rendered, "for _, __release := range __ownedNested_extra") {
+		t.Errorf("hoisted release closure must iterate __ownedNested_extra; rendered:\n%s", rendered)
+	}
+}
+
+// TestPreambleThreadsOwnedNestedThroughNestedHelpers pins F1's nested
+// arm: when a converter's body contains another converter call (via
+// `nestedStructConversion`'s Direct / *Struct / slice / *[]Struct
+// branches), and the inner converter takes `ownedNested`, the outer
+// converter must thread its own `ownedNested` parameter into the inner
+// call. With the closure-context shape this is uniform: every
+// converter that propagates pooled state takes the same
+// `*[]func()` parameter regardless of the specific inner element
+// types its descendants pool.
+//
+// We exercise this by generating mirror converters for the outer
+// `f1OuterWrapper`, whose Inner field is a value-type
+// `f1MessageWithMedia` (the F1 type above — its converter needs
+// ownedNested). The outer converter's rendered body must contain a
+// 3-arg call to the inner converter.
+func TestPreambleThreadsOwnedNestedThroughNestedHelpers(t *testing.T) {
+	t.Parallel()
+
+	pkgs := DefaultPackageConfig()
+	pkgs.BamlPkg = reflect.TypeOf(Image{}).PkgPath()
+
+	out := common.MakeFile()
+	tracker := newMirrorStructTracker()
+	pools := newSlicePoolTracker(pkgs)
+
+	outerType := reflect.TypeOf(f1OuterWrapper{})
+	outerMirror := tracker.ensureMirrorStruct(out, outerType, pkgs, pools)
+	innerType := reflect.TypeOf(f1MessageWithMedia{})
+	if !tracker.convertNeedsOwnedNestedFor(innerType) {
+		t.Fatal("fixture invariant: inner converter must need ownedNested")
+	}
+	if !tracker.convertNeedsOwnedNestedFor(outerType) {
+		t.Fatal("outer converter must transitively need ownedNested (its body calls the inner one)")
+	}
+
+	rendered := out.GoString()
+
+	// The outer converter's signature must propagate ownedNested.
+	wantOuterSig := "func convert" + outerMirror + "(adapter bamlutils.Adapter, input *" + outerMirror + ", ownedNested *[]func())"
+	if !strings.Contains(rendered, wantOuterSig) {
+		t.Errorf("outer converter signature must take ownedNested; expected:\n%s\nrendered:\n%s", wantOuterSig, rendered)
+	}
+
+	// The outer converter's body must call the inner with the 3-arg
+	// shape — passing its own `ownedNested` through unchanged. Pre-
+	// fix the nested helpers emitted 2-arg calls and the file did
+	// not compile.
+	innerMirror := "convert" + tracker.generated[innerType]
+	wantInnerCall := innerMirror + "(adapter, &input.Inner, ownedNested)"
+	if !strings.Contains(rendered, wantInnerCall) {
+		t.Errorf("outer converter must thread ownedNested through nested helper call; expected fragment %q; rendered:\n%s", wantInnerCall, rendered)
+	}
+}
+
+// f2MultiPooledMixed is the cold-review F2 shape: a mirror struct with
+// TWO distinct `*[]Struct` value-element fields whose nested
+// converters target DIFFERENT BAML element types. Pre-fix the
+// converter signature carried a single `ownedNested *[]*[]T` and the
+// second field's `append(*ownedNested, *[]OtherT)` was a type-error.
+// Post-fix (closure context) both fields append `func()` closures
+// to the same `*[]func()` slice.
+type f2ContentPart struct {
+	Text *string
+	Img  *Image
+}
+
+type f2ToolPart struct {
+	Name *string
+	Doc  *Image
+}
+
+type f2MultiPooledMixed struct {
+	Role  string
+	Parts *[]f2ContentPart
+	Tools *[]f2ToolPart
+}
+
+// TestConvertFuncHandlesMultiplePooledNestedTypes pins F2: a mirror
+// converter with two distinct `*[]Struct` value-element fields must
+// generate code that compiles cleanly. The closure-context shape
+// resolves the type mismatch — both fields append `func()` closures
+// to the same `ownedNested *[]func()` slice. Pre-fix the converter's
+// signature carried a single concrete `*[]*[]T` and the second
+// append site was a type error.
+//
+// Compile-checks the rendered output via go/parser plus a focused
+// textual assertion that both pool sites use the closure shape.
+func TestConvertFuncHandlesMultiplePooledNestedTypes(t *testing.T) {
+	t.Parallel()
+
+	pkgs := DefaultPackageConfig()
+	pkgs.BamlPkg = reflect.TypeOf(Image{}).PkgPath()
+
+	out := common.MakeFile()
+	tracker := newMirrorStructTracker()
+	pools := newSlicePoolTracker(pkgs)
+
+	outerType := reflect.TypeOf(f2MultiPooledMixed{})
+	mirrorName := tracker.ensureMirrorStruct(out, outerType, pkgs, pools)
+	if mirrorName == "" {
+		t.Fatal("ensureMirrorStruct returned empty mirror name")
+	}
+	if !tracker.convertNeedsOwnedNestedFor(outerType) {
+		t.Fatal("converter must need ownedNested when it pools any nested slice")
+	}
+
+	rendered := out.GoString()
+
+	// Signature must use closure-context shape — exactly one slice,
+	// regardless of how many distinct nested element types are
+	// pooled.
+	wantSig := "func convert" + mirrorName + "(adapter bamlutils.Adapter, input *" + mirrorName + ", ownedNested *[]func())"
+	if !strings.Contains(rendered, wantSig) {
+		t.Errorf("converter signature must use *[]func() closure context; expected:\n%s\nrendered:\n%s", wantSig, rendered)
+	}
+
+	// Each pool site must append a closure capturing its specific
+	// inner `put<X>Slice` call. Substring-match the two distinct
+	// inner-type names (lowerFirst applied) — the closure-context
+	// shape means both share the same `*ownedNested` slice but
+	// invoke different put helpers.
+	for _, innerName := range []string{"f2ContentPart", "f2ToolPart"} {
+		wantAppend := "*ownedNested = append(*ownedNested, func() {\n\t\t\tput" + innerName + "Slice(__partsPtr)"
+		if !strings.Contains(rendered, wantAppend) {
+			t.Errorf("expected closure append for inner type %q; want fragment:\n%s\nrendered:\n%s", innerName, wantAppend, rendered)
+		}
+	}
+
+	// The rendered code must parse as valid Go. Pre-fix the second
+	// pooled site emitted a `*[]*[]f2ToolPart` append into
+	// `*[]*[]f2ContentPart`, which the type checker rejects (parser
+	// would still accept it; we add an explicit textual sanity
+	// check to catch the regression even when parsing alone passes).
+	fset := token.NewFileSet()
+	if _, err := parser.ParseFile(fset, "multi_pooled_synth.go", rendered, parser.AllErrors); err != nil {
+		t.Errorf("generated source does not parse as valid Go: %v\n--- rendered ---\n%s", err, rendered)
 	}
 }

--- a/adapters/common/codegen/codegen_slice_pool_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_test.go
@@ -232,6 +232,176 @@ type f2OuterStructPtrSliceOfPointers struct {
 	Parts *[]*f2Inner
 }
 
+// nonPooledMessageElem is a value-type mirror struct used to construct
+// non-slice / pointer-element struct-media params in F3's fixture.
+// It pairs with nonPooledContentPart (the would-be-nested type) so
+// structContainsMedia would have returned true under a real
+// PackageConfig — but the F3 test doesn't traverse ensureMirrorStruct,
+// only methodEmitter.makePreambleWithArgs, which reads structMediaParams
+// directly without re-deriving them from BAML media detection.
+type nonPooledMessageElem struct {
+	Role string
+	Note *string
+}
+
+// newMixedMethodEmitter constructs a methodEmitter whose
+// structMediaParams mix one pooled `[]ClassWithMedia` slice (param
+// "messages") with one non-pooled struct-media param of the shape
+// described by `nonPooledKind`:
+//
+//   - "ptr_slice"      → `*[]ClassWithMedia` field shape
+//   - "ptr_struct"     → `*ClassWithMedia` field shape
+//   - "direct"         →  `ClassWithMedia` direct field shape
+//   - "slice_of_ptr"   → `[]*ClassWithMedia` (slice with pointer elements;
+//     skipped from pooling per F2 guard)
+//
+// All four shapes hit a Phase-B error-return site that — pre-fix —
+// did not call `__releaseConverted()` before propagating the
+// conversion failure, leaking the pooled outer slice + ownedNested
+// from param "messages".
+func newMixedMethodEmitter(t *testing.T, nonPooledKind string) *methodEmitter {
+	t.Helper()
+
+	pkgs := DefaultPackageConfig()
+	g := &generator{
+		opts:                 Options{SupportsWithClient: true, Packages: pkgs, Introspection: RootIntrospection()},
+		pkgs:                 pkgs,
+		intro:                RootIntrospection(),
+		out:                  common.MakeFile(),
+		supportsWithClient:   true,
+		mirrors:              newMirrorStructTracker(),
+		emittedUnwrapHelpers: map[string]bool{},
+		slicePools:           newSlicePoolTracker(pkgs),
+	}
+
+	pooledElem := reflect.TypeOf(testMessageElemA{})
+	innerElem := reflect.TypeOf(testContentPartElem{})
+	g.mirrors.convertOwnedNested[pooledElem] = innerElem
+	pooledType := reflect.SliceOf(pooledElem)
+
+	nonPooledStruct := reflect.TypeOf(nonPooledMessageElem{})
+	var nonPooledType reflect.Type
+	switch nonPooledKind {
+	case "ptr_slice":
+		nonPooledType = reflect.PointerTo(reflect.SliceOf(nonPooledStruct))
+	case "ptr_struct":
+		nonPooledType = reflect.PointerTo(nonPooledStruct)
+	case "direct":
+		nonPooledType = nonPooledStruct
+	case "slice_of_ptr":
+		nonPooledType = reflect.SliceOf(reflect.PointerTo(nonPooledStruct))
+	default:
+		t.Fatalf("unknown nonPooledKind %q", nonPooledKind)
+	}
+
+	smps := []structMediaParam{
+		{
+			paramName:   "messages",
+			mirrorName:  "TestMirrorMessages",
+			convertFunc: "convertTestMirrorMessages",
+			paramType:   pooledType,
+		},
+		{
+			paramName:   "context",
+			mirrorName:  "TestMirrorContext",
+			convertFunc: "convertTestMirrorContext",
+			paramType:   nonPooledType,
+		},
+	}
+
+	me := &methodEmitter{
+		g:                 g,
+		methodName:        "TestMethod",
+		args:              []string{"messages", "context"},
+		syncFuncType:      synthSyncFuncType([]reflect.Type{pooledType, nonPooledType}),
+		methodMediaParams: map[string]bamlutils.MediaKind{},
+		structMediaParams: smps,
+		inputStructName:   "TestMethodInput",
+	}
+	me.structMediaParamSet = make(map[string]bool, len(me.structMediaParams))
+	for _, smp := range me.structMediaParams {
+		me.structMediaParamSet[smp.paramName] = true
+	}
+	return me
+}
+
+// TestPreambleReleasesPooledResourcesOnNonPooledConversionError pins
+// F3: every Phase-B conversion-error return must call
+// `__releaseConverted()` before propagating the error when any pooled
+// resources were allocated in Phase A. The pre-fix codegen only added
+// the release call to the pooled-slice branch — non-pooled siblings'
+// error paths leaked the outer slice + ownedNested.
+//
+// Drives one fixture per non-pooled shape (the four Phase-B branches
+// that currently emit `return fmt.Errorf(...)`): `*[]C`, `*C`,
+// direct `C`, and `[]*C`. The shared assertion is that
+// `__releaseConverted()` is called immediately before the
+// non-pooled param's `return fmt.Errorf("<paramName>: %w", ...)` /
+// `return fmt.Errorf("<paramName>[%d]: %w", ...)` site. We match the
+// exact two-statement block jen emits — release call, then the
+// `return fmt.Errorf` literal — so a regression that drops the
+// release call (or moves it elsewhere in the block) fails the
+// assertion regardless of surrounding context.
+func TestPreambleReleasesPooledResourcesOnNonPooledConversionError(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		kind string
+		// wantBlock is the literal two-statement block that must
+		// appear in the rendered preamble for the non-pooled param's
+		// error path: `__releaseConverted()` followed by the matching
+		// `return fmt.Errorf(...)`. We anchor on the "context"
+		// param-name fragment so the assertion targets the non-pooled
+		// branch, not the pooled "messages" branch.
+		wantBlock string
+	}{
+		{
+			name:      "ptr_slice",
+			kind:      "ptr_slice",
+			wantBlock: "__releaseConverted()\n\t\t\t\treturn fmt.Errorf(\"context[%d]: %w\",",
+		},
+		{
+			name:      "ptr_struct",
+			kind:      "ptr_struct",
+			wantBlock: "__releaseConverted()\n\t\t\treturn fmt.Errorf(\"context: %w\",",
+		},
+		{
+			name:      "direct",
+			kind:      "direct",
+			wantBlock: "__releaseConverted()\n\t\treturn fmt.Errorf(\"context: %w\",",
+		},
+		{
+			name:      "slice_of_ptr",
+			kind:      "slice_of_ptr",
+			wantBlock: "__releaseConverted()\n\t\t\t\treturn fmt.Errorf(\"context[%d]: %w\",",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			me := newMixedMethodEmitter(t, tc.kind)
+			preamble := me.makePreambleWithArgs("makeOptionsFromAdapter")
+
+			out := common.MakeFile()
+			out.Func().Id("preambleHarness").Params().Block(preamble...)
+			rendered := out.GoString()
+
+			// The pooled-slice param must have set hasReleaseConverted —
+			// otherwise the assertion would be vacuously passing (no
+			// release call would be expected anywhere).
+			if !me.hasReleaseConverted {
+				t.Fatalf("fixture invariant: pooled param must set hasReleaseConverted; rendered:\n%s", rendered)
+			}
+
+			if !strings.Contains(rendered, tc.wantBlock) {
+				t.Errorf("non-pooled %q error path must call __releaseConverted() immediately before the error return; expected block:\n%s\n\nrendered:\n%s",
+					tc.kind, tc.wantBlock, rendered)
+			}
+		})
+	}
+}
+
 // TestGenerateConversionFunc_PointerElementSliceSkipsPool pins F2: a
 // `*[]*Inner` field on a mirror struct must take the legacy
 // `make([]*Inner, n)` path inside nestedStructConversion AND must

--- a/adapters/common/codegen/codegen_slice_pool_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_test.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"context"
 	"go/parser"
 	"go/token"
 	"reflect"
@@ -747,5 +748,41 @@ func TestConvertFuncHandlesMultiplePooledNestedTypes(t *testing.T) {
 	fset := token.NewFileSet()
 	if _, err := parser.ParseFile(fset, "multi_pooled_synth.go", rendered, parser.AllErrors); err != nil {
 		t.Errorf("generated source does not parse as valid Go: %v\n--- rendered ---\n%s", err, rendered)
+	}
+}
+
+func TestEmitMethodsNilSlicePoolsKeepsOwnedNestedDisabled(t *testing.T) {
+	t.Parallel()
+
+	pkgs := DefaultPackageConfig()
+	pkgs.BamlPkg = reflect.TypeOf(Image{}).PkgPath()
+
+	outerType := reflect.TypeOf(f1OuterWrapper{})
+	intro := Introspection{
+		SyncMethods:        map[string][]string{"TestMethod": {"extra"}},
+		SyncFuncs:          map[string]any{"TestMethod": func(context.Context, f1OuterWrapper, ...any) (string, error) { return "", nil }},
+		ParseStreamMethods: map[string]struct{}{"TestMethod": {}},
+		MediaParams:        map[string]map[string]bamlutils.MediaKind{"TestMethod": {}},
+	}
+	g := &generator{
+		opts:                 Options{SupportsWithClient: true, Packages: pkgs, Introspection: intro},
+		pkgs:                 pkgs,
+		intro:                intro,
+		out:                  common.MakeFile(),
+		supportsWithClient:   true,
+		mirrors:              newMirrorStructTracker(),
+		emittedUnwrapHelpers: map[string]bool{},
+		// Nil slicePools exercises the legacy non-pooling emission mode.
+		slicePools: nil,
+	}
+
+	g.emitMethods()
+	rendered := g.out.GoString()
+
+	if g.mirrors.convertNeedsOwnedNestedFor(outerType) {
+		t.Fatal("nil slicePools mode must not precompute ownedNested requirements")
+	}
+	if strings.Contains(rendered, "ownedNested") {
+		t.Fatalf("nil slicePools mode must not emit ownedNested signatures or call-site args; rendered:\n%s", rendered)
 	}
 }

--- a/adapters/common/codegen/codegen_slice_pool_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_test.go
@@ -1,0 +1,320 @@
+package codegen
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/adapters/common"
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// testContentPartMediaInput mimics the dynclient's
+// Baml_Rest_ContentPartMediaInput shape: a value-type mirror struct
+// that contains media fields (here represented by a string-typed
+// stand-in — the codegen branches we exercise read field types, not
+// the actual media interfaces).
+type testContentPartMediaInput struct {
+	Text *string
+}
+
+// testContentPartElem is the BAML-side element type the pool helpers
+// would be generated for. The convert function's ownedNested parameter
+// is typed against this element, so we use it as the `pooledInner`
+// sentinel in the convertOwnedNested map.
+type testContentPartElem struct {
+	Text *string
+}
+
+// testMessageMediaInputA / testMessageMediaInputB are two distinct
+// outer mirror types that both route through the pooled-slice path.
+// The structMediaParams loop adds one entry per such param, so a
+// method with two pooled slice params used to emit two
+// `__releaseConverted := func()` declarations in the same scope —
+// the F1 regression.
+type testMessageMediaInputA struct {
+	Role  string
+	Parts *[]testContentPartMediaInput
+}
+
+type testMessageMediaInputB struct {
+	Role  string
+	Parts *[]testContentPartMediaInput
+}
+
+// testMessageElemA / testMessageElemB are the BAML-side outer
+// element types matching the mirror inputs above. We only need their
+// reflect.Type identity to plumb the slice-pool tracker and the
+// convertOwnedNested map.
+type testMessageElemA struct {
+	Role  string
+	Parts *[]testContentPartElem
+}
+
+type testMessageElemB struct {
+	Role  string
+	Parts *[]testContentPartElem
+}
+
+// newPooledMethodEmitter builds a minimal methodEmitter wired against
+// `n` pooled slice params, each with paramType []testMessageElem<i>.
+// Pre-populates the slice-pool tracker and convertOwnedNested map so
+// the dispatch site takes the pooled branch without first running the
+// mirror-struct emitter.
+func newPooledMethodEmitter(t *testing.T, paramNames []string) (*methodEmitter, []reflect.Type) {
+	t.Helper()
+	if len(paramNames) == 0 || len(paramNames) > 2 {
+		t.Fatalf("newPooledMethodEmitter: paramNames must have 1 or 2 entries, got %d", len(paramNames))
+	}
+
+	pkgs := DefaultPackageConfig()
+	g := &generator{
+		opts:                 Options{SupportsWithClient: true, Packages: pkgs, Introspection: RootIntrospection()},
+		pkgs:                 pkgs,
+		intro:                RootIntrospection(),
+		out:                  common.MakeFile(),
+		supportsWithClient:   true,
+		mirrors:              newMirrorStructTracker(),
+		emittedUnwrapHelpers: map[string]bool{},
+		slicePools:           newSlicePoolTracker(pkgs),
+	}
+
+	elemTypes := []reflect.Type{
+		reflect.TypeOf(testMessageElemA{}),
+		reflect.TypeOf(testMessageElemB{}),
+	}
+	innerElem := reflect.TypeOf(testContentPartElem{})
+
+	var smps []structMediaParam
+	var paramTypes []reflect.Type
+	for i, name := range paramNames {
+		elem := elemTypes[i]
+		sliceType := reflect.SliceOf(elem)
+		smps = append(smps, structMediaParam{
+			paramName:   name,
+			mirrorName:  "TestMirror" + name,
+			convertFunc: "convertTestMirror" + name,
+			paramType:   sliceType,
+		})
+		paramTypes = append(paramTypes, sliceType)
+		g.mirrors.convertOwnedNested[elem] = innerElem
+	}
+
+	me := &methodEmitter{
+		g:                 g,
+		methodName:        "TestMethod",
+		args:              paramNames,
+		syncFuncType:      synthSyncFuncType(paramTypes),
+		methodMediaParams: map[string]bamlutils.MediaKind{}, // direct media-typed params: none for this fixture
+		structMediaParams: smps,
+		inputStructName:   "TestMethodInput",
+	}
+	me.structMediaParamSet = make(map[string]bool, len(me.structMediaParams))
+	for _, smp := range me.structMediaParams {
+		me.structMediaParamSet[smp.paramName] = true
+	}
+	return me, paramTypes
+}
+
+// synthSyncFuncType builds a reflect.Type approximating BAML's sync
+// function signature: ctx, <one param per smp>, ...opts. The codegen
+// loop only consults In(paramIdx) for the slice/ptr branches the test
+// exercises, so we use string-typed sentinels for ctx and opts.
+func synthSyncFuncType(paramTypes []reflect.Type) reflect.Type {
+	in := []reflect.Type{
+		reflect.TypeOf((*[0]byte)(nil)).Elem(), // ctx slot — replaced below
+	}
+	// reflect.FuncOf can't build a context.Context placeholder directly
+	// from a non-interface; use any so In(0) has a value, and append
+	// each param + a trailing variadic opts slot.
+	in[0] = reflect.TypeOf((*any)(nil)).Elem()
+	in = append(in, paramTypes...)
+	// trailing variadic: reflect.FuncOf with isVariadic=true requires
+	// the last param to be a slice. The codegen loop reads
+	// `NumIn()-1` (exclusive variadic), so the slot just has to exist.
+	in = append(in, reflect.TypeOf([]any{}))
+	return reflect.FuncOf(in, []reflect.Type{reflect.TypeOf((*any)(nil)).Elem()}, true)
+}
+
+// TestPreambleHoistsSingleReleaseConvertedForMultiplePooledParams pins
+// F1: a method with two pooled struct-media slice params must emit
+// exactly ONE `__releaseConverted := func()` declaration. The pre-fix
+// codegen emitted one per param in the same scope and failed to
+// compile with "no new variables on left side of :=".
+//
+// We render the preamble and substring-count the redeclaration. We
+// also assert each pooled param's per-name resources
+// (`__messagesPtr_<name>`, `__ownedNested_<name>`) are declared so the
+// hoisted closure body has every reference it expects.
+func TestPreambleHoistsSingleReleaseConvertedForMultiplePooledParams(t *testing.T) {
+	me, _ := newPooledMethodEmitter(t, []string{"messages", "context_messages"})
+	preamble := me.makePreambleWithArgs("makeOptionsFromAdapter")
+
+	out := common.MakeFile()
+	out.Func().Id("preambleHarness").Params().Block(preamble...)
+	rendered := out.GoString()
+
+	// F1 pin — exactly one `__releaseConverted := func()` line. Two
+	// would re-declare the closure in the same scope and the file
+	// would not compile.
+	if got := strings.Count(rendered, "__releaseConverted := func()"); got != 1 {
+		t.Errorf("expected exactly 1 `__releaseConverted := func()` declaration; got %d. Rendered:\n%s", got, rendered)
+	}
+
+	// Per-param resource declarations must use unique names so the
+	// hoisted closure body's references stay unambiguous.
+	for _, name := range []string{"messages", "context_messages"} {
+		wantPtr := "__messagesPtr_" + name + " :="
+		wantOwned := "var __ownedNested_" + name
+		if !strings.Contains(rendered, wantPtr) {
+			t.Errorf("expected per-param outer-slice ptr declaration %q; rendered:\n%s", wantPtr, rendered)
+		}
+		if !strings.Contains(rendered, wantOwned) {
+			t.Errorf("expected per-param ownedNested declaration %q; rendered:\n%s", wantOwned, rendered)
+		}
+	}
+
+	// hasReleaseConverted must be set so dispatch-site emitters defer
+	// the closure at the right spot (inside the orchestration goroutine
+	// for async paths, inside the body callback for legacy paths).
+	if !me.hasReleaseConverted {
+		t.Error("methodEmitter.hasReleaseConverted must be true after pooled preamble emission")
+	}
+}
+
+// TestPreambleSingleParamStillEmitsHoistedRelease pins the trivial
+// case: one pooled param also routes through the hoisted closure (the
+// dispatch site can't tell whether there are 0/1/N pooled params, so
+// the hoist is unconditional). Functionally identical pre/post-fix
+// for this shape, but covered so a future "only-hoist-when-N>1"
+// shortcut would surface here.
+func TestPreambleSingleParamStillEmitsHoistedRelease(t *testing.T) {
+	me, _ := newPooledMethodEmitter(t, []string{"messages"})
+	preamble := me.makePreambleWithArgs("makeOptionsFromAdapter")
+
+	out := common.MakeFile()
+	out.Func().Id("preambleHarness").Params().Block(preamble...)
+	rendered := out.GoString()
+
+	if got := strings.Count(rendered, "__releaseConverted := func()"); got != 1 {
+		t.Errorf("expected exactly 1 `__releaseConverted := func()` declaration for single pooled param; got %d. Rendered:\n%s", got, rendered)
+	}
+	if !strings.Contains(rendered, "__messagesPtr_messages :=") {
+		t.Errorf("expected `__messagesPtr_messages :=` declaration; rendered:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "var __ownedNested_messages") {
+		t.Errorf("expected `var __ownedNested_messages` declaration; rendered:\n%s", rendered)
+	}
+}
+
+// Image is a stand-in for a BAML media type so the codegen's
+// `isMediaReflectType` (which keys on the name + the configured BAML
+// PkgPath) detects f2Inner as media-bearing. The F2 test below
+// constructs a custom PackageConfig that points BamlPkg at this test
+// package so the name match resolves.
+type Image struct{}
+
+// f2OuterStructPtrSliceOfPointers is the BAML-side mirror shape that
+// triggered F2: a struct with a `*[]*Inner` field. Pre-fix, the
+// pooledInner-detection branch would unwrap `*Inner` to `Inner` and
+// record `convertOwnedNested[Outer] = Inner`, while
+// nestedStructConversion would call `pools.ensure(out, *Inner, 256)`
+// and produce a `*[]*Inner` pool — the resulting append
+// `*ownedNested = append(*ownedNested, __partsPtr)` would not type-
+// check (`*[]*[]Inner` vs `*[]*Inner`).
+type f2Inner struct {
+	Text *string
+	Img  *Image
+}
+
+type f2OuterStructPtrSliceOfPointers struct {
+	Role  string
+	Parts *[]*f2Inner
+}
+
+// TestGenerateConversionFunc_PointerElementSliceSkipsPool pins F2: a
+// `*[]*Inner` field on a mirror struct must take the legacy
+// `make([]*Inner, n)` path inside nestedStructConversion AND must
+// NOT register the outer struct in `convertOwnedNested` (which would
+// add an unused `ownedNested` parameter the dispatch site can't pass
+// matching arguments for).
+//
+// We drive the codegen against the synthetic mirror shape, render the
+// convert function, and assert:
+//
+//  1. The convert function signature has 2 params (adapter, input) —
+//     no `ownedNested *[]*[]X` parameter snuck in.
+//  2. The body emits `__ptrSlice := make([]*` — the legacy pointer-
+//     element path.
+//  3. The body does NOT call any `getf2InnerMediaInputSlice` or
+//     `putf2InnerMediaInputSlice` pool helper — the slice pool tracker
+//     was never asked to emit a pool for the `*Inner` element type.
+//  4. `tracker.convertOwnedNested` does NOT have an entry for the
+//     outer type (the dispatch site keys off this map to decide
+//     whether to thread `&__ownedNested_<name>` through).
+func TestGenerateConversionFunc_PointerElementSliceSkipsPool(t *testing.T) {
+	out := common.MakeFile()
+	tracker := newMirrorStructTracker()
+	// Point BamlPkg at this test package so `isMediaReflectType` resolves
+	// the locally-declared `Image` type as a BAML media field. Without
+	// this, `structContainsMedia(f2Inner)` returns false and the convert
+	// emitter shortcuts to a direct `result.Parts = input.Parts` copy,
+	// never exercising the nestedStructConversion `*[]*T` branch this
+	// test targets.
+	pkgs := DefaultPackageConfig()
+	pkgs.BamlPkg = reflect.TypeOf(Image{}).PkgPath()
+	pools := newSlicePoolTracker(pkgs)
+
+	outerType := reflect.TypeOf(f2OuterStructPtrSliceOfPointers{})
+	mirrorName := tracker.ensureMirrorStruct(out, outerType, pkgs, pools)
+	if mirrorName == "" {
+		t.Fatal("ensureMirrorStruct returned empty mirror name")
+	}
+	rendered := out.GoString()
+
+	convertFunc := "convert" + mirrorName
+	fnStart := strings.Index(rendered, "func "+convertFunc+"(")
+	if fnStart < 0 {
+		t.Fatalf("convert function %q not found in rendered source:\n%s", convertFunc, rendered)
+	}
+	nextFn := strings.Index(rendered[fnStart+1:], "\nfunc ")
+	end := len(rendered)
+	if nextFn >= 0 {
+		end = fnStart + 1 + nextFn
+	}
+	body := rendered[fnStart:end]
+
+	// 1. Signature must have exactly the legacy two-param shape. The
+	// post-fix detection branch declines to register the outer type
+	// in `convertOwnedNested`, so generateConversionFunc emits the
+	// original (adapter, input) params and nothing else.
+	if strings.Contains(body, "ownedNested") {
+		t.Errorf("convert function for `*[]*T` field must NOT take ownedNested parameter; body:\n%s", body)
+	}
+
+	// 2. Body must use the legacy make path. We don't pin the exact
+	// inner element name (the mirror-name suffix depends on the
+	// synthetic input type), only that `make([]*` appears — the
+	// hallmark of the pointer-element fallback inside
+	// nestedStructConversion's `if isPtr { if innerAfterPtr.Kind() ==
+	// Slice { ... } }` branch.
+	if !strings.Contains(body, "__ptrSlice := make([]*") {
+		t.Errorf("convert function for `*[]*T` field must use `__ptrSlice := make([]*...)` legacy path; body:\n%s", body)
+	}
+
+	// 3. No pool helper for the pointer element type. The pool
+	// emitter would have written `var <name>SlicePool sync.Pool` at
+	// the file level if pools.ensure was called; substring-match
+	// against that signature scoped to the inner type name.
+	if strings.Contains(rendered, "f2InnerSlicePool") {
+		t.Errorf("pointer-element slice must NOT trigger a slice-pool emission for the inner element; rendered:\n%s", rendered)
+	}
+
+	// 4. convertOwnedNested must be unset for the outer type so the
+	// dispatch site does not try to pass `&__ownedNested_*` into a
+	// convert call that has no matching parameter.
+	if got := tracker.convertOwnedNestedFor(outerType); got != nil {
+		t.Errorf("convertOwnedNestedFor(%v) = %v, want nil — pointer-element nested slices must NOT register an ownedNested contract",
+			outerType, got)
+	}
+}

--- a/adapters/common/codegen/codegen_slice_pool_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_test.go
@@ -438,6 +438,7 @@ func TestGenerateConversionFunc_PointerElementSliceSkipsPool(t *testing.T) {
 	pools := newSlicePoolTracker(pkgs)
 
 	outerType := reflect.TypeOf(f2OuterStructPtrSliceOfPointers{})
+	tracker.precomputeOwnedNestedNeeds([]reflect.Type{outerType}, pkgs)
 	mirrorName := tracker.ensureMirrorStruct(out, outerType, pkgs, pools)
 	if mirrorName == "" {
 		t.Fatal("ensureMirrorStruct returned empty mirror name")
@@ -551,14 +552,14 @@ func TestPreambleThreadsOwnedNestedThroughNonPooledCallSites(t *testing.T) {
 		slicePools:           newSlicePoolTracker(pkgs),
 	}
 
-	// Generate the mirror struct + converter for the outer type. The
-	// recursive ensureMirrorStruct call walks fields, sees the inner
-	// `*[]ContentPart` pooled slice, and registers the outer
-	// converter as needing `ownedNested *[]func()`.
+	// Run the analysis pass first so generateConversionFunc sees
+	// the final convertNeedsOwnedNested value. The mirror-struct
+	// emission then queries it from the (already-populated) map.
 	outerType := reflect.TypeOf(f1MessageWithMedia{})
+	g.mirrors.precomputeOwnedNestedNeeds([]reflect.Type{outerType}, pkgs)
 	mirrorName := g.mirrors.ensureMirrorStruct(g.out, outerType, pkgs, g.slicePools)
 	if !g.mirrors.convertNeedsOwnedNestedFor(outerType) {
-		t.Fatalf("fixture invariant: convertNeedsOwnedNestedFor(%v) must be true after ensureMirrorStruct — otherwise the dispatch site under test has nothing to thread", outerType)
+		t.Fatalf("fixture invariant: convertNeedsOwnedNestedFor(%v) must be true after precompute — otherwise the dispatch site under test has nothing to thread", outerType)
 	}
 
 	// Set up a methodEmitter whose single struct-media param is
@@ -634,6 +635,7 @@ func TestPreambleThreadsOwnedNestedThroughNestedHelpers(t *testing.T) {
 	pools := newSlicePoolTracker(pkgs)
 
 	outerType := reflect.TypeOf(f1OuterWrapper{})
+	tracker.precomputeOwnedNestedNeeds([]reflect.Type{outerType}, pkgs)
 	outerMirror := tracker.ensureMirrorStruct(out, outerType, pkgs, pools)
 	innerType := reflect.TypeOf(f1MessageWithMedia{})
 	if !tracker.convertNeedsOwnedNestedFor(innerType) {
@@ -706,6 +708,7 @@ func TestConvertFuncHandlesMultiplePooledNestedTypes(t *testing.T) {
 	pools := newSlicePoolTracker(pkgs)
 
 	outerType := reflect.TypeOf(f2MultiPooledMixed{})
+	tracker.precomputeOwnedNestedNeeds([]reflect.Type{outerType}, pkgs)
 	mirrorName := tracker.ensureMirrorStruct(out, outerType, pkgs, pools)
 	if mirrorName == "" {
 		t.Fatal("ensureMirrorStruct returned empty mirror name")

--- a/adapters/common/codegen/internal/fixtures/fixtures.go
+++ b/adapters/common/codegen/internal/fixtures/fixtures.go
@@ -1,0 +1,102 @@
+// Package fixtures declares the BAML-side type fixtures the
+// codegen compile-matrix test feeds to ensureMirrorStruct /
+// makePreambleWithArgs. The package is non-test (regular .go file)
+// so the rendered output the matrix test writes to a temp module can
+// import it for type references like `fixtures.Image` or
+// `fixtures.MessageA`.
+//
+// The types intentionally have no behavior — only field shapes
+// matter. `Image` stands in for BAML media types (the matrix
+// configures pkgs.BamlPkg to point at this package so
+// `isMediaReflectType` resolves Image as a media field). Every
+// `*Image` field on a struct marks that struct as "contains media",
+// which triggers the mirror-struct / convert-function emission path
+// the matrix exercises.
+package fixtures
+
+// Image stands in for a BAML media type. The codegen detects it as
+// media because (a) its declared name "Image" is in `mediaTypeNames`
+// and (b) the matrix test sets pkgs.BamlPkg = this package's import
+// path.
+type Image struct{}
+
+// ContentPartA is the value-element nested type used by MessageA's
+// `*[]ContentPartA` field. Triggers the closure-context pool branch
+// in nestedStructConversion.
+type ContentPartA struct {
+	Img *Image
+}
+
+// MessageA pairs with ContentPartA: a struct with a `*[]Struct`
+// value-element field. Its converter pools the parts slice through
+// the slice pool and takes the closure-context `ownedNested
+// *[]func()` parameter.
+type MessageA struct {
+	Parts *[]ContentPartA
+}
+
+// ContentPartB is the pointer-element variant used by MessageB. The
+// `*[]*ContentPartB` field falls through nestedStructConversion's
+// pointer-element guard to the legacy `make` path; the converter
+// does NOT take ownedNested.
+type ContentPartB struct {
+	Img *Image
+}
+
+// MessageB has a `*[]*Struct` pointer-element field — the F2-guard
+// fallback shape. Its converter does NOT take ownedNested because
+// nestedStructConversion skips the pool branch for pointer
+// elements.
+type MessageB struct {
+	Parts *[]*ContentPartB
+}
+
+// ContentPartC + ToolPartC are the two distinct nested types used
+// by MessageC to exercise the F2 multi-pooled-types shape.
+type ContentPartC struct {
+	Img *Image
+}
+
+type ToolPartC struct {
+	Img *Image
+}
+
+// MessageC has two value-element pooled fields with DISTINCT inner
+// types. The closure-context shape from F2's refactor lets both
+// fields append release closures to a single `ownedNested
+// *[]func()` slice.
+type MessageC struct {
+	Parts *[]ContentPartC
+	Tools *[]ToolPartC
+}
+
+// Class<X> / Other<X> mirror Message<X> for the matrix's
+// multi-param top-level shapes (e.g. `Method(messages []Message,
+// classes []Class)` for two-pooled-params coverage). They duplicate
+// the same field shapes under distinct names so each test cell can
+// register an independent pool without sharing helper symbols.
+type ClassA struct {
+	Parts *[]ContentPartA
+}
+
+type ClassB struct {
+	Parts *[]*ContentPartB
+}
+
+type ClassC struct {
+	Parts *[]ContentPartC
+	Tools *[]ToolPartC
+}
+
+type OtherA struct {
+	Parts *[]ContentPartA
+}
+
+type OtherB struct {
+	Parts *[]*ContentPartB
+}
+
+type OtherC struct {
+	Parts *[]ContentPartC
+	Tools *[]ToolPartC
+}

--- a/adapters/common/codegen/internal/fixtures/fixtures.go
+++ b/adapters/common/codegen/internal/fixtures/fixtures.go
@@ -100,3 +100,37 @@ type OtherC struct {
 	Parts *[]ContentPartC
 	Tools *[]ToolPartC
 }
+
+// CycleA + CycleB form a mutually-recursive media-bearing pair used
+// by the cycle regression test. CycleA directly pools (its `Parts`
+// field is `*[]CyclePartWithMedia` with value elements). CycleB
+// references *CycleA, and CycleA references *CycleB.
+//
+// Without the precompute pass, generation order is:
+//   ensure(CycleA) -> mark generated, recurse into *CycleB
+//     ensure(CycleB) -> mark generated, recurse into *CycleA
+//       ensure(CycleA) -> already generated, return cached name
+//     emit body of CycleB -> snapshot
+//       convertNeedsOwnedNestedFor(CycleA) == false (A hasn't
+//       finished its own analysis yet) so the call site for the
+//       A field in B is 2-arg
+//     CycleB body done, generateConversionFunc sets needs for B
+//   emit body of CycleA -> sets needs for A
+// The rendered Go has B's 2-arg call site against A's 3-arg
+// signature -> compile error.
+//
+// With the precompute pass: both A and B are flagged BEFORE any
+// body is emitted, so every call site sees the final transitive
+// answer.
+type CyclePartWithMedia struct {
+	Img *Image
+}
+
+type CycleA struct {
+	B     *CycleB
+	Parts *[]CyclePartWithMedia
+}
+
+type CycleB struct {
+	A *CycleA
+}

--- a/adapters/common/embed.go
+++ b/adapters/common/embed.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed adapterversions codegen/codegen.go codegen/codegen_adapter.go codegen/codegen_buildrequest.go codegen/codegen_dynamic_types.go codegen/codegen_legacy_stream.go codegen/codegen_methods.go codegen/codegen_options.go codegen/codegen_reflect.go codegen/codegen_router.go codegen/codegen_stream_helpers.go embed.go go.mod go.sum helpers.go testdriver testhelpers/snapshot.go utils/dynamic.go
+//go:embed adapterversions codegen/codegen.go codegen/codegen_adapter.go codegen/codegen_buildrequest.go codegen/codegen_dynamic_types.go codegen/codegen_legacy_stream.go codegen/codegen_methods.go codegen/codegen_options.go codegen/codegen_reflect.go codegen/codegen_router.go codegen/codegen_slice_pool.go codegen/codegen_stream_helpers.go embed.go go.mod go.sum helpers.go testdriver testhelpers/snapshot.go utils/dynamic.go
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -4,11 +4,81 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/bytedance/sonic"
 	"github.com/bytedance/sonic/ast"
 	"github.com/cloudwego/gjson"
 )
+
+// Pool retention thresholds: keep slices around the size of a typical
+// request, drop anything larger to avoid pinning pathological payloads.
+// `internalMessage` retains messages, `internalContentPart` retains
+// per-message multipart slices.
+const (
+	internalMessageSlicePoolMaxCap     = 1024
+	internalContentPartSlicePoolMaxCap = 256
+)
+
+var (
+	internalMessageSlicePool     sync.Pool
+	internalContentPartSlicePool sync.Pool
+)
+
+func getInternalMessageSlice(n int) *[]internalMessage {
+	if v := internalMessageSlicePool.Get(); v != nil {
+		sp := v.(*[]internalMessage)
+		if cap(*sp) >= n {
+			*sp = (*sp)[:0]
+			return sp
+		}
+		// Returned slice is too small; drop it and allocate to size.
+	}
+	s := make([]internalMessage, 0, n)
+	return &s
+}
+
+func putInternalMessageSlice(sp *[]internalMessage) {
+	if sp == nil {
+		return
+	}
+	if cap(*sp) > internalMessageSlicePoolMaxCap {
+		return
+	}
+	used := (*sp)[:len(*sp):cap(*sp)]
+	for i := range used {
+		used[i] = internalMessage{}
+	}
+	*sp = (*sp)[:0]
+	internalMessageSlicePool.Put(sp)
+}
+
+func getInternalContentPartSlice(n int) *[]internalContentPart {
+	if v := internalContentPartSlicePool.Get(); v != nil {
+		sp := v.(*[]internalContentPart)
+		if cap(*sp) >= n {
+			*sp = (*sp)[:0]
+			return sp
+		}
+	}
+	s := make([]internalContentPart, 0, n)
+	return &s
+}
+
+func putInternalContentPartSlice(sp *[]internalContentPart) {
+	if sp == nil {
+		return
+	}
+	if cap(*sp) > internalContentPartSlicePoolMaxCap {
+		return
+	}
+	used := (*sp)[:len(*sp):cap(*sp)]
+	for i := range used {
+		used[i] = internalContentPart{}
+	}
+	*sp = (*sp)[:0]
+	internalContentPartSlicePool.Put(sp)
+}
 
 // Dynamic endpoint constants
 const (
@@ -258,7 +328,14 @@ type internalMessage struct {
 }
 
 // toInternalMessage converts a user-facing DynamicMessage to the internal format.
-func (m *DynamicMessage) toInternalMessage() internalMessage {
+//
+// When the message is multipart, the returned message's Parts slice
+// references a pooled backing array. The caller appends the slice
+// pointer to ownedParts before any other work so a panic between
+// acquisition and the deferred release in ToWorkerInput cannot leak
+// the slice. Callers MUST release the slice via putInternalContentPartSlice
+// after sonic.Marshal returns.
+func (m *DynamicMessage) toInternalMessage(ownedParts *[]*[]internalContentPart) internalMessage {
 	msg := internalMessage{Role: m.Role}
 	if m.Metadata != nil && m.Metadata.CacheControl != nil {
 		msg.Metadata = &internalMessageMetadata{
@@ -269,7 +346,9 @@ func (m *DynamicMessage) toInternalMessage() internalMessage {
 	}
 
 	if m.PartsContent != nil {
-		parts := make([]internalContentPart, 0, len(m.PartsContent))
+		partsPtr := getInternalContentPartSlice(len(m.PartsContent))
+		*ownedParts = append(*ownedParts, partsPtr)
+		parts := *partsPtr
 		for _, p := range m.PartsContent {
 			part := internalContentPart{}
 			switch p.Type {
@@ -289,6 +368,7 @@ func (m *DynamicMessage) toInternalMessage() internalMessage {
 			}
 			parts = append(parts, part)
 		}
+		*partsPtr = parts
 		msg.Parts = parts
 	} else if m.TextContent != nil {
 		msg.Content = m.TextContent
@@ -588,10 +668,20 @@ func (d *DynamicInput) ToWorkerInput() (b []byte, err error) {
 		return nil, err
 	}
 
-	internalMessages := make([]internalMessage, 0, len(d.Messages))
-	for _, m := range d.Messages {
-		internalMessages = append(internalMessages, m.toInternalMessage())
+	messagesPtr := getInternalMessageSlice(len(d.Messages))
+	var ownedParts []*[]internalContentPart
+	defer func() {
+		for _, partsPtr := range ownedParts {
+			putInternalContentPartSlice(partsPtr)
+		}
+		putInternalMessageSlice(messagesPtr)
+	}()
+
+	internalMessages := *messagesPtr
+	for i := range d.Messages {
+		internalMessages = append(internalMessages, d.Messages[i].toInternalMessage(&ownedParts))
 	}
+	*messagesPtr = internalMessages
 
 	dynamicTypes := &DynamicTypes{
 		Classes: classes,

--- a/bamlutils/dynamic_benchmark_test.go
+++ b/bamlutils/dynamic_benchmark_test.go
@@ -1,0 +1,112 @@
+package bamlutils
+
+import (
+	"strings"
+	"testing"
+)
+
+func benchClientRegistry() *ClientRegistry {
+	primary := "TestClient"
+	provider := "anthropic"
+	return &ClientRegistry{
+		Primary: &primary,
+		Clients: []*ClientProperty{{
+			Name:     primary,
+			Provider: provider,
+			Options:  map[string]any{"model": "m", "api_key": "k"},
+		}},
+	}
+}
+
+func benchOutputSchema() *DynamicOutputSchema {
+	return &DynamicOutputSchema{
+		Properties: MustOrderedMap(OrderedKV("name", &DynamicProperty{Type: "string"})),
+	}
+}
+
+func benchTextMessages(n int) []DynamicMessage {
+	body := strings.Repeat("a", 256)
+	msgs := make([]DynamicMessage, n)
+	for i := 0; i < n; i++ {
+		text := body
+		msgs[i] = DynamicMessage{Role: "user", TextContent: &text}
+	}
+	return msgs
+}
+
+func benchMultimodalMessages(n int) []DynamicMessage {
+	url := "https://example.com/image.png"
+	mediaType := "image/png"
+	text := "describe"
+	cacheType := "ephemeral"
+	msgs := make([]DynamicMessage, n)
+	for i := 0; i < n; i++ {
+		t := text
+		msgs[i] = DynamicMessage{
+			Role: "user",
+			PartsContent: []DynamicContentPart{
+				{Type: "text", Text: &t},
+				{Type: "image", Image: &MediaInput{URL: &url, MediaType: &mediaType}},
+				{Type: "pdf", PDF: &MediaInput{URL: &url, MediaType: &mediaType}},
+				{Type: "output_format"},
+			},
+			Metadata: &MessageMetadata{CacheControl: &CacheControl{Type: cacheType}},
+		}
+	}
+	return msgs
+}
+
+func runWorkerInputBench(b *testing.B, in *DynamicInput) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := in.ToWorkerInput()
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = out
+	}
+}
+
+func BenchmarkDynamicInputToWorkerInput(b *testing.B) {
+	registry := benchClientRegistry()
+	schema := benchOutputSchema()
+
+	for _, tc := range []struct {
+		name string
+		n    int
+	}{
+		{name: "single_text_message", n: 1},
+		{name: "10_text_messages", n: 10},
+		{name: "100_text_messages", n: 100},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			in := &DynamicInput{
+				Messages:       benchTextMessages(tc.n),
+				ClientRegistry: registry,
+				OutputSchema:   schema,
+			}
+			runWorkerInputBench(b, in)
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		n    int
+	}{
+		{name: "single_multimodal_message", n: 1},
+		{name: "10_multimodal_messages", n: 10},
+		{name: "100_multimodal_messages", n: 100},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			in := &DynamicInput{
+				Messages:       benchMultimodalMessages(tc.n),
+				ClientRegistry: registry,
+				OutputSchema:   schema,
+			}
+			runWorkerInputBench(b, in)
+		})
+	}
+}

--- a/bamlutils/sseclient/sseclient.go
+++ b/bamlutils/sseclient/sseclient.go
@@ -12,7 +12,45 @@ import (
 	"context"
 	"io"
 	"strings"
+	"sync"
 )
+
+const (
+	sseScannerInitialBufferSize = 64 * 1024
+	sseScannerMaxTokenSize      = 1024 * 1024
+)
+
+// sseScannerBufferPool retains the 64 KiB initial buffer that backs each
+// bufio.Scanner created by scan. Tokens above 64 KiB cause the scanner to
+// allocate a larger internal buffer that is not written back into the
+// caller's slice pointer, so the pool stays bounded at the initial size.
+var sseScannerBufferPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, 0, sseScannerInitialBufferSize)
+		return &buf
+	},
+}
+
+func getSSEScannerBuffer() *[]byte {
+	bufp := sseScannerBufferPool.Get().(*[]byte)
+	*bufp = (*bufp)[:0]
+	if cap(*bufp) < sseScannerInitialBufferSize {
+		buf := make([]byte, 0, sseScannerInitialBufferSize)
+		bufp = &buf
+	}
+	return bufp
+}
+
+func putSSEScannerBuffer(bufp *[]byte) {
+	if bufp == nil {
+		return
+	}
+	if cap(*bufp) != sseScannerInitialBufferSize {
+		return
+	}
+	*bufp = (*bufp)[:0]
+	sseScannerBufferPool.Put(bufp)
+}
 
 // Event represents a single SSE event parsed from the stream.
 type Event struct {
@@ -61,10 +99,17 @@ func Stream(ctx context.Context, r io.Reader) (<-chan Event, <-chan error) {
 // scan is the internal SSE parser loop. It reads lines from r and assembles
 // them into Event values sent on the out channel.
 func scan(ctx context.Context, r io.Reader, out chan<- Event) error {
+	bufp := getSSEScannerBuffer()
+	defer putSSEScannerBuffer(bufp)
+
 	scanner := bufio.NewScanner(r)
 	// LLM SSE events are typically small JSON objects, but set a generous
 	// max line size to handle edge cases (e.g., base64-encoded images).
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	// The initial buffer is pooled. Parsing uses scanner.Text() (owned
+	// string) so event fields never alias the pooled buffer; if anything
+	// here ever switches to scanner.Bytes(), it must copy before sending
+	// events or before putSSEScannerBuffer runs.
+	scanner.Buffer((*bufp)[:0], sseScannerMaxTokenSize)
 
 	var (
 		eventType string

--- a/bamlutils/sseclient/sseclient_benchmark_test.go
+++ b/bamlutils/sseclient/sseclient_benchmark_test.go
@@ -1,0 +1,71 @@
+package sseclient
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func buildSSEStream(eventCount int, payload string) []byte {
+	var buf bytes.Buffer
+	for i := 0; i < eventCount; i++ {
+		buf.WriteString("data: ")
+		buf.WriteString(payload)
+		buf.WriteString("\n\n")
+	}
+	return buf.Bytes()
+}
+
+func buildMultilineSSEStream(eventCount int, linesPerEvent int, linePayload string) []byte {
+	var buf bytes.Buffer
+	for i := 0; i < eventCount; i++ {
+		for j := 0; j < linesPerEvent; j++ {
+			buf.WriteString("data: ")
+			buf.WriteString(linePayload)
+			buf.WriteByte('\n')
+		}
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes()
+}
+
+func runStreamBench(b *testing.B, body []byte) {
+	b.SetParallelism(16)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			events, errc := Stream(context.Background(), bytes.NewReader(body))
+			for range events {
+			}
+			if err := <-errc; err != nil {
+				b.Fatalf("stream error: %v", err)
+			}
+		}
+	})
+}
+
+func BenchmarkStreamParallel(b *testing.B) {
+	smallPayload := strings.Repeat("x", 128)
+	mediumPayload := strings.Repeat("x", 4*1024)
+	largePayload := strings.Repeat("x", 80*1024)
+
+	b.Run("small_128B", func(b *testing.B) {
+		body := buildSSEStream(1000, smallPayload)
+		runStreamBench(b, body)
+	})
+	b.Run("medium_4KiB", func(b *testing.B) {
+		body := buildSSEStream(1000, mediumPayload)
+		runStreamBench(b, body)
+	})
+	b.Run("large_80KiB", func(b *testing.B) {
+		body := buildSSEStream(100, largePayload)
+		runStreamBench(b, body)
+	})
+	b.Run("multiline_4KiB", func(b *testing.B) {
+		linePayload := strings.Repeat("x", 1024)
+		body := buildMultilineSSEStream(1000, 4, linePayload)
+		runStreamBench(b, body)
+	})
+}

--- a/cmd/serve/streamwriter.go
+++ b/cmd/serve/streamwriter.go
@@ -15,7 +15,14 @@ import (
 	"github.com/invakid404/baml-rest/internal/unsafeutil"
 	"github.com/invakid404/baml-rest/pool"
 	"github.com/invakid404/baml-rest/workerplugin"
+	"github.com/valyala/bytebufferpool"
 )
+
+// streamFrameBufferPool pools per-frame scratch buffers shared by SSE and
+// NDJSON publishers. Each event acquires a buffer for the duration of
+// writeEvent/writeComment and returns it after the synchronous Write +
+// Flush completes; frame bytes never escape to other goroutines.
+var streamFrameBufferPool bytebufferpool.Pool
 
 // ContentTypeNDJSON is the MIME type for NDJSON streams.
 const ContentTypeNDJSON = "application/x-ndjson"
@@ -61,12 +68,17 @@ type NDJSONStreamWriterPublisher struct {
 	mu sync.Mutex
 }
 
-func encodeNDJSONEvent(event *NDJSONEvent) ([]byte, error) {
+// encodeNDJSONEvent serializes event as a single NDJSON frame (JSON +
+// trailing newline) into dst. The caller owns dst; bytes must not escape
+// outside the synchronous Write/Flush that follows.
+func encodeNDJSONEvent(dst *bytebufferpool.ByteBuffer, event *NDJSONEvent) error {
 	data, err := sonic.Marshal(event)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return append(data, '\n'), nil
+	_, _ = dst.Write(data)
+	_ = dst.WriteByte('\n')
+	return nil
 }
 
 func (p *NDJSONStreamWriterPublisher) writeFrame(frame []byte) error {
@@ -87,13 +99,15 @@ func (p *NDJSONStreamWriterPublisher) writeFrame(frame []byte) error {
 }
 
 func (p *NDJSONStreamWriterPublisher) writeEvent(event *NDJSONEvent) error {
-	frame, err := encodeNDJSONEvent(event)
-	if err != nil {
+	buf := streamFrameBufferPool.Get()
+	defer streamFrameBufferPool.Put(buf)
+	buf.Reset()
+	if err := encodeNDJSONEvent(buf, event); err != nil {
 		p.cancel()
 		return err
 	}
 
-	return p.writeFrame(frame)
+	return p.writeFrame(buf.B)
 }
 
 func (p *NDJSONStreamWriterPublisher) writeKeepalive() error {
@@ -290,36 +304,56 @@ type SSEStreamWriterPublisher struct {
 	mu sync.Mutex
 }
 
-func formatSSEEvent(eventType string, payload string) string {
-	var frame strings.Builder
-
+// appendSSEEventFrame writes an SSE event frame (event: line + repeated
+// data: lines + terminating blank line) into dst. Payload lines are
+// iterated manually to avoid strings.Split's intermediate slice; trailing
+// newlines in payload preserve the existing "empty final data line"
+// behavior pinned by the publisher tests.
+func appendSSEEventFrame(dst *bytebufferpool.ByteBuffer, eventType, payload string) {
 	if eventType != "" {
-		frame.WriteString("event: ")
-		frame.WriteString(eventType)
-		frame.WriteByte('\n')
+		_, _ = dst.WriteString("event: ")
+		_, _ = dst.WriteString(eventType)
+		_ = dst.WriteByte('\n')
 	}
 
 	if payload != "" {
-		for _, line := range strings.Split(payload, "\n") {
-			frame.WriteString("data: ")
-			frame.WriteString(line)
-			frame.WriteByte('\n')
+		rest := payload
+		for {
+			idx := strings.IndexByte(rest, '\n')
+			if idx < 0 {
+				_, _ = dst.WriteString("data: ")
+				_, _ = dst.WriteString(rest)
+				_ = dst.WriteByte('\n')
+				break
+			}
+			_, _ = dst.WriteString("data: ")
+			_, _ = dst.WriteString(rest[:idx])
+			_ = dst.WriteByte('\n')
+			rest = rest[idx+1:]
+			if rest == "" {
+				// payload ended with '\n' — mirror strings.Split's empty
+				// trailing segment so we emit the final blank data line.
+				_, _ = dst.WriteString("data: \n")
+				break
+			}
 		}
 	}
 
-	frame.WriteByte('\n')
-	return frame.String()
+	_ = dst.WriteByte('\n')
 }
 
-func formatSSEComment(comment string) string {
-	return ": " + comment + "\n\n"
+// appendSSECommentFrame writes an SSE comment frame into dst.
+func appendSSECommentFrame(dst *bytebufferpool.ByteBuffer, comment string) {
+	_, _ = dst.WriteString(": ")
+	_, _ = dst.WriteString(comment)
+	_, _ = dst.WriteString("\n\n")
 }
 
-func (p *SSEStreamWriterPublisher) writeFrame(frame string) error {
+func (p *SSEStreamWriterPublisher) writeFrame(frame []byte) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if _, err := p.w.WriteString(frame); err != nil {
+	if _, err := p.w.Write(frame); err != nil {
 		p.cancel()
 		return err
 	}
@@ -333,11 +367,19 @@ func (p *SSEStreamWriterPublisher) writeFrame(frame string) error {
 }
 
 func (p *SSEStreamWriterPublisher) writeEvent(eventType string, payload string) error {
-	return p.writeFrame(formatSSEEvent(eventType, payload))
+	buf := streamFrameBufferPool.Get()
+	defer streamFrameBufferPool.Put(buf)
+	buf.Reset()
+	appendSSEEventFrame(buf, eventType, payload)
+	return p.writeFrame(buf.B)
 }
 
 func (p *SSEStreamWriterPublisher) writeComment(comment string) error {
-	return p.writeFrame(formatSSEComment(comment))
+	buf := streamFrameBufferPool.Get()
+	defer streamFrameBufferPool.Put(buf)
+	buf.Reset()
+	appendSSECommentFrame(buf, comment)
+	return p.writeFrame(buf.B)
 }
 
 func (p *SSEStreamWriterPublisher) startKeepalive(ctx context.Context, interval time.Duration) {

--- a/cmd/serve/streamwriter_benchmark_test.go
+++ b/cmd/serve/streamwriter_benchmark_test.go
@@ -141,4 +141,3 @@ func BenchmarkNDJSONEncode(b *testing.B) {
 		})
 	}
 }
-

--- a/cmd/serve/streamwriter_benchmark_test.go
+++ b/cmd/serve/streamwriter_benchmark_test.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"bufio"
+	stdjson "encoding/json"
 	"io"
+	"strings"
 	"testing"
+
+	"github.com/invakid404/baml-rest/internal/apierror"
 )
 
 func BenchmarkNDJSONPublishDataParallel(b *testing.B) {
@@ -56,3 +60,85 @@ func BenchmarkSSEPublishDataParallel(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkSSEFrame exercises the SSE frame builder in isolation so we
+// can measure the bytebufferpool win without bufio.Writer / Flush noise.
+func BenchmarkSSEFrame(b *testing.B) {
+	cases := []struct {
+		name      string
+		eventType string
+		payload   string
+	}{
+		{name: "small_no_event", eventType: "", payload: `{"v":1}`},
+		{name: "small_final", eventType: sseEventFinal, payload: `{"v":1}`},
+		{name: "small_multiline", eventType: sseEventFinal, payload: "line1\nline2\nline3"},
+		{name: "large_16KiB", eventType: sseEventFinal, payload: strings.Repeat("x", 16*1024)},
+		{name: "large_multiline_64KiB", eventType: sseEventFinal, payload: strings.Repeat(strings.Repeat("x", 1024)+"\n", 64)},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				buf := streamFrameBufferPool.Get()
+				buf.Reset()
+				appendSSEEventFrame(buf, tc.eventType, tc.payload)
+				streamFrameBufferPool.Put(buf)
+			}
+		})
+	}
+}
+
+// BenchmarkNDJSONEncode measures encodeNDJSONEvent in isolation across
+// representative event shapes (data, raw reasoning, metadata, error).
+func BenchmarkNDJSONEncode(b *testing.B) {
+	small := &NDJSONEvent{
+		Type: NDJSONEventData,
+		Data: stdjson.RawMessage(`{"v":1}`),
+	}
+	rawReasoning := &NDJSONEvent{
+		Type:      NDJSONEventData,
+		Data:      stdjson.RawMessage(`{"v":1}`),
+		Raw:       strings.Repeat("r", 1024),
+		Reasoning: strings.Repeat("e", 1024),
+	}
+	metadata := &NDJSONEvent{
+		Type: NDJSONEventMetadata,
+		Data: stdjson.RawMessage(`{"client":"primary","attempt":1}`),
+	}
+	errEvent := &NDJSONEvent{
+		Type:    NDJSONEventError,
+		Error:   "upstream temporarily unavailable",
+		Code:    apierror.Code("worker_unavailable"),
+		Details: stdjson.RawMessage(`{"retryable":true,"attempts":3}`),
+	}
+
+	cases := []struct {
+		name  string
+		event *NDJSONEvent
+	}{
+		{name: "data_small", event: small},
+		{name: "data_with_raw_reasoning", event: rawReasoning},
+		{name: "metadata", event: metadata},
+		{name: "error_with_details", event: errEvent},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				buf := streamFrameBufferPool.Get()
+				buf.Reset()
+				if err := encodeNDJSONEvent(buf, tc.event); err != nil {
+					b.Fatal(err)
+				}
+				streamFrameBufferPool.Put(buf)
+			}
+		})
+	}
+}
+

--- a/cmd/serve/streamwriter_test.go
+++ b/cmd/serve/streamwriter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/internal/apierror"
 	"github.com/invakid404/baml-rest/workerplugin"
+	"github.com/valyala/bytebufferpool"
 )
 
 type recordingPublisher struct {
@@ -75,30 +76,67 @@ func TestEncodeNDJSONEvent(t *testing.T) {
 		Raw:  "raw-value",
 	}
 
-	got, err := encodeNDJSONEvent(event)
-	if err != nil {
+	var buf bytebufferpool.ByteBuffer
+	if err := encodeNDJSONEvent(&buf, event); err != nil {
 		t.Fatalf("encodeNDJSONEvent: %v", err)
 	}
 
 	want := "{\"type\":\"data\",\"data\":{\"value\":1},\"raw\":\"raw-value\"}\n"
-	if string(got) != want {
-		t.Fatalf("encoded NDJSON = %q, want %q", string(got), want)
+	if string(buf.B) != want {
+		t.Fatalf("encoded NDJSON = %q, want %q", string(buf.B), want)
 	}
 }
 
-func TestFormatSSEEvent(t *testing.T) {
-	got := formatSSEEvent(sseEventFinal, "first\nsecond")
-	want := "event: final\ndata: first\ndata: second\n\n"
-	if got != want {
-		t.Fatalf("formatted SSE event = %q, want %q", got, want)
+func TestAppendSSEEventFrame(t *testing.T) {
+	cases := []struct {
+		name      string
+		eventType string
+		payload   string
+		want      string
+	}{
+		{
+			name:      "multiline",
+			eventType: sseEventFinal,
+			payload:   "first\nsecond",
+			want:      "event: final\ndata: first\ndata: second\n\n",
+		},
+		{
+			name:      "trailing_newline_emits_empty_data_line",
+			eventType: "",
+			payload:   "a\n",
+			want:      "data: a\ndata: \n\n",
+		},
+		{
+			name:      "no_event_no_payload",
+			eventType: "",
+			payload:   "",
+			want:      "\n",
+		},
+		{
+			name:      "event_only",
+			eventType: sseEventReset,
+			payload:   "",
+			want:      "event: reset\n\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytebufferpool.ByteBuffer
+			appendSSEEventFrame(&buf, tc.eventType, tc.payload)
+			if string(buf.B) != tc.want {
+				t.Fatalf("frame = %q, want %q", string(buf.B), tc.want)
+			}
+		})
 	}
 }
 
-func TestFormatSSEComment(t *testing.T) {
-	got := formatSSEComment("keepalive")
+func TestAppendSSECommentFrame(t *testing.T) {
+	var buf bytebufferpool.ByteBuffer
+	appendSSECommentFrame(&buf, "keepalive")
 	want := ": keepalive\n\n"
-	if got != want {
-		t.Fatalf("formatted SSE comment = %q, want %q", got, want)
+	if string(buf.B) != want {
+		t.Fatalf("comment = %q, want %q", string(buf.B), want)
 	}
 }
 

--- a/dynclient/internal/generated/adapter.go
+++ b/dynclient/internal/generated/adapter.go
@@ -264,15 +264,15 @@ func bamlRestDynamicNoRaw(adapter bamlutils.Adapter, rawInput any, out chan baml
 	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
 	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
 	__struct_messages := *__messagesPtr_messages
-	var __ownedNested []*[]types.Baml_Rest_ContentPart
+	var __ownedNested_messages []*[]types.Baml_Rest_ContentPart
 	__releaseConverted := func() {
-		for _, __partsPtr := range __ownedNested {
+		for _, __partsPtr := range __ownedNested_messages {
 			putbaml_Rest_ContentPartSlice(__partsPtr)
 		}
 		putbaml_Rest_MessageSlice(__messagesPtr_messages)
 	}
 	for __i, __v := range input.Messages {
-		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested)
+		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested_messages)
 		if __err___struct_messages != nil {
 			__releaseConverted()
 			return fmt.Errorf("messages[%d]: %w", __i, __err___struct_messages)
@@ -367,15 +367,15 @@ func bamlRestDynamicFull(adapter bamlutils.Adapter, rawInput any, out chan bamlu
 	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
 	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
 	__struct_messages := *__messagesPtr_messages
-	var __ownedNested []*[]types.Baml_Rest_ContentPart
+	var __ownedNested_messages []*[]types.Baml_Rest_ContentPart
 	__releaseConverted := func() {
-		for _, __partsPtr := range __ownedNested {
+		for _, __partsPtr := range __ownedNested_messages {
 			putbaml_Rest_ContentPartSlice(__partsPtr)
 		}
 		putbaml_Rest_MessageSlice(__messagesPtr_messages)
 	}
 	for __i, __v := range input.Messages {
-		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested)
+		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested_messages)
 		if __err___struct_messages != nil {
 			__releaseConverted()
 			return fmt.Errorf("messages[%d]: %w", __i, __err___struct_messages)
@@ -581,15 +581,15 @@ func bamlRestDynamicBuildRequest(adapter bamlutils.Adapter, rawInput any, out ch
 	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
 	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
 	__struct_messages := *__messagesPtr_messages
-	var __ownedNested []*[]types.Baml_Rest_ContentPart
+	var __ownedNested_messages []*[]types.Baml_Rest_ContentPart
 	__releaseConverted := func() {
-		for _, __partsPtr := range __ownedNested {
+		for _, __partsPtr := range __ownedNested_messages {
 			putbaml_Rest_ContentPartSlice(__partsPtr)
 		}
 		putbaml_Rest_MessageSlice(__messagesPtr_messages)
 	}
 	for __i, __v := range input.Messages {
-		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested)
+		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested_messages)
 		if __err___struct_messages != nil {
 			__releaseConverted()
 			return fmt.Errorf("messages[%d]: %w", __i, __err___struct_messages)
@@ -822,15 +822,15 @@ func bamlRestDynamicBuildCallRequest(adapter bamlutils.Adapter, rawInput any, ou
 	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
 	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
 	__struct_messages := *__messagesPtr_messages
-	var __ownedNested []*[]types.Baml_Rest_ContentPart
+	var __ownedNested_messages []*[]types.Baml_Rest_ContentPart
 	__releaseConverted := func() {
-		for _, __partsPtr := range __ownedNested {
+		for _, __partsPtr := range __ownedNested_messages {
 			putbaml_Rest_ContentPartSlice(__partsPtr)
 		}
 		putbaml_Rest_MessageSlice(__messagesPtr_messages)
 	}
 	for __i, __v := range input.Messages {
-		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested)
+		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested_messages)
 		if __err___struct_messages != nil {
 			__releaseConverted()
 			return fmt.Errorf("messages[%d]: %w", __i, __err___struct_messages)

--- a/dynclient/internal/generated/adapter.go
+++ b/dynclient/internal/generated/adapter.go
@@ -80,12 +80,42 @@ type Baml_Rest_MessageMediaInput struct {
 	Metadata *types.Baml_Rest_MessageMetadata   `json:"metadata"`
 }
 
-func convertBaml_Rest_MessageMediaInput(adapter bamlutils.Adapter, input *Baml_Rest_MessageMediaInput) (types.Baml_Rest_Message, error) {
+var baml_Rest_ContentPartSlicePool sync.Pool
+
+func getbaml_Rest_ContentPartSlice(n int) *[]types.Baml_Rest_ContentPart {
+	if v := baml_Rest_ContentPartSlicePool.Get(); v != nil {
+		sp := v.(*[]types.Baml_Rest_ContentPart)
+		if cap(*sp) >= n {
+			*sp = (*sp)[:0]
+			return sp
+		}
+	}
+	s := make([]types.Baml_Rest_ContentPart, 0, n)
+	return &s
+}
+func putbaml_Rest_ContentPartSlice(sp *[]types.Baml_Rest_ContentPart) {
+	if sp == nil {
+		return
+	}
+	if cap(*sp) > 256 {
+		return
+	}
+	used := (*sp)[0:len(*sp):cap(*sp)]
+	for i := range used {
+		used[i] = types.Baml_Rest_ContentPart{}
+	}
+	*sp = (*sp)[:0]
+	baml_Rest_ContentPartSlicePool.Put(sp)
+}
+func convertBaml_Rest_MessageMediaInput(adapter bamlutils.Adapter, input *Baml_Rest_MessageMediaInput, ownedNested *[]*[]types.Baml_Rest_ContentPart) (types.Baml_Rest_Message, error) {
 	var result types.Baml_Rest_Message
 	result.Role = input.Role
 	result.Content = input.Content
 	if input.Parts != nil {
-		__ptrSlice := make([]types.Baml_Rest_ContentPart, len(*input.Parts))
+		__partsPtr := getbaml_Rest_ContentPartSlice(len(*input.Parts))
+		*ownedNested = append(*ownedNested, __partsPtr)
+		*__partsPtr = (*__partsPtr)[:len(*input.Parts)]
+		__ptrSlice := *__partsPtr
 		for __i, __v := range *input.Parts {
 			__converted, __err := convertBaml_Rest_ContentPartMediaInput(adapter, &__v)
 			if __err != nil {
@@ -194,6 +224,34 @@ func newBamlRestDynamicOutputMetadata(md *bamlutils.Metadata) *BamlRestDynamicOu
 	r.metadata = md
 	return r
 }
+
+var baml_Rest_MessageSlicePool sync.Pool
+
+func getbaml_Rest_MessageSlice(n int) *[]types.Baml_Rest_Message {
+	if v := baml_Rest_MessageSlicePool.Get(); v != nil {
+		sp := v.(*[]types.Baml_Rest_Message)
+		if cap(*sp) >= n {
+			*sp = (*sp)[:0]
+			return sp
+		}
+	}
+	s := make([]types.Baml_Rest_Message, 0, n)
+	return &s
+}
+func putbaml_Rest_MessageSlice(sp *[]types.Baml_Rest_Message) {
+	if sp == nil {
+		return
+	}
+	if cap(*sp) > 1024 {
+		return
+	}
+	used := (*sp)[0:len(*sp):cap(*sp)]
+	for i := range used {
+		used[i] = types.Baml_Rest_Message{}
+	}
+	*sp = (*sp)[:0]
+	baml_Rest_MessageSlicePool.Put(sp)
+}
 func bamlRestDynamicNoRaw(adapter bamlutils.Adapter, rawInput any, out chan bamlutils.StreamResult, skipPartials bool, plannedMetadata *bamlutils.Metadata, clientOverride string) error {
 	options, err := makeLegacyStreamOptionsFromAdapter(adapter, clientOverride)
 	if err != nil {
@@ -203,14 +261,25 @@ func bamlRestDynamicNoRaw(adapter bamlutils.Adapter, rawInput any, out chan baml
 	if !ok {
 		return fmt.Errorf("invalid input type: expected *%s, got %T", "BamlRestDynamicInput", rawInput)
 	}
-	__struct_messages := make([]types.Baml_Rest_Message, len(input.Messages))
+	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
+	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
+	__struct_messages := *__messagesPtr_messages
+	var __ownedNested []*[]types.Baml_Rest_ContentPart
+	__releaseConverted := func() {
+		for _, __partsPtr := range __ownedNested {
+			putbaml_Rest_ContentPartSlice(__partsPtr)
+		}
+		putbaml_Rest_MessageSlice(__messagesPtr_messages)
+	}
 	for __i, __v := range input.Messages {
-		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v)
+		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested)
 		if __err___struct_messages != nil {
+			__releaseConverted()
 			return fmt.Errorf("messages[%d]: %w", __i, __err___struct_messages)
 		}
 		__struct_messages[__i] = __converted
 	}
+	defer __releaseConverted()
 	return runNoRawOrchestration(adapter, out, func() bamlutils.StreamResult {
 		__r := getBamlRestDynamicOutput()
 		__r.kind = bamlutils.StreamResultKindHeartbeat
@@ -295,14 +364,25 @@ func bamlRestDynamicFull(adapter bamlutils.Adapter, rawInput any, out chan bamlu
 	if !ok {
 		return fmt.Errorf("invalid input type: expected *%s, got %T", "BamlRestDynamicInput", rawInput)
 	}
-	__struct_messages := make([]types.Baml_Rest_Message, len(input.Messages))
+	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
+	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
+	__struct_messages := *__messagesPtr_messages
+	var __ownedNested []*[]types.Baml_Rest_ContentPart
+	__releaseConverted := func() {
+		for _, __partsPtr := range __ownedNested {
+			putbaml_Rest_ContentPartSlice(__partsPtr)
+		}
+		putbaml_Rest_MessageSlice(__messagesPtr_messages)
+	}
 	for __i, __v := range input.Messages {
-		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v)
+		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested)
 		if __err___struct_messages != nil {
+			__releaseConverted()
 			return fmt.Errorf("messages[%d]: %w", __i, __err___struct_messages)
 		}
 		__struct_messages[__i] = __converted
 	}
+	defer __releaseConverted()
 	return runFullOrchestration(adapter, out, options, func() bamlutils.StreamResult {
 		__r := getBamlRestDynamicOutput()
 		__r.kind = bamlutils.StreamResultKindHeartbeat
@@ -498,10 +578,20 @@ func bamlRestDynamicBuildRequest(adapter bamlutils.Adapter, rawInput any, out ch
 	if !ok {
 		return fmt.Errorf("invalid input type: expected *%s, got %T", "BamlRestDynamicInput", rawInput)
 	}
-	__struct_messages := make([]types.Baml_Rest_Message, len(input.Messages))
+	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
+	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
+	__struct_messages := *__messagesPtr_messages
+	var __ownedNested []*[]types.Baml_Rest_ContentPart
+	__releaseConverted := func() {
+		for _, __partsPtr := range __ownedNested {
+			putbaml_Rest_ContentPartSlice(__partsPtr)
+		}
+		putbaml_Rest_MessageSlice(__messagesPtr_messages)
+	}
 	for __i, __v := range input.Messages {
-		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v)
+		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested)
 		if __err___struct_messages != nil {
+			__releaseConverted()
 			return fmt.Errorf("messages[%d]: %w", __i, __err___struct_messages)
 		}
 		__struct_messages[__i] = __converted
@@ -706,6 +796,7 @@ func bamlRestDynamicBuildRequest(adapter bamlutils.Adapter, rawInput any, out ch
 	}
 	go func() {
 		defer close(out)
+		defer __releaseConverted()
 		gorecovery.GoHandler(func(err error) {
 			__errR := newResultFn(bamlutils.StreamResultKindError, nil, nil, "", "", err, false)
 			select {
@@ -728,10 +819,20 @@ func bamlRestDynamicBuildCallRequest(adapter bamlutils.Adapter, rawInput any, ou
 	if !ok {
 		return fmt.Errorf("invalid input type: expected *%s, got %T", "BamlRestDynamicInput", rawInput)
 	}
-	__struct_messages := make([]types.Baml_Rest_Message, len(input.Messages))
+	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
+	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
+	__struct_messages := *__messagesPtr_messages
+	var __ownedNested []*[]types.Baml_Rest_ContentPart
+	__releaseConverted := func() {
+		for _, __partsPtr := range __ownedNested {
+			putbaml_Rest_ContentPartSlice(__partsPtr)
+		}
+		putbaml_Rest_MessageSlice(__messagesPtr_messages)
+	}
 	for __i, __v := range input.Messages {
-		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v)
+		__converted, __err___struct_messages := convertBaml_Rest_MessageMediaInput(adapter, &__v, &__ownedNested)
 		if __err___struct_messages != nil {
+			__releaseConverted()
 			return fmt.Errorf("messages[%d]: %w", __i, __err___struct_messages)
 		}
 		__struct_messages[__i] = __converted
@@ -881,6 +982,7 @@ func bamlRestDynamicBuildCallRequest(adapter bamlutils.Adapter, rawInput any, ou
 	}
 	go func() {
 		defer close(out)
+		defer __releaseConverted()
 		gorecovery.GoHandler(func(err error) {
 			__errR := newResultFn(bamlutils.StreamResultKindError, nil, nil, "", "", err, false)
 			select {

--- a/dynclient/internal/generated/adapter.go
+++ b/dynclient/internal/generated/adapter.go
@@ -279,7 +279,6 @@ func bamlRestDynamicNoRaw(adapter bamlutils.Adapter, rawInput any, out chan baml
 		}
 		__struct_messages[__i] = __converted
 	}
-	defer __releaseConverted()
 	return runNoRawOrchestration(adapter, out, func() bamlutils.StreamResult {
 		__r := getBamlRestDynamicOutput()
 		__r.kind = bamlutils.StreamResultKindHeartbeat
@@ -291,6 +290,7 @@ func bamlRestDynamicNoRaw(adapter bamlutils.Adapter, rawInput any, out chan baml
 	}, plannedMetadata, func(md *bamlutils.Metadata) bamlutils.StreamResult {
 		return newBamlRestDynamicOutputMetadata(md)
 	}, func(beforeFinal func(), onTick func(context.Context, pkg.TickReason, pkg.FunctionLog) pkg.FunctionSignal) error {
+		defer __releaseConverted()
 		streamOpts := append(options, bamlclient.WithOnTick(onTick))
 		if clientOverride != "" {
 			streamOpts = append(slices.Clone(streamOpts), bamlclient.WithClient(clientOverride))
@@ -382,7 +382,6 @@ func bamlRestDynamicFull(adapter bamlutils.Adapter, rawInput any, out chan bamlu
 		}
 		__struct_messages[__i] = __converted
 	}
-	defer __releaseConverted()
 	return runFullOrchestration(adapter, out, options, func() bamlutils.StreamResult {
 		__r := getBamlRestDynamicOutput()
 		__r.kind = bamlutils.StreamResultKindHeartbeat
@@ -532,6 +531,7 @@ func bamlRestDynamicFull(adapter bamlutils.Adapter, rawInput any, out chan bamlu
 		}
 		return nil
 	}, func(opts []bamlclient.CallOptionFunc) (any, error) {
+		defer __releaseConverted()
 		driveOpts := opts
 		if clientOverride != "" {
 			driveOpts = append(slices.Clone(opts), bamlclient.WithClient(clientOverride))

--- a/dynclient/internal/generated/adapter.go
+++ b/dynclient/internal/generated/adapter.go
@@ -107,13 +107,15 @@ func putbaml_Rest_ContentPartSlice(sp *[]types.Baml_Rest_ContentPart) {
 	*sp = (*sp)[:0]
 	baml_Rest_ContentPartSlicePool.Put(sp)
 }
-func convertBaml_Rest_MessageMediaInput(adapter bamlutils.Adapter, input *Baml_Rest_MessageMediaInput, ownedNested *[]*[]types.Baml_Rest_ContentPart) (types.Baml_Rest_Message, error) {
+func convertBaml_Rest_MessageMediaInput(adapter bamlutils.Adapter, input *Baml_Rest_MessageMediaInput, ownedNested *[]func()) (types.Baml_Rest_Message, error) {
 	var result types.Baml_Rest_Message
 	result.Role = input.Role
 	result.Content = input.Content
 	if input.Parts != nil {
 		__partsPtr := getbaml_Rest_ContentPartSlice(len(*input.Parts))
-		*ownedNested = append(*ownedNested, __partsPtr)
+		*ownedNested = append(*ownedNested, func() {
+			putbaml_Rest_ContentPartSlice(__partsPtr)
+		})
 		*__partsPtr = (*__partsPtr)[:len(*input.Parts)]
 		__ptrSlice := *__partsPtr
 		for __i, __v := range *input.Parts {
@@ -264,10 +266,10 @@ func bamlRestDynamicNoRaw(adapter bamlutils.Adapter, rawInput any, out chan baml
 	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
 	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
 	__struct_messages := *__messagesPtr_messages
-	var __ownedNested_messages []*[]types.Baml_Rest_ContentPart
+	var __ownedNested_messages []func()
 	__releaseConverted := func() {
-		for _, __partsPtr := range __ownedNested_messages {
-			putbaml_Rest_ContentPartSlice(__partsPtr)
+		for _, __release := range __ownedNested_messages {
+			__release()
 		}
 		putbaml_Rest_MessageSlice(__messagesPtr_messages)
 	}
@@ -367,10 +369,10 @@ func bamlRestDynamicFull(adapter bamlutils.Adapter, rawInput any, out chan bamlu
 	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
 	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
 	__struct_messages := *__messagesPtr_messages
-	var __ownedNested_messages []*[]types.Baml_Rest_ContentPart
+	var __ownedNested_messages []func()
 	__releaseConverted := func() {
-		for _, __partsPtr := range __ownedNested_messages {
-			putbaml_Rest_ContentPartSlice(__partsPtr)
+		for _, __release := range __ownedNested_messages {
+			__release()
 		}
 		putbaml_Rest_MessageSlice(__messagesPtr_messages)
 	}
@@ -581,10 +583,10 @@ func bamlRestDynamicBuildRequest(adapter bamlutils.Adapter, rawInput any, out ch
 	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
 	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
 	__struct_messages := *__messagesPtr_messages
-	var __ownedNested_messages []*[]types.Baml_Rest_ContentPart
+	var __ownedNested_messages []func()
 	__releaseConverted := func() {
-		for _, __partsPtr := range __ownedNested_messages {
-			putbaml_Rest_ContentPartSlice(__partsPtr)
+		for _, __release := range __ownedNested_messages {
+			__release()
 		}
 		putbaml_Rest_MessageSlice(__messagesPtr_messages)
 	}
@@ -822,10 +824,10 @@ func bamlRestDynamicBuildCallRequest(adapter bamlutils.Adapter, rawInput any, ou
 	__messagesPtr_messages := getbaml_Rest_MessageSlice(len(input.Messages))
 	*__messagesPtr_messages = (*__messagesPtr_messages)[:len(input.Messages)]
 	__struct_messages := *__messagesPtr_messages
-	var __ownedNested_messages []*[]types.Baml_Rest_ContentPart
+	var __ownedNested_messages []func()
 	__releaseConverted := func() {
-		for _, __partsPtr := range __ownedNested_messages {
-			putbaml_Rest_ContentPartSlice(__partsPtr)
+		for _, __release := range __ownedNested_messages {
+			__release()
 		}
 		putbaml_Rest_MessageSlice(__messagesPtr_messages)
 	}

--- a/dynclient/internal/generated/adapter_dynamic_benchmark_test.go
+++ b/dynclient/internal/generated/adapter_dynamic_benchmark_test.go
@@ -1,0 +1,79 @@
+package generated
+
+import (
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/dynclient/internal/generated/adapter"
+	"github.com/invakid404/baml-rest/dynclient/internal/generated/baml_client/types"
+)
+
+// noopMediaFactory returns nil so this benchmark exercises only the
+// pool plumbing for text-only messages (no media). Multimodal coverage
+// lives in `bamlutils/dynamic_benchmark_test.go` where the conversion
+// runs without depending on real BAML media values.
+func noopMediaFactory(_ bamlutils.MediaKind, _ *string, _ *string, _ *string) (any, error) {
+	return nil, nil
+}
+
+func benchAdapter() bamlutils.Adapter {
+	return &adapter.BamlAdapter{MediaFactory: noopMediaFactory}
+}
+
+func benchTextOnlyInput(n int) *BamlRestDynamicInput {
+	text := "hello"
+	msgs := make([]Baml_Rest_MessageMediaInput, n)
+	for i := range msgs {
+		t := text
+		msgs[i] = Baml_Rest_MessageMediaInput{Role: "user", Content: &t}
+	}
+	return &BamlRestDynamicInput{Messages: msgs}
+}
+
+// runMessageConvert drives the same conversion shape the generated
+// dispatch sites use: pool checkout for the outer message slice,
+// ownedNested tracking, convertBaml_Rest_MessageMediaInput per message,
+// release on exit. Mirrors the codegen-emitted shape so the benchmark
+// measures the pool win at the layer the codegen actually emits.
+func runMessageConvert(b *testing.B, adp bamlutils.Adapter, in *BamlRestDynamicInput) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		messagesPtr := getbaml_Rest_MessageSlice(len(in.Messages))
+		*messagesPtr = (*messagesPtr)[:len(in.Messages)]
+		structMessages := *messagesPtr
+		var ownedNested []*[]types.Baml_Rest_ContentPart
+		release := func() {
+			for _, p := range ownedNested {
+				putbaml_Rest_ContentPartSlice(p)
+			}
+			putbaml_Rest_MessageSlice(messagesPtr)
+		}
+		for j := range in.Messages {
+			converted, err := convertBaml_Rest_MessageMediaInput(adp, &in.Messages[j], &ownedNested)
+			if err != nil {
+				release()
+				b.Fatal(err)
+			}
+			structMessages[j] = converted
+		}
+		release()
+	}
+}
+
+func BenchmarkBamlRestMessageConvert(b *testing.B) {
+	adp := benchAdapter()
+	for _, tc := range []struct {
+		name string
+		n    int
+	}{
+		{name: "1_text_message", n: 1},
+		{name: "10_text_messages", n: 10},
+		{name: "100_text_messages", n: 100},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			runMessageConvert(b, adp, benchTextOnlyInput(tc.n))
+		})
+	}
+}

--- a/dynclient/internal/generated/adapter_dynamic_benchmark_test.go
+++ b/dynclient/internal/generated/adapter_dynamic_benchmark_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/dynclient/internal/generated/adapter"
-	"github.com/invakid404/baml-rest/dynclient/internal/generated/baml_client/types"
 )
 
 // noopMediaFactory returns nil so this benchmark exercises only the
@@ -42,10 +41,13 @@ func runMessageConvert(b *testing.B, adp bamlutils.Adapter, in *BamlRestDynamicI
 		messagesPtr := getbaml_Rest_MessageSlice(len(in.Messages))
 		*messagesPtr = (*messagesPtr)[:len(in.Messages)]
 		structMessages := *messagesPtr
-		var ownedNested []*[]types.Baml_Rest_ContentPart
+		// Closure-context ownedNested: each pooled nested branch
+		// inside the converter appends a release closure capturing
+		// its own put<X>Slice + pointer. Drain in any order.
+		var ownedNested []func()
 		release := func() {
-			for _, p := range ownedNested {
-				putbaml_Rest_ContentPartSlice(p)
+			for _, fn := range ownedNested {
+				fn()
 			}
 			putbaml_Rest_MessageSlice(messagesPtr)
 		}

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stoewer/go-strcase v1.3.1
 	github.com/testcontainers/testcontainers-go v0.42.0
+	github.com/valyala/bytebufferpool v1.0.0
 	golang.org/x/mod v0.36.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
@@ -166,7 +167,6 @@ require (
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
 	github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.71.0 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Implements the top-3 picks from a codex memory-pooling audit
(/tmp/codex-perf-scope-top3-v1.md). Three coupled, package-local pools
that together drop the largest steady-state allocations on the hot
streaming and dynamic-dispatch paths. No public API changes; no
existing pools (workerplugin.StreamResult, generated output result
pools) touched.

## What changed

**Pick #1 — `perf(sseclient): pool SSE scanner buffers`**
- `sync.Pool` of `*[]byte` around the 64 KiB initial `bufio.Scanner`
  buffer in `bamlutils/sseclient/sseclient.go:scan`.
- Pool only retains the fixed 64 KiB size; tokens > 64 KiB still grow
  up to the 1 MiB max but stay GC-owned. Parsing uses `scanner.Text()`
  so event fields never alias the pooled buffer.

**Pick #2 — `perf(serve): pool stream frame buffers with bytebufferpool`**
- `bytebufferpool.Pool` in `cmd/serve/streamwriter.go`. SSE frame
  helpers (`appendSSEEventFrame`, `appendSSECommentFrame`) and
  `encodeNDJSONEvent` now append into a per-event checked-out
  `ByteBuffer`; `writeFrame` takes `[]byte`.
- Manual line iteration via `strings.IndexByte` replaces the
  `strings.Split` allocation; trailing-newline framing preserved
  (covered by `TestAppendSSEEventFrame`).
- `github.com/valyala/bytebufferpool` promoted from indirect to
  direct dep in the root `go.mod`.

**Pick #3 — `perf(bamlutils): pool dynamic conversion slices`**
- Host-side (`bamlutils/dynamic.go`): typed `sync.Pool` wrappers
  for `[]internalMessage` (cap ≤ 1024) and `[]internalContentPart`
  (cap ≤ 256). `DynamicMessage.toInternalMessage` threads an
  `ownedParts *[]*[]internalContentPart` through so
  `ToWorkerInput` releases pooled nested slices via one deferred
  drain. Every pooled element is zeroed before put so the pool
  cannot retain request strings, media URLs/base64 payloads, or
  metadata pointers.
- Codegen (`adapters/common/codegen/`): new `codegen_slice_pool.go`
  emits per-inner-type pool + get/put helpers with the same cap
  thresholds and pointer-clearing.
  `nestedStructConversion` routes `*[]Struct` fields through the
  pool helpers; the convert function gains an `ownedNested`
  parameter. `makeBuildRequestPreambleSlice` pools the outer
  `[]Message` slice and builds a `__releaseConverted` closure that
  dispatch emitters defer.
- **Async-release rule in generated dispatch** (corrected in
  `ae08594` after the initial framing missed that the legacy
  orchestrators are themselves async): ALL four dispatch paths
  defer `__releaseConverted()` inside the orchestration goroutine,
  never at the outer function level. BuildRequest / BuildCallRequest
  defer inside their own `go func()`. Legacy `_noRaw` / `_full`
  defer inside the body / driveStream callbacks that
  `runNoRawOrchestration` / `runFullOrchestration` invoke from THEIR
  spawned goroutines (those helpers also `go func() { ... }` and
  return immediately — the outer defer would fire before the
  goroutine ever read `__struct_messages`, zeroing the pooled
  backing array out from under BAML).
- `dynclient/internal/generated/adapter.go` regenerated via
  `cmd/regenerate-dynclient`; that command is idempotent against
  this tree.

## Review fixes folded in

Sequenced after the three perf commits; each landed as its own commit
on top of the original implementation so the history records both the
bug and the fix:

- **`ae08594` — `fix(codegen): defer pool release inside legacy stream body closures`**
  Reproduced via the integration matrix entry the user flagged
  (`TestDynclient` failing with `messages: []` upstream bodies under
  BAML 0.222.0 / build-request=true / unary=false / http-client=auto).
  Root cause was the outer-function defer described above — the
  orchestrator goroutine read a zeroed backing array because release
  fired before it started. The fix moves the defer into
  `noRawGoroutineBody` and `driveStreamBody` so it lives inside the
  body callback the orchestrator goroutine actually invokes.
- **`6f4b733` — `fix(codegen): hoist __releaseConverted + guard pooledInner against pointer-element slices`**
  Two latent codegen bugs the user surfaced after the initial PR:
  (F1) multiple pooled slice params would have emitted duplicate
  `__releaseConverted := func() { ... }` declarations in the same
  scope; (F2) `*[]*T` nested slice fields would have triggered the
  pool branch with a `*[]*T` checkout that does not match the
  `ownedNested *[]*[]T` parameter type. Both currently dormant
  because the dynclient schema only has one pooled slice param
  (`messages`) and uses `*[]T` (value elements) for `Parts`.
  Regression tests in `codegen_slice_pool_test.go` cover both
  shapes and were verified to fail pre-fix.
- **`1c70c9f` — `fix(codegen): release pooled resources on Phase-B conversion errors`**
  Phase-B's non-pooled struct-media branches (`*[]C`, `*C`, direct
  `C`, `[]*C`) emitted `return fmt.Errorf(...)` without first calling
  `__releaseConverted()`. A sibling pooled `[]C` param's resources
  would leak on the non-pooled error path. Currently dormant for
  the same single-pooled-param reason. Centralized via a
  `releaseThenReturnError` helper scoped to Phase B (pre-pool
  errors do NOT route through it). Regression test in
  `codegen_slice_pool_test.go` covers all four non-pooled shapes
  and was verified to fail pre-fix.

## Before / after benchmarks (-benchtime=2s on Apple M4)

Re-measured against the branch tip after all fixes landed. Numbers
match the originally published deltas within run-to-run noise.

**Pick #1 — `BenchmarkStreamParallel`:**
```
small_128B         B/op:  338789 -> 274020   (~64 KiB saved/op)
medium_4KiB        B/op:  9026800 -> 8969121 (~57 KiB saved/op)
large_80KiB        ns/op: 1162021 -> 656580  (~43% faster)
multiline_4KiB     ns/op: 2774061 -> 1356565 (~51% faster)
```

**Pick #2 — `cmd/serve` publisher + frame benchmarks:**
```
NDJSONPublishDataParallel:       479 -> 270 B/op (-44%), 4 -> 3 allocs/op
SSEPublishDataParallel/no_raw:   88  -> 0   B/op (-100%), 3 -> 0 allocs/op
SSEPublishDataParallel/with_raw: 328 -> 196 B/op (-40%),  6 -> 3 allocs/op
SSEFrame/*:                      0   B/op,   0   allocs/op (small/multiline/16 KiB/64 KiB)
NDJSONEncode/*:                  only sonic.Marshal output remains (2 allocs/op)
```

**Pick #3 — `BenchmarkDynamicInputToWorkerInput`:**
```
single_text_message       B/op:  3286 -> 3226  (-1.8%)
10_text_messages          B/op:  6631 -> 6011  (-9.4%)
100_text_messages         B/op:  46990 -> 40029 (-14.8%)
single_multimodal         B/op:  3499 -> 3272  (-6.5%)
10_multimodal_messages    B/op:  8749 -> 6452  (-26.3%)
100_multimodal_messages   B/op:  64142 -> 41234 (-35.7%), 443 -> 351 allocs/op
```

Generated convert (`BenchmarkBamlRestMessageConvert`) drops to
`0 B/op / 0 allocs/op` steady-state for 1 / 10 / 100 text messages
once the pool warms.

## Test plan

- [x] `go test ./bamlutils/sseclient ./cmd/serve ./bamlutils`
- [x] `go test -race ./bamlutils/sseclient ./cmd/serve ./bamlutils`
- [x] `(cd adapters/common && GOWORK=off go test ./...)` — codegen
      + testdriver + testhelpers (incl. new F1 / F2 / F3 regression
      tests in `codegen_slice_pool_test.go`)
- [x] `(cd dynclient && GOWORK=off go test ./...)` — generated
      adapter compiles + runtime wiring
- [x] `go run ./cmd/regenerate-dynclient` is idempotent against this
      tree
- [x] Integration `TestDynclient` suite passes under the matrix
      cell the failure was reported on (BAML 0.222.0 / unary=false
      / build-request=true / http-client=auto, both subprocess and
      in-process flavors)
- [x] Focused `-bench=. -benchmem` runs per pick (numbers above,
      re-measured on branch tip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced allocations and improved throughput via pooled slice and buffer reuse across conversions, stream framing, SSE parsing, and dynamic message handling.
* **Bug Fixes**
  * Fixed pooled-resource release timing so pooled resources are reliably returned inside orchestration goroutines.
* **Refactor**
  * Unified NDJSON/SSE framing to use shared pooled buffers and in-place encoding to avoid extra allocations.
* **Tests**
  * Added benchmarks and comprehensive compile-matrix/unit tests for pooling, nested conversions, dynamic messages, and SSE/stream framing.
* **Chores**
  * Updated embed rules and module setup to support new tests and pooling helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
