### PR TITLE
feat(bamlfuzz): union support — IR, emitters, oracle, shrinking

### DIFF
--- a/adapters/common/codegen/bamlfuzz/case.go
+++ b/adapters/common/codegen/bamlfuzz/case.go
@@ -38,6 +38,26 @@ type CaseMetadata struct {
 	// report depth 1. Self-ref and mutual-cycle schemas report higher
 	// peaks up to MaxValueRecursion.
 	RecursionDepths map[string]int `json:"recursion_depths,omitempty"`
+	// UnionChoices maps a JSON-path-style key to the union-variant
+	// choice the value walker recorded at that path. Populated for
+	// every KindUnion node encountered. The order checker and the
+	// failure envelope read this to explain which arm was exercised;
+	// callers reading union choices fail closed when an entry is
+	// missing.
+	UnionChoices map[string]UnionChoice `json:"union_choices,omitempty"`
+}
+
+// UnionChoice records which arm of a KindUnion was selected at one
+// JSON path. Index is the zero-based slot in FuzzType.Variants;
+// Kind / Ref describe the selected arm's discriminator so a
+// developer can interpret the envelope without re-deriving the
+// schema. VariantCount lets a consumer detect a single-arm shrink
+// state (where the union collapsed to a bare type during shrinking).
+type UnionChoice struct {
+	Index        int          `json:"index"`
+	Kind         FuzzTypeKind `json:"kind"`
+	Ref          string       `json:"ref,omitempty"`
+	VariantCount int          `json:"variant_count"`
 }
 
 // OracleCase is the fully-materialized fuzz case downstream PRs ship

--- a/adapters/common/codegen/bamlfuzz/cmd/seedcorpus/main.go
+++ b/adapters/common/codegen/bamlfuzz/cmd/seedcorpus/main.go
@@ -51,6 +51,11 @@ func main() {
 			mapToClass(),
 			mutualRecursion(),
 			literalsAll(),
+			unionFieldString(),
+			unionListElement(),
+			unionMapValue(),
+			unionNestedInsideUnion(),
+			unionTNull(),
 		}
 		modeValue = bamlfuzz.OracleDynamicThreeWay
 	case "static":
@@ -105,11 +110,12 @@ func materialize(idx int, spec seedSpec, mode bamlfuzz.OracleMode) bamlfuzz.Orac
 	}
 }
 
-// staticCases returns the five hand-curated static-mode seed cases.
-// Scope D7 lists the static corpus shape: scalar object, nested class
-// with enum, optional three shapes, terminating mutual recursion, and
-// one self-referential tree. The self-ref case is exclusive to static
-// mode; the dynamic emitter rejects it.
+// staticCases returns the hand-curated static-mode seed cases. The
+// first five cases mirror the original v1 static corpus (scalar
+// object, nested class with enum, optional three shapes, terminating
+// mutual recursion, self-referential tree). The union cases sit on
+// top so the integration test can chunk the corpus into 5-function
+// batches.
 func staticCases() []seedSpec {
 	return []seedSpec{
 		staticScalarObject(),
@@ -117,6 +123,12 @@ func staticCases() []seedSpec {
 		staticOptionalThreeShapes(),
 		staticTerminatingMutualRecursion(),
 		staticSelfReferentialTree(),
+		staticUnionFieldString(),
+		staticUnionListElement(),
+		staticUnionMapValue(),
+		staticUnionNested(),
+		staticUnionTNull(),
+		staticRawTopLevelUnion(),
 	}
 }
 
@@ -563,6 +575,231 @@ func mutualRecursion() seedSpec {
 				vField("a", vOptAbsent()),
 			))),
 		),
+		Preserve: false,
+	}
+}
+
+func tUnion(variants ...bamlfuzz.FuzzType) bamlfuzz.FuzzType {
+	return bamlfuzz.FuzzType{Kind: bamlfuzz.KindUnion, Variants: variants}
+}
+
+func vUnion(idx int, picked bamlfuzz.FuzzValue) bamlfuzz.FuzzValue {
+	return bamlfuzz.FuzzValue{Kind: bamlfuzz.KindUnion, VariantIndex: idx, Variant: &picked}
+}
+
+// unionFieldString covers a class field typed as union(string, int)
+// where the value picks the int arm. Exercises the dynamic emitter's
+// type=union + OneOf lowering and the walker's variant-aware
+// rendering. Schema-order preservation is on so the order checker
+// runs the union-aware path through CaseMetadata.UnionChoices.
+func unionFieldString() seedSpec {
+	return seedSpec{
+		Name: "union_field_string_or_int",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("either", tUnion(tStr(), tInt())),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("either", vUnion(1, vInt(7))),
+		),
+		Preserve: true,
+	}
+}
+
+// unionListElement covers a list whose element type is a union.
+// Element 0 picks the string arm, element 1 picks the int arm: the
+// walker and order checker must dispatch per-element on the recorded
+// choice.
+func unionListElement() seedSpec {
+	return seedSpec{
+		Name: "union_list_element",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("xs", tList(tUnion(tStr(), tInt()))),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("xs", vList(
+				vUnion(0, vStr("alpha")),
+				vUnion(1, vInt(42)),
+			)),
+		),
+		Preserve: false,
+	}
+}
+
+// unionMapValue covers a map whose value type is a union. The two
+// keys pick different arms so the metadata records distinct paths.
+func unionMapValue() seedSpec {
+	return seedSpec{
+		Name: "union_map_value",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("m", tMap(tUnion(tStr(), tBool()))),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("m", vMap(
+				mapEntry("a", vUnion(0, vStr("v"))),
+				mapEntry("b", vUnion(1, vBool(true))),
+			)),
+		),
+		Preserve: false,
+	}
+}
+
+// unionNestedInsideUnion covers union(union(string, int), bool). The
+// walker records distinct choices at the outer and inner positions
+// using the path-with-`:v`-suffix convention.
+func unionNestedInsideUnion() seedSpec {
+	return seedSpec{
+		Name: "union_nested_inside_union",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("x", tUnion(
+					tUnion(tStr(), tInt()),
+					tBool(),
+				)),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("x", vUnion(0, vUnion(1, vInt(123)))),
+		),
+		Preserve: true,
+	}
+}
+
+// unionTNull encodes the T|null pattern. The value picks the null
+// arm so the mock emits explicit JSON null at the field — not the
+// absent-key behaviour optional carries.
+func unionTNull() seedSpec {
+	return seedSpec{
+		Name: "union_t_null",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("maybe", tUnion(tStr(), tNull())),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("maybe", vUnion(1, vNull())),
+		),
+		Preserve: true,
+	}
+}
+
+// staticUnionFieldString is the static-mode equivalent of
+// unionFieldString. Same shape; lives in the static corpus so the
+// static oracle exercises the pipe-syntax lowering end-to-end.
+func staticUnionFieldString() seedSpec {
+	return seedSpec{
+		Name: "static_union_field_string_or_int",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("either", tUnion(tStr(), tInt())),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("either", vUnion(1, vInt(7))),
+		),
+		Preserve: true,
+	}
+}
+
+func staticUnionListElement() seedSpec {
+	return seedSpec{
+		Name: "static_union_list_element",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("xs", tList(tUnion(tStr(), tInt()))),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("xs", vList(
+				vUnion(0, vStr("alpha")),
+				vUnion(1, vInt(42)),
+			)),
+		),
+		Preserve: false,
+	}
+}
+
+func staticUnionMapValue() seedSpec {
+	return seedSpec{
+		Name: "static_union_map_value",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("m", tMap(tUnion(tStr(), tBool()))),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("m", vMap(
+				mapEntry("a", vUnion(0, vStr("v"))),
+				mapEntry("b", vUnion(1, vBool(true))),
+			)),
+		),
+		Preserve: false,
+	}
+}
+
+func staticUnionNested() seedSpec {
+	return seedSpec{
+		Name: "static_union_nested_inside_union",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("x", tUnion(
+					tUnion(tStr(), tInt()),
+					tBool(),
+				)),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("x", vUnion(0, vUnion(1, vInt(123)))),
+		),
+		Preserve: true,
+	}
+}
+
+func staticUnionTNull() seedSpec {
+	return seedSpec{
+		Name: "static_union_t_null",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes: []bamlfuzz.FuzzClass{cls("Root",
+				prop("maybe", tUnion(tStr(), tNull())),
+			)},
+			RootClass: "Root",
+		},
+		Value: vClass("Root",
+			vField("maybe", vUnion(1, vNull())),
+		),
+		Preserve: true,
+	}
+}
+
+// staticRawTopLevelUnion declares a non-class effective root: the
+// synthesized function returns `string | int` directly. The dynamic
+// emitter rejects this shape with ErrDynamicRootTypeUnsupported
+// (raw roots are gated to static); the static .baml lowering
+// supports it natively.
+func staticRawTopLevelUnion() seedSpec {
+	root := tUnion(tStr(), tInt())
+	return seedSpec{
+		Name: "static_raw_top_level_union",
+		Schema: bamlfuzz.FuzzSchema{
+			Classes:  []bamlfuzz.FuzzClass{},
+			Enums:    []bamlfuzz.FuzzEnum{},
+			RootType: &root,
+		},
+		Value:    vUnion(0, vStr("top-level")),
 		Preserve: false,
 	}
 }

--- a/adapters/common/codegen/bamlfuzz/emit_dynamic.go
+++ b/adapters/common/codegen/bamlfuzz/emit_dynamic.go
@@ -175,6 +175,17 @@ func lowerProperty(ft FuzzType) (*bamlutils.DynamicProperty, error) {
 		}
 		prop.Ref = ft.Ref
 	case KindUnion:
+		// Single-arm unions short-circuit to the bare variant for
+		// parity with the static emitter (which renders the lone arm
+		// without pipe syntax). A one-element OneOf is not legal
+		// BAML. Single-arm unions are unreachable from the random
+		// generator — drawUnion picks at least MinUnionVariants —
+		// but they can land on the dynamic emitter through
+		// hand-written / replay schemas, so the defensive collapse
+		// keeps both paths in lockstep.
+		if len(ft.Variants) == 1 {
+			return lowerProperty(ft.Variants[0])
+		}
 		variants, err := lowerVariants(ft.Variants)
 		if err != nil {
 			return nil, err
@@ -245,6 +256,12 @@ func lowerTypeSpec(ft FuzzType) (*bamlutils.DynamicTypeSpec, error) {
 		}
 		spec.Ref = ft.Ref
 	case KindUnion:
+		// See the matching short-circuit in lowerProperty: a
+		// one-element OneOf is invalid BAML; the static emitter
+		// drops the wrapper in the same case.
+		if len(ft.Variants) == 1 {
+			return lowerTypeSpec(ft.Variants[0])
+		}
 		variants, err := lowerVariants(ft.Variants)
 		if err != nil {
 			return nil, err
@@ -258,10 +275,9 @@ func lowerTypeSpec(ft FuzzType) (*bamlutils.DynamicTypeSpec, error) {
 }
 
 // lowerVariants renders each union variant as a DynamicTypeSpec.
-// Empty / single-arm variants are rejected: an empty union is
-// invalid BAML, and a single-arm union should have been collapsed
-// to the bare variant before reaching the dynamic emitter
-// (LowerToBamlSource enforces the static-side equivalent).
+// Empty variants are rejected (no BAML form). Single-arm unions are
+// collapsed to the bare variant by the callers in lowerProperty /
+// lowerTypeSpec before reaching here, mirroring the static emitter.
 func lowerVariants(variants []FuzzType) ([]*bamlutils.DynamicTypeSpec, error) {
 	if len(variants) == 0 {
 		return nil, fmt.Errorf("union has no variants")

--- a/adapters/common/codegen/bamlfuzz/emit_dynamic.go
+++ b/adapters/common/codegen/bamlfuzz/emit_dynamic.go
@@ -31,6 +31,16 @@ var ErrDynamicSelfRefUnsupported = fmt.Errorf("%w: self-referential schema", Err
 // ErrDynamicSchemaUnsupported.
 var ErrDynamicMutualCycleUnsupported = fmt.Errorf("%w: mutual-cycle schema", ErrDynamicSchemaUnsupported)
 
+// ErrDynamicRootTypeUnsupported is returned by LowerToDynamicSchema
+// when the schema declares a non-class effective root type (a raw
+// top-level union / list / map / primitive). The production
+// /call/_dynamic endpoint accepts object-shaped output schemas
+// only — the contract is "fill in a class" — so the dynamic emitter
+// rejects raw roots. Static lowering handles the same shapes
+// natively via the synthesized function's return type. Wraps
+// ErrDynamicSchemaUnsupported.
+var ErrDynamicRootTypeUnsupported = fmt.Errorf("%w: raw non-class root type", ErrDynamicSchemaUnsupported)
+
 // LowerToDynamicSchema lowers a FuzzSchema into a bamlutils.DynamicOutputSchema
 // suitable for posting to /call/_dynamic or driving dynclient.Client.DynamicCall.
 //
@@ -55,6 +65,9 @@ func LowerToDynamicSchema(schema FuzzSchema) (bamlutils.DynamicOutputSchema, err
 	}
 	if flags.HasMutualCycle {
 		return bamlutils.DynamicOutputSchema{}, fmt.Errorf("%w: root=%q", ErrDynamicMutualCycleUnsupported, schema.RootClass)
+	}
+	if schema.RootType != nil && schema.RootType.Kind != KindClassRef {
+		return bamlutils.DynamicOutputSchema{}, fmt.Errorf("%w: root kind=%q", ErrDynamicRootTypeUnsupported, schema.RootType.Kind)
 	}
 	rootCls, ok := schema.FindClass(schema.RootClass)
 	if !ok {
@@ -161,6 +174,13 @@ func lowerProperty(ft FuzzType) (*bamlutils.DynamicProperty, error) {
 			return nil, fmt.Errorf("ref kind %q missing target", ft.Kind)
 		}
 		prop.Ref = ft.Ref
+	case KindUnion:
+		variants, err := lowerVariants(ft.Variants)
+		if err != nil {
+			return nil, err
+		}
+		prop.Type = "union"
+		prop.OneOf = variants
 	default:
 		return nil, fmt.Errorf("unsupported kind %q", ft.Kind)
 	}
@@ -224,10 +244,37 @@ func lowerTypeSpec(ft FuzzType) (*bamlutils.DynamicTypeSpec, error) {
 			return nil, fmt.Errorf("ref kind %q missing target", ft.Kind)
 		}
 		spec.Ref = ft.Ref
+	case KindUnion:
+		variants, err := lowerVariants(ft.Variants)
+		if err != nil {
+			return nil, err
+		}
+		spec.Type = "union"
+		spec.OneOf = variants
 	default:
 		return nil, fmt.Errorf("unsupported kind %q", ft.Kind)
 	}
 	return spec, nil
+}
+
+// lowerVariants renders each union variant as a DynamicTypeSpec.
+// Empty / single-arm variants are rejected: an empty union is
+// invalid BAML, and a single-arm union should have been collapsed
+// to the bare variant before reaching the dynamic emitter
+// (LowerToBamlSource enforces the static-side equivalent).
+func lowerVariants(variants []FuzzType) ([]*bamlutils.DynamicTypeSpec, error) {
+	if len(variants) == 0 {
+		return nil, fmt.Errorf("union has no variants")
+	}
+	out := make([]*bamlutils.DynamicTypeSpec, len(variants))
+	for i, v := range variants {
+		spec, err := lowerTypeSpec(v)
+		if err != nil {
+			return nil, fmt.Errorf("union variant %d: %w", i, err)
+		}
+		out[i] = spec
+	}
+	return out, nil
 }
 
 func literalTypeAndValue(lit *FuzzLiteral) (string, any, error) {

--- a/adapters/common/codegen/bamlfuzz/emit_static.go
+++ b/adapters/common/codegen/bamlfuzz/emit_static.go
@@ -52,6 +52,11 @@ var caseIDPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
 // equivalent to the dynamic TypeBuilder's self-ref/mutual-cycle gates.
 // Value-side termination is enforced earlier, at value generation.
 //
+// When FuzzSchema.RootType is non-nil the synthesized function
+// returns that type spelled in BAML source (raw union, list, map,
+// or primitive). Otherwise the function returns RootClass — the v1
+// default, kept for replay-artifact compatibility.
+//
 // The emitted function declares `client TestClient`, expecting the
 // integration test to supply a per-request `client_registry` override
 // pointing TestClient at the scenario for this case.
@@ -59,11 +64,13 @@ func LowerToBamlSource(schema FuzzSchema, caseID string) (StaticBamlSource, erro
 	if !caseIDPattern.MatchString(caseID) {
 		return StaticBamlSource{}, fmt.Errorf("bamlfuzz: invalid caseID %q (must match %s)", caseID, caseIDPattern)
 	}
-	if schema.RootClass == "" {
-		return StaticBamlSource{}, fmt.Errorf("bamlfuzz: schema missing RootClass")
+	if schema.RootClass == "" && schema.RootType == nil {
+		return StaticBamlSource{}, fmt.Errorf("bamlfuzz: schema missing both RootClass and RootType")
 	}
-	if _, ok := schema.FindClass(schema.RootClass); !ok {
-		return StaticBamlSource{}, fmt.Errorf("bamlfuzz: root class %q not present in schema", schema.RootClass)
+	if schema.RootClass != "" {
+		if _, ok := schema.FindClass(schema.RootClass); !ok {
+			return StaticBamlSource{}, fmt.Errorf("bamlfuzz: root class %q not present in schema", schema.RootClass)
+		}
 	}
 
 	classNames := make(map[string]string, len(schema.Classes))
@@ -97,8 +104,15 @@ func LowerToBamlSource(schema FuzzSchema, caseID string) (StaticBamlSource, erro
 	}
 
 	funcName := "FuzzFn_" + caseID
-	rootMangled := classNames[schema.RootClass]
-	if err := writeFunction(&b, funcName, rootMangled); err != nil {
+	rootMangled := ""
+	if schema.RootClass != "" {
+		rootMangled = classNames[schema.RootClass]
+	}
+	returnSpelling, err := returnTypeSpelling(schema, classNames, enumNames)
+	if err != nil {
+		return StaticBamlSource{}, fmt.Errorf("bamlfuzz: emit function return type: %w", err)
+	}
+	if err := writeFunction(&b, funcName, returnSpelling); err != nil {
 		return StaticBamlSource{}, fmt.Errorf("bamlfuzz: emit function: %w", err)
 	}
 
@@ -110,6 +124,24 @@ func LowerToBamlSource(schema FuzzSchema, caseID string) (StaticBamlSource, erro
 		EnumNames:    enumOrder,
 		RootClass:    rootMangled,
 	}, nil
+}
+
+// returnTypeSpelling renders the BAML return type for the
+// synthesized function. When RootType is set it walks the spelled
+// type tree (parens around unions in nested positions); otherwise it
+// returns the mangled RootClass name for the v1 default.
+func returnTypeSpelling(schema FuzzSchema, classNames, enumNames map[string]string) (string, error) {
+	if schema.RootType != nil {
+		// Top-level return types do not need outer parens — they
+		// are not nested inside another wrapper. typeSpelling adds
+		// inner parens where needed for precedence.
+		return typeSpellingNoUnionParens(*schema.RootType, classNames, enumNames)
+	}
+	mangled, ok := classNames[schema.RootClass]
+	if !ok {
+		return "", fmt.Errorf("class ref %q not declared in schema", schema.RootClass)
+	}
+	return mangled, nil
 }
 
 // writeEnum emits a BAML enum declaration. Values are written in the
@@ -158,18 +190,18 @@ func writeClass(b *strings.Builder, cls FuzzClass, classNames, enumNames map[str
 }
 
 // writeFunction emits the synthesized BAML function. The function
-// returns the suffixed root class and references the existing
-// TestClient declared in the integration testdata baml_src/. Tests
-// override TestClient via a per-request client_registry to point at
-// the mockllm scenario for this case.
+// returns `returnType` (already spelled in BAML source) and
+// references the existing TestClient declared in the integration
+// testdata baml_src/. Tests override TestClient via a per-request
+// client_registry to point at the mockllm scenario for this case.
 //
 // The prompt includes {{ ctx.output_format }} so schema rendering is
 // exercised in the upstream request.
-func writeFunction(b *strings.Builder, funcName, rootMangled string) error {
+func writeFunction(b *strings.Builder, funcName, returnType string) error {
 	b.WriteString("function ")
 	b.WriteString(funcName)
 	b.WriteString("(input: string) -> ")
-	b.WriteString(rootMangled)
+	b.WriteString(returnType)
 	b.WriteString(" {\n")
 	b.WriteString("  client TestClient\n")
 	b.WriteString("  prompt #\"{{ ctx.output_format }}\n")
@@ -181,6 +213,9 @@ func writeFunction(b *strings.Builder, funcName, rootMangled string) error {
 // typeSpelling returns the BAML source-level type spelling for a
 // FuzzType. ClassRef/EnumRef targets are resolved through the mangle
 // maps so the emitted source matches the declared symbol names.
+// Unions are spelled as pipe-separated variants. A single-arm union
+// (only reachable through shrink-collapse) is spelled as the bare
+// variant — emitting a one-operand pipe is invalid BAML.
 func typeSpelling(t FuzzType, classNames, enumNames map[string]string) (string, error) {
 	switch t.Kind {
 	case KindString, KindInt, KindFloat, KindBool, KindNull:
@@ -236,9 +271,56 @@ func typeSpelling(t FuzzType, classNames, enumNames map[string]string) (string, 
 			return "", fmt.Errorf("enum ref %q not declared in schema", t.Ref)
 		}
 		return mangled, nil
+	case KindUnion:
+		if len(t.Variants) == 0 {
+			return "", fmt.Errorf("union has no variants")
+		}
+		if len(t.Variants) == 1 {
+			return typeSpelling(t.Variants[0], classNames, enumNames)
+		}
+		parts := make([]string, len(t.Variants))
+		for i, v := range t.Variants {
+			s, err := typeSpelling(v, classNames, enumNames)
+			if err != nil {
+				return "", fmt.Errorf("union variant %d: %w", i, err)
+			}
+			parts[i] = s
+		}
+		// Union appearing inside another wrapper (optional, list,
+		// map) is rendered with outer parens here so the surrounding
+		// `?` / `[]` / `map<...>` spelling binds correctly. Standalone
+		// top-level unions don't need parens; returnTypeSpelling
+		// uses the noUnionParens variant to omit them.
+		return "(" + strings.Join(parts, " | ") + ")", nil
 	default:
 		return "", fmt.Errorf("unsupported kind %q", t.Kind)
 	}
+}
+
+// typeSpellingNoUnionParens spells `t` but, when t is a KindUnion,
+// omits the outer parens around the pipe expression. Used only by
+// the function-return-type spelling: a top-level union doesn't need
+// parens (nothing wraps it) and BAML's pretty-printer style prefers
+// the unparenthesized form.
+func typeSpellingNoUnionParens(t FuzzType, classNames, enumNames map[string]string) (string, error) {
+	if t.Kind != KindUnion {
+		return typeSpelling(t, classNames, enumNames)
+	}
+	if len(t.Variants) == 0 {
+		return "", fmt.Errorf("union has no variants")
+	}
+	if len(t.Variants) == 1 {
+		return typeSpelling(t.Variants[0], classNames, enumNames)
+	}
+	parts := make([]string, len(t.Variants))
+	for i, v := range t.Variants {
+		s, err := typeSpelling(v, classNames, enumNames)
+		if err != nil {
+			return "", fmt.Errorf("union variant %d: %w", i, err)
+		}
+		parts[i] = s
+	}
+	return strings.Join(parts, " | "), nil
 }
 
 // literalSpelling renders a FuzzLiteral as its BAML source-level

--- a/adapters/common/codegen/bamlfuzz/envelope.go
+++ b/adapters/common/codegen/bamlfuzz/envelope.go
@@ -14,17 +14,22 @@ import (
 
 // GeneratorVersion is the on-the-wire version stamp embedded in replay
 // artifacts. Bumped when the generator semantics change in a way that
-// invalidates older replays.
-const GeneratorVersion = "0.1.0"
+// invalidates older replays. 0.2.0 introduces KindUnion as a
+// first-class IR node plus CaseMetadata.UnionChoices; older v1
+// replays decode cleanly (the new fields default to zero values).
+const GeneratorVersion = "0.2.0"
 
 // DynamicFailureEnvelope captures the full context surrounding a
 // disagreement between the three dynamic-oracle legs (expected /
 // dynclient / REST). Release gates: semantic equality always, and
 // schema-aware key order at every class instance when
 // PreserveSchemaOrder is true (see SchemaOrderDiff). Strict order
-// mismatches are recorded under OrderWarning for replay; unsupported
-// schemas (today: union-bearing) skip the order assertion with a log
-// line only and don't populate OrderWarning.
+// mismatches are recorded under OrderWarning for replay; schemas
+// the order checker cannot resolve (missing union-choice metadata)
+// skip the assertion with a log line only and don't populate
+// OrderWarning. Per-arm union choices travel in Metadata.UnionChoices
+// so a developer reading the envelope can see exactly which variant
+// the value walker selected at each union node.
 type DynamicFailureEnvelope struct {
 	GeneratorVersion    string                         `json:"generator_version"`
 	GeneratedAt         string                         `json:"generated_at"`

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -284,7 +284,18 @@ func drawKind(t *rapid.T, label string, choices []FuzzTypeKind) FuzzTypeKind {
 }
 
 func drawLiteral(t *rapid.T, label string) *FuzzLiteral {
-	kindChoices := []FuzzLiteralKind{LiteralString, LiteralInt, LiteralBool}
+	// Integer literals (LiteralInt) are intentionally excluded. BAML
+	// validates `field (0 | bool | 42)` style class properties as
+	// "not a valid field or attribute definition" — the grammar does
+	// not accept integer literals as union variants, and the static
+	// emitter regularly surfaces them inside unions. Negative integer
+	// literals additionally tripped the Go codegen identifier path
+	// (`expected ';', found '-'` in baml_client/stream_types/classes.go)
+	// when they reached the post-codegen Go parser. Dropping the kind
+	// entirely keeps every drawn schema compilable by BAML;
+	// integer-literal coverage can be reinstated when BAML's grammar /
+	// Go codegen is verified to accept the shape end-to-end.
+	kindChoices := []FuzzLiteralKind{LiteralString, LiteralBool}
 	kidx := rapid.IntRange(0, len(kindChoices)-1).Draw(t, label+":lit_kind")
 	switch kindChoices[kidx] {
 	case LiteralString:
@@ -294,18 +305,6 @@ func drawLiteral(t *rapid.T, label string) *FuzzLiteral {
 		options := []string{"alpha", "beta", "gamma", "", `"quoted"`}
 		oidx := rapid.IntRange(0, len(options)-1).Draw(t, label+":lit_str")
 		return &FuzzLiteral{Kind: LiteralString, String: options[oidx]}
-	case LiteralInt:
-		// Stick to non-negative literal ints. BAML's Go codegen derives
-		// identifier-bearing tokens from literal type spellings; a `-`
-		// in a literal-int spelling lands as a non-identifier byte in
-		// the generated Go source (e.g. `expected ';', found '-'`
-		// inside `baml_client/stream_types/classes.go`) when the
-		// literal appears as a union variant. Cover the surrounding
-		// integer space without the hyphen sigil; negative literals
-		// can be re-enabled if BAML's codegen learns to sanitize them.
-		options := []int64{0, 1, 42}
-		oidx := rapid.IntRange(0, len(options)-1).Draw(t, label+":lit_int")
-		return &FuzzLiteral{Kind: LiteralInt, Int: options[oidx]}
 	case LiteralBool:
 		b := rapid.Bool().Draw(t, label+":lit_bool")
 		return &FuzzLiteral{Kind: LiteralBool, Bool: b}

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -783,6 +783,21 @@ func walkClassesInValue(t FuzzType, v FuzzValue, schema FuzzSchema, visit func(c
 	}
 }
 
+// recordUnionChoices walks a (type, value) pair and stamps observed
+// union-arm choices into `p` keyed by structural position in the type
+// tree. The path scheme matches rewriteTypeAtPath exactly: union arms
+// use ":v%d" so distinct variants of an outer union resolve to
+// distinct slots; list elements all collapse onto ":l" and map values
+// onto ":m" so observations across siblings merge at the element-type
+// position. Merging at the element position is what makes "every
+// element picked the same arm" collapse correctly and "elements
+// disagree" invalidate cleanly.
+//
+// These paths are Move B's internal collapse-plan keys. They are
+// SEPARATE from the JSON-path convention used by the walker,
+// normalizer, and order checker (which key into
+// CaseMetadata.UnionChoices and use `.<field>[idx][key]:v` paths);
+// changing one does not require changing the other.
 func recordUnionChoices(t FuzzType, v FuzzValue, path string, p collapsePlan) {
 	switch t.Kind {
 	case KindUnion:
@@ -797,7 +812,7 @@ func recordUnionChoices(t FuzzType, v FuzzValue, path string, p collapsePlan) {
 		case existing != v.VariantIndex:
 			p.choices[path] = -1
 		}
-		recordUnionChoices(t.Variants[v.VariantIndex], *v.Variant, path+":v", p)
+		recordUnionChoices(t.Variants[v.VariantIndex], *v.Variant, fmt.Sprintf("%s:v%d", path, v.VariantIndex), p)
 	case KindOptional:
 		if v.OptionalShape == OptionalPresent && v.Inner != nil && t.Inner != nil {
 			recordUnionChoices(*t.Inner, *v.Inner, path+":o", p)
@@ -806,15 +821,15 @@ func recordUnionChoices(t FuzzType, v FuzzValue, path string, p collapsePlan) {
 		if t.Inner == nil {
 			return
 		}
-		for i, item := range v.Items {
-			recordUnionChoices(*t.Inner, item, fmt.Sprintf("%s:l%d", path, i), p)
+		for _, item := range v.Items {
+			recordUnionChoices(*t.Inner, item, path+":l", p)
 		}
 	case KindMap:
 		if t.Inner == nil {
 			return
 		}
 		for _, e := range v.MapEntries {
-			recordUnionChoices(*t.Inner, e.Value, path+":m:"+e.Key, p)
+			recordUnionChoices(*t.Inner, e.Value, path+":m", p)
 		}
 	}
 }
@@ -878,7 +893,12 @@ func rewriteTypeAtPath(t FuzzType, path string, plan collapsePlan) FuzzType {
 	switch t.Kind {
 	case KindUnion:
 		if idx, ok := plan.choices[path]; ok && idx >= 0 && idx < len(t.Variants) {
-			return rewriteTypeAtPath(t.Variants[idx], path+":v", plan)
+			// Step the path with ":v<idx>" (matching the
+			// recordUnionChoices scheme) so collapse descents land
+			// at the same key used when stamping nested unions
+			// inside the picked variant. Mismatched keys here would
+			// silently leave nested unions uncollapsed.
+			return rewriteTypeAtPath(t.Variants[idx], fmt.Sprintf("%s:v%d", path, idx), plan)
 		}
 		out := t
 		out.Variants = make([]FuzzType, len(t.Variants))

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -701,12 +701,22 @@ func collapseUnionsToPicked(schema FuzzSchema, value FuzzValue) (FuzzSchema, Fuz
 		}
 		out.Classes[i] = FuzzClass{Name: cls.Name, Properties: newProps}
 	}
+	rootPlan := newCollapsePlan()
 	if schema.RootType != nil {
-		rootPlan := planRoot(*schema.RootType, value)
+		rootPlan = planRoot(*schema.RootType, value)
 		newRoot := rewriteTypeWithPlan(*schema.RootType, rootPlan)
 		out.RootType = &newRoot
 	}
-	newValue := rewriteValueAgainstSchema(out.EffectiveRoot(), value, out)
+	// Drive the value rewrite off the ORIGINAL schema's type tree +
+	// the same per-field plans the schema rewrite used. The previous
+	// implementation walked the NEW (post-collapse) schema and used
+	// `v.VariantIndex` to descend into arms, which silently dropped
+	// alignment whenever a nested union was collapsed: the surviving
+	// outer wrapper's index then pointed at a different post-collapse
+	// arm than the value's leaf chose, and the walker landed on the
+	// wrong schema kind (e.g. enum_ref with an empty-string value).
+	rootType := schema.EffectiveRoot()
+	newValue := rewriteValueByPlans(schema, rootType, value, collapseMap, rootPlan, "")
 	out = AnalyzeGraph(out)
 	return out, newValue, nil
 }
@@ -951,10 +961,25 @@ func rewriteTypeAtPath(t FuzzType, path string, plan collapsePlan) FuzzType {
 	return t
 }
 
-// rewriteValueAgainstSchema walks (effective-root-type, value)
-// in parallel and strips union wrappers wherever the rewritten
-// schema no longer carries a union at the matching position.
-func rewriteValueAgainstSchema(t FuzzType, v FuzzValue, schema FuzzSchema) FuzzValue {
+// rewriteValueByPlans rewrites the value to match a schema rewritten
+// via collapse plans. It walks the ORIGINAL pre-collapse schema type
+// `t` in parallel with `v`. At every KindUnion node it consults the
+// active `currentPlan` keyed by `path`: a recorded non-negative arm
+// index means that union collapsed in the new schema, so the value's
+// wrapper at this position is stripped to keep the post-collapse
+// schema and the rewritten value aligned. Without this strip the
+// retained wrapper's index would slot in at the wrong arm of the
+// post-collapse union (whose arity is unchanged but whose arm types
+// have shifted) and the walker would dispatch on a mismatched schema
+// kind — landing, for example, on KindEnumRef with a union-shaped
+// value whose Enum field is empty.
+//
+// The path scheme matches recordUnionChoices exactly: ":v<idx>" for a
+// union arm step, ":o" for an optional Inner, ":l" for any list
+// element, ":m" for any map value. Path resets to "" at every class-
+// instance boundary because collapse plans are per-field; the global
+// `plans` map supplies the field's plan on entry.
+func rewriteValueByPlans(schema FuzzSchema, t FuzzType, v FuzzValue, plans map[fieldKey]collapsePlan, currentPlan collapsePlan, path string) FuzzValue {
 	switch t.Kind {
 	case KindUnion:
 		if v.Kind != KindUnion || v.Variant == nil {
@@ -963,7 +988,16 @@ func rewriteValueAgainstSchema(t FuzzType, v FuzzValue, schema FuzzSchema) FuzzV
 		if v.VariantIndex < 0 || v.VariantIndex >= len(t.Variants) {
 			return v
 		}
-		newInner := rewriteValueAgainstSchema(t.Variants[v.VariantIndex], *v.Variant, schema)
+		if idx, ok := currentPlan.choices[path]; ok && idx >= 0 {
+			// Union collapsed in the new schema: drop the wrapper and
+			// descend into the picked arm. v.VariantIndex equals idx
+			// for every visit whose observations were merged (the plan
+			// only retains paths where every visiting instance agreed
+			// on the same arm), so the picked arm unambiguously
+			// selects the surviving subtree.
+			return rewriteValueByPlans(schema, t.Variants[idx], *v.Variant, plans, currentPlan, fmt.Sprintf("%s:v%d", path, idx))
+		}
+		newInner := rewriteValueByPlans(schema, t.Variants[v.VariantIndex], *v.Variant, plans, currentPlan, fmt.Sprintf("%s:v%d", path, v.VariantIndex))
 		out := v
 		out.Variant = &newInner
 		return out
@@ -984,9 +1018,10 @@ func rewriteValueAgainstSchema(t FuzzType, v FuzzValue, schema FuzzSchema) FuzzV
 					break
 				}
 			}
+			fieldPlan := plans[fieldKey{v.ClassName, fv.Name}]
 			newFields[i] = FuzzFieldValue{
 				Name:  fv.Name,
-				Value: rewriteValueAgainstType(propType, fv.Value, schema),
+				Value: rewriteValueByPlans(schema, propType, fv.Value, plans, fieldPlan, ""),
 			}
 		}
 		out := v
@@ -994,7 +1029,7 @@ func rewriteValueAgainstSchema(t FuzzType, v FuzzValue, schema FuzzSchema) FuzzV
 		return out
 	case KindOptional:
 		if v.OptionalShape == OptionalPresent && v.Inner != nil && t.Inner != nil {
-			newInner := rewriteValueAgainstType(*t.Inner, *v.Inner, schema)
+			newInner := rewriteValueByPlans(schema, *t.Inner, *v.Inner, plans, currentPlan, path+":o")
 			out := v
 			out.Inner = &newInner
 			return out
@@ -1006,7 +1041,7 @@ func rewriteValueAgainstSchema(t FuzzType, v FuzzValue, schema FuzzSchema) FuzzV
 		}
 		newItems := make([]FuzzValue, len(v.Items))
 		for i, item := range v.Items {
-			newItems[i] = rewriteValueAgainstType(*t.Inner, item, schema)
+			newItems[i] = rewriteValueByPlans(schema, *t.Inner, item, plans, currentPlan, path+":l")
 		}
 		out := v
 		out.Items = newItems
@@ -1019,7 +1054,7 @@ func rewriteValueAgainstSchema(t FuzzType, v FuzzValue, schema FuzzSchema) FuzzV
 		for i, e := range v.MapEntries {
 			newEntries[i] = FuzzMapEntry{
 				Key:   e.Key,
-				Value: rewriteValueAgainstType(*t.Inner, e.Value, schema),
+				Value: rewriteValueByPlans(schema, *t.Inner, e.Value, plans, currentPlan, path+":m"),
 			}
 		}
 		out := v
@@ -1027,20 +1062,6 @@ func rewriteValueAgainstSchema(t FuzzType, v FuzzValue, schema FuzzSchema) FuzzV
 		return out
 	}
 	return v
-}
-
-// rewriteValueAgainstType matches a value to its (possibly-rewritten)
-// type. When the type no longer has a union at the value position,
-// the union wrapper is stripped; when both still carry a union the
-// helper recurses into the picked arm.
-func rewriteValueAgainstType(t FuzzType, v FuzzValue, schema FuzzSchema) FuzzValue {
-	if v.Kind == KindUnion && t.Kind != KindUnion {
-		if v.Variant == nil {
-			return v
-		}
-		return rewriteValueAgainstType(t, *v.Variant, schema)
-	}
-	return rewriteValueAgainstSchema(t, v, schema)
 }
 
 // drawString uses rapid's biased generator: short strings, common

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -20,6 +20,19 @@ const (
 	MaxValueRecursion = 2
 	EnumValuesMin     = 1
 	EnumValuesMax     = 4
+	// MinUnionVariants is the smallest legal arm count drawn by the
+	// generator. Single-arm unions are reachable only through the
+	// shrink-collapse pass (Move B), never the random draw.
+	MinUnionVariants = 2
+	// MaxUnionVariants caps random union arm counts. Larger unions
+	// quickly dominate coverage without exercising additional code
+	// paths in the emitters, so the upper bound stays modest.
+	MaxUnionVariants = 3
+	// UnionDrawProbability is the chance that an eligible drawType
+	// slot is filled with a KindUnion. Tuned low enough that
+	// non-union shapes still dominate random corpora — too high and
+	// every random case becomes a union test.
+	UnionDrawProbability = 0.15
 )
 
 // classNameFor / enumNameFor / fieldNameFor produce the stable
@@ -212,6 +225,14 @@ func drawType(t *rapid.T, label string, refTargets []string, enums []FuzzEnum, d
 	choices := append([]FuzzTypeKind(nil), atomicKinds...)
 	if depth+1 < MaxTypeDepth {
 		choices = append(choices, KindOptional, KindList, KindMap)
+		// Union counts toward MaxTypeDepth the same way the other
+		// wrappers do: each variant is drawn at depth+1 so a chain
+		// of nested unions still terminates on the existing budget.
+		// A separate dice roll gates the union path so the wrapper
+		// mix isn't skewed by adding a fourth equally-weighted kind.
+		if rapid.Float64Range(0, 1).Draw(t, label+":union_dice") < UnionDrawProbability {
+			return drawUnion(t, label, refTargets, enums, depth+1)
+		}
 	}
 
 	kind := drawKind(t, label, choices)
@@ -240,6 +261,21 @@ func drawType(t *rapid.T, label string, refTargets []string, enums []FuzzEnum, d
 	}
 	// Unreachable; drawKind always returns one of the choices above.
 	return FuzzType{Kind: KindString}
+}
+
+// drawUnion draws a KindUnion type with rapid-controlled arm count
+// in [MinUnionVariants, MaxUnionVariants]. The arm count is drawn
+// with a separate `variant_count` label so rapid's shrinker can drag
+// it toward the lower bound independently of arm contents — this is
+// the "Move A" shrink behaviour from the scope doc. Each variant is
+// drawn at `depth` already advanced by the caller.
+func drawUnion(t *rapid.T, label string, refTargets []string, enums []FuzzEnum, depth int) FuzzType {
+	count := rapid.IntRange(MinUnionVariants, MaxUnionVariants).Draw(t, label+":variant_count")
+	variants := make([]FuzzType, count)
+	for i := 0; i < count; i++ {
+		variants[i] = drawType(t, fmt.Sprintf("%s:variant_%d", label, i), refTargets, enums, depth)
+	}
+	return FuzzType{Kind: KindUnion, Variants: variants}
 }
 
 func drawKind(t *rapid.T, label string, choices []FuzzTypeKind) FuzzTypeKind {
@@ -320,11 +356,13 @@ func wireBackEdge(cls *FuzzClass, targetClassName string) {
 }
 
 // ValueGen returns a generator that produces a FuzzValue conforming
-// to the schema's root class. The generator threads a per-class
-// recursion depth counter through the walk and forces termination at
-// the depth cap by emitting OptionalAbsent / empty list / empty map
-// for any nested edge that would recurse further into the same
-// class.
+// to the schema's effective root type. When the schema declares a
+// non-class root via RootType the generator walks that type
+// directly; otherwise it dispatches to the RootClass class
+// generator. The generator threads a per-class recursion depth
+// counter through the walk and forces termination at the depth cap
+// by emitting OptionalAbsent / empty list / empty map for any
+// nested edge that would recurse further into the same class.
 func ValueGen(schema FuzzSchema) *rapid.Generator[FuzzValue] {
 	return rapid.Custom(func(t *rapid.T) FuzzValue {
 		// Rapid requires every Custom invocation to draw at
@@ -336,7 +374,8 @@ func ValueGen(schema FuzzSchema) *rapid.Generator[FuzzValue] {
 			schema: schema,
 			depth:  make(map[string]int),
 		}
-		return ctx.drawClass(t, schema.RootClass, "root")
+		root := schema.EffectiveRoot()
+		return ctx.drawValueForType(t, root, "root")
 	})
 }
 
@@ -406,8 +445,46 @@ func (c *valueDrawCtx) drawValueForType(t *rapid.T, ft FuzzType, label string) F
 		// Self-ref / cycle edges are always wrapped in optional/
 		// list/map (handled above) where termination is enforced.
 		return c.drawClass(t, ft.Ref, label)
+	case KindUnion:
+		return c.drawUnion(t, ft, label)
 	}
 	return FuzzValue{Kind: KindString}
+}
+
+// drawUnion picks one variant arm and recurses into its type.
+// Variants whose realization would blow the per-class recursion
+// budget are filtered out before the arm draw so the rapid bitstream
+// shrinks toward terminating arms first. When every arm is unsafe
+// the helper falls back to any arm (the inner draw still enforces
+// optional/list/map termination); this is a defensive branch the
+// schema generator's depth bounds make unreachable.
+func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValue {
+	if len(ft.Variants) == 0 {
+		t.Fatalf("bamlfuzz: union has no variants (label=%s); schema is malformed", label)
+	}
+	safe := make([]int, 0, len(ft.Variants))
+	for i := range ft.Variants {
+		v := ft.Variants[i]
+		if !c.wouldExceedDepth(&v) {
+			safe = append(safe, i)
+		}
+	}
+	if len(safe) == 0 {
+		// Every arm reaches an already-exhausted class. Fall through
+		// to the full index range — the inner draw still enforces
+		// termination at the next optional/list/map wrapper.
+		for i := range ft.Variants {
+			safe = append(safe, i)
+		}
+	}
+	pick := rapid.IntRange(0, len(safe)-1).Draw(t, label+":variant_pick")
+	idx := safe[pick]
+	inner := c.drawValueForType(t, ft.Variants[idx], fmt.Sprintf("%s:variant_%d", label, idx))
+	return FuzzValue{
+		Kind:         KindUnion,
+		VariantIndex: idx,
+		Variant:      &inner,
+	}
 }
 
 func (c *valueDrawCtx) drawOptional(t *rapid.T, ft FuzzType, label string) FuzzValue {
@@ -522,6 +599,411 @@ func (c *valueDrawCtx) drawLiteralValue(lit *FuzzLiteral) FuzzValue {
 		return FuzzValue{Kind: KindLiteral, Bool: lit.Bool}
 	}
 	return FuzzValue{Kind: KindLiteral}
+}
+
+// CoupledCase pairs a schema + value with the Walk output computed
+// from them. CoupledCaseGen returns these so the integration test
+// can build an OracleCase without redoing the (schema, value, walk)
+// dance per call site.
+type CoupledCase struct {
+	Schema FuzzSchema
+	Value  FuzzValue
+	Walk   WalkResult
+}
+
+// CoupledCaseGen returns a rapid generator that draws a schema from
+// schemaGen, draws a value conforming to that schema, walks the
+// pair to compute MockLLMContent + Expected, and — at a rapid-
+// controlled probability — applies the union-collapse pass
+// ("Move B" in the scope doc) that rewrites unions where the value
+// tree picked a single arm consistently.
+//
+// The collapse is gated by a rapid boolean draw so the shrinker can
+// independently bias toward the collapsed shape: when the rapid
+// engine flips the dice off the original schema is returned,
+// exercising the union-shape contract; when it flips on the
+// collapsed schema is returned, which proves the behaviour replays
+// correctly without the union wrapper. The collapse falls back to
+// the original (uncollapsed) shape when union choices disagree
+// across class instances or when re-walking the collapsed value
+// fails for any reason — coupled cases must always be walkable.
+func CoupledCaseGen(schemaGen *rapid.Generator[FuzzSchema]) *rapid.Generator[CoupledCase] {
+	return rapid.Custom(func(t *rapid.T) CoupledCase {
+		schema := schemaGen.Draw(t, "schema")
+		value := ValueGen(schema).Draw(t, "value")
+		walk, err := Walk(schema, value)
+		if err != nil {
+			t.Fatalf("bamlfuzz: walk drawn (schema, value): %v", err)
+		}
+		out := CoupledCase{Schema: schema, Value: value, Walk: walk}
+		if rapid.Bool().Draw(t, "collapse_unions") {
+			cs, cv, cerr := collapseUnionsToPicked(schema, value)
+			if cerr == nil {
+				cw, werr := Walk(cs, cv)
+				if werr == nil {
+					out.Schema = cs
+					out.Value = cv
+					out.Walk = cw
+				}
+			}
+		}
+		return out
+	})
+}
+
+// collapseUnionsToPicked rewrites every KindUnion node in
+// (schema, value) for which the value tree's observed arm choices
+// are consistent. A union node is consistent when every instance
+// of the surrounding class field selected the same variant — this
+// keeps the schema-level rewrite valid for all callers of the class.
+// Returns the original (schema, value) when no union qualifies and
+// an error only when the schema/value pair is structurally
+// inconsistent (defensive — the generator never produces such pairs).
+//
+// Move B applies at three positions:
+//   - the effective root type (RootType when non-nil),
+//   - each class property type,
+//   - and recursively inside wrappers (optional/list/map) and
+//     other unions.
+func collapseUnionsToPicked(schema FuzzSchema, value FuzzValue) (FuzzSchema, FuzzValue, error) {
+	visits := gatherClassVisits(schema.EffectiveRoot(), value, schema)
+	collapseMap, err := planCollapses(schema, visits)
+	if err != nil {
+		return FuzzSchema{}, FuzzValue{}, err
+	}
+	out := schema
+	out.Classes = make([]FuzzClass, len(schema.Classes))
+	for i, cls := range schema.Classes {
+		newProps := make([]FuzzProperty, len(cls.Properties))
+		for j, prop := range cls.Properties {
+			plan := collapseMap[fieldKey{cls.Name, prop.Name}]
+			newProps[j] = FuzzProperty{
+				Name: prop.Name,
+				Type: rewriteTypeWithPlan(prop.Type, plan),
+			}
+		}
+		out.Classes[i] = FuzzClass{Name: cls.Name, Properties: newProps}
+	}
+	if schema.RootType != nil {
+		rootPlan := planRoot(*schema.RootType, value)
+		newRoot := rewriteTypeWithPlan(*schema.RootType, rootPlan)
+		out.RootType = &newRoot
+	}
+	newValue := rewriteValueAgainstSchema(out.EffectiveRoot(), value, out)
+	out = AnalyzeGraph(out)
+	return out, newValue, nil
+}
+
+// fieldKey names one (class, property) slot — Move B's collapse
+// decisions key off these so rewrites stay class-scoped.
+type fieldKey struct {
+	Class string
+	Field string
+}
+
+// collapsePlan records, for one position in a type tree, which
+// union arm index to keep (-1 means "no collapse here"). The
+// position is identified by the structural path through the type,
+// represented as the sequence of accessor steps from the type
+// root. Plans are merged across visits: a position is collapsible
+// only when every observation agrees on the same arm index.
+type collapsePlan struct {
+	// At each path the entry maps "yes-collapse-to-N" or
+	// "saw-disagreement" (encoded as -1). Missing entries mean the
+	// path was not a union at any visit and stays untouched.
+	choices map[string]int
+}
+
+func newCollapsePlan() collapsePlan { return collapsePlan{choices: map[string]int{}} }
+
+// gatherClassVisits scans the (root-type, root-value) tree and
+// returns, for each class instance in the value tree, the union
+// choices it made for each of its fields keyed by the structural
+// path through the field's type.
+type classVisit struct {
+	className string
+	fieldName string
+	plan      collapsePlan
+}
+
+func gatherClassVisits(t FuzzType, v FuzzValue, schema FuzzSchema) []classVisit {
+	var out []classVisit
+	walkClassesInValue(t, v, schema, func(className string, fieldName string, ft FuzzType, fv FuzzValue) {
+		p := newCollapsePlan()
+		recordUnionChoices(ft, fv, "", p)
+		out = append(out, classVisit{className: className, fieldName: fieldName, plan: p})
+	})
+	return out
+}
+
+func walkClassesInValue(t FuzzType, v FuzzValue, schema FuzzSchema, visit func(className, fieldName string, ft FuzzType, fv FuzzValue)) {
+	switch t.Kind {
+	case KindClassRef:
+		if v.Kind != KindClassRef {
+			return
+		}
+		cls, ok := schema.FindClass(v.ClassName)
+		if !ok {
+			return
+		}
+		for _, prop := range cls.Properties {
+			fv, ok := v.LookupField(prop.Name)
+			if !ok {
+				continue
+			}
+			visit(v.ClassName, prop.Name, prop.Type, fv)
+			walkClassesInValue(prop.Type, fv, schema, visit)
+		}
+	case KindOptional:
+		if v.OptionalShape == OptionalPresent && v.Inner != nil && t.Inner != nil {
+			walkClassesInValue(*t.Inner, *v.Inner, schema, visit)
+		}
+	case KindList:
+		if t.Inner == nil {
+			return
+		}
+		for _, item := range v.Items {
+			walkClassesInValue(*t.Inner, item, schema, visit)
+		}
+	case KindMap:
+		if t.Inner == nil {
+			return
+		}
+		for _, e := range v.MapEntries {
+			walkClassesInValue(*t.Inner, e.Value, schema, visit)
+		}
+	case KindUnion:
+		if v.Kind != KindUnion || v.Variant == nil {
+			return
+		}
+		if v.VariantIndex < 0 || v.VariantIndex >= len(t.Variants) {
+			return
+		}
+		walkClassesInValue(t.Variants[v.VariantIndex], *v.Variant, schema, visit)
+	}
+}
+
+func recordUnionChoices(t FuzzType, v FuzzValue, path string, p collapsePlan) {
+	switch t.Kind {
+	case KindUnion:
+		if v.Kind != KindUnion || v.Variant == nil {
+			p.choices[path] = -1
+			return
+		}
+		existing, seen := p.choices[path]
+		switch {
+		case !seen:
+			p.choices[path] = v.VariantIndex
+		case existing != v.VariantIndex:
+			p.choices[path] = -1
+		}
+		recordUnionChoices(t.Variants[v.VariantIndex], *v.Variant, path+":v", p)
+	case KindOptional:
+		if v.OptionalShape == OptionalPresent && v.Inner != nil && t.Inner != nil {
+			recordUnionChoices(*t.Inner, *v.Inner, path+":o", p)
+		}
+	case KindList:
+		if t.Inner == nil {
+			return
+		}
+		for i, item := range v.Items {
+			recordUnionChoices(*t.Inner, item, fmt.Sprintf("%s:l%d", path, i), p)
+		}
+	case KindMap:
+		if t.Inner == nil {
+			return
+		}
+		for _, e := range v.MapEntries {
+			recordUnionChoices(*t.Inner, e.Value, path+":m:"+e.Key, p)
+		}
+	}
+}
+
+func planCollapses(schema FuzzSchema, visits []classVisit) (map[fieldKey]collapsePlan, error) {
+	merged := map[fieldKey]collapsePlan{}
+	for _, v := range visits {
+		key := fieldKey{Class: v.className, Field: v.fieldName}
+		existing, ok := merged[key]
+		if !ok {
+			merged[key] = v.plan
+			continue
+		}
+		for path, idx := range v.plan.choices {
+			prev, seen := existing.choices[path]
+			switch {
+			case !seen:
+				existing.choices[path] = idx
+			case prev == -1:
+				// already invalidated
+			case prev != idx:
+				existing.choices[path] = -1
+			}
+		}
+		merged[key] = existing
+	}
+	// Strip disagreement markers so rewriteTypeWithPlan can treat
+	// missing entries uniformly.
+	for k, p := range merged {
+		for path, idx := range p.choices {
+			if idx < 0 {
+				delete(p.choices, path)
+			}
+		}
+		merged[k] = p
+	}
+	return merged, nil
+}
+
+// planRoot collapses the unions in the effective root type using
+// the value at the root as the single observation.
+func planRoot(rootType FuzzType, value FuzzValue) collapsePlan {
+	p := newCollapsePlan()
+	recordUnionChoices(rootType, value, "", p)
+	for path, idx := range p.choices {
+		if idx < 0 {
+			delete(p.choices, path)
+		}
+	}
+	return p
+}
+
+func rewriteTypeWithPlan(t FuzzType, plan collapsePlan) FuzzType {
+	if len(plan.choices) == 0 {
+		return t
+	}
+	return rewriteTypeAtPath(t, "", plan)
+}
+
+func rewriteTypeAtPath(t FuzzType, path string, plan collapsePlan) FuzzType {
+	switch t.Kind {
+	case KindUnion:
+		if idx, ok := plan.choices[path]; ok && idx >= 0 && idx < len(t.Variants) {
+			return rewriteTypeAtPath(t.Variants[idx], path+":v", plan)
+		}
+		out := t
+		out.Variants = make([]FuzzType, len(t.Variants))
+		for i, v := range t.Variants {
+			out.Variants[i] = rewriteTypeAtPath(v, fmt.Sprintf("%s:v%d", path, i), plan)
+		}
+		return out
+	case KindOptional:
+		if t.Inner == nil {
+			return t
+		}
+		inner := rewriteTypeAtPath(*t.Inner, path+":o", plan)
+		out := t
+		out.Inner = &inner
+		return out
+	case KindList:
+		if t.Inner == nil {
+			return t
+		}
+		inner := rewriteTypeAtPath(*t.Inner, path+":l", plan)
+		out := t
+		out.Inner = &inner
+		return out
+	case KindMap:
+		if t.Inner == nil {
+			return t
+		}
+		inner := rewriteTypeAtPath(*t.Inner, path+":m", plan)
+		out := t
+		out.Inner = &inner
+		return out
+	}
+	return t
+}
+
+// rewriteValueAgainstSchema walks (effective-root-type, value)
+// in parallel and strips union wrappers wherever the rewritten
+// schema no longer carries a union at the matching position.
+func rewriteValueAgainstSchema(t FuzzType, v FuzzValue, schema FuzzSchema) FuzzValue {
+	switch t.Kind {
+	case KindUnion:
+		if v.Kind != KindUnion || v.Variant == nil {
+			return v
+		}
+		if v.VariantIndex < 0 || v.VariantIndex >= len(t.Variants) {
+			return v
+		}
+		newInner := rewriteValueAgainstSchema(t.Variants[v.VariantIndex], *v.Variant, schema)
+		out := v
+		out.Variant = &newInner
+		return out
+	case KindClassRef:
+		if v.Kind != KindClassRef {
+			return v
+		}
+		cls, ok := schema.FindClass(v.ClassName)
+		if !ok {
+			return v
+		}
+		newFields := make([]FuzzFieldValue, len(v.Fields))
+		for i, fv := range v.Fields {
+			var propType FuzzType
+			for _, p := range cls.Properties {
+				if p.Name == fv.Name {
+					propType = p.Type
+					break
+				}
+			}
+			newFields[i] = FuzzFieldValue{
+				Name:  fv.Name,
+				Value: rewriteValueAgainstType(propType, fv.Value, schema),
+			}
+		}
+		out := v
+		out.Fields = newFields
+		return out
+	case KindOptional:
+		if v.OptionalShape == OptionalPresent && v.Inner != nil && t.Inner != nil {
+			newInner := rewriteValueAgainstType(*t.Inner, *v.Inner, schema)
+			out := v
+			out.Inner = &newInner
+			return out
+		}
+		return v
+	case KindList:
+		if t.Inner == nil {
+			return v
+		}
+		newItems := make([]FuzzValue, len(v.Items))
+		for i, item := range v.Items {
+			newItems[i] = rewriteValueAgainstType(*t.Inner, item, schema)
+		}
+		out := v
+		out.Items = newItems
+		return out
+	case KindMap:
+		if t.Inner == nil {
+			return v
+		}
+		newEntries := make([]FuzzMapEntry, len(v.MapEntries))
+		for i, e := range v.MapEntries {
+			newEntries[i] = FuzzMapEntry{
+				Key:   e.Key,
+				Value: rewriteValueAgainstType(*t.Inner, e.Value, schema),
+			}
+		}
+		out := v
+		out.MapEntries = newEntries
+		return out
+	}
+	return v
+}
+
+// rewriteValueAgainstType matches a value to its (possibly-rewritten)
+// type. When the type no longer has a union at the value position,
+// the union wrapper is stripped; when both still carry a union the
+// helper recurses into the picked arm.
+func rewriteValueAgainstType(t FuzzType, v FuzzValue, schema FuzzSchema) FuzzValue {
+	if v.Kind == KindUnion && t.Kind != KindUnion {
+		if v.Variant == nil {
+			return v
+		}
+		return rewriteValueAgainstType(t, *v.Variant, schema)
+	}
+	return rewriteValueAgainstSchema(t, v, schema)
 }
 
 // drawString uses rapid's biased generator: short strings, common

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -309,7 +309,17 @@ func drawLiteral(t *rapid.T, label string) *FuzzLiteral {
 		b := rapid.Bool().Draw(t, label+":lit_bool")
 		return &FuzzLiteral{Kind: LiteralBool, Bool: b}
 	}
-	return &FuzzLiteral{Kind: LiteralString}
+	// Fail closed: a literal kind appeared in kindChoices that the
+	// switch above does not handle. The previous string-literal
+	// fallback silently masked a kindChoices reintroduction of
+	// LiteralInt (the switch would skip the int arm and the function
+	// would emit a string literal under the LiteralString tag),
+	// defeating `TestSchemaGenDoesNotProduceLiteralInt`'s mutation
+	// guard. A fatal here pins the contract: every entry in
+	// kindChoices must have a matching arm, so a future widening is
+	// visible at test time.
+	t.Fatalf("drawLiteral: unhandled literal kind %v", kindChoices[kidx])
+	return nil
 }
 
 // injectSelfRef replaces `cls`'s last property with a self-

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -295,7 +295,15 @@ func drawLiteral(t *rapid.T, label string) *FuzzLiteral {
 		oidx := rapid.IntRange(0, len(options)-1).Draw(t, label+":lit_str")
 		return &FuzzLiteral{Kind: LiteralString, String: options[oidx]}
 	case LiteralInt:
-		options := []int64{0, 1, -1, 42, -42}
+		// Stick to non-negative literal ints. BAML's Go codegen derives
+		// identifier-bearing tokens from literal type spellings; a `-`
+		// in a literal-int spelling lands as a non-identifier byte in
+		// the generated Go source (e.g. `expected ';', found '-'`
+		// inside `baml_client/stream_types/classes.go`) when the
+		// literal appears as a union variant. Cover the surrounding
+		// integer space without the hyphen sigil; negative literals
+		// can be re-enabled if BAML's codegen learns to sanitize them.
+		options := []int64{0, 1, 42}
 		oidx := rapid.IntRange(0, len(options)-1).Draw(t, label+":lit_int")
 		return &FuzzLiteral{Kind: LiteralInt, Int: options[oidx]}
 	case LiteralBool:

--- a/adapters/common/codegen/bamlfuzz/generator_test.go
+++ b/adapters/common/codegen/bamlfuzz/generator_test.go
@@ -232,7 +232,7 @@ func TestWalkRoundTripNormalizesAbsent(t *testing.T) {
 		if err != nil {
 			rt.Fatalf("walk: %v", err)
 		}
-		normalized, err := NormalizeMockToExpected(schema, res.MockLLMContent, schema.RootClass)
+		normalized, err := NormalizeMockToExpectedWithChoices(schema, res.MockLLMContent, schema.RootClass, res.Metadata.UnionChoices)
 		if err != nil {
 			rt.Fatalf("normalize: %v\nmock: %s\nschema: %s",
 				err, string(res.MockLLMContent), schemaDump(schema))

--- a/adapters/common/codegen/bamlfuzz/normalize.go
+++ b/adapters/common/codegen/bamlfuzz/normalize.go
@@ -26,29 +26,32 @@ type WalkResult struct {
 }
 
 // Walk renders a (schema, root-value) pair through the LLM-output
-// and schema-normalized-output paths. The root value must be a
-// class instance (KindClassRef); the BAML output type is always a
-// named class in v1.
+// and schema-normalized-output paths. The root type is the schema's
+// effective root (FuzzSchema.EffectiveRoot): when the schema sets
+// RootType the value walks that type directly; otherwise the value
+// is treated as the named RootClass instance, preserving the v1
+// behaviour for existing replay artifacts.
 //
 // Field iteration follows the class's declaration order so the
 // emitted JSON is byte-stable across runs at the same seed.
 // Per-instance map values inside the value tree iterate in the
 // FuzzValue.MapEntries order (also generator-determined), so those
-// too are stable.
+// too are stable. Union values are rendered via the recorded
+// VariantIndex / Variant fields; the walker fails closed when a
+// union value lacks a recorded choice.
 func Walk(schema FuzzSchema, value FuzzValue) (WalkResult, error) {
-	if value.Kind != KindClassRef {
-		return WalkResult{}, fmt.Errorf("walk: root value must be class instance, got kind %q", value.Kind)
-	}
 	meta := CaseMetadata{
 		OptionalShapes:  make(map[string]string),
 		RecursionDepths: make(map[string]int),
+		UnionChoices:    make(map[string]UnionChoice),
 	}
 	state := &walkState{schema: schema, meta: &meta, depths: make(map[string]int)}
+	root := schema.EffectiveRoot()
 	var mockBuf, expectBuf bytes.Buffer
-	if err := state.renderClassMock(&mockBuf, value, ""); err != nil {
+	if err := state.renderValueMock(&mockBuf, root, value, ""); err != nil {
 		return WalkResult{}, err
 	}
-	if err := state.renderClassExpected(&expectBuf, value); err != nil {
+	if err := state.renderValueExpected(&expectBuf, root, value); err != nil {
 		return WalkResult{}, err
 	}
 	return WalkResult{
@@ -220,7 +223,7 @@ func (s *walkState) renderValueMock(buf *bytes.Buffer, t FuzzType, val FuzzValue
 			}
 			buf.Write(keyBytes)
 			buf.WriteByte(':')
-			if err := s.renderValueMock(buf, *t.Inner, entry.Value, fmt.Sprintf("%s[%s]", path, entry.Key)); err != nil {
+			if err := s.renderValueMock(buf, *t.Inner, entry.Value, fmt.Sprintf("%s[%q]", path, entry.Key)); err != nil {
 				return err
 			}
 		}
@@ -228,6 +231,20 @@ func (s *walkState) renderValueMock(buf *bytes.Buffer, t FuzzType, val FuzzValue
 		return nil
 	case KindClassRef:
 		return s.renderClassMock(buf, val, path)
+	case KindUnion:
+		if val.Kind != KindUnion || val.Variant == nil {
+			return fmt.Errorf("walk: union value missing selected variant at %q", path)
+		}
+		if val.VariantIndex < 0 || val.VariantIndex >= len(t.Variants) {
+			return fmt.Errorf("walk: union variant index %d out of range [0,%d) at %q", val.VariantIndex, len(t.Variants), path)
+		}
+		s.recordUnionChoice(path, t, val)
+		// Step the path with ":v" before recursing so nested unions
+		// (the picked arm contains another KindUnion) get distinct
+		// UnionChoices entries; without the step the inner choice
+		// would overwrite the outer one. The normalizer and order
+		// checker use the same suffix.
+		return s.renderValueMock(buf, t.Variants[val.VariantIndex], *val.Variant, path+":v")
 	default:
 		return fmt.Errorf("walk: unknown kind %q at %q", t.Kind, path)
 	}
@@ -305,9 +322,27 @@ func (s *walkState) renderValueExpected(buf *bytes.Buffer, t FuzzType, val FuzzV
 		return nil
 	case KindClassRef:
 		return s.renderClassExpected(buf, val)
+	case KindUnion:
+		if val.Kind != KindUnion || val.Variant == nil {
+			return fmt.Errorf("expected: union value missing selected variant")
+		}
+		if val.VariantIndex < 0 || val.VariantIndex >= len(t.Variants) {
+			return fmt.Errorf("expected: union variant index %d out of range [0,%d)", val.VariantIndex, len(t.Variants))
+		}
+		return s.renderValueExpected(buf, t.Variants[val.VariantIndex], *val.Variant)
 	default:
 		return fmt.Errorf("expected: unknown kind %q", t.Kind)
 	}
+}
+
+func (s *walkState) recordUnionChoice(path string, t FuzzType, val FuzzValue) {
+	choice := UnionChoice{
+		Index:        val.VariantIndex,
+		Kind:         t.Variants[val.VariantIndex].Kind,
+		Ref:          t.Variants[val.VariantIndex].Ref,
+		VariantCount: len(t.Variants),
+	}
+	s.meta.UnionChoices[path] = choice
 }
 
 // writeJSON marshals `v` and writes the result into buf. For floats
@@ -352,19 +387,31 @@ func writeLiteral(buf *bytes.Buffer, lit *FuzzLiteral) error {
 //
 // This is the invariant the tests assert: walking (mock) ->
 // normalize -> bytes-equal walker's expected.
+//
+// Union schemas require union-choice metadata to disambiguate which
+// arm produced the mock; call NormalizeMockToExpectedWithChoices
+// directly when the schema contains KindUnion. This entry point
+// fails closed on encountering a union without recorded choices.
 func NormalizeMockToExpected(schema FuzzSchema, mock json.RawMessage, rootClass string) (json.RawMessage, error) {
+	return NormalizeMockToExpectedWithChoices(schema, mock, rootClass, nil)
+}
+
+// NormalizeMockToExpectedWithChoices is the union-aware variant. The
+// `choices` map mirrors CaseMetadata.UnionChoices: each entry tells
+// the normalizer which arm produced the JSON at that path.
+func NormalizeMockToExpectedWithChoices(schema FuzzSchema, mock json.RawMessage, rootClass string, choices map[string]UnionChoice) (json.RawMessage, error) {
 	var raw any
 	if err := json.Unmarshal(mock, &raw); err != nil {
 		return nil, fmt.Errorf("normalize: parse mock: %w", err)
 	}
-	out, err := normalizeClass(schema, rootClass, raw)
+	out, err := normalizeClass(schema, rootClass, raw, "", choices)
 	if err != nil {
 		return nil, err
 	}
-	return marshalSchemaOrdered(schema, rootClass, out)
+	return marshalSchemaOrdered(schema, rootClass, out, choices)
 }
 
-func normalizeClass(schema FuzzSchema, className string, raw any) (map[string]any, error) {
+func normalizeClass(schema FuzzSchema, className string, raw any, basePath string, choices map[string]UnionChoice) (map[string]any, error) {
 	cls, ok := schema.FindClass(className)
 	if !ok {
 		return nil, fmt.Errorf("normalize: unknown class %q", className)
@@ -386,7 +433,7 @@ func normalizeClass(schema FuzzSchema, className string, raw any) (map[string]an
 			out[prop.Name] = nil
 			continue
 		}
-		nv, err := normalizeValue(schema, prop.Type, fv)
+		nv, err := normalizeValue(schema, prop.Type, fv, basePath+"."+prop.Name, choices)
 		if err != nil {
 			return nil, fmt.Errorf("normalize: field %q on %q: %w", prop.Name, className, err)
 		}
@@ -395,7 +442,7 @@ func normalizeClass(schema FuzzSchema, className string, raw any) (map[string]an
 	return out, nil
 }
 
-func normalizeValue(schema FuzzSchema, t FuzzType, raw any) (any, error) {
+func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices map[string]UnionChoice) (any, error) {
 	switch t.Kind {
 	case KindString, KindInt, KindFloat, KindBool, KindLiteral, KindEnumRef:
 		return raw, nil
@@ -408,7 +455,7 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any) (any, error) {
 		if t.Inner == nil {
 			return nil, fmt.Errorf("optional missing inner")
 		}
-		return normalizeValue(schema, *t.Inner, raw)
+		return normalizeValue(schema, *t.Inner, raw, path, choices)
 	case KindList:
 		if raw == nil {
 			return nil, nil
@@ -419,7 +466,7 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any) (any, error) {
 		}
 		out := make([]any, len(arr))
 		for i, item := range arr {
-			nv, err := normalizeValue(schema, *t.Inner, item)
+			nv, err := normalizeValue(schema, *t.Inner, item, fmt.Sprintf("%s[%d]", path, i), choices)
 			if err != nil {
 				return nil, fmt.Errorf("list[%d]: %w", i, err)
 			}
@@ -436,7 +483,7 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any) (any, error) {
 		}
 		out := make(map[string]any, len(obj))
 		for k, v := range obj {
-			nv, err := normalizeValue(schema, *t.Inner, v)
+			nv, err := normalizeValue(schema, *t.Inner, v, fmt.Sprintf("%s[%q]", path, k), choices)
 			if err != nil {
 				return nil, fmt.Errorf("map[%q]: %w", k, err)
 			}
@@ -444,7 +491,16 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any) (any, error) {
 		}
 		return out, nil
 	case KindClassRef:
-		return normalizeClass(schema, t.Ref, raw)
+		return normalizeClass(schema, t.Ref, raw, path, choices)
+	case KindUnion:
+		choice, ok := choices[path]
+		if !ok {
+			return nil, fmt.Errorf("normalize: union at %q has no recorded choice", path)
+		}
+		if choice.Index < 0 || choice.Index >= len(t.Variants) {
+			return nil, fmt.Errorf("normalize: union choice index %d out of range at %q", choice.Index, path)
+		}
+		return normalizeValue(schema, t.Variants[choice.Index], raw, path+":v", choices)
 	default:
 		return nil, fmt.Errorf("normalize: unknown kind %q", t.Kind)
 	}
@@ -454,15 +510,16 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any) (any, error) {
 // class-instance keys in schema declaration order. Inner map keys
 // retain encoding/json's alphabetical order — they're not class
 // instances, so there's no schema-defined ordering to preserve.
-func marshalSchemaOrdered(schema FuzzSchema, rootClass string, normalized any) (json.RawMessage, error) {
+// Union arms inside the type tree resolve through `choices`.
+func marshalSchemaOrdered(schema FuzzSchema, rootClass string, normalized any, choices map[string]UnionChoice) (json.RawMessage, error) {
 	var buf bytes.Buffer
-	if err := writeOrderedClass(&buf, schema, rootClass, normalized); err != nil {
+	if err := writeOrderedClass(&buf, schema, rootClass, normalized, "", choices); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
 }
 
-func writeOrderedClass(buf *bytes.Buffer, schema FuzzSchema, className string, v any) error {
+func writeOrderedClass(buf *bytes.Buffer, schema FuzzSchema, className string, v any, path string, choices map[string]UnionChoice) error {
 	cls, ok := schema.FindClass(className)
 	if !ok {
 		return fmt.Errorf("ordered: unknown class %q", className)
@@ -482,7 +539,7 @@ func writeOrderedClass(buf *bytes.Buffer, schema FuzzSchema, className string, v
 		}
 		buf.Write(keyBytes)
 		buf.WriteByte(':')
-		if err := writeOrderedValue(buf, schema, prop.Type, obj[prop.Name]); err != nil {
+		if err := writeOrderedValue(buf, schema, prop.Type, obj[prop.Name], path+"."+prop.Name, choices); err != nil {
 			return err
 		}
 	}
@@ -490,14 +547,14 @@ func writeOrderedClass(buf *bytes.Buffer, schema FuzzSchema, className string, v
 	return nil
 }
 
-func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any) error {
+func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any, path string, choices map[string]UnionChoice) error {
 	switch t.Kind {
 	case KindOptional:
 		if v == nil {
 			buf.WriteString("null")
 			return nil
 		}
-		return writeOrderedValue(buf, schema, *t.Inner, v)
+		return writeOrderedValue(buf, schema, *t.Inner, v, path, choices)
 	case KindList:
 		if v == nil {
 			buf.WriteString("null")
@@ -512,7 +569,7 @@ func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any) 
 			if i > 0 {
 				buf.WriteByte(',')
 			}
-			if err := writeOrderedValue(buf, schema, *t.Inner, item); err != nil {
+			if err := writeOrderedValue(buf, schema, *t.Inner, item, fmt.Sprintf("%s[%d]", path, i), choices); err != nil {
 				return err
 			}
 		}
@@ -544,14 +601,23 @@ func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any) 
 			}
 			buf.Write(kb)
 			buf.WriteByte(':')
-			if err := writeOrderedValue(buf, schema, *t.Inner, obj[k]); err != nil {
+			if err := writeOrderedValue(buf, schema, *t.Inner, obj[k], fmt.Sprintf("%s[%q]", path, k), choices); err != nil {
 				return err
 			}
 		}
 		buf.WriteByte('}')
 		return nil
 	case KindClassRef:
-		return writeOrderedClass(buf, schema, t.Ref, v)
+		return writeOrderedClass(buf, schema, t.Ref, v, path, choices)
+	case KindUnion:
+		choice, ok := choices[path]
+		if !ok {
+			return fmt.Errorf("ordered: union at %q has no recorded choice", path)
+		}
+		if choice.Index < 0 || choice.Index >= len(t.Variants) {
+			return fmt.Errorf("ordered: union choice index %d out of range at %q", choice.Index, path)
+		}
+		return writeOrderedValue(buf, schema, t.Variants[choice.Index], v, path+":v", choices)
 	default:
 		// Primitives, literals, enums: emit through encoding/json.
 		b, err := json.Marshal(v)

--- a/adapters/common/codegen/bamlfuzz/normalize.go
+++ b/adapters/common/codegen/bamlfuzz/normalize.go
@@ -399,16 +399,42 @@ func NormalizeMockToExpected(schema FuzzSchema, mock json.RawMessage, rootClass 
 // NormalizeMockToExpectedWithChoices is the union-aware variant. The
 // `choices` map mirrors CaseMetadata.UnionChoices: each entry tells
 // the normalizer which arm produced the JSON at that path.
+//
+// Normalization is driven by the schema's effective root type
+// (FuzzSchema.EffectiveRoot): when the schema sets RootType the
+// payload is normalized against that type directly, so raw-root
+// union/list/map/scalar schemas round-trip correctly. When RootType
+// is nil the effective root is a class ref pointing at RootClass,
+// keeping the v1 behaviour. The `rootClass` parameter is honoured
+// only as a fallback for callers that supply it before RootType was
+// added to the IR.
 func NormalizeMockToExpectedWithChoices(schema FuzzSchema, mock json.RawMessage, rootClass string, choices map[string]UnionChoice) (json.RawMessage, error) {
 	var raw any
 	if err := json.Unmarshal(mock, &raw); err != nil {
 		return nil, fmt.Errorf("normalize: parse mock: %w", err)
 	}
-	out, err := normalizeClass(schema, rootClass, raw, "", choices)
+	root := effectiveNormalizeRoot(schema, rootClass)
+	out, err := normalizeValue(schema, root, raw, "", choices)
 	if err != nil {
 		return nil, err
 	}
-	return marshalSchemaOrdered(schema, rootClass, out, choices)
+	return marshalSchemaOrdered(schema, root, out, choices)
+}
+
+// effectiveNormalizeRoot picks the FuzzType to normalize and re-emit
+// against. RootType wins when set (so raw roots work); otherwise the
+// `rootClass` argument is used to stay compatible with callers that
+// still hand a class name through. Falling further back to
+// schema.EffectiveRoot covers schemas where both RootType is nil and
+// the caller passed an empty rootClass.
+func effectiveNormalizeRoot(schema FuzzSchema, rootClass string) FuzzType {
+	if schema.RootType != nil {
+		return *schema.RootType
+	}
+	if rootClass != "" {
+		return FuzzType{Kind: KindClassRef, Ref: rootClass}
+	}
+	return schema.EffectiveRoot()
 }
 
 func normalizeClass(schema FuzzSchema, className string, raw any, basePath string, choices map[string]UnionChoice) (map[string]any, error) {
@@ -510,10 +536,13 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices
 // class-instance keys in schema declaration order. Inner map keys
 // retain encoding/json's alphabetical order — they're not class
 // instances, so there's no schema-defined ordering to preserve.
-// Union arms inside the type tree resolve through `choices`.
-func marshalSchemaOrdered(schema FuzzSchema, rootClass string, normalized any, choices map[string]UnionChoice) (json.RawMessage, error) {
+// Union arms inside the type tree resolve through `choices`. The
+// `root` FuzzType drives dispatch directly, so raw-root
+// union/list/map/scalar schemas are walked as-is without going
+// through the class helper.
+func marshalSchemaOrdered(schema FuzzSchema, root FuzzType, normalized any, choices map[string]UnionChoice) (json.RawMessage, error) {
 	var buf bytes.Buffer
-	if err := writeOrderedClass(&buf, schema, rootClass, normalized, "", choices); err != nil {
+	if err := writeOrderedValue(&buf, schema, root, normalized, "", choices); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil

--- a/adapters/common/codegen/bamlfuzz/order.go
+++ b/adapters/common/codegen/bamlfuzz/order.go
@@ -12,11 +12,13 @@ import (
 )
 
 // ErrSchemaOrderUnsupported is returned by SchemaOrderDiff when the
-// schema shape carries semantics the walker does not yet model. Today
-// this is union-bearing schemas (FuzzSchema.HasUnion); the walker has
-// no canonical "expected order" for a union value without a union-aware
-// dispatch. Callers detect with errors.Is and typically skip the order
-// assertion while still running the semantic-equality checks.
+// schema shape carries semantics the walker cannot drive without
+// additional metadata. Today this fires when a union node is
+// reached without a recorded UnionChoice entry — the walker has no
+// canonical "expected order" for a union value without knowing
+// which arm produced it. Callers detect with errors.Is and
+// typically skip the order assertion while still running the
+// semantic-equality checks.
 var ErrSchemaOrderUnsupported = errors.New("bamlfuzz: schema order check unsupported")
 
 // SchemaOrderDiffEntry names one schema-order disagreement at a JSON
@@ -36,26 +38,33 @@ type SchemaOrderDiffEntry struct {
 // `schema`, asserting wire key order only at JSON nodes the schema
 // types as a class instance. Map nodes participate in recursion but
 // their key order is not asserted; map values are walked through the
-// inner type.
+// inner type. Union nodes resolve through `choices` (typically
+// CaseMetadata.UnionChoices from the walker), advancing into the
+// recorded variant arm; a missing or out-of-range entry returns
+// ErrSchemaOrderUnsupported so callers can skip the order assertion
+// without abandoning semantic diagnostics.
 //
 // `label` is opaque and is stored on every emitted entry's Side field.
 //
 // Pure: takes no *testing.T. Callers decide whether a non-empty diff
-// fails, logs, or feeds the replay envelope. Returns
-// ErrSchemaOrderUnsupported when schema.HasUnion is true so callers can
-// skip the order assertion without abandoning semantic diagnostics.
+// fails, logs, or feeds the replay envelope.
 //
 // An empty diff slice with a nil error means the inputs agreed on key
-// order at every class node reachable from schema.RootClass.
+// order at every class node reachable from schema's effective root.
 func SchemaOrderDiff(label string, schema FuzzSchema, expected, actual json.RawMessage) ([]SchemaOrderDiffEntry, error) {
-	if schema.HasUnion {
-		return nil, ErrSchemaOrderUnsupported
+	return SchemaOrderDiffWithChoices(label, schema, expected, actual, nil)
+}
+
+// SchemaOrderDiffWithChoices is the union-aware variant of
+// SchemaOrderDiff. `choices` mirrors CaseMetadata.UnionChoices.
+func SchemaOrderDiffWithChoices(label string, schema FuzzSchema, expected, actual json.RawMessage, choices map[string]UnionChoice) ([]SchemaOrderDiffEntry, error) {
+	if schema.RootClass == "" && schema.RootType == nil {
+		return nil, fmt.Errorf("bamlfuzz: schema missing both RootClass and RootType")
 	}
-	if schema.RootClass == "" {
-		return nil, fmt.Errorf("bamlfuzz: schema missing RootClass")
-	}
-	if _, ok := schema.FindClass(schema.RootClass); !ok {
-		return nil, fmt.Errorf("bamlfuzz: root class %q not present in schema", schema.RootClass)
+	if schema.RootClass != "" {
+		if _, ok := schema.FindClass(schema.RootClass); !ok {
+			return nil, fmt.Errorf("bamlfuzz: root class %q not present in schema", schema.RootClass)
+		}
 	}
 	exp, err := decodeOrderedJSON(expected)
 	if err != nil {
@@ -65,8 +74,8 @@ func SchemaOrderDiff(label string, schema FuzzSchema, expected, actual json.RawM
 	if err != nil {
 		return nil, fmt.Errorf("decode actual: %w", err)
 	}
-	w := &orderWalker{schema: schema, side: label}
-	w.walkClass("$", schema.RootClass, exp, got)
+	w := &orderWalker{schema: schema, side: label, choices: choices}
+	w.walkType("$", schema.EffectiveRoot(), exp, got)
 	return w.diffs, w.err
 }
 
@@ -171,10 +180,11 @@ func decodeOrderedJSON(data json.RawMessage) (orderedJSON, error) {
 }
 
 type orderWalker struct {
-	schema FuzzSchema
-	side   string
-	diffs  []SchemaOrderDiffEntry
-	err    error
+	schema  FuzzSchema
+	side    string
+	diffs   []SchemaOrderDiffEntry
+	err     error
+	choices map[string]UnionChoice
 }
 
 func (w *orderWalker) setErr(err error) {
@@ -246,6 +256,25 @@ func (w *orderWalker) walkType(path string, typ FuzzType, exp, got orderedJSON) 
 		for _, key := range sortedIntersection(exp.byKey, got.byKey) {
 			w.walkType(fmt.Sprintf("%s[%q]", path, key), *typ.Inner, exp.byKey[key], got.byKey[key])
 		}
+	case KindUnion:
+		// CaseMetadata.UnionChoices uses paths rooted at "" (the
+		// renderer convention); SchemaOrderDiff paths are rooted at
+		// "$". Strip the leading "$" so the two conventions match
+		// without leaking the path format into the metadata.
+		key := path
+		if len(key) > 0 && key[0] == '$' {
+			key = key[1:]
+		}
+		choice, ok := w.choices[key]
+		if !ok {
+			w.setErr(ErrSchemaOrderUnsupported)
+			return
+		}
+		if choice.Index < 0 || choice.Index >= len(typ.Variants) {
+			w.setErr(ErrSchemaOrderUnsupported)
+			return
+		}
+		w.walkType(path+":v", typ.Variants[choice.Index], exp, got)
 	}
 }
 

--- a/adapters/common/codegen/bamlfuzz/order.go
+++ b/adapters/common/codegen/bamlfuzz/order.go
@@ -274,6 +274,25 @@ func (w *orderWalker) walkType(path string, typ FuzzType, exp, got orderedJSON) 
 			w.setErr(ErrSchemaOrderUnsupported)
 			return
 		}
+		// Fail closed on stale or schema-incompatible metadata. The
+		// scope's D11 contract requires the order checker to bail
+		// before traversing the wrong arm when a corpus / replay
+		// envelope was recorded against a different shape. Treat any
+		// of variant-count, arm-kind, or arm-ref drift as
+		// unsupported.
+		selected := typ.Variants[choice.Index]
+		if choice.VariantCount != len(typ.Variants) {
+			w.setErr(ErrSchemaOrderUnsupported)
+			return
+		}
+		if choice.Kind != selected.Kind {
+			w.setErr(ErrSchemaOrderUnsupported)
+			return
+		}
+		if (selected.Kind == KindClassRef || selected.Kind == KindEnumRef) && choice.Ref != selected.Ref {
+			w.setErr(ErrSchemaOrderUnsupported)
+			return
+		}
 		w.walkType(path+":v", typ.Variants[choice.Index], exp, got)
 	}
 }

--- a/adapters/common/codegen/bamlfuzz/order_test.go
+++ b/adapters/common/codegen/bamlfuzz/order_test.go
@@ -298,6 +298,11 @@ func TestSchemaOrderDiff_UnionWithChoiceWalksArm(t *testing.T) {
 		},
 		RootClass: "Root",
 	}
+	// The metadata key `.u` names the union node itself — the field
+	// `u` on Root. Suffixed `:v` segments only appear for paths that
+	// live INSIDE the picked arm (e.g. a nested union below `u` would
+	// be at `.u:v...`); the outer union's own choice lives at the
+	// unsuffixed field path.
 	choices := map[string]UnionChoice{
 		".u": {Index: 0, Kind: KindClassRef, Ref: "Inner", VariantCount: 2},
 	}
@@ -311,6 +316,119 @@ func TestSchemaOrderDiff_UnionWithChoiceWalksArm(t *testing.T) {
 	}
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff in the Inner class, got %d", len(diffs))
+	}
+}
+
+// TestSchemaOrderDiff_UnionStaleVariantCountFailsClosed asserts the
+// order walker bails when the recorded UnionChoice.VariantCount does
+// not match the schema's current variant slice. Stale corpus/replay
+// metadata after a schema-side variant reorder must surface as
+// ErrSchemaOrderUnsupported, not silent traversal of the wrong arm.
+func TestSchemaOrderDiff_UnionStaleVariantCountFailsClosed(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "u", Type: FuzzType{
+					Kind: KindUnion,
+					Variants: []FuzzType{
+						{Kind: KindString},
+						{Kind: KindInt},
+					},
+				}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	choices := map[string]UnionChoice{
+		// Stale: schema has 2 arms, choice claims 3.
+		".u": {Index: 0, Kind: KindString, VariantCount: 3},
+	}
+	_, err := SchemaOrderDiffWithChoices("side", schema,
+		json.RawMessage(`{"u":"x"}`),
+		json.RawMessage(`{"u":"x"}`),
+		choices,
+	)
+	if !errors.Is(err, ErrSchemaOrderUnsupported) {
+		t.Errorf("stale variant count should be unsupported, got %v", err)
+	}
+}
+
+// TestSchemaOrderDiff_UnionStaleKindFailsClosed asserts the order
+// walker bails when the recorded UnionChoice.Kind disagrees with the
+// kind of the selected variant in the current schema.
+func TestSchemaOrderDiff_UnionStaleKindFailsClosed(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "u", Type: FuzzType{
+					Kind: KindUnion,
+					Variants: []FuzzType{
+						{Kind: KindString},
+						{Kind: KindInt},
+					},
+				}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	choices := map[string]UnionChoice{
+		// Stale: index 0 is string in the schema but the metadata
+		// records it as int (the variants were reordered).
+		".u": {Index: 0, Kind: KindInt, VariantCount: 2},
+	}
+	_, err := SchemaOrderDiffWithChoices("side", schema,
+		json.RawMessage(`{"u":"x"}`),
+		json.RawMessage(`{"u":"x"}`),
+		choices,
+	)
+	if !errors.Is(err, ErrSchemaOrderUnsupported) {
+		t.Errorf("stale arm kind should be unsupported, got %v", err)
+	}
+}
+
+// TestSchemaOrderDiff_UnionStaleRefFailsClosed asserts the order
+// walker bails when the recorded UnionChoice.Ref differs from the
+// selected variant's class/enum ref name. A class rename or swap
+// upstream of the corpus would otherwise let the walker traverse the
+// wrong target.
+func TestSchemaOrderDiff_UnionStaleRefFailsClosed(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{
+			{
+				Name: "Root",
+				Properties: []FuzzProperty{
+					{Name: "u", Type: FuzzType{
+						Kind: KindUnion,
+						Variants: []FuzzType{
+							{Kind: KindClassRef, Ref: "Inner"},
+							{Kind: KindString},
+						},
+					}},
+				},
+			},
+			{
+				Name: "Inner",
+				Properties: []FuzzProperty{
+					{Name: "a", Type: FuzzType{Kind: KindInt}},
+				},
+			},
+		},
+		RootClass: "Root",
+	}
+	choices := map[string]UnionChoice{
+		// Stale: schema points the class-ref arm at "Inner" but the
+		// metadata still names "Other" from a prior schema.
+		".u": {Index: 0, Kind: KindClassRef, Ref: "Other", VariantCount: 2},
+	}
+	_, err := SchemaOrderDiffWithChoices("side", schema,
+		json.RawMessage(`{"u":{"a":1}}`),
+		json.RawMessage(`{"u":{"a":1}}`),
+		choices,
+	)
+	if !errors.Is(err, ErrSchemaOrderUnsupported) {
+		t.Errorf("stale arm ref should be unsupported, got %v", err)
 	}
 }
 

--- a/adapters/common/codegen/bamlfuzz/order_test.go
+++ b/adapters/common/codegen/bamlfuzz/order_test.go
@@ -240,15 +240,77 @@ func TestSchemaOrderDiff_MissingExtraKeysDoNotPanic(t *testing.T) {
 	}
 }
 
-func TestSchemaOrderDiff_HasUnionReturnsUnsupported(t *testing.T) {
-	schema := schemaRootOnly("a", "b")
-	schema.HasUnion = true
+// TestSchemaOrderDiff_UnionWithoutChoiceReturnsUnsupported pins the
+// union contract: when the order walker reaches a KindUnion node
+// without a matching UnionChoices entry, SchemaOrderDiff returns
+// ErrSchemaOrderUnsupported and the caller falls back to
+// semantic-only diagnostics.
+func TestSchemaOrderDiff_UnionWithoutChoiceReturnsUnsupported(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "u", Type: FuzzType{
+					Kind: KindUnion,
+					Variants: []FuzzType{
+						{Kind: KindString},
+						{Kind: KindInt},
+					},
+				}},
+			},
+		}},
+		RootClass: "Root",
+	}
 	_, err := SchemaOrderDiff("side", schema,
-		json.RawMessage(`{"a":1,"b":2}`),
-		json.RawMessage(`{"b":2,"a":1}`),
+		json.RawMessage(`{"u":"x"}`),
+		json.RawMessage(`{"u":"x"}`),
 	)
 	if !errors.Is(err, ErrSchemaOrderUnsupported) {
 		t.Errorf("got err=%v, want errors.Is(err, ErrSchemaOrderUnsupported)", err)
+	}
+}
+
+// TestSchemaOrderDiff_UnionWithChoiceWalksArm pins the positive
+// path: given a recorded UnionChoices entry the walker descends into
+// the named arm and continues the order check from there.
+func TestSchemaOrderDiff_UnionWithChoiceWalksArm(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{
+			{
+				Name: "Root",
+				Properties: []FuzzProperty{
+					{Name: "u", Type: FuzzType{
+						Kind: KindUnion,
+						Variants: []FuzzType{
+							{Kind: KindClassRef, Ref: "Inner"},
+							{Kind: KindString},
+						},
+					}},
+				},
+			},
+			{
+				Name: "Inner",
+				Properties: []FuzzProperty{
+					{Name: "a", Type: FuzzType{Kind: KindInt}},
+					{Name: "b", Type: FuzzType{Kind: KindInt}},
+				},
+			},
+		},
+		RootClass: "Root",
+	}
+	choices := map[string]UnionChoice{
+		".u": {Index: 0, Kind: KindClassRef, Ref: "Inner", VariantCount: 2},
+	}
+	diffs, err := SchemaOrderDiffWithChoices("side", schema,
+		json.RawMessage(`{"u":{"a":1,"b":2}}`),
+		json.RawMessage(`{"u":{"b":2,"a":1}}`),
+		choices,
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff in the Inner class, got %d", len(diffs))
 	}
 }
 

--- a/adapters/common/codegen/bamlfuzz/schema.go
+++ b/adapters/common/codegen/bamlfuzz/schema.go
@@ -27,6 +27,13 @@ const (
 	KindMap      FuzzTypeKind = "map"
 	KindClassRef FuzzTypeKind = "class_ref"
 	KindEnumRef  FuzzTypeKind = "enum_ref"
+	// KindUnion represents an ordered sum of alternative types. The
+	// type's Variants slice carries the alternatives in declaration
+	// order; emitters render them with BAML pipe syntax (static) or
+	// the upstream `union` / `oneOf` shape (dynamic). T | null is
+	// expressed as a union with a KindNull variant — KindOptional
+	// stays as the separate absent-key wrapper.
+	KindUnion FuzzTypeKind = "union"
 )
 
 // FuzzLiteralKind narrows the literal payload to one of the BAML
@@ -57,18 +64,21 @@ type FuzzLiteral struct {
 //     Inner
 //   - KindClassRef / KindEnumRef: Ref
 //   - KindLiteral:                Literal
+//   - KindUnion:                  Variants (>=1)
 //   - primitives, KindNull:       nothing else.
 //
 // Inner / Key are pointers so the IR can hold recursive schemas:
 // self-ref classes reach themselves only through a ClassRef edge,
 // never through structural nesting, so the type spec itself stays
-// finite.
+// finite. Variants is a slice so unions stay ordered: the chosen
+// arm index in a FuzzValue refers to this declaration order.
 type FuzzType struct {
-	Kind    FuzzTypeKind `json:"kind"`
-	Inner   *FuzzType    `json:"inner,omitempty"`
-	Key     *FuzzType    `json:"key,omitempty"`
-	Literal *FuzzLiteral `json:"literal,omitempty"`
-	Ref     string       `json:"ref,omitempty"`
+	Kind     FuzzTypeKind `json:"kind"`
+	Inner    *FuzzType    `json:"inner,omitempty"`
+	Key      *FuzzType    `json:"key,omitempty"`
+	Literal  *FuzzLiteral `json:"literal,omitempty"`
+	Ref      string       `json:"ref,omitempty"`
+	Variants []FuzzType   `json:"variants,omitempty"`
 }
 
 // FuzzProperty is one field inside a class declaration.
@@ -94,7 +104,17 @@ type FuzzEnum struct {
 
 // FuzzSchema is the top-level IR. Classes / Enums are declared in
 // the order the generator emitted them; RootClass names the class
-// the synthesized BAML function returns.
+// the synthesized BAML function returns when the effective root is
+// a class instance.
+//
+// RootType is the optional non-class effective root. When set it
+// overrides RootClass for emission and value-walking: the
+// synthesized function returns the spelled type (raw union /
+// list / map / primitive), and the value walker drives the value
+// as the corresponding kind. When RootType is nil the schema
+// behaves exactly as v1: RootClass names the returned class. The
+// fallback keeps existing corpus replay files (which serialize
+// with no root_type) compatible.
 //
 // The Has* / Requires* flags are graph metadata derived from the
 // class-ref reachability graph. They are not authoritative — call
@@ -104,10 +124,24 @@ type FuzzSchema struct {
 	Classes             []FuzzClass `json:"classes"`
 	Enums               []FuzzEnum  `json:"enums"`
 	RootClass           string      `json:"root_class"`
+	RootType            *FuzzType   `json:"root_type,omitempty"`
 	HasSelfRef          bool        `json:"has_self_ref"`
 	HasMutualCycle      bool        `json:"has_mutual_cycle"`
 	HasUnion            bool        `json:"has_union"`
 	RequiresDynamicSkip bool        `json:"requires_dynamic_skip"`
+}
+
+// EffectiveRoot returns the FuzzType the schema returns from its
+// synthesized function. When RootType is non-nil it is returned
+// verbatim. Otherwise the result is a synthesized
+// KindClassRef pointing at RootClass — the v1 default, kept so
+// callers (emitters, walker, order checker) can always reason in
+// terms of one return type.
+func (s FuzzSchema) EffectiveRoot() FuzzType {
+	if s.RootType != nil {
+		return *s.RootType
+	}
+	return FuzzType{Kind: KindClassRef, Ref: s.RootClass}
 }
 
 // FindClass returns the named class declaration plus a found flag.

--- a/adapters/common/codegen/bamlfuzz/selfref.go
+++ b/adapters/common/codegen/bamlfuzz/selfref.go
@@ -134,10 +134,17 @@ func closureFromDirect(schema FuzzSchema, direct map[string]map[string]bool) map
 	return closure
 }
 
-// directClassRefs returns the one-hop class-ref edges per class.
-// Edges in the effective root type are attributed to the RootClass
-// (when the root is a class) so a top-level union that references
-// the root class still folds into the self-ref calculation.
+// directClassRefs returns the one-hop class-ref edges per class. Only
+// property-tree edges count: a class's direct refs are exactly the
+// class refs reachable through its own properties.
+//
+// Edges in the effective root type are NOT attributed to RootClass.
+// RootType and RootClass can coexist (a schema may have both a
+// non-class effective root and a v1-compatible RootClass), and folding
+// root-reachable refs into RootClass's edge set would falsely mark
+// classes self-referential just because the raw root happens to
+// mention them. Root reachability is a separate concern and lives
+// outside the property-edge graph.
 func directClassRefs(schema FuzzSchema) map[string]map[string]bool {
 	out := make(map[string]map[string]bool, len(schema.Classes))
 	for _, cls := range schema.Classes {
@@ -146,11 +153,6 @@ func directClassRefs(schema FuzzSchema) map[string]map[string]bool {
 			collectClassRefs(prop.Type, set)
 		}
 		out[cls.Name] = set
-	}
-	if schema.RootType != nil && schema.RootClass != "" {
-		if existing, ok := out[schema.RootClass]; ok {
-			collectClassRefs(*schema.RootType, existing)
-		}
 	}
 	return out
 }

--- a/adapters/common/codegen/bamlfuzz/selfref.go
+++ b/adapters/common/codegen/bamlfuzz/selfref.go
@@ -1,11 +1,9 @@
 package bamlfuzz
 
 // AnalyzeGraph computes the graph-metadata flags (HasSelfRef,
-// HasMutualCycle, RequiresDynamicSkip) from the class-ref
+// HasMutualCycle, HasUnion, RequiresDynamicSkip) from the class-ref
 // reachability graph and returns a copy of `schema` with those
-// fields refreshed. HasUnion is left unchanged — unions are excluded
-// from the v1 grammar, so the field is always false here but kept
-// as a forward-compat slot.
+// fields refreshed.
 //
 // HasSelfRef is true when at least one class C has a class-ref edge
 // to C in its own property tree (the direct one-hop edges, before
@@ -15,6 +13,11 @@ package bamlfuzz
 // HasMutualCycle is true when at least one class is in a cycle
 // through OTHER classes — i.e. the transitive closure reports
 // reach[C][C]=true but C does not have a direct self-ref edge.
+//
+// HasUnion is true when any KindUnion node appears in any class's
+// property tree, in the effective root type, or in any union
+// variant of either. The graph descent recurses through unions so
+// nested unions still register.
 //
 // RequiresDynamicSkip is true whenever the dynamic emitter cannot
 // safely realize the schema. Two upstream limitations gate it today:
@@ -27,6 +30,10 @@ package bamlfuzz
 //     generator already terminates such cycles via the per-class
 //     recursion cap, so the IR + walker side is ready; only the
 //     dynamic emission path is gated.
+//
+// A raw non-class effective root (RootType non-nil and not a
+// KindClassRef) also flips RequiresDynamicSkip because the production
+// /call/_dynamic endpoint only accepts object-shaped outputs today.
 func AnalyzeGraph(schema FuzzSchema) FuzzSchema {
 	direct := directClassRefs(schema)
 	reach := closureFromDirect(schema, direct)
@@ -44,8 +51,44 @@ func AnalyzeGraph(schema FuzzSchema) FuzzSchema {
 			out.HasMutualCycle = true
 		}
 	}
-	out.RequiresDynamicSkip = out.HasSelfRef || out.HasMutualCycle
+	out.HasUnion = hasUnionAnywhere(schema)
+	rawRoot := schema.RootType != nil && schema.RootType.Kind != KindClassRef
+	out.RequiresDynamicSkip = out.HasSelfRef || out.HasMutualCycle || rawRoot
 	return out
+}
+
+// hasUnionAnywhere returns true if any FuzzType in the schema is
+// (or contains) a KindUnion. Descends through wrapper kinds and
+// through union variants.
+func hasUnionAnywhere(schema FuzzSchema) bool {
+	for _, cls := range schema.Classes {
+		for _, prop := range cls.Properties {
+			if typeContainsUnion(prop.Type) {
+				return true
+			}
+		}
+	}
+	if schema.RootType != nil && typeContainsUnion(*schema.RootType) {
+		return true
+	}
+	return false
+}
+
+func typeContainsUnion(t FuzzType) bool {
+	switch t.Kind {
+	case KindUnion:
+		return true
+	case KindOptional, KindList, KindMap:
+		if t.Inner != nil && typeContainsUnion(*t.Inner) {
+			return true
+		}
+	}
+	for _, v := range t.Variants {
+		if typeContainsUnion(v) {
+			return true
+		}
+	}
+	return false
 }
 
 // ReachabilityClosure returns the transitive class-ref reachability
@@ -92,6 +135,9 @@ func closureFromDirect(schema FuzzSchema, direct map[string]map[string]bool) map
 }
 
 // directClassRefs returns the one-hop class-ref edges per class.
+// Edges in the effective root type are attributed to the RootClass
+// (when the root is a class) so a top-level union that references
+// the root class still folds into the self-ref calculation.
 func directClassRefs(schema FuzzSchema) map[string]map[string]bool {
 	out := make(map[string]map[string]bool, len(schema.Classes))
 	for _, cls := range schema.Classes {
@@ -100,6 +146,11 @@ func directClassRefs(schema FuzzSchema) map[string]map[string]bool {
 			collectClassRefs(prop.Type, set)
 		}
 		out[cls.Name] = set
+	}
+	if schema.RootType != nil && schema.RootClass != "" {
+		if existing, ok := out[schema.RootClass]; ok {
+			collectClassRefs(*schema.RootType, existing)
+		}
 	}
 	return out
 }
@@ -115,6 +166,10 @@ func collectClassRefs(t FuzzType, out map[string]bool) {
 		// needs to descend into Inner.
 		if t.Inner != nil {
 			collectClassRefs(*t.Inner, out)
+		}
+	case KindUnion:
+		for _, v := range t.Variants {
+			collectClassRefs(v, out)
 		}
 	}
 }

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -1,0 +1,591 @@
+package bamlfuzz
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// TestUnionIRJSONRoundTrip pins on-disk format stability for the
+// new KindUnion + UnionChoices fields. Failure here means an existing
+// replay artifact (corpus or envelope) cannot be re-loaded after a
+// rename or tag drift.
+func TestUnionIRJSONRoundTrip(t *testing.T) {
+	original := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindInt},
+			{Kind: KindNull},
+		},
+	}
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded FuzzType
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(original, decoded) {
+		t.Fatalf("FuzzType round trip mismatch\noriginal: %#v\ndecoded:  %#v", original, decoded)
+	}
+
+	val := FuzzValue{
+		Kind:         KindUnion,
+		VariantIndex: 2,
+		Variant:      &FuzzValue{Kind: KindNull},
+	}
+	encVal, err := json.Marshal(val)
+	if err != nil {
+		t.Fatalf("marshal value: %v", err)
+	}
+	var decVal FuzzValue
+	if err := json.Unmarshal(encVal, &decVal); err != nil {
+		t.Fatalf("unmarshal value: %v", err)
+	}
+	if !reflect.DeepEqual(val, decVal) {
+		t.Fatalf("FuzzValue round trip mismatch\noriginal: %#v\ndecoded:  %#v", val, decVal)
+	}
+
+	choice := UnionChoice{Index: 2, Kind: KindNull, VariantCount: 3}
+	encChoice, err := json.Marshal(choice)
+	if err != nil {
+		t.Fatalf("marshal choice: %v", err)
+	}
+	var decChoice UnionChoice
+	if err := json.Unmarshal(encChoice, &decChoice); err != nil {
+		t.Fatalf("unmarshal choice: %v", err)
+	}
+	if !reflect.DeepEqual(choice, decChoice) {
+		t.Fatalf("UnionChoice round trip mismatch\noriginal: %#v\ndecoded:  %#v", choice, decChoice)
+	}
+}
+
+// TestAnalyzeGraphFollowsUnionsForClassRefs asserts a self-ref that
+// only reaches the class through a union variant still flips
+// HasSelfRef. Without union-aware descent in collectClassRefs the
+// graph analyzer would miss it.
+func TestAnalyzeGraphFollowsUnionsForClassRefs(t *testing.T) {
+	self := FuzzType{Kind: KindClassRef, Ref: "FuzzClass0"}
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindOptional, Inner: &self},
+		},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "FuzzClass0",
+			Properties: []FuzzProperty{
+				{Name: "f", Type: uni},
+			},
+		}},
+		RootClass: "FuzzClass0",
+	}
+	got := AnalyzeGraph(schema)
+	if !got.HasSelfRef {
+		t.Errorf("HasSelfRef should fire for self-ref through union variant, got %+v", got)
+	}
+	if !got.HasUnion {
+		t.Errorf("HasUnion should be true, got false")
+	}
+}
+
+// TestAnalyzeGraphHasUnionDescendsNestedWrappers makes sure unions
+// nested inside list / map / optional wrappers still flip HasUnion.
+func TestAnalyzeGraphHasUnionDescendsNestedWrappers(t *testing.T) {
+	inner := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindInt},
+		},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "f", Type: FuzzType{Kind: KindList, Inner: &inner}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	got := AnalyzeGraph(schema)
+	if !got.HasUnion {
+		t.Errorf("HasUnion should be true for union inside list, got false")
+	}
+}
+
+// TestAnalyzeGraphHasUnionFalseForUnionFree asserts the flag isn't
+// stamped when no KindUnion appears anywhere.
+func TestAnalyzeGraphHasUnionFalseForUnionFree(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "f", Type: FuzzType{Kind: KindString}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	got := AnalyzeGraph(schema)
+	if got.HasUnion {
+		t.Errorf("HasUnion should be false for union-free schema, got true")
+	}
+}
+
+// TestAnalyzeGraphRawRootRequiresDynamicSkip pins the contract that a
+// non-class effective root flips RequiresDynamicSkip — the dynamic
+// emitter rejects raw roots with ErrDynamicRootTypeUnsupported.
+func TestAnalyzeGraphRawRootRequiresDynamicSkip(t *testing.T) {
+	root := FuzzType{Kind: KindString}
+	schema := FuzzSchema{
+		Classes:   []FuzzClass{{Name: "Root", Properties: []FuzzProperty{{Name: "f", Type: FuzzType{Kind: KindString}}}}},
+		RootClass: "Root",
+		RootType:  &root,
+	}
+	got := AnalyzeGraph(schema)
+	if !got.RequiresDynamicSkip {
+		t.Errorf("RequiresDynamicSkip should be true for raw root type, got false")
+	}
+}
+
+// TestWalkUnionRendersPickedArm asserts the walker emits the JSON
+// for the chosen variant and records the choice in metadata.
+func TestWalkUnionRendersPickedArm(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "u", Type: FuzzType{
+					Kind: KindUnion,
+					Variants: []FuzzType{
+						{Kind: KindString},
+						{Kind: KindInt},
+					},
+				}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{
+			{Name: "u", Value: FuzzValue{
+				Kind: KindUnion, VariantIndex: 1,
+				Variant: &FuzzValue{Kind: KindInt, Int: 42},
+			}},
+		},
+	}
+	res, err := Walk(schema, value)
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	want := `{"u":42}`
+	if string(res.MockLLMContent) != want {
+		t.Errorf("mock mismatch\nwant: %s\ngot:  %s", want, string(res.MockLLMContent))
+	}
+	if string(res.Expected) != want {
+		t.Errorf("expected mismatch\nwant: %s\ngot:  %s", want, string(res.Expected))
+	}
+	choice, ok := res.Metadata.UnionChoices[".u"]
+	if !ok {
+		t.Fatalf("missing union choice for .u")
+	}
+	if choice.Index != 1 || choice.Kind != KindInt || choice.VariantCount != 2 {
+		t.Errorf("choice: got %+v", choice)
+	}
+}
+
+// TestWalkTNullUnionEmitsExplicitNull asserts T|null implemented as a
+// union with a KindNull variant emits JSON null when the null arm is
+// picked, separately from KindOptional's absent-key semantics.
+func TestWalkTNullUnionEmitsExplicitNull(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "x", Type: FuzzType{
+					Kind: KindUnion,
+					Variants: []FuzzType{
+						{Kind: KindString},
+						{Kind: KindNull},
+					},
+				}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{
+			{Name: "x", Value: FuzzValue{
+				Kind: KindUnion, VariantIndex: 1,
+				Variant: &FuzzValue{Kind: KindNull},
+			}},
+		},
+	}
+	res, err := Walk(schema, value)
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	want := `{"x":null}`
+	if string(res.MockLLMContent) != want {
+		t.Errorf("T|null with null arm picked should emit explicit null in mock\nwant: %s\ngot:  %s", want, string(res.MockLLMContent))
+	}
+}
+
+// TestWalkUnionMissingChoiceFailsClosed asserts the walker rejects a
+// union value with no Variant set rather than silently skipping the
+// node.
+func TestWalkUnionMissingChoiceFailsClosed(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "u", Type: FuzzType{
+					Kind: KindUnion,
+					Variants: []FuzzType{
+						{Kind: KindString},
+						{Kind: KindInt},
+					},
+				}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{
+			{Name: "u", Value: FuzzValue{Kind: KindUnion, VariantIndex: 0, Variant: nil}},
+		},
+	}
+	_, err := Walk(schema, value)
+	if err == nil {
+		t.Fatal("expected error for union value without selected variant, got nil")
+	}
+}
+
+// TestNormalizeUnionRequiresChoice asserts the normalizer fails
+// closed when a union node is reached without a recorded choice.
+func TestNormalizeUnionRequiresChoice(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "u", Type: FuzzType{
+					Kind: KindUnion,
+					Variants: []FuzzType{
+						{Kind: KindString},
+						{Kind: KindInt},
+					},
+				}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	_, err := NormalizeMockToExpected(schema, json.RawMessage(`{"u":"x"}`), "Root")
+	if err == nil {
+		t.Fatal("expected error for union without choice, got nil")
+	}
+	if !strings.Contains(err.Error(), "union") {
+		t.Errorf("error should mention union, got %v", err)
+	}
+}
+
+// TestEmitDynamicLowersUnionAsOneOf asserts the dynamic emitter
+// converts a KindUnion to type=union with OneOf populated.
+func TestEmitDynamicLowersUnionAsOneOf(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "u", Type: FuzzType{
+					Kind: KindUnion,
+					Variants: []FuzzType{
+						{Kind: KindString},
+						{Kind: KindNull},
+					},
+				}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	out, err := LowerToDynamicSchema(schema)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	prop, ok := out.Properties.Get("u")
+	if !ok {
+		t.Fatalf("missing root property u")
+	}
+	if prop.Type != "union" {
+		t.Errorf("expected type=union, got %q", prop.Type)
+	}
+	if len(prop.OneOf) != 2 {
+		t.Fatalf("expected 2 variants in OneOf, got %d", len(prop.OneOf))
+	}
+	if prop.OneOf[0].Type != "string" || prop.OneOf[1].Type != "null" {
+		t.Errorf("variants: got %q, %q", prop.OneOf[0].Type, prop.OneOf[1].Type)
+	}
+}
+
+// TestEmitDynamicRejectsRawRoot asserts the dynamic emitter refuses a
+// non-class effective root with ErrDynamicRootTypeUnsupported, which
+// wraps ErrDynamicSchemaUnsupported.
+func TestEmitDynamicRejectsRawRoot(t *testing.T) {
+	root := FuzzType{Kind: KindString}
+	schema := FuzzSchema{
+		Classes:   []FuzzClass{{Name: "Root", Properties: []FuzzProperty{{Name: "f", Type: FuzzType{Kind: KindString}}}}},
+		RootClass: "Root",
+		RootType:  &root,
+	}
+	_, err := LowerToDynamicSchema(schema)
+	if !errors.Is(err, ErrDynamicRootTypeUnsupported) {
+		t.Fatalf("expected ErrDynamicRootTypeUnsupported, got %v", err)
+	}
+	if !errors.Is(err, ErrDynamicSchemaUnsupported) {
+		t.Errorf("ErrDynamicRootTypeUnsupported should wrap ErrDynamicSchemaUnsupported, got %v", err)
+	}
+}
+
+// TestEmitStaticUnionPipeSyntax pins the static pipe-with-parens
+// spelling at three nesting positions: a top-level field, inside
+// optional, and inside list. The function-return position uses the
+// unparenthesised pipe form.
+func TestEmitStaticUnionPipeSyntax(t *testing.T) {
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindInt},
+		},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "field", Type: uni},
+				{Name: "opt", Type: FuzzType{Kind: KindOptional, Inner: &uni}},
+				{Name: "lst", Type: FuzzType{Kind: KindList, Inner: &uni}},
+				{Name: "tnull", Type: FuzzType{
+					Kind: KindUnion,
+					Variants: []FuzzType{
+						{Kind: KindString},
+						{Kind: KindNull},
+					},
+				}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	src, err := LowerToBamlSource(schema, "TestC")
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	// Top-level field union: appears inline with parens (typeSpelling
+	// always wraps unions in parens to keep precedence with the
+	// surrounding `(...)?` / `(...)[]` wrappers).
+	if !strings.Contains(src.Source, "field (string | int)") {
+		t.Errorf("missing field union spelling, got source:\n%s", src.Source)
+	}
+	// Optional-around-union: outer parens for the union, `?` after.
+	if !strings.Contains(src.Source, "opt ((string | int))?") {
+		t.Errorf("missing optional-around-union spelling, got source:\n%s", src.Source)
+	}
+	// List-of-union: outer parens for the union, `[]` after.
+	if !strings.Contains(src.Source, "lst ((string | int))[]") {
+		t.Errorf("missing list-of-union spelling, got source:\n%s", src.Source)
+	}
+	// T|null variant.
+	if !strings.Contains(src.Source, "tnull (string | null)") {
+		t.Errorf("missing T|null spelling, got source:\n%s", src.Source)
+	}
+}
+
+// TestEmitStaticSingleArmUnionEmitsBareVariant asserts the static
+// emitter renders a single-arm union (only reachable through the
+// shrink-collapse pass) as the bare variant. Emitting a one-operand
+// pipe (`string | `) would be invalid BAML.
+func TestEmitStaticSingleArmUnionEmitsBareVariant(t *testing.T) {
+	uni := FuzzType{
+		Kind:     KindUnion,
+		Variants: []FuzzType{{Kind: KindString}},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "f", Type: uni},
+			},
+		}},
+		RootClass: "Root",
+	}
+	src, err := LowerToBamlSource(schema, "TestC")
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	if strings.Contains(src.Source, "|") {
+		t.Errorf("single-arm union should not emit pipe, got source:\n%s", src.Source)
+	}
+	if !strings.Contains(src.Source, "f string") {
+		t.Errorf("single-arm union should render as bare variant, got source:\n%s", src.Source)
+	}
+}
+
+// TestEmitStaticRawTopLevelUnion asserts the static emitter
+// generates a function return type from FuzzSchema.RootType when
+// the effective root is a raw union (no class wrapper).
+func TestEmitStaticRawTopLevelUnion(t *testing.T) {
+	root := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindInt},
+		},
+	}
+	schema := FuzzSchema{
+		Classes:  []FuzzClass{},
+		Enums:    []FuzzEnum{},
+		RootType: &root,
+	}
+	src, err := LowerToBamlSource(schema, "TestC")
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	if !strings.Contains(src.Source, "-> string | int {") {
+		t.Errorf("expected '-> string | int {' in source, got:\n%s", src.Source)
+	}
+}
+
+// TestValueGenTerminatesThroughUnionRecursion is a rapid-driven
+// safety test: union variants can contain class refs that, when
+// chosen, would recurse into the same class. The value generator
+// must terminate via the per-class depth cap.
+func TestValueGenTerminatesThroughUnionRecursion(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		schema := StaticSchemaGen().Draw(rt, "schema")
+		value := ValueGen(schema).Draw(rt, "value")
+		if _, err := Walk(schema, value); err != nil {
+			rt.Fatalf("walk failed: %v\nschema: %s", err, schemaDumpJSON(schema))
+		}
+	})
+}
+
+// TestValueGenRespectsUnionVariantBounds asserts the schema
+// generator stays within [MinUnionVariants, MaxUnionVariants] for
+// every union it draws.
+func TestValueGenRespectsUnionVariantBounds(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		schema := StaticSchemaGen().Draw(rt, "schema")
+		for _, cls := range schema.Classes {
+			for _, prop := range cls.Properties {
+				checkUnionBounds(rt, prop.Type)
+			}
+		}
+		if schema.RootType != nil {
+			checkUnionBounds(rt, *schema.RootType)
+		}
+	})
+}
+
+func checkUnionBounds(rt *rapid.T, t FuzzType) {
+	switch t.Kind {
+	case KindUnion:
+		if len(t.Variants) < MinUnionVariants || len(t.Variants) > MaxUnionVariants {
+			rt.Fatalf("union arm count %d out of bounds [%d, %d]", len(t.Variants), MinUnionVariants, MaxUnionVariants)
+		}
+		for _, v := range t.Variants {
+			checkUnionBounds(rt, v)
+		}
+	case KindOptional, KindList, KindMap:
+		if t.Inner != nil {
+			checkUnionBounds(rt, *t.Inner)
+		}
+	}
+}
+
+// TestCoupledCaseGenProducesWalkableCases is a rapid-driven smoke
+// test that CoupledCaseGen always returns a (schema, value) pair
+// whose Walk output round-trips through normalize. Catches a future
+// regression where the Move B collapse pass leaves the value
+// inconsistent with the rewritten schema.
+func TestCoupledCaseGenProducesWalkableCases(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		cc := CoupledCaseGen(StaticSchemaGen()).Draw(rt, "case")
+		normalized, err := NormalizeMockToExpectedWithChoices(cc.Schema, cc.Walk.MockLLMContent, cc.Schema.RootClass, cc.Walk.Metadata.UnionChoices)
+		if err != nil {
+			rt.Fatalf("normalize: %v\nschema: %s", err, schemaDumpJSON(cc.Schema))
+		}
+		if string(normalized) != string(cc.Walk.Expected) {
+			rt.Fatalf("round-trip mismatch\nnormalized: %s\nexpected:   %s",
+				string(normalized), string(cc.Walk.Expected))
+		}
+	})
+}
+
+// TestCollapseUnionsToPickedReplacesConsistentChoices pins the Move
+// B contract: when every value visit through a class field's union
+// picks the same arm, the rewritten schema has the union removed at
+// that position and the value tree drops the wrapper.
+func TestCollapseUnionsToPickedReplacesConsistentChoices(t *testing.T) {
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindInt},
+		},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "u", Type: uni},
+			},
+		}},
+		RootClass: "Root",
+	}
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{
+			{Name: "u", Value: FuzzValue{
+				Kind: KindUnion, VariantIndex: 0,
+				Variant: &FuzzValue{Kind: KindString, String: "hi"},
+			}},
+		},
+	}
+	newSchema, newValue, err := collapseUnionsToPicked(schema, value)
+	if err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+	cls, ok := newSchema.FindClass("Root")
+	if !ok {
+		t.Fatal("Root class missing after collapse")
+	}
+	if cls.Properties[0].Type.Kind != KindString {
+		t.Errorf("expected u to collapse to string, got %q", cls.Properties[0].Type.Kind)
+	}
+	if newValue.Fields[0].Value.Kind != KindString {
+		t.Errorf("value union wrapper should be stripped, got kind %q", newValue.Fields[0].Value.Kind)
+	}
+	if newValue.Fields[0].Value.String != "hi" {
+		t.Errorf("expected value 'hi', got %q", newValue.Fields[0].Value.String)
+	}
+}
+
+// schemaDumpJSON is a test helper for printing schemas in failure
+// messages. The dump is best-effort: a marshal error degrades to an
+// empty string rather than failing the test.
+func schemaDumpJSON(s FuzzSchema) string {
+	b, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -1281,6 +1281,106 @@ func (a *alignError) Error() string {
 	return a.path + ": want kind " + string(a.want) + ", got " + string(a.got)
 }
 
+// TestAssertValueAlignsWithSchemaRejectsScalarKindMismatch directly
+// exercises the strict scalar-kind check in assertValueAlignsWithSchema.
+// The property test that backs the helper does not draw adversarial
+// kind mismatches, so without this unit-level guard a regression that
+// reverts the scalar check to `v.Kind == KindUnion` would go unnoticed.
+func TestAssertValueAlignsWithSchemaRejectsScalarKindMismatch(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{
+			{Name: "Root", Properties: []FuzzProperty{
+				{Name: "f", Type: FuzzType{Kind: KindString}},
+			}},
+		},
+		RootClass: "Root",
+	}
+	value := FuzzValue{
+		Kind:      KindClassRef,
+		ClassName: "Root",
+		Fields: []FuzzFieldValue{
+			{Name: "f", Value: FuzzValue{Kind: KindInt, Int: 7}},
+		},
+	}
+	err := assertValueAlignsWithSchema(schema, schema.EffectiveRoot(), value)
+	if err == nil {
+		t.Fatalf("expected scalar-kind mismatch error, got nil")
+	}
+	leaf := err
+	for {
+		ae, ok := leaf.(*alignError)
+		if !ok || ae.inner == nil {
+			break
+		}
+		leaf = ae.inner
+	}
+	ae, ok := leaf.(*alignError)
+	if !ok {
+		t.Fatalf("expected leaf *alignError, got %T: %v", leaf, leaf)
+	}
+	if ae.want != KindString || ae.got != KindInt {
+		t.Fatalf("alignError want=%q got=%q; expected want=KindString got=KindInt (full: %v)",
+			ae.want, ae.got, err)
+	}
+}
+
+// TestAssertValueAlignsWithSchemaRejectsClassRefDrift directly exercises
+// the strict class-name check. Without this, a regression that resolves
+// schema.FindClass(v.ClassName) and walks the wrong class would slip
+// through the property test (which never produces drifted class names).
+func TestAssertValueAlignsWithSchemaRejectsClassRefDrift(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{
+			{Name: "Root", Properties: []FuzzProperty{
+				{Name: "inner", Type: FuzzType{Kind: KindClassRef, Ref: "Foo"}},
+			}},
+			{Name: "Foo", Properties: []FuzzProperty{
+				{Name: "x", Type: FuzzType{Kind: KindString}},
+			}},
+			{Name: "Bar", Properties: []FuzzProperty{
+				{Name: "x", Type: FuzzType{Kind: KindString}},
+			}},
+		},
+		RootClass: "Root",
+	}
+	value := FuzzValue{
+		Kind:      KindClassRef,
+		ClassName: "Root",
+		Fields: []FuzzFieldValue{
+			{Name: "inner", Value: FuzzValue{
+				Kind:      KindClassRef,
+				ClassName: "Bar",
+				Fields: []FuzzFieldValue{
+					{Name: "x", Value: FuzzValue{Kind: KindString, String: "hi"}},
+				},
+			}},
+		},
+	}
+	err := assertValueAlignsWithSchema(schema, schema.EffectiveRoot(), value)
+	if err == nil {
+		t.Fatalf("expected class-ref drift error, got nil")
+	}
+	leaf := err
+	for {
+		ae, ok := leaf.(*alignError)
+		if !ok || ae.inner == nil {
+			break
+		}
+		leaf = ae.inner
+	}
+	ae, ok := leaf.(*alignError)
+	if !ok {
+		t.Fatalf("expected leaf *alignError, got %T: %v", leaf, leaf)
+	}
+	if ae.wantRef != "Foo" || ae.gotRef != "Bar" {
+		t.Fatalf("alignError wantRef=%q gotRef=%q; expected Foo/Bar (full: %v)",
+			ae.wantRef, ae.gotRef, err)
+	}
+	if !strings.Contains(err.Error(), "ref Foo") || !strings.Contains(err.Error(), "ref Bar") {
+		t.Fatalf("rendered error missing ref Foo / ref Bar: %s", err.Error())
+	}
+}
+
 func itoa(i int) string {
 	if i == 0 {
 		return "0"

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -988,3 +988,311 @@ func schemaDumpJSON(s FuzzSchema) string {
 	}
 	return string(b)
 }
+
+// TestCollapseUnionsToPickedStripsWrappersForCollapsedNestedUnions
+// pins the Move B value-rewrite contract for the multi-level union
+// shape that surfaced as TestBamlfuzzDynamicOracle/rapid/preserve_off
+// /case_3: a 3-level union where the outer arm is consistent across
+// observations (collapses), and at least one nested union arm is
+// visited by a single observation and collapses too. The pre-fix
+// rewrite walked the post-collapse schema using `v.VariantIndex` as
+// the descent key, which kept stale wrappers in place — the walker
+// then dispatched on a non-union schema kind (e.g. enum_ref) with a
+// union-shaped value whose payload field was the zero value, emitting
+// the wrapper's zero ("", 0, false) — not the actual leaf payload at
+// the bottom of the value tree.
+//
+// The contract this test pins: after collapseUnionsToPicked returns,
+// the rewritten value's structural kinds must align with the rewritten
+// schema. No union wrapper must survive at a position where the new
+// schema's type is no longer a union, regardless of how many union
+// levels the original schema had.
+func TestCollapseUnionsToPickedStripsWrappersForCollapsedNestedUnions(t *testing.T) {
+	// Schema modelled after the kD branch of the case_3 schema:
+	// FuzzClass1.Fuzz_field_0 = union[union[union[null, enum, lit-false],
+	//                                          union[bool, lit-false],
+	//                                          union[bool, bool, int]],
+	//                                  union[<other shapes>]]
+	// Reduced to the minimal shape that exercises the bug: a 3-level
+	// union where the outer's arm 0 is a middle union, and the middle's
+	// arm 1 is a sub-union whose first arm is enum_ref.
+	enum := FuzzEnum{Name: "E", Values: []string{"E_V0"}}
+	subA := FuzzType{Kind: KindUnion, Variants: []FuzzType{
+		{Kind: KindBool},
+		{Kind: KindLiteral, Literal: &FuzzLiteral{Kind: LiteralBool, Bool: false}},
+	}}
+	subB := FuzzType{Kind: KindUnion, Variants: []FuzzType{
+		{Kind: KindEnumRef, Ref: enum.Name},
+		{Kind: KindBool},
+	}}
+	subC := FuzzType{Kind: KindUnion, Variants: []FuzzType{
+		{Kind: KindString},
+		{Kind: KindInt},
+	}}
+	middle := FuzzType{Kind: KindUnion, Variants: []FuzzType{subA, subB, subC}}
+	otherOuterArm := FuzzType{Kind: KindString}
+	outer := FuzzType{Kind: KindUnion, Variants: []FuzzType{middle, otherOuterArm}}
+
+	// Wrap in a map so two visits can take different middle arms,
+	// disagreeing at the middle level (so middle stays a 3-arm union)
+	// while still agreeing at the outer level (so outer collapses to
+	// its arm 0 = middle).
+	keyT := FuzzType{Kind: KindString}
+	mapT := FuzzType{Kind: KindMap, Key: &keyT, Inner: &outer}
+
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "m", Type: mapT},
+			},
+		}},
+		Enums:     []FuzzEnum{enum},
+		RootClass: "Root",
+	}
+
+	// kA visit: outer=0, middle=0 (subA), inner=1 (lit-false). All
+	// three wrappers present, leaf is the literal payload.
+	kA := FuzzValue{
+		Kind: KindUnion, VariantIndex: 0,
+		Variant: &FuzzValue{
+			Kind: KindUnion, VariantIndex: 0,
+			Variant: &FuzzValue{
+				Kind: KindUnion, VariantIndex: 1,
+				Variant: &FuzzValue{Kind: KindLiteral, Bool: false},
+			},
+		},
+	}
+	// kD visit: outer=0, middle=1 (subB), inner=0 (enum_ref). This
+	// reproduces the case_3 failure shape: the inner enum_ref slot
+	// retained a union wrapper after rewrite, and the walker emitted
+	// "" — not "E_V0" — at that position.
+	kD := FuzzValue{
+		Kind: KindUnion, VariantIndex: 0,
+		Variant: &FuzzValue{
+			Kind: KindUnion, VariantIndex: 1,
+			Variant: &FuzzValue{
+				Kind: KindUnion, VariantIndex: 0,
+				Variant: &FuzzValue{Kind: KindEnumRef, Enum: "E_V0"},
+			},
+		},
+	}
+
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{{
+			Name: "m",
+			Value: FuzzValue{Kind: KindMap, MapEntries: []FuzzMapEntry{
+				{Key: "kA", Value: kA},
+				{Key: "kD", Value: kD},
+			}},
+		}},
+	}
+
+	newSchema, newValue, err := collapseUnionsToPicked(schema, value)
+	if err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+
+	// The new schema's m.inner should be the middle union with its
+	// three arms rewritten: subA, subB, subC each collapsed (single
+	// observation per arm), so the new middle is union[lit-false,
+	// enum_ref, string] (visited inner arms collapsed; arm 0 sub-arm
+	// 1 was kA's pick → lit-false; arm 1 sub-arm 0 was kD's pick →
+	// enum_ref; arm 2 was never visited so stays a string|int union).
+	cls, _ := newSchema.FindClass("Root")
+	mapType := cls.Properties[0].Type
+	if mapType.Kind != KindMap || mapType.Inner == nil {
+		t.Fatalf("expected map<string, T>, got %#v", mapType)
+	}
+	collapsedOuter := *mapType.Inner
+	if collapsedOuter.Kind != KindUnion {
+		t.Fatalf("expected outer union preserved as a union, got %q\nschema: %s",
+			collapsedOuter.Kind, schemaDumpJSON(newSchema))
+	}
+	if len(collapsedOuter.Variants) != 3 {
+		t.Fatalf("collapsed outer should expose middle's 3 arms, got %d: %s",
+			len(collapsedOuter.Variants), schemaDumpJSON(newSchema))
+	}
+	if got := collapsedOuter.Variants[0].Kind; got != KindLiteral {
+		t.Errorf("arm 0 (kA's middle arm = subA collapsed via inner=1) should be lit-bool, got %q", got)
+	}
+	if got := collapsedOuter.Variants[1].Kind; got != KindEnumRef {
+		t.Errorf("arm 1 (kD's middle arm = subB collapsed via inner=0) should be enum_ref, got %q", got)
+	}
+	// arm 2 (subC) was never visited so it stays as the original
+	// 2-arm union of unrelated kinds.
+	if got := collapsedOuter.Variants[2].Kind; got != KindUnion {
+		t.Errorf("arm 2 (never visited) should stay as a union, got %q", got)
+	}
+
+	// Now the load-bearing assertion: the rewritten map entries must
+	// align with the rewritten schema — kA's value at arm 0 must
+	// dispatch as KindLiteral, kD's value at arm 1 must dispatch as
+	// KindEnumRef, and crucially the inner slots must carry the leaf
+	// payload, not a stale union wrapper.
+	if err := assertValueAlignsWithSchema(newSchema, newSchema.EffectiveRoot(), newValue); err != nil {
+		t.Fatalf("rewritten value not aligned with new schema: %v\nschema: %s\nvalue: %s",
+			err, schemaDumpJSON(newSchema), valueDumpJSON(newValue))
+	}
+
+	// And the walked output must reflect the leaf payloads (no ""
+	// from a wrapper's zero-value Enum/Bool/Int).
+	walked, err := Walk(newSchema, newValue)
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	got := string(walked.Expected)
+	if !strings.Contains(got, `"E_V0"`) {
+		t.Errorf("expected enum value E_V0 in walked output, got %s", got)
+	}
+	if strings.Contains(got, `""`) {
+		t.Errorf("walked output contains \"\" — wrapper stripping regressed: %s", got)
+	}
+}
+
+// TestCoupledCaseGenValueShapeMatchesSchema is the property-level
+// counterpart to the focused regression test above: across a large
+// number of random draws, the post-collapse value's structural shape
+// must align with the post-collapse schema. The original round-trip
+// test (TestCoupledCaseGenProducesWalkableCases) only checked that
+// MockLLMContent and Expected normalized to each other, which is
+// satisfied even when both are equally wrong — a value-wrapper bug
+// renders both via the same broken walker, so the round-trip survives
+// while the actual emitted JSON is structurally meaningless. This
+// test compares against the schema directly to catch that class of
+// drift.
+func TestCoupledCaseGenValueShapeMatchesSchema(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		cc := CoupledCaseGen(StaticSchemaGen()).Draw(rt, "case")
+		if err := assertValueAlignsWithSchema(cc.Schema, cc.Schema.EffectiveRoot(), cc.Value); err != nil {
+			rt.Fatalf("value/schema misalignment: %v\nschema: %s\nvalue: %s",
+				err, schemaDumpJSON(cc.Schema), valueDumpJSON(cc.Value))
+		}
+	})
+}
+
+// assertValueAlignsWithSchema walks a FuzzType and FuzzValue in
+// lockstep and reports the first kind mismatch. The check is strict:
+// every wrapper (optional/list/map/union/class_ref) in the schema must
+// have a matching wrapper in the value, and every primitive/literal/
+// enum schema slot must NOT have a union value sitting in it. The
+// latter is the failure shape the case_3 bug surfaced.
+func assertValueAlignsWithSchema(schema FuzzSchema, t FuzzType, v FuzzValue) error {
+	switch t.Kind {
+	case KindString, KindInt, KindFloat, KindBool, KindNull, KindLiteral, KindEnumRef:
+		if v.Kind == KindUnion {
+			return &alignError{path: "<scalar>", want: t.Kind, got: v.Kind}
+		}
+		return nil
+	case KindUnion:
+		if v.Kind != KindUnion {
+			return &alignError{path: "<union>", want: KindUnion, got: v.Kind}
+		}
+		if v.Variant == nil {
+			return errors.New("union value missing Variant")
+		}
+		if v.VariantIndex < 0 || v.VariantIndex >= len(t.Variants) {
+			return errors.New("union variant index out of range")
+		}
+		return assertValueAlignsWithSchema(schema, t.Variants[v.VariantIndex], *v.Variant)
+	case KindOptional:
+		if v.Kind != KindOptional {
+			return &alignError{path: "<optional>", want: KindOptional, got: v.Kind}
+		}
+		if v.OptionalShape == OptionalPresent && v.Inner != nil && t.Inner != nil {
+			return assertValueAlignsWithSchema(schema, *t.Inner, *v.Inner)
+		}
+		return nil
+	case KindList:
+		if v.Kind != KindList {
+			return &alignError{path: "<list>", want: KindList, got: v.Kind}
+		}
+		if t.Inner == nil {
+			return nil
+		}
+		for i, item := range v.Items {
+			if err := assertValueAlignsWithSchema(schema, *t.Inner, item); err != nil {
+				return &alignError{path: "list[" + itoa(i) + "]", inner: err}
+			}
+		}
+		return nil
+	case KindMap:
+		if v.Kind != KindMap {
+			return &alignError{path: "<map>", want: KindMap, got: v.Kind}
+		}
+		if t.Inner == nil {
+			return nil
+		}
+		for _, e := range v.MapEntries {
+			if err := assertValueAlignsWithSchema(schema, *t.Inner, e.Value); err != nil {
+				return &alignError{path: "map[" + e.Key + "]", inner: err}
+			}
+		}
+		return nil
+	case KindClassRef:
+		if v.Kind != KindClassRef {
+			return &alignError{path: "<class>", want: KindClassRef, got: v.Kind}
+		}
+		cls, ok := schema.FindClass(v.ClassName)
+		if !ok {
+			return errors.New("class ref " + v.ClassName + " not in schema")
+		}
+		for _, prop := range cls.Properties {
+			fv, ok := v.LookupField(prop.Name)
+			if !ok {
+				continue
+			}
+			if err := assertValueAlignsWithSchema(schema, prop.Type, fv); err != nil {
+				return &alignError{path: v.ClassName + "." + prop.Name, inner: err}
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+type alignError struct {
+	path  string
+	want  FuzzTypeKind
+	got   FuzzTypeKind
+	inner error
+}
+
+func (a *alignError) Error() string {
+	if a.inner != nil {
+		return a.path + ": " + a.inner.Error()
+	}
+	return a.path + ": want kind " + string(a.want) + ", got " + string(a.got)
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := false
+	if i < 0 {
+		neg = true
+		i = -i
+	}
+	var b [20]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		b[pos] = '-'
+	}
+	return string(b[pos:])
+}
+
+func valueDumpJSON(v FuzzValue) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -1181,7 +1181,7 @@ func TestCoupledCaseGenValueShapeMatchesSchema(t *testing.T) {
 func assertValueAlignsWithSchema(schema FuzzSchema, t FuzzType, v FuzzValue) error {
 	switch t.Kind {
 	case KindString, KindInt, KindFloat, KindBool, KindNull, KindLiteral, KindEnumRef:
-		if v.Kind == KindUnion {
+		if v.Kind != t.Kind {
 			return &alignError{path: "<scalar>", want: t.Kind, got: v.Kind}
 		}
 		return nil
@@ -1234,9 +1234,18 @@ func assertValueAlignsWithSchema(schema FuzzSchema, t FuzzType, v FuzzValue) err
 		if v.Kind != KindClassRef {
 			return &alignError{path: "<class>", want: KindClassRef, got: v.Kind}
 		}
-		cls, ok := schema.FindClass(v.ClassName)
+		if v.ClassName != t.Ref {
+			return &alignError{
+				path:    "<class>",
+				want:    KindClassRef,
+				got:     v.Kind,
+				wantRef: t.Ref,
+				gotRef:  v.ClassName,
+			}
+		}
+		cls, ok := schema.FindClass(t.Ref)
 		if !ok {
-			return errors.New("class ref " + v.ClassName + " not in schema")
+			return errors.New("class ref " + t.Ref + " not in schema")
 		}
 		for _, prop := range cls.Properties {
 			fv, ok := v.LookupField(prop.Name)
@@ -1244,7 +1253,7 @@ func assertValueAlignsWithSchema(schema FuzzSchema, t FuzzType, v FuzzValue) err
 				continue
 			}
 			if err := assertValueAlignsWithSchema(schema, prop.Type, fv); err != nil {
-				return &alignError{path: v.ClassName + "." + prop.Name, inner: err}
+				return &alignError{path: t.Ref + "." + prop.Name, inner: err}
 			}
 		}
 		return nil
@@ -1253,15 +1262,21 @@ func assertValueAlignsWithSchema(schema FuzzSchema, t FuzzType, v FuzzValue) err
 }
 
 type alignError struct {
-	path  string
-	want  FuzzTypeKind
-	got   FuzzTypeKind
-	inner error
+	path    string
+	want    FuzzTypeKind
+	got     FuzzTypeKind
+	wantRef string
+	gotRef  string
+	inner   error
 }
 
 func (a *alignError) Error() string {
 	if a.inner != nil {
 		return a.path + ": " + a.inner.Error()
+	}
+	if a.wantRef != "" || a.gotRef != "" {
+		return a.path + ": want kind " + string(a.want) + " ref " + a.wantRef +
+			", got " + string(a.got) + " ref " + a.gotRef
 	}
 	return a.path + ": want kind " + string(a.want) + ", got " + string(a.got)
 }

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -657,6 +657,47 @@ func checkUnionBounds(rt *rapid.T, t FuzzType) {
 	}
 }
 
+// TestSchemaGenDoesNotProduceNegativeLiteralInt is a rapid-driven
+// invariant: literal-int types drawn anywhere in the schema must be
+// non-negative. BAML's Go codegen derives identifier-bearing tokens
+// from literal type spellings; a `-` in a literal-int spelling lands
+// as a non-identifier byte in the generated Go source when the literal
+// appears inside a union, surfacing as `expected ';', found '-'` in
+// baml_client/stream_types/classes.go and breaking the context-fix
+// hack's downstream parse. Pin the generator's safe-literal-int set
+// so a future widening of drawLiteral cannot silently reintroduce the
+// CI failure class.
+func TestSchemaGenDoesNotProduceNegativeLiteralInt(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		schema := StaticSchemaGen().Draw(rt, "schema")
+		for _, cls := range schema.Classes {
+			for _, prop := range cls.Properties {
+				checkNoNegativeLiteralInt(rt, prop.Type)
+			}
+		}
+		if schema.RootType != nil {
+			checkNoNegativeLiteralInt(rt, *schema.RootType)
+		}
+	})
+}
+
+func checkNoNegativeLiteralInt(rt *rapid.T, t FuzzType) {
+	switch t.Kind {
+	case KindLiteral:
+		if t.Literal != nil && t.Literal.Kind == LiteralInt && t.Literal.Int < 0 {
+			rt.Fatalf("negative literal-int %d drawn; BAML Go codegen cannot represent the hyphen safely inside a union arm", t.Literal.Int)
+		}
+	case KindUnion:
+		for _, v := range t.Variants {
+			checkNoNegativeLiteralInt(rt, v)
+		}
+	case KindOptional, KindList, KindMap:
+		if t.Inner != nil {
+			checkNoNegativeLiteralInt(rt, *t.Inner)
+		}
+	}
+}
+
 // TestCoupledCaseGenProducesWalkableCases is a rapid-driven smoke
 // test that CoupledCaseGen always returns a (schema, value) pair
 // whose Walk output round-trips through normalize. Catches a future

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -140,6 +140,40 @@ func TestAnalyzeGraphHasUnionFalseForUnionFree(t *testing.T) {
 	}
 }
 
+// TestAnalyzeGraphRootTypeRefsDoNotPollutePropertyGraph pins that a
+// RootType referencing the root class does not flip HasSelfRef when
+// the class's own property tree has no self edge. The two fields can
+// coexist (RootType wins for emission, RootClass stays for replay
+// compatibility), so root-reachable refs must not be folded into the
+// class's direct-edge set.
+func TestAnalyzeGraphRootTypeRefsDoNotPollutePropertyGraph(t *testing.T) {
+	rootRef := FuzzType{Kind: KindClassRef, Ref: "Root"}
+	rootUnion := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			rootRef,
+			{Kind: KindString},
+		},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "f", Type: FuzzType{Kind: KindInt}},
+			},
+		}},
+		RootClass: "Root",
+		RootType:  &rootUnion,
+	}
+	got := AnalyzeGraph(schema)
+	if got.HasSelfRef {
+		t.Errorf("HasSelfRef should stay false when Root's properties have no self edge, got true")
+	}
+	if got.HasMutualCycle {
+		t.Errorf("HasMutualCycle should be false here, got true")
+	}
+}
+
 // TestAnalyzeGraphRawRootRequiresDynamicSkip pins the contract that a
 // non-class effective root flips RequiresDynamicSkip — the dynamic
 // emitter rejects raw roots with ErrDynamicRootTypeUnsupported.
@@ -242,8 +276,8 @@ func TestWalkTNullUnionEmitsExplicitNull(t *testing.T) {
 }
 
 // TestWalkUnionMissingChoiceFailsClosed asserts the walker rejects a
-// union value with no Variant set rather than silently skipping the
-// node.
+// union value with no Variant set; silently skipping the node would
+// hide an upstream invariant break.
 func TestWalkUnionMissingChoiceFailsClosed(t *testing.T) {
 	schema := FuzzSchema{
 		Classes: []FuzzClass{{
@@ -299,6 +333,64 @@ func TestNormalizeUnionRequiresChoice(t *testing.T) {
 	}
 }
 
+// TestNormalizeRawRootUnion asserts the normalizer round-trips a raw
+// top-level union (RootClass == "", RootType set). Without EffectiveRoot
+// dispatch the normalizer would try to read the payload as a class
+// and bail with "unknown class".
+func TestNormalizeRawRootUnion(t *testing.T) {
+	root := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindInt},
+		},
+	}
+	schema := FuzzSchema{RootType: &root}
+	choices := map[string]UnionChoice{
+		"": {Index: 1, Kind: KindInt, VariantCount: 2},
+	}
+	out, err := NormalizeMockToExpectedWithChoices(schema, json.RawMessage(`42`), "", choices)
+	if err != nil {
+		t.Fatalf("normalize raw root union: %v", err)
+	}
+	if string(out) != "42" {
+		t.Errorf("normalize raw root union\nwant: 42\ngot:  %s", string(out))
+	}
+}
+
+// TestNormalizeRawRootList asserts the normalizer handles a raw
+// top-level list root by dispatching off EffectiveRoot.
+func TestNormalizeRawRootList(t *testing.T) {
+	elem := FuzzType{Kind: KindInt}
+	root := FuzzType{Kind: KindList, Inner: &elem}
+	schema := FuzzSchema{RootType: &root}
+	out, err := NormalizeMockToExpectedWithChoices(schema, json.RawMessage(`[1,2,3]`), "", nil)
+	if err != nil {
+		t.Fatalf("normalize raw root list: %v", err)
+	}
+	if string(out) != "[1,2,3]" {
+		t.Errorf("normalize raw root list\nwant: [1,2,3]\ngot:  %s", string(out))
+	}
+}
+
+// TestNormalizeRawRootMap asserts the normalizer handles a raw
+// top-level map root.
+func TestNormalizeRawRootMap(t *testing.T) {
+	key := FuzzType{Kind: KindString}
+	val := FuzzType{Kind: KindInt}
+	root := FuzzType{Kind: KindMap, Key: &key, Inner: &val}
+	schema := FuzzSchema{RootType: &root}
+	out, err := NormalizeMockToExpectedWithChoices(schema, json.RawMessage(`{"a":1,"b":2}`), "", nil)
+	if err != nil {
+		t.Fatalf("normalize raw root map: %v", err)
+	}
+	// Map keys sort alphabetically.
+	want := `{"a":1,"b":2}`
+	if string(out) != want {
+		t.Errorf("normalize raw root map\nwant: %s\ngot:  %s", want, string(out))
+	}
+}
+
 // TestEmitDynamicLowersUnionAsOneOf asserts the dynamic emitter
 // converts a KindUnion to type=union with OneOf populated.
 func TestEmitDynamicLowersUnionAsOneOf(t *testing.T) {
@@ -333,6 +425,60 @@ func TestEmitDynamicLowersUnionAsOneOf(t *testing.T) {
 	}
 	if prop.OneOf[0].Type != "string" || prop.OneOf[1].Type != "null" {
 		t.Errorf("variants: got %q, %q", prop.OneOf[0].Type, prop.OneOf[1].Type)
+	}
+}
+
+// TestEmitDynamicSingleArmUnionEmitsBareVariant asserts the dynamic
+// emitter collapses a single-arm union to its bare variant at both
+// top-level and nested positions. Matches the static emitter's
+// behaviour so hand-written or replay schemas that survived through
+// the Move B shrink-collapse pass with a single-arm union lower as
+// the bare variant; a one-element OneOf would not be legal BAML.
+func TestEmitDynamicSingleArmUnionEmitsBareVariant(t *testing.T) {
+	topLevelUni := FuzzType{
+		Kind:     KindUnion,
+		Variants: []FuzzType{{Kind: KindString}},
+	}
+	nestedUni := FuzzType{
+		Kind:     KindUnion,
+		Variants: []FuzzType{{Kind: KindInt}},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "top", Type: topLevelUni},
+				{Name: "lst", Type: FuzzType{Kind: KindList, Inner: &nestedUni}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	out, err := LowerToDynamicSchema(schema)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	top, ok := out.Properties.Get("top")
+	if !ok {
+		t.Fatal("missing top property")
+	}
+	if top.Type != "string" {
+		t.Errorf("expected bare string at top, got type %q", top.Type)
+	}
+	if len(top.OneOf) != 0 {
+		t.Errorf("expected no OneOf entries at top, got %d", len(top.OneOf))
+	}
+	lst, ok := out.Properties.Get("lst")
+	if !ok {
+		t.Fatal("missing lst property")
+	}
+	if lst.Type != "list" {
+		t.Fatalf("expected list, got %q", lst.Type)
+	}
+	if lst.Items == nil || lst.Items.Type != "int" {
+		t.Errorf("expected nested single-arm union to collapse to int, got %#v", lst.Items)
+	}
+	if lst.Items != nil && len(lst.Items.OneOf) != 0 {
+		t.Errorf("expected no nested OneOf entries, got %d", len(lst.Items.OneOf))
 	}
 }
 
@@ -579,9 +725,223 @@ func TestCollapseUnionsToPickedReplacesConsistentChoices(t *testing.T) {
 	}
 }
 
+// TestCollapseUnionsToPickedListAllSameCollapses pins that a list of
+// union elements collapses when every element picks the same arm.
+// The Move B internal path uses ":l" (aggregate, no index) so
+// observations across list positions merge.
+func TestCollapseUnionsToPickedListAllSameCollapses(t *testing.T) {
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindInt},
+		},
+	}
+	listOfUnion := FuzzType{Kind: KindList, Inner: &uni}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "items", Type: listOfUnion},
+			},
+		}},
+		RootClass: "Root",
+	}
+	mkArm := func(s string) FuzzValue {
+		return FuzzValue{Kind: KindUnion, VariantIndex: 0, Variant: &FuzzValue{Kind: KindString, String: s}}
+	}
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{
+			{Name: "items", Value: FuzzValue{Kind: KindList, Items: []FuzzValue{
+				mkArm("a"), mkArm("b"), mkArm("c"),
+			}}},
+		},
+	}
+	newSchema, newValue, err := collapseUnionsToPicked(schema, value)
+	if err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+	cls, _ := newSchema.FindClass("Root")
+	if cls.Properties[0].Type.Kind != KindList {
+		t.Fatalf("expected list kind, got %q", cls.Properties[0].Type.Kind)
+	}
+	if cls.Properties[0].Type.Inner == nil || cls.Properties[0].Type.Inner.Kind != KindString {
+		t.Errorf("expected list<string> after collapse, got inner %#v", cls.Properties[0].Type.Inner)
+	}
+	for i, item := range newValue.Fields[0].Value.Items {
+		if item.Kind != KindString {
+			t.Errorf("list[%d]: expected string, got kind %q", i, item.Kind)
+		}
+	}
+}
+
+// TestCollapseUnionsToPickedListMixedChoicesDoesNotCollapse pins that
+// mixed arm picks across list elements leave the union shape intact.
+// Merging at the element-type position invalidates the plan when
+// elements disagree.
+func TestCollapseUnionsToPickedListMixedChoicesDoesNotCollapse(t *testing.T) {
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindInt},
+		},
+	}
+	listOfUnion := FuzzType{Kind: KindList, Inner: &uni}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "items", Type: listOfUnion},
+			},
+		}},
+		RootClass: "Root",
+	}
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{
+			{Name: "items", Value: FuzzValue{Kind: KindList, Items: []FuzzValue{
+				{Kind: KindUnion, VariantIndex: 0, Variant: &FuzzValue{Kind: KindString, String: "a"}},
+				{Kind: KindUnion, VariantIndex: 1, Variant: &FuzzValue{Kind: KindInt, Int: 7}},
+			}}},
+		},
+	}
+	newSchema, newValue, err := collapseUnionsToPicked(schema, value)
+	if err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+	cls, _ := newSchema.FindClass("Root")
+	if cls.Properties[0].Type.Inner == nil || cls.Properties[0].Type.Inner.Kind != KindUnion {
+		t.Errorf("mixed list picks should preserve union, got inner %#v", cls.Properties[0].Type.Inner)
+	}
+	for i, item := range newValue.Fields[0].Value.Items {
+		if item.Kind != KindUnion {
+			t.Errorf("list[%d]: expected union wrapper preserved, got kind %q", i, item.Kind)
+		}
+	}
+}
+
+// TestCollapseUnionsToPickedMapValueCollapses pins that a map<string,
+// union> collapses when every value picks the same arm.
+func TestCollapseUnionsToPickedMapValueCollapses(t *testing.T) {
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindInt},
+		},
+	}
+	key := FuzzType{Kind: KindString}
+	mapOfUnion := FuzzType{Kind: KindMap, Key: &key, Inner: &uni}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "m", Type: mapOfUnion},
+			},
+		}},
+		RootClass: "Root",
+	}
+	mkArm := func(s string) FuzzValue {
+		return FuzzValue{Kind: KindUnion, VariantIndex: 0, Variant: &FuzzValue{Kind: KindString, String: s}}
+	}
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{
+			{Name: "m", Value: FuzzValue{Kind: KindMap, MapEntries: []FuzzMapEntry{
+				{Key: "a", Value: mkArm("x")},
+				{Key: "b", Value: mkArm("y")},
+			}}},
+		},
+	}
+	newSchema, newValue, err := collapseUnionsToPicked(schema, value)
+	if err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+	cls, _ := newSchema.FindClass("Root")
+	if cls.Properties[0].Type.Inner == nil || cls.Properties[0].Type.Inner.Kind != KindString {
+		t.Errorf("expected map<string,string> after collapse, got inner %#v", cls.Properties[0].Type.Inner)
+	}
+	for _, e := range newValue.Fields[0].Value.MapEntries {
+		if e.Value.Kind != KindString {
+			t.Errorf("map[%q]: expected string, got kind %q", e.Key, e.Value.Kind)
+		}
+	}
+}
+
+// TestCollapseUnionsToPickedNestedUnionInsideMixedOuter pins that an
+// inner union nested inside a non-collapsed outer union still
+// collapses when the inner choice is consistent within the variant it
+// lives in. Move B's path scheme distinguishes ":v0" from ":v1" so
+// nested unions are not merged across distinct outer variants.
+func TestCollapseUnionsToPickedNestedUnionInsideMixedOuter(t *testing.T) {
+	innerUni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindBool},
+		},
+	}
+	outer := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			innerUni,
+			{Kind: KindInt},
+		},
+	}
+	// `items` is a list so we get two visits — one picking outer
+	// variant 0 (the nested-union arm) and one picking outer variant 1
+	// (an int). The outer choice disagrees → outer stays. Inside
+	// variant 0 the inner-union choice is consistent across the single
+	// visit there, so it collapses to its single arm.
+	listOuter := FuzzType{Kind: KindList, Inner: &outer}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "items", Type: listOuter},
+			},
+		}},
+		RootClass: "Root",
+	}
+	innerArm := FuzzValue{
+		Kind: KindUnion, VariantIndex: 0,
+		Variant: &FuzzValue{Kind: KindString, String: "x"},
+	}
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{
+			{Name: "items", Value: FuzzValue{Kind: KindList, Items: []FuzzValue{
+				{Kind: KindUnion, VariantIndex: 0, Variant: &innerArm},
+				{Kind: KindUnion, VariantIndex: 1, Variant: &FuzzValue{Kind: KindInt, Int: 9}},
+			}}},
+		},
+	}
+	newSchema, _, err := collapseUnionsToPicked(schema, value)
+	if err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+	cls, _ := newSchema.FindClass("Root")
+	listType := cls.Properties[0].Type
+	if listType.Kind != KindList || listType.Inner == nil {
+		t.Fatalf("expected list type, got %#v", listType)
+	}
+	outerType := *listType.Inner
+	if outerType.Kind != KindUnion || len(outerType.Variants) != 2 {
+		t.Fatalf("outer union should be preserved, got %#v", outerType)
+	}
+	if outerType.Variants[0].Kind != KindString {
+		t.Errorf("nested inner union inside outer variant 0 should have collapsed to string, got %#v", outerType.Variants[0])
+	}
+	if outerType.Variants[1].Kind != KindInt {
+		t.Errorf("outer variant 1 should still be int, got %#v", outerType.Variants[1])
+	}
+}
+
 // schemaDumpJSON is a test helper for printing schemas in failure
 // messages. The dump is best-effort: a marshal error degrades to an
-// empty string rather than failing the test.
+// empty string; the helper does not fail the test on its own.
 func schemaDumpJSON(s FuzzSchema) string {
 	b, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -657,43 +657,41 @@ func checkUnionBounds(rt *rapid.T, t FuzzType) {
 	}
 }
 
-// TestSchemaGenDoesNotProduceNegativeLiteralInt is a rapid-driven
-// invariant: literal-int types drawn anywhere in the schema must be
-// non-negative. BAML's Go codegen derives identifier-bearing tokens
-// from literal type spellings; a `-` in a literal-int spelling lands
-// as a non-identifier byte in the generated Go source when the literal
-// appears inside a union, surfacing as `expected ';', found '-'` in
-// baml_client/stream_types/classes.go and breaking the context-fix
-// hack's downstream parse. Pin the generator's safe-literal-int set
-// so a future widening of drawLiteral cannot silently reintroduce the
-// CI failure class.
-func TestSchemaGenDoesNotProduceNegativeLiteralInt(t *testing.T) {
+// TestSchemaGenDoesNotProduceLiteralInt is a rapid-driven invariant:
+// no `KindLiteral` of kind `LiteralInt` may appear anywhere in a
+// drawn schema. BAML's grammar does not accept integer literals as
+// union variants (`field (0 | bool | 42)` is rejected as "not a valid
+// field or attribute definition"), and the static emitter regularly
+// surfaces them inside unions where they break the BAML CLI build.
+// Pin the generator's literal-kind set so a future reintroduction of
+// `LiteralInt` cannot silently reproduce the CI failure class.
+func TestSchemaGenDoesNotProduceLiteralInt(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		schema := StaticSchemaGen().Draw(rt, "schema")
 		for _, cls := range schema.Classes {
 			for _, prop := range cls.Properties {
-				checkNoNegativeLiteralInt(rt, prop.Type)
+				checkNoLiteralInt(rt, prop.Type)
 			}
 		}
 		if schema.RootType != nil {
-			checkNoNegativeLiteralInt(rt, *schema.RootType)
+			checkNoLiteralInt(rt, *schema.RootType)
 		}
 	})
 }
 
-func checkNoNegativeLiteralInt(rt *rapid.T, t FuzzType) {
+func checkNoLiteralInt(rt *rapid.T, t FuzzType) {
 	switch t.Kind {
 	case KindLiteral:
-		if t.Literal != nil && t.Literal.Kind == LiteralInt && t.Literal.Int < 0 {
-			rt.Fatalf("negative literal-int %d drawn; BAML Go codegen cannot represent the hyphen safely inside a union arm", t.Literal.Int)
+		if t.Literal != nil && t.Literal.Kind == LiteralInt {
+			rt.Fatalf("literal-int %d drawn; BAML rejects integer literals as union variants", t.Literal.Int)
 		}
 	case KindUnion:
 		for _, v := range t.Variants {
-			checkNoNegativeLiteralInt(rt, v)
+			checkNoLiteralInt(rt, v)
 		}
 	case KindOptional, KindList, KindMap:
 		if t.Inner != nil {
-			checkNoNegativeLiteralInt(rt, *t.Inner)
+			checkNoLiteralInt(rt, *t.Inner)
 		}
 	}
 }

--- a/adapters/common/codegen/bamlfuzz/value.go
+++ b/adapters/common/codegen/bamlfuzz/value.go
@@ -45,6 +45,10 @@ type FuzzFieldValue struct {
 //   - KindMap: MapEntries (may be empty).
 //   - KindClassRef: ClassName + Fields (one per class property, in
 //     declaration order).
+//   - KindUnion: VariantIndex names the FuzzType.Variants slot the
+//     value chose; Variant carries the generated value for that
+//     arm. A KindUnion value MUST always wrap a Variant — the walker,
+//     emitters, and order checker fail closed when it does not.
 type FuzzValue struct {
 	Kind FuzzTypeKind `json:"kind"`
 
@@ -63,6 +67,9 @@ type FuzzValue struct {
 
 	ClassName string           `json:"class_name,omitempty"`
 	Fields    []FuzzFieldValue `json:"fields,omitempty"`
+
+	VariantIndex int        `json:"variant_index,omitempty"`
+	Variant      *FuzzValue `json:"variant,omitempty"`
 }
 
 // LookupField returns the FuzzValue for the named property on a

--- a/adapters/common/codegen/testdata/bamlfuzz/dynamic/12_union_field_string_or_int.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/dynamic/12_union_field_string_or_int.json
@@ -1,0 +1,71 @@
+{
+  "name": "union_field_string_or_int",
+  "seed": 13,
+  "case_index": 12,
+  "mode": "dynamic_three_way",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "either",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {
+                  "kind": "string"
+                },
+                {
+                  "kind": "int"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "either",
+        "value": {
+          "kind": "union",
+          "variant_index": 1,
+          "variant": {
+            "kind": "int",
+            "int": 7
+          }
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "either": 7
+  },
+  "expected": {
+    "either": 7
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    },
+    "union_choices": {
+      ".either": {
+        "index": 1,
+        "kind": "int",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/dynamic/13_union_list_element.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/dynamic/13_union_list_element.json
@@ -1,0 +1,97 @@
+{
+  "name": "union_list_element",
+  "seed": 14,
+  "case_index": 13,
+  "mode": "dynamic_three_way",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "xs",
+            "type": {
+              "kind": "list",
+              "inner": {
+                "kind": "union",
+                "variants": [
+                  {
+                    "kind": "string"
+                  },
+                  {
+                    "kind": "int"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "xs",
+        "value": {
+          "kind": "list",
+          "items": [
+            {
+              "kind": "union",
+              "variant": {
+                "kind": "string",
+                "string": "alpha"
+              }
+            },
+            {
+              "kind": "union",
+              "variant_index": 1,
+              "variant": {
+                "kind": "int",
+                "int": 42
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "xs": [
+      "alpha",
+      42
+    ]
+  },
+  "expected": {
+    "xs": [
+      "alpha",
+      42
+    ]
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    },
+    "union_choices": {
+      ".xs[0]": {
+        "index": 0,
+        "kind": "string",
+        "variant_count": 2
+      },
+      ".xs[1]": {
+        "index": 1,
+        "kind": "int",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/dynamic/14_union_map_value.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/dynamic/14_union_map_value.json
@@ -1,0 +1,106 @@
+{
+  "name": "union_map_value",
+  "seed": 15,
+  "case_index": 14,
+  "mode": "dynamic_three_way",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "m",
+            "type": {
+              "kind": "map",
+              "inner": {
+                "kind": "union",
+                "variants": [
+                  {
+                    "kind": "string"
+                  },
+                  {
+                    "kind": "bool"
+                  }
+                ]
+              },
+              "key": {
+                "kind": "string"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "m",
+        "value": {
+          "kind": "map",
+          "map_entries": [
+            {
+              "key": "a",
+              "value": {
+                "kind": "union",
+                "variant": {
+                  "kind": "string",
+                  "string": "v"
+                }
+              }
+            },
+            {
+              "key": "b",
+              "value": {
+                "kind": "union",
+                "variant_index": 1,
+                "variant": {
+                  "kind": "bool",
+                  "bool": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "m": {
+      "a": "v",
+      "b": true
+    }
+  },
+  "expected": {
+    "m": {
+      "a": "v",
+      "b": true
+    }
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    },
+    "union_choices": {
+      ".m[\"a\"]": {
+        "index": 0,
+        "kind": "string",
+        "variant_count": 2
+      },
+      ".m[\"b\"]": {
+        "index": 1,
+        "kind": "bool",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/dynamic/15_union_nested_inside_union.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/dynamic/15_union_nested_inside_union.json
@@ -1,0 +1,87 @@
+{
+  "name": "union_nested_inside_union",
+  "seed": 16,
+  "case_index": 15,
+  "mode": "dynamic_three_way",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "x",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {
+                  "kind": "union",
+                  "variants": [
+                    {
+                      "kind": "string"
+                    },
+                    {
+                      "kind": "int"
+                    }
+                  ]
+                },
+                {
+                  "kind": "bool"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "x",
+        "value": {
+          "kind": "union",
+          "variant": {
+            "kind": "union",
+            "variant_index": 1,
+            "variant": {
+              "kind": "int",
+              "int": 123
+            }
+          }
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "x": 123
+  },
+  "expected": {
+    "x": 123
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    },
+    "union_choices": {
+      ".x": {
+        "index": 0,
+        "kind": "union",
+        "variant_count": 2
+      },
+      ".x:v": {
+        "index": 1,
+        "kind": "int",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/dynamic/16_union_t_null.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/dynamic/16_union_t_null.json
@@ -1,0 +1,70 @@
+{
+  "name": "union_t_null",
+  "seed": 17,
+  "case_index": 16,
+  "mode": "dynamic_three_way",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "maybe",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {
+                  "kind": "string"
+                },
+                {
+                  "kind": "null"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "maybe",
+        "value": {
+          "kind": "union",
+          "variant_index": 1,
+          "variant": {
+            "kind": "null"
+          }
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "maybe": null
+  },
+  "expected": {
+    "maybe": null
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    },
+    "union_choices": {
+      ".maybe": {
+        "index": 1,
+        "kind": "null",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/static/05_static_union_field_string_or_int.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/05_static_union_field_string_or_int.json
@@ -1,0 +1,71 @@
+{
+  "name": "static_union_field_string_or_int",
+  "seed": 6,
+  "case_index": 5,
+  "mode": "static_prompt",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "either",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {
+                  "kind": "string"
+                },
+                {
+                  "kind": "int"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "either",
+        "value": {
+          "kind": "union",
+          "variant_index": 1,
+          "variant": {
+            "kind": "int",
+            "int": 7
+          }
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "either": 7
+  },
+  "expected": {
+    "either": 7
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    },
+    "union_choices": {
+      ".either": {
+        "index": 1,
+        "kind": "int",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/static/06_static_union_list_element.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/06_static_union_list_element.json
@@ -1,0 +1,97 @@
+{
+  "name": "static_union_list_element",
+  "seed": 7,
+  "case_index": 6,
+  "mode": "static_prompt",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "xs",
+            "type": {
+              "kind": "list",
+              "inner": {
+                "kind": "union",
+                "variants": [
+                  {
+                    "kind": "string"
+                  },
+                  {
+                    "kind": "int"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "xs",
+        "value": {
+          "kind": "list",
+          "items": [
+            {
+              "kind": "union",
+              "variant": {
+                "kind": "string",
+                "string": "alpha"
+              }
+            },
+            {
+              "kind": "union",
+              "variant_index": 1,
+              "variant": {
+                "kind": "int",
+                "int": 42
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "xs": [
+      "alpha",
+      42
+    ]
+  },
+  "expected": {
+    "xs": [
+      "alpha",
+      42
+    ]
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    },
+    "union_choices": {
+      ".xs[0]": {
+        "index": 0,
+        "kind": "string",
+        "variant_count": 2
+      },
+      ".xs[1]": {
+        "index": 1,
+        "kind": "int",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/static/07_static_union_map_value.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/07_static_union_map_value.json
@@ -1,0 +1,106 @@
+{
+  "name": "static_union_map_value",
+  "seed": 8,
+  "case_index": 7,
+  "mode": "static_prompt",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "m",
+            "type": {
+              "kind": "map",
+              "inner": {
+                "kind": "union",
+                "variants": [
+                  {
+                    "kind": "string"
+                  },
+                  {
+                    "kind": "bool"
+                  }
+                ]
+              },
+              "key": {
+                "kind": "string"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "m",
+        "value": {
+          "kind": "map",
+          "map_entries": [
+            {
+              "key": "a",
+              "value": {
+                "kind": "union",
+                "variant": {
+                  "kind": "string",
+                  "string": "v"
+                }
+              }
+            },
+            {
+              "key": "b",
+              "value": {
+                "kind": "union",
+                "variant_index": 1,
+                "variant": {
+                  "kind": "bool",
+                  "bool": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "m": {
+      "a": "v",
+      "b": true
+    }
+  },
+  "expected": {
+    "m": {
+      "a": "v",
+      "b": true
+    }
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    },
+    "union_choices": {
+      ".m[\"a\"]": {
+        "index": 0,
+        "kind": "string",
+        "variant_count": 2
+      },
+      ".m[\"b\"]": {
+        "index": 1,
+        "kind": "bool",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/static/08_static_union_nested_inside_union.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/08_static_union_nested_inside_union.json
@@ -1,0 +1,87 @@
+{
+  "name": "static_union_nested_inside_union",
+  "seed": 9,
+  "case_index": 8,
+  "mode": "static_prompt",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "x",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {
+                  "kind": "union",
+                  "variants": [
+                    {
+                      "kind": "string"
+                    },
+                    {
+                      "kind": "int"
+                    }
+                  ]
+                },
+                {
+                  "kind": "bool"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "x",
+        "value": {
+          "kind": "union",
+          "variant": {
+            "kind": "union",
+            "variant_index": 1,
+            "variant": {
+              "kind": "int",
+              "int": 123
+            }
+          }
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "x": 123
+  },
+  "expected": {
+    "x": 123
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    },
+    "union_choices": {
+      ".x": {
+        "index": 0,
+        "kind": "union",
+        "variant_count": 2
+      },
+      ".x:v": {
+        "index": 1,
+        "kind": "int",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/static/09_static_union_t_null.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/09_static_union_t_null.json
@@ -1,0 +1,70 @@
+{
+  "name": "static_union_t_null",
+  "seed": 10,
+  "case_index": 9,
+  "mode": "static_prompt",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "maybe",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {
+                  "kind": "string"
+                },
+                {
+                  "kind": "null"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "maybe",
+        "value": {
+          "kind": "union",
+          "variant_index": 1,
+          "variant": {
+            "kind": "null"
+          }
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "maybe": null
+  },
+  "expected": {
+    "maybe": null
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    },
+    "union_choices": {
+      ".maybe": {
+        "index": 1,
+        "kind": "null",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/static/10_static_raw_top_level_union.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/10_static_raw_top_level_union.json
@@ -1,0 +1,45 @@
+{
+  "name": "static_raw_top_level_union",
+  "seed": 11,
+  "case_index": 10,
+  "mode": "static_prompt",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [],
+    "enums": [],
+    "root_class": "",
+    "root_type": {
+      "kind": "union",
+      "variants": [
+        {
+          "kind": "string"
+        },
+        {
+          "kind": "int"
+        }
+      ]
+    },
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": true
+  },
+  "value": {
+    "kind": "union",
+    "variant": {
+      "kind": "string",
+      "string": "top-level"
+    }
+  },
+  "mock_llm_content": "top-level",
+  "expected": "top-level",
+  "metadata": {
+    "union_choices": {
+      "": {
+        "index": 0,
+        "kind": "string",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -170,29 +170,25 @@ func fnv64aString(s string) uint64 {
 }
 
 // buildRapidCase synthesizes one OracleCase by drawing a dynamic-safe
-// schema + value deterministically from seed. Generator.Example is the
-// rapid API for one-shot seeded draws; rapid.Check uses unstable
-// internal selection that we don't need for the dynamic three-way oracle.
+// schema + value deterministically from seed. Uses bamlfuzz.CoupledCaseGen
+// so the value generator's union-choice metadata + the Move B
+// shrink-biased collapse pass land on the case together — the
+// integration test then runs the three-way oracle against the (possibly
+// collapsed) schema/value pair.
 func buildRapidCase(t *testing.T, seed uint64, preserve bool, idx int) bamlfuzz.OracleCase {
 	t.Helper()
-	schemaSeed := int(seed)
-	schema := bamlfuzz.DynamicSafeSchemaGen().Example(schemaSeed)
-	value := bamlfuzz.ValueGen(schema).Example(schemaSeed + 1)
-	walk, err := bamlfuzz.Walk(schema, value)
-	if err != nil {
-		t.Fatalf("walk: %v", err)
-	}
+	cc := bamlfuzz.CoupledCaseGen(bamlfuzz.DynamicSafeSchemaGen()).Example(int(seed))
 	return bamlfuzz.OracleCase{
 		Name:                fmt.Sprintf("rapid_%t_%d", preserve, idx),
 		Seed:                int64(seed),
 		CaseIndex:           idx,
 		Mode:                bamlfuzz.OracleDynamicThreeWay,
 		PreserveSchemaOrder: preserve,
-		Schema:              schema,
-		Value:               value,
-		MockLLMContent:      walk.MockLLMContent,
-		Expected:            walk.Expected,
-		Metadata:            walk.Metadata,
+		Schema:              cc.Schema,
+		Value:               cc.Value,
+		MockLLMContent:      cc.Walk.MockLLMContent,
+		Expected:            cc.Walk.Expected,
+		Metadata:            cc.Walk.Metadata,
 	}
 }
 
@@ -391,7 +387,7 @@ func checkSchemaOrder(t *testing.T, c bamlfuzz.OracleCase, envelope *bamlfuzz.Dy
 	if !c.PreserveSchemaOrder {
 		return
 	}
-	diffs, err := bamlfuzz.SchemaOrderDiff(label, c.Schema, expected, actual)
+	diffs, err := bamlfuzz.SchemaOrderDiffWithChoices(label, c.Schema, expected, actual, c.Metadata.UnionChoices)
 	switch {
 	case errors.Is(err, bamlfuzz.ErrSchemaOrderUnsupported):
 		t.Logf("schema order check skipped for %s %s: %v", c.Name, label, err)

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -82,13 +82,23 @@ func TestBamlfuzzStaticOracle(t *testing.T) {
 	if len(corpus) == 0 {
 		t.Fatalf("static corpus at %s is empty — PR-C must ship hand-curated cases", staticOracleCorpusDir)
 	}
-	if len(corpus) != staticCasesPerBatch {
-		t.Fatalf("corpus must have exactly %d cases for one batch, got %d", staticCasesPerBatch, len(corpus))
-	}
 
-	t.Run("corpus", func(t *testing.T) {
-		runStaticBatch(t, corpus, "corpus", staticCaseSourceCorpus)
-	})
+	// Chunk the corpus into batches of staticCasesPerBatch so a single
+	// build always covers at most five functions. The union expansion
+	// of the corpus pushes the count past one batch; each batch keeps
+	// the build-failure-isolation contract from D4.
+	corpusBatches := chunkStaticCorpus(corpus, staticCasesPerBatch)
+	for i, batch := range corpusBatches {
+		i := i
+		batch := batch
+		label := "corpus"
+		if len(corpusBatches) > 1 {
+			label = fmt.Sprintf("corpus_batch_%d", i)
+		}
+		t.Run(label, func(t *testing.T) {
+			runStaticBatch(t, batch, label, staticCaseSourceCorpus)
+		})
+	}
 
 	rapidBatches := envIntDefault("BAMLFUZZ_STATIC_BATCHES", 1)
 	for b := 0; b < rapidBatches; b++ {
@@ -98,6 +108,25 @@ func TestBamlfuzzStaticOracle(t *testing.T) {
 			runStaticBatch(t, cases, fmt.Sprintf("rapid_batch_%d", b), staticCaseSourceRapid)
 		})
 	}
+}
+
+// chunkStaticCorpus splits cases into consecutive batches of at most
+// batchSize entries. The last batch may be smaller; an empty input
+// returns nil. Used so a corpus that exceeds the locked five-function
+// batch ceiling still fits the build-isolation harness.
+func chunkStaticCorpus(cases []bamlfuzz.OracleCase, batchSize int) [][]bamlfuzz.OracleCase {
+	if len(cases) == 0 {
+		return nil
+	}
+	var out [][]bamlfuzz.OracleCase
+	for i := 0; i < len(cases); i += batchSize {
+		end := i + batchSize
+		if end > len(cases) {
+			end = len(cases)
+		}
+		out = append(out, cases[i:end])
+	}
+	return out
 }
 
 // staticCaseSource mirrors caseSource from the dynamic oracle: corpus
@@ -255,7 +284,7 @@ func runOneStaticCase(t *testing.T, env *testutil.TestEnvironment, mockClient *m
 		return
 	}
 	if lc.Case.PreserveSchemaOrder {
-		diffs, err := bamlfuzz.SchemaOrderDiff("expected_vs_rest", lc.Case.Schema, lc.Case.Expected, resp.Body)
+		diffs, err := bamlfuzz.SchemaOrderDiffWithChoices("expected_vs_rest", lc.Case.Schema, lc.Case.Expected, resp.Body, lc.Case.Metadata.UnionChoices)
 		switch {
 		case errors.Is(err, bamlfuzz.ErrSchemaOrderUnsupported):
 			t.Logf("schema order check skipped for %s: %v", lc.Case.Name, err)
@@ -536,32 +565,28 @@ func staticReproductionFor(c bamlfuzz.OracleCase, caseIdx int, batchLabel string
 }
 
 // buildStaticRapidBatch draws `n` static-mode cases deterministically
-// from a seed derived from batchIdx. Uses bamlfuzz.StaticSchemaGen so
-// self-ref and mutual-cycle schemas appear at scope D9's density. Each
-// case is materialised into an OracleCase up front so a failure
-// envelope can describe the exact shape that triggered the bug.
+// from a seed derived from batchIdx. Uses bamlfuzz.CoupledCaseGen so
+// the union-aware Move B shrink-biased collapse pass and the value
+// generator's choice metadata land on the case together. Each case
+// is materialised into an OracleCase up front so a failure envelope
+// can describe the exact shape that triggered the bug.
 func buildStaticRapidBatch(t *testing.T, batchIdx int, n int) []bamlfuzz.OracleCase {
 	t.Helper()
 	cases := make([]bamlfuzz.OracleCase, n)
 	for i := 0; i < n; i++ {
 		seed := staticSeedFor(batchIdx, i)
-		schema := bamlfuzz.StaticSchemaGen().Example(int(seed))
-		value := bamlfuzz.ValueGen(schema).Example(int(seed) + 1)
-		walk, err := bamlfuzz.Walk(schema, value)
-		if err != nil {
-			t.Fatalf("walk batch=%d idx=%d: %v", batchIdx, i, err)
-		}
+		cc := bamlfuzz.CoupledCaseGen(bamlfuzz.StaticSchemaGen()).Example(int(seed))
 		cases[i] = bamlfuzz.OracleCase{
 			Name:                fmt.Sprintf("rapid_b%d_c%d", batchIdx, i),
 			Seed:                int64(seed),
 			CaseIndex:           i,
 			Mode:                bamlfuzz.OracleStaticPrompt,
 			PreserveSchemaOrder: i%2 == 0,
-			Schema:              schema,
-			Value:               value,
-			MockLLMContent:      walk.MockLLMContent,
-			Expected:            walk.Expected,
-			Metadata:            walk.Metadata,
+			Schema:              cc.Schema,
+			Value:               cc.Value,
+			MockLLMContent:      cc.Walk.MockLLMContent,
+			Expected:            cc.Walk.Expected,
+			Metadata:            cc.Walk.Metadata,
 		}
 	}
 	return cases

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -548,9 +548,15 @@ func staticReproductionFor(c bamlfuzz.OracleCase, caseIdx int, batchLabel string
 	}
 	segments := []string{"^TestBamlfuzzStaticOracle$"}
 	switch source {
-	case staticCaseSourceCorpus:
-		segments = append(segments, "^corpus$", "^"+regexp.QuoteMeta(leaf)+"$")
-	case staticCaseSourceRapid:
+	case staticCaseSourceCorpus, staticCaseSourceRapid:
+		// Both sources use the parent's actual batch label. The
+		// corpus path used to be hardcoded to "^corpus$", but
+		// chunkStaticCorpus emits "corpus_batch_<i>" subtest names
+		// when there is more than one batch, so the repro command
+		// would not select the failing case for any non-first
+		// corpus batch. Routing the label through here keeps the
+		// repro string aligned with the subtest tree the harness
+		// actually builds.
 		segments = append(segments,
 			"^"+regexp.QuoteMeta(batchLabel)+"$",
 			"^"+regexp.QuoteMeta(leaf)+"$",
@@ -724,6 +730,34 @@ func TestStaticReproductionFor(t *testing.T) {
 	wantWithSeed := "BAMLFUZZ_SEED=9999 go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^corpus$/^scalar_object$' ./integration -count=1"
 	if withSeed != wantWithSeed {
 		t.Errorf("corpus+seed repro:\n got:  %s\n want: %s", withSeed, wantWithSeed)
+	}
+
+	// Corpus chunking with more than one batch emits
+	// "corpus_batch_<i>" subtest names. The repro command must use
+	// that exact label, including the isolated leaf shape, so the
+	// developer can copy-paste straight from the envelope.
+	t.Setenv("BAMLFUZZ_SEED", "")
+	corpusBatch := staticReproductionFor(
+		bamlfuzz.OracleCase{Name: "raw_union_root"},
+		1,
+		"corpus_batch_3",
+		staticCaseSourceCorpus,
+		false,
+	)
+	wantCorpusBatch := "go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^corpus_batch_3$/^raw_union_root$' ./integration -count=1"
+	if corpusBatch != wantCorpusBatch {
+		t.Errorf("corpus_batch repro:\n got:  %s\n want: %s", corpusBatch, wantCorpusBatch)
+	}
+	corpusBatchIsolated := staticReproductionFor(
+		bamlfuzz.OracleCase{Name: "raw_union_root"},
+		1,
+		"corpus_batch_3",
+		staticCaseSourceCorpus,
+		true,
+	)
+	wantCorpusBatchIsolated := "go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^corpus_batch_3$/^raw_union_root_isolated$' ./integration -count=1"
+	if corpusBatchIsolated != wantCorpusBatchIsolated {
+		t.Errorf("corpus_batch isolated repro:\n got:  %s\n want: %s", corpusBatchIsolated, wantCorpusBatchIsolated)
 	}
 }
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Implements the v1.1 union support item from issue #349. Scope doc:
`notes/issue-349-unions-scope.md` (local; D1–D19 + locked scope cuts).

## Summary

- **IR**: `KindUnion` is a first-class `FuzzType` carrying ordered
  `Variants []FuzzType`. `FuzzValue` gains `VariantIndex` + `Variant`.
  `CaseMetadata.UnionChoices` records per-path `UnionChoice` so the
  walker, normalizer, and order checker can resolve the picked arm
  without re-deriving it.
- **Effective root**: `FuzzSchema.RootType` is optional; when nil the
  schema falls back to `RootClass` so v1 corpus files decode
  unchanged. `EffectiveRoot()` collapses the two into one return
  type for emitters, walker, and order checker.
- **Generator**: `drawType` produces unions at a low probability with
  `MinUnionVariants`/`MaxUnionVariants` bounds, recursing through
  variants for unions-of-unions. `ValueGen` picks a depth-safe arm.
  `CoupledCaseGen` ships (schema, value, walk) together and applies
  the Move B shrink-biased union collapse where every class-instance
  visit picked the same arm.
- **Emitters**: dynamic lowers `KindUnion` to `type: "union"` + `OneOf`;
  raw non-class roots are rejected with `ErrDynamicRootTypeUnsupported`
  (wrapping `ErrDynamicSchemaUnsupported`) so the production
  `/call/_dynamic` contract stays object-shaped. Static lowers
  pipe-separated variants with outer parens inside wrappers; the
  function-return-type form omits the parens; single-arm shrink
  states render as the bare variant so emitted BAML stays valid;
  raw top-level unions flow through `returnTypeSpelling`.
- **Order checker**: `SchemaOrderDiffWithChoices` consults the
  recorded `UnionChoices` to descend into the picked arm. Missing or
  inconsistent metadata returns `ErrSchemaOrderUnsupported` (fail
  closed; semantic checks still run).
- **Walker / normalizer**: both step the path with `":v"` on union
  descent so nested unions keep distinct entries; both fail closed
  when an entry is missing.
- **Seed corpus**: curated dynamic + static seeds covering class
  field, list element, map value, nested-in-union, T|null, and a
  static-only raw top-level union. Existing v1 seeds preserved
  byte-for-byte (empty UnionChoices omits via `omitempty`).
- **Integration**: both oracles switch rapid construction to
  `CoupledCaseGen` and pass the choices map into the order check.
  The static harness chunks the corpus into 5-function batches now
  that union seeds push it past one batch.
- `GeneratorVersion` bumps to `0.2.0`.

Scope cuts (locked, unchanged): `Optional` stays separate from
unions; the `/call/_dynamic` API is not extended for raw non-class
roots; no invalid-schema fuzzing in this PR.

## Test plan

- [x] `go build ./...`
- [x] `cd bamlutils && go test ./... -race -count=1`
- [x] `cd adapters/common && GOWORK=off go test ./... -race -count=1`
- [x] `cd cmd/hacks && go test ./... -count=1`
- [x] `cd dynclient && GOWORK=off go test ./...`
- [x] `cd cmd/serve && go test ./...`
- [x] `go test -tags integration -c -o /dev/null ./integration/...`
- [x] `go vet ./...`
- [x] `go run ./cmd/embed && git diff embed.go` (empty)
- [x] Banned-phrase grep: 0 matches
- [ ] Integration matrix runs against the new dynamic + static union seeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end union-type support: per-path union-choice metadata and optional non-class (raw) roots; generators can produce coupled schema+value cases.

* **Behavior**
  * Emitters, normalization, ordering checks and generation are union-aware; they collapse single-variant unions, render multi-variant unions, and fail closed on missing or stale union-choice data. Static corpus processing now runs in batches.

* **Tests**
  * Extensive union-focused unit/integration tests and many new union JSON fixtures.

* **Chores**
  * Generator version bumped to 0.2.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->