### PR TITLE
test(codegen): #340 PR-C static emitter + static prompt oracle

### DIFF
--- a/adapters/common/codegen/bamlfuzz/cmd/seedcorpus/main.go
+++ b/adapters/common/codegen/bamlfuzz/cmd/seedcorpus/main.go
@@ -1,12 +1,12 @@
-// seedcorpus generates the dynamic oracle seed corpus
-// (testdata/bamlfuzz/dynamic/*.json). The corpus is hand-curated to cover
-// every type-kind branch the dynamic emitter has to handle; each JSON
-// file is an OracleCase that the integration test loads and replays.
+// seedcorpus generates the hand-curated oracle seed corpora under
+// testdata/bamlfuzz/{dynamic,static}/. Each JSON file is an
+// OracleCase the integration test loads and replays.
 //
 // Re-run with:
 //
 //	cd adapters/common
-//	GOWORK=off go run ./codegen/bamlfuzz/cmd/seedcorpus -out=./codegen/testdata/bamlfuzz/dynamic
+//	GOWORK=off go run ./codegen/bamlfuzz/cmd/seedcorpus -mode=dynamic -out=./codegen/testdata/bamlfuzz/dynamic
+//	GOWORK=off go run ./codegen/bamlfuzz/cmd/seedcorpus -mode=static  -out=./codegen/testdata/bamlfuzz/static
 package main
 
 import (
@@ -21,6 +21,7 @@ import (
 
 func main() {
 	outDir := flag.String("out", "", "output directory")
+	mode := flag.String("mode", "dynamic", "corpus mode: dynamic or static")
 	flag.Parse()
 	if *outDir == "" {
 		fmt.Fprintln(os.Stderr, "missing -out")
@@ -31,23 +32,37 @@ func main() {
 		os.Exit(1)
 	}
 
-	cases := []seedSpec{
-		scalarString(),
-		multiScalar(),
-		listOfStrings(),
-		mapOfInts(),
-		optionalThreeShapes(),
-		enumRef(),
-		nestedClass(),
-		classWithEnum(),
-		optionalListOfClass(),
-		mapToClass(),
-		mutualRecursion(),
-		literalsAll(),
+	var (
+		cases     []seedSpec
+		modeValue bamlfuzz.OracleMode
+	)
+	switch *mode {
+	case "dynamic":
+		cases = []seedSpec{
+			scalarString(),
+			multiScalar(),
+			listOfStrings(),
+			mapOfInts(),
+			optionalThreeShapes(),
+			enumRef(),
+			nestedClass(),
+			classWithEnum(),
+			optionalListOfClass(),
+			mapToClass(),
+			mutualRecursion(),
+			literalsAll(),
+		}
+		modeValue = bamlfuzz.OracleDynamicThreeWay
+	case "static":
+		cases = staticCases()
+		modeValue = bamlfuzz.OracleStaticPrompt
+	default:
+		fmt.Fprintln(os.Stderr, "unknown -mode (want dynamic|static)")
+		os.Exit(2)
 	}
 
 	for i, spec := range cases {
-		ocase := materialize(i, spec)
+		ocase := materialize(i, spec, modeValue)
 		path := filepath.Join(*outDir, fmt.Sprintf("%02d_%s.json", i, ocase.Name))
 		data, err := json.MarshalIndent(ocase, "", "  ")
 		if err != nil {
@@ -69,7 +84,7 @@ type seedSpec struct {
 	Preserve bool
 }
 
-func materialize(idx int, spec seedSpec) bamlfuzz.OracleCase {
+func materialize(idx int, spec seedSpec, mode bamlfuzz.OracleMode) bamlfuzz.OracleCase {
 	schema := bamlfuzz.AnalyzeGraph(spec.Schema)
 	walk, err := bamlfuzz.Walk(schema, spec.Value)
 	if err != nil {
@@ -80,13 +95,160 @@ func materialize(idx int, spec seedSpec) bamlfuzz.OracleCase {
 		Name:                spec.Name,
 		Seed:                int64(idx + 1),
 		CaseIndex:           idx,
-		Mode:                bamlfuzz.OracleDynamicThreeWay,
+		Mode:                mode,
 		PreserveSchemaOrder: spec.Preserve,
 		Schema:              schema,
 		Value:               spec.Value,
 		MockLLMContent:      walk.MockLLMContent,
 		Expected:            walk.Expected,
 		Metadata:            walk.Metadata,
+	}
+}
+
+// staticCases returns the five hand-curated static-mode seed cases.
+// Scope D7 lists the static corpus shape: scalar object, nested class
+// with enum, optional three shapes, terminating mutual recursion, and
+// one self-referential tree. The self-ref case is exclusive to static
+// mode; the dynamic emitter rejects it.
+func staticCases() []seedSpec {
+	return []seedSpec{
+		staticScalarObject(),
+		staticNestedClassWithEnum(),
+		staticOptionalThreeShapes(),
+		staticTerminatingMutualRecursion(),
+		staticSelfReferentialTree(),
+	}
+}
+
+func staticScalarObject() seedSpec {
+	return seedSpec{
+		Name: "scalar_object",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("name", tStr()),
+				prop("age", tInt()),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("name", vStr("Ada")),
+			vField("age", vInt(36)),
+		),
+		Preserve: false,
+	}
+}
+
+func staticNestedClassWithEnum() seedSpec {
+	return seedSpec{
+		Name: "nested_class_with_enum",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{
+				cls("Root",
+					prop("title", tStr()),
+					prop("priority", tEnumRef("Priority")),
+					prop("inner", tClassRef("Inner")),
+				),
+				cls("Inner",
+					prop("label", tStr()),
+					prop("count", tInt()),
+				),
+			},
+			Enums:     []bamlfuzz.FuzzEnum{{Name: "Priority", Values: []string{"HIGH", "MEDIUM", "LOW"}}},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("title", vStr("ship it")),
+			vField("priority", vEnum("HIGH")),
+			vField("inner", vClass("Inner",
+				vField("label", vStr("inside")),
+				vField("count", vInt(7)),
+			)),
+		),
+		Preserve: false,
+	}
+}
+
+func staticOptionalThreeShapes() seedSpec {
+	return seedSpec{
+		Name: "optional_three_shapes",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("present_field", tOpt(tStr())),
+				prop("null_field", tOpt(tStr())),
+				prop("absent_field", tOpt(tStr())),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("present_field", vOptPresent(vStr("here"))),
+			vField("null_field", vOptNull()),
+			vField("absent_field", vOptAbsent()),
+		),
+		Preserve: false,
+	}
+}
+
+// staticTerminatingMutualRecursion mirrors the dynamic mutual_recursion
+// seed: A -> optional<B>, B -> optional<A>, value walks one step then
+// terminates via OptionalAbsent. Dynamic mode gates this shape with
+// TODO(upstream-mutual-rec-dynamic-crash); static mode lowers it
+// cleanly.
+func staticTerminatingMutualRecursion() seedSpec {
+	return seedSpec{
+		Name: "terminating_mutual_recursion",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{
+				cls("A",
+					prop("name", tStr()),
+					prop("b", tOpt(tClassRef("B"))),
+				),
+				cls("B",
+					prop("kind", tStr()),
+					prop("a", tOpt(tClassRef("A"))),
+				),
+			},
+			RootClass: "A",
+		},
+		Value: vClass("A",
+			vField("name", vStr("root-a")),
+			vField("b", vOptPresent(vClass("B",
+				vField("kind", vStr("nested-b")),
+				vField("a", vOptAbsent()),
+			))),
+		),
+		Preserve: false,
+	}
+}
+
+// staticSelfReferentialTree is the static-only shape: a class
+// referencing itself through an optional<list<self>> edge, value
+// terminates at depth 2 by emitting an empty list at the leaf. The
+// dynamic emitter rejects self-ref via TODO(upstream-self-ref); the
+// static .baml path supports it natively.
+func staticSelfReferentialTree() seedSpec {
+	return seedSpec{
+		Name: "self_referential_tree",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Tree",
+				prop("value", tStr()),
+				prop("children", tOpt(tList(tClassRef("Tree")))),
+			)},
+			RootClass: "Tree",
+		},
+		Value: vClass("Tree",
+			vField("value", vStr("root")),
+			vField("children", vOptPresent(vList(
+				vClass("Tree",
+					vField("value", vStr("leaf-a")),
+					vField("children", vOptAbsent()),
+				),
+				vClass("Tree",
+					vField("value", vStr("leaf-b")),
+					vField("children", vOptPresent(vList())),
+				),
+			))),
+		),
+		Preserve: false,
 	}
 }
 

--- a/adapters/common/codegen/bamlfuzz/emit_static.go
+++ b/adapters/common/codegen/bamlfuzz/emit_static.go
@@ -261,4 +261,3 @@ func literalSpelling(lit *FuzzLiteral) (string, error) {
 		return "", fmt.Errorf("unknown literal kind %q", lit.Kind)
 	}
 }
-

--- a/adapters/common/codegen/bamlfuzz/emit_static.go
+++ b/adapters/common/codegen/bamlfuzz/emit_static.go
@@ -1,0 +1,264 @@
+package bamlfuzz
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// StaticBamlSource is the lowered form of a FuzzSchema for the static
+// prompt oracle. The integration test wires FunctionName into the
+// /call/<FunctionName> URL; ClassNames / EnumNames go into the failure
+// envelope so a build failure points at the offending symbols.
+type StaticBamlSource struct {
+	// Source is the emitted .baml text. Safe to drop directly into a
+	// generated baml_src/ alongside the existing integration fixtures —
+	// the lowering emits classes/enums/function only, no client block.
+	Source string
+	// FunctionName is the BAML function declared by Source. Always
+	// equals "FuzzFn_" + CaseID.
+	FunctionName string
+	// CaseID is the suffix added to every generated symbol. Tests pass
+	// this through to compose subtest names and replay paths.
+	CaseID string
+	// ClassNames are the suffixed class declarations in the emitted
+	// source, in declaration order.
+	ClassNames []string
+	// EnumNames are the suffixed enum declarations in the emitted
+	// source, in declaration order.
+	EnumNames []string
+	// RootClass is the suffixed name of the function's return type.
+	RootClass string
+}
+
+// caseIDPattern is the contract LowerToBamlSource enforces on caseID:
+// alphanumerics + underscore, must start with a letter. The pattern
+// keeps the suffix safe to splice into a BAML identifier without
+// further escaping.
+var caseIDPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
+
+// LowerToBamlSource lowers a FuzzSchema into a .baml source string.
+//
+// Every generated symbol (classes, enums, the synthesized function) is
+// suffixed with `_<caseID>` so multiple cases can be batched into one
+// baml_src/ directory without name collisions. The returned
+// StaticBamlSource exposes the mangled names so the failure envelope
+// and the /call/<FunctionName> URL stay in sync with what landed in
+// the BAML symbol table.
+//
+// Static lowering accepts self-referential and mutually-recursive
+// schemas: the static .baml path has no upstream limitation
+// equivalent to the dynamic TypeBuilder's self-ref/mutual-cycle gates.
+// Value-side termination is enforced earlier, at value generation.
+//
+// The emitted function declares `client TestClient`, expecting the
+// integration test to supply a per-request `client_registry` override
+// pointing TestClient at the scenario for this case.
+func LowerToBamlSource(schema FuzzSchema, caseID string) (StaticBamlSource, error) {
+	if !caseIDPattern.MatchString(caseID) {
+		return StaticBamlSource{}, fmt.Errorf("bamlfuzz: invalid caseID %q (must match %s)", caseID, caseIDPattern)
+	}
+	if schema.RootClass == "" {
+		return StaticBamlSource{}, fmt.Errorf("bamlfuzz: schema missing RootClass")
+	}
+	if _, ok := schema.FindClass(schema.RootClass); !ok {
+		return StaticBamlSource{}, fmt.Errorf("bamlfuzz: root class %q not present in schema", schema.RootClass)
+	}
+
+	classNames := make(map[string]string, len(schema.Classes))
+	enumNames := make(map[string]string, len(schema.Enums))
+	classOrder := make([]string, 0, len(schema.Classes))
+	enumOrder := make([]string, 0, len(schema.Enums))
+
+	for _, cls := range schema.Classes {
+		mangled := cls.Name + "_" + caseID
+		classNames[cls.Name] = mangled
+		classOrder = append(classOrder, mangled)
+	}
+	for _, enum := range schema.Enums {
+		mangled := enum.Name + "_" + caseID
+		enumNames[enum.Name] = mangled
+		enumOrder = append(enumOrder, mangled)
+	}
+
+	var b strings.Builder
+	for _, enum := range schema.Enums {
+		if err := writeEnum(&b, enum, enumNames[enum.Name]); err != nil {
+			return StaticBamlSource{}, fmt.Errorf("bamlfuzz: emit enum %s: %w", enum.Name, err)
+		}
+		b.WriteByte('\n')
+	}
+	for _, cls := range schema.Classes {
+		if err := writeClass(&b, cls, classNames, enumNames); err != nil {
+			return StaticBamlSource{}, fmt.Errorf("bamlfuzz: emit class %s: %w", cls.Name, err)
+		}
+		b.WriteByte('\n')
+	}
+
+	funcName := "FuzzFn_" + caseID
+	rootMangled := classNames[schema.RootClass]
+	if err := writeFunction(&b, funcName, rootMangled); err != nil {
+		return StaticBamlSource{}, fmt.Errorf("bamlfuzz: emit function: %w", err)
+	}
+
+	return StaticBamlSource{
+		Source:       b.String(),
+		FunctionName: funcName,
+		CaseID:       caseID,
+		ClassNames:   classOrder,
+		EnumNames:    enumOrder,
+		RootClass:    rootMangled,
+	}, nil
+}
+
+// writeEnum emits a BAML enum declaration. Values are written in the
+// order the IR records them so failure replay produces byte-stable
+// source across runs at the same seed.
+func writeEnum(b *strings.Builder, enum FuzzEnum, mangledName string) error {
+	if len(enum.Values) == 0 {
+		return fmt.Errorf("enum %s has no values", enum.Name)
+	}
+	b.WriteString("enum ")
+	b.WriteString(mangledName)
+	b.WriteString(" {\n")
+	for _, v := range enum.Values {
+		b.WriteString("  ")
+		b.WriteString(v)
+		b.WriteByte('\n')
+	}
+	b.WriteString("}\n")
+	return nil
+}
+
+// writeClass emits a BAML class declaration. Property order follows
+// the IR; type spellings come from typeSpelling which consults the
+// mangle maps for class/enum refs.
+func writeClass(b *strings.Builder, cls FuzzClass, classNames, enumNames map[string]string) error {
+	mangled, ok := classNames[cls.Name]
+	if !ok {
+		return fmt.Errorf("class %s not in mangle map", cls.Name)
+	}
+	b.WriteString("class ")
+	b.WriteString(mangled)
+	b.WriteString(" {\n")
+	for _, prop := range cls.Properties {
+		spell, err := typeSpelling(prop.Type, classNames, enumNames)
+		if err != nil {
+			return fmt.Errorf("property %s: %w", prop.Name, err)
+		}
+		b.WriteString("  ")
+		b.WriteString(prop.Name)
+		b.WriteByte(' ')
+		b.WriteString(spell)
+		b.WriteByte('\n')
+	}
+	b.WriteString("}\n")
+	return nil
+}
+
+// writeFunction emits the synthesized BAML function. The function
+// returns the suffixed root class and references the existing
+// TestClient declared in the integration testdata baml_src/. Tests
+// override TestClient via a per-request client_registry to point at
+// the mockllm scenario for this case.
+//
+// The prompt includes {{ ctx.output_format }} so schema rendering is
+// exercised in the upstream request.
+func writeFunction(b *strings.Builder, funcName, rootMangled string) error {
+	b.WriteString("function ")
+	b.WriteString(funcName)
+	b.WriteString("(input: string) -> ")
+	b.WriteString(rootMangled)
+	b.WriteString(" {\n")
+	b.WriteString("  client TestClient\n")
+	b.WriteString("  prompt #\"{{ ctx.output_format }}\n")
+	b.WriteString("  {{ input }}\"#\n")
+	b.WriteString("}\n")
+	return nil
+}
+
+// typeSpelling returns the BAML source-level type spelling for a
+// FuzzType. ClassRef/EnumRef targets are resolved through the mangle
+// maps so the emitted source matches the declared symbol names.
+func typeSpelling(t FuzzType, classNames, enumNames map[string]string) (string, error) {
+	switch t.Kind {
+	case KindString, KindInt, KindFloat, KindBool, KindNull:
+		return string(t.Kind), nil
+	case KindLiteral:
+		if t.Literal == nil {
+			return "", fmt.Errorf("literal kind missing payload")
+		}
+		return literalSpelling(t.Literal)
+	case KindOptional:
+		if t.Inner == nil {
+			return "", fmt.Errorf("optional missing inner")
+		}
+		inner, err := typeSpelling(*t.Inner, classNames, enumNames)
+		if err != nil {
+			return "", err
+		}
+		// Wrap composite inners in parens so e.g. `int[]?` parses as
+		// optional<list<int>>, not list<optional<int>>. Atomic
+		// spellings don't need parens but adding them uniformly keeps
+		// the precedence story unambiguous.
+		return "(" + inner + ")?", nil
+	case KindList:
+		if t.Inner == nil {
+			return "", fmt.Errorf("list missing inner")
+		}
+		inner, err := typeSpelling(*t.Inner, classNames, enumNames)
+		if err != nil {
+			return "", err
+		}
+		return "(" + inner + ")[]", nil
+	case KindMap:
+		if t.Key == nil || t.Inner == nil {
+			return "", fmt.Errorf("map missing key or inner")
+		}
+		if t.Key.Kind != KindString {
+			return "", fmt.Errorf("map key must be string in v1, got %q", t.Key.Kind)
+		}
+		inner, err := typeSpelling(*t.Inner, classNames, enumNames)
+		if err != nil {
+			return "", err
+		}
+		return "map<string, " + inner + ">", nil
+	case KindClassRef:
+		mangled, ok := classNames[t.Ref]
+		if !ok {
+			return "", fmt.Errorf("class ref %q not declared in schema", t.Ref)
+		}
+		return mangled, nil
+	case KindEnumRef:
+		mangled, ok := enumNames[t.Ref]
+		if !ok {
+			return "", fmt.Errorf("enum ref %q not declared in schema", t.Ref)
+		}
+		return mangled, nil
+	default:
+		return "", fmt.Errorf("unsupported kind %q", t.Kind)
+	}
+}
+
+// literalSpelling renders a FuzzLiteral as its BAML source-level
+// literal type spelling: literal_string -> "value", literal_int -> 42,
+// literal_bool -> true/false. The string form uses strconv.Quote so
+// embedded quotes, backslashes, and non-ASCII characters land
+// escape-clean.
+func literalSpelling(lit *FuzzLiteral) (string, error) {
+	switch lit.Kind {
+	case LiteralString:
+		return strconv.Quote(lit.String), nil
+	case LiteralInt:
+		return strconv.FormatInt(lit.Int, 10), nil
+	case LiteralBool:
+		if lit.Bool {
+			return "true", nil
+		}
+		return "false", nil
+	default:
+		return "", fmt.Errorf("unknown literal kind %q", lit.Kind)
+	}
+}
+

--- a/adapters/common/codegen/bamlfuzz/emit_static_test.go
+++ b/adapters/common/codegen/bamlfuzz/emit_static_test.go
@@ -1,0 +1,360 @@
+package bamlfuzz
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLowerToBamlSource_ScalarKinds(t *testing.T) {
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{{Name: "Root", Properties: []FuzzProperty{
+			{Name: "s", Type: FuzzType{Kind: KindString}},
+			{Name: "i", Type: FuzzType{Kind: KindInt}},
+			{Name: "f", Type: FuzzType{Kind: KindFloat}},
+			{Name: "b", Type: FuzzType{Kind: KindBool}},
+			{Name: "n", Type: FuzzType{Kind: KindNull}},
+		}}},
+		RootClass: "Root",
+	})
+	got, err := LowerToBamlSource(schema, "C01")
+	if err != nil {
+		t.Fatalf("LowerToBamlSource: %v", err)
+	}
+
+	wantSubs := []string{
+		"class Root_C01 {",
+		"  s string",
+		"  i int",
+		"  f float",
+		"  b bool",
+		"  n null",
+		"function FuzzFn_C01(input: string) -> Root_C01 {",
+		"  client TestClient",
+	}
+	for _, sub := range wantSubs {
+		if !strings.Contains(got.Source, sub) {
+			t.Errorf("missing substring %q in source:\n%s", sub, got.Source)
+		}
+	}
+	if got.FunctionName != "FuzzFn_C01" {
+		t.Errorf("FunctionName: got %q want FuzzFn_C01", got.FunctionName)
+	}
+	if got.RootClass != "Root_C01" {
+		t.Errorf("RootClass: got %q want Root_C01", got.RootClass)
+	}
+	if len(got.ClassNames) != 1 || got.ClassNames[0] != "Root_C01" {
+		t.Errorf("ClassNames: got %v want [Root_C01]", got.ClassNames)
+	}
+	if len(got.EnumNames) != 0 {
+		t.Errorf("EnumNames: got %v want []", got.EnumNames)
+	}
+}
+
+func TestLowerToBamlSource_Optional(t *testing.T) {
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{{Name: "Root", Properties: []FuzzProperty{
+			{Name: "maybe", Type: FuzzType{Kind: KindOptional, Inner: &FuzzType{Kind: KindString}}},
+		}}},
+		RootClass: "Root",
+	})
+	got, err := LowerToBamlSource(schema, "C02")
+	if err != nil {
+		t.Fatalf("LowerToBamlSource: %v", err)
+	}
+	if !strings.Contains(got.Source, "  maybe (string)?") {
+		t.Errorf("optional spelling missing:\n%s", got.Source)
+	}
+}
+
+func TestLowerToBamlSource_List(t *testing.T) {
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{{Name: "Root", Properties: []FuzzProperty{
+			{Name: "items", Type: FuzzType{Kind: KindList, Inner: &FuzzType{Kind: KindInt}}},
+		}}},
+		RootClass: "Root",
+	})
+	got, err := LowerToBamlSource(schema, "C03")
+	if err != nil {
+		t.Fatalf("LowerToBamlSource: %v", err)
+	}
+	if !strings.Contains(got.Source, "  items (int)[]") {
+		t.Errorf("list spelling missing:\n%s", got.Source)
+	}
+}
+
+func TestLowerToBamlSource_Map(t *testing.T) {
+	key := FuzzType{Kind: KindString}
+	inner := FuzzType{Kind: KindBool}
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{{Name: "Root", Properties: []FuzzProperty{
+			{Name: "flags", Type: FuzzType{Kind: KindMap, Key: &key, Inner: &inner}},
+		}}},
+		RootClass: "Root",
+	})
+	got, err := LowerToBamlSource(schema, "C04")
+	if err != nil {
+		t.Fatalf("LowerToBamlSource: %v", err)
+	}
+	if !strings.Contains(got.Source, "  flags map<string, bool>") {
+		t.Errorf("map spelling missing:\n%s", got.Source)
+	}
+}
+
+func TestLowerToBamlSource_EnumRef(t *testing.T) {
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{{Name: "Root", Properties: []FuzzProperty{
+			{Name: "status", Type: FuzzType{Kind: KindEnumRef, Ref: "Status"}},
+		}}},
+		Enums: []FuzzEnum{{Name: "Status", Values: []string{"ACTIVE", "INACTIVE"}}},
+		RootClass: "Root",
+	})
+	got, err := LowerToBamlSource(schema, "C05")
+	if err != nil {
+		t.Fatalf("LowerToBamlSource: %v", err)
+	}
+	wantSubs := []string{
+		"enum Status_C05 {",
+		"  ACTIVE",
+		"  INACTIVE",
+		"  status Status_C05",
+	}
+	for _, sub := range wantSubs {
+		if !strings.Contains(got.Source, sub) {
+			t.Errorf("missing %q in source:\n%s", sub, got.Source)
+		}
+	}
+	if len(got.EnumNames) != 1 || got.EnumNames[0] != "Status_C05" {
+		t.Errorf("EnumNames: got %v", got.EnumNames)
+	}
+}
+
+func TestLowerToBamlSource_ClassRef(t *testing.T) {
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{
+			{Name: "Root", Properties: []FuzzProperty{
+				{Name: "inner", Type: FuzzType{Kind: KindClassRef, Ref: "Inner"}},
+			}},
+			{Name: "Inner", Properties: []FuzzProperty{
+				{Name: "label", Type: FuzzType{Kind: KindString}},
+			}},
+		},
+		RootClass: "Root",
+	})
+	got, err := LowerToBamlSource(schema, "C06")
+	if err != nil {
+		t.Fatalf("LowerToBamlSource: %v", err)
+	}
+	if !strings.Contains(got.Source, "  inner Root_C06") && !strings.Contains(got.Source, "  inner Inner_C06") {
+		t.Errorf("class ref spelling missing:\n%s", got.Source)
+	}
+	if !strings.Contains(got.Source, "  inner Inner_C06") {
+		t.Errorf("class ref should target Inner_C06, got:\n%s", got.Source)
+	}
+}
+
+func TestLowerToBamlSource_LiteralKinds(t *testing.T) {
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{{Name: "Root", Properties: []FuzzProperty{
+			{Name: "kind", Type: FuzzType{Kind: KindLiteral, Literal: &FuzzLiteral{Kind: LiteralString, String: "widget"}}},
+			{Name: "count", Type: FuzzType{Kind: KindLiteral, Literal: &FuzzLiteral{Kind: LiteralInt, Int: 42}}},
+			{Name: "active", Type: FuzzType{Kind: KindLiteral, Literal: &FuzzLiteral{Kind: LiteralBool, Bool: true}}},
+		}}},
+		RootClass: "Root",
+	})
+	got, err := LowerToBamlSource(schema, "C07")
+	if err != nil {
+		t.Fatalf("LowerToBamlSource: %v", err)
+	}
+	wantSubs := []string{
+		`  kind "widget"`,
+		"  count 42",
+		"  active true",
+	}
+	for _, sub := range wantSubs {
+		if !strings.Contains(got.Source, sub) {
+			t.Errorf("missing %q in source:\n%s", sub, got.Source)
+		}
+	}
+}
+
+// TestLowerToBamlSource_LiteralStringEscapes pins the strconv.Quote
+// escaping contract — the emitted .baml must remain syntactically
+// valid when a literal value carries quotes, backslashes, or non-
+// ASCII characters.
+func TestLowerToBamlSource_LiteralStringEscapes(t *testing.T) {
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{{Name: "Root", Properties: []FuzzProperty{
+			{Name: "quoted", Type: FuzzType{Kind: KindLiteral, Literal: &FuzzLiteral{Kind: LiteralString, String: `with "quote"`}}},
+		}}},
+		RootClass: "Root",
+	})
+	got, err := LowerToBamlSource(schema, "C08")
+	if err != nil {
+		t.Fatalf("LowerToBamlSource: %v", err)
+	}
+	if !strings.Contains(got.Source, `  quoted "with \"quote\""`) {
+		t.Errorf("literal escape missing:\n%s", got.Source)
+	}
+}
+
+// TestLowerToBamlSource_SelfRef pins the contract the dynamic emitter
+// gates against and the static emitter accepts: a class whose property
+// type tree can reach itself must lower successfully on the static
+// path.
+func TestLowerToBamlSource_SelfRef(t *testing.T) {
+	self := FuzzType{Kind: KindClassRef, Ref: "Tree"}
+	listSelf := FuzzType{Kind: KindList, Inner: &self}
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{{Name: "Tree", Properties: []FuzzProperty{
+			{Name: "value", Type: FuzzType{Kind: KindString}},
+			{Name: "children", Type: FuzzType{Kind: KindOptional, Inner: &listSelf}},
+		}}},
+		RootClass: "Tree",
+	})
+	if !schema.HasSelfRef {
+		t.Fatalf("expected HasSelfRef=true, got false")
+	}
+	got, err := LowerToBamlSource(schema, "C09")
+	if err != nil {
+		t.Fatalf("LowerToBamlSource self-ref: %v", err)
+	}
+	wantSubs := []string{
+		"class Tree_C09 {",
+		"  value string",
+		"  children ((Tree_C09)[])?",
+		"function FuzzFn_C09(input: string) -> Tree_C09 {",
+	}
+	for _, sub := range wantSubs {
+		if !strings.Contains(got.Source, sub) {
+			t.Errorf("missing %q in source:\n%s", sub, got.Source)
+		}
+	}
+}
+
+// TestLowerToBamlSource_MutualCycle pins that static lowering accepts
+// the dynamic-gated A->B->A shape — only the dynamic TypeBuilder has
+// the upstream cgo crash for mutual cycles.
+func TestLowerToBamlSource_MutualCycle(t *testing.T) {
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{
+			{Name: "A", Properties: []FuzzProperty{
+				{Name: "name", Type: FuzzType{Kind: KindString}},
+				{Name: "b", Type: FuzzType{Kind: KindOptional, Inner: &FuzzType{Kind: KindClassRef, Ref: "B"}}},
+			}},
+			{Name: "B", Properties: []FuzzProperty{
+				{Name: "kind", Type: FuzzType{Kind: KindString}},
+				{Name: "a", Type: FuzzType{Kind: KindOptional, Inner: &FuzzType{Kind: KindClassRef, Ref: "A"}}},
+			}},
+		},
+		RootClass: "A",
+	})
+	if !schema.HasMutualCycle {
+		t.Fatalf("expected HasMutualCycle=true")
+	}
+	got, err := LowerToBamlSource(schema, "C10")
+	if err != nil {
+		t.Fatalf("LowerToBamlSource mutual-cycle: %v", err)
+	}
+	wantSubs := []string{
+		"class A_C10 {",
+		"class B_C10 {",
+		"  b (B_C10)?",
+		"  a (A_C10)?",
+		"function FuzzFn_C10(input: string) -> A_C10 {",
+	}
+	for _, sub := range wantSubs {
+		if !strings.Contains(got.Source, sub) {
+			t.Errorf("missing %q in source:\n%s", sub, got.Source)
+		}
+	}
+}
+
+// TestLowerToBamlSource_NullRequired covers the edge case the scope
+// pins: a class with KindNull as a required (non-optional) field type
+// must lower to `null` directly.
+func TestLowerToBamlSource_NullRequired(t *testing.T) {
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{{Name: "Root", Properties: []FuzzProperty{
+			{Name: "nothing", Type: FuzzType{Kind: KindNull}},
+		}}},
+		RootClass: "Root",
+	})
+	got, err := LowerToBamlSource(schema, "C11")
+	if err != nil {
+		t.Fatalf("LowerToBamlSource null-required: %v", err)
+	}
+	if !strings.Contains(got.Source, "  nothing null") {
+		t.Errorf("KindNull spelling missing:\n%s", got.Source)
+	}
+}
+
+// TestLowerToBamlSource_DeterministicOutput pins that lowering the
+// same schema twice yields byte-identical source. The replay/failure
+// envelope contract depends on this.
+func TestLowerToBamlSource_DeterministicOutput(t *testing.T) {
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes: []FuzzClass{
+			{Name: "Root", Properties: []FuzzProperty{
+				{Name: "a", Type: FuzzType{Kind: KindString}},
+				{Name: "b", Type: FuzzType{Kind: KindOptional, Inner: &FuzzType{Kind: KindClassRef, Ref: "Inner"}}},
+			}},
+			{Name: "Inner", Properties: []FuzzProperty{
+				{Name: "x", Type: FuzzType{Kind: KindInt}},
+			}},
+		},
+		Enums: []FuzzEnum{{Name: "E", Values: []string{"X", "Y"}}},
+		RootClass: "Root",
+	})
+	a, err := LowerToBamlSource(schema, "CDET")
+	if err != nil {
+		t.Fatalf("first lower: %v", err)
+	}
+	b, err := LowerToBamlSource(schema, "CDET")
+	if err != nil {
+		t.Fatalf("second lower: %v", err)
+	}
+	if a.Source != b.Source {
+		t.Errorf("non-deterministic output:\n--a--\n%s\n--b--\n%s", a.Source, b.Source)
+	}
+}
+
+func TestLowerToBamlSource_InvalidCaseID(t *testing.T) {
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes:   []FuzzClass{{Name: "Root", Properties: []FuzzProperty{{Name: "x", Type: FuzzType{Kind: KindString}}}}},
+		RootClass: "Root",
+	})
+	tests := []string{"", "0bad", "has-dash", "has space", "has.dot", "1leading"}
+	for _, id := range tests {
+		_, err := LowerToBamlSource(schema, id)
+		if err == nil {
+			t.Errorf("expected error for caseID %q, got nil", id)
+		}
+	}
+}
+
+func TestLowerToBamlSource_MissingRoot(t *testing.T) {
+	schema := FuzzSchema{
+		Classes:   []FuzzClass{{Name: "Other"}},
+		RootClass: "Missing",
+	}
+	_, err := LowerToBamlSource(schema, "C00")
+	if err == nil {
+		t.Fatalf("expected error for missing root class")
+	}
+	if !strings.Contains(err.Error(), "root class") {
+		t.Errorf("error should mention root class, got %v", err)
+	}
+}
+
+func TestLowerToBamlSource_UnknownClassRef(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{Name: "Root", Properties: []FuzzProperty{
+			{Name: "missing_ref", Type: FuzzType{Kind: KindClassRef, Ref: "Ghost"}},
+		}}},
+		RootClass: "Root",
+	}
+	_, err := LowerToBamlSource(schema, "C12")
+	if err == nil {
+		t.Fatalf("expected error for unknown class ref")
+	}
+}

--- a/adapters/common/codegen/bamlfuzz/emit_static_test.go
+++ b/adapters/common/codegen/bamlfuzz/emit_static_test.go
@@ -105,7 +105,7 @@ func TestLowerToBamlSource_EnumRef(t *testing.T) {
 		Classes: []FuzzClass{{Name: "Root", Properties: []FuzzProperty{
 			{Name: "status", Type: FuzzType{Kind: KindEnumRef, Ref: "Status"}},
 		}}},
-		Enums: []FuzzEnum{{Name: "Status", Values: []string{"ACTIVE", "INACTIVE"}}},
+		Enums:     []FuzzEnum{{Name: "Status", Values: []string{"ACTIVE", "INACTIVE"}}},
 		RootClass: "Root",
 	})
 	got, err := LowerToBamlSource(schema, "C05")
@@ -302,7 +302,7 @@ func TestLowerToBamlSource_DeterministicOutput(t *testing.T) {
 				{Name: "x", Type: FuzzType{Kind: KindInt}},
 			}},
 		},
-		Enums: []FuzzEnum{{Name: "E", Values: []string{"X", "Y"}}},
+		Enums:     []FuzzEnum{{Name: "E", Values: []string{"X", "Y"}}},
 		RootClass: "Root",
 	})
 	a, err := LowerToBamlSource(schema, "CDET")

--- a/adapters/common/codegen/bamlfuzz/envelope.go
+++ b/adapters/common/codegen/bamlfuzz/envelope.go
@@ -57,6 +57,44 @@ type SemanticDiffEntry struct {
 	Want any    `json:"want"`
 }
 
+// StaticFailureEnvelope captures the full context around a failure in
+// the static prompt oracle. It mirrors DynamicFailureEnvelope on the
+// common header fields and adds the static-specific lowering + build
+// metadata listed in scope D8. v1 release-gates on semantic equality
+// only; order mismatches travel under OrderWarning.
+//
+// BuildError populates when the integration build fails for the case;
+// after single-case isolation it identifies the offending case alone.
+// RESTStatus / RESTBody / RESTError populate when the build succeeds
+// and /call/<FunctionName> runs.
+type StaticFailureEnvelope struct {
+	GeneratorVersion  string              `json:"generator_version"`
+	GeneratedAt       string              `json:"generated_at"`
+	RapidSeed         int64               `json:"rapid_seed"`
+	CaseIndex         int                 `json:"case_index"`
+	CaseName          string              `json:"case_name"`
+	OracleMode        OracleMode          `json:"oracle_mode"`
+	Schema            FuzzSchema          `json:"schema"`
+	BamlSource        string              `json:"baml_source,omitempty"`
+	FunctionName      string              `json:"function_name,omitempty"`
+	ClassNames        []string            `json:"class_names,omitempty"`
+	EnumNames         []string            `json:"enum_names,omitempty"`
+	HasSelfRef        bool                `json:"has_self_ref"`
+	BuildSourcePath   string              `json:"build_source_path,omitempty"`
+	MockLLMScenarioID string              `json:"mockllm_scenario_id,omitempty"`
+	MockLLMContent    json.RawMessage     `json:"mockllm_content,omitempty"`
+	Expected          json.RawMessage     `json:"expected,omitempty"`
+	BuildError        string              `json:"build_error,omitempty"`
+	RESTStatus        int                 `json:"rest_status,omitempty"`
+	RESTBody          json.RawMessage     `json:"rest_body,omitempty"`
+	RESTError         string              `json:"rest_error,omitempty"`
+	SemanticDiff      []SemanticDiffEntry `json:"semantic_diff,omitempty"`
+	OrderWarning      []string            `json:"order_warning,omitempty"`
+	ReplayPath        string              `json:"replay_path"`
+	Reproduction      string              `json:"reproduction"`
+	Metadata          CaseMetadata        `json:"metadata"`
+}
+
 // WriteReplayArtifact writes the failure envelope to `dir` as a JSON
 // file and returns the resulting `filepath.Join(dir, basename+".json")`
 // (which is absolute exactly when `dir` is). The basename is derived
@@ -70,6 +108,37 @@ type SemanticDiffEntry struct {
 // Content is rendered with 2-space indent for human readability.
 // `dir` is created if it does not already exist.
 func WriteReplayArtifact(dir string, envelope *DynamicFailureEnvelope) (string, error) {
+	if envelope == nil {
+		return "", fmt.Errorf("bamlfuzz: nil envelope")
+	}
+	if envelope.GeneratorVersion == "" {
+		envelope.GeneratorVersion = GeneratorVersion
+	}
+	if envelope.GeneratedAt == "" {
+		envelope.GeneratedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("bamlfuzz: mkdir %s: %w", dir, err)
+	}
+	name := sanitizeArtifactBasename(envelope.CaseName, envelope.CaseIndex)
+	path := filepath.Join(dir, name+".json")
+	envelope.ReplayPath = path
+	buf, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("bamlfuzz: marshal envelope: %w", err)
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		return "", fmt.Errorf("bamlfuzz: write %s: %w", path, err)
+	}
+	return path, nil
+}
+
+// WriteStaticReplayArtifact writes a StaticFailureEnvelope to `dir`
+// as a JSON file. Same on-disk format as WriteReplayArtifact (2-space
+// indent, deterministic basename via sanitizeArtifactBasename);
+// envelope.ReplayPath is stamped with the resulting path so the
+// t.Errorf message can point at the artifact.
+func WriteStaticReplayArtifact(dir string, envelope *StaticFailureEnvelope) (string, error) {
 	if envelope == nil {
 		return "", fmt.Errorf("bamlfuzz: nil envelope")
 	}

--- a/adapters/common/codegen/bamlfuzz/envelope_test.go
+++ b/adapters/common/codegen/bamlfuzz/envelope_test.go
@@ -142,6 +142,73 @@ func TestWriteReplayArtifact_SanitizesUnsafeCaseName(t *testing.T) {
 	}
 }
 
+func TestWriteStaticReplayArtifact_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	env := &StaticFailureEnvelope{
+		CaseName:       "static_demo",
+		CaseIndex:      3,
+		OracleMode:     OracleStaticPrompt,
+		BamlSource:     "class Demo {}",
+		FunctionName:   "FuzzFn_C03",
+		ClassNames:     []string{"Demo_C03"},
+		HasSelfRef:     true,
+		MockLLMContent: json.RawMessage(`{"k":"v"}`),
+		Expected:       json.RawMessage(`{"k":"v"}`),
+	}
+	path, err := WriteStaticReplayArtifact(dir, env)
+	if err != nil {
+		t.Fatalf("WriteStaticReplayArtifact: %v", err)
+	}
+	if got, want := filepath.Base(path), "static_demo.json"; got != want {
+		t.Errorf("path basename: got %q want %q", got, want)
+	}
+	if env.ReplayPath != path {
+		t.Errorf("envelope.ReplayPath: got %q want %q", env.ReplayPath, path)
+	}
+	if env.GeneratorVersion == "" {
+		t.Error("envelope.GeneratorVersion not stamped")
+	}
+	if env.GeneratedAt == "" {
+		t.Error("envelope.GeneratedAt not stamped")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var roundtrip StaticFailureEnvelope
+	if err := json.Unmarshal(data, &roundtrip); err != nil {
+		t.Fatalf("Unmarshal envelope: %v", err)
+	}
+	if roundtrip.CaseName != env.CaseName {
+		t.Errorf("CaseName round-trip: got %q want %q", roundtrip.CaseName, env.CaseName)
+	}
+	if roundtrip.FunctionName != env.FunctionName {
+		t.Errorf("FunctionName round-trip: got %q want %q", roundtrip.FunctionName, env.FunctionName)
+	}
+	if roundtrip.BamlSource != env.BamlSource {
+		t.Errorf("BamlSource round-trip mismatch")
+	}
+	if !roundtrip.HasSelfRef {
+		t.Error("HasSelfRef round-trip lost")
+	}
+}
+
+func TestWriteStaticReplayArtifact_SanitizesUnsafeCaseName(t *testing.T) {
+	dir := t.TempDir()
+	env := &StaticFailureEnvelope{
+		CaseName:  "../escape",
+		CaseIndex: 9,
+	}
+	path, err := WriteStaticReplayArtifact(dir, env)
+	if err != nil {
+		t.Fatalf("WriteStaticReplayArtifact: %v", err)
+	}
+	if got, want := filepath.Base(path), "case_9.json"; got != want {
+		t.Errorf("basename: got %q want %q (raw=%q)", got, want, path)
+	}
+}
+
 func TestWriteReplayArtifact_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	env := &DynamicFailureEnvelope{

--- a/adapters/common/codegen/testdata/bamlfuzz/static/00_scalar_object.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/00_scalar_object.json
@@ -1,0 +1,67 @@
+{
+  "name": "scalar_object",
+  "seed": 1,
+  "case_index": 0,
+  "mode": "static_prompt",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "name",
+            "type": {
+              "kind": "string"
+            }
+          },
+          {
+            "name": "age",
+            "type": {
+              "kind": "int"
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": false,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "name",
+        "value": {
+          "kind": "string",
+          "string": "Ada"
+        }
+      },
+      {
+        "name": "age",
+        "value": {
+          "kind": "int",
+          "int": 36
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "name": "Ada",
+    "age": 36
+  },
+  "expected": {
+    "name": "Ada",
+    "age": 36
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/static/01_nested_class_with_enum.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/01_nested_class_with_enum.json
@@ -1,0 +1,133 @@
+{
+  "name": "nested_class_with_enum",
+  "seed": 2,
+  "case_index": 1,
+  "mode": "static_prompt",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "title",
+            "type": {
+              "kind": "string"
+            }
+          },
+          {
+            "name": "priority",
+            "type": {
+              "kind": "enum_ref",
+              "ref": "Priority"
+            }
+          },
+          {
+            "name": "inner",
+            "type": {
+              "kind": "class_ref",
+              "ref": "Inner"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Inner",
+        "properties": [
+          {
+            "name": "label",
+            "type": {
+              "kind": "string"
+            }
+          },
+          {
+            "name": "count",
+            "type": {
+              "kind": "int"
+            }
+          }
+        ]
+      }
+    ],
+    "enums": [
+      {
+        "name": "Priority",
+        "values": [
+          "HIGH",
+          "MEDIUM",
+          "LOW"
+        ]
+      }
+    ],
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": false,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "title",
+        "value": {
+          "kind": "string",
+          "string": "ship it"
+        }
+      },
+      {
+        "name": "priority",
+        "value": {
+          "kind": "enum_ref",
+          "enum": "HIGH"
+        }
+      },
+      {
+        "name": "inner",
+        "value": {
+          "kind": "class_ref",
+          "class_name": "Inner",
+          "fields": [
+            {
+              "name": "label",
+              "value": {
+                "kind": "string",
+                "string": "inside"
+              }
+            },
+            {
+              "name": "count",
+              "value": {
+                "kind": "int",
+                "int": 7
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "title": "ship it",
+    "priority": "HIGH",
+    "inner": {
+      "label": "inside",
+      "count": 7
+    }
+  },
+  "expected": {
+    "title": "ship it",
+    "priority": "HIGH",
+    "inner": {
+      "label": "inside",
+      "count": 7
+    }
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Inner": 1,
+      "Root": 1
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/static/02_optional_three_shapes.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/02_optional_three_shapes.json
@@ -1,0 +1,99 @@
+{
+  "name": "optional_three_shapes",
+  "seed": 3,
+  "case_index": 2,
+  "mode": "static_prompt",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "present_field",
+            "type": {
+              "kind": "optional",
+              "inner": {
+                "kind": "string"
+              }
+            }
+          },
+          {
+            "name": "null_field",
+            "type": {
+              "kind": "optional",
+              "inner": {
+                "kind": "string"
+              }
+            }
+          },
+          {
+            "name": "absent_field",
+            "type": {
+              "kind": "optional",
+              "inner": {
+                "kind": "string"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": false,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "present_field",
+        "value": {
+          "kind": "optional",
+          "optional_shape": "present",
+          "inner": {
+            "kind": "string",
+            "string": "here"
+          }
+        }
+      },
+      {
+        "name": "null_field",
+        "value": {
+          "kind": "optional",
+          "optional_shape": "null"
+        }
+      },
+      {
+        "name": "absent_field",
+        "value": {
+          "kind": "optional",
+          "optional_shape": "absent"
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "present_field": "here",
+    "null_field": null
+  },
+  "expected": {
+    "present_field": "here",
+    "null_field": null,
+    "absent_field": null
+  },
+  "metadata": {
+    "optional_shapes": {
+      ".absent_field": "absent",
+      ".null_field": "null",
+      ".present_field": "present"
+    },
+    "recursion_depths": {
+      "Root": 1
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/static/03_terminating_mutual_recursion.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/03_terminating_mutual_recursion.json
@@ -1,0 +1,122 @@
+{
+  "name": "terminating_mutual_recursion",
+  "seed": 4,
+  "case_index": 3,
+  "mode": "static_prompt",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "A",
+        "properties": [
+          {
+            "name": "name",
+            "type": {
+              "kind": "string"
+            }
+          },
+          {
+            "name": "b",
+            "type": {
+              "kind": "optional",
+              "inner": {
+                "kind": "class_ref",
+                "ref": "B"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "B",
+        "properties": [
+          {
+            "name": "kind",
+            "type": {
+              "kind": "string"
+            }
+          },
+          {
+            "name": "a",
+            "type": {
+              "kind": "optional",
+              "inner": {
+                "kind": "class_ref",
+                "ref": "A"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "A",
+    "has_self_ref": false,
+    "has_mutual_cycle": true,
+    "has_union": false,
+    "requires_dynamic_skip": true
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "A",
+    "fields": [
+      {
+        "name": "name",
+        "value": {
+          "kind": "string",
+          "string": "root-a"
+        }
+      },
+      {
+        "name": "b",
+        "value": {
+          "kind": "optional",
+          "optional_shape": "present",
+          "inner": {
+            "kind": "class_ref",
+            "class_name": "B",
+            "fields": [
+              {
+                "name": "kind",
+                "value": {
+                  "kind": "string",
+                  "string": "nested-b"
+                }
+              },
+              {
+                "name": "a",
+                "value": {
+                  "kind": "optional",
+                  "optional_shape": "absent"
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "name": "root-a",
+    "b": {
+      "kind": "nested-b"
+    }
+  },
+  "expected": {
+    "name": "root-a",
+    "b": {
+      "kind": "nested-b",
+      "a": null
+    }
+  },
+  "metadata": {
+    "optional_shapes": {
+      ".b": "present",
+      ".b.a": "absent"
+    },
+    "recursion_depths": {
+      "A": 1,
+      "B": 1
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/static/04_self_referential_tree.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/04_self_referential_tree.json
@@ -1,0 +1,144 @@
+{
+  "name": "self_referential_tree",
+  "seed": 5,
+  "case_index": 4,
+  "mode": "static_prompt",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Tree",
+        "properties": [
+          {
+            "name": "value",
+            "type": {
+              "kind": "string"
+            }
+          },
+          {
+            "name": "children",
+            "type": {
+              "kind": "optional",
+              "inner": {
+                "kind": "list",
+                "inner": {
+                  "kind": "class_ref",
+                  "ref": "Tree"
+                }
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Tree",
+    "has_self_ref": true,
+    "has_mutual_cycle": false,
+    "has_union": false,
+    "requires_dynamic_skip": true
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Tree",
+    "fields": [
+      {
+        "name": "value",
+        "value": {
+          "kind": "string",
+          "string": "root"
+        }
+      },
+      {
+        "name": "children",
+        "value": {
+          "kind": "optional",
+          "optional_shape": "present",
+          "inner": {
+            "kind": "list",
+            "items": [
+              {
+                "kind": "class_ref",
+                "class_name": "Tree",
+                "fields": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "kind": "string",
+                      "string": "leaf-a"
+                    }
+                  },
+                  {
+                    "name": "children",
+                    "value": {
+                      "kind": "optional",
+                      "optional_shape": "absent"
+                    }
+                  }
+                ]
+              },
+              {
+                "kind": "class_ref",
+                "class_name": "Tree",
+                "fields": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "kind": "string",
+                      "string": "leaf-b"
+                    }
+                  },
+                  {
+                    "name": "children",
+                    "value": {
+                      "kind": "optional",
+                      "optional_shape": "present",
+                      "inner": {
+                        "kind": "list"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "value": "root",
+    "children": [
+      {
+        "value": "leaf-a"
+      },
+      {
+        "value": "leaf-b",
+        "children": []
+      }
+    ]
+  },
+  "expected": {
+    "value": "root",
+    "children": [
+      {
+        "value": "leaf-a",
+        "children": null
+      },
+      {
+        "value": "leaf-b",
+        "children": []
+      }
+    ]
+  },
+  "metadata": {
+    "optional_shapes": {
+      ".children": "present",
+      ".children[0].children": "absent",
+      ".children[1].children": "present"
+    },
+    "recursion_depths": {
+      "Tree": 2
+    }
+  }
+}

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -57,11 +57,6 @@ const staticEnvSetupTimeout = 10 * time.Minute
 // before the integration server reports a real failure.
 const staticCallTimeout = 60 * time.Second
 
-// rapidSelfRefProbability sets the self-ref density for randomly-
-// generated static batches. Scope D9 says 10-20%; pinning here keeps
-// each rapid batch reproducible at the seed level.
-const rapidSelfRefProbability = 0.15
-
 // TestBamlfuzzStaticOracle drives the static prompt oracle: lower
 // each FuzzSchema to .baml source, batch five cases into a temporary
 // baml_src/, spin up a dedicated integration environment, register a
@@ -398,17 +393,17 @@ func terminateStaticEnv(t *testing.T, env *testutil.TestEnvironment) {
 func newStaticEnvelope(c bamlfuzz.OracleCase, caseIdx int, batchLabel string, source staticCaseSource) *bamlfuzz.StaticFailureEnvelope {
 	flags := bamlfuzz.AnalyzeGraph(c.Schema)
 	return &bamlfuzz.StaticFailureEnvelope{
-		GeneratorVersion:  bamlfuzz.GeneratorVersion,
-		RapidSeed:         c.Seed,
-		CaseIndex:         caseIdx,
-		CaseName:          c.Name,
-		OracleMode:        bamlfuzz.OracleStaticPrompt,
-		Schema:            c.Schema,
-		HasSelfRef:        flags.HasSelfRef,
-		MockLLMContent:    c.MockLLMContent,
-		Expected:          c.Expected,
-		Metadata:          c.Metadata,
-		Reproduction:      staticReproductionFor(c, caseIdx, batchLabel, source),
+		GeneratorVersion: bamlfuzz.GeneratorVersion,
+		RapidSeed:        c.Seed,
+		CaseIndex:        caseIdx,
+		CaseName:         c.Name,
+		OracleMode:       bamlfuzz.OracleStaticPrompt,
+		Schema:           c.Schema,
+		HasSelfRef:       flags.HasSelfRef,
+		MockLLMContent:   c.MockLLMContent,
+		Expected:         c.Expected,
+		Metadata:         c.Metadata,
+		Reproduction:     staticReproductionFor(c, caseIdx, batchLabel, source),
 	}
 }
 
@@ -648,4 +643,3 @@ func TestCaseIDFor(t *testing.T) {
 		})
 	}
 }
-

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -133,7 +133,7 @@ func runStaticBatch(t *testing.T, cases []bamlfuzz.OracleCase, batchLabel string
 		caseID := caseIDFor(batchLabel, i)
 		src, err := bamlfuzz.LowerToBamlSource(cases[i].Schema, caseID)
 		if err != nil {
-			envelope := newStaticEnvelope(cases[i], i, batchLabel, source)
+			envelope := newStaticEnvelope(cases[i], i, batchLabel, source, false)
 			envelope.BuildError = fmt.Sprintf("LowerToBamlSource: %v", err)
 			failStaticAndDump(t, envelope, "LowerToBamlSource for case %s: %v", cases[i].Name, err)
 			return
@@ -154,7 +154,15 @@ func runStaticBatch(t *testing.T, cases []bamlfuzz.OracleCase, batchLabel string
 	env, err := setupStaticEnv(batchDir)
 	if err != nil {
 		t.Logf("batch build failed for %s: %v; isolating cases singly", batchLabel, err)
-		isolateStaticBatch(t, lowered, batchLabel, source)
+		if !isolateStaticBatch(t, lowered, batchLabel, source) {
+			// All isolated rebuilds passed, but the batch build failed.
+			// Without this guard the parent subtest would pass and the
+			// batch-only regression would land in CI silently. Use
+			// t.Errorf so any envelope artifacts already on disk stay
+			// readable and the test still tears down cleanly.
+			t.Errorf("batch build failed for %s (%v) but every isolated rebuild passed — batch-only failure must not pass silently",
+				batchLabel, err)
+		}
 		return
 	}
 	defer terminateStaticEnv(t, env)
@@ -166,7 +174,7 @@ func runStaticBatch(t *testing.T, cases []bamlfuzz.OracleCase, batchLabel string
 		i := i
 		lc := lc
 		t.Run(lc.Case.Name, func(t *testing.T) {
-			runOneStaticCase(t, env, mockClient, bamlClient, lc, i, batchLabel, source)
+			runOneStaticCase(t, env, mockClient, bamlClient, lc, batchDir, i, batchLabel, source)
 		})
 	}
 }
@@ -184,12 +192,13 @@ type loweredStaticCase struct {
 // mockllm scenario, post /call/<FunctionName>, compare the parsed
 // response against Expected, and write a StaticFailureEnvelope on any
 // disagreement.
-func runOneStaticCase(t *testing.T, env *testutil.TestEnvironment, mockClient *mockllm.Client, bamlClient *testutil.BAMLRestClient, lc loweredStaticCase, caseIdx int, batchLabel string, source staticCaseSource) {
-	envelope := newStaticEnvelope(lc.Case, caseIdx, batchLabel, source)
+func runOneStaticCase(t *testing.T, env *testutil.TestEnvironment, mockClient *mockllm.Client, bamlClient *testutil.BAMLRestClient, lc loweredStaticCase, batchDir string, caseIdx int, batchLabel string, source staticCaseSource) {
+	envelope := newStaticEnvelope(lc.Case, caseIdx, batchLabel, source, false)
 	envelope.BamlSource = lc.Source.Source
 	envelope.FunctionName = lc.Source.FunctionName
 	envelope.ClassNames = lc.Source.ClassNames
 	envelope.EnumNames = lc.Source.EnumNames
+	envelope.BuildSourcePath = caseSourcePath(batchDir, lc.CaseID)
 
 	scenarioID := fmt.Sprintf("bamlfuzz-static-%s", scenarioSafe(lc.CaseID))
 	envelope.MockLLMScenarioID = scenarioID
@@ -259,32 +268,60 @@ func runOneStaticCase(t *testing.T, env *testutil.TestEnvironment, mockClient *m
 // requires this whenever a five-function batch build fails — the
 // batched error message rarely identifies which case carries the bad
 // source.
-func isolateStaticBatch(t *testing.T, lowered []loweredStaticCase, batchLabel string, source staticCaseSource) {
+//
+// Returns whether any isolated rebuild failed. The caller treats a
+// false return as a batch-only regression and fails the parent
+// subtest explicitly: a Go `t.Run` only propagates failures from its
+// own body, so without that explicit signal a transient batched
+// build failure would pass silently when the isolated reruns happen
+// to succeed.
+func isolateStaticBatch(t *testing.T, lowered []loweredStaticCase, batchLabel string, source staticCaseSource) (anyFailed bool) {
 	for i, lc := range lowered {
 		i := i
 		lc := lc
-		t.Run(lc.Case.Name+"_isolated", func(t *testing.T) {
-			envelope := newStaticEnvelope(lc.Case, i, batchLabel, source)
-			envelope.BamlSource = lc.Source.Source
-			envelope.FunctionName = lc.Source.FunctionName
-			envelope.ClassNames = lc.Source.ClassNames
-			envelope.EnumNames = lc.Source.EnumNames
-
-			singleDir := t.TempDir()
-			if err := writeBatchBamlSrc(singleDir, []loweredStaticCase{lc}); err != nil {
-				envelope.BuildError = fmt.Sprintf("write isolated baml_src: %v", err)
-				failStaticAndDump(t, envelope, "isolated write: %v", err)
-				return
-			}
-			env, err := setupStaticEnv(singleDir)
-			if err != nil {
-				envelope.BuildError = err.Error()
-				failStaticAndDump(t, envelope, "isolated build failed: %v", err)
-				return
-			}
-			terminateStaticEnv(t, env)
-		})
+		if !t.Run(lc.Case.Name+"_isolated", func(t *testing.T) {
+			runIsolatedStaticCase(t, lc, i, batchLabel, source)
+		}) {
+			anyFailed = true
+		}
 	}
+	return anyFailed
+}
+
+// runIsolatedStaticCase is the per-case body of isolateStaticBatch.
+// Extracted so the t.Run aggregation pattern stays readable and so
+// the body's envelope wiring can evolve without rewriting the loop.
+// The isolated flag on newStaticEnvelope is what routes the
+// reproduction command at the `<case>_isolated` subtest leaf.
+func runIsolatedStaticCase(t *testing.T, lc loweredStaticCase, caseIdx int, batchLabel string, source staticCaseSource) {
+	envelope := newStaticEnvelope(lc.Case, caseIdx, batchLabel, source, true)
+	envelope.BamlSource = lc.Source.Source
+	envelope.FunctionName = lc.Source.FunctionName
+	envelope.ClassNames = lc.Source.ClassNames
+	envelope.EnumNames = lc.Source.EnumNames
+
+	singleDir := t.TempDir()
+	envelope.BuildSourcePath = caseSourcePath(singleDir, lc.CaseID)
+	if err := writeBatchBamlSrc(singleDir, []loweredStaticCase{lc}); err != nil {
+		envelope.BuildError = fmt.Sprintf("write isolated baml_src: %v", err)
+		failStaticAndDump(t, envelope, "isolated write: %v", err)
+		return
+	}
+	env, err := setupStaticEnv(singleDir)
+	if err != nil {
+		envelope.BuildError = err.Error()
+		failStaticAndDump(t, envelope, "isolated build failed: %v", err)
+		return
+	}
+	terminateStaticEnv(t, env)
+}
+
+// caseSourcePath returns the absolute path to the generated .baml
+// file inside `bamlSrcDir` for the given caseID. Pinned to the
+// `bamlfuzz_<CaseID>.baml` naming used by writeBatchBamlSrc so the
+// envelope's BuildSourcePath always identifies a real file on disk.
+func caseSourcePath(bamlSrcDir, caseID string) string {
+	return filepath.Join(bamlSrcDir, fmt.Sprintf("bamlfuzz_%s.baml", caseID))
 }
 
 // writeBatchBamlSrc materialises a baml_src/ at `dir` that is the
@@ -389,8 +426,11 @@ func terminateStaticEnv(t *testing.T, env *testutil.TestEnvironment) {
 
 // newStaticEnvelope returns a partially-populated envelope with the
 // common header fields stamped. Callers fill in lowering / build /
-// REST fields as the case progresses.
-func newStaticEnvelope(c bamlfuzz.OracleCase, caseIdx int, batchLabel string, source staticCaseSource) *bamlfuzz.StaticFailureEnvelope {
+// REST fields as the case progresses. `isolated` selects the
+// reproduction-command shape: the isolated rebuild path runs as a
+// `<case>_isolated` subtest so the developer's copy-paste needs the
+// correct leaf segment.
+func newStaticEnvelope(c bamlfuzz.OracleCase, caseIdx int, batchLabel string, source staticCaseSource, isolated bool) *bamlfuzz.StaticFailureEnvelope {
 	flags := bamlfuzz.AnalyzeGraph(c.Schema)
 	return &bamlfuzz.StaticFailureEnvelope{
 		GeneratorVersion: bamlfuzz.GeneratorVersion,
@@ -403,7 +443,7 @@ func newStaticEnvelope(c bamlfuzz.OracleCase, caseIdx int, batchLabel string, so
 		MockLLMContent:   c.MockLLMContent,
 		Expected:         c.Expected,
 		Metadata:         c.Metadata,
-		Reproduction:     staticReproductionFor(c, caseIdx, batchLabel, source),
+		Reproduction:     staticReproductionFor(c, caseIdx, batchLabel, source, isolated),
 	}
 }
 
@@ -448,19 +488,29 @@ func caseIDFor(batchLabel string, idx int) string {
 // developer can copy-paste from the failure log.
 //
 //	TestBamlfuzzStaticOracle / corpus           / <case_name>
+//	TestBamlfuzzStaticOracle / corpus           / <case_name>_isolated
 //	TestBamlfuzzStaticOracle / rapid_batch_<n>  / <case_name>
+//	TestBamlfuzzStaticOracle / rapid_batch_<n>  / <case_name>_isolated
+//
+// `isolated` flips the leaf segment to the `_isolated` subtest name
+// that isolateStaticBatch creates, so an isolated build failure's
+// envelope command actually selects the failing subtest.
 //
 // BAMLFUZZ_SEED is echoed when set so a rapid-seeded draw is
 // reproducible.
-func staticReproductionFor(c bamlfuzz.OracleCase, caseIdx int, batchLabel string, source staticCaseSource) string {
+func staticReproductionFor(c bamlfuzz.OracleCase, caseIdx int, batchLabel string, source staticCaseSource, isolated bool) string {
+	leaf := c.Name
+	if isolated {
+		leaf = c.Name + "_isolated"
+	}
 	segments := []string{"^TestBamlfuzzStaticOracle$"}
 	switch source {
 	case staticCaseSourceCorpus:
-		segments = append(segments, "^corpus$", "^"+regexp.QuoteMeta(c.Name)+"$")
+		segments = append(segments, "^corpus$", "^"+regexp.QuoteMeta(leaf)+"$")
 	case staticCaseSourceRapid:
 		segments = append(segments,
 			"^"+regexp.QuoteMeta(batchLabel)+"$",
-			"^"+regexp.QuoteMeta(c.Name)+"$",
+			"^"+regexp.QuoteMeta(leaf)+"$",
 		)
 	}
 	cmd := fmt.Sprintf("go test -tags=integration -run='%s' ./integration -count=1",
@@ -571,7 +621,8 @@ func loadStaticCorpus(dir string) ([]bamlfuzz.OracleCase, error) {
 
 // TestStaticReproductionFor pins the shape of the reproduction command
 // embedded in static failure envelopes. Mirrors the dynamic oracle's
-// TestReproductionFor coverage for the static subtest tree.
+// TestReproductionFor coverage for the static subtest tree, plus the
+// `_isolated` leaf shape isolateStaticBatch emits.
 func TestStaticReproductionFor(t *testing.T) {
 	t.Setenv("BAMLFUZZ_SEED", "")
 	corpus := staticReproductionFor(
@@ -579,10 +630,23 @@ func TestStaticReproductionFor(t *testing.T) {
 		4,
 		"corpus",
 		staticCaseSourceCorpus,
+		false,
 	)
 	wantCorpus := "go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^corpus$/^self_referential_tree$' ./integration -count=1"
 	if corpus != wantCorpus {
 		t.Errorf("corpus repro:\n got:  %s\n want: %s", corpus, wantCorpus)
+	}
+
+	corpusIsolated := staticReproductionFor(
+		bamlfuzz.OracleCase{Name: "self_referential_tree"},
+		4,
+		"corpus",
+		staticCaseSourceCorpus,
+		true,
+	)
+	wantCorpusIsolated := "go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^corpus$/^self_referential_tree_isolated$' ./integration -count=1"
+	if corpusIsolated != wantCorpusIsolated {
+		t.Errorf("corpus isolated repro:\n got:  %s\n want: %s", corpusIsolated, wantCorpusIsolated)
 	}
 
 	rapid := staticReproductionFor(
@@ -590,10 +654,23 @@ func TestStaticReproductionFor(t *testing.T) {
 		2,
 		"rapid_batch_0",
 		staticCaseSourceRapid,
+		false,
 	)
 	wantRapid := "go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^rapid_batch_0$/^rapid_b0_c2$' ./integration -count=1"
 	if rapid != wantRapid {
 		t.Errorf("rapid repro:\n got:  %s\n want: %s", rapid, wantRapid)
+	}
+
+	rapidIsolated := staticReproductionFor(
+		bamlfuzz.OracleCase{Name: "rapid_b0_c2"},
+		2,
+		"rapid_batch_0",
+		staticCaseSourceRapid,
+		true,
+	)
+	wantRapidIsolated := "go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^rapid_batch_0$/^rapid_b0_c2_isolated$' ./integration -count=1"
+	if rapidIsolated != wantRapidIsolated {
+		t.Errorf("rapid isolated repro:\n got:  %s\n want: %s", rapidIsolated, wantRapidIsolated)
 	}
 
 	t.Setenv("BAMLFUZZ_SEED", "9999")
@@ -602,10 +679,48 @@ func TestStaticReproductionFor(t *testing.T) {
 		0,
 		"corpus",
 		staticCaseSourceCorpus,
+		false,
 	)
 	wantWithSeed := "BAMLFUZZ_SEED=9999 go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^corpus$/^scalar_object$' ./integration -count=1"
 	if withSeed != wantWithSeed {
 		t.Errorf("corpus+seed repro:\n got:  %s\n want: %s", withSeed, wantWithSeed)
+	}
+}
+
+// TestSubtestAggregationContract pins the Go testing-API contract
+// isolateStaticBatch relies on for F1's batch-mask guard: a t.Run
+// invocation returns the pass/fail state of its body, so the parent
+// can aggregate failures across iterations and detect the case where
+// every isolated rebuild passed but the batched build still failed.
+//
+// Only the green path (no subtest failures => aggregator stays false)
+// is asserted here — deliberately failing a subtest from within this
+// test would propagate up to TestSubtestAggregationContract itself,
+// which there's no built-in way to suppress. The red path is locked
+// by the Go testing package's contract that t.Run returns false on
+// any t.Errorf inside the body.
+func TestSubtestAggregationContract(t *testing.T) {
+	var anyFailed bool
+	if !t.Run("ok_a", func(t *testing.T) {}) {
+		anyFailed = true
+	}
+	if !t.Run("ok_b", func(t *testing.T) {}) {
+		anyFailed = true
+	}
+	if anyFailed {
+		t.Errorf("expected anyFailed=false when no subtest body failed, got true")
+	}
+}
+
+// TestCaseSourcePath pins the on-disk filename writeBatchBamlSrc uses
+// for each generated case. The envelope's BuildSourcePath assignment
+// targets exactly this path, so a drift between the two breaks the
+// developer's path-from-envelope-to-source lookup.
+func TestCaseSourcePath(t *testing.T) {
+	got := caseSourcePath("/tmp/bamlsrc", "corpus_C03")
+	want := filepath.Join("/tmp/bamlsrc", "bamlfuzz_corpus_C03.baml")
+	if got != want {
+		t.Errorf("caseSourcePath: got %q want %q", got, want)
 	}
 }
 

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -1,0 +1,651 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/bamlfuzz"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// staticOracleCorpusDir is the in-tree directory holding hand-curated
+// static oracle replay artifacts. The bamlfuzz package lives in
+// adapters/common; tests in package integration reach it via a relative
+// path from the repo root.
+const staticOracleCorpusDir = "../adapters/common/codegen/testdata/bamlfuzz/static"
+
+// staticOracleArtifactDir is where envelope artifacts land on failure
+// or with BAMLFUZZ_KEEP_ARTIFACTS=1.
+const staticOracleArtifactDir = "../adapters/common/codegen/testdata/bamlfuzz/static/_artifacts"
+
+// integrationBamlSrcDir is the integration testdata baml_src/ that
+// every static batch is layered on top of. The generated case files
+// merge with the existing clients.baml / types.baml / functions.baml
+// / generators.baml so TestClient (the client referenced by every
+// generated function) resolves at build time.
+const integrationBamlSrcDir = "testdata/baml_src"
+
+// staticCasesPerBatch is the locked batch size from scope D4: exactly
+// five generated functions per temporary baml_src/. Build-failure
+// isolation reruns the five cases singly when the batched build
+// fails; PR-gating coverage rides on this size as the upper bound on
+// blast radius per Docker build.
+const staticCasesPerBatch = 5
+
+// staticEnvSetupTimeout caps how long any one batch is allowed to
+// spend bringing up its dedicated integration environment. Scope D9
+// sets 10 minutes inside the 12-minute job timeout; tests get the
+// full slice so cold-cache builds can complete on slower runners.
+const staticEnvSetupTimeout = 10 * time.Minute
+
+// staticCallTimeout bounds one /call/<FunctionName> request inside a
+// batch. Generous so a slow worker doesn't trip a per-case timeout
+// before the integration server reports a real failure.
+const staticCallTimeout = 60 * time.Second
+
+// rapidSelfRefProbability sets the self-ref density for randomly-
+// generated static batches. Scope D9 says 10-20%; pinning here keeps
+// each rapid batch reproducible at the seed level.
+const rapidSelfRefProbability = 0.15
+
+// TestBamlfuzzStaticOracle drives the static prompt oracle: lower
+// each FuzzSchema to .baml source, batch five cases into a temporary
+// baml_src/, spin up a dedicated integration environment, register a
+// mockllm scenario per case, then exercise /call/<FunctionName>
+// against the per-request client_registry override.
+//
+// The oracle compares the parsed REST response to bamlfuzz.Walk's
+// schema-driven expected JSON. Order mismatches travel under
+// OrderWarning per scope D8 and log but do not fail in v1.
+//
+// PR coverage: one corpus batch (the five hand-curated seeds) +
+// BAMLFUZZ_STATIC_BATCHES rapid batches (default 1, scope D9). Nightly
+// can crank the rapid batch count via the env knob.
+func TestBamlfuzzStaticOracle(t *testing.T) {
+	dynclientCallGate(t)
+
+	corpus, err := loadStaticCorpus(staticOracleCorpusDir)
+	if err != nil {
+		t.Fatalf("load corpus from %s: %v", staticOracleCorpusDir, err)
+	}
+	if len(corpus) == 0 {
+		t.Fatalf("static corpus at %s is empty — PR-C must ship hand-curated cases", staticOracleCorpusDir)
+	}
+	if len(corpus) != staticCasesPerBatch {
+		t.Fatalf("corpus must have exactly %d cases for one batch, got %d", staticCasesPerBatch, len(corpus))
+	}
+
+	t.Run("corpus", func(t *testing.T) {
+		runStaticBatch(t, corpus, "corpus", staticCaseSourceCorpus)
+	})
+
+	rapidBatches := envIntDefault("BAMLFUZZ_STATIC_BATCHES", 1)
+	for b := 0; b < rapidBatches; b++ {
+		b := b
+		t.Run(fmt.Sprintf("rapid_batch_%d", b), func(t *testing.T) {
+			cases := buildStaticRapidBatch(t, b, staticCasesPerBatch)
+			runStaticBatch(t, cases, fmt.Sprintf("rapid_batch_%d", b), staticCaseSourceRapid)
+		})
+	}
+}
+
+// staticCaseSource mirrors caseSource from the dynamic oracle: corpus
+// cases get one set of failure semantics, rapid-generated cases get
+// another. v1 treats both identically inside the static oracle (every
+// shape must build and call cleanly), but the source label travels
+// through into the reproduction command so the developer copy-pastes
+// the correct subtest path.
+type staticCaseSource int
+
+const (
+	staticCaseSourceCorpus staticCaseSource = iota
+	staticCaseSourceRapid
+)
+
+// runStaticBatch lowers each OracleCase in `cases` to .baml source,
+// materialises a temporary baml_src/ that layers the generated case
+// files on top of the integration fixtures, then spins up a dedicated
+// integration environment. On Setup failure the harness reruns the
+// cases singly to isolate the offending source per scope D4. On
+// successful Setup it registers a mockllm scenario per case and runs
+// the /call/<FunctionName> request, comparing the parsed response to
+// the schema-driven expected JSON.
+func runStaticBatch(t *testing.T, cases []bamlfuzz.OracleCase, batchLabel string, source staticCaseSource) {
+	t.Helper()
+	if len(cases) == 0 {
+		t.Fatalf("empty batch")
+	}
+	if len(cases) > staticCasesPerBatch {
+		t.Fatalf("batch size %d exceeds locked maximum %d", len(cases), staticCasesPerBatch)
+	}
+
+	lowered := make([]loweredStaticCase, len(cases))
+	for i := range cases {
+		caseID := caseIDFor(batchLabel, i)
+		src, err := bamlfuzz.LowerToBamlSource(cases[i].Schema, caseID)
+		if err != nil {
+			envelope := newStaticEnvelope(cases[i], i, batchLabel, source)
+			envelope.BuildError = fmt.Sprintf("LowerToBamlSource: %v", err)
+			failStaticAndDump(t, envelope, "LowerToBamlSource for case %s: %v", cases[i].Name, err)
+			return
+		}
+		lowered[i] = loweredStaticCase{
+			Case:   cases[i],
+			Source: src,
+			CaseID: caseID,
+		}
+	}
+
+	// Attempt the batched build first; isolate on failure.
+	batchDir := t.TempDir()
+	if err := writeBatchBamlSrc(batchDir, lowered); err != nil {
+		t.Fatalf("write batch baml_src: %v", err)
+	}
+
+	env, err := setupStaticEnv(batchDir)
+	if err != nil {
+		t.Logf("batch build failed for %s: %v; isolating cases singly", batchLabel, err)
+		isolateStaticBatch(t, lowered, batchLabel, source)
+		return
+	}
+	defer terminateStaticEnv(t, env)
+
+	mockClient := mockllm.NewClient(env.MockLLMURL)
+	bamlClient := testutil.NewBAMLRestClient(env.BAMLRestURL)
+
+	for i, lc := range lowered {
+		i := i
+		lc := lc
+		t.Run(lc.Case.Name, func(t *testing.T) {
+			runOneStaticCase(t, env, mockClient, bamlClient, lc, i, batchLabel, source)
+		})
+	}
+}
+
+// loweredStaticCase pairs an OracleCase with the static lowering
+// output. Kept as a tiny struct so the batch driver and the isolation
+// path share the same case shape.
+type loweredStaticCase struct {
+	Case   bamlfuzz.OracleCase
+	Source bamlfuzz.StaticBamlSource
+	CaseID string
+}
+
+// runOneStaticCase exercises one already-built case: register a
+// mockllm scenario, post /call/<FunctionName>, compare the parsed
+// response against Expected, and write a StaticFailureEnvelope on any
+// disagreement.
+func runOneStaticCase(t *testing.T, env *testutil.TestEnvironment, mockClient *mockllm.Client, bamlClient *testutil.BAMLRestClient, lc loweredStaticCase, caseIdx int, batchLabel string, source staticCaseSource) {
+	envelope := newStaticEnvelope(lc.Case, caseIdx, batchLabel, source)
+	envelope.BamlSource = lc.Source.Source
+	envelope.FunctionName = lc.Source.FunctionName
+	envelope.ClassNames = lc.Source.ClassNames
+	envelope.EnumNames = lc.Source.EnumNames
+
+	scenarioID := fmt.Sprintf("bamlfuzz-static-%s", scenarioSafe(lc.CaseID))
+	envelope.MockLLMScenarioID = scenarioID
+	registerCtx, registerCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer registerCancel()
+	scenario := &mockllm.Scenario{
+		ID:             scenarioID,
+		Provider:       "openai",
+		Content:        string(lc.Case.MockLLMContent),
+		ChunkSize:      0,
+		InitialDelayMs: 0,
+	}
+	if err := mockClient.RegisterScenario(registerCtx, scenario); err != nil {
+		failStaticAndDump(t, envelope, "register scenario: %v", err)
+		return
+	}
+
+	clientReg := testutil.CreateTestClient(env.MockLLMInternal, scenarioID)
+
+	callCtx, callCancel := context.WithTimeout(context.Background(), staticCallTimeout)
+	defer callCancel()
+	resp, err := bamlClient.Call(callCtx, testutil.CallRequest{
+		Method:  lc.Source.FunctionName,
+		Input:   map[string]any{"input": "Static fuzz call."},
+		Options: &testutil.BAMLOptions{ClientRegistry: clientReg},
+	})
+	switch {
+	case err != nil:
+		envelope.RESTError = err.Error()
+		failStaticAndDump(t, envelope, "/call/%s: %v", lc.Source.FunctionName, err)
+		return
+	case resp == nil:
+		envelope.RESTError = "nil response from bamlClient.Call"
+		failStaticAndDump(t, envelope, "/call/%s returned nil response without an error", lc.Source.FunctionName)
+		return
+	}
+	envelope.RESTStatus = resp.StatusCode
+	if resp.StatusCode >= 400 {
+		envelope.RESTError = resp.Error
+		failStaticAndDump(t, envelope, "/call/%s status %d: %s", lc.Source.FunctionName, resp.StatusCode, resp.Error)
+		return
+	}
+	envelope.RESTBody = resp.Body
+
+	if diff, err := bamlfuzz.SemanticDiff("expected_vs_rest", lc.Case.Expected, resp.Body); err != nil {
+		envelope.RESTError = err.Error()
+		failStaticAndDump(t, envelope, "expected_vs_rest diff: %v", err)
+		return
+	} else if len(diff) > 0 {
+		envelope.SemanticDiff = diff
+		failStaticAndDump(t, envelope, "expected ≠ /call/%s", lc.Source.FunctionName)
+		return
+	}
+	envelope.OrderWarning = bamlfuzz.DetectOrderWarning("expected_vs_rest", lc.Case.Expected, resp.Body)
+	if len(envelope.OrderWarning) > 0 {
+		t.Logf("order warnings (non-fatal in v1) for %s: %s", lc.Case.Name, strings.Join(envelope.OrderWarning, "; "))
+	}
+	if os.Getenv("BAMLFUZZ_KEEP_ARTIFACTS") == "1" {
+		if path, err := bamlfuzz.WriteStaticReplayArtifact(staticOracleArtifactDir, envelope); err == nil {
+			t.Logf("kept replay artifact (success): %s", path)
+		}
+	}
+}
+
+// isolateStaticBatch reruns each lowered case in its own baml_src/ so
+// the failing one can be named in the failure envelope. Scope D4
+// requires this whenever a five-function batch build fails — the
+// batched error message rarely identifies which case carries the bad
+// source.
+func isolateStaticBatch(t *testing.T, lowered []loweredStaticCase, batchLabel string, source staticCaseSource) {
+	for i, lc := range lowered {
+		i := i
+		lc := lc
+		t.Run(lc.Case.Name+"_isolated", func(t *testing.T) {
+			envelope := newStaticEnvelope(lc.Case, i, batchLabel, source)
+			envelope.BamlSource = lc.Source.Source
+			envelope.FunctionName = lc.Source.FunctionName
+			envelope.ClassNames = lc.Source.ClassNames
+			envelope.EnumNames = lc.Source.EnumNames
+
+			singleDir := t.TempDir()
+			if err := writeBatchBamlSrc(singleDir, []loweredStaticCase{lc}); err != nil {
+				envelope.BuildError = fmt.Sprintf("write isolated baml_src: %v", err)
+				failStaticAndDump(t, envelope, "isolated write: %v", err)
+				return
+			}
+			env, err := setupStaticEnv(singleDir)
+			if err != nil {
+				envelope.BuildError = err.Error()
+				failStaticAndDump(t, envelope, "isolated build failed: %v", err)
+				return
+			}
+			terminateStaticEnv(t, env)
+		})
+	}
+}
+
+// writeBatchBamlSrc materialises a baml_src/ at `dir` that is the
+// union of the integration testdata fixtures and one .baml file per
+// lowered case. The generated case files are named
+// `bamlfuzz_<CaseID>.baml` so the failure envelope's BuildSourcePath
+// + on-disk filename uniquely identify each case during diagnosis.
+func writeBatchBamlSrc(dir string, lowered []loweredStaticCase) error {
+	srcRoot, err := absIntegrationBamlSrc()
+	if err != nil {
+		return err
+	}
+	if err := copyDir(srcRoot, dir); err != nil {
+		return fmt.Errorf("copy integration baml_src: %w", err)
+	}
+	for _, lc := range lowered {
+		fileName := fmt.Sprintf("bamlfuzz_%s.baml", lc.CaseID)
+		out := filepath.Join(dir, fileName)
+		if err := os.WriteFile(out, []byte(lc.Source.Source), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", out, err)
+		}
+	}
+	return nil
+}
+
+// absIntegrationBamlSrc returns the absolute path to the integration
+// fixtures' baml_src directory. Resolved relative to the test working
+// directory (the package directory), which is where `go test` starts
+// before TestMain runs cwd-dependent helpers.
+func absIntegrationBamlSrc() (string, error) {
+	abs, err := filepath.Abs(integrationBamlSrcDir)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(abs); err != nil {
+		return "", fmt.Errorf("integration baml_src not found at %s: %w", abs, err)
+	}
+	return abs, nil
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return nil
+}
+
+// setupStaticEnv spins up a dedicated integration environment with
+// the supplied baml_src/. Matrix axes from TestMain (BAML version,
+// build-request gate, in-process vs subprocess) inherit through
+// matrixSetupOptions so the static oracle runs under the same
+// runtime shape as the rest of the integration suite.
+func setupStaticEnv(bamlSrcDir string) (*testutil.TestEnvironment, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), staticEnvSetupTimeout)
+	defer cancel()
+	opts := matrixSetupOptions()
+	opts.BAMLSrcPath = bamlSrcDir
+	return testutil.Setup(ctx, opts)
+}
+
+func terminateStaticEnv(t *testing.T, env *testutil.TestEnvironment) {
+	t.Helper()
+	if env == nil {
+		return
+	}
+	termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer termCancel()
+	if err := env.Terminate(termCtx); err != nil {
+		t.Logf("static env Terminate: %v", err)
+	}
+}
+
+// newStaticEnvelope returns a partially-populated envelope with the
+// common header fields stamped. Callers fill in lowering / build /
+// REST fields as the case progresses.
+func newStaticEnvelope(c bamlfuzz.OracleCase, caseIdx int, batchLabel string, source staticCaseSource) *bamlfuzz.StaticFailureEnvelope {
+	flags := bamlfuzz.AnalyzeGraph(c.Schema)
+	return &bamlfuzz.StaticFailureEnvelope{
+		GeneratorVersion:  bamlfuzz.GeneratorVersion,
+		RapidSeed:         c.Seed,
+		CaseIndex:         caseIdx,
+		CaseName:          c.Name,
+		OracleMode:        bamlfuzz.OracleStaticPrompt,
+		Schema:            c.Schema,
+		HasSelfRef:        flags.HasSelfRef,
+		MockLLMContent:    c.MockLLMContent,
+		Expected:          c.Expected,
+		Metadata:          c.Metadata,
+		Reproduction:      staticReproductionFor(c, caseIdx, batchLabel, source),
+	}
+}
+
+// failStaticAndDump writes the envelope to the artifact directory and
+// fails the test with a message that points at the replay path.
+func failStaticAndDump(t *testing.T, envelope *bamlfuzz.StaticFailureEnvelope, format string, args ...any) {
+	t.Helper()
+	path, err := bamlfuzz.WriteStaticReplayArtifact(staticOracleArtifactDir, envelope)
+	if err != nil {
+		t.Errorf("write static replay artifact: %v", err)
+		t.Errorf(format, args...)
+		return
+	}
+	msg := fmt.Sprintf(format, args...)
+	t.Errorf("%s\nreplay: %s\nrepro: %s", msg, path, envelope.Reproduction)
+}
+
+// caseIDFor returns the per-case BAML identifier suffix for a slot in
+// a batch. The label encodes batch provenance (corpus vs
+// rapid_batch_N) so the mangled symbol names hint at the source when
+// staring at a build error.
+func caseIDFor(batchLabel string, idx int) string {
+	clean := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		}
+		return '_'
+	}, batchLabel)
+	if clean == "" {
+		clean = "batch"
+	}
+	if !(clean[0] >= 'A' && clean[0] <= 'Z') && !(clean[0] >= 'a' && clean[0] <= 'z') {
+		clean = "B" + clean
+	}
+	return fmt.Sprintf("%s_C%02d", clean, idx)
+}
+
+// staticReproductionFor returns the canonical `go test` command to
+// rerun one failing static case. The reproduction path mirrors the
+// subtest tree this file builds (corpus / rapid_batch_N) so the
+// developer can copy-paste from the failure log.
+//
+//	TestBamlfuzzStaticOracle / corpus           / <case_name>
+//	TestBamlfuzzStaticOracle / rapid_batch_<n>  / <case_name>
+//
+// BAMLFUZZ_SEED is echoed when set so a rapid-seeded draw is
+// reproducible.
+func staticReproductionFor(c bamlfuzz.OracleCase, caseIdx int, batchLabel string, source staticCaseSource) string {
+	segments := []string{"^TestBamlfuzzStaticOracle$"}
+	switch source {
+	case staticCaseSourceCorpus:
+		segments = append(segments, "^corpus$", "^"+regexp.QuoteMeta(c.Name)+"$")
+	case staticCaseSourceRapid:
+		segments = append(segments,
+			"^"+regexp.QuoteMeta(batchLabel)+"$",
+			"^"+regexp.QuoteMeta(c.Name)+"$",
+		)
+	}
+	cmd := fmt.Sprintf("go test -tags=integration -run='%s' ./integration -count=1",
+		strings.Join(segments, "/"))
+	if seed := os.Getenv("BAMLFUZZ_SEED"); seed != "" {
+		cmd = "BAMLFUZZ_SEED=" + seed + " " + cmd
+	}
+	return cmd
+}
+
+// buildStaticRapidBatch draws `n` static-mode cases deterministically
+// from a seed derived from batchIdx. Uses bamlfuzz.StaticSchemaGen so
+// self-ref and mutual-cycle schemas appear at scope D9's density. Each
+// case is materialised into an OracleCase up front so a failure
+// envelope can describe the exact shape that triggered the bug.
+func buildStaticRapidBatch(t *testing.T, batchIdx int, n int) []bamlfuzz.OracleCase {
+	t.Helper()
+	cases := make([]bamlfuzz.OracleCase, n)
+	for i := 0; i < n; i++ {
+		seed := staticSeedFor(batchIdx, i)
+		schema := bamlfuzz.StaticSchemaGen().Example(int(seed))
+		value := bamlfuzz.ValueGen(schema).Example(int(seed) + 1)
+		walk, err := bamlfuzz.Walk(schema, value)
+		if err != nil {
+			t.Fatalf("walk batch=%d idx=%d: %v", batchIdx, i, err)
+		}
+		cases[i] = bamlfuzz.OracleCase{
+			Name:           fmt.Sprintf("rapid_b%d_c%d", batchIdx, i),
+			Seed:           int64(seed),
+			CaseIndex:      i,
+			Mode:           bamlfuzz.OracleStaticPrompt,
+			Schema:         schema,
+			Value:          value,
+			MockLLMContent: walk.MockLLMContent,
+			Expected:       walk.Expected,
+			Metadata:       walk.Metadata,
+		}
+	}
+	return cases
+}
+
+func staticSeedFor(batchIdx, caseIdx int) uint64 {
+	h := fnv.New64a()
+	fmt.Fprintf(h, "static_b%d_c%d", batchIdx, caseIdx)
+	base := h.Sum64()
+	if v := os.Getenv("BAMLFUZZ_SEED"); v != "" {
+		base ^= fnv64aStaticString(v)
+	}
+	return base
+}
+
+func fnv64aStaticString(s string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(s))
+	return h.Sum64()
+}
+
+// envIntDefault reads `key` from the environment, parses it as an int,
+// and returns `def` on missing/invalid. Used for the
+// BAMLFUZZ_STATIC_BATCHES knob.
+func envIntDefault(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return def
+	}
+	return n
+}
+
+// loadStaticCorpus reads every `*.json` file under dir and decodes it
+// as an OracleCase. Filenames sort lexicographically so subtests run
+// in a stable order.
+func loadStaticCorpus(dir string) ([]bamlfuzz.OracleCase, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+
+	out := make([]bamlfuzz.OracleCase, 0, len(names))
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		var c bamlfuzz.OracleCase
+		if err := json.Unmarshal(data, &c); err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		if c.Name == "" {
+			c.Name = strings.TrimSuffix(name, ".json")
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+// TestStaticReproductionFor pins the shape of the reproduction command
+// embedded in static failure envelopes. Mirrors the dynamic oracle's
+// TestReproductionFor coverage for the static subtest tree.
+func TestStaticReproductionFor(t *testing.T) {
+	t.Setenv("BAMLFUZZ_SEED", "")
+	corpus := staticReproductionFor(
+		bamlfuzz.OracleCase{Name: "self_referential_tree"},
+		4,
+		"corpus",
+		staticCaseSourceCorpus,
+	)
+	wantCorpus := "go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^corpus$/^self_referential_tree$' ./integration -count=1"
+	if corpus != wantCorpus {
+		t.Errorf("corpus repro:\n got:  %s\n want: %s", corpus, wantCorpus)
+	}
+
+	rapid := staticReproductionFor(
+		bamlfuzz.OracleCase{Name: "rapid_b0_c2"},
+		2,
+		"rapid_batch_0",
+		staticCaseSourceRapid,
+	)
+	wantRapid := "go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^rapid_batch_0$/^rapid_b0_c2$' ./integration -count=1"
+	if rapid != wantRapid {
+		t.Errorf("rapid repro:\n got:  %s\n want: %s", rapid, wantRapid)
+	}
+
+	t.Setenv("BAMLFUZZ_SEED", "9999")
+	withSeed := staticReproductionFor(
+		bamlfuzz.OracleCase{Name: "scalar_object"},
+		0,
+		"corpus",
+		staticCaseSourceCorpus,
+	)
+	wantWithSeed := "BAMLFUZZ_SEED=9999 go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^corpus$/^scalar_object$' ./integration -count=1"
+	if withSeed != wantWithSeed {
+		t.Errorf("corpus+seed repro:\n got:  %s\n want: %s", withSeed, wantWithSeed)
+	}
+}
+
+// TestCaseIDFor pins the BAML-identifier-safe transform applied to
+// batch labels. The lowering rejects unsafe caseIDs at the
+// LowerToBamlSource boundary; the test harness is the producer that
+// must guarantee a valid suffix even when batch labels carry
+// separators or numeric prefixes.
+func TestCaseIDFor(t *testing.T) {
+	cases := []struct {
+		label string
+		idx   int
+		want  string
+	}{
+		{"corpus", 0, "corpus_C00"},
+		{"rapid_batch_0", 3, "rapid_batch_0_C03"},
+		{"rapid-batch-0", 1, "rapid_batch_0_C01"},
+		{"0bad", 2, "B0bad_C02"},
+		{"", 4, "batch_C04"},
+	}
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			got := caseIDFor(c.label, c.idx)
+			if got != c.want {
+				t.Errorf("caseIDFor(%q, %d) = %q, want %q", c.label, c.idx, got, c.want)
+			}
+			if _, err := bamlfuzz.LowerToBamlSource(bamlfuzz.FuzzSchema{
+				Classes: []bamlfuzz.FuzzClass{{Name: "Root", Properties: []bamlfuzz.FuzzProperty{
+					{Name: "x", Type: bamlfuzz.FuzzType{Kind: bamlfuzz.KindString}},
+				}}},
+				RootClass: "Root",
+			}, got); err != nil {
+				t.Errorf("caseID %q rejected by LowerToBamlSource: %v", got, err)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

**Part 3 of 3 for #340 v1.** Static emitter + static prompt oracle + 5 hand-curated static seeds. **Closes #340 v1.** v1.1 brings unions + strict order assertions; v2+ adds media, streaming, raw-response, reasoning channels, dynamic self-ref (post upstream fix), cross-version matrix.

## What lands

The static prompt oracle, end-to-end:
```
expected(static_schema, value)
  ≡ REST /call/<GeneratedFunction>(generated .baml source, mockllm(value))
```

Static path **accepts self-ref and mutual recursion** (the upstream BAML cgo crash is dynamic-only — gated separately in PR-B).

### Static emitter — `LowerToBamlSource`

`adapters/common/codegen/bamlfuzz/emit_static.go`:
- `LowerToBamlSource(schema FuzzSchema) (StaticSource, error)` lowers the shared `FuzzSchema` IR to a `.baml` source string. Generated function declaration, classes/enums in declaration order, every `FuzzTypeKind` mapped to BAML syntax (including `KindNull`).
- Accepts self-ref AND mutual-recursive class graphs.
- Deterministic output for a given seed.
- Unit tests cover every type kind + the two recursion shapes.

### Static prompt oracle integration test

`integration/bamlfuzz_static_test.go` (integration-tagged):
- Two-way oracle: `expected ≡ REST /call/<GeneratedFunction>`.
- Uses existing `testutil.Setup` + mockllm + `SetupOptions.BAMLSrcPath` pointing at a generated `baml_src/`.
- Per-case `client_registry` override to point at the mockllm scenario (same pattern PR-B uses).
- Failure envelope structured per scope D8: emitted source, function name, classes/enums, `has_self_ref` flag, build source path, REST status/body.

### 5-function batching + single-case isolation

- Each container build batches 5 generated functions into one `baml_src/`.
- On batch BUILD failure, harness re-renders the 5 cases SINGLY to isolate the bad source.
- On batch RUNTIME failure, the failing function name identifies the case unambiguously.
- `isolateStaticBatch` returns `(anyFailed bool)`; the caller fails the parent when the batch failed but every isolated rebuild passed, so transient batch-only failures cannot pass silently.
- `BAMLFUZZ_STATIC_BATCHES` env knob for nightly expansion.

### Static seed corpus (5 cases, scope D7 bootstrap)

`adapters/common/codegen/testdata/bamlfuzz/static/`:

```
00_scalar_object.json                          ← scalars in a class
01_nested_class_with_enum.json                 ← class containing enum + nested class
02_optional_three_shapes.json                  ← present, null, absent
03_terminating_mutual_recursion.json           ← A ↔ B with terminating edge
04_self_referential_tree.json                  ← static-exclusive: tree node with optional(list(ref Self))
```

Regeneratable via `cmd/seedcorpus`.

### Reproduction commands match the actual failing subtest

`staticReproductionFor` emits anchored segmented `-run` paths AND distinguishes isolated subtests (`<case>_isolated` suffix when reproducing build-isolation failures). The repro line in any failure envelope selects exactly one subtest.

### `BuildSourcePath` populated

Both runtime and isolated failure envelopes carry the generated `bamlfuzz_<CaseID>.baml` path, identifying the case + on-disk source for diagnosis.

## What this PR does NOT deliver (v1.1+)

- Unions (first v1.1 follow-up).
- Strict key-order assertions (currently warning-only; promoted in v1.1).
- Media, streaming, raw-response, reasoning channels (v2+).
- Dynamic self-ref / mutual recursion (post BAML upstream fix on BoundaryML/baml#3390).
- Cross-version adapter matrix expansion (deferred).

## Touches codegen output

No. `.embedignore` excludes `codegen/bamlfuzz` and `codegen/testdata`; `cmd/regenerate-dynclient` is clean.

## Verification

- `cd adapters/common && GOWORK=off go test -race ./codegen/bamlfuzz/... -count=1` ✅
- `cd adapters/common && GOWORK=off go test -race ./codegen/bamlfuzz/... -count=3` ✅ (flake detector)
- `cd adapters/common && GOWORK=off go test -race ./codegen/... -count=1` ✅
- `go vet -tags=integration ./integration/...` ✅
- `go build -tags=integration ./integration/...` ✅
- `gofmt -l adapters/common/codegen/bamlfuzz/ integration/bamlfuzz_static_test.go` ✅ empty
- `go run ./cmd/regenerate-dynclient && git status dynclient/ adapters/common/embed.go .embedignore` ✅ clean
- Integration leg (`TestBamlfuzzStaticOracle/corpus/`) runs on the existing CI matrix via `//go:build integration` — Docker-bound, not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
