### PR TITLE
feat(bamlfuzz): active CI fuzz workflow (nightly, random seed, sticky issue) (#372)

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -1,0 +1,133 @@
+name: bamlfuzz nightly
+
+on:
+  schedule:
+    # 03:17 UTC nightly — off the :00 mark so we don't queue behind the
+    # crowd of cron jobs that fire on the hour.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: BAMLFUZZ_SEED override (defaults to github.run_id)
+        type: string
+        required: false
+      dynamic_cases:
+        description: Cases per preserve mode (default 50)
+        type: string
+        required: false
+        default: "50"
+      static_batches:
+        description: Rapid static batches (default 10)
+        type: string
+        required: false
+        default: "10"
+
+concurrency:
+  group: bamlfuzz-nightly
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+env:
+  GO_VERSION: "1.26.3"
+
+jobs:
+  get-latest-version:
+    runs-on: ubuntu-latest
+    outputs:
+      latest: ${{ steps.read.outputs.latest }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Read latest BAML version
+        id: read
+        run: |
+          latest=$(jq -r '.latest // empty' integration/baml_versions.json)
+          if [ -z "$latest" ] || [ "$latest" = "null" ]; then
+            echo "::error file=integration/baml_versions.json::missing non-empty .latest BAML version"
+            exit 1
+          fi
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+
+  fuzz:
+    needs: get-latest-version
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        unary-server: [false, true]
+    env:
+      BAML_VERSION: ${{ needs.get-latest-version.outputs.latest }}
+      UNARY_SERVER: ${{ matrix.unary-server }}
+      BAML_REST_HTTP_CLIENT: nethttp
+      BAMLFUZZ_KEEP_ARTIFACTS: "1"
+      BAMLFUZZ_DYNAMIC_CASES: ${{ github.event.inputs.dynamic_cases || '50' }}
+      BAMLFUZZ_STATIC_BATCHES: ${{ github.event.inputs.static_batches || '10' }}
+      BAMLFUZZ_SEED: ${{ github.event.inputs.seed || github.run_id }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run bamlfuzz oracles (BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }})
+        # `subprocess` matches the normal server deployment path (server +
+        # cmd/worker go-plugin), same as integration-tests.yml. -p 1 keeps
+        # the integration env setup serial; the two oracles share state.
+        run: |
+          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
+            -run='^TestBamlfuzz(Static|Dynamic)Oracle$' ./integration/...
+
+      - name: Upload replay artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bamlfuzz-envelopes-${{ matrix.unary-server }}-${{ github.run_id }}
+          path: adapters/common/codegen/testdata/bamlfuzz/*/_artifacts/
+          if-no-files-found: ignore
+
+      - name: Comment on sticky tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: "bamlfuzz nightly status"
+          UNARY: ${{ matrix.unary-server }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+          # Find existing open issue (first match by title).
+          ISSUE_NUMBER=$(gh issue list --repo "$REPO" --state open \
+            --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')
+          # Create the sticky stub if none exists. gh issue create prints
+          # the URL on stdout; we strip the trailing path segment for the
+          # number.
+          if [ -z "$ISSUE_NUMBER" ]; then
+            ISSUE_URL=$(gh issue create --repo "$REPO" \
+              --title "$TITLE" \
+              --body "Sticky tracking issue for bamlfuzz nightly failures. Each failed run appends a comment here. See #372 for the workflow design.")
+            ISSUE_NUMBER="${ISSUE_URL##*/}"
+          fi
+          {
+            echo "## bamlfuzz nightly failed (run ${RUN_ID})"
+            echo
+            echo "Seed: \`${BAMLFUZZ_SEED}\`"
+            echo "Matrix: unary-server=${UNARY}"
+            echo "Workflow: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+            echo "Envelope artifact: bamlfuzz-envelopes-${UNARY}-${RUN_ID}"
+            echo
+            echo "Repro (after downloading the artifact and locating the envelope JSON):"
+            echo
+            echo '```'
+            echo "BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_DYNAMIC_CASES=${BAMLFUZZ_DYNAMIC_CASES} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} go test -tags=integration -run='^TestBamlfuzz(Static|Dynamic)Oracle\$' ./integration -count=1"
+            echo '```'
+          } | gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file -

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -28,7 +28,6 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write
   actions: read
 
 env:
@@ -42,6 +41,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Read latest BAML version
         id: read
@@ -57,6 +58,10 @@ jobs:
     needs: get-latest-version
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    permissions:
+      contents: read
+      actions: read
+      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +77,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -35,10 +35,12 @@ const dynamicOracleCorpusDir = "../adapters/common/codegen/testdata/bamlfuzz/dyn
 const dynamicOracleArtifactDir = "../adapters/common/codegen/testdata/bamlfuzz/dynamic/_artifacts"
 
 // rapidCasesPerMode controls how many random dynamic cases run per
-// preserve mode in PR-B. v1's full target is 20 per mode (40 total);
-// PR-B keeps the count small to bound CI wall time until the static
-// path lands in PR-C and the full smoke matrix runs.
-const rapidCasesPerMode = 4
+// preserve mode. The default of 4 is sized for PR CI wall time; the
+// nightly fuzz workflow cranks it up via BAMLFUZZ_DYNAMIC_CASES so
+// each scheduled run explores a broader slice of the schema space.
+func rapidCasesPerMode() int {
+	return envIntDefault("BAMLFUZZ_DYNAMIC_CASES", 4)
+}
 
 // TestBamlfuzzDynamicOracle drives the three-way dynamic oracle: for each
 // fuzz case we
@@ -96,7 +98,8 @@ func TestBamlfuzzDynamicOracle(t *testing.T) {
 				label = "preserve_on"
 			}
 			t.Run(label, func(t *testing.T) {
-				for i := 0; i < rapidCasesPerMode; i++ {
+				cases := rapidCasesPerMode()
+				for i := 0; i < cases; i++ {
 					i := i
 					seed := dynamicSeedFor(preserve, i)
 					t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -588,6 +588,21 @@ func TestReproductionFor(t *testing.T) {
 	if withCases != wantWithCases {
 		t.Errorf("rapid+cases repro:\n got:  %s\n want: %s", withCases, wantWithCases)
 	}
+
+	// Both env knobs set together. BAMLFUZZ_SEED is prepended first
+	// in reproductionFor, then BAMLFUZZ_DYNAMIC_CASES wraps it, so
+	// the cases prefix sits leftmost in the rendered command.
+	t.Setenv("BAMLFUZZ_SEED", "12345")
+	t.Setenv("BAMLFUZZ_DYNAMIC_CASES", "50")
+	withSeedAndCases := reproductionFor(
+		bamlfuzz.OracleCase{PreserveSchemaOrder: false},
+		25,
+		caseSourceRapid,
+	)
+	wantWithSeedAndCases := "BAMLFUZZ_DYNAMIC_CASES=50 BAMLFUZZ_SEED=12345 go test -tags=integration -run='^TestBamlfuzzDynamicOracle$/^rapid$/^preserve_off$/^case_25$' ./integration -count=1"
+	if withSeedAndCases != wantWithSeedAndCases {
+		t.Errorf("rapid+seed+cases repro:\n got:  %s\n want: %s", withSeedAndCases, wantWithSeedAndCases)
+	}
 }
 
 // TestUnsupportedActionFor pins the source-dependent dispatch for the

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -452,6 +452,9 @@ func reproductionFor(c bamlfuzz.OracleCase, caseIdx int, source caseSource) stri
 	if seed := os.Getenv("BAMLFUZZ_SEED"); seed != "" {
 		cmd = "BAMLFUZZ_SEED=" + seed + " " + cmd
 	}
+	if cases := os.Getenv("BAMLFUZZ_DYNAMIC_CASES"); cases != "" {
+		cmd = "BAMLFUZZ_DYNAMIC_CASES=" + cases + " " + cmd
+	}
 	return cmd
 }
 
@@ -528,6 +531,7 @@ func loadDynamicCorpus(dir string) ([]bamlfuzz.OracleCase, error) {
 // applied when set; this test exercises both.
 func TestReproductionFor(t *testing.T) {
 	t.Setenv("BAMLFUZZ_SEED", "")
+	t.Setenv("BAMLFUZZ_DYNAMIC_CASES", "")
 	corpus := reproductionFor(
 		bamlfuzz.OracleCase{Name: "scalar_string"},
 		0,
@@ -567,6 +571,22 @@ func TestReproductionFor(t *testing.T) {
 	wantWithSeed := "BAMLFUZZ_SEED=12345 go test -tags=integration -run='^TestBamlfuzzDynamicOracle$/^rapid$/^preserve_on$/^case_0$' ./integration -count=1"
 	if withSeed != wantWithSeed {
 		t.Errorf("rapid+seed repro:\n got:  %s\n want: %s", withSeed, wantWithSeed)
+	}
+
+	// Nightly raises BAMLFUZZ_DYNAMIC_CASES to surface cases beyond
+	// the default 4. The repro recipe must propagate that count so a
+	// developer rerunning the printed command reaches the failing
+	// case index.
+	t.Setenv("BAMLFUZZ_SEED", "")
+	t.Setenv("BAMLFUZZ_DYNAMIC_CASES", "50")
+	withCases := reproductionFor(
+		bamlfuzz.OracleCase{PreserveSchemaOrder: false},
+		25,
+		caseSourceRapid,
+	)
+	wantWithCases := "BAMLFUZZ_DYNAMIC_CASES=50 go test -tags=integration -run='^TestBamlfuzzDynamicOracle$/^rapid$/^preserve_off$/^case_25$' ./integration -count=1"
+	if withCases != wantWithCases {
+		t.Errorf("rapid+cases repro:\n got:  %s\n want: %s", withCases, wantWithCases)
 	}
 }
 

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -804,6 +804,24 @@ func TestStaticReproductionFor(t *testing.T) {
 	if withBatches != wantWithBatches {
 		t.Errorf("rapid+batches repro:\n got:  %s\n want: %s", withBatches, wantWithBatches)
 	}
+
+	// Both env knobs set together. BAMLFUZZ_SEED is prepended first
+	// in staticReproductionFor, then BAMLFUZZ_STATIC_BATCHES wraps
+	// it, so the batches prefix sits leftmost in the rendered
+	// command.
+	t.Setenv("BAMLFUZZ_SEED", "9999")
+	t.Setenv("BAMLFUZZ_STATIC_BATCHES", "10")
+	withSeedAndBatches := staticReproductionFor(
+		bamlfuzz.OracleCase{Name: "rapid_b7_c2"},
+		2,
+		"rapid_batch_7",
+		staticCaseSourceRapid,
+		false,
+	)
+	wantWithSeedAndBatches := "BAMLFUZZ_STATIC_BATCHES=10 BAMLFUZZ_SEED=9999 go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^rapid_batch_7$/^rapid_b7_c2$' ./integration -count=1"
+	if withSeedAndBatches != wantWithSeedAndBatches {
+		t.Errorf("rapid+seed+batches repro:\n got:  %s\n want: %s", withSeedAndBatches, wantWithSeedAndBatches)
+	}
 }
 
 // TestSubtestAggregationContract pins the Go testing-API contract

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -1,5 +1,28 @@
 //go:build integration
 
+// Nightly fuzz workflow
+//
+// The bamlfuzz oracles (this file + bamlfuzz_dynamic_test.go) run on
+// every PR with their default case counts (4 dynamic cases per
+// preserve mode, 1 static rapid batch). They additionally run nightly
+// under .github/workflows/bamlfuzz-nightly.yml with a random seed
+// (github.run_id) and the cranked-up knobs BAMLFUZZ_DYNAMIC_CASES=50
+// and BAMLFUZZ_STATIC_BATCHES=10 so each scheduled run explores a
+// broader slice of the schema space than PR CI can afford.
+//
+// Failures are tracked on the sticky "bamlfuzz nightly status" issue
+// in the GitHub repo. Each failed run appends a comment with the
+// seed, the matrix cell (unary-server=true|false), the workflow URL,
+// and the envelope artifact name. To triage:
+//
+//  1. Open the failed run, download the
+//     `bamlfuzz-envelopes-<unary>-<run_id>` artifact.
+//  2. Locate the failing case's envelope JSON under
+//     adapters/common/codegen/testdata/bamlfuzz/{static,dynamic}/_artifacts/.
+//  3. Run the repro command from the sticky-issue comment locally with
+//     BAML/Docker available (the comment echoes the exact BAMLFUZZ_SEED
+//     + BAMLFUZZ_DYNAMIC_CASES + BAMLFUZZ_STATIC_BATCHES the run used).
+
 package integration
 
 import (

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -592,6 +592,9 @@ func staticReproductionFor(c bamlfuzz.OracleCase, caseIdx int, batchLabel string
 	if seed := os.Getenv("BAMLFUZZ_SEED"); seed != "" {
 		cmd = "BAMLFUZZ_SEED=" + seed + " " + cmd
 	}
+	if batches := os.Getenv("BAMLFUZZ_STATIC_BATCHES"); batches != "" {
+		cmd = "BAMLFUZZ_STATIC_BATCHES=" + batches + " " + cmd
+	}
 	return cmd
 }
 
@@ -696,6 +699,7 @@ func loadStaticCorpus(dir string) ([]bamlfuzz.OracleCase, error) {
 // `_isolated` leaf shape isolateStaticBatch emits.
 func TestStaticReproductionFor(t *testing.T) {
 	t.Setenv("BAMLFUZZ_SEED", "")
+	t.Setenv("BAMLFUZZ_STATIC_BATCHES", "")
 	corpus := staticReproductionFor(
 		bamlfuzz.OracleCase{Name: "self_referential_tree"},
 		4,
@@ -783,6 +787,22 @@ func TestStaticReproductionFor(t *testing.T) {
 	wantCorpusBatchIsolated := "go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^corpus_batch_3$/^raw_union_root_isolated$' ./integration -count=1"
 	if corpusBatchIsolated != wantCorpusBatchIsolated {
 		t.Errorf("corpus_batch isolated repro:\n got:  %s\n want: %s", corpusBatchIsolated, wantCorpusBatchIsolated)
+	}
+
+	// Nightly raises BAMLFUZZ_STATIC_BATCHES so rapid_batch_<i>
+	// beyond batch 0 actually exists in the repro. Verify the
+	// prefix propagates.
+	t.Setenv("BAMLFUZZ_STATIC_BATCHES", "10")
+	withBatches := staticReproductionFor(
+		bamlfuzz.OracleCase{Name: "rapid_b7_c2"},
+		2,
+		"rapid_batch_7",
+		staticCaseSourceRapid,
+		false,
+	)
+	wantWithBatches := "BAMLFUZZ_STATIC_BATCHES=10 go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^rapid_batch_7$/^rapid_b7_c2$' ./integration -count=1"
+	if withBatches != wantWithBatches {
+		t.Errorf("rapid+batches repro:\n got:  %s\n want: %s", withBatches, wantWithBatches)
 	}
 }
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Closes #372. Adds the missing D1–D4 pieces for an active CI fuzz workflow:

- **D1** — `integration/bamlfuzz_dynamic_test.go`: replaces the hardcoded `const rapidCasesPerMode = 4` with a function that reads `BAMLFUZZ_DYNAMIC_CASES` via the existing `envIntDefault` helper. Default of 4 keeps PR CI wall time unchanged.
- **D2** — `.github/workflows/bamlfuzz-nightly.yml`: schedules `TestBamlfuzzStaticOracle` + `TestBamlfuzzDynamicOracle` at 03:17 UTC nightly on `ubuntu-latest`, matrixed over `unary-server=[false,true]`. Seeds with `github.run_id` so each run draws a fresh slice of the schema space; `workflow_dispatch` inputs let humans override seed + case counts for targeted repros. Defaults to `BAMLFUZZ_DYNAMIC_CASES=50` and `BAMLFUZZ_STATIC_BATCHES=10`. Pinned to the latest BAML version read from `integration/baml_versions.json` and runs with `BAML_REST_HTTP_CLIENT=nethttp` + the standard `integration,subprocess` build tags.
- **D3** — failure path uploads `bamlfuzz-envelopes-<unary>-<run_id>` artifacts and posts to a sticky "bamlfuzz nightly status" issue (creating the stub on first failure). Each comment includes the seed, matrix cell, workflow URL, artifact name, and a copy-paste repro command.
- **D4** — file-level doc comment at the top of `integration/bamlfuzz_static_test.go` describing the nightly workflow + 3-step triage flow. No `CONTRIBUTING.md` / `docs/bamlfuzz.md` exists yet, so the closest existing home is the integration test file itself.

## Test plan

- [x] `go build ./...` — clean
- [x] `cd bamlutils && go test ./... -race -count=1` — pass
- [x] `cd adapters/common && GOWORK=off go test ./... -race -count=1` — pass
- [x] `cd cmd/hacks && go test ./... -count=1` — pass
- [x] `cd dynclient && GOWORK=off go test ./...` — pass
- [x] `cd cmd/serve && go test ./...` — pass
- [x] `go test -tags integration -c -o /dev/null ./integration/...` — compiles
- [x] `go vet ./...` — clean
- [x] `go run ./cmd/embed` + empty `git diff embed.go`
- [x] `cd adapters/common && GOWORK=off go test -count=20 -race ./codegen/bamlfuzz/...` — pass
- [x] `python3 yaml.safe_load` on the workflow — parses; jobs = `get-latest-version`, `fuzz`
- [x] Banned-phrase grep on `git diff master` — zero matches
- [ ] Local dry-run with `BAMLFUZZ_DYNAMIC_CASES=10 go test -tags=integration -run='^TestBamlfuzzDynamicOracle$/^rapid$' ./integration -count=1 -v` — skipped: this machine has Docker but not rootless-Docker, so testcontainers can't bring up the network. CI will exercise the knob.
- [ ] First scheduled run on master (will verify cron + sticky-issue path end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a nightly + manual CI workflow to run integration fuzz tests and create sticky issue comments on failures with repro details and uploaded artifacts.
* **Tests**
  * Integration tests now accept runtime-configurable case counts (env vars) and include those values in generated reproduction commands.
* **Documentation**
  * In-test docs added describing nightly run behavior, artifact download, and local reproduction steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->