### PR TITLE
fix(scripts): off-tidy standalone-tested modules in sync.sh

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # sync.sh — the equivalent of `go work sync` for a repo whose
 # adapter_v* and adapters/common modules sit outside the workspace on
-# purpose.
+# purpose, with the per-module go.sum maintenance that GOWORK=off
+# consumers and CI's standalone-modules matrix need on top.
 #
 # Each adapters/adapter_vX_Y_Z module pins a specific
 # github.com/boundaryml/baml version on purpose; including them in
@@ -13,14 +14,25 @@ set -euo pipefail
 # adapter has a local `replace ../common` that propagates whatever
 # version common pins.
 #
+# `go work sync` reconciles workspace members' go.mod requirements
+# against the workspace build list, but it does NOT populate the
+# per-module go.sum hashes that an external consumer (or CI's
+# standalone-modules matrix, which runs `GOWORK=off go test ./...`
+# from inside each published module) needs to build the same module
+# outside the workspace. The standalone tidy loop closes that gap by
+# running `GOWORK=off go mod tidy` over every entry in
+# release_required_modules — the canonical published module set,
+# sourced from scripts/release-lib.sh so this script and the release
+# tooling agree on what "published" means.
+#
 # This script:
 #   1. Runs `go work sync` for the workspace members so their go.mod
 #      files stay reconciled the way they always were.
-#   2. Runs `GOWORK=off go mod tidy` in adapters/common. common is no
-#      longer in the workspace, so `go work sync` won't refresh its
-#      indirect requires; tidy it explicitly with the per-module
-#      go.mod as the build list so its BAML pin stays at the
-#      lowest-adapter version.
+#   2. Runs `GOWORK=off go mod tidy` in every release_required_modules
+#      entry. The loop owns adapters/common (whose BAML pin must stay
+#      at the lowest-adapter version, since it's still outside
+#      go.work) along with every published Go module, so each
+#      standalone go.sum carries the hashes a GOWORK=off build needs.
 #   3. Walks adapters/adapter_v*/go.mod and runs `GOWORK=off go mod
 #      tidy` in each one. Tidying with GOWORK=off forces Go to use
 #      that adapter's own go.mod for the build list, so MVS only ever
@@ -30,9 +42,9 @@ set -euo pipefail
 #      module's go.mod still resolves the canonical BAML version.
 #
 # Usage:
-#   scripts/sync.sh                  # workspace + every adapter + verify
-#   scripts/sync.sh --only-workspace # skip per-adapter tidy + verify
-#   scripts/sync.sh --only-adapters  # skip `go work sync`
+#   scripts/sync.sh                  # workspace + standalone + every adapter + verify
+#   scripts/sync.sh --only-workspace # workspace + standalone; skip adapter tidy + verify
+#   scripts/sync.sh --only-adapters  # standalone + adapter tidy + verify; skip `go work sync`
 #   scripts/sync.sh --check-pins-only# skip every tidy step; only verify
 #   scripts/sync.sh -h | --help      # print this header
 
@@ -66,11 +78,14 @@ if [ "$mode_count" -gt 1 ]; then
     exit 2
 fi
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./release-lib.sh
+source "$script_dir/release-lib.sh"
+
 # Walk up from the script's own location to find the repo root (the
 # directory containing go.work). This lets the script be invoked from
 # anywhere — including via a symlink — without the user worrying about
 # the working directory.
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$script_dir"
 while [ "$repo_root" != "/" ] && [ ! -f "$repo_root/go.work" ]; do
     repo_root="$(dirname "$repo_root")"
@@ -81,11 +96,13 @@ if [ ! -f "$repo_root/go.work" ]; then
 fi
 cd "$repo_root"
 
-# common_dir and adapter_dirs are populated up-front so the same lists
-# drive the tidy loop and the pin-only path. Using nullglob means a
-# layout change that drops every adapter directory is a clean no-op
-# rather than a failed glob expansion.
-common_dir="adapters/common"
+# standalone_dirs is the canonical published module set from
+# release-lib.sh; adapter_dirs is the workspace-excluded per-version
+# adapter set. Both are populated up-front so the same lists drive the
+# tidy loops and the pin-only path. nullglob means a layout change
+# that drops every adapter directory is a clean no-op, not a failed
+# glob expansion.
+standalone_dirs=("${release_required_modules[@]}")
 shopt -s nullglob
 adapter_dirs=(adapters/adapter_v*/)
 shopt -u nullglob
@@ -94,6 +111,50 @@ verify_pins() {
     echo
     echo "Verifying BAML pin matrix..."
     go run ./cmd/verify-adapter-pins
+}
+
+# tidy_standalone_modules runs `GOWORK=off go mod tidy` in every
+# published standalone module. A missing go.mod is fatal: this is the
+# canonical release module set, and silently skipping an entry would
+# hide release/CI drift the moment a module is renamed or moved.
+tidy_standalone_modules() {
+    echo "Tidying standalone-tested module(s) with GOWORK=off..."
+    local dir
+    for dir in "${standalone_dirs[@]}"; do
+        if [ ! -f "$dir/go.mod" ]; then
+            echo "ERROR: required standalone module missing go.mod: $dir" >&2
+            exit 1
+        fi
+        printf '  %s ... ' "$dir"
+        (cd "$dir" && GOWORK=off go mod tidy)
+        echo "ok"
+    done
+}
+
+# tidy_adapter_version_modules runs `GOWORK=off go mod tidy` in every
+# adapters/adapter_v* module and records the count in the global
+# adapter_tidy_count so the final status line can report it.
+adapter_tidy_count=0
+tidy_adapter_version_modules() {
+    local count=0
+    local dir
+    for dir in "${adapter_dirs[@]}"; do
+        dir="${dir%/}"
+        if [ ! -f "$dir/go.mod" ]; then
+            continue
+        fi
+        if [ "$count" -eq 0 ]; then
+            echo "Tidying adapter version module(s) with GOWORK=off..."
+        fi
+        printf '  %s ... ' "$dir"
+        (cd "$dir" && GOWORK=off go mod tidy)
+        echo "ok"
+        count=$((count + 1))
+    done
+    if [ "$count" -eq 0 ]; then
+        echo "No adapter version modules to tidy."
+    fi
+    adapter_tidy_count="$count"
 }
 
 if $check_pins_only; then
@@ -106,49 +167,20 @@ if ! $only_adapters; then
     go work sync
 fi
 
+tidy_standalone_modules
+
 if $only_workspace; then
-    echo "Done."
+    echo
+    echo "Done. Synced workspace + ${#standalone_dirs[@]} standalone module(s)."
     exit 0
 fi
 
-# adapters/common is no longer a workspace member, so `go work sync`
-# above no longer refreshes it. Tidy it explicitly before the adapter
-# loop so the adapters' `replace ../common` directives see an
-# up-to-date common/go.mod with its BAML pin still at the canonical
-# lowest-adapter version.
-if [ -f "$common_dir/go.mod" ]; then
-    echo "Tidying $common_dir with GOWORK=off..."
-    (cd "$common_dir" && GOWORK=off go mod tidy)
-fi
-
-count=0
-for dir in "${adapter_dirs[@]}"; do
-    dir="${dir%/}"
-    if [ ! -f "$dir/go.mod" ]; then
-        continue
-    fi
-    if [ "$count" -eq 0 ]; then
-        echo "Tidying adapter module(s) with GOWORK=off..."
-    fi
-    printf '  %s ... ' "$dir"
-    (cd "$dir" && GOWORK=off go mod tidy)
-    echo "ok"
-    count=$((count + 1))
-done
-
-if [ "$count" -eq 0 ]; then
-    echo "No adapter version modules to tidy."
-    # Still verify pins — the common module has a pin to assert even
-    # in a layout with zero versioned adapters.
-    verify_pins
-    exit 0
-fi
-
+tidy_adapter_version_modules
 verify_pins
 
 echo
 if $only_adapters; then
-    echo "Done. Synced $count adapter(s) + common."
+    echo "Done. Synced ${#standalone_dirs[@]} standalone module(s) + $adapter_tidy_count adapter version(s)."
 else
-    echo "Done. Synced workspace + common + $count adapter(s)."
+    echo "Done. Synced workspace + ${#standalone_dirs[@]} standalone module(s) + $adapter_tidy_count adapter version(s)."
 fi

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -117,6 +117,15 @@ verify_pins() {
 # published standalone module. A missing go.mod is fatal: this is the
 # canonical release module set, and silently skipping an entry would
 # hide release/CI drift the moment a module is renamed or moved.
+#
+# A single pass is sufficient given the current graph: `go work sync`
+# above already reconciles workspace members' go.mod files, and the
+# two non-workspace standalone modules — adapters/common and
+# dynclient/baml-patched — depend only on workspace members and on
+# nothing first-party, respectively. If a future standalone module
+# gains a local first-party replace that points outside the
+# workspace, revisit this loop and either order it dependency-first
+# or add a bounded second pass with an idempotency check.
 tidy_standalone_modules() {
     echo "Tidying standalone-tested module(s) with GOWORK=off..."
     local dir


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes #358.

## Why

The Renovate AWS SDK bump in PR #351 ran the renovate-sync workflow successfully but the `standalone-modules` CI matrix then failed on four modules (`dynclient`, `introspected`, `worker`, `workerplugin`) with errors like:

```
../bamlutils/llmhttp/awssigv4.go:28:2:
  github.com/aws/aws-sdk-go-v2/config@v1.32.18: missing go.sum entry for go.mod file
```

Root cause: `go work sync` reconciles workspace members' `go.mod` files against the workspace build list, but it does NOT populate each per-module `go.sum`. Workspace builds pass because they consult the shared workspace go.sum; `GOWORK=off` standalone builds — which CI runs against every entry in `release_required_modules` — cannot.

`scripts/sync.sh` previously off-tidied only `adapters/common` and `adapters/adapter_v*`. The other five `release_required_modules` (`bamlutils, dynclient, dynclient/baml-patched, introspected, worker, workerplugin`) relied on `go work sync` to keep their go.sums consistent, which it doesn't.

## What

Add a `tidy_standalone_modules` loop that runs `GOWORK=off go mod tidy` in every `release_required_modules` entry. `scripts/sync.sh` now `source`s `scripts/release-lib.sh` so the standalone module set lives in one place (no duplication between `unit-tests.yml`, `release-lib.sh`, and `sync.sh`).

The special-case `adapters/common` tidy block is dropped — the standalone loop owns it. `adapters/adapter_v*` continues to have its own loop, run AFTER the standalone loop, because per-adapter BAML pins must stay isolated from workspace MVS.

Order is significant. The pipeline:

1. `go work sync` (propagates indirect requires across workspace member go.mods).
2. `tidy_standalone_modules` — refresh per-module go.sums for the standalone matrix.
3. `tidy_adapter_version_modules` — keep adapter BAML pins isolated.
4. `verify-adapter-pins`.

A final `go work sync` is **deliberately not added**: it could re-introduce the exact failure class this PR fixes (adding requirements to go.mod without matching per-module go.sum hashes). The test plan instead asks for manual verification that `go work sync` post-sync.sh is a no-op; if it isn't, the right response is to investigate drift, not paper it over.

## Mode interaction (unchanged where preserved)

| Mode | `go work sync` | standalone tidy | adapter_v* tidy | verify-pins |
|------|----------------|-----------------|------------------|-------------|
| default | yes | yes | yes | yes |
| `--only-workspace` | yes | yes | no | no |
| `--only-adapters` | no | yes | yes | yes |
| `--check-pins-only` | no | no | no | yes |

## Risk

- `scripts/sync.sh` now depends on `scripts/release-lib.sh` defining `release_required_modules`. Acceptable: that array is the canonical published module set, already authoritative for release tooling. `release-lib.sh` has no top-level side effects (verified by cold review).
- Renovate-sync CI runs slightly longer (~5 additional `go mod tidy` invocations). Acceptable — moves failures from downstream standalone tests into the sync commit that's supposed to fix module metadata.
- Single-pass safety (no fixpoint loop) is documented in `tidy_standalone_modules`'s comment block. Holds for the current graph; commented future-proofing note explains when to revisit.

## Touches codegen output

No.

## Verification

- `bash -n scripts/sync.sh` passes.
- Banned PR-process-metadata grep is clean.
- Cold review at tip `ff0814572` was APPROVE with zero findings on first read.
- Empirical proof comes when this lands and Renovate-sync re-runs on a non-trivial bump (e.g., rebase PR #351 after merge).

## Follow-up

After this lands, the failing PR #351 (AWS SDK) should be rebased so the new `sync.sh` runs against the AWS branch. The next sync commit will populate the missing standalone go.sum entries; the `standalone-modules` matrix should then pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal build maintenance script to improve Go module state management and verification across workspace and adapter modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->