### PR TITLE
test(codegen): pool-lifecycle harness for #339

### DIFF
--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -184,12 +184,12 @@ type Options struct {
 	EmitPoolAuditHooks bool
 
 	// Test-only regression seeds — DO NOT use in production codegen.
-	// Each seed reintroduces one bug class the #338 review surfaced.
-	// The pool-lifecycle harness flips them one at a time and
-	// asserts the inner `go test` fails. If a seed test starts
-	// passing on master, either the bug class is no longer
-	// reproducible at all (harness lost coverage) or this seed has
-	// drifted and needs updating to match a current emission path.
+	// Each seed reintroduces one bug class the slice-pool lifecycle
+	// harness is designed to catch. The harness flips them one at a
+	// time and asserts the inner `go test` fails. If a seed test
+	// starts passing on this branch, either the targeted bug class
+	// is no longer reproducible or this seed needs updating to match
+	// the current emission path.
 	//
 	// Production callers must never set these — leaving them false
 	// is the contract that keeps the audit-mode harness honest.

--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -257,7 +257,7 @@ func newGenerator(opts Options) *generator {
 		supportsWithClient:   resolved.SupportsWithClient,
 		mirrors:              newMirrorStructTracker(),
 		emittedUnwrapHelpers: make(map[string]bool),
-		slicePools:           newSlicePoolTracker(resolved.Packages, resolved.EmitPoolAuditHooks),
+		slicePools:           newSlicePoolTracker(resolved.Packages, resolved.EmitPoolAuditHooks, resolved.Seed_OmitZeroLoop),
 	}
 }
 

--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -175,6 +175,21 @@ type Options struct {
 	// internal/poolaudit package and surface counter + zero-violation
 	// observations to a running test.
 	EmitPoolAuditHooks bool
+
+	// Test-only regression seeds — DO NOT use in production codegen.
+	// Each seed reintroduces one bug class the #338 review surfaced.
+	// The pool-lifecycle harness flips them one at a time and
+	// asserts the inner `go test` fails. If a seed test starts
+	// passing on master, either the bug class is no longer
+	// reproducible at all (harness lost coverage) or this seed has
+	// drifted and needs updating to match a current emission path.
+	//
+	// Production callers must never set these — leaving them false
+	// is the contract that keeps the audit-mode harness honest.
+	Seed_OmitPhaseBRelease     bool
+	Seed_OmitOwnedNestedThread bool
+	Seed_OmitZeroLoop          bool
+	Seed_OmitAsyncDefer        bool
 }
 
 // Generate generates the adapter.go file for the given adapter

--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -67,6 +67,12 @@ type PackageConfig struct {
 	// QueuePkg is the import path of the go-concurrent-queue dependency
 	// used by the streaming helpers.
 	QueuePkg string
+	// PoolAuditPkg is the import path of the test-only poolaudit hooks
+	// package. Referenced only when slicePoolTracker.audit is true,
+	// which only the lifecycle harness flips. Sits on PackageConfig so
+	// a forked / vendored audit runtime can substitute its own path
+	// without touching the slicePoolTracker emission sites.
+	PoolAuditPkg string
 }
 
 // DefaultPackageConfig returns the PackageConfig that reproduces the
@@ -87,6 +93,7 @@ func DefaultPackageConfig() PackageConfig {
 		RetryPkg:           common.RetryPkg,
 		BamlPkg:            BamlPkg,
 		QueuePkg:           common.GoConcurrentQueuePkg,
+		PoolAuditPkg:       "github.com/invakid404/baml-rest/adapters/common/codegen/internal/poolaudit",
 	}
 }
 

--- a/adapters/common/codegen/codegen.go
+++ b/adapters/common/codegen/codegen.go
@@ -167,6 +167,14 @@ type Options struct {
 	// as "use the root introspected package" for backwards
 	// compatibility with [Generate].
 	Introspection Introspection
+	// EmitPoolAuditHooks toggles emission of pool checkout / release /
+	// zero-pre-put hooks inside getXSlice / putXSlice. Used only by
+	// the pool-lifecycle test harness — production codegen leaves
+	// this false, in which case the emitted helpers are byte-identical
+	// to the pre-audit baseline. When true, the helpers import the
+	// internal/poolaudit package and surface counter + zero-violation
+	// observations to a running test.
+	EmitPoolAuditHooks bool
 }
 
 // Generate generates the adapter.go file for the given adapter
@@ -227,7 +235,7 @@ func newGenerator(opts Options) *generator {
 		supportsWithClient:   resolved.SupportsWithClient,
 		mirrors:              newMirrorStructTracker(),
 		emittedUnwrapHelpers: make(map[string]bool),
-		slicePools:           newSlicePoolTracker(resolved.Packages),
+		slicePools:           newSlicePoolTracker(resolved.Packages, resolved.EmitPoolAuditHooks),
 	}
 }
 

--- a/adapters/common/codegen/codegen_buildrequest.go
+++ b/adapters/common/codegen/codegen_buildrequest.go
@@ -608,10 +608,12 @@ func (me *methodEmitter) emitBuildRequest() {
 
 		jen.Go().Func().Params().BlockFunc(func(grp *jen.Group) {
 			grp.Defer().Close(jen.Id("out"))
-			if me.hasReleaseConverted {
+			if me.hasReleaseConverted && !me.g.opts.Seed_OmitAsyncDefer {
 				// Retry closures captured by RunStreamOrchestration
 				// outlive the outer function, so the converted slice
 				// release belongs inside the orchestration goroutine.
+				// Seed_OmitAsyncDefer drops the defer so the pooled
+				// slice leaks for the duration of the orchestration.
 				grp.Defer().Id("__releaseConverted").Call()
 			}
 			grp.Qual("github.com/gregwebs/go-recovery", "GoHandler").Call(
@@ -886,10 +888,12 @@ func (me *methodEmitter) emitBuildCallRequest() {
 		// Run in goroutine with panic recovery
 		jen.Go().Func().Params().BlockFunc(func(grp *jen.Group) {
 			grp.Defer().Close(jen.Id("out"))
-			if me.hasReleaseConverted {
+			if me.hasReleaseConverted && !me.g.opts.Seed_OmitAsyncDefer {
 				// Retry closures captured by RunCallOrchestration
 				// outlive the outer function, so the converted slice
 				// release belongs inside the orchestration goroutine.
+				// Seed_OmitAsyncDefer drops the defer so the pooled
+				// slice leaks for the duration of the orchestration.
 				grp.Defer().Id("__releaseConverted").Call()
 			}
 			grp.Qual("github.com/gregwebs/go-recovery", "GoHandler").Call(

--- a/adapters/common/codegen/codegen_buildrequest.go
+++ b/adapters/common/codegen/codegen_buildrequest.go
@@ -605,15 +605,23 @@ func (me *methodEmitter) emitBuildRequest() {
 		).Block(
 			jen.Id("__httpClient").Op("=").Id("__c"),
 		),
+	)
 
+	// Seed_OmitAsyncDefer relocates the release defer to the outer
+	// buildRequest function body — it fires when the outer function
+	// returns, racing the orchestration goroutine's reads of
+	// __struct_messages.
+	if me.hasReleaseConverted && me.g.opts.Seed_OmitAsyncDefer {
+		buildRequestBody = append(buildRequestBody, jen.Defer().Id("__releaseConverted").Call())
+	}
+
+	buildRequestBody = append(buildRequestBody,
 		jen.Go().Func().Params().BlockFunc(func(grp *jen.Group) {
 			grp.Defer().Close(jen.Id("out"))
 			if me.hasReleaseConverted && !me.g.opts.Seed_OmitAsyncDefer {
 				// Retry closures captured by RunStreamOrchestration
 				// outlive the outer function, so the converted slice
 				// release belongs inside the orchestration goroutine.
-				// Seed_OmitAsyncDefer drops the defer so the pooled
-				// slice leaks for the duration of the orchestration.
 				grp.Defer().Id("__releaseConverted").Call()
 			}
 			grp.Qual("github.com/gregwebs/go-recovery", "GoHandler").Call(
@@ -884,7 +892,16 @@ func (me *methodEmitter) emitBuildCallRequest() {
 		).Block(
 			jen.Id("__httpClient").Op("=").Id("__c"),
 		),
+	)
 
+	// Seed_OmitAsyncDefer relocates the release defer to the outer
+	// buildCallRequest function body so it fires when the outer
+	// function returns, racing the orchestration goroutine's reads.
+	if me.hasReleaseConverted && me.g.opts.Seed_OmitAsyncDefer {
+		buildCallRequestBody = append(buildCallRequestBody, jen.Defer().Id("__releaseConverted").Call())
+	}
+
+	buildCallRequestBody = append(buildCallRequestBody,
 		// Run in goroutine with panic recovery
 		jen.Go().Func().Params().BlockFunc(func(grp *jen.Group) {
 			grp.Defer().Close(jen.Id("out"))
@@ -892,8 +909,6 @@ func (me *methodEmitter) emitBuildCallRequest() {
 				// Retry closures captured by RunCallOrchestration
 				// outlive the outer function, so the converted slice
 				// release belongs inside the orchestration goroutine.
-				// Seed_OmitAsyncDefer drops the defer so the pooled
-				// slice leaks for the duration of the orchestration.
 				grp.Defer().Id("__releaseConverted").Call()
 			}
 			grp.Qual("github.com/gregwebs/go-recovery", "GoHandler").Call(

--- a/adapters/common/codegen/codegen_legacy_stream.go
+++ b/adapters/common/codegen/codegen_legacy_stream.go
@@ -155,11 +155,17 @@ func (me *methodEmitter) emitLegacyStream() {
 	// body closure, not at the outer function level (where the defer
 	// would fire before the orchestrator even read the slice).
 	//
-	// Seed_OmitAsyncDefer drops the defer at this site, leaking the
-	// pooled slice. The seed is the test-only switch backing the
-	// async-defer regression in the pool-lifecycle harness.
-	if me.hasReleaseConverted && !me.g.opts.Seed_OmitAsyncDefer {
-		noRawGoroutineBody = append([]jen.Code{jen.Defer().Id("__releaseConverted").Call()}, noRawGoroutineBody...)
+	// Seed_OmitAsyncDefer relocates the defer to the outer
+	// noRawBody. When _noRaw returns, the defer fires while the
+	// orchestrator's goroutine is still reading __struct_messages —
+	// the timing-race shape backing the async-defer regression in
+	// the pool-lifecycle harness.
+	if me.hasReleaseConverted {
+		if me.g.opts.Seed_OmitAsyncDefer {
+			noRawBody = append(noRawBody, jen.Defer().Id("__releaseConverted").Call())
+		} else {
+			noRawGoroutineBody = append([]jen.Code{jen.Defer().Id("__releaseConverted").Call()}, noRawGoroutineBody...)
+		}
 	}
 
 	// Delegate to shared orchestration helper - supplies per-method closures
@@ -480,7 +486,7 @@ func (me *methodEmitter) emitLegacyStream() {
 	// Same legacy-view rationale as _noRaw.
 	var fullBody []jen.Code
 	fullBody = append(fullBody, me.makeLegacyPreamble()...)
-	if me.hasReleaseConverted && !me.g.opts.Seed_OmitAsyncDefer {
+	if me.hasReleaseConverted {
 		// runFullOrchestration spawns its own goroutines and returns
 		// immediately. driveStream is the only callback that touches
 		// __struct_messages, and it runs inside the orchestrator
@@ -489,10 +495,14 @@ func (me *methodEmitter) emitLegacyStream() {
 		// the defer would fire before the orchestrator even started
 		// the stream). Mirror of the _noRaw fix.
 		//
-		// Seed_OmitAsyncDefer drops the defer entirely so the pooled
-		// slice leaks — the async-defer regression seed's production
-		// reintroduction.
-		driveStreamBody = append([]jen.Code{jen.Defer().Id("__releaseConverted").Call()}, driveStreamBody...)
+		// Seed_OmitAsyncDefer relocates the defer to the outer
+		// fullBody so it fires when _full returns, racing the
+		// driveStream callback still reading the converted slice.
+		if me.g.opts.Seed_OmitAsyncDefer {
+			fullBody = append(fullBody, jen.Defer().Id("__releaseConverted").Call())
+		} else {
+			driveStreamBody = append([]jen.Code{jen.Defer().Id("__releaseConverted").Call()}, driveStreamBody...)
+		}
 	}
 
 	// Delegate to shared full orchestration helper with per-method closures

--- a/adapters/common/codegen/codegen_legacy_stream.go
+++ b/adapters/common/codegen/codegen_legacy_stream.go
@@ -154,7 +154,11 @@ func (me *methodEmitter) emitLegacyStream() {
 	// goroutine — so the pooled-slice release MUST live inside the
 	// body closure, not at the outer function level (where the defer
 	// would fire before the orchestrator even read the slice).
-	if me.hasReleaseConverted {
+	//
+	// Seed_OmitAsyncDefer drops the defer at this site, leaking the
+	// pooled slice. The seed is the test-only switch backing the
+	// async-defer regression in the pool-lifecycle harness.
+	if me.hasReleaseConverted && !me.g.opts.Seed_OmitAsyncDefer {
 		noRawGoroutineBody = append([]jen.Code{jen.Defer().Id("__releaseConverted").Call()}, noRawGoroutineBody...)
 	}
 
@@ -476,7 +480,7 @@ func (me *methodEmitter) emitLegacyStream() {
 	// Same legacy-view rationale as _noRaw.
 	var fullBody []jen.Code
 	fullBody = append(fullBody, me.makeLegacyPreamble()...)
-	if me.hasReleaseConverted {
+	if me.hasReleaseConverted && !me.g.opts.Seed_OmitAsyncDefer {
 		// runFullOrchestration spawns its own goroutines and returns
 		// immediately. driveStream is the only callback that touches
 		// __struct_messages, and it runs inside the orchestrator
@@ -484,6 +488,10 @@ func (me *methodEmitter) emitLegacyStream() {
 		// driveStream's body, not at the outer function level (where
 		// the defer would fire before the orchestrator even started
 		// the stream). Mirror of the _noRaw fix.
+		//
+		// Seed_OmitAsyncDefer drops the defer entirely so the pooled
+		// slice leaks — the async-defer regression seed's production
+		// reintroduction.
 		driveStreamBody = append([]jen.Code{jen.Defer().Id("__releaseConverted").Call()}, driveStreamBody...)
 	}
 

--- a/adapters/common/codegen/codegen_methods.go
+++ b/adapters/common/codegen/codegen_methods.go
@@ -550,22 +550,15 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 			// closure operates on a disjoint pointer — but draining
 			// innermost-to-outermost mirrors the original allocation
 			// order and reads more naturally.)
-			//
-			// Seed_OmitOwnedNestedThread skips the per-param drain so
-			// inner pool releases never bubble up to the dispatch.
-			// The harness flips it to verify imbalance surfaces when
-			// the ownedNested wiring breaks.
-			if !me.g.opts.Seed_OmitOwnedNestedThread {
-				for _, p := range paramInfos {
-					if !p.needsOwnedNested {
-						continue
-					}
-					releaseBody = append(releaseBody,
-						jen.For(jen.List(jen.Id("_"), jen.Id("__release")).Op(":=").Range().Id(p.ownedNestedName)).Block(
-							jen.Id("__release").Call(),
-						),
-					)
+			for _, p := range paramInfos {
+				if !p.needsOwnedNested {
+					continue
 				}
+				releaseBody = append(releaseBody,
+					jen.For(jen.List(jen.Id("_"), jen.Id("__release")).Op(":=").Range().Id(p.ownedNestedName)).Block(
+						jen.Id("__release").Call(),
+					),
+				)
 			}
 			for _, p := range paramInfos {
 				if p.outerPool == nil {
@@ -634,9 +627,16 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 			// the call when the inner converter takes it. Shared by
 			// every branch so call sites and the converter signature
 			// stay in sync regardless of the param's outer wrapping.
+			//
+			// Seed_OmitOwnedNestedThread drops the threading at this
+			// call site — the converter signature still expects the
+			// param, so the rendered file fails to compile at the
+			// dispatch call. The harness observes a non-nil
+			// subprocess error from the build step, which is the
+			// "missing threading" bug class the seed name describes.
 			buildConvertArgs := func(vArg jen.Code) []jen.Code {
 				args := []jen.Code{jen.Id("adapter"), vArg}
-				if info.needsOwnedNested {
+				if info.needsOwnedNested && !me.g.opts.Seed_OmitOwnedNestedThread {
 					args = append(args, jen.Op("&").Id(info.ownedNestedName))
 				}
 				return args

--- a/adapters/common/codegen/codegen_methods.go
+++ b/adapters/common/codegen/codegen_methods.go
@@ -550,15 +550,22 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 			// closure operates on a disjoint pointer — but draining
 			// innermost-to-outermost mirrors the original allocation
 			// order and reads more naturally.)
-			for _, p := range paramInfos {
-				if !p.needsOwnedNested {
-					continue
+			//
+			// Seed_OmitOwnedNestedThread skips the per-param drain so
+			// inner pool releases never bubble up to the dispatch.
+			// The harness flips it to verify imbalance surfaces when
+			// the ownedNested wiring breaks.
+			if !me.g.opts.Seed_OmitOwnedNestedThread {
+				for _, p := range paramInfos {
+					if !p.needsOwnedNested {
+						continue
+					}
+					releaseBody = append(releaseBody,
+						jen.For(jen.List(jen.Id("_"), jen.Id("__release")).Op(":=").Range().Id(p.ownedNestedName)).Block(
+							jen.Id("__release").Call(),
+						),
+					)
 				}
-				releaseBody = append(releaseBody,
-					jen.For(jen.List(jen.Id("_"), jen.Id("__release")).Op(":=").Range().Id(p.ownedNestedName)).Block(
-						jen.Id("__release").Call(),
-					),
-				)
 			}
 			for _, p := range paramInfos {
 				if p.outerPool == nil {
@@ -600,7 +607,12 @@ func (me *methodEmitter) makePreambleWithArgs(optionsHelperName string, extraCal
 		// reference an undeclared identifier and fail to compile when
 		// hasReleaseConverted is false too).
 		releaseThenReturnError := func(returnStmt jen.Code) []jen.Code {
-			if me.hasReleaseConverted {
+			// Seed_OmitPhaseBRelease drops the explicit
+			// __releaseConverted() prepend so a Phase-B conv error
+			// leaks the Phase-A checkouts — the dispatch's deferred
+			// drain lives inside a goroutine that never starts on
+			// this path. Harness asserts the imbalance surfaces.
+			if me.hasReleaseConverted && !me.g.opts.Seed_OmitPhaseBRelease {
 				return []jen.Code{jen.Id("__releaseConverted").Call(), returnStmt}
 			}
 			return []jen.Code{returnStmt}

--- a/adapters/common/codegen/codegen_pool_lifecycle_test.go
+++ b/adapters/common/codegen/codegen_pool_lifecycle_test.go
@@ -93,18 +93,31 @@ func runLifecycleHarness(t *testing.T, opts Options, expectFail bool, label stri
 
 // summarizeInnerFails extracts the first few FAIL lines from inner
 // go test output so the regression-seed diagnostic stays compact.
-// Full output is omitted to keep -v noise manageable.
+// Full output is omitted to keep -v noise manageable. Recognises
+// both runtime FAIL lines (imbalance / zero-on-Put / barrier) and
+// build-step compiler errors (e.g. arg-count mismatches), since the
+// ownedNested-thread seed surfaces as a compile failure rather than
+// a runtime assertion.
 func summarizeInnerFails(stdout string) string {
 	const maxLines = 20
 	var fails []string
 	for _, line := range strings.Split(stdout, "\n") {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "--- FAIL:") || strings.Contains(trimmed, "imbalance") || strings.Contains(trimmed, "zero-on-Put") || strings.Contains(trimmed, "release fired before") {
-			fails = append(fails, trimmed)
-			if len(fails) >= maxLines {
-				fails = append(fails, "(truncated)")
-				break
-			}
+		switch {
+		case strings.HasPrefix(trimmed, "--- FAIL:"),
+			strings.Contains(trimmed, "imbalance"),
+			strings.Contains(trimmed, "zero-on-Put"),
+			strings.Contains(trimmed, "release fired before"),
+			strings.Contains(trimmed, "not enough arguments"),
+			strings.Contains(trimmed, "cannot use"),
+			strings.Contains(trimmed, "[build failed]"):
+		default:
+			continue
+		}
+		fails = append(fails, trimmed)
+		if len(fails) >= maxLines {
+			fails = append(fails, "(truncated)")
+			break
 		}
 	}
 	if len(fails) == 0 {

--- a/adapters/common/codegen/codegen_pool_lifecycle_test.go
+++ b/adapters/common/codegen/codegen_pool_lifecycle_test.go
@@ -166,8 +166,7 @@ func emitLifecycleMatrix(t *testing.T, opts Options) (string, []lifecycleCellMet
 
 	out := jen.NewFilePathName(pkgs.OutputPkg, pkgs.OutputPkgName)
 	tracker := newMirrorStructTracker()
-	pools := newSlicePoolTracker(pkgs, opts.EmitPoolAuditHooks)
-	pools.seedOmitZeroLoop = opts.Seed_OmitZeroLoop
+	pools := newSlicePoolTracker(pkgs, opts.EmitPoolAuditHooks, opts.Seed_OmitZeroLoop)
 
 	// Precompute ownedNested needs across the whole reachable graph.
 	// Same shape as the compile-matrix path. Without this the cycle

--- a/adapters/common/codegen/codegen_pool_lifecycle_test.go
+++ b/adapters/common/codegen/codegen_pool_lifecycle_test.go
@@ -81,13 +81,46 @@ func runLifecycleHarness(t *testing.T, opts Options, expectFail bool, label stri
 		if err == nil {
 			t.Fatalf("%s: inner go test passed but a regression seed should have made it FAIL — the bug class either no longer reproduces or the seed has drifted\n--- inner output ---\n%s", label, stdout)
 		}
-		// Diagnostic only — surfaced under `go test -v` so seed
-		// drift is visible without having to break the harness.
+		if !recognizedLifecycleRegression(label, stdout) {
+			t.Fatalf("%s: inner test failed but stdout does not match this seed's expected regression signature — the failure may be a harness wiring break or unrelated compile error, not the targeted bug class\n--- inner output ---\n%s\n--- error ---\n%v", label, stdout, err)
+		}
 		t.Logf("%s caught expected failures in inner output:\n%s", label, summarizeInnerFails(stdout))
 		return
 	}
 	if err != nil {
 		t.Fatalf("%s: inner go test failed unexpectedly\n--- inner output ---\n%s\n--- error ---\n%v", label, stdout, err)
+	}
+}
+
+// recognizedLifecycleRegression reports whether `stdout` from the
+// inner subprocess contains the failure signature unique to the
+// named seed. Pinning each seed to its own signature prevents a
+// harness-wiring break or unrelated compile error from masquerading
+// as a successful regression catch.
+func recognizedLifecycleRegression(seedName, stdout string) bool {
+	switch seedName {
+	case "Seed_OmitPhaseBRelease":
+		// Inner test asserts via poolaudit.Imbalanced() and logs
+		// "pool imbalance:" on Phase-B error paths whose Phase-A
+		// pool checkout never gets released.
+		return strings.Contains(stdout, "pool imbalance:")
+	case "Seed_OmitOwnedNestedThread":
+		// Rendered matrix no longer threads &__ownedNested_<name>,
+		// so the dispatch call site is short an argument and `go
+		// test` fails at the build step.
+		return strings.Contains(stdout, "not enough arguments in call to convert") &&
+			strings.Contains(stdout, "[build failed]")
+	case "Seed_OmitZeroLoop":
+		// putXSlice skips zeroing, so CheckZeroPrePut records a
+		// violation and the inner test reports it.
+		return strings.Contains(stdout, "zero-on-Put violations:")
+	case "Seed_OmitAsyncDefer":
+		// Production async sites move the release defer to the
+		// outer function body; the barrier test catches the
+		// pre-consume release.
+		return strings.Contains(stdout, "release fired before async barrier signal")
+	default:
+		return false
 	}
 }
 
@@ -801,6 +834,12 @@ func TestPoolLifecycle_Async(t *testing.T) {
 			}
 			if violations := poolaudit.ZeroOnPutViolations(); len(violations) > 0 {
 				t.Errorf("cell %q: zero-on-Put violations: %v", cell.Name, violations)
+			}
+			if cell.ExpectNoPoolForType != "" {
+				snap := poolaudit.Snapshot()
+				if _, has := snap.Checkouts[cell.ExpectNoPoolForType]; has {
+					t.Errorf("cell %q: expected no pool activity for type %q, got %v", cell.Name, cell.ExpectNoPoolForType, snap.Checkouts)
+				}
 			}
 		})
 	}

--- a/adapters/common/codegen/codegen_pool_lifecycle_test.go
+++ b/adapters/common/codegen/codegen_pool_lifecycle_test.go
@@ -185,9 +185,9 @@ func emitLifecycleMatrix(t *testing.T, opts Options) (string, []lifecycleCellMet
 		ptrElem   bool
 	}
 	nestedShapes := []nestedShape{
-		{tag: "a_value_elem", messageTy: reflect.TypeOf(fixtures.MessageA{}), classTy: reflect.TypeOf(fixtures.ClassA{}), otherTy: reflect.TypeOf(fixtures.OtherA{})},
-		{tag: "b_ptr_elem", messageTy: reflect.TypeOf(fixtures.MessageB{}), classTy: reflect.TypeOf(fixtures.ClassB{}), otherTy: reflect.TypeOf(fixtures.OtherB{}), ptrElem: true},
-		{tag: "c_two_pooled_types", messageTy: reflect.TypeOf(fixtures.MessageC{}), classTy: reflect.TypeOf(fixtures.ClassC{}), otherTy: reflect.TypeOf(fixtures.OtherC{})},
+		{tag: testharness.NestedValueElem.String(), messageTy: reflect.TypeOf(fixtures.MessageA{}), classTy: reflect.TypeOf(fixtures.ClassA{}), otherTy: reflect.TypeOf(fixtures.OtherA{})},
+		{tag: testharness.NestedPtrElem.String(), messageTy: reflect.TypeOf(fixtures.MessageB{}), classTy: reflect.TypeOf(fixtures.ClassB{}), otherTy: reflect.TypeOf(fixtures.OtherB{}), ptrElem: true},
+		{tag: testharness.NestedTwoPooledTypes.String(), messageTy: reflect.TypeOf(fixtures.MessageC{}), classTy: reflect.TypeOf(fixtures.ClassC{}), otherTy: reflect.TypeOf(fixtures.OtherC{})},
 	}
 
 	type topShape struct {
@@ -233,7 +233,12 @@ func emitLifecycleMatrix(t *testing.T, opts Options) (string, []lifecycleCellMet
 		}},
 	}
 
-	failModes := []string{"success", "fail_at_idx_0", "fail_at_idx_2", "fail_in_nested"}
+	failModes := []string{
+		testharness.FailureSuccess.String(),
+		testharness.FailureAtIdx0.String(),
+		testharness.FailureAtIdx2.String(),
+		testharness.FailureInNested.String(),
+	}
 
 	var cells []lifecycleCellMeta
 
@@ -327,13 +332,13 @@ func emitLifecycleSyncCell(
 	meta := lifecycleCellMeta{
 		Name:            cellName,
 		FailMode:        failMode,
-		ExpectError:     failMode != "success",
+		ExpectError:     failMode != testharness.FailureSuccess.String(),
 		Async:           false,
 		DispatchName:    dispatchName,
 		InputStructName: cellName + "Input",
 		NestedShapeTag:  nestedTag,
 	}
-	if nestedIsPtrElem && failMode == "success" {
+	if nestedIsPtrElem && failMode == testharness.FailureSuccess.String() {
 		meta.ExpectNoPoolForType = "ContentPartB"
 	}
 	return meta
@@ -382,11 +387,11 @@ func emitLifecycleCycleCell(
 	return lifecycleCellMeta{
 		Name:            cellName,
 		FailMode:        failMode,
-		ExpectError:     failMode != "success",
+		ExpectError:     failMode != testharness.FailureSuccess.String(),
 		Async:           false,
 		DispatchName:    dispatchName,
 		InputStructName: cellName + "Input",
-		NestedShapeTag:  "cycle",
+		NestedShapeTag:  testharness.NestedCycle.String(),
 	}
 }
 
@@ -477,7 +482,7 @@ func emitLifecycleAsyncCell(
 
 	meta := lifecycleCellMeta{
 		Name:            cellName,
-		FailMode:        "async_late_consume",
+		FailMode:        testharness.FailureAsyncLateConsume.String(),
 		ExpectError:     false,
 		Async:           true,
 		DispatchName:    dispatchName,

--- a/adapters/common/codegen/codegen_pool_lifecycle_test.go
+++ b/adapters/common/codegen/codegen_pool_lifecycle_test.go
@@ -95,9 +95,9 @@ func runLifecycleHarness(t *testing.T, opts Options, expectFail bool, label stri
 // go test output so the regression-seed diagnostic stays compact.
 // Full output is omitted to keep -v noise manageable. Recognises
 // both runtime FAIL lines (imbalance / zero-on-Put / barrier) and
-// build-step compiler errors (e.g. arg-count mismatches), since the
-// ownedNested-thread seed surfaces as a compile failure rather than
-// a runtime assertion.
+// build-step compiler errors (e.g. arg-count mismatches); the
+// ownedNested-thread seed surfaces as a compile failure, so the
+// summary has to cover the build-step output too.
 func summarizeInnerFails(stdout string) string {
 	const maxLines = 20
 	var fails []string

--- a/adapters/common/codegen/codegen_pool_lifecycle_test.go
+++ b/adapters/common/codegen/codegen_pool_lifecycle_test.go
@@ -1,0 +1,885 @@
+package codegen
+
+import (
+	"fmt"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dave/jennifer/jen"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/internal/fixtures"
+	"github.com/invakid404/baml-rest/adapters/common/codegen/internal/testharness"
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// TestPoolLifecycle is the runtime complement to TestCompileMatrix.
+// The compile matrix proves the rendered output type-checks; this
+// harness EXECUTES the rendered output against a controlled fake
+// adapter and asserts pool checkout / release balance + the zero-on-
+// Put invariant. It crosses the existing 21+cycle structural cells
+// with four sync failure modes (success, fail_at_idx_0, fail_at_idx_2,
+// fail_in_nested) plus three async barrier cells (one per nested
+// shape).
+//
+// Lifecycle assertions per cell:
+//   - The dispatch returns the expected outcome (nil on success, non-
+//     nil on failure injection).
+//   - poolaudit.Imbalanced() is empty.
+//   - poolaudit.ZeroOnPutViolations() is empty.
+//   - For b_ptr_elem success cells, poolaudit recorded zero pool
+//     activity — pointer-element shapes must skip the pool entirely.
+//
+// Inner failures bubble up as the captured `go test` output pinned
+// into the outer fatal message.
+func TestPoolLifecycle(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go binary not on PATH: %v", err)
+	}
+	runLifecycleHarness(t, Options{EmitPoolAuditHooks: true}, false, "lifecycle harness")
+}
+
+// TestPoolLifecycle_RegressionSeeds flips one regression seed at a
+// time and asserts the inner go test FAILS. A green inner run for any
+// seed means either the bug class is no longer reproducible at all
+// (so the harness lost coverage) or this seed has drifted out of sync
+// with the relevant emission path.
+func TestPoolLifecycle_RegressionSeeds(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go binary not on PATH: %v", err)
+	}
+
+	seeds := []struct {
+		name string
+		opts Options
+	}{
+		{name: "Seed_OmitPhaseBRelease", opts: Options{EmitPoolAuditHooks: true, Seed_OmitPhaseBRelease: true}},
+		{name: "Seed_OmitOwnedNestedThread", opts: Options{EmitPoolAuditHooks: true, Seed_OmitOwnedNestedThread: true}},
+		{name: "Seed_OmitZeroLoop", opts: Options{EmitPoolAuditHooks: true, Seed_OmitZeroLoop: true}},
+		{name: "Seed_OmitAsyncDefer", opts: Options{EmitPoolAuditHooks: true, Seed_OmitAsyncDefer: true}},
+	}
+	for _, s := range seeds {
+		s := s
+		t.Run(s.name, func(t *testing.T) {
+			runLifecycleHarness(t, s.opts, true, s.name)
+		})
+	}
+}
+
+func runLifecycleHarness(t *testing.T, opts Options, expectFail bool, label string) {
+	t.Helper()
+
+	rendered, _ := emitLifecycleMatrix(t, opts)
+	tmp := t.TempDir()
+	testharness.WriteTempModule(t, tmp, rendered, map[string]string{
+		"lifecycle_test.go": lifecycleTestTemplate,
+	})
+
+	stdout, err := testharness.RunGoTest(t, tmp, "")
+	if expectFail {
+		if err == nil {
+			t.Fatalf("%s: inner go test passed but a regression seed should have made it FAIL — the bug class either no longer reproduces or the seed has drifted\n--- inner output ---\n%s", label, stdout)
+		}
+		// Diagnostic only — surfaced under `go test -v` so seed
+		// drift is visible without having to break the harness.
+		t.Logf("%s caught expected failures in inner output:\n%s", label, summarizeInnerFails(stdout))
+		return
+	}
+	if err != nil {
+		t.Fatalf("%s: inner go test failed unexpectedly\n--- inner output ---\n%s\n--- error ---\n%v", label, stdout, err)
+	}
+}
+
+// summarizeInnerFails extracts the first few FAIL lines from inner
+// go test output so the regression-seed diagnostic stays compact.
+// Full output is omitted to keep -v noise manageable.
+func summarizeInnerFails(stdout string) string {
+	const maxLines = 20
+	var fails []string
+	for _, line := range strings.Split(stdout, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "--- FAIL:") || strings.Contains(trimmed, "imbalance") || strings.Contains(trimmed, "zero-on-Put") || strings.Contains(trimmed, "release fired before") {
+			fails = append(fails, trimmed)
+			if len(fails) >= maxLines {
+				fails = append(fails, "(truncated)")
+				break
+			}
+		}
+	}
+	if len(fails) == 0 {
+		return "(no recognised failure lines — inner stdout may have a new format)"
+	}
+	return strings.Join(fails, "\n")
+}
+
+// lifecycleCellMeta is the test-author view of one rendered cell.
+// Returned by emitLifecycleMatrix and consumed by emitCellRegistry to
+// build the SyncLifecycleCells / AsyncLifecycleCells var blocks in the
+// rendered matrix.
+type lifecycleCellMeta struct {
+	Name string
+	// FailMode tags the cell with its configured adapter failure
+	// mode: "success", "fail_at_idx_0", "fail_at_idx_2",
+	// "fail_in_nested", or "async_late_consume" (async cells).
+	FailMode    string
+	ExpectError bool
+	// ExpectNoPoolForType, when non-empty, asserts the given audit
+	// type name does NOT appear in poolaudit.Checkouts after the
+	// dispatch returns. Set to "ContentPartB" for b_ptr_elem cells
+	// under success mode — the pointer-element fallback path must
+	// not touch the nested pool. (The OUTER MessageB slice is
+	// still pooled because its element type is a value struct;
+	// only ContentPartB is exempt.)
+	ExpectNoPoolForType string
+	Async               bool
+	DispatchName        string
+	InputStructName     string
+	NestedShapeTag      string
+}
+
+type paramSpec struct {
+	name string
+	ty   reflect.Type
+}
+
+func emitLifecycleMatrix(t *testing.T, opts Options) (string, []lifecycleCellMeta) {
+	t.Helper()
+
+	pkgs := DefaultPackageConfig()
+	pkgs.BamlPkg = reflect.TypeOf(fixtures.Image{}).PkgPath()
+	pkgs.OutputPkg = "github.com/invakid404/baml-rest/adapters/common/codegen/matrixtest"
+	pkgs.OutputPkgName = "matrix"
+
+	out := jen.NewFilePathName(pkgs.OutputPkg, pkgs.OutputPkgName)
+	tracker := newMirrorStructTracker()
+	pools := newSlicePoolTracker(pkgs, opts.EmitPoolAuditHooks)
+	pools.seedOmitZeroLoop = opts.Seed_OmitZeroLoop
+
+	// Precompute ownedNested needs across the whole reachable graph.
+	// Same shape as the compile-matrix path. Without this the cycle
+	// cell's emission would race itself.
+	var precomputeRoots []reflect.Type
+	for _, ty := range []reflect.Type{
+		reflect.TypeOf(fixtures.MessageA{}),
+		reflect.TypeOf(fixtures.MessageB{}),
+		reflect.TypeOf(fixtures.MessageC{}),
+		reflect.TypeOf(fixtures.ClassA{}),
+		reflect.TypeOf(fixtures.ClassB{}),
+		reflect.TypeOf(fixtures.ClassC{}),
+		reflect.TypeOf(fixtures.OtherA{}),
+		reflect.TypeOf(fixtures.OtherB{}),
+		reflect.TypeOf(fixtures.OtherC{}),
+		reflect.TypeOf(fixtures.CycleA{}),
+		reflect.TypeOf(fixtures.CycleB{}),
+	} {
+		precomputeRoots = append(precomputeRoots, ty)
+	}
+	tracker.precomputeOwnedNestedNeeds(precomputeRoots, pkgs)
+
+	type nestedShape struct {
+		tag       string
+		messageTy reflect.Type
+		classTy   reflect.Type
+		otherTy   reflect.Type
+		ptrElem   bool
+	}
+	nestedShapes := []nestedShape{
+		{tag: "a_value_elem", messageTy: reflect.TypeOf(fixtures.MessageA{}), classTy: reflect.TypeOf(fixtures.ClassA{}), otherTy: reflect.TypeOf(fixtures.OtherA{})},
+		{tag: "b_ptr_elem", messageTy: reflect.TypeOf(fixtures.MessageB{}), classTy: reflect.TypeOf(fixtures.ClassB{}), otherTy: reflect.TypeOf(fixtures.OtherB{}), ptrElem: true},
+		{tag: "c_two_pooled_types", messageTy: reflect.TypeOf(fixtures.MessageC{}), classTy: reflect.TypeOf(fixtures.ClassC{}), otherTy: reflect.TypeOf(fixtures.OtherC{})},
+	}
+
+	type topShape struct {
+		name        string
+		buildParams func(messageTy, classTy, otherTy reflect.Type) []paramSpec
+	}
+	topShapes := []topShape{
+		{name: "1_pooled_baseline", buildParams: func(messageTy, _, _ reflect.Type) []paramSpec {
+			return []paramSpec{{name: "messages", ty: reflect.SliceOf(messageTy)}}
+		}},
+		{name: "2_two_pooled_params", buildParams: func(messageTy, classTy, _ reflect.Type) []paramSpec {
+			return []paramSpec{
+				{name: "messages", ty: reflect.SliceOf(messageTy)},
+				{name: "classes", ty: reflect.SliceOf(classTy)},
+			}
+		}},
+		{name: "3_pooled_plus_slice_of_ptr", buildParams: func(messageTy, _, otherTy reflect.Type) []paramSpec {
+			return []paramSpec{
+				{name: "messages", ty: reflect.SliceOf(messageTy)},
+				{name: "extra", ty: reflect.SliceOf(reflect.PointerTo(otherTy))},
+			}
+		}},
+		{name: "4_pooled_plus_ptr_to_slice", buildParams: func(messageTy, _, otherTy reflect.Type) []paramSpec {
+			return []paramSpec{
+				{name: "messages", ty: reflect.SliceOf(messageTy)},
+				{name: "extra", ty: reflect.PointerTo(reflect.SliceOf(otherTy))},
+			}
+		}},
+		{name: "5_pooled_plus_ptr", buildParams: func(messageTy, _, otherTy reflect.Type) []paramSpec {
+			return []paramSpec{
+				{name: "messages", ty: reflect.SliceOf(messageTy)},
+				{name: "extra", ty: reflect.PointerTo(otherTy)},
+			}
+		}},
+		{name: "6_pooled_plus_direct", buildParams: func(messageTy, _, otherTy reflect.Type) []paramSpec {
+			return []paramSpec{
+				{name: "messages", ty: reflect.SliceOf(messageTy)},
+				{name: "extra", ty: otherTy},
+			}
+		}},
+		{name: "7_single_non_pooled_ptr", buildParams: func(_, _, otherTy reflect.Type) []paramSpec {
+			return []paramSpec{{name: "extra", ty: reflect.PointerTo(otherTy)}}
+		}},
+	}
+
+	failModes := []string{"success", "fail_at_idx_0", "fail_at_idx_2", "fail_in_nested"}
+
+	var cells []lifecycleCellMeta
+
+	for topIdx, top := range topShapes {
+		for nestedIdx, nested := range nestedShapes {
+			for _, failMode := range failModes {
+				cellIdx := topIdx*len(nestedShapes) + nestedIdx
+				cellName := fmt.Sprintf("cell_%02d_%s_%s_%s", cellIdx, top.name, nested.tag, failMode)
+				params := top.buildParams(nested.messageTy, nested.classTy, nested.otherTy)
+				meta := emitLifecycleSyncCell(out, tracker, pools, pkgs, opts, cellName, params, nested.tag, nested.ptrElem, failMode)
+				cells = append(cells, meta)
+			}
+		}
+	}
+
+	for _, failMode := range failModes {
+		meta := emitLifecycleCycleCell(out, tracker, pools, pkgs, opts, failMode)
+		cells = append(cells, meta)
+	}
+
+	for nestedIdx, nested := range nestedShapes {
+		cellName := fmt.Sprintf("cell_async_%02d_%s", nestedIdx, nested.tag)
+		params := topShapes[0].buildParams(nested.messageTy, nested.classTy, nested.otherTy)
+		meta := emitLifecycleAsyncCell(out, tracker, pools, pkgs, opts, cellName, params, nested.tag, nested.ptrElem)
+		cells = append(cells, meta)
+	}
+
+	out.Func().Id("makeOptionsFromAdapter").
+		Params(jen.Id("adapter").Qual(pkgs.InterfacesPkg, "Adapter")).
+		Params(jen.Index().Any(), jen.Error()).
+		Block(jen.Return(jen.Nil(), jen.Nil()))
+
+	emitCellRegistry(out, pkgs, cells)
+
+	return out.GoString(), cells
+}
+
+func emitLifecycleSyncCell(
+	out *jen.File,
+	tracker *mirrorStructTracker,
+	pools *slicePoolTracker,
+	pkgs PackageConfig,
+	opts Options,
+	cellName string,
+	params []paramSpec,
+	nestedTag string,
+	nestedIsPtrElem bool,
+	failMode string,
+) lifecycleCellMeta {
+	smps := make([]structMediaParam, 0, len(params))
+	paramTypes := make([]reflect.Type, 0, len(params))
+	for _, p := range params {
+		mirrorName := tracker.ensureMirrorStruct(out, p.ty, pkgs, pools)
+		smps = append(smps, structMediaParam{
+			paramName:   p.name,
+			mirrorName:  mirrorName,
+			convertFunc: "convert" + mirrorName,
+			paramType:   p.ty,
+		})
+		paramTypes = append(paramTypes, p.ty)
+	}
+
+	me := newLifecycleMethodEmitter(out, tracker, pools, pkgs, opts, cellName, smps, paramTypes)
+	preamble := me.makePreambleWithArgs("makeOptionsFromAdapter")
+
+	tail := []jen.Code{jen.Id("_").Op("=").Id("options")}
+	for _, smp := range smps {
+		tail = append(tail, jen.Id("_").Op("=").Id("__struct_"+smp.paramName))
+	}
+	if me.hasReleaseConverted {
+		// Mirror what production's body callback / goroutine
+		// achieves via the deferred release at its successful exit.
+		// Phase B errors call __releaseConverted() explicitly via
+		// releaseThenReturnError; this is the happy-path exit.
+		tail = append(tail, jen.Id("__releaseConverted").Call())
+	}
+	tail = append(tail, jen.Return(jen.Nil()))
+
+	body := append([]jen.Code{}, preamble...)
+	body = append(body, tail...)
+
+	dispatchName := cellName + "_dispatch"
+	out.Func().Id(dispatchName).
+		Params(
+			jen.Id("adapter").Qual(pkgs.InterfacesPkg, "Adapter"),
+			jen.Id("rawInput").Any(),
+		).
+		Error().
+		Block(body...)
+
+	meta := lifecycleCellMeta{
+		Name:            cellName,
+		FailMode:        failMode,
+		ExpectError:     failMode != "success",
+		Async:           false,
+		DispatchName:    dispatchName,
+		InputStructName: cellName + "Input",
+		NestedShapeTag:  nestedTag,
+	}
+	if nestedIsPtrElem && failMode == "success" {
+		meta.ExpectNoPoolForType = "ContentPartB"
+	}
+	return meta
+}
+
+func emitLifecycleCycleCell(
+	out *jen.File,
+	tracker *mirrorStructTracker,
+	pools *slicePoolTracker,
+	pkgs PackageConfig,
+	opts Options,
+	failMode string,
+) lifecycleCellMeta {
+	cycleAType := reflect.TypeOf(fixtures.CycleA{})
+	mirrorName := tracker.ensureMirrorStruct(out, cycleAType, pkgs, pools)
+	paramType := reflect.SliceOf(cycleAType)
+	smps := []structMediaParam{{
+		paramName:   "cycles",
+		mirrorName:  mirrorName,
+		convertFunc: "convert" + mirrorName,
+		paramType:   paramType,
+	}}
+	cellName := fmt.Sprintf("cell_cycle_mutually_recursive_%s", failMode)
+	me := newLifecycleMethodEmitter(out, tracker, pools, pkgs, opts, cellName, smps, []reflect.Type{paramType})
+	preamble := me.makePreambleWithArgs("makeOptionsFromAdapter")
+	tail := []jen.Code{
+		jen.Id("_").Op("=").Id("options"),
+		jen.Id("_").Op("=").Id("__struct_cycles"),
+	}
+	if me.hasReleaseConverted {
+		tail = append(tail, jen.Id("__releaseConverted").Call())
+	}
+	tail = append(tail, jen.Return(jen.Nil()))
+	body := append([]jen.Code{}, preamble...)
+	body = append(body, tail...)
+
+	dispatchName := cellName + "_dispatch"
+	out.Func().Id(dispatchName).
+		Params(
+			jen.Id("adapter").Qual(pkgs.InterfacesPkg, "Adapter"),
+			jen.Id("rawInput").Any(),
+		).
+		Error().
+		Block(body...)
+
+	return lifecycleCellMeta{
+		Name:            cellName,
+		FailMode:        failMode,
+		ExpectError:     failMode != "success",
+		Async:           false,
+		DispatchName:    dispatchName,
+		InputStructName: cellName + "Input",
+		NestedShapeTag:  "cycle",
+	}
+}
+
+func emitLifecycleAsyncCell(
+	out *jen.File,
+	tracker *mirrorStructTracker,
+	pools *slicePoolTracker,
+	pkgs PackageConfig,
+	opts Options,
+	cellName string,
+	params []paramSpec,
+	nestedTag string,
+	nestedIsPtrElem bool,
+) lifecycleCellMeta {
+	smps := make([]structMediaParam, 0, len(params))
+	paramTypes := make([]reflect.Type, 0, len(params))
+	for _, p := range params {
+		mirrorName := tracker.ensureMirrorStruct(out, p.ty, pkgs, pools)
+		smps = append(smps, structMediaParam{
+			paramName:   p.name,
+			mirrorName:  mirrorName,
+			convertFunc: "convert" + mirrorName,
+			paramType:   p.ty,
+		})
+		paramTypes = append(paramTypes, p.ty)
+	}
+
+	me := newLifecycleMethodEmitter(out, tracker, pools, pkgs, opts, cellName, smps, paramTypes)
+	preamble := me.makePreambleWithArgs("makeOptionsFromAdapter")
+
+	preambleTail := []jen.Code{jen.Id("_").Op("=").Id("options")}
+	for _, smp := range smps {
+		preambleTail = append(preambleTail, jen.Id("_").Op("=").Id("__struct_"+smp.paramName))
+	}
+
+	// AsyncWait is the test's signal/wait barrier — the goroutine
+	// closes the adapter's `asyncStart` channel, then blocks on
+	// `asyncCont`. The test reads from asyncStart to know the
+	// goroutine entered, snapshots release counts (asserts 0),
+	// then closes asyncCont. Correct emission defers
+	// __releaseConverted inside the goroutine; the bug seed fires
+	// it synchronously before the goroutine starts so the snapshot
+	// already sees a release.
+	barrierWait := []jen.Code{
+		jen.If(
+			jen.List(jen.Id("b"), jen.Id("ok")).Op(":=").Id("adapter").Assert(jen.Id("asyncBarrierAdapter")),
+			jen.Id("ok"),
+		).Block(
+			jen.Id("b").Dot("AsyncWait").Call(),
+		),
+	}
+
+	// The dispatch takes the `done` channel from the caller so the
+	// preamble's Phase B `return fmt.Errorf(...)` paths match the
+	// outer signature (single error return). The goroutine closes
+	// `done` after the barrier so the test can synchronise on
+	// completion.
+	goroutineBody := []jen.Code{
+		jen.Defer().Id("close").Call(jen.Id("done")),
+	}
+	if me.hasReleaseConverted && !opts.Seed_OmitAsyncDefer {
+		goroutineBody = append(goroutineBody, jen.Defer().Id("__releaseConverted").Call())
+	}
+	goroutineBody = append(goroutineBody, barrierWait...)
+
+	asyncBody := append([]jen.Code{}, preamble...)
+	asyncBody = append(asyncBody, preambleTail...)
+	if me.hasReleaseConverted && opts.Seed_OmitAsyncDefer {
+		// Buggy ordering — release fires before the goroutine reads
+		// the converted slice. The barrier test reports the release
+		// count is non-zero after asyncStart, catching the bug.
+		asyncBody = append(asyncBody, jen.Id("__releaseConverted").Call())
+	}
+	asyncBody = append(asyncBody,
+		jen.Go().Func().Params().Block(goroutineBody...).Call(),
+		jen.Return(jen.Nil()),
+	)
+
+	dispatchName := cellName + "_async_dispatch"
+	out.Func().Id(dispatchName).
+		Params(
+			jen.Id("adapter").Qual(pkgs.InterfacesPkg, "Adapter"),
+			jen.Id("rawInput").Any(),
+			jen.Id("done").Chan().Struct(),
+		).
+		Error().
+		Block(asyncBody...)
+
+	meta := lifecycleCellMeta{
+		Name:            cellName,
+		FailMode:        "async_late_consume",
+		ExpectError:     false,
+		Async:           true,
+		DispatchName:    dispatchName,
+		InputStructName: cellName + "Input",
+		NestedShapeTag:  nestedTag,
+	}
+	if nestedIsPtrElem {
+		meta.ExpectNoPoolForType = "ContentPartB"
+	}
+	return meta
+}
+
+// newLifecycleMethodEmitter constructs a synthetic methodEmitter whose
+// generator carries the regression-seed Options. The matrix uses
+// methodEmitter directly because the lifecycle dispatcher reuses the
+// production Phase A / Phase B preamble emission unchanged — what
+// differs is the dispatch wrapper around it and the seed flags
+// methodEmitter consults via me.g.opts.
+func newLifecycleMethodEmitter(
+	out *jen.File,
+	tracker *mirrorStructTracker,
+	pools *slicePoolTracker,
+	pkgs PackageConfig,
+	opts Options,
+	cellName string,
+	smps []structMediaParam,
+	paramTypes []reflect.Type,
+) *methodEmitter {
+	merged := opts
+	merged.SupportsWithClient = true
+	merged.Packages = pkgs
+	merged.Introspection = RootIntrospection()
+	g := &generator{
+		opts:                 merged,
+		pkgs:                 pkgs,
+		intro:                RootIntrospection(),
+		out:                  out,
+		supportsWithClient:   true,
+		mirrors:              tracker,
+		emittedUnwrapHelpers: map[string]bool{},
+		slicePools:           pools,
+	}
+	args := make([]string, 0, len(smps))
+	for _, smp := range smps {
+		args = append(args, smp.paramName)
+	}
+	me := &methodEmitter{
+		g:                 g,
+		methodName:        cellName,
+		args:              args,
+		syncFuncType:      synthSyncFuncType(paramTypes),
+		methodMediaParams: map[string]bamlutils.MediaKind{},
+		structMediaParams: smps,
+		inputStructName:   cellName + "Input",
+	}
+	me.structMediaParamSet = make(map[string]bool, len(smps))
+	for _, smp := range smps {
+		me.structMediaParamSet[smp.paramName] = true
+	}
+	var fields []jen.Code
+	for _, smp := range smps {
+		fields = append(fields, jen.Id(upperCamelForMatrix(smp.paramName)).Add(mirrorFieldType(smp.paramType, smp.mirrorName)))
+	}
+	out.Type().Id(me.inputStructName).Struct(fields...)
+	return me
+}
+
+// emitCellRegistry writes the asyncBarrierAdapter interface, the
+// SyncLifecycleCell / AsyncLifecycleCell record types, and the two
+// iteration tables. lifecycle_test.go consumes them by name.
+func emitCellRegistry(out *jen.File, pkgs PackageConfig, cells []lifecycleCellMeta) {
+	out.Type().Id("asyncBarrierAdapter").Interface(
+		jen.Id("AsyncWait").Params(),
+	)
+
+	out.Type().Id("SyncLifecycleCell").Struct(
+		jen.Id("Name").String(),
+		jen.Id("FailMode").String(),
+		jen.Id("ExpectError").Bool(),
+		jen.Id("ExpectNoPoolForType").String(),
+		jen.Id("NestedShapeTag").String(),
+		jen.Id("Dispatch").Func().Params(jen.Qual(pkgs.InterfacesPkg, "Adapter"), jen.Any()).Error(),
+		jen.Id("InputType").Qual("reflect", "Type"),
+	)
+
+	out.Type().Id("AsyncLifecycleCell").Struct(
+		jen.Id("Name").String(),
+		jen.Id("ExpectError").Bool(),
+		jen.Id("ExpectNoPoolForType").String(),
+		jen.Id("NestedShapeTag").String(),
+		jen.Id("Dispatch").Func().Params(jen.Qual(pkgs.InterfacesPkg, "Adapter"), jen.Any(), jen.Chan().Struct()).Error(),
+		jen.Id("InputType").Qual("reflect", "Type"),
+	)
+
+	var syncEntries, asyncEntries []jen.Code
+	for _, c := range cells {
+		if c.Async {
+			asyncEntries = append(asyncEntries, jen.Values(jen.Dict{
+				jen.Id("Name"):                jen.Lit(c.Name),
+				jen.Id("ExpectError"):         jen.Lit(c.ExpectError),
+				jen.Id("ExpectNoPoolForType"): jen.Lit(c.ExpectNoPoolForType),
+				jen.Id("NestedShapeTag"):      jen.Lit(c.NestedShapeTag),
+				jen.Id("Dispatch"):            jen.Id(c.DispatchName),
+				jen.Id("InputType"):           jen.Qual("reflect", "TypeOf").Call(jen.Id(c.InputStructName).Values()),
+			}))
+		} else {
+			syncEntries = append(syncEntries, jen.Values(jen.Dict{
+				jen.Id("Name"):                jen.Lit(c.Name),
+				jen.Id("FailMode"):            jen.Lit(c.FailMode),
+				jen.Id("ExpectError"):         jen.Lit(c.ExpectError),
+				jen.Id("ExpectNoPoolForType"): jen.Lit(c.ExpectNoPoolForType),
+				jen.Id("NestedShapeTag"):      jen.Lit(c.NestedShapeTag),
+				jen.Id("Dispatch"):            jen.Id(c.DispatchName),
+				jen.Id("InputType"):           jen.Qual("reflect", "TypeOf").Call(jen.Id(c.InputStructName).Values()),
+			}))
+		}
+	}
+
+	out.Var().Id("SyncLifecycleCells").Op("=").Index().Id("SyncLifecycleCell").Values(syncEntries...)
+	out.Var().Id("AsyncLifecycleCells").Op("=").Index().Id("AsyncLifecycleCell").Values(asyncEntries...)
+}
+
+// lifecycleTestTemplate is the source for lifecycle_test.go shipped
+// into the temp module. It declares a fakeAdapter modelled on
+// bamlutils/buildrequest/resolve_test.go's mockAdapter, the reflect-
+// driven input builder, and the two table-driven test bodies.
+const lifecycleTestTemplate = `package matrix
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/internal/fixtures"
+	"github.com/invakid404/baml-rest/adapters/common/codegen/internal/poolaudit"
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
+)
+
+// fakeAdapter satisfies bamlutils.Adapter for the lifecycle tests.
+// The only methods the generated converters reach are
+// NewMediaFromURL / NewMediaFromBase64 (via bamlutils.ConvertMedia);
+// the rest of the surface returns trivially-safe defaults.
+type fakeAdapter struct {
+	context.Context
+	mu        sync.Mutex
+	callCount int
+	failAt    int
+	// asyncStart fires when the goroutine has entered AsyncWait.
+	// The test reads it to gate the pre-barrier snapshot, avoiding
+	// the sleep-based timing that goes flaky under -race.
+	asyncStart chan struct{}
+	// asyncCont is closed by the test to let the goroutine proceed
+	// past the barrier and exit.
+	asyncCont chan struct{}
+}
+
+func newFakeAdapter(failAt int) *fakeAdapter {
+	return &fakeAdapter{Context: context.Background(), failAt: failAt}
+}
+
+func newAsyncFakeAdapter() *fakeAdapter {
+	return &fakeAdapter{
+		Context:    context.Background(),
+		asyncStart: make(chan struct{}),
+		asyncCont:  make(chan struct{}),
+	}
+}
+
+func (a *fakeAdapter) AsyncWait() {
+	close(a.asyncStart)
+	<-a.asyncCont
+}
+
+func (a *fakeAdapter) NewMediaFromURL(_ bamlutils.MediaKind, _ string, _ *string) (any, error) {
+	a.mu.Lock()
+	a.callCount++
+	c := a.callCount
+	a.mu.Unlock()
+	if a.failAt > 0 && c == a.failAt {
+		return nil, errors.New("fakeAdapter: injected failure")
+	}
+	return fixtures.Image{}, nil
+}
+
+func (a *fakeAdapter) NewMediaFromBase64(kind bamlutils.MediaKind, b64 string, mt *string) (any, error) {
+	return a.NewMediaFromURL(kind, "data:"+b64, mt)
+}
+
+func (a *fakeAdapter) SetClientRegistry(*bamlutils.ClientRegistry) error    { return nil }
+func (a *fakeAdapter) SetTypeBuilder(*bamlutils.TypeBuilder) error          { return nil }
+func (a *fakeAdapter) SetStreamMode(bamlutils.StreamMode)                   {}
+func (a *fakeAdapter) StreamMode() bamlutils.StreamMode                     { return 0 }
+func (a *fakeAdapter) SetLogger(bamlutils.Logger)                           {}
+func (a *fakeAdapter) Logger() bamlutils.Logger                             { return nil }
+func (a *fakeAdapter) SetRetryConfig(*bamlutils.RetryConfig)                {}
+func (a *fakeAdapter) RetryConfig() *bamlutils.RetryConfig                  { return nil }
+func (a *fakeAdapter) SetIncludeReasoning(bool)                             {}
+func (a *fakeAdapter) IncludeReasoning() bool                               { return false }
+func (a *fakeAdapter) ClientRegistryProvider() string                       { return "" }
+func (a *fakeAdapter) OriginalClientRegistry() *bamlutils.ClientRegistry    { return nil }
+func (a *fakeAdapter) HTTPClient() *llmhttp.Client                          { return nil }
+func (a *fakeAdapter) SetHTTPClient(*llmhttp.Client)                        {}
+func (a *fakeAdapter) SetBuildRequestConfig(bamlutils.BuildRequestConfig)   {}
+func (a *fakeAdapter) BuildRequestConfig() bamlutils.BuildRequestConfig {
+	return bamlutils.BuildRequestConfig{}
+}
+func (a *fakeAdapter) SetRoundRobinAdvancer(bamlutils.RoundRobinAdvancer)   {}
+func (a *fakeAdapter) RoundRobinAdvancer() bamlutils.RoundRobinAdvancer     { return nil }
+
+// TestPoolLifecycle drives the sync cell table.
+func TestPoolLifecycle(t *testing.T) {
+	for _, cell := range SyncLifecycleCells {
+		cell := cell
+		t.Run(cell.Name, func(t *testing.T) {
+			poolaudit.Reset()
+			t.Cleanup(poolaudit.Reset)
+
+			failAt := pickFailAt(cell.FailMode)
+			adapter := newFakeAdapter(failAt)
+			rawInput := buildInputFor(cell.InputType, 3)
+
+			err := cell.Dispatch(adapter, rawInput)
+			if cell.ExpectError && err == nil {
+				t.Errorf("cell %q (failMode=%s): expected error, got nil", cell.Name, cell.FailMode)
+			}
+			if !cell.ExpectError && err != nil {
+				t.Errorf("cell %q (failMode=%s): expected success, got %v", cell.Name, cell.FailMode, err)
+			}
+
+			if imbalances := poolaudit.Imbalanced(); len(imbalances) > 0 {
+				t.Errorf("cell %q: pool imbalance: %v", cell.Name, imbalances)
+			}
+			if violations := poolaudit.ZeroOnPutViolations(); len(violations) > 0 {
+				t.Errorf("cell %q: zero-on-Put violations: %v", cell.Name, violations)
+			}
+			if cell.ExpectNoPoolForType != "" {
+				snap := poolaudit.Snapshot()
+				if _, ok := snap.Checkouts[cell.ExpectNoPoolForType]; ok {
+					t.Errorf("cell %q: expected no pool activity for type %q, got %v", cell.Name, cell.ExpectNoPoolForType, snap.Checkouts)
+				}
+			}
+		})
+	}
+}
+
+// pickFailAt maps the failure-mode tag to the 1-based ConvertMedia
+// call index the fake adapter fails on. 0 disables injection.
+func pickFailAt(failMode string) int {
+	switch failMode {
+	case "fail_at_idx_0":
+		return 1
+	case "fail_at_idx_2":
+		return 3
+	case "fail_in_nested":
+		// Cells with nested converters exercise their inner pools
+		// via ConvertMedia too — failing on call 3 falls inside a
+		// per-message inner loop for the 3-element builder.
+		return 3
+	}
+	return 0
+}
+
+// TestPoolLifecycle_Async drives the async barrier cells.
+func TestPoolLifecycle_Async(t *testing.T) {
+	for _, cell := range AsyncLifecycleCells {
+		cell := cell
+		t.Run(cell.Name, func(t *testing.T) {
+			poolaudit.Reset()
+			t.Cleanup(poolaudit.Reset)
+
+			adapter := newAsyncFakeAdapter()
+			rawInput := buildInputFor(cell.InputType, 3)
+
+			done := make(chan struct{})
+			err := cell.Dispatch(adapter, rawInput, done)
+			if err != nil {
+				t.Fatalf("cell %q: async dispatch error: %v", cell.Name, err)
+			}
+
+			<-adapter.asyncStart
+
+			snap := poolaudit.Snapshot()
+			totalReleases := 0
+			for _, n := range snap.Releases {
+				totalReleases += n
+			}
+			// For b_ptr_elem cells the nested pool isn't touched,
+			// but the outer MessageB pool still is. The barrier
+			// invariant is: no RELEASE has fired (still in the
+			// goroutine waiting). totalReleases must be 0 in both
+			// shapes — ExpectNoPoolForType is incidental here.
+			if totalReleases > 0 {
+				t.Errorf("cell %q: release fired before async barrier signal: releases=%v", cell.Name, snap.Releases)
+			}
+
+			close(adapter.asyncCont)
+			<-done
+
+			if imbalances := poolaudit.Imbalanced(); len(imbalances) > 0 {
+				t.Errorf("cell %q: pool imbalance after async dispatch: %v", cell.Name, imbalances)
+			}
+			if violations := poolaudit.ZeroOnPutViolations(); len(violations) > 0 {
+				t.Errorf("cell %q: zero-on-Put violations: %v", cell.Name, violations)
+			}
+		})
+	}
+}
+
+// buildInputFor reflects over the cell's input struct and populates
+// it with sliceN elements per slice field, each leaf
+// *bamlutils.MediaInput pointing at a stub URL so the generated
+// converter's ConvertMedia call returns a non-nil image.
+func buildInputFor(t reflect.Type, sliceN int) any {
+	v := reflect.New(t)
+	buildMirrorValue(v.Elem(), sliceN, 0)
+	return v.Interface()
+}
+
+// maxBuildDepth is the recursion cap for the reflect-driven input
+// builder. Set tight enough to cut the mutually-recursive cycle
+// fixture (CycleA → CycleB → CycleA) at the second hop while still
+// reaching the leaf *bamlutils.MediaInput pointer in the deeper
+// pooled-nested shapes. The depth budget counts both
+// populateField -> buildMirrorValue and populateSliceElem ->
+// buildMirrorValue transitions, so a value: Input(0) → Messages
+// field(1) → MessageA elem(2) → Parts field(3) → ContentPartA
+// elem(4) → Img field(5) reaches the media leaf only when the cap
+// is >= 4.
+const maxBuildDepth = 4
+
+func buildMirrorValue(v reflect.Value, sliceN, depth int) {
+	if depth > maxBuildDepth {
+		return
+	}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		ft := t.Field(i)
+		if !ft.IsExported() {
+			continue
+		}
+		populateField(v.Field(i), sliceN, depth+1)
+	}
+}
+
+func populateField(fv reflect.Value, sliceN, depth int) {
+	t := fv.Type()
+	switch t.Kind() {
+	case reflect.Ptr:
+		elem := t.Elem()
+		switch elem.Kind() {
+		case reflect.Slice:
+			slice := reflect.MakeSlice(elem, sliceN, sliceN)
+			for i := 0; i < sliceN; i++ {
+				populateSliceElem(slice.Index(i), depth)
+			}
+			ptr := reflect.New(elem)
+			ptr.Elem().Set(slice)
+			fv.Set(ptr)
+		case reflect.Struct:
+			if isMediaInputType(elem) {
+				url := "https://example.test/img.png"
+				fv.Set(reflect.ValueOf(&bamlutils.MediaInput{URL: &url}))
+				return
+			}
+			ptr := reflect.New(elem)
+			buildMirrorValue(ptr.Elem(), sliceN, depth)
+			fv.Set(ptr)
+		}
+	case reflect.Slice:
+		slice := reflect.MakeSlice(t, sliceN, sliceN)
+		for i := 0; i < sliceN; i++ {
+			populateSliceElem(slice.Index(i), depth)
+		}
+		fv.Set(slice)
+	case reflect.Struct:
+		if isMediaInputType(t) {
+			url := "https://example.test/img.png"
+			fv.Set(reflect.ValueOf(bamlutils.MediaInput{URL: &url}))
+			return
+		}
+		buildMirrorValue(fv, sliceN, depth)
+	}
+}
+
+func populateSliceElem(ev reflect.Value, depth int) {
+	switch ev.Kind() {
+	case reflect.Ptr:
+		elem := ev.Type().Elem()
+		ptr := reflect.New(elem)
+		if elem.Kind() == reflect.Struct {
+			buildMirrorValue(ptr.Elem(), 1, depth+1)
+		}
+		ev.Set(ptr)
+	case reflect.Struct:
+		buildMirrorValue(ev, 1, depth+1)
+	}
+}
+
+func isMediaInputType(t reflect.Type) bool {
+	return t.Name() == "MediaInput" && t.PkgPath() == "github.com/invakid404/baml-rest/bamlutils"
+}
+`

--- a/adapters/common/codegen/codegen_slice_pool.go
+++ b/adapters/common/codegen/codegen_slice_pool.go
@@ -7,6 +7,13 @@ import (
 	"github.com/dave/jennifer/jen"
 )
 
+// poolAuditPkg is the import path of the test-only poolaudit hooks
+// package. Referenced only when slicePoolTracker.audit is true, which
+// only the lifecycle harness flips. Sits behind a constant so the
+// rendered import is identical across cells without threading a
+// PackageConfig field through every test.
+const poolAuditPkg = "github.com/invakid404/baml-rest/adapters/common/codegen/internal/poolaudit"
+
 // slicePoolNames captures the symbol names emitted for a single pooled
 // slice type. Tracked centrally so emitters and call sites stay in
 // lockstep; one entry covers `[]T` where T is the unwrapped BAML
@@ -33,18 +40,26 @@ type slicePoolNames struct {
 // Names are deterministic functions of the unwrapped BAML type name so
 // repeat encounters reuse the same helpers across the file.
 type slicePoolTracker struct {
-	mu       sync.Mutex
-	entries  map[reflect.Type]*slicePoolNames
-	emitOrd  int
-	pkgs     PackageConfig
-	jenSync  string
+	mu      sync.Mutex
+	entries map[reflect.Type]*slicePoolNames
+	emitOrd int
+	pkgs    PackageConfig
+	jenSync string
+	// audit mirrors Options.EmitPoolAuditHooks. When true, ensure()
+	// emits poolaudit.OnCheckout / CheckZeroPrePut / OnRelease calls
+	// inside the generated get/put helpers so the lifecycle harness
+	// can observe pool activity and zero-loop coverage. Production
+	// codegen leaves this false, in which case helper emission is
+	// byte-identical to the pre-audit baseline.
+	audit bool
 }
 
-func newSlicePoolTracker(pkgs PackageConfig) *slicePoolTracker {
+func newSlicePoolTracker(pkgs PackageConfig, audit bool) *slicePoolTracker {
 	return &slicePoolTracker{
 		entries: make(map[reflect.Type]*slicePoolNames),
 		pkgs:    pkgs,
 		jenSync: "sync",
+		audit:   audit,
 	}
 }
 
@@ -84,35 +99,63 @@ func (t *slicePoolTracker) ensure(out *jen.File, elemType reflect.Type, maxCap i
 	// var <pool> sync.Pool
 	out.Var().Id(names.poolVar).Qual(t.jenSync, "Pool")
 
+	// auditTypeLiteral is the literal type-name string the audit
+	// hooks key counters on. Element type's plain name (no package
+	// qualifier) matches what slicePoolBaseName already uses, so an
+	// imbalance report points at the same name a developer sees in
+	// the generated helper symbols.
+	auditTypeLiteral := elemType.Name()
+
 	// func get<Name>Slice(n int) *[]Elem { ... }
+	getBody := []jen.Code{}
+	if t.audit {
+		getBody = append(getBody, jen.Qual(poolAuditPkg, "OnCheckout").Call(jen.Lit(auditTypeLiteral)))
+	}
+	getBody = append(getBody,
+		jen.If(jen.Id("v").Op(":=").Id(names.poolVar).Dot("Get").Call(), jen.Id("v").Op("!=").Nil()).Block(
+			jen.Id("sp").Op(":=").Id("v").Assert(jen.Op("*").Index().Add(names.elemQual.Clone())),
+			jen.If(jen.Cap(jen.Op("*").Id("sp")).Op(">=").Id("n")).Block(
+				jen.Op("*").Id("sp").Op("=").Parens(jen.Op("*").Id("sp")).Index(jen.Empty(), jen.Lit(0)),
+				jen.Return(jen.Id("sp")),
+			),
+		),
+		jen.Id("s").Op(":=").Make(jen.Index().Add(names.elemQual.Clone()), jen.Lit(0), jen.Id("n")),
+		jen.Return(jen.Op("&").Id("s")),
+	)
 	out.Func().Id(names.getFunc).
 		Params(jen.Id("n").Int()).
 		Op("*").Index().Add(names.elemQual.Clone()).
-		Block(
-			jen.If(jen.Id("v").Op(":=").Id(names.poolVar).Dot("Get").Call(), jen.Id("v").Op("!=").Nil()).Block(
-				jen.Id("sp").Op(":=").Id("v").Assert(jen.Op("*").Index().Add(names.elemQual.Clone())),
-				jen.If(jen.Cap(jen.Op("*").Id("sp")).Op(">=").Id("n")).Block(
-					jen.Op("*").Id("sp").Op("=").Parens(jen.Op("*").Id("sp")).Index(jen.Empty(), jen.Lit(0)),
-					jen.Return(jen.Id("sp")),
-				),
-			),
-			jen.Id("s").Op(":=").Make(jen.Index().Add(names.elemQual.Clone()), jen.Lit(0), jen.Id("n")),
-			jen.Return(jen.Op("&").Id("s")),
-		)
+		Block(getBody...)
 
 	// func put<Name>Slice(sp *[]Elem) { ... }
+	putBody := []jen.Code{
+		jen.If(jen.Id("sp").Op("==").Nil()).Block(jen.Return()),
+		jen.If(jen.Cap(jen.Op("*").Id("sp")).Op(">").Lit(maxCap)).Block(jen.Return()),
+		jen.Id("used").Op(":=").Parens(jen.Op("*").Id("sp")).Index(jen.Lit(0), jen.Len(jen.Op("*").Id("sp")), jen.Cap(jen.Op("*").Id("sp"))),
+		jen.For(jen.Id("i").Op(":=").Range().Id("used")).Block(
+			jen.Id("used").Index(jen.Id("i")).Op("=").Add(names.elemQual.Clone()).Values(),
+		),
+	}
+	if t.audit {
+		// CheckZeroPrePut runs AFTER the zero loop and BEFORE pool.Put
+		// so a violation surfaces precisely when the loop is missing
+		// or fails to cover a slot. The seed that omits the loop
+		// makes every non-zero slot light up.
+		putBody = append(putBody, jen.Qual(poolAuditPkg, "CheckZeroPrePut").Call(jen.Lit(auditTypeLiteral), jen.Id("used")))
+	}
+	putBody = append(putBody,
+		jen.Op("*").Id("sp").Op("=").Parens(jen.Op("*").Id("sp")).Index(jen.Empty(), jen.Lit(0)),
+		jen.Id(names.poolVar).Dot("Put").Call(jen.Id("sp")),
+	)
+	if t.audit {
+		// OnRelease pairs 1:1 with OnCheckout. Placed after pool.Put
+		// so a non-trivial failure between the zero loop and the
+		// pool handoff still leaves the imbalance visible.
+		putBody = append(putBody, jen.Qual(poolAuditPkg, "OnRelease").Call(jen.Lit(auditTypeLiteral)))
+	}
 	out.Func().Id(names.putFunc).
 		Params(jen.Id("sp").Op("*").Index().Add(names.elemQual.Clone())).
-		Block(
-			jen.If(jen.Id("sp").Op("==").Nil()).Block(jen.Return()),
-			jen.If(jen.Cap(jen.Op("*").Id("sp")).Op(">").Lit(maxCap)).Block(jen.Return()),
-			jen.Id("used").Op(":=").Parens(jen.Op("*").Id("sp")).Index(jen.Lit(0), jen.Len(jen.Op("*").Id("sp")), jen.Cap(jen.Op("*").Id("sp"))),
-			jen.For(jen.Id("i").Op(":=").Range().Id("used")).Block(
-				jen.Id("used").Index(jen.Id("i")).Op("=").Add(names.elemQual.Clone()).Values(),
-			),
-			jen.Op("*").Id("sp").Op("=").Parens(jen.Op("*").Id("sp")).Index(jen.Empty(), jen.Lit(0)),
-			jen.Id(names.poolVar).Dot("Put").Call(jen.Id("sp")),
-		)
+		Block(putBody...)
 
 	return names
 }

--- a/adapters/common/codegen/codegen_slice_pool.go
+++ b/adapters/common/codegen/codegen_slice_pool.go
@@ -52,6 +52,11 @@ type slicePoolTracker struct {
 	// codegen leaves this false, in which case helper emission is
 	// byte-identical to the pre-audit baseline.
 	audit bool
+	// seedOmitZeroLoop mirrors Options.Seed_OmitZeroLoop — a
+	// test-only switch the lifecycle harness flips to verify
+	// CheckZeroPrePut still catches a missing zero loop in putXSlice.
+	// Set only by the regression-seed renderer.
+	seedOmitZeroLoop bool
 }
 
 func newSlicePoolTracker(pkgs PackageConfig, audit bool) *slicePoolTracker {
@@ -132,9 +137,17 @@ func (t *slicePoolTracker) ensure(out *jen.File, elemType reflect.Type, maxCap i
 		jen.If(jen.Id("sp").Op("==").Nil()).Block(jen.Return()),
 		jen.If(jen.Cap(jen.Op("*").Id("sp")).Op(">").Lit(maxCap)).Block(jen.Return()),
 		jen.Id("used").Op(":=").Parens(jen.Op("*").Id("sp")).Index(jen.Lit(0), jen.Len(jen.Op("*").Id("sp")), jen.Cap(jen.Op("*").Id("sp"))),
-		jen.For(jen.Id("i").Op(":=").Range().Id("used")).Block(
-			jen.Id("used").Index(jen.Id("i")).Op("=").Add(names.elemQual.Clone()).Values(),
-		),
+	}
+	if !t.seedOmitZeroLoop {
+		// Production path. The seed flips this off so the lifecycle
+		// harness can verify CheckZeroPrePut catches the missing
+		// loop — every non-zero element in `used` becomes a
+		// recorded violation.
+		putBody = append(putBody,
+			jen.For(jen.Id("i").Op(":=").Range().Id("used")).Block(
+				jen.Id("used").Index(jen.Id("i")).Op("=").Add(names.elemQual.Clone()).Values(),
+			),
+		)
 	}
 	if t.audit {
 		// CheckZeroPrePut runs AFTER the zero loop and BEFORE pool.Put

--- a/adapters/common/codegen/codegen_slice_pool.go
+++ b/adapters/common/codegen/codegen_slice_pool.go
@@ -48,16 +48,19 @@ type slicePoolTracker struct {
 	// seedOmitZeroLoop mirrors Options.Seed_OmitZeroLoop — a
 	// test-only switch the lifecycle harness flips to verify
 	// CheckZeroPrePut still catches a missing zero loop in putXSlice.
-	// Set only by the regression-seed renderer.
+	// Threaded at tracker construction so GenerateWithOptions
+	// callers reach this gate through the same path as the audit
+	// flag.
 	seedOmitZeroLoop bool
 }
 
-func newSlicePoolTracker(pkgs PackageConfig, audit bool) *slicePoolTracker {
+func newSlicePoolTracker(pkgs PackageConfig, audit, seedOmitZeroLoop bool) *slicePoolTracker {
 	return &slicePoolTracker{
-		entries: make(map[reflect.Type]*slicePoolNames),
-		pkgs:    pkgs,
-		jenSync: "sync",
-		audit:   audit,
+		entries:          make(map[reflect.Type]*slicePoolNames),
+		pkgs:             pkgs,
+		jenSync:          "sync",
+		audit:            audit,
+		seedOmitZeroLoop: seedOmitZeroLoop,
 	}
 }
 

--- a/adapters/common/codegen/codegen_slice_pool.go
+++ b/adapters/common/codegen/codegen_slice_pool.go
@@ -7,13 +7,6 @@ import (
 	"github.com/dave/jennifer/jen"
 )
 
-// poolAuditPkg is the import path of the test-only poolaudit hooks
-// package. Referenced only when slicePoolTracker.audit is true, which
-// only the lifecycle harness flips. Sits behind a constant so the
-// rendered import is identical across cells without threading a
-// PackageConfig field through every test.
-const poolAuditPkg = "github.com/invakid404/baml-rest/adapters/common/codegen/internal/poolaudit"
-
 // slicePoolNames captures the symbol names emitted for a single pooled
 // slice type. Tracked centrally so emitters and call sites stay in
 // lockstep; one entry covers `[]T` where T is the unwrapped BAML
@@ -114,7 +107,7 @@ func (t *slicePoolTracker) ensure(out *jen.File, elemType reflect.Type, maxCap i
 	// func get<Name>Slice(n int) *[]Elem { ... }
 	getBody := []jen.Code{}
 	if t.audit {
-		getBody = append(getBody, jen.Qual(poolAuditPkg, "OnCheckout").Call(jen.Lit(auditTypeLiteral)))
+		getBody = append(getBody, jen.Qual(t.pkgs.PoolAuditPkg, "OnCheckout").Call(jen.Lit(auditTypeLiteral)))
 	}
 	getBody = append(getBody,
 		jen.If(jen.Id("v").Op(":=").Id(names.poolVar).Dot("Get").Call(), jen.Id("v").Op("!=").Nil()).Block(
@@ -154,7 +147,7 @@ func (t *slicePoolTracker) ensure(out *jen.File, elemType reflect.Type, maxCap i
 		// so a violation surfaces precisely when the loop is missing
 		// or fails to cover a slot. The seed that omits the loop
 		// makes every non-zero slot light up.
-		putBody = append(putBody, jen.Qual(poolAuditPkg, "CheckZeroPrePut").Call(jen.Lit(auditTypeLiteral), jen.Id("used")))
+		putBody = append(putBody, jen.Qual(t.pkgs.PoolAuditPkg, "CheckZeroPrePut").Call(jen.Lit(auditTypeLiteral), jen.Id("used")))
 	}
 	putBody = append(putBody,
 		jen.Op("*").Id("sp").Op("=").Parens(jen.Op("*").Id("sp")).Index(jen.Empty(), jen.Lit(0)),
@@ -164,7 +157,7 @@ func (t *slicePoolTracker) ensure(out *jen.File, elemType reflect.Type, maxCap i
 		// OnRelease pairs 1:1 with OnCheckout. Placed after pool.Put
 		// so a non-trivial failure between the zero loop and the
 		// pool handoff still leaves the imbalance visible.
-		putBody = append(putBody, jen.Qual(poolAuditPkg, "OnRelease").Call(jen.Lit(auditTypeLiteral)))
+		putBody = append(putBody, jen.Qual(t.pkgs.PoolAuditPkg, "OnRelease").Call(jen.Lit(auditTypeLiteral)))
 	}
 	out.Func().Id(names.putFunc).
 		Params(jen.Id("sp").Op("*").Index().Add(names.elemQual.Clone())).

--- a/adapters/common/codegen/codegen_slice_pool_audit_emission_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_audit_emission_test.go
@@ -27,11 +27,11 @@ func TestEmitPoolAuditHooks_Toggle(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name             string
-		audit            bool
-		wantOnCheckout   int
-		wantOnRelease    int
-		wantCheckZero    int
+		name           string
+		audit          bool
+		wantOnCheckout int
+		wantOnRelease  int
+		wantCheckZero  int
 	}{
 		{name: "off", audit: false},
 		{name: "on", audit: true, wantOnCheckout: 1, wantOnRelease: 1, wantCheckZero: 1},

--- a/adapters/common/codegen/codegen_slice_pool_audit_emission_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_audit_emission_test.go
@@ -44,7 +44,7 @@ func TestEmitPoolAuditHooks_Toggle(t *testing.T) {
 			pkgs.OutputPkgName = "matrix"
 
 			out := jen.NewFilePathName(pkgs.OutputPkg, pkgs.OutputPkgName)
-			tracker := newSlicePoolTracker(pkgs, tc.audit)
+			tracker := newSlicePoolTracker(pkgs, tc.audit, false)
 			tracker.ensure(out, reflect.TypeOf(fixtures.ContentPartA{}), 256)
 
 			rendered := out.GoString()

--- a/adapters/common/codegen/codegen_slice_pool_audit_emission_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_audit_emission_test.go
@@ -1,0 +1,151 @@
+package codegen
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dave/jennifer/jen"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/internal/fixtures"
+)
+
+// TestEmitPoolAuditHooks_Toggle is the contract guarantee for the
+// EmitPoolAuditHooks option: with the flag off, getXSlice / putXSlice
+// reference no symbol from the internal/poolaudit package and the
+// emitted helpers are byte-identical to the pre-audit baseline; with
+// it on, getXSlice contains exactly one OnCheckout call and putXSlice
+// contains exactly one CheckZeroPrePut and one OnRelease call. AST
+// scanning rather than text matching catches accidental partial-emit
+// regressions (an extra OnCheckout inside the if-branch, a missing
+// OnRelease past an early-return, etc.) that a substring check would
+// silently accept.
+func TestEmitPoolAuditHooks_Toggle(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name             string
+		audit            bool
+		wantOnCheckout   int
+		wantOnRelease    int
+		wantCheckZero    int
+	}{
+		{name: "off", audit: false},
+		{name: "on", audit: true, wantOnCheckout: 1, wantOnRelease: 1, wantCheckZero: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pkgs := DefaultPackageConfig()
+			pkgs.BamlPkg = reflect.TypeOf(fixtures.Image{}).PkgPath()
+			pkgs.OutputPkg = "github.com/invakid404/baml-rest/adapters/common/codegen/matrixtest"
+			pkgs.OutputPkgName = "matrix"
+
+			out := jen.NewFilePathName(pkgs.OutputPkg, pkgs.OutputPkgName)
+			tracker := newSlicePoolTracker(pkgs, tc.audit)
+			tracker.ensure(out, reflect.TypeOf(fixtures.ContentPartA{}), 256)
+
+			rendered := out.GoString()
+
+			gotCheckout := strings.Count(rendered, "poolaudit.OnCheckout(")
+			gotRelease := strings.Count(rendered, "poolaudit.OnRelease(")
+			gotCheckZero := strings.Count(rendered, "poolaudit.CheckZeroPrePut(")
+			if gotCheckout != tc.wantOnCheckout {
+				t.Errorf("OnCheckout count: got %d want %d\n%s", gotCheckout, tc.wantOnCheckout, rendered)
+			}
+			if gotRelease != tc.wantOnRelease {
+				t.Errorf("OnRelease count: got %d want %d\n%s", gotRelease, tc.wantOnRelease, rendered)
+			}
+			if gotCheckZero != tc.wantCheckZero {
+				t.Errorf("CheckZeroPrePut count: got %d want %d\n%s", gotCheckZero, tc.wantCheckZero, rendered)
+			}
+
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, "audit.go", rendered, parser.AllErrors)
+			if err != nil {
+				t.Fatalf("rendered helper file does not parse: %v\n--- rendered ---\n%s", err, rendered)
+			}
+
+			elemTy := reflect.TypeOf(fixtures.ContentPartA{})
+			base := slicePoolBaseName(elemTy)
+			getFn := findFunc(f, "get"+base+"Slice")
+			putFn := findFunc(f, "put"+base+"Slice")
+			if getFn == nil || putFn == nil {
+				t.Fatalf("expected get/put helpers (base=%q) in rendered file:\n%s", base, rendered)
+			}
+			gotInGet := countPoolauditCalls(getFn)
+			gotInPut := countPoolauditCalls(putFn)
+			wantInGet := tc.wantOnCheckout
+			wantInPut := tc.wantOnRelease + tc.wantCheckZero
+			if gotInGet != wantInGet {
+				t.Errorf("poolaudit calls inside get helper: got %d want %d", gotInGet, wantInGet)
+			}
+			if gotInPut != wantInPut {
+				t.Errorf("poolaudit calls inside put helper: got %d want %d", gotInPut, wantInPut)
+			}
+
+			// Off-mode must NOT import the poolaudit package — any
+			// non-zero count above would already have failed, but
+			// double-check the import list so a future regression
+			// where the qual leaks into a different statement
+			// surfaces here.
+			hasImport := false
+			for _, imp := range f.Imports {
+				if strings.Contains(imp.Path.Value, "internal/poolaudit") {
+					hasImport = true
+					break
+				}
+			}
+			if tc.audit && !hasImport {
+				t.Errorf("audit=on but rendered file does not import poolaudit")
+			}
+			if !tc.audit && hasImport {
+				t.Errorf("audit=off but rendered file still imports poolaudit")
+			}
+		})
+	}
+}
+
+// findFunc walks the file's top-level declarations and returns the
+// function named `name`, or nil if absent.
+func findFunc(f *ast.File, name string) *ast.FuncDecl {
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fd.Name.Name == name {
+			return fd
+		}
+	}
+	return nil
+}
+
+// countPoolauditCalls returns the number of call expressions inside
+// fd whose selector is rooted at the poolaudit package identifier.
+// Counts CheckZeroPrePut, OnCheckout, OnRelease together so the
+// caller can assert per-helper totals.
+func countPoolauditCalls(fd *ast.FuncDecl) int {
+	count := 0
+	ast.Inspect(fd, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		id, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if id.Name == "poolaudit" {
+			count++
+		}
+		return true
+	})
+	return count
+}

--- a/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
@@ -5,11 +5,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"reflect"
-	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -17,6 +14,7 @@ import (
 	"github.com/dave/jennifer/jen"
 
 	"github.com/invakid404/baml-rest/adapters/common/codegen/internal/fixtures"
+	"github.com/invakid404/baml-rest/adapters/common/codegen/internal/testharness"
 	"github.com/invakid404/baml-rest/bamlutils"
 )
 
@@ -57,8 +55,8 @@ func TestCompileMatrix(t *testing.T) {
 	rendered := out.GoString()
 
 	tmp := t.TempDir()
-	writeTempModule(t, tmp, rendered)
-	runGoBuild(t, tmp)
+	testharness.WriteTempModule(t, tmp, rendered, nil)
+	testharness.RunGoBuild(t, tmp)
 
 	parsed, fset := parseRendered(t, rendered)
 	assertNoReleaseConvertedInNonPooledCell(t, parsed, fset, cells)
@@ -452,94 +450,6 @@ func upperCamelForMatrix(s string) string {
 	return strings.Join(parts, "")
 }
 
-// writeTempModule lays out a self-contained Go module under `dir`
-// that compiles the rendered file against bamlutils + the fixtures
-// package via replace directives. The temp module reuses
-// adapters/common's go.mod + go.sum verbatim — that module already
-// pins every transitive dep bamlutils needs — and rewrites the
-// module path / replace directives to point at the local sources.
-// Without inheriting the transitive-dep pins `go build` would
-// complain "updates to go.mod needed" and refuse to proceed without
-// network access.
-func writeTempModule(t *testing.T, dir, rendered string) {
-	t.Helper()
-
-	bamlutilsAbs := absRepoPath(t, "bamlutils")
-	introspectedAbs := absRepoPath(t, "introspected")
-	fixturesAbs := absRepoPath(t, "adapters/common/codegen/internal/fixtures")
-	commonAbs := absRepoPath(t, "adapters/common")
-
-	_ = fixturesAbs // fixtures is a sub-package of adapters/common; the adapters/common replace below covers it
-
-	commonModBytes, err := os.ReadFile(filepath.Join(commonAbs, "go.mod"))
-	if err != nil {
-		t.Fatalf("read adapters/common go.mod: %v", err)
-	}
-	commonMod := string(commonModBytes)
-
-	// Rewrite the module path so the temp module is a standalone
-	// build target (`matrixtest`). Replace the original
-	// first-party replaces (which used `../../...` relative paths)
-	// with absolute paths so the temp dir's CWD doesn't matter.
-	// Declare the temp module under the adapters/common/codegen
-	// import-path prefix so the matrix file can import
-	// `.../codegen/internal/fixtures` — Go's `internal/`
-	// visibility rule allows that from any package whose path is
-	// rooted at the same parent (`adapters/common/codegen/`).
-	// Any module path outside that prefix would be rejected as a
-	// cross-tree internal import.
-	rewritten := strings.Replace(
-		commonMod,
-		"module github.com/invakid404/baml-rest/adapters/common",
-		"module github.com/invakid404/baml-rest/adapters/common/codegen/matrixtest",
-		1,
-	)
-	rewritten = strings.Replace(
-		rewritten,
-		"github.com/invakid404/baml-rest/bamlutils => ../../bamlutils",
-		"github.com/invakid404/baml-rest/bamlutils => "+bamlutilsAbs,
-		1,
-	)
-	rewritten = strings.Replace(
-		rewritten,
-		"github.com/invakid404/baml-rest/introspected => ../../introspected",
-		"github.com/invakid404/baml-rest/introspected => "+introspectedAbs,
-		1,
-	)
-	// Add a require + replace for the adapters/common module so the
-	// rendered file's fixtures import (a sub-package of
-	// adapters/common) resolves to the local source tree.
-	rewritten += "\nrequire github.com/invakid404/baml-rest/adapters/common v0.0.0-00010101000000-000000000000\n"
-	rewritten += "\nreplace github.com/invakid404/baml-rest/adapters/common => " + commonAbs + "\n"
-	writeFile(t, filepath.Join(dir, "go.mod"), rewritten)
-
-	// Reuse adapters/common's go.sum verbatim so transitive
-	// dep hashes don't trip the "module verification" gate.
-	commonSum, err := os.ReadFile(filepath.Join(commonAbs, "go.sum"))
-	if err != nil {
-		t.Fatalf("read adapters/common go.sum: %v", err)
-	}
-	writeFile(t, filepath.Join(dir, "go.sum"), string(commonSum))
-
-	writeFile(t, filepath.Join(dir, "matrix.go"), rendered)
-}
-
-// runGoBuild shells out to `go build ./...` in `dir`. The matrix is
-// rendered into a single file, so a single build invocation
-// type-checks every cell in one shot. Any failure (undeclared
-// identifier, arg-count mismatch, type mismatch) surfaces as a
-// build error.
-func runGoBuild(t *testing.T, dir string) {
-	t.Helper()
-	cmd := exec.Command("go", "build", "./...")
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GOWORK=off")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("matrix temp module failed to compile (the rendered codegen output type-checks against bamlutils + fixtures):\n%s\nerror: %v", out, err)
-	}
-}
-
 // parseRendered re-parses the rendered file in-process so the AST
 // scan in `assertNoReleaseConvertedInNonPooledCell` can look at the
 // emitter's exact textual output rather than reading the temp file
@@ -624,26 +534,3 @@ func dispatchHasReleaseConverted(fd *ast.FuncDecl) bool {
 	return found
 }
 
-// absRepoPath returns the absolute path to a repo-relative directory.
-// Used to wire the temp module's go.mod replaces against the real
-// bamlutils + fixtures source trees.
-func absRepoPath(t *testing.T, rel string) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("could not resolve test file path via runtime.Caller")
-	}
-	// Walk up from adapters/common/codegen/<this file> to the repo
-	// root, then descend into the requested rel path.
-	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
-	return filepath.Join(repoRoot, rel)
-}
-
-// writeFile is a t.Helper wrapper that fails the test on write error
-// rather than ignoring it.
-func writeFile(t *testing.T, path, content string) {
-	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
-}

--- a/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
@@ -91,7 +91,7 @@ func emitMatrix(t *testing.T) (*jen.File, []matrixCell) {
 
 	out := jen.NewFilePathName(pkgs.OutputPkg, pkgs.OutputPkgName)
 	tracker := newMirrorStructTracker()
-	pools := newSlicePoolTracker(pkgs)
+	pools := newSlicePoolTracker(pkgs, false)
 
 	// Precompute the convertNeedsOwnedNested transitive closure
 	// across every reachable struct-media type the matrix exercises.

--- a/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
@@ -91,7 +91,7 @@ func emitMatrix(t *testing.T) (*jen.File, []matrixCell) {
 
 	out := jen.NewFilePathName(pkgs.OutputPkg, pkgs.OutputPkgName)
 	tracker := newMirrorStructTracker()
-	pools := newSlicePoolTracker(pkgs, false)
+	pools := newSlicePoolTracker(pkgs, false, false)
 
 	// Precompute the convertNeedsOwnedNested transitive closure
 	// across every reachable struct-media type the matrix exercises.

--- a/adapters/common/codegen/codegen_slice_pool_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_test.go
@@ -79,7 +79,7 @@ func newPooledMethodEmitter(t *testing.T, paramNames []string) (*methodEmitter, 
 		supportsWithClient:   true,
 		mirrors:              newMirrorStructTracker(),
 		emittedUnwrapHelpers: map[string]bool{},
-		slicePools:           newSlicePoolTracker(pkgs, false),
+		slicePools:           newSlicePoolTracker(pkgs, false, false),
 	}
 
 	elemTypes := []reflect.Type{
@@ -275,7 +275,7 @@ func newMixedMethodEmitter(t *testing.T, nonPooledKind string) *methodEmitter {
 		supportsWithClient:   true,
 		mirrors:              newMirrorStructTracker(),
 		emittedUnwrapHelpers: map[string]bool{},
-		slicePools:           newSlicePoolTracker(pkgs, false),
+		slicePools:           newSlicePoolTracker(pkgs, false, false),
 	}
 
 	pooledElem := reflect.TypeOf(testMessageElemA{})
@@ -436,7 +436,7 @@ func TestGenerateConversionFunc_PointerElementSliceSkipsPool(t *testing.T) {
 	// test targets.
 	pkgs := DefaultPackageConfig()
 	pkgs.BamlPkg = reflect.TypeOf(Image{}).PkgPath()
-	pools := newSlicePoolTracker(pkgs, false)
+	pools := newSlicePoolTracker(pkgs, false, false)
 
 	outerType := reflect.TypeOf(f2OuterStructPtrSliceOfPointers{})
 	tracker.precomputeOwnedNestedNeeds([]reflect.Type{outerType}, pkgs)
@@ -550,7 +550,7 @@ func TestPreambleThreadsOwnedNestedThroughNonPooledCallSites(t *testing.T) {
 		supportsWithClient:   true,
 		mirrors:              newMirrorStructTracker(),
 		emittedUnwrapHelpers: map[string]bool{},
-		slicePools:           newSlicePoolTracker(pkgs, false),
+		slicePools:           newSlicePoolTracker(pkgs, false, false),
 	}
 
 	// Run the analysis pass first so generateConversionFunc sees
@@ -633,7 +633,7 @@ func TestPreambleThreadsOwnedNestedThroughNestedHelpers(t *testing.T) {
 
 	out := common.MakeFile()
 	tracker := newMirrorStructTracker()
-	pools := newSlicePoolTracker(pkgs, false)
+	pools := newSlicePoolTracker(pkgs, false, false)
 
 	outerType := reflect.TypeOf(f1OuterWrapper{})
 	tracker.precomputeOwnedNestedNeeds([]reflect.Type{outerType}, pkgs)
@@ -706,7 +706,7 @@ func TestConvertFuncHandlesMultiplePooledNestedTypes(t *testing.T) {
 
 	out := common.MakeFile()
 	tracker := newMirrorStructTracker()
-	pools := newSlicePoolTracker(pkgs, false)
+	pools := newSlicePoolTracker(pkgs, false, false)
 
 	outerType := reflect.TypeOf(f2MultiPooledMixed{})
 	tracker.precomputeOwnedNestedNeeds([]reflect.Type{outerType}, pkgs)

--- a/adapters/common/codegen/codegen_slice_pool_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_test.go
@@ -79,7 +79,7 @@ func newPooledMethodEmitter(t *testing.T, paramNames []string) (*methodEmitter, 
 		supportsWithClient:   true,
 		mirrors:              newMirrorStructTracker(),
 		emittedUnwrapHelpers: map[string]bool{},
-		slicePools:           newSlicePoolTracker(pkgs),
+		slicePools:           newSlicePoolTracker(pkgs, false),
 	}
 
 	elemTypes := []reflect.Type{
@@ -275,7 +275,7 @@ func newMixedMethodEmitter(t *testing.T, nonPooledKind string) *methodEmitter {
 		supportsWithClient:   true,
 		mirrors:              newMirrorStructTracker(),
 		emittedUnwrapHelpers: map[string]bool{},
-		slicePools:           newSlicePoolTracker(pkgs),
+		slicePools:           newSlicePoolTracker(pkgs, false),
 	}
 
 	pooledElem := reflect.TypeOf(testMessageElemA{})
@@ -436,7 +436,7 @@ func TestGenerateConversionFunc_PointerElementSliceSkipsPool(t *testing.T) {
 	// test targets.
 	pkgs := DefaultPackageConfig()
 	pkgs.BamlPkg = reflect.TypeOf(Image{}).PkgPath()
-	pools := newSlicePoolTracker(pkgs)
+	pools := newSlicePoolTracker(pkgs, false)
 
 	outerType := reflect.TypeOf(f2OuterStructPtrSliceOfPointers{})
 	tracker.precomputeOwnedNestedNeeds([]reflect.Type{outerType}, pkgs)
@@ -550,7 +550,7 @@ func TestPreambleThreadsOwnedNestedThroughNonPooledCallSites(t *testing.T) {
 		supportsWithClient:   true,
 		mirrors:              newMirrorStructTracker(),
 		emittedUnwrapHelpers: map[string]bool{},
-		slicePools:           newSlicePoolTracker(pkgs),
+		slicePools:           newSlicePoolTracker(pkgs, false),
 	}
 
 	// Run the analysis pass first so generateConversionFunc sees
@@ -633,7 +633,7 @@ func TestPreambleThreadsOwnedNestedThroughNestedHelpers(t *testing.T) {
 
 	out := common.MakeFile()
 	tracker := newMirrorStructTracker()
-	pools := newSlicePoolTracker(pkgs)
+	pools := newSlicePoolTracker(pkgs, false)
 
 	outerType := reflect.TypeOf(f1OuterWrapper{})
 	tracker.precomputeOwnedNestedNeeds([]reflect.Type{outerType}, pkgs)
@@ -706,7 +706,7 @@ func TestConvertFuncHandlesMultiplePooledNestedTypes(t *testing.T) {
 
 	out := common.MakeFile()
 	tracker := newMirrorStructTracker()
-	pools := newSlicePoolTracker(pkgs)
+	pools := newSlicePoolTracker(pkgs, false)
 
 	outerType := reflect.TypeOf(f2MultiPooledMixed{})
 	tracker.precomputeOwnedNestedNeeds([]reflect.Type{outerType}, pkgs)

--- a/adapters/common/codegen/internal/poolaudit/poolaudit.go
+++ b/adapters/common/codegen/internal/poolaudit/poolaudit.go
@@ -1,0 +1,167 @@
+// Package poolaudit is the test-only counterpart to the slice-pool
+// helpers emitted by codegen. When the generator is run with
+// EmitPoolAuditHooks=true (test mode only), the rendered get/put
+// helpers call into this package so the lifecycle harness can observe
+// pool checkouts, releases, and zero-on-Put behavior.
+//
+// Production codegen output never imports this package — the option
+// defaults to false and the package itself lives under `internal/` so
+// dynclient cannot depend on it even transitively.
+package poolaudit
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// Counters is the snapshot returned by Snapshot. The maps are copies
+// of the package-level state; callers may mutate them freely.
+type Counters struct {
+	Checkouts map[string]int
+	Releases  map[string]int
+}
+
+// Violation records a single zero-on-Put failure: the slice element at
+// Index was not zero by the time the put helper was about to return
+// its slice to the pool.
+type Violation struct {
+	TypeName string
+	Index    int
+	Detail   string
+}
+
+var (
+	mu         sync.Mutex
+	checkouts  = map[string]int{}
+	releases   = map[string]int{}
+	violations []Violation
+)
+
+// Reset clears all observed state. Tests call this in setup. Safe to
+// call concurrently with no other access — the mutex serializes.
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	checkouts = map[string]int{}
+	releases = map[string]int{}
+	violations = nil
+}
+
+// OnCheckout is emitted at the head of getXSlice in audit mode. The
+// rendered call passes the unwrapped BAML type name as a string
+// literal so the audit can group counts per pooled element type.
+func OnCheckout(typeName string) {
+	mu.Lock()
+	checkouts[typeName]++
+	mu.Unlock()
+}
+
+// OnRelease is emitted at the tail of putXSlice in audit mode, after
+// the pool.Put call. Pairs 1:1 with OnCheckout for a healthy lifecycle.
+func OnRelease(typeName string) {
+	mu.Lock()
+	releases[typeName]++
+	mu.Unlock()
+}
+
+// CheckZeroPrePut is emitted in putXSlice in audit mode immediately
+// AFTER the generator's existing zero loop completes and BEFORE the
+// pool.Put call. It reflects over the slice header and records a
+// violation for every element that is not equal to the zero value of
+// the element type — i.e. it asserts "the zero loop is still present
+// and executed every live slot".
+//
+// `used` arrives as `any` because the audit package is type-erased;
+// reflection extracts the element type and the zero comparison runs
+// element-wise via reflect.DeepEqual against reflect.Zero. The
+// generator emits this with the same `used` expression the zero loop
+// iterated, so an omitted-loop seed surfaces here as one violation
+// per non-zero element.
+func CheckZeroPrePut(typeName string, used any) {
+	if used == nil {
+		return
+	}
+	rv := reflect.ValueOf(used)
+	if rv.Kind() != reflect.Slice {
+		mu.Lock()
+		violations = append(violations, Violation{
+			TypeName: typeName,
+			Index:    -1,
+			Detail:   fmt.Sprintf("expected slice, got %s", rv.Kind()),
+		})
+		mu.Unlock()
+		return
+	}
+	elemType := rv.Type().Elem()
+	zero := reflect.Zero(elemType).Interface()
+	var found []Violation
+	for i := 0; i < rv.Len(); i++ {
+		got := rv.Index(i).Interface()
+		if !reflect.DeepEqual(got, zero) {
+			found = append(found, Violation{
+				TypeName: typeName,
+				Index:    i,
+				Detail:   fmt.Sprintf("non-zero element at index %d: %#v", i, got),
+			})
+		}
+	}
+	if len(found) == 0 {
+		return
+	}
+	mu.Lock()
+	violations = append(violations, found...)
+	mu.Unlock()
+}
+
+// Imbalanced returns the type names whose checkout count differs from
+// release count, plus the magnitude of the gap. Empty result means
+// every checkout was paired with a release.
+func Imbalanced() []string {
+	mu.Lock()
+	defer mu.Unlock()
+	seen := map[string]struct{}{}
+	for name := range checkouts {
+		seen[name] = struct{}{}
+	}
+	for name := range releases {
+		seen[name] = struct{}{}
+	}
+	var out []string
+	for name := range seen {
+		c := checkouts[name]
+		r := releases[name]
+		if c != r {
+			out = append(out, fmt.Sprintf("%s: checkouts=%d releases=%d (delta=%d)", name, c, r, c-r))
+		}
+	}
+	return out
+}
+
+// ZeroOnPutViolations returns a copy of the recorded violations. Tests
+// assert len() == 0 for the happy path; the regression seed for the
+// zero-loop bug class expects a non-empty result.
+func ZeroOnPutViolations() []Violation {
+	mu.Lock()
+	defer mu.Unlock()
+	out := make([]Violation, len(violations))
+	copy(out, violations)
+	return out
+}
+
+// Snapshot returns a copy of the per-type counters at this instant.
+// The async-stream barrier test reads it to assert "no releases yet"
+// after dispatch returns but before the adapter unblocks.
+func Snapshot() Counters {
+	mu.Lock()
+	defer mu.Unlock()
+	cs := make(map[string]int, len(checkouts))
+	for k, v := range checkouts {
+		cs[k] = v
+	}
+	rs := make(map[string]int, len(releases))
+	for k, v := range releases {
+		rs[k] = v
+	}
+	return Counters{Checkouts: cs, Releases: rs}
+}

--- a/adapters/common/codegen/internal/poolaudit/poolaudit_test.go
+++ b/adapters/common/codegen/internal/poolaudit/poolaudit_test.go
@@ -1,0 +1,130 @@
+package poolaudit
+
+import (
+	"sync"
+	"testing"
+)
+
+type elem struct {
+	N int
+	S string
+}
+
+func TestResetClearsAll(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+	OnCheckout("A")
+	OnRelease("A")
+	CheckZeroPrePut("A", []elem{{N: 1}})
+	if got := Snapshot(); got.Checkouts["A"] != 1 || got.Releases["A"] != 1 {
+		t.Fatalf("pre-reset snapshot wrong: %+v", got)
+	}
+	if got := ZeroOnPutViolations(); len(got) != 1 {
+		t.Fatalf("pre-reset violations wrong: %+v", got)
+	}
+	Reset()
+	if got := Snapshot(); len(got.Checkouts) != 0 || len(got.Releases) != 0 {
+		t.Fatalf("post-reset snapshot not empty: %+v", got)
+	}
+	if got := ZeroOnPutViolations(); len(got) != 0 {
+		t.Fatalf("post-reset violations not empty: %+v", got)
+	}
+}
+
+func TestCheckoutReleaseBalance(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+	OnCheckout("X")
+	OnCheckout("X")
+	OnRelease("X")
+	OnRelease("X")
+	if got := Imbalanced(); len(got) != 0 {
+		t.Fatalf("balanced X reported as imbalanced: %v", got)
+	}
+	OnCheckout("Y")
+	got := Imbalanced()
+	if len(got) != 1 {
+		t.Fatalf("expected one imbalance entry for Y, got %v", got)
+	}
+}
+
+func TestCheckZeroPrePutAllZero(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+	CheckZeroPrePut("E", []elem{{}, {}, {}})
+	if got := ZeroOnPutViolations(); len(got) != 0 {
+		t.Fatalf("all-zero slice produced violations: %v", got)
+	}
+}
+
+func TestCheckZeroPrePutNonZero(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+	CheckZeroPrePut("E", []elem{{}, {N: 7}, {}, {S: "x"}})
+	got := ZeroOnPutViolations()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 violations, got %d: %v", len(got), got)
+	}
+	if got[0].Index != 1 || got[1].Index != 3 {
+		t.Fatalf("violation indices wrong: %v", got)
+	}
+}
+
+func TestCheckZeroPrePutEmptySlice(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+	CheckZeroPrePut("E", []elem{})
+	if got := ZeroOnPutViolations(); len(got) != 0 {
+		t.Fatalf("empty slice produced violations: %v", got)
+	}
+}
+
+func TestCheckZeroPrePutNilSlice(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+	CheckZeroPrePut("E", nil)
+	if got := ZeroOnPutViolations(); len(got) != 0 {
+		t.Fatalf("nil produced violations: %v", got)
+	}
+}
+
+func TestCheckZeroPrePutWrongKind(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+	CheckZeroPrePut("E", 42)
+	got := ZeroOnPutViolations()
+	if len(got) != 1 || got[0].Index != -1 {
+		t.Fatalf("expected kind-mismatch violation, got %v", got)
+	}
+}
+
+func TestSnapshotIsCopy(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+	OnCheckout("A")
+	snap := Snapshot()
+	snap.Checkouts["A"] = 99
+	if got := Snapshot(); got.Checkouts["A"] != 1 {
+		t.Fatalf("mutating snapshot leaked into package state: %v", got)
+	}
+}
+
+// TestRaceClean drives counters from many goroutines so go test -race
+// surfaces any missing synchronization.
+func TestRaceClean(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+	var wg sync.WaitGroup
+	const n = 50
+	wg.Add(n * 3)
+	for i := 0; i < n; i++ {
+		go func() { defer wg.Done(); OnCheckout("R") }()
+		go func() { defer wg.Done(); OnRelease("R") }()
+		go func() { defer wg.Done(); _ = Snapshot() }()
+	}
+	wg.Wait()
+	got := Snapshot()
+	if got.Checkouts["R"] != n || got.Releases["R"] != n {
+		t.Fatalf("counter loss under concurrency: %+v", got)
+	}
+}

--- a/adapters/common/codegen/internal/poolaudit/poolaudit_test.go
+++ b/adapters/common/codegen/internal/poolaudit/poolaudit_test.go
@@ -109,22 +109,31 @@ func TestSnapshotIsCopy(t *testing.T) {
 	}
 }
 
-// TestRaceClean drives counters from many goroutines so go test -race
-// surfaces any missing synchronization.
+// TestRaceClean drives counters AND the violations slice from many
+// goroutines so go test -race surfaces any missing synchronization on
+// either path. Violations recording and reading share the same mutex
+// as the counter maps today; the extra goroutines guard against a
+// future refactor that splits the lock and lets the slice access
+// race.
 func TestRaceClean(t *testing.T) {
 	t.Cleanup(Reset)
 	Reset()
 	var wg sync.WaitGroup
 	const n = 50
-	wg.Add(n * 3)
+	wg.Add(n * 5)
 	for i := 0; i < n; i++ {
 		go func() { defer wg.Done(); OnCheckout("R") }()
 		go func() { defer wg.Done(); OnRelease("R") }()
 		go func() { defer wg.Done(); _ = Snapshot() }()
+		go func() { defer wg.Done(); CheckZeroPrePut("R", []elem{{N: 1}}) }()
+		go func() { defer wg.Done(); _ = ZeroOnPutViolations() }()
 	}
 	wg.Wait()
 	got := Snapshot()
 	if got.Checkouts["R"] != n || got.Releases["R"] != n {
 		t.Fatalf("counter loss under concurrency: %+v", got)
+	}
+	if v := ZeroOnPutViolations(); len(v) != n {
+		t.Fatalf("violation loss under concurrency: got %d, want %d", len(v), n)
 	}
 }

--- a/adapters/common/codegen/internal/testharness/cells.go
+++ b/adapters/common/codegen/internal/testharness/cells.go
@@ -86,9 +86,9 @@ func (m AdapterFailureMode) String() string {
 // its name, its nested shape, the failure mode being injected, and
 // whether the dispatch is expected to emit `__releaseConverted`.
 //
-// #340 will plug a property/QuickCheck generator into this interface;
-// the same emission backend in the codegen package consumes whatever
-// the enumerator yields, so the matrix dimensions can grow without
+// The same emission backend in the codegen package consumes whatever
+// implementation of CellEnumerator below yields, so the matrix
+// dimensions can grow (e.g. via a property-based generator) without
 // touching the harness wiring.
 type CellSpec struct {
 	Name                   string
@@ -98,9 +98,10 @@ type CellSpec struct {
 }
 
 // CellEnumerator yields the matrix cells under test. The compile
-// matrix today uses an enumerated implementation; #339's lifecycle
-// harness extends it with the failure-mode cross-product; #340 will
-// plug in a property/QuickCheck generator.
+// matrix uses an enumerated implementation; the lifecycle harness
+// extends that set with the failure-mode cross-product. Property-
+// based generators can plug into the same interface to grow the
+// matrix without altering the consumers.
 type CellEnumerator interface {
 	Cells() []CellSpec
 }

--- a/adapters/common/codegen/internal/testharness/cells.go
+++ b/adapters/common/codegen/internal/testharness/cells.go
@@ -1,0 +1,106 @@
+package testharness
+
+// NestedKind is the nested-field shape under test for a single cell —
+// the same three shapes the compile matrix already crosses plus the
+// mutually-recursive cycle.
+type NestedKind int
+
+const (
+	// NestedValueElem is the `*[]Struct` value-element shape — the
+	// closure-context pool branch happy path.
+	NestedValueElem NestedKind = iota
+	// NestedPtrElem is `*[]*Struct` — fallback to the legacy make
+	// path; converter must NOT touch the pool.
+	NestedPtrElem
+	// NestedTwoPooledTypes is the multi-pool shape (Parts + Tools
+	// each pool a distinct inner type from the same converter).
+	NestedTwoPooledTypes
+	// NestedCycle is the mutually-recursive A↔B fixture.
+	NestedCycle
+)
+
+// String returns a stable lowercase tag used in cell names.
+func (k NestedKind) String() string {
+	switch k {
+	case NestedValueElem:
+		return "a_value_elem"
+	case NestedPtrElem:
+		return "b_ptr_elem"
+	case NestedTwoPooledTypes:
+		return "c_two_pooled_types"
+	case NestedCycle:
+		return "cycle"
+	}
+	return "unknown"
+}
+
+// AdapterFailureMode controls when the fake adapter returns an error
+// from ConvertMedia, exercising different points in the
+// dispatch/converter call graph.
+type AdapterFailureMode int
+
+const (
+	// FailureSuccess is the happy path — every ConvertMedia call
+	// returns a valid value. Asserts balance + zero-on-Put.
+	FailureSuccess AdapterFailureMode = iota
+	// FailureAtIdx0 fails on the very first ConvertMedia call; the
+	// outer slice has zero filled elements but Phase A already
+	// checked it out — release must still fire.
+	FailureAtIdx0
+	// FailureAtIdx2 fails on the third ConvertMedia call; partial
+	// fill exercises the same release path with non-zero used
+	// elements that still need zeroing.
+	FailureAtIdx2
+	// FailureInNested fails inside a nested converter (a *[]Struct
+	// child) — both outer AND inner pools must release.
+	FailureInNested
+	// FailureAsyncLateConsume defers consumption past the dispatch
+	// goroutine's first wake-up so the barrier test can assert
+	// release hasn't fired yet. Only meaningful for stream-path
+	// cells.
+	FailureAsyncLateConsume
+)
+
+// String returns a stable lowercase tag used in cell names.
+func (m AdapterFailureMode) String() string {
+	switch m {
+	case FailureSuccess:
+		return "success"
+	case FailureAtIdx0:
+		return "fail_at_idx_0"
+	case FailureAtIdx2:
+		return "fail_at_idx_2"
+	case FailureInNested:
+		return "fail_in_nested"
+	case FailureAsyncLateConsume:
+		return "async_late_consume"
+	}
+	return "unknown"
+}
+
+// CellSpec is the matrix-cell descriptor consumed by both the compile-
+// matrix test and the lifecycle harness. It is intentionally narrow
+// — emission lives in the codegen package because it depends on
+// internal generator types (methodEmitter, slicePoolTracker). What
+// CellSpec captures is the test-author-visible identity of a cell:
+// its name, its nested shape, the failure mode being injected, and
+// whether the dispatch is expected to emit `__releaseConverted`.
+//
+// #340 will plug a property/QuickCheck generator into this interface;
+// the same emission backend in the codegen package consumes whatever
+// the enumerator yields, so the matrix dimensions can grow without
+// touching the harness wiring.
+type CellSpec struct {
+	Name                   string
+	NestedShape            NestedKind
+	Failure                AdapterFailureMode
+	ExpectReleaseConverted bool
+}
+
+// CellEnumerator yields the matrix cells under test. The compile
+// matrix today uses an enumerated implementation; #339's lifecycle
+// harness extends it with the failure-mode cross-product; #340 will
+// plug in a property/QuickCheck generator.
+type CellEnumerator interface {
+	Cells() []CellSpec
+}

--- a/adapters/common/codegen/internal/testharness/module.go
+++ b/adapters/common/codegen/internal/testharness/module.go
@@ -122,7 +122,8 @@ func AbsRepoPath(t *testing.T, rel string) string {
 
 // WriteFile is a t.Helper wrapper that fails the test on write error
 // so a permissions / disk failure surfaces immediately with a labelled
-// line. Tests use it instead of bare os.WriteFile.
+// line. Test code should always go through this helper for filesystem
+// writes.
 func WriteFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {

--- a/adapters/common/codegen/internal/testharness/module.go
+++ b/adapters/common/codegen/internal/testharness/module.go
@@ -1,0 +1,123 @@
+// Package testharness is the shared infrastructure backing the codegen
+// compile matrix and the pool-lifecycle harness. It owns the temp-
+// module synthesis, the go build / go test subprocess wrappers, and
+// the cell-enumeration interface that #340's property generator will
+// extend. The package lives under `internal/` so dynclient cannot
+// import it: lifecycle infrastructure is a test-only seam.
+package testharness
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// WriteTempModule lays out a self-contained Go module under `dir` that
+// compiles `rendered` (the generator's output) against bamlutils +
+// fixtures via replace directives. The temp module reuses
+// adapters/common's go.mod + go.sum verbatim — that module already
+// pins every transitive dep bamlutils needs — and rewrites the module
+// path / replace directives to point at the local sources. Without
+// inheriting the transitive-dep pins `go build` would complain
+// "updates to go.mod needed" and refuse to proceed without network
+// access.
+//
+// `extraFiles` are written alongside `matrix.go` and let callers ship
+// additional Go sources into the temp module — the lifecycle harness
+// uses it to install a generated `lifecycle_test.go`. Keys are file
+// names relative to `dir`. Pass nil for the compile-matrix case.
+func WriteTempModule(t *testing.T, dir, rendered string, extraFiles map[string]string) {
+	t.Helper()
+
+	bamlutilsAbs := AbsRepoPath(t, "bamlutils")
+	introspectedAbs := AbsRepoPath(t, "introspected")
+	commonAbs := AbsRepoPath(t, "adapters/common")
+
+	commonModBytes, err := os.ReadFile(filepath.Join(commonAbs, "go.mod"))
+	if err != nil {
+		t.Fatalf("read adapters/common go.mod: %v", err)
+	}
+	commonMod := string(commonModBytes)
+
+	// Rewrite the module path so the temp module is a standalone
+	// build target (`matrixtest`). Replace the original first-party
+	// replaces (which used `../../...` relative paths) with absolute
+	// paths so the temp dir's CWD doesn't matter. Declare the temp
+	// module under the adapters/common/codegen import-path prefix so
+	// the matrix file can import `.../codegen/internal/fixtures` (and
+	// `.../codegen/internal/poolaudit`) — Go's `internal/`
+	// visibility rule allows that from any package whose path is
+	// rooted at the same parent (`adapters/common/codegen/`). Any
+	// module path outside that prefix would be rejected as a
+	// cross-tree internal import.
+	rewritten := strings.Replace(
+		commonMod,
+		"module github.com/invakid404/baml-rest/adapters/common",
+		"module github.com/invakid404/baml-rest/adapters/common/codegen/matrixtest",
+		1,
+	)
+	rewritten = strings.Replace(
+		rewritten,
+		"github.com/invakid404/baml-rest/bamlutils => ../../bamlutils",
+		"github.com/invakid404/baml-rest/bamlutils => "+bamlutilsAbs,
+		1,
+	)
+	rewritten = strings.Replace(
+		rewritten,
+		"github.com/invakid404/baml-rest/introspected => ../../introspected",
+		"github.com/invakid404/baml-rest/introspected => "+introspectedAbs,
+		1,
+	)
+	// Add a require + replace for the adapters/common module so the
+	// rendered file's fixtures / poolaudit imports (sub-packages of
+	// adapters/common) resolve to the local source tree.
+	rewritten += "\nrequire github.com/invakid404/baml-rest/adapters/common v0.0.0-00010101000000-000000000000\n"
+	rewritten += "\nreplace github.com/invakid404/baml-rest/adapters/common => " + commonAbs + "\n"
+	WriteFile(t, filepath.Join(dir, "go.mod"), rewritten)
+
+	// Reuse adapters/common's go.sum verbatim so transitive dep
+	// hashes don't trip the "module verification" gate.
+	commonSum, err := os.ReadFile(filepath.Join(commonAbs, "go.sum"))
+	if err != nil {
+		t.Fatalf("read adapters/common go.sum: %v", err)
+	}
+	WriteFile(t, filepath.Join(dir, "go.sum"), string(commonSum))
+
+	WriteFile(t, filepath.Join(dir, "matrix.go"), rendered)
+
+	for name, content := range extraFiles {
+		WriteFile(t, filepath.Join(dir, name), content)
+	}
+}
+
+// AbsRepoPath returns the absolute path to a repo-relative directory.
+// Used to wire the temp module's go.mod replaces against the real
+// bamlutils + fixtures source trees. Uses runtime.Caller against this
+// file (which is at adapters/common/codegen/internal/testharness/) to
+// locate the repo root.
+func AbsRepoPath(t *testing.T, rel string) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not resolve testharness file path via runtime.Caller")
+	}
+	// Walk up from adapters/common/codegen/internal/testharness/<this
+	// file> to the repo root, then descend into the requested rel
+	// path. The parent chain is internal -> codegen -> common ->
+	// adapters -> <repo>.
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", "..", ".."))
+	return filepath.Join(repoRoot, rel)
+}
+
+// WriteFile is a t.Helper wrapper that fails the test on write error
+// rather than ignoring it. Tests use it instead of bare os.WriteFile
+// so a permissions / disk error surfaces immediately with a labelled
+// line.
+func WriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/adapters/common/codegen/internal/testharness/module.go
+++ b/adapters/common/codegen/internal/testharness/module.go
@@ -86,12 +86,12 @@ func WriteTempModule(t *testing.T, dir, rendered string, extraFiles map[string]s
 	}
 }
 
-// replaceRequired is strings.Replace with count=1, but it fails the
-// test loudly when the substring is absent. Used for the three
+// replaceRequired is strings.Replace with count=1 that fails the test
+// loudly when `old` is not present in `src`. Used for the three
 // adapters/common/go.mod rewrites so a future drift in that file
 // (e.g. a module-path rename or a reformatted replace directive)
-// surfaces as a clear "rewrite target missing" error rather than a
-// downstream `go build` failure with no obvious cause.
+// surfaces as a clear "rewrite target missing" error at the rewrite
+// step itself, pinpointing which substring drifted.
 func replaceRequired(t *testing.T, src, old, new string) string {
 	t.Helper()
 	if !strings.Contains(src, old) {

--- a/adapters/common/codegen/internal/testharness/module.go
+++ b/adapters/common/codegen/internal/testharness/module.go
@@ -52,23 +52,17 @@ func WriteTempModule(t *testing.T, dir, rendered string, extraFiles map[string]s
 	// rooted at the same parent (`adapters/common/codegen/`). Any
 	// module path outside that prefix would be rejected as a
 	// cross-tree internal import.
-	rewritten := strings.Replace(
-		commonMod,
+	rewritten := replaceRequired(t, commonMod,
 		"module github.com/invakid404/baml-rest/adapters/common",
 		"module github.com/invakid404/baml-rest/adapters/common/codegen/matrixtest",
-		1,
 	)
-	rewritten = strings.Replace(
-		rewritten,
+	rewritten = replaceRequired(t, rewritten,
 		"github.com/invakid404/baml-rest/bamlutils => ../../bamlutils",
 		"github.com/invakid404/baml-rest/bamlutils => "+bamlutilsAbs,
-		1,
 	)
-	rewritten = strings.Replace(
-		rewritten,
+	rewritten = replaceRequired(t, rewritten,
 		"github.com/invakid404/baml-rest/introspected => ../../introspected",
 		"github.com/invakid404/baml-rest/introspected => "+introspectedAbs,
-		1,
 	)
 	// Add a require + replace for the adapters/common module so the
 	// rendered file's fixtures / poolaudit imports (sub-packages of
@@ -90,6 +84,20 @@ func WriteTempModule(t *testing.T, dir, rendered string, extraFiles map[string]s
 	for name, content := range extraFiles {
 		WriteFile(t, filepath.Join(dir, name), content)
 	}
+}
+
+// replaceRequired is strings.Replace with count=1, but it fails the
+// test loudly when the substring is absent. Used for the three
+// adapters/common/go.mod rewrites so a future drift in that file
+// (e.g. a module-path rename or a reformatted replace directive)
+// surfaces as a clear "rewrite target missing" error rather than a
+// downstream `go build` failure with no obvious cause.
+func replaceRequired(t *testing.T, src, old, new string) string {
+	t.Helper()
+	if !strings.Contains(src, old) {
+		t.Fatalf("testharness: rewrite target missing in adapters/common/go.mod: %q", old)
+	}
+	return strings.Replace(src, old, new, 1)
 }
 
 // AbsRepoPath returns the absolute path to a repo-relative directory.

--- a/adapters/common/codegen/internal/testharness/module.go
+++ b/adapters/common/codegen/internal/testharness/module.go
@@ -1,9 +1,10 @@
 // Package testharness is the shared infrastructure backing the codegen
 // compile matrix and the pool-lifecycle harness. It owns the temp-
 // module synthesis, the go build / go test subprocess wrappers, and
-// the cell-enumeration interface that #340's property generator will
-// extend. The package lives under `internal/` so dynclient cannot
-// import it: lifecycle infrastructure is a test-only seam.
+// the cell-enumeration interface that downstream property-based
+// generators can extend. The package lives under `internal/` so
+// dynclient cannot import it: lifecycle infrastructure is a test-only
+// seam.
 package testharness
 
 import (
@@ -120,9 +121,8 @@ func AbsRepoPath(t *testing.T, rel string) string {
 }
 
 // WriteFile is a t.Helper wrapper that fails the test on write error
-// rather than ignoring it. Tests use it instead of bare os.WriteFile
-// so a permissions / disk error surfaces immediately with a labelled
-// line.
+// so a permissions / disk failure surfaces immediately with a labelled
+// line. Tests use it instead of bare os.WriteFile.
 func WriteFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {

--- a/adapters/common/codegen/internal/testharness/runner.go
+++ b/adapters/common/codegen/internal/testharness/runner.go
@@ -1,0 +1,43 @@
+package testharness
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// RunGoBuild shells out to `go build ./...` in `dir`. The matrix is
+// rendered into a single file, so a single build invocation type-
+// checks every cell in one shot. Any failure (undeclared identifier,
+// arg-count mismatch, type mismatch) surfaces as a build error and
+// fails the outer test with the captured subprocess output.
+func RunGoBuild(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("go", "build", "./...")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("matrix temp module failed to compile (the rendered codegen output type-checks against bamlutils + fixtures):\n%s\nerror: %v", out, err)
+	}
+}
+
+// RunGoTest shells out to `go test -count=1` in `dir`, narrowing the
+// run to tests matching `runPattern` when non-empty. Returns the
+// combined stdout/stderr plus the subprocess error (nil on green
+// run). Callers — the pool-lifecycle harness in particular — decide
+// whether a non-nil error is expected (regression-seed paths expect
+// the inner test to FAIL).
+func RunGoTest(t *testing.T, dir, runPattern string) (string, error) {
+	t.Helper()
+	args := []string{"test", "-count=1"}
+	if runPattern != "" {
+		args = append(args, "-run", runPattern)
+	}
+	args = append(args, "./...")
+	cmd := exec.Command("go", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Closes #339.

Adds a pool-lifecycle harness that executes the generator's slice-pool helpers under controlled failure injection — the runtime complement to the compile-matrix added in #338. Three-commit shape:

1. **`refactor(codegen): extract testharness package + add poolaudit hooks runtime`** — moves the temp-module synthesis, `go build` / `go test` wrappers, and cell-shape descriptors out of the compile-matrix test into `internal/testharness/`. Adds `internal/poolaudit/`, a test-only counters + zero-loop-violation runtime that codegen-emitted helpers will call into when audit mode is enabled. No production behavior change.
2. **`feat(codegen): emit pool audit hooks under EmitPoolAuditHooks option`** — `Options.EmitPoolAuditHooks` (default `false`) toggles emission of `poolaudit.OnCheckout` / `CheckZeroPrePut` / `OnRelease` calls inside `getXSlice` / `putXSlice`. `CheckZeroPrePut` runs after the existing zero loop so a missing-loop seed surfaces as a violation. Unit test scans the rendered helpers (AST + token count) to pin the contract.
3. **`test(codegen): pool lifecycle harness + regression seeds`** — renders the existing 21+cycle structural matrix with audit hooks on, emits per-cell dispatchers that actually invoke the converters, and ships a `lifecycle_test.go` into the temp module that asserts pool balance, zero-on-Put, and pointer-element no-pool across four sync failure modes plus three async barrier modes (~91 inner subtests). Adds four test-only regression seeds (`OmitPhaseBRelease`, `OmitOwnedNestedThread`, `OmitZeroLoop`, `OmitAsyncDefer`) that re-introduce the bug classes #338 surfaced; the harness flips each in turn and asserts the inner `go test` FAILS.

## Touches codegen output: no

Verified with `go run ./cmd/regenerate-dynclient && git status dynclient/` — clean. The new `EmitPoolAuditHooks` and `Seed_*` options default to `false`, so production codegen is byte-identical to master.

## Risk callouts

- **Changed (test-only)**: `internal/poolaudit/`, `internal/testharness/`, new `codegen_pool_lifecycle_test.go`, AST-scan unit test for the toggle. The compile-matrix test was refactored to call into `testharness` — same assertions, same shape.
- **Changed (production codegen surface)**: `slicePoolTracker` gained an `audit bool` field; `Options` gained `EmitPoolAuditHooks` + four `Seed_*` flags. All default to `false`; emission is gated by the flag and matches today's behavior when off.
- **Race-clean**: `go test -race ./adapters/common/codegen/... -count=1` is green. `poolaudit` counters are mutex-protected; the async barrier test uses an edge-triggered `asyncStart` channel (no sleeps).
- **CI cost**: the inner `go test` compiles a ~91-cell matrix once per outer test, plus 4 regression-seed re-renders. Local timing: ~10 s wall under `-race`.

## Verification commands run

- `GOWORK=off go test -race ./codegen/... -count=1` ✅
- `GOWORK=off go test ./codegen/... -count=1 -run TestPoolLifecycle` ✅
- `GOWORK=off go test ./codegen/... -count=1 -run TestPoolLifecycle_RegressionSeeds -v` ✅ (each seed catches the expected failure pattern — see test `Logf` output)
- `GOWORK=off go test -race ./...` (under `adapters/common`) ✅
- `go run ./cmd/regenerate-dynclient && git status dynclient/` → clean ✅

## Test plan

- [x] Compile matrix test (`TestCompileMatrix`) still green after refactor.
- [x] `TestEmitPoolAuditHooks_Toggle` asserts no `poolaudit` references when off, exactly one each of `OnCheckout` / `OnRelease` / `CheckZeroPrePut` when on.
- [x] `TestPoolLifecycle` runs ~88 sync + 3 async inner subtests, all green.
- [x] `TestPoolLifecycle_RegressionSeeds`: each of 4 seeds causes the inner test to fail with the bug class it targets.
- [x] Codegen idempotency: `dynclient/internal/generated/` shows zero diff after regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional slice-pool audit hooks and a new internal audit recorder to detect imbalanced checkouts/releases and zero-on-put violations.
  * Runtime toggles to emit audit hooks and test-only seeds that alter generated helper behavior (e.g., omit zeroing or change async release ordering).

* **Tests**
  * New unit and integration suites exercising lifecycle matrices, audit-hook emission, and regression-seed variants.

* **Chores**
  * Reusable test-harness utilities for creating temp modules and running build/test subprocesses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->