### PR TITLE
ci: auto-sync go.mod/go.sum on Renovate PRs (closes #352)

### DIFF
--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -1,0 +1,123 @@
+name: Renovate Go Module Sync
+
+on:
+  push:
+    branches:
+      - "renovate/**"
+
+concurrency:
+  group: renovate-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+env:
+  GO_VERSION: "1.26.3"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event.head_commit.author.name != 'github-actions[bot]'
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run scripts/sync.sh
+        run: ./scripts/sync.sh
+
+      - name: Validate changed-file allowlist
+        run: |
+          # Allowlist: only Go module metadata may change.
+          #   go.mod, go.sum, go.work.sum at the root, and go.mod / go.sum
+          #   under any nested module directory. Anything else (tracked or
+          #   untracked) means scripts/sync.sh produced unexpected drift —
+          #   refuse to commit/push so a human inspects the diff.
+          #
+          # --untracked-files=all expands untracked directories into their
+          # individual file entries so a new submod/ directory containing
+          # only allowlisted paths is matched correctly.
+          violators=$(
+            git status --porcelain --untracked-files=all \
+              | awk '{print $NF}' \
+              | while read -r path; do
+                  case "$path" in
+                    go.mod|go.sum|go.work.sum) ;;
+                    */go.mod|*/go.sum) ;;
+                    "") ;;
+                    *) echo "$path" ;;
+                  esac
+                done
+          )
+          if [ -n "$violators" ]; then
+            echo "ERROR: scripts/sync.sh changed files outside the allowlist:"
+            echo "$violators"
+            echo
+            echo "Full git status:"
+            git status --porcelain --untracked-files=all
+            exit 1
+          fi
+
+      - name: Commit and push sync result
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No diff after scripts/sync.sh; nothing to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          add_allowlisted() {
+            # Stage only the Go module metadata paths the allowlist covers.
+            # `git add -A` would also pick up any unexpected drift that
+            # somehow slipped past the allowlist check above.
+            git ls-files --modified --others --exclude-standard \
+              -- 'go.mod' 'go.sum' 'go.work.sum' '*/go.mod' '*/go.sum' \
+              | xargs -r git add --
+          }
+
+          commit_msg() {
+            printf '%s\n\n%s\n' \
+              'chore(deps): sync Go module metadata' \
+              'Run scripts/sync.sh after Renovate dependency update.'
+          }
+
+          add_allowlisted
+          if git diff --cached --quiet; then
+            echo "Nothing staged after allowlisted add; treating as no-op."
+            exit 0
+          fi
+          git commit -m "$(commit_msg)"
+
+          if git push origin "HEAD:${GITHUB_REF_NAME}"; then
+            exit 0
+          fi
+
+          echo "Initial push rejected; attempting one rebase/retry."
+          git fetch origin "${GITHUB_REF_NAME}"
+          git reset --hard "origin/${GITHUB_REF_NAME}"
+          ./scripts/sync.sh
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Sync is a no-op on top of remote; nothing to push."
+            exit 0
+          fi
+          add_allowlisted
+          if git diff --cached --quiet; then
+            echo "Nothing staged after retry; nothing to push."
+            exit 0
+          fi
+          git commit -m "$(commit_msg)"
+          if ! git push origin "HEAD:${GITHUB_REF_NAME}"; then
+            echo "ERROR: push still rejected after one retry; aborting."
+            exit 1
+          fi

--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -59,11 +59,13 @@ jobs:
                 git diff --name-only -z HEAD
                 git ls-files --others --exclude-standard -z
               } | while IFS= read -r -d '' path; do
+                  # Parenthesize case arms so bash doesn't read the
+                  # unbalanced `)` as closing the enclosing $( … ).
                   case "$path" in
-                    go.mod|go.sum|go.work.sum) ;;
-                    */go.mod|*/go.sum) ;;
-                    "") ;;
-                    *) printf '%s\n' "$path" ;;
+                    (go.mod|go.sum|go.work.sum) ;;
+                    (*/go.mod|*/go.sum) ;;
+                    ("") ;;
+                    (*) printf '%s\n' "$path" ;;
                   esac
                 done
             )

--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -9,9 +9,6 @@ concurrency:
   group: renovate-sync-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-
 env:
   GO_VERSION: "1.26.3"
 
@@ -19,6 +16,8 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
     if: github.event.head_commit.author.name != 'github-actions[bot]'
 
     steps:

--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -81,9 +81,9 @@ jobs:
             # Stage only the Go module metadata paths the allowlist covers.
             # `git add -A` would also pick up any unexpected drift that
             # somehow slipped past the allowlist check above.
-            git ls-files --modified --others --exclude-standard \
+            git ls-files -z --modified --others --exclude-standard \
               -- 'go.mod' 'go.sum' 'go.work.sum' '*/go.mod' '*/go.sum' \
-              | xargs -r git add --
+              | xargs -0 -r git add --
           }
 
           commit_msg() {

--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -31,11 +31,15 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: |
+            go.sum
+            go.work.sum
+            **/go.sum
 
       - name: Run scripts/sync.sh
         run: ./scripts/sync.sh
 
-      - name: Validate changed-file allowlist
+      - name: Validate, commit, and push sync result
         run: |
           # Allowlist: only Go module metadata may change.
           #   go.mod, go.sum, go.work.sum at the root, and go.mod / go.sum
@@ -43,39 +47,36 @@ jobs:
           #   untracked) means scripts/sync.sh produced unexpected drift —
           #   refuse to commit/push so a human inspects the diff.
           #
-          # --untracked-files=all expands untracked directories into their
-          # individual file entries so a new submod/ directory containing
-          # only allowlisted paths is matched correctly.
-          violators=$(
-            git status --porcelain --untracked-files=all \
-              | awk '{print $NF}' \
-              | while read -r path; do
+          # NUL-delimited path streams: git status's text format collapses
+          # whitespace and quotes special names, so awk-on-status would
+          # mis-parse a path like `weird name/something.go`. Pairing
+          # `git diff --name-only -z HEAD` (tracked changes, incl. deletes)
+          # with `git ls-files --others --exclude-standard -z` (untracked)
+          # gives a clean NUL-terminated stream of one literal path each.
+          validate_diff_allowlist() {
+            local violators
+            violators=$(
+              {
+                git diff --name-only -z HEAD
+                git ls-files --others --exclude-standard -z
+              } | while IFS= read -r -d '' path; do
                   case "$path" in
                     go.mod|go.sum|go.work.sum) ;;
                     */go.mod|*/go.sum) ;;
                     "") ;;
-                    *) echo "$path" ;;
+                    *) printf '%s\n' "$path" ;;
                   esac
                 done
-          )
-          if [ -n "$violators" ]; then
-            echo "ERROR: scripts/sync.sh changed files outside the allowlist:"
-            echo "$violators"
-            echo
-            echo "Full git status:"
-            git status --porcelain --untracked-files=all
-            exit 1
-          fi
-
-      - name: Commit and push sync result
-        run: |
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "No diff after scripts/sync.sh; nothing to commit."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            )
+            if [ -n "$violators" ]; then
+              echo "ERROR: scripts/sync.sh changed files outside the allowlist:"
+              echo "$violators"
+              echo
+              echo "Full git status:"
+              git status --porcelain --untracked-files=all
+              exit 1
+            fi
+          }
 
           add_allowlisted() {
             # Stage only the Go module metadata paths the allowlist covers.
@@ -92,6 +93,17 @@ jobs:
               'Run scripts/sync.sh after Renovate dependency update.'
           }
 
+          # ---- first pass: validate, commit, push ----
+          validate_diff_allowlist
+
+          if [ -z "$(git status --porcelain --untracked-files=all)" ]; then
+            echo "No diff after scripts/sync.sh; nothing to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           add_allowlisted
           if git diff --cached --quiet; then
             echo "Nothing staged after allowlisted add; treating as no-op."
@@ -103,11 +115,13 @@ jobs:
             exit 0
           fi
 
+          # ---- single retry on non-fast-forward ----
           echo "Initial push rejected; attempting one rebase/retry."
           git fetch origin "${GITHUB_REF_NAME}"
           git reset --hard "origin/${GITHUB_REF_NAME}"
           ./scripts/sync.sh
-          if [ -z "$(git status --porcelain)" ]; then
+          validate_diff_allowlist
+          if [ -z "$(git status --porcelain --untracked-files=all)" ]; then
             echo "Sync is a no-op on top of remote; nothing to push."
             exit 0
           fi

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "local>invakid404/renovate-config"
   ],
+  "rebaseWhen": "conflicted",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Auto-sync go.mod/go.sum across modules on Renovate PRs. Closes #352.

## What it does

- **Trigger**: `push` on `renovate/**` (no path filters in v1), with `concurrency` cancel-in-progress per ref.
- **Sync**: checks out the branch with `actions/checkout@v6`, installs Go via `actions/setup-go@v6` at the repo-wide `GO_VERSION: "1.26.3"`, and runs `./scripts/sync.sh` — the canonical multi-module sync.
- **Allowlist**: after sync, asserts the only changed files are `go.mod`, `go.sum`, `go.work.sum`, or `**/go.mod` / `**/go.sum`. Any other tracked or untracked drift fails the workflow without pushing. `git status --untracked-files=all` is used so brand-new submodule directories expand to their file entries.
- **Commit / push**: if the allowlisted diff is non-empty, configures `github-actions[bot]` identity, stages **only** the allowlisted paths (no `git add -A`), commits with `chore(deps): sync Go module metadata` + body `Run scripts/sync.sh after Renovate dependency update.`, and `git push origin HEAD:<ref_name>` (no force).
- **Race retry**: on non-fast-forward rejection, fetches, hard-resets to the remote branch, re-runs `scripts/sync.sh`, re-stages allowlisted paths, recommits, and pushes once. If the second push fails, the workflow exits non-zero so the next Renovate push (or a manual rerun) can recover.
- **Loop guard**: job-level `if:` skips runs whose `head_commit.author.name == 'github-actions[bot]'`, complementing GitHub's built-in `GITHUB_TOKEN` recursion suppression.

## What it doesn't do

- Doesn't run `cmd/regenerate-dynclient`; codegen drift remains gated by `unit-tests.yml`'s fresh-tree check (D9).
- Doesn't auto-merge Renovate PRs.
- Doesn't force-push (D8).
- Doesn't change repository branch-protection settings.
- Doesn't add any caching beyond what `actions/setup-go` provides (D10).
- Doesn't use a custom committer identity — standard `github-actions[bot]` only.

## Trade-offs

- Uses `GITHUB_TOKEN` (D5). GitHub suppresses recursive workflow runs caused by `GITHUB_TOKEN`, so the post-sync commit may not auto-rerun `Unit Tests` / `Integration Tests` on the new head. Accepted for v1; if zero-touch CI on sync commits is needed later, switch to a PAT/App token or add an explicit dispatch step.
- `rebaseWhen: "conflicted"` is set explicitly because the upstream private preset `local>invakid404/renovate-config` is opaque from this checkout. The conservative default keeps Renovate from recreating branches and discarding sync commits whenever `master` moves.

## Operational validation

The workflow's behavior under real Renovate force-pushes can only be proven post-merge — token interaction with branch protection, recursive-trigger suppression, and Renovate's branch-recreation policy all live on GitHub. **Canary**: the first dependency-bump PR that Renovate opens after this merges. Watch for (a) the workflow firing on the Renovate push, (b) the allowlist passing, (c) the commit landing on the branch, (d) downstream CI behavior on the post-sync commit.

Touches codegen output: no (verified with `go run ./cmd/regenerate-dynclient && git status dynclient/` — clean).

## Test plan

- [ ] After merge, watch the first Renovate dep-bump PR: confirm `Renovate Go Module Sync` runs, allowlist passes, and a sync commit lands (or it cleanly no-ops).
- [ ] Confirm `github-actions[bot]` can push to `renovate/**` under current branch protection.
- [ ] Confirm `unit-tests.yml`'s `scripts/sync.sh fresh-tree gate` passes on the post-sync head (rerun manually if `GITHUB_TOKEN` suppression prevents auto-run).
- [ ] Confirm `rebaseWhen: "conflicted"` does not cause Renovate to thrash existing PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to sync Go module metadata on Renovate branches: it validates that only allowed module metadata files change, stages and commits those changes, and retries once if a push is rejected.
  * Updated dependency management to rebase automatically when Renovate updates encounter conflicts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->