### PR TITLE
fix(ci): route renovate-sync auth through actions/checkout

### DIFF
--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -25,11 +25,24 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
-          # Don't persist the default GITHUB_TOKEN into .git/config.
-          # The push step below injects RENOVATE_SYNC_TOKEN via a
-          # `-c extraheader` at push time, so no credential lands on
-          # the runner filesystem.
-          persist-credentials: false
+          # PAT used both for checkout and the sync commit's push.
+          # actions/checkout writes a URL-scoped HTTP Basic
+          # extraheader (`x-access-token:<PAT>`) to the runner's
+          # git config and removes it during post-job cleanup.
+          # PAT-authored pushes retrigger normal PR-event CI;
+          # GITHUB_TOKEN-authored pushes are suppressed by GitHub
+          # to prevent workflow recursion.
+          token: ${{ secrets.RENOVATE_SYNC_TOKEN }}
+
+      - name: Verify PAT push auth
+        # Preflight: exercise git-receive-pack auth before doing
+        # any sync work. If the PAT lacks Contents:write or the
+        # auth wiring is otherwise broken, we want to fail here
+        # with a clear error, not after producing a sync commit
+        # that has nowhere to go.
+        env:
+          GIT_TERMINAL_PROMPT: "0"
+        run: git push --dry-run origin "HEAD:${GITHUB_REF_NAME}"
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -44,14 +57,6 @@ jobs:
         run: ./scripts/sync.sh
 
       - name: Validate, commit, and push sync result
-        env:
-          # PAT used by git_push() to push the sync commit. The PAT
-          # makes the push look like a user push so GitHub reruns
-          # normal PR-event CI on the new tip; GITHUB_TOKEN-authored
-          # pushes are suppressed to prevent workflow recursion. The
-          # token is injected via -c extraheader at push time, so
-          # nothing persists in .git/config.
-          RENOVATE_SYNC_TOKEN: ${{ secrets.RENOVATE_SYNC_TOKEN }}
         run: |
           # Allowlist: only Go module metadata may change.
           #   go.mod, go.sum, go.work.sum at the root, and go.mod / go.sum
@@ -107,23 +112,13 @@ jobs:
               'Run scripts/sync.sh after Renovate dependency update.'
           }
 
-          # Push helper: injects the PAT via an in-memory git
-          # extraheader override (-c). The unscoped
-          # `http.extraheader` key is required: a URL-scoped key
-          # like `http.https://github.com/.extraheader` does not
-          # propagate auth through `git -c`, so git falls back to
-          # the credential helper and the push fails. The unscoped
-          # form is safe here because the override lasts for one
-          # `git push` only — no other HTTPS calls run in this
-          # command. The token never lands in .git/config and
-          # GitHub's log redactor masks it if it ever echoes.
+          # Auth for `git push` is configured by actions/checkout
+          # (URL-scoped Basic extraheader with `x-access-token:<PAT>`),
+          # so a plain `git push` works. The Verify PAT push auth
+          # step above guards against PAT/auth regressions before
+          # we reach this point.
           git_push() {
-            if [ -z "${RENOVATE_SYNC_TOKEN:-}" ]; then
-              echo "ERROR: RENOVATE_SYNC_TOKEN is unset or empty; cannot push." >&2
-              return 1
-            fi
-            git -c "http.extraheader=AUTHORIZATION: bearer ${RENOVATE_SYNC_TOKEN}" \
-              push origin "HEAD:${GITHUB_REF_NAME}"
+            git push origin "HEAD:${GITHUB_REF_NAME}"
           }
 
           # ---- first pass: validate, commit, push ----


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Why

PR #355 and PR #356 both shipped variants of `git -c "http.…extraheader=AUTHORIZATION: bearer ${TOKEN}" push …`. Both passed multiple rounds of cold review (semantically valid, well-formed). Both failed in production on the first non-empty Renovate sync push with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

A fresh codex diagnosis with the failure log + actions/checkout source pointed at the **auth scheme**, not the extraheader plumbing:

- GitHub's git-receive-pack HTTPS endpoint accepts **Basic** auth with `x-access-token:<PAT>` base64'd. It does not accept `Authorization: Bearer <PAT>` (which is only the REST API path).
- `actions/checkout@v6` already implements the correct Basic-extraheader wiring internally when given a `token:` input — see [its `git-auth-helper.ts`](https://github.com/actions/checkout/blob/v6.0.2/src/git-auth-helper.ts).
- Our previous `git fetch` in the retry path returned a misleading success because the repo is public (anonymous fetch).

This PR delegates auth wiring back to `actions/checkout` and adds a preflight that exercises the receive-pack auth path before doing any sync work.

## Changes

### `.github/workflows/renovate-sync.yml`

1. **Checkout step**: pass `token: ${{ secrets.RENOVATE_SYNC_TOKEN }}`; drop `persist-credentials: false`. checkout now writes a URL-scoped Basic extraheader for the PAT and removes it during post-job cleanup.

2. **New step "Verify PAT push auth"** (immediately after checkout):
   ```yaml
   - name: Verify PAT push auth
     env:
       GIT_TERMINAL_PROMPT: "0"
     run: git push --dry-run origin "HEAD:${GITHUB_REF_NAME}"
   ```
   `git push --dry-run` still invokes `git-receive-pack` even when the ref is up-to-date (codex verified with `GIT_TRACE=1`), so this exercises auth without changing repo state. `GIT_TERMINAL_PROMPT=0` makes missing credentials fail immediately instead of hanging.

3. **Push step**: drop step-level `env: RENOVATE_SYNC_TOKEN: …` (no longer needed); simplify `git_push()` to a plain `git push origin "HEAD:${GITHUB_REF_NAME}"`; rewrite the surrounding comment to point at checkout's auth + the preflight.

## Touches codegen output

No.

## Verification commands

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/renovate-sync.yml'))"` (passes).
- `bash -n` on extracted `run:` block (passes).
- `git grep -nP '(rather than|instead of|in-scope fix|removed for|follow-up PR|added for|to address|PR #[0-9]+|see PR)' .github/workflows/renovate-sync.yml` (empty).
- **Real validation**: on merge, the next Renovate-triggered run will execute the dry-run preflight FIRST. If auth is wired correctly, it succeeds silently; if not, the workflow fails on the preflight with a clear receive-pack auth error, before any sync commit is produced.

## Risk

- PAT is persisted to git config for the job duration (in `$RUNNER_TEMP`, removed by post-checkout cleanup). This was the model before PR #355's hardening landed. On an ephemeral, single-tenant runner with no untrusted code in the job, the exposure is bounded.
- The trade-off the previous hardening tried to make (`persist-credentials: false`) is reverted because it required custom auth code that turned out to be unreliable (bearer rejected by git-receive-pack). The maintained `actions/checkout` path is the simpler, verified-working option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD authentication configuration with improved security validation for internal sync processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->