### PR TITLE
feat(bamlfuzz): strict key-order assertions across nested classes + map policy (#370)

### DIFF
--- a/adapters/common/codegen/bamlfuzz/envelope.go
+++ b/adapters/common/codegen/bamlfuzz/envelope.go
@@ -24,12 +24,12 @@ const GeneratorVersion = "0.2.0"
 // dynclient / REST). Release gates: semantic equality always, and
 // schema-aware key order at every class instance when
 // PreserveSchemaOrder is true (see SchemaOrderDiff). Strict order
-// mismatches are recorded under OrderWarning for replay; schemas
-// the order checker cannot resolve (missing union-choice metadata)
-// skip the assertion with a log line only and don't populate
-// OrderWarning. Per-arm union choices travel in Metadata.UnionChoices
-// so a developer reading the envelope can see exactly which variant
-// the value walker selected at each union node.
+// mismatches and schemas the order checker cannot resolve (e.g.
+// missing union-choice metadata) are both release-blocking; the
+// diagnostic lands on OrderWarning before the envelope is dumped.
+// Per-arm union choices travel in Metadata.UnionChoices so a
+// developer reading the envelope can see exactly which variant the
+// value walker selected at each union node.
 type DynamicFailureEnvelope struct {
 	GeneratorVersion    string                         `json:"generator_version"`
 	GeneratedAt         string                         `json:"generated_at"`
@@ -71,9 +71,9 @@ type SemanticDiffEntry struct {
 // common header fields and adds the static-specific lowering + build
 // metadata listed in scope D8. Release gates: semantic equality
 // always, and schema-aware key order at every class instance when
-// PreserveSchemaOrder is true. Strict order mismatches are recorded
-// under OrderWarning for replay; unsupported schemas skip the order
-// assertion with a log line only and don't populate OrderWarning.
+// PreserveSchemaOrder is true. Strict order mismatches and schemas
+// the order checker cannot resolve are both release-blocking; the
+// diagnostic lands on OrderWarning before the envelope is dumped.
 //
 // BuildError populates when the integration build fails for the case;
 // after single-case isolation it identifies the offending case alone.

--- a/adapters/common/codegen/bamlfuzz/normalize.go
+++ b/adapters/common/codegen/bamlfuzz/normalize.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+
+	"github.com/invakid404/baml-rest/bamlutils"
 )
 
 // WalkResult captures the two JSON renderings the oracle paths need
@@ -35,8 +37,10 @@ type WalkResult struct {
 // Field iteration follows the class's declaration order so the
 // emitted JSON is byte-stable across runs at the same seed.
 // Per-instance map values inside the value tree iterate in the
-// FuzzValue.MapEntries order (also generator-determined), so those
-// too are stable. Union values are rendered via the recorded
+// FuzzValue.MapEntries slice order verbatim — the walker no longer
+// sorts map keys, which lets the strict map key-order assertion in
+// order.go's walkType(KindMap) actually exercise non-lexicographic
+// orders end-to-end. Union values are rendered via the recorded
 // VariantIndex / Variant fields; the walker fails closed when a
 // union value lacks a recorded choice.
 func Walk(schema FuzzSchema, value FuzzValue) (WalkResult, error) {
@@ -212,8 +216,7 @@ func (s *walkState) renderValueMock(buf *bytes.Buffer, t FuzzType, val FuzzValue
 			return fmt.Errorf("walk: map type missing inner at %q", path)
 		}
 		buf.WriteByte('{')
-		entries := sortedMapEntries(val.MapEntries)
-		for i, entry := range entries {
+		for i, entry := range val.MapEntries {
 			if i > 0 {
 				buf.WriteByte(',')
 			}
@@ -303,8 +306,7 @@ func (s *walkState) renderValueExpected(buf *bytes.Buffer, t FuzzType, val FuzzV
 			return fmt.Errorf("expected: map type missing inner")
 		}
 		buf.WriteByte('{')
-		entries := sortedMapEntries(val.MapEntries)
-		for i, entry := range entries {
+		for i, entry := range val.MapEntries {
 			if i > 0 {
 				buf.WriteByte(',')
 			}
@@ -382,11 +384,11 @@ func writeLiteral(buf *bytes.Buffer, lit *FuzzLiteral) error {
 // NormalizeMockToExpected re-parses `mock` and walks the schema's
 // class graph to insert JSON null for every optional field that the
 // LLM omitted. The returned bytes are the canonical-equivalent of
-// the walker's Expected output, modulo encoding/json's map-key
-// sorting (top-level class field order still follows the schema).
-//
-// This is the invariant the tests assert: walking (mock) ->
-// normalize -> bytes-equal walker's expected.
+// the walker's Expected output: class instance keys follow schema
+// declaration order, and map keys retain the mock's wire order —
+// which, given a well-formed mock, mirrors FuzzValue.MapEntries
+// insertion order. This is the invariant the tests assert: walking
+// (mock) -> normalize -> bytes-equal walker's expected.
 //
 // Union schemas require union-choice metadata to disambiguate which
 // arm produced the mock; call NormalizeMockToExpectedWithChoices
@@ -409,8 +411,8 @@ func NormalizeMockToExpected(schema FuzzSchema, mock json.RawMessage, rootClass 
 // only as a fallback for callers that supply it before RootType was
 // added to the IR.
 func NormalizeMockToExpectedWithChoices(schema FuzzSchema, mock json.RawMessage, rootClass string, choices map[string]UnionChoice) (json.RawMessage, error) {
-	var raw any
-	if err := json.Unmarshal(mock, &raw); err != nil {
+	raw, err := decodePreserveOrder(mock)
+	if err != nil {
 		return nil, fmt.Errorf("normalize: parse mock: %w", err)
 	}
 	root := effectiveNormalizeRoot(schema, rootClass)
@@ -419,6 +421,66 @@ func NormalizeMockToExpectedWithChoices(schema FuzzSchema, mock json.RawMessage,
 		return nil, err
 	}
 	return marshalSchemaOrdered(schema, root, out, choices)
+}
+
+// decodePreserveOrder decodes JSON into an `any`-shaped tree where
+// every object node is a *bamlutils.OrderedMap[any] keyed in wire
+// order. Arrays become []any whose elements are recursively decoded
+// the same way; scalars and nulls decode through encoding/json's
+// default rules. The order-preserving carrier is what lets the
+// normalizer emit map values in the mock's wire order, so the
+// round-trip against the walker's MapEntries insertion order is
+// byte-stable.
+func decodePreserveOrder(data json.RawMessage) (any, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("empty JSON payload")
+	}
+	switch trimmed[0] {
+	case '{':
+		var raw bamlutils.OrderedMap[json.RawMessage]
+		if err := raw.UnmarshalJSON(data); err != nil {
+			return nil, err
+		}
+		out := &bamlutils.OrderedMap[any]{}
+		var firstErr error
+		raw.Range(func(k string, v json.RawMessage) bool {
+			child, err := decodePreserveOrder(v)
+			if err != nil {
+				firstErr = fmt.Errorf("%s: %w", k, err)
+				return false
+			}
+			if err := out.Set(k, child); err != nil {
+				firstErr = err
+				return false
+			}
+			return true
+		})
+		if firstErr != nil {
+			return nil, firstErr
+		}
+		return out, nil
+	case '[':
+		var rawArr []json.RawMessage
+		if err := json.Unmarshal(data, &rawArr); err != nil {
+			return nil, err
+		}
+		arr := make([]any, len(rawArr))
+		for i, r := range rawArr {
+			v, err := decodePreserveOrder(r)
+			if err != nil {
+				return nil, fmt.Errorf("[%d]: %w", i, err)
+			}
+			arr[i] = v
+		}
+		return arr, nil
+	default:
+		var v any
+		if err := json.Unmarshal(data, &v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	}
 }
 
 // effectiveNormalizeRoot picks the FuzzType to normalize and re-emit
@@ -437,18 +499,18 @@ func effectiveNormalizeRoot(schema FuzzSchema, rootClass string) FuzzType {
 	return schema.EffectiveRoot()
 }
 
-func normalizeClass(schema FuzzSchema, className string, raw any, basePath string, choices map[string]UnionChoice) (map[string]any, error) {
+func normalizeClass(schema FuzzSchema, className string, raw any, basePath string, choices map[string]UnionChoice) (*bamlutils.OrderedMap[any], error) {
 	cls, ok := schema.FindClass(className)
 	if !ok {
 		return nil, fmt.Errorf("normalize: unknown class %q", className)
 	}
-	obj, ok := raw.(map[string]any)
+	obj, ok := raw.(*bamlutils.OrderedMap[any])
 	if !ok {
 		return nil, fmt.Errorf("normalize: class %q expected JSON object, got %T", className, raw)
 	}
-	out := make(map[string]any, len(cls.Properties))
+	out := &bamlutils.OrderedMap[any]{}
 	for _, prop := range cls.Properties {
-		fv, present := obj[prop.Name]
+		fv, present := obj.Get(prop.Name)
 		if !present {
 			// Absent optionals normalize to null; absent non-
 			// optionals are a contract violation upstream of the
@@ -456,14 +518,18 @@ func normalizeClass(schema FuzzSchema, className string, raw any, basePath strin
 			if prop.Type.Kind != KindOptional {
 				return nil, fmt.Errorf("normalize: required field %q on %q missing from mock", prop.Name, className)
 			}
-			out[prop.Name] = nil
+			if err := out.Set(prop.Name, nil); err != nil {
+				return nil, err
+			}
 			continue
 		}
 		nv, err := normalizeValue(schema, prop.Type, fv, basePath+"."+prop.Name, choices)
 		if err != nil {
 			return nil, fmt.Errorf("normalize: field %q on %q: %w", prop.Name, className, err)
 		}
-		out[prop.Name] = nv
+		if err := out.Set(prop.Name, nv); err != nil {
+			return nil, err
+		}
 	}
 	return out, nil
 }
@@ -503,17 +569,26 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices
 		if raw == nil {
 			return nil, nil
 		}
-		obj, ok := raw.(map[string]any)
+		obj, ok := raw.(*bamlutils.OrderedMap[any])
 		if !ok {
 			return nil, fmt.Errorf("map expected object, got %T", raw)
 		}
-		out := make(map[string]any, len(obj))
-		for k, v := range obj {
+		out := &bamlutils.OrderedMap[any]{}
+		var firstErr error
+		obj.Range(func(k string, v any) bool {
 			nv, err := normalizeValue(schema, *t.Inner, v, fmt.Sprintf("%s[%q]", path, k), choices)
 			if err != nil {
-				return nil, fmt.Errorf("map[%q]: %w", k, err)
+				firstErr = fmt.Errorf("map[%q]: %w", k, err)
+				return false
 			}
-			out[k] = nv
+			if err := out.Set(k, nv); err != nil {
+				firstErr = err
+				return false
+			}
+			return true
+		})
+		if firstErr != nil {
+			return nil, firstErr
 		}
 		return out, nil
 	case KindClassRef:
@@ -533,9 +608,11 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices
 }
 
 // marshalSchemaOrdered re-emits a normalized value as JSON with
-// class-instance keys in schema declaration order. Inner map keys
-// retain encoding/json's alphabetical order — they're not class
-// instances, so there's no schema-defined ordering to preserve.
+// class-instance keys in schema declaration order and inner map
+// keys in the carrier's recorded insertion order. The carrier is
+// the *bamlutils.OrderedMap[any] tree produced by normalizeClass /
+// normalizeValue (which themselves consume the decodePreserveOrder
+// output, so wire order from the mock flows through unchanged).
 // Union arms inside the type tree resolve through `choices`. The
 // `root` FuzzType drives dispatch directly, so raw-root
 // union/list/map/scalar schemas are walked as-is without going
@@ -553,7 +630,7 @@ func writeOrderedClass(buf *bytes.Buffer, schema FuzzSchema, className string, v
 	if !ok {
 		return fmt.Errorf("ordered: unknown class %q", className)
 	}
-	obj, ok := v.(map[string]any)
+	obj, ok := v.(*bamlutils.OrderedMap[any])
 	if !ok {
 		return fmt.Errorf("ordered: class %q expected object, got %T", className, v)
 	}
@@ -568,7 +645,8 @@ func writeOrderedClass(buf *bytes.Buffer, schema FuzzSchema, className string, v
 		}
 		buf.Write(keyBytes)
 		buf.WriteByte(':')
-		if err := writeOrderedValue(buf, schema, prop.Type, obj[prop.Name], path+"."+prop.Name, choices); err != nil {
+		fv, _ := obj.Get(prop.Name)
+		if err := writeOrderedValue(buf, schema, prop.Type, fv, path+"."+prop.Name, choices); err != nil {
 			return err
 		}
 	}
@@ -609,30 +687,38 @@ func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any, 
 			buf.WriteString("null")
 			return nil
 		}
-		// Sort the keys ourselves so the byte-stream matches the
-		// walker's lexicographic emission order. encoding/json's
-		// map encoder also sorts alphabetically, but going through
-		// it would re-emit any class-instance map without the
-		// schema-ordered field layout we need at outer levels.
-		obj, ok := v.(map[string]any)
+		// Emit map values in the carrier's recorded insertion order
+		// (the OrderedMap[any] tree threaded through from the mock
+		// via decodePreserveOrder). This matches the walker's
+		// FuzzValue.MapEntries slice-order emission, so the
+		// (walk → normalize) round-trip is byte-stable.
+		obj, ok := v.(*bamlutils.OrderedMap[any])
 		if !ok {
 			return fmt.Errorf("map expected object, got %T", v)
 		}
-		keys := sortedKeys(obj)
 		buf.WriteByte('{')
-		for i, k := range keys {
+		i := 0
+		var firstErr error
+		obj.Range(func(k string, mv any) bool {
 			if i > 0 {
 				buf.WriteByte(',')
 			}
+			i++
 			kb, err := json.Marshal(k)
 			if err != nil {
-				return err
+				firstErr = err
+				return false
 			}
 			buf.Write(kb)
 			buf.WriteByte(':')
-			if err := writeOrderedValue(buf, schema, *t.Inner, obj[k], fmt.Sprintf("%s[%q]", path, k), choices); err != nil {
-				return err
+			if err := writeOrderedValue(buf, schema, *t.Inner, mv, fmt.Sprintf("%s[%q]", path, k), choices); err != nil {
+				firstErr = err
+				return false
 			}
+			return true
+		})
+		if firstErr != nil {
+			return firstErr
 		}
 		buf.WriteByte('}')
 		return nil
@@ -658,31 +744,3 @@ func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any, 
 	}
 }
 
-// sortedMapEntries returns a copy of entries sorted lexicographically
-// by Key. encoding/json's map encoder uses the same comparison, so
-// emitting in sorted order keeps walker output byte-identical to a
-// post-normalize round-trip through encoding/json.
-func sortedMapEntries(entries []FuzzMapEntry) []FuzzMapEntry {
-	out := make([]FuzzMapEntry, len(entries))
-	copy(out, entries)
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1].Key > out[j].Key; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
-	return out
-}
-
-func sortedKeys(m map[string]any) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	// Insertion sort (n ≤ 3 in v1).
-	for i := 1; i < len(keys); i++ {
-		for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
-			keys[j-1], keys[j] = keys[j], keys[j-1]
-		}
-	}
-	return keys
-}

--- a/adapters/common/codegen/bamlfuzz/order.go
+++ b/adapters/common/codegen/bamlfuzz/order.go
@@ -16,9 +16,10 @@ import (
 // additional metadata. Today this fires when a union node is
 // reached without a recorded UnionChoice entry — the walker has no
 // canonical "expected order" for a union value without knowing
-// which arm produced it. Callers detect with errors.Is and
-// typically skip the order assertion while still running the
-// semantic-equality checks.
+// which arm produced it. The integration oracles treat this as a
+// hard failure because UnionChoices are propagated for every union
+// path the walker visits; a missing or stale choice is an integrity
+// bug, not a skippable shape.
 var ErrSchemaOrderUnsupported = errors.New("bamlfuzz: schema order check unsupported")
 
 // SchemaOrderDiffEntry names one schema-order disagreement at a JSON
@@ -43,8 +44,8 @@ type SchemaOrderDiffEntry struct {
 // through `choices` (typically
 // CaseMetadata.UnionChoices from the walker), advancing into the
 // recorded variant arm; a missing or out-of-range entry returns
-// ErrSchemaOrderUnsupported so callers can skip the order assertion
-// without abandoning semantic diagnostics.
+// ErrSchemaOrderUnsupported, which the integration oracles surface
+// as a hard failure (see ErrSchemaOrderUnsupported's doc comment).
 //
 // `label` is opaque and is stored on every emitted entry's Side field.
 //

--- a/adapters/common/codegen/bamlfuzz/order.go
+++ b/adapters/common/codegen/bamlfuzz/order.go
@@ -35,10 +35,12 @@ type SchemaOrderDiffEntry struct {
 }
 
 // SchemaOrderDiff walks `expected` and `actual` in parallel with
-// `schema`, asserting wire key order only at JSON nodes the schema
-// types as a class instance. Map nodes participate in recursion but
-// their key order is not asserted; map values are walked through the
-// inner type. Union nodes resolve through `choices` (typically
+// `schema`, asserting wire key order at JSON nodes the schema types
+// as either a class instance or a map. The map-key contract is
+// insertion order: FuzzValue.MapEntries carries the request's
+// insertion order and the wire is expected to echo it back. Map
+// values are then walked through the inner type. Union nodes resolve
+// through `choices` (typically
 // CaseMetadata.UnionChoices from the walker), advancing into the
 // recorded variant arm; a missing or out-of-range entry returns
 // ErrSchemaOrderUnsupported so callers can skip the order assertion
@@ -252,6 +254,14 @@ func (w *orderWalker) walkType(path string, typ FuzzType, exp, got orderedJSON) 
 		}
 		if exp.kind != orderedObject || got.kind != orderedObject {
 			return
+		}
+		if !slices.Equal(exp.keys, got.keys) {
+			w.diffs = append(w.diffs, SchemaOrderDiffEntry{
+				Side:     w.side,
+				Path:     path,
+				Expected: append([]string{}, exp.keys...),
+				Actual:   append([]string{}, got.keys...),
+			})
 		}
 		for _, key := range sortedIntersection(exp.byKey, got.byKey) {
 			w.walkType(fmt.Sprintf("%s[%q]", path, key), *typ.Inner, exp.byKey[key], got.byKey[key])

--- a/adapters/common/codegen/bamlfuzz/order_test.go
+++ b/adapters/common/codegen/bamlfuzz/order_test.go
@@ -249,8 +249,8 @@ func TestSchemaOrderDiff_MissingExtraKeysDoNotPanic(t *testing.T) {
 // TestSchemaOrderDiff_UnionWithoutChoiceReturnsUnsupported pins the
 // union contract: when the order walker reaches a KindUnion node
 // without a matching UnionChoices entry, SchemaOrderDiff returns
-// ErrSchemaOrderUnsupported and the caller falls back to
-// semantic-only diagnostics.
+// ErrSchemaOrderUnsupported. The integration oracles promote this
+// to a hard failure (see ErrSchemaOrderUnsupported's doc comment).
 func TestSchemaOrderDiff_UnionWithoutChoiceReturnsUnsupported(t *testing.T) {
 	schema := FuzzSchema{
 		Classes: []FuzzClass{{

--- a/adapters/common/codegen/bamlfuzz/order_test.go
+++ b/adapters/common/codegen/bamlfuzz/order_test.go
@@ -183,7 +183,10 @@ func TestSchemaOrderDiff_OptionalNullDoesNotRecurse(t *testing.T) {
 	}
 }
 
-func TestSchemaOrderDiff_MapKeyReorderingIgnored(t *testing.T) {
+// TestSchemaOrderDiff_MapKeyReorderFlagged pins the map insertion-order
+// policy: FuzzValue.MapEntries carries the request's insertion order;
+// the wire must echo it back when preserve_schema_order=true.
+func TestSchemaOrderDiff_MapKeyReorderFlagged(t *testing.T) {
 	outer := FuzzClass{Name: "Root", Properties: []FuzzProperty{
 		{Name: "by_id", Type: mapOf(FuzzType{Kind: KindInt})},
 	}}
@@ -195,8 +198,11 @@ func TestSchemaOrderDiff_MapKeyReorderingIgnored(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SchemaOrderDiff: %v", err)
 	}
-	if len(diffs) != 0 {
-		t.Errorf("map key reorder should be ignored, got %v", diffs)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d (%v)", len(diffs), diffs)
+	}
+	if diffs[0].Path != "$.by_id" {
+		t.Errorf("path: got %q want %q", diffs[0].Path, "$.by_id")
 	}
 }
 

--- a/adapters/common/codegen/bamlfuzz/order_test.go
+++ b/adapters/common/codegen/bamlfuzz/order_test.go
@@ -512,6 +512,168 @@ func TestFormatSchemaOrderDiffs(t *testing.T) {
 	}
 }
 
+// TestSchemaOrderDiffMapInsertionOrderMismatch pins the D1 map policy
+// directly: insertion-order swap surfaces a single diff entry at the
+// map node's own path.
+func TestSchemaOrderDiffMapInsertionOrderMismatch(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "m", Type: FuzzType{
+					Kind:  KindMap,
+					Key:   &FuzzType{Kind: KindString},
+					Inner: &FuzzType{Kind: KindString},
+				}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	exp := json.RawMessage(`{"m":{"kA":"a","kB":"b"}}`)
+	got := json.RawMessage(`{"m":{"kB":"b","kA":"a"}}`)
+	diffs, err := SchemaOrderDiff("side", schema, exp, got)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d (%v)", len(diffs), diffs)
+	}
+	if diffs[0].Path != "$.m" {
+		t.Errorf("path: got %q want %q", diffs[0].Path, "$.m")
+	}
+	if !keysEqual(diffs[0].Expected, []string{"kA", "kB"}) {
+		t.Errorf("expected keys: got %v want %v", diffs[0].Expected, []string{"kA", "kB"})
+	}
+	if !keysEqual(diffs[0].Actual, []string{"kB", "kA"}) {
+		t.Errorf("actual keys: got %v want %v", diffs[0].Actual, []string{"kB", "kA"})
+	}
+}
+
+// TestSchemaOrderDiffMapWithNestedClassPropagates pins that map-key
+// order and nested-class-property order are asserted independently
+// at distinct paths.
+func TestSchemaOrderDiffMapWithNestedClassPropagates(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{
+			{
+				Name: "Root",
+				Properties: []FuzzProperty{
+					{Name: "m", Type: mapOf(classRef("Inner"))},
+				},
+			},
+			{
+				Name: "Inner",
+				Properties: []FuzzProperty{
+					{Name: "a", Type: FuzzType{Kind: KindInt}},
+					{Name: "b", Type: FuzzType{Kind: KindInt}},
+				},
+			},
+		},
+		RootClass: "Root",
+	}
+
+	// Variant 1: map order kept, inner class order swapped → one
+	// diff at $.m["kA"] for the class.
+	exp := json.RawMessage(`{"m":{"kA":{"a":1,"b":2}}}`)
+	got := json.RawMessage(`{"m":{"kA":{"b":2,"a":1}}}`)
+	diffs, err := SchemaOrderDiff("side", schema, exp, got)
+	if err != nil {
+		t.Fatalf("variant 1: SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("variant 1: expected 1 diff, got %d (%v)", len(diffs), diffs)
+	}
+	if diffs[0].Path != `$.m["kA"]` {
+		t.Errorf("variant 1: path: got %q want %q", diffs[0].Path, `$.m["kA"]`)
+	}
+
+	// Variant 2: map order swapped, inner class order kept → one
+	// diff at $.m for the map.
+	exp = json.RawMessage(`{"m":{"kA":{"a":1,"b":2},"kB":{"a":3,"b":4}}}`)
+	got = json.RawMessage(`{"m":{"kB":{"a":3,"b":4},"kA":{"a":1,"b":2}}}`)
+	diffs, err = SchemaOrderDiff("side", schema, exp, got)
+	if err != nil {
+		t.Fatalf("variant 2: SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("variant 2: expected 1 diff, got %d (%v)", len(diffs), diffs)
+	}
+	if diffs[0].Path != "$.m" {
+		t.Errorf("variant 2: path: got %q want %q", diffs[0].Path, "$.m")
+	}
+}
+
+// TestSchemaOrderDiffMapSameOrderPasses asserts identical insertion
+// order on both sides produces no diff entries and no error.
+func TestSchemaOrderDiffMapSameOrderPasses(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "m", Type: mapOf(FuzzType{Kind: KindString})},
+			},
+		}},
+		RootClass: "Root",
+	}
+	exp := json.RawMessage(`{"m":{"kA":"a","kB":"b"}}`)
+	got := json.RawMessage(`{"m":{"kA":"a","kB":"b"}}`)
+	diffs, err := SchemaOrderDiff("side", schema, exp, got)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+// TestSchemaOrderDiffMapStructuralDisagreementSilent pins that the
+// walker silently bails when the two sides disagree on shape at a map
+// node — SemanticDiff is the gate for structural mismatches.
+func TestSchemaOrderDiffMapStructuralDisagreementSilent(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "m", Type: mapOf(FuzzType{Kind: KindString})},
+			},
+		}},
+		RootClass: "Root",
+	}
+	exp := json.RawMessage(`{"m":{"k":"v"}}`)
+	got := json.RawMessage(`{"m":null}`)
+	diffs, err := SchemaOrderDiff("side", schema, exp, got)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("structural disagreement should be silent, got %v", diffs)
+	}
+}
+
+// TestSchemaOrderDiffUnionMissingChoiceReturnsUnsupported pins that
+// a union-rooted schema with zero recorded choices still returns
+// ErrSchemaOrderUnsupported. Exercises the hard-fail wiring end to
+// end: any future regression that strips a choice from the metadata
+// map will surface here.
+func TestSchemaOrderDiffUnionMissingChoiceReturnsUnsupported(t *testing.T) {
+	schema := FuzzSchema{
+		RootType: &FuzzType{
+			Kind: KindUnion,
+			Variants: []FuzzType{
+				{Kind: KindString},
+				{Kind: KindInt},
+			},
+		},
+	}
+	_, err := SchemaOrderDiff("side", schema,
+		json.RawMessage(`"x"`),
+		json.RawMessage(`"x"`),
+	)
+	if !errors.Is(err, ErrSchemaOrderUnsupported) {
+		t.Errorf("got err=%v, want errors.Is(err, ErrSchemaOrderUnsupported)", err)
+	}
+}
+
 func keysEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/adapters/common/codegen/bamlfuzz/schema_test.go
+++ b/adapters/common/codegen/bamlfuzz/schema_test.go
@@ -292,10 +292,13 @@ func TestWalkKindNull(t *testing.T) {
 	}
 }
 
-// TestWalkMapKeysSortLexically asserts the walker emits map entries
-// in lexicographic order regardless of FuzzMapEntries input order.
-// This is the canonical-form invariant the round-trip relies on.
-func TestWalkMapKeysSortLexically(t *testing.T) {
+// TestWalkMapKeysPreserveInsertionOrder asserts the walker emits map
+// entries in FuzzValue.MapEntries slice order, byte-identical for both
+// MockLLMContent and Expected. This is the property the strict
+// map key-order assertion in order.go's walkType(KindMap) relies on:
+// without it, the gate is materially unverified because every walked
+// map already shares the same canonical (sorted) shape.
+func TestWalkMapKeysPreserveInsertionOrder(t *testing.T) {
 	mapType := FuzzType{
 		Kind:  KindMap,
 		Key:   &FuzzType{Kind: KindString},
@@ -310,27 +313,59 @@ func TestWalkMapKeysSortLexically(t *testing.T) {
 		}},
 		RootClass: "FuzzClass0",
 	}
-	value := FuzzValue{
-		Kind:      KindClassRef,
-		ClassName: "FuzzClass0",
-		Fields: []FuzzFieldValue{{
-			Name: "Fuzz_field_0", Value: FuzzValue{
-				Kind: KindMap,
-				MapEntries: []FuzzMapEntry{
-					{Key: "kZ", Value: FuzzValue{Kind: KindInt, Int: 1}},
-					{Key: "kA", Value: FuzzValue{Kind: KindInt, Int: 2}},
-					{Key: "kM", Value: FuzzValue{Kind: KindInt, Int: 3}},
-				},
+	mkValue := func(entries []FuzzMapEntry) FuzzValue {
+		return FuzzValue{
+			Kind:      KindClassRef,
+			ClassName: "FuzzClass0",
+			Fields: []FuzzFieldValue{{
+				Name: "Fuzz_field_0", Value: FuzzValue{Kind: KindMap, MapEntries: entries},
+			}},
+		}
+	}
+	cases := []struct {
+		name    string
+		entries []FuzzMapEntry
+		want    string
+	}{
+		{
+			name: "z_a_m",
+			entries: []FuzzMapEntry{
+				{Key: "kZ", Value: FuzzValue{Kind: KindInt, Int: 1}},
+				{Key: "kA", Value: FuzzValue{Kind: KindInt, Int: 2}},
+				{Key: "kM", Value: FuzzValue{Kind: KindInt, Int: 3}},
 			},
-		}},
+			want: `{"Fuzz_field_0":{"kZ":1,"kA":2,"kM":3}}`,
+		},
+		{
+			name: "m_a_z",
+			entries: []FuzzMapEntry{
+				{Key: "kM", Value: FuzzValue{Kind: KindInt, Int: 1}},
+				{Key: "kA", Value: FuzzValue{Kind: KindInt, Int: 2}},
+				{Key: "kZ", Value: FuzzValue{Kind: KindInt, Int: 3}},
+			},
+			want: `{"Fuzz_field_0":{"kM":1,"kA":2,"kZ":3}}`,
+		},
 	}
-	res, err := Walk(schema, value)
-	if err != nil {
-		t.Fatalf("walk: %v", err)
-	}
-	want := `{"Fuzz_field_0":{"kA":2,"kM":3,"kZ":1}}`
-	if string(res.MockLLMContent) != want {
-		t.Errorf("mock keys not lexicographic\nwant: %s\ngot:  %s", want, string(res.MockLLMContent))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := Walk(schema, mkValue(tc.entries))
+			if err != nil {
+				t.Fatalf("walk: %v", err)
+			}
+			if string(res.MockLLMContent) != tc.want {
+				t.Errorf("mock keys not in MapEntries order\nwant: %s\ngot:  %s", tc.want, string(res.MockLLMContent))
+			}
+			if string(res.Expected) != tc.want {
+				t.Errorf("expected keys not in MapEntries order\nwant: %s\ngot:  %s", tc.want, string(res.Expected))
+			}
+			normalized, err := NormalizeMockToExpected(schema, res.MockLLMContent, "FuzzClass0")
+			if err != nil {
+				t.Fatalf("normalize: %v", err)
+			}
+			if string(normalized) != tc.want {
+				t.Errorf("normalize round-trip not in MapEntries order\nwant: %s\ngot:  %s", tc.want, string(normalized))
+			}
+		})
 	}
 }
 

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -390,10 +390,10 @@ func checkSchemaOrder(t *testing.T, c bamlfuzz.OracleCase, envelope *bamlfuzz.Dy
 	diffs, err := bamlfuzz.SchemaOrderDiffWithChoices(label, c.Schema, expected, actual, c.Metadata.UnionChoices)
 	switch {
 	case errors.Is(err, bamlfuzz.ErrSchemaOrderUnsupported):
-		envelope.OrderWarning = append(envelope.OrderWarning, err.Error())
+		envelope.OrderWarning = append(envelope.OrderWarning, fmt.Sprintf("%s: %v", label, err))
 		*failures = append(*failures, fmt.Sprintf("%s schema order unsupported: %v", label, err))
 	case err != nil:
-		envelope.OrderWarning = append(envelope.OrderWarning, err.Error())
+		envelope.OrderWarning = append(envelope.OrderWarning, fmt.Sprintf("%s: %v", label, err))
 		*failures = append(*failures, fmt.Sprintf("%s schema order: %v", label, err))
 	case len(diffs) > 0:
 		envelope.OrderWarning = append(envelope.OrderWarning, bamlfuzz.FormatSchemaOrderDiffs(diffs)...)

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -390,8 +390,10 @@ func checkSchemaOrder(t *testing.T, c bamlfuzz.OracleCase, envelope *bamlfuzz.Dy
 	diffs, err := bamlfuzz.SchemaOrderDiffWithChoices(label, c.Schema, expected, actual, c.Metadata.UnionChoices)
 	switch {
 	case errors.Is(err, bamlfuzz.ErrSchemaOrderUnsupported):
+		envelope.OrderWarning = append(envelope.OrderWarning, err.Error())
 		*failures = append(*failures, fmt.Sprintf("%s schema order unsupported: %v", label, err))
 	case err != nil:
+		envelope.OrderWarning = append(envelope.OrderWarning, err.Error())
 		*failures = append(*failures, fmt.Sprintf("%s schema order: %v", label, err))
 	case len(diffs) > 0:
 		envelope.OrderWarning = append(envelope.OrderWarning, bamlfuzz.FormatSchemaOrderDiffs(diffs)...)

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -379,9 +379,9 @@ func runDynamicOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Oracle
 // non-empty diff records the diagnostic lines on envelope.OrderWarning
 // (the field still travels in the replay artifact for forensics) and
 // appends a failure reason so the caller's collected `failures` list
-// flows through failAndDump. ErrSchemaOrderUnsupported is a soft skip:
-// union-bearing schemas have no canonical order contract today, so the
-// semantic-equality oracle remains the gate.
+// flows through failAndDump. ErrSchemaOrderUnsupported is a hard
+// failure: UnionChoices are propagated for every union path the walker
+// visits, so a missing or stale choice is an integrity bug.
 func checkSchemaOrder(t *testing.T, c bamlfuzz.OracleCase, envelope *bamlfuzz.DynamicFailureEnvelope, failures *[]string, label string, expected, actual json.RawMessage) {
 	t.Helper()
 	if !c.PreserveSchemaOrder {
@@ -390,7 +390,7 @@ func checkSchemaOrder(t *testing.T, c bamlfuzz.OracleCase, envelope *bamlfuzz.Dy
 	diffs, err := bamlfuzz.SchemaOrderDiffWithChoices(label, c.Schema, expected, actual, c.Metadata.UnionChoices)
 	switch {
 	case errors.Is(err, bamlfuzz.ErrSchemaOrderUnsupported):
-		t.Logf("schema order check skipped for %s %s: %v", c.Name, label, err)
+		*failures = append(*failures, fmt.Sprintf("%s schema order unsupported: %v", label, err))
 	case err != nil:
 		*failures = append(*failures, fmt.Sprintf("%s schema order: %v", label, err))
 	case len(diffs) > 0:

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -287,7 +287,9 @@ func runOneStaticCase(t *testing.T, env *testutil.TestEnvironment, mockClient *m
 		diffs, err := bamlfuzz.SchemaOrderDiffWithChoices("expected_vs_rest", lc.Case.Schema, lc.Case.Expected, resp.Body, lc.Case.Metadata.UnionChoices)
 		switch {
 		case errors.Is(err, bamlfuzz.ErrSchemaOrderUnsupported):
-			t.Logf("schema order check skipped for %s: %v", lc.Case.Name, err)
+			envelope.OrderWarning = append(envelope.OrderWarning, err.Error())
+			failStaticAndDump(t, envelope, "schema order check unsupported for %s: %v", lc.Case.Name, err)
+			return
 		case err != nil:
 			envelope.OrderWarning = append(envelope.OrderWarning, err.Error())
 			failStaticAndDump(t, envelope, "schema order check failed for %s: %v", lc.Case.Name, err)


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Closes #370 — bamlfuzz v1.1 strict key-order assertions across nested classes + map-vs-class policy.

- **D1**: `walkType(KindMap)` now compares wire keys with `slices.Equal` and emits a `SchemaOrderDiffEntry` at the map's own path on mismatch. Pins the documented insertion-order policy: `FuzzValue.MapEntries` carries request order; the wire must echo it back when `preserve_schema_order=true`. The existing value-recursion loop is untouched.
- **D2**: Both oracles promote `ErrSchemaOrderUnsupported` from a `t.Logf` soft-skip to a hard fail (`failStaticAndDump` / append-to-failures). With `UnionChoices` propagated for every union path the walker visits, a missing or stale choice is an integrity bug, not a missing feature.
- **D3**: All five `setErr` sites in `walkType(KindUnion)` retained as fail-closed diagnostics; the existing union-stale tests already pin lines 285/289/295, and `TestSchemaOrderDiffUnionMissingChoiceReturnsUnsupported` now exercises lines 270/274 end-to-end through the hard-fail wiring.
- **D4**: Five new unit tests in `order_test.go` covering map insertion-order mismatch, nested-class propagation (two variants), happy path, structural-disagreement silence, and union sentinel; the legacy `MapKeyReorderingIgnored` test is flipped to `MapKeyReorderFlagged` to pin the new behavior.
- **D5**: `DynamicSafeSchemaGen` already draws `KindMap` in its type grammar (generator.go:227, 256-260), and rapid cases toggle `PreserveSchemaOrder` (static_test.go:592). No new corpus entry needed.

## Test plan

- [x] `go build ./...`
- [x] `cd bamlutils && go test ./... -race -count=1`
- [x] `cd adapters/common && GOWORK=off go test ./... -race -count=1`
- [x] `cd cmd/hacks && go test ./... -count=1`
- [x] `cd dynclient && GOWORK=off go test ./...`
- [x] `cd cmd/serve && go test ./...`
- [x] `go test -tags integration -c -o /dev/null ./integration/...`
- [x] `go vet ./...`
- [x] `go run ./cmd/embed && git diff embed.go` (empty)
- [x] `cd adapters/common && GOWORK=off go test -count=20 -race ./codegen/bamlfuzz/...`
- [ ] `go test -tags=integration -run='^TestBamlfuzzStaticOracle$' ./integration -count=1` — skipped locally (no Docker daemon / BAML CLI); CI gates this
- [ ] `go test -tags=integration -run='^TestBamlfuzzDynamicOracle$' ./integration -count=1` — skipped locally; CI gates this

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Map insertion-order is now enforced and reported as a schema-order diff when mismatched; order checks recurse into inner values independently.
  * Cases where schema-order is unsupported are now recorded as failures and surfaced as order warnings instead of being skipped.

* **Tests**
  * Expanded order tests covering insertion-order mismatches, nested-map propagation, same-order success, structural-disagreement silence, and union-missing-choice returning unsupported.

* **Documentation**
  * Clarified how order mismatches and unsupported-schema-order are recorded and presented.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->