### PR TITLE
fix(ci): use unscoped http.extraheader in renovate-sync git_push

### DIFF
--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -107,16 +107,22 @@ jobs:
               'Run scripts/sync.sh after Renovate dependency update.'
           }
 
-          # Push helper: injects the PAT through an in-memory git
-          # config override (-c). The token never lands in
-          # .git/config and GitHub's log redactor masks it if it
-          # ever echoes.
+          # Push helper: injects the PAT via an in-memory git
+          # extraheader override (-c). The unscoped
+          # `http.extraheader` key is required: a URL-scoped key
+          # like `http.https://github.com/.extraheader` does not
+          # propagate auth through `git -c`, so git falls back to
+          # the credential helper and the push fails. The unscoped
+          # form is safe here because the override lasts for one
+          # `git push` only — no other HTTPS calls run in this
+          # command. The token never lands in .git/config and
+          # GitHub's log redactor masks it if it ever echoes.
           git_push() {
             if [ -z "${RENOVATE_SYNC_TOKEN:-}" ]; then
               echo "ERROR: RENOVATE_SYNC_TOKEN is unset or empty; cannot push." >&2
               return 1
             fi
-            git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${RENOVATE_SYNC_TOKEN}" \
+            git -c "http.extraheader=AUTHORIZATION: bearer ${RENOVATE_SYNC_TOKEN}" \
               push origin "HEAD:${GITHUB_REF_NAME}"
           }
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Why

PR #355's `git_push()` used a URL-scoped extraheader override:

```sh
git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${TOKEN}" \
  push origin "HEAD:${GITHUB_REF_NAME}"
```

This parsed without error, multiple cold reviews passed, but in production on Renovate PR #354 (AWS SDK) the push failed with:

```
fatal: could not read Username for 'https://github.com': No such device or address
ERROR: push still rejected after one retry; aborting.
```

Root cause: `git -c http.<URL>.extraheader=...` parses as a valid config key, but the URL-match logic does not pick up the header for the actual push request. Git falls back to the credential helper, which has nothing configured (because `persist-credentials: false`), and exits.

The widely-used pattern for "push with PAT after `persist-credentials: false`" uses the unscoped form:

```sh
git -c "http.extraheader=AUTHORIZATION: bearer ${TOKEN}" \
  push origin "HEAD:${GITHUB_REF_NAME}"
```

The override applies to all HTTPS calls in this single invocation, but only `git push` runs in this command, so scope is effectively the same.

## Risk

- Same token-handling model as PR #355: PAT is in step `env:` only, injected at command time via `-c`, never persisted to `.git/config`.
- The unscoped form would matter if `git push` made HTTPS calls to other hosts — it does not for a normal push to `origin`.
- The OpenAPI Renovate PR that succeeded after PR #355 merged did so only because it was a no-op (sync.sh produced no diff, so `git_push()` was never invoked). Any PR with a real sync diff would have hit the same failure as the AWS PR.

## Touches codegen output

No.

## Verification commands

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/renovate-sync.yml'))"` (passes).
- `git grep -nP '(rather than|instead of|in-scope fix|removed for|follow-up PR|added for|to address|PR #[0-9]+|see PR)' .github/workflows/renovate-sync.yml` (empty).
- Real validation: re-base the failing Renovate PR after this merges and confirm the sync push succeeds.

## What's NOT changed

- Checkout step (no `token:`, `persist-credentials: false`) — unchanged.
- `RENOVATE_SYNC_TOKEN` step-level `env:` — unchanged.
- Fail-fast guard at start of `git_push()` — unchanged.
- Allowlist, NUL staging, retry path, loop guard — all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for synchronization processes.

---

**Note:** This release contains no user-facing changes or new features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->