### PR TITLE
fix(ci): use PAT for renovate-sync push to trigger downstream CI

### DIFF
--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -31,6 +31,10 @@ jobs:
           # prevent recursion; a PAT looks like a user push and
           # reruns Unit/Integration on the sync commit.
           token: ${{ secrets.RENOVATE_SYNC_TOKEN }}
+          # Don't write the PAT into .git/config. Pushes below
+          # inject the credential explicitly via -c extraheader so
+          # the token never persists on the runner filesystem.
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -45,6 +49,11 @@ jobs:
         run: ./scripts/sync.sh
 
       - name: Validate, commit, and push sync result
+        env:
+          # Exposed to the step's run script so git push can inject
+          # the credential explicitly via -c extraheader. Pairs with
+          # persist-credentials: false on the checkout step above.
+          RENOVATE_SYNC_TOKEN: ${{ secrets.RENOVATE_SYNC_TOKEN }}
         run: |
           # Allowlist: only Go module metadata may change.
           #   go.mod, go.sum, go.work.sum at the root, and go.mod / go.sum
@@ -100,6 +109,15 @@ jobs:
               'Run scripts/sync.sh after Renovate dependency update.'
           }
 
+          # Push helper: injects the PAT through an in-memory git
+          # config override (-c) instead of relying on a persisted
+          # credential. The token never lands in .git/config and
+          # GitHub's log redactor masks it if it ever echoes.
+          git_push() {
+            git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${RENOVATE_SYNC_TOKEN}" \
+              push origin "HEAD:${GITHUB_REF_NAME}"
+          }
+
           # ---- first pass: validate, commit, push ----
           validate_diff_allowlist
 
@@ -118,7 +136,7 @@ jobs:
           fi
           git commit -m "$(commit_msg)"
 
-          if git push origin "HEAD:${GITHUB_REF_NAME}"; then
+          if git_push; then
             exit 0
           fi
 
@@ -138,7 +156,7 @@ jobs:
             exit 0
           fi
           git commit -m "$(commit_msg)"
-          if ! git push origin "HEAD:${GITHUB_REF_NAME}"; then
+          if ! git_push; then
             echo "ERROR: push still rejected after one retry; aborting."
             exit 1
           fi

--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -25,11 +25,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
-          # PAT instead of GITHUB_TOKEN so the sync commit's push
-          # triggers normal PR-event CI on the new tip. GitHub
-          # suppresses workflow runs from GITHUB_TOKEN pushes to
-          # prevent recursion; a PAT looks like a user push and
-          # reruns Unit/Integration on the sync commit.
+          # Use a PAT so the sync commit's push triggers normal
+          # PR-event CI on the new tip. GitHub suppresses workflow
+          # runs from GITHUB_TOKEN-authored pushes to prevent
+          # recursion; a PAT push looks like a user push and reruns
+          # Unit/Integration on the sync commit.
           token: ${{ secrets.RENOVATE_SYNC_TOKEN }}
           # Don't write the PAT into .git/config. Pushes below
           # inject the credential explicitly via -c extraheader so
@@ -110,9 +110,9 @@ jobs:
           }
 
           # Push helper: injects the PAT through an in-memory git
-          # config override (-c) instead of relying on a persisted
-          # credential. The token never lands in .git/config and
-          # GitHub's log redactor masks it if it ever echoes.
+          # config override (-c). The token never lands in
+          # .git/config and GitHub's log redactor masks it if it
+          # ever echoes.
           git_push() {
             if [ -z "${RENOVATE_SYNC_TOKEN:-}" ]; then
               echo "ERROR: RENOVATE_SYNC_TOKEN is unset or empty; cannot push." >&2

--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -25,15 +25,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
-          # Use a PAT so the sync commit's push triggers normal
-          # PR-event CI on the new tip. GitHub suppresses workflow
-          # runs from GITHUB_TOKEN-authored pushes to prevent
-          # recursion; a PAT push looks like a user push and reruns
-          # Unit/Integration on the sync commit.
-          token: ${{ secrets.RENOVATE_SYNC_TOKEN }}
-          # Don't write the PAT into .git/config. Pushes below
-          # inject the credential explicitly via -c extraheader so
-          # the token never persists on the runner filesystem.
+          # Don't persist the default GITHUB_TOKEN into .git/config.
+          # The push step below injects RENOVATE_SYNC_TOKEN via a
+          # `-c extraheader` at push time, so no credential lands on
+          # the runner filesystem.
           persist-credentials: false
 
       - name: Set up Go
@@ -50,9 +45,12 @@ jobs:
 
       - name: Validate, commit, and push sync result
         env:
-          # Exposed to the step's run script so git push can inject
-          # the credential explicitly via -c extraheader. Pairs with
-          # persist-credentials: false on the checkout step above.
+          # PAT used by git_push() to push the sync commit. The PAT
+          # makes the push look like a user push so GitHub reruns
+          # normal PR-event CI on the new tip; GITHUB_TOKEN-authored
+          # pushes are suppressed to prevent workflow recursion. The
+          # token is injected via -c extraheader at push time, so
+          # nothing persists in .git/config.
           RENOVATE_SYNC_TOKEN: ${{ secrets.RENOVATE_SYNC_TOKEN }}
         run: |
           # Allowlist: only Go module metadata may change.

--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -114,6 +114,10 @@ jobs:
           # credential. The token never lands in .git/config and
           # GitHub's log redactor masks it if it ever echoes.
           git_push() {
+            if [ -z "${RENOVATE_SYNC_TOKEN:-}" ]; then
+              echo "ERROR: RENOVATE_SYNC_TOKEN is unset or empty; cannot push." >&2
+              return 1
+            fi
             git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${RENOVATE_SYNC_TOKEN}" \
               push origin "HEAD:${GITHUB_REF_NAME}"
           }

--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -25,6 +25,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
+          # PAT instead of GITHUB_TOKEN so the sync commit's push
+          # triggers normal PR-event CI on the new tip. GitHub
+          # suppresses workflow runs from GITHUB_TOKEN pushes to
+          # prevent recursion; a PAT looks like a user push and
+          # reruns Unit/Integration on the sync commit.
+          token: ${{ secrets.RENOVATE_SYNC_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Why

PR #353 shipped the renovate-sync workflow using `GITHUB_TOKEN`. The first real Renovate PR after merge (#351, AWS SDK bump) proved the predicted trade-off: GitHub suppresses workflow runs from `GITHUB_TOKEN`-authenticated pushes, so the sync commit on #351 landed but neither Unit Tests nor Integration Tests fired against the post-sync SHA.

Switching the checkout token from `GITHUB_TOKEN` to a fine-grained PAT makes the push look like a regular user push, so the full CI matrix reruns on the sync commit. Recursion is still bounded by the existing loop guard (`if: github.event.head_commit.author.name != 'github-actions[bot]'`), which checks the commit AUTHOR (`github-actions[bot]` — unchanged), independent of who PUSHED.

## Required setup before merge

Add a repository secret `RENOVATE_SYNC_TOKEN`:

- **Fine-grained PAT** (NOT classic).
- Scope: **only invakid404/baml-rest**.
- Permissions: **Contents: Read and write** — and nothing else.
- Expiry: 90 days. Set a calendar reminder to rotate.
- Issued from your account is fine, given you're the only privileged collaborator and Renovate is the only other write-capable identity. A dedicated machine-user account is optional hardening, not required.

If the secret is missing when the workflow runs, `actions/checkout` fails loudly rather than silently falling back to `GITHUB_TOKEN` — failure mode is observable, not silent.

## Risk

- Forks **cannot** exfiltrate the PAT: trigger is `push` on `renovate/**` branches in this repo only; fork PRs push to their own branches, not ours. Even if they could trigger us, fork-PR workflow runs are stripped of secrets by GitHub.
- Only collaborators + Renovate-bot can push to `renovate/**` branches in this repo. Same trust boundary as direct write access — the PAT doesn't grant capability they don't already have.
- GitHub auto-redacts secret values from workflow logs.

## Touches codegen output

No.

## Verification commands

- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/renovate-sync.yml'))"`).
- One-line addition: `token: ${{ secrets.RENOVATE_SYNC_TOKEN }}` under `actions/checkout`'s `with:` block. Plus a 5-line explanatory comment.
- Loop guard (`if: ... != 'github-actions[bot]'`) unchanged — commit author still attributed to `github-actions[bot]`, just the push now uses the PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI sync workflow now performs authenticated pushes using a dedicated personal access token so sync commits are treated as normal user pushes and reliably trigger CI.
  * Credentials for push operations are injected transiently and not persisted to the repo.
  * Existing push validation and retry behavior is preserved, including a single rebase/reset + retry flow on push rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->