### PR TITLE
feat(bamlfuzz): Go testing.F bridge + cross-version BAML matrix for the nightly (#375)

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -232,10 +232,11 @@ jobs:
             if [ "${MODE}" = "fuzz" ]; then
               echo "Corpus artifact: bamlfuzz-corpus-${BAML}-${UNARY}"
               echo
-              echo "Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/):"
+              echo "Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/). \`go test -fuzz\` accepts only a single target per invocation, so run the static and dynamic targets sequentially. The \`-fuzzcachedir\` flag points the engine at the extracted corpus so the failing input is replayed:"
               echo
               echo '```'
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration -fuzz='^FuzzBamlfuzz(Static|Dynamic)$' -fuzztime=30s ./integration"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration -run='^\$' -fuzz='^FuzzBamlfuzzStatic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration -run='^\$' -fuzz='^FuzzBamlfuzzDynamic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
               echo '```'
             else
               echo

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -135,8 +135,22 @@ jobs:
         # gets half the configured fuzztime budget. The corpus dir is
         # shared so seed inputs that the dynamic target discovered also
         # influence the static target on the next nightly.
+        #
+        # `-run='^$'` matches no ordinary test name, which keeps the
+        # cranked-up TestBamlfuzz{Static,Dynamic}Oracle rapid runs from
+        # consuming the per-step budget before fuzzing starts.
+        # BAMLFUZZ_KEEP_ARTIFACTS is forced off here; the success-path
+        # envelope dump in the oracle bodies all writes to
+        # _artifacts/fuzz.json (one filename per fuzz case), which races
+        # under parallel fuzz workers and can overwrite a failure
+        # envelope on the way out. Failures still dump unconditionally
+        # via failAndDump/failStaticAndDump, so the workflow's
+        # upload-on-failure step still captures the right artifact.
+        env:
+          BAMLFUZZ_KEEP_ARTIFACTS: ""
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
+            -run='^$' \
             -fuzz='^FuzzBamlfuzzStatic$' \
             -fuzztime="${FUZZTIME}" \
             -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
@@ -144,8 +158,11 @@ jobs:
 
       - name: Run bamlfuzz nightly — dynamic fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'fuzz' }}
+        env:
+          BAMLFUZZ_KEEP_ARTIFACTS: ""
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
+            -run='^$' \
             -fuzz='^FuzzBamlfuzzDynamic$' \
             -fuzztime="${FUZZTIME}" \
             -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -44,28 +44,32 @@ env:
   GO_VERSION: "1.26.3"
 
 jobs:
-  get-latest-version:
+  get-versions:
     runs-on: ubuntu-latest
     outputs:
-      latest: ${{ steps.read.outputs.latest }}
+      matrix: ${{ steps.set.outputs.matrix }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - name: Read latest BAML version
-        id: read
+      - name: Build version matrix
+        id: set
+        # The fuzz matrix expands the prior single-version nightly to
+        # every pinned BAML version + the latest. Pinned versions
+        # exercise older adapter shapes (pre-0.219 lacks BuildRequest,
+        # for example); the latest catches regressions against the
+        # newest BAML. Each version × unary-server combination gets its
+        # own corpus, so an adapter-specific failure mode persists in
+        # the corpus that triggered it; newer-version draws cannot
+        # crowd it out across cells.
         run: |
-          latest=$(jq -r '.latest // empty' integration/baml_versions.json)
-          if [ -z "$latest" ] || [ "$latest" = "null" ]; then
-            echo "::error file=integration/baml_versions.json::missing non-empty .latest BAML version"
-            exit 1
-          fi
-          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          matrix=$(jq -c '{"baml-version": ([.pinned[], .latest] | unique), "unary-server": [false, true]}' integration/baml_versions.json)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   fuzz:
-    needs: get-latest-version
+    needs: get-versions
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -74,10 +78,9 @@ jobs:
       issues: write
     strategy:
       fail-fast: false
-      matrix:
-        unary-server: [false, true]
+      matrix: ${{ fromJson(needs.get-versions.outputs.matrix) }}
     env:
-      BAML_VERSION: ${{ needs.get-latest-version.outputs.latest }}
+      BAML_VERSION: ${{ matrix.baml-version }}
       UNARY_SERVER: ${{ matrix.unary-server }}
       BAML_REST_HTTP_CLIENT: nethttp
       BAMLFUZZ_KEEP_ARTIFACTS: "1"
@@ -103,7 +106,7 @@ jobs:
         if: ${{ env.MODE == 'fuzz' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ARTIFACT_NAME: bamlfuzz-corpus-${{ matrix.unary-server }}
+          ARTIFACT_NAME: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}
         run: |
           set -euo pipefail
           mkdir -p adapters/common/codegen/testdata/bamlfuzz/.fuzzcache
@@ -125,7 +128,7 @@ jobs:
             echo "prior nightly had no corpus artifact for ${ARTIFACT_NAME}; starting fresh"
           fi
 
-      - name: Run bamlfuzz nightly — static fuzz target (BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }})
+      - name: Run bamlfuzz nightly — static fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'fuzz' }}
         # `go test -fuzz` runs ONE target per invocation, so the static
         # and dynamic targets are split across sequential steps. Each
@@ -139,7 +142,7 @@ jobs:
             -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
             ./integration
 
-      - name: Run bamlfuzz nightly — dynamic fuzz target (BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }})
+      - name: Run bamlfuzz nightly — dynamic fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'fuzz' }}
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
@@ -148,7 +151,7 @@ jobs:
             -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
             ./integration
 
-      - name: Run bamlfuzz oracles — rapid mode (BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }})
+      - name: Run bamlfuzz oracles — rapid mode (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'rapid' }}
         # `subprocess` matches the normal server deployment path (server +
         # cmd/worker go-plugin), same as integration-tests.yml. -p 1 keeps
@@ -165,7 +168,7 @@ jobs:
         # fuzzer keep building on prior progress.
         uses: actions/upload-artifact@v7
         with:
-          name: bamlfuzz-corpus-${{ matrix.unary-server }}
+          name: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}
           path: adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/
           if-no-files-found: ignore
           retention-days: 90
@@ -174,7 +177,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: bamlfuzz-envelopes-${{ matrix.unary-server }}-${{ github.run_id }}
+          name: bamlfuzz-envelopes-${{ matrix.baml-version }}-${{ matrix.unary-server }}-${{ github.run_id }}
           path: adapters/common/codegen/testdata/bamlfuzz/*/_artifacts/
           if-no-files-found: ignore
 
@@ -183,6 +186,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TITLE: "bamlfuzz nightly status"
+          BAML: ${{ matrix.baml-version }}
           UNARY: ${{ matrix.unary-server }}
           RUN_ID: ${{ github.run_id }}
           REPO: ${{ github.repository }}
@@ -205,23 +209,23 @@ jobs:
             echo "## bamlfuzz nightly failed (run ${RUN_ID})"
             echo
             echo "Mode: \`${MODE}\`"
-            echo "Matrix: unary-server=${UNARY}"
+            echo "Matrix: baml-version=${BAML}, unary-server=${UNARY}"
             echo "Workflow: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
-            echo "Envelope artifact: bamlfuzz-envelopes-${UNARY}-${RUN_ID}"
+            echo "Envelope artifact: bamlfuzz-envelopes-${BAML}-${UNARY}-${RUN_ID}"
             if [ "${MODE}" = "fuzz" ]; then
-              echo "Corpus artifact: bamlfuzz-corpus-${UNARY}"
+              echo "Corpus artifact: bamlfuzz-corpus-${BAML}-${UNARY}"
               echo
               echo "Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/):"
               echo
               echo '```'
-              echo "UNARY_SERVER=${UNARY} go test -tags=integration -fuzz='^FuzzBamlfuzz(Static|Dynamic)$' -fuzztime=30s ./integration"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration -fuzz='^FuzzBamlfuzz(Static|Dynamic)$' -fuzztime=30s ./integration"
               echo '```'
             else
               echo
               echo "Repro:"
               echo
               echo '```'
-              echo "UNARY_SERVER=${UNARY} BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_DYNAMIC_CASES=${BAMLFUZZ_DYNAMIC_CASES} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} go test -tags=integration -run='^TestBamlfuzz(Static|Dynamic)Oracle\$' ./integration -count=1"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_DYNAMIC_CASES=${BAMLFUZZ_DYNAMIC_CASES} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} go test -tags=integration -run='^TestBamlfuzz(Static|Dynamic)Oracle\$' ./integration -count=1"
               echo '```'
             fi
           } | gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file -

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -7,20 +7,30 @@ on:
     - cron: "17 3 * * *"
   workflow_dispatch:
     inputs:
+      mode:
+        description: Run mode (fuzz uses Go's testing.F + corpus persistence; rapid uses the property-based oracles)
+        type: choice
+        options: [fuzz, rapid]
+        default: fuzz
       seed:
-        description: BAMLFUZZ_SEED override (defaults to github.run_id)
+        description: BAMLFUZZ_SEED override (defaults to github.run_id; rapid mode only)
         type: string
         required: false
       dynamic_cases:
-        description: Cases per preserve mode (default 50)
+        description: Rapid-mode cases per preserve mode (default 50)
         type: string
         required: false
         default: "50"
       static_batches:
-        description: Rapid static batches (default 10)
+        description: Rapid-mode static batches (default 10)
         type: string
         required: false
         default: "10"
+      fuzztime:
+        description: Fuzz-mode duration per target (default 15m; total wall time roughly 2× this)
+        type: string
+        required: false
+        default: "15m"
 
 concurrency:
   group: bamlfuzz-nightly
@@ -71,6 +81,10 @@ jobs:
       UNARY_SERVER: ${{ matrix.unary-server }}
       BAML_REST_HTTP_CLIENT: nethttp
       BAMLFUZZ_KEEP_ARTIFACTS: "1"
+      MODE: ${{ github.event.inputs.mode || 'fuzz' }}
+      FUZZTIME: ${{ github.event.inputs.fuzztime || '15m' }}
+      # Rapid-mode knobs: ignored by the fuzz-mode step. Kept addressable
+      # via dispatch inputs so a manual run can mix-and-match.
       BAMLFUZZ_DYNAMIC_CASES: ${{ github.event.inputs.dynamic_cases || '50' }}
       BAMLFUZZ_STATIC_BATCHES: ${{ github.event.inputs.static_batches || '10' }}
       BAMLFUZZ_SEED: ${{ github.event.inputs.seed || github.run_id }}
@@ -85,13 +99,76 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Run bamlfuzz oracles (BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }})
+      - name: Restore corpus from prior nightly
+        if: ${{ env.MODE == 'fuzz' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT_NAME: bamlfuzz-corpus-${{ matrix.unary-server }}
+        run: |
+          set -euo pipefail
+          mkdir -p adapters/common/codegen/testdata/bamlfuzz/.fuzzcache
+          prior_run=$(gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow=bamlfuzz-nightly.yml \
+            --status=success \
+            --branch=master \
+            --limit=1 \
+            --json databaseId \
+            --jq '.[0].databaseId // empty')
+          if [ -z "$prior_run" ]; then
+            echo "no prior successful nightly run; starting with empty corpus"
+            exit 0
+          fi
+          if ! gh run download "$prior_run" --repo "$GITHUB_REPOSITORY" \
+              --name "$ARTIFACT_NAME" \
+              --dir adapters/common/codegen/testdata/bamlfuzz/.fuzzcache; then
+            echo "prior nightly had no corpus artifact for ${ARTIFACT_NAME}; starting fresh"
+          fi
+
+      - name: Run bamlfuzz nightly — static fuzz target (BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }})
+        if: ${{ env.MODE == 'fuzz' }}
+        # `go test -fuzz` runs ONE target per invocation, so the static
+        # and dynamic targets are split across sequential steps. Each
+        # gets half the configured fuzztime budget. The corpus dir is
+        # shared so seed inputs that the dynamic target discovered also
+        # influence the static target on the next nightly.
+        run: |
+          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
+            -fuzz='^FuzzBamlfuzzStatic$' \
+            -fuzztime="${FUZZTIME}" \
+            -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
+            ./integration
+
+      - name: Run bamlfuzz nightly — dynamic fuzz target (BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }})
+        if: ${{ env.MODE == 'fuzz' }}
+        run: |
+          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
+            -fuzz='^FuzzBamlfuzzDynamic$' \
+            -fuzztime="${FUZZTIME}" \
+            -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
+            ./integration
+
+      - name: Run bamlfuzz oracles — rapid mode (BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }})
+        if: ${{ env.MODE == 'rapid' }}
         # `subprocess` matches the normal server deployment path (server +
         # cmd/worker go-plugin), same as integration-tests.yml. -p 1 keeps
         # the integration env setup serial; the two oracles share state.
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
             -run='^TestBamlfuzz(Static|Dynamic)Oracle$' ./integration/...
+
+      - name: Upload corpus for next nightly
+        if: ${{ always() && env.MODE == 'fuzz' }}
+        # Uploaded on every run (including failures) so a fuzz failure
+        # the engine already wrote to the cache survives into the next
+        # restore pass — the corpus is the only mechanism that lets the
+        # fuzzer keep building on prior progress.
+        uses: actions/upload-artifact@v7
+        with:
+          name: bamlfuzz-corpus-${{ matrix.unary-server }}
+          path: adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/
+          if-no-files-found: ignore
+          retention-days: 90
 
       - name: Upload replay artifacts on failure
         if: failure()
@@ -127,14 +204,24 @@ jobs:
           {
             echo "## bamlfuzz nightly failed (run ${RUN_ID})"
             echo
-            echo "Seed: \`${BAMLFUZZ_SEED}\`"
+            echo "Mode: \`${MODE}\`"
             echo "Matrix: unary-server=${UNARY}"
             echo "Workflow: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
             echo "Envelope artifact: bamlfuzz-envelopes-${UNARY}-${RUN_ID}"
-            echo
-            echo "Repro (after downloading the artifact and locating the envelope JSON):"
-            echo
-            echo '```'
-            echo "BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_DYNAMIC_CASES=${BAMLFUZZ_DYNAMIC_CASES} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} go test -tags=integration -run='^TestBamlfuzz(Static|Dynamic)Oracle\$' ./integration -count=1"
-            echo '```'
+            if [ "${MODE}" = "fuzz" ]; then
+              echo "Corpus artifact: bamlfuzz-corpus-${UNARY}"
+              echo
+              echo "Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/):"
+              echo
+              echo '```'
+              echo "UNARY_SERVER=${UNARY} go test -tags=integration -fuzz='^FuzzBamlfuzz(Static|Dynamic)$' -fuzztime=30s ./integration"
+              echo '```'
+            else
+              echo
+              echo "Repro:"
+              echo
+              echo '```'
+              echo "UNARY_SERVER=${UNARY} BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_DYNAMIC_CASES=${BAMLFUZZ_DYNAMIC_CASES} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} go test -tags=integration -run='^TestBamlfuzz(Static|Dynamic)Oracle\$' ./integration -count=1"
+              echo '```'
+            fi
           } | gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file -

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -235,8 +235,8 @@ jobs:
               echo "Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/). \`go test -fuzz\` accepts only a single target per invocation, so run the static and dynamic targets sequentially. The \`-fuzzcachedir\` flag points the engine at the extracted corpus so the failing input is replayed:"
               echo
               echo '```'
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration -run='^\$' -fuzz='^FuzzBamlfuzzStatic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration -run='^\$' -fuzz='^FuzzBamlfuzzDynamic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzStatic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzDynamic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
               echo '```'
             else
               echo

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -156,7 +156,13 @@ jobs:
 
   integration-tests-baml-source:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # The baml-source matrix builds BAML from source, which dominates
+    # the per-cell wall time and pushes consistent runs into the 38-45m
+    # window. The pinned-version `integration-tests` job above stays at
+    # 45m because it pulls prebuilt BAML and finishes in 6-17m. 60m
+    # gives the baml-source matrix headroom without changing the
+    # nominal budget for the lighter jobs.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -200,5 +206,8 @@ jobs:
           BAML_REST_USE_BUILD_REQUEST: ${{ matrix.use-build-request }}
           BAML_REST_HTTP_CLIENT: ${{ matrix.http-client }}
         # `subprocess` matches the normal server deployment path used
-        # by the versioned integration job above.
-        run: go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 40m ./integration/...
+        # by the versioned integration job above. The 55m Go timeout
+        # sits below the 60m GHA step budget so a near-timeout case
+        # still has room to dump its envelope before the runner kills
+        # the job.
+        run: go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 55m ./integration/...

--- a/adapters/common/codegen/bamlfuzz/fuzzbridge.go
+++ b/adapters/common/codegen/bamlfuzz/fuzzbridge.go
@@ -17,10 +17,9 @@ import (
 // are recognised:
 //
 //   - Exactly 8 bytes: interpreted as a little-endian uint64 seed
-//     verbatim. The seed corpus the integration fuzz targets ship via
-//     f.Add encodes `dynamicSeedFor` / `staticSeedFor` outputs this way,
-//     so a corpus entry replays the same rapid stream as the rapid
-//     oracle subtree.
+//     verbatim. The nightly workflow's persisted -fuzzcachedir corpus
+//     stores its entries this way, so a restored corpus entry replays
+//     the exact rapid stream the engine recorded.
 //   - Anything else (including the empty input): hashed with fnv-64a
 //     into a single uint64 (see SeedFromBytes). The hashing layer is
 //     what lets short inputs like {1, 2, 3} and their zero-padded

--- a/adapters/common/codegen/bamlfuzz/fuzzbridge.go
+++ b/adapters/common/codegen/bamlfuzz/fuzzbridge.go
@@ -1,0 +1,53 @@
+package bamlfuzz
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// MakeFuzz adapts rapid's bit-stream-driven generator model onto Go's
+// testing.F []byte-driven fuzz model. The raw fuzz input is hashed with
+// fnv-64a into a single uint64, which is then fed to rapid.MakeFuzz as
+// 8 little-endian bytes. The hashing layer is what lets short inputs
+// like {1, 2, 3} and their zero-padded extension {1, 2, 3, 0, 0, 0, 0, 0}
+// drive distinct rapid runs — rapid.MakeFuzz's own bytes→uint64 routine
+// pads with zeros, so the unhashed path would collapse those two inputs
+// into the same bit stream.
+//
+// body runs once per fuzz invocation with the per-call *testing.T and a
+// rapid *rapid.T configured from the derived seed. rapid handles its
+// own Cleanup paths inside its checkOnce; the wrapping testing.T's
+// Cleanup runs after body returns.
+func MakeFuzz(f *testing.F, body func(*testing.T, *rapid.T)) {
+	f.Helper()
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		seed := SeedFromBytes(raw)
+		var encoded [8]byte
+		binary.LittleEndian.PutUint64(encoded[:], seed)
+		rapid.MakeFuzz(func(rt *rapid.T) {
+			body(t, rt)
+		})(t, encoded[:])
+	})
+}
+
+// SeedFromBytes derives a deterministic uint64 from raw fuzz input via
+// fnv-64a. Empty input pins to 0 (the fnv-64a offset basis would yield
+// a non-zero seed for a zero-byte hash; pinning empty input to 0
+// matches the "no input → degenerate seed" intuition and keeps the
+// helper trivially reproducible across Go releases).
+//
+// Exported so the unit tests can pin the encoding without going
+// through MakeFuzz, and so future tooling (e.g. corpus minimisation
+// scripts) can compute the same seed without re-deriving the hashing
+// rule from the source.
+func SeedFromBytes(b []byte) uint64 {
+	if len(b) == 0 {
+		return 0
+	}
+	h := fnv.New64a()
+	h.Write(b)
+	return h.Sum64()
+}

--- a/adapters/common/codegen/bamlfuzz/fuzzbridge.go
+++ b/adapters/common/codegen/bamlfuzz/fuzzbridge.go
@@ -9,22 +9,37 @@ import (
 )
 
 // MakeFuzz adapts rapid's bit-stream-driven generator model onto Go's
-// testing.F []byte-driven fuzz model. The raw fuzz input is hashed with
-// fnv-64a into a single uint64, which is then fed to rapid.MakeFuzz as
-// 8 little-endian bytes. The hashing layer is what lets short inputs
-// like {1, 2, 3} and their zero-padded extension {1, 2, 3, 0, 0, 0, 0, 0}
-// drive distinct rapid runs — rapid.MakeFuzz's own bytes→uint64 routine
-// pads with zeros, so the unhashed path would collapse those two inputs
-// into the same bit stream.
+// testing.F []byte-driven fuzz model.
 //
-// body runs once per fuzz invocation with the per-call *testing.T and a
-// rapid *rapid.T configured from the derived seed. rapid handles its
-// own Cleanup paths inside its checkOnce; the wrapping testing.T's
-// Cleanup runs after body returns.
+// Two input shapes are recognised:
+//
+//   - Exactly 8 bytes: treated as a little-endian uint64 seed and
+//     forwarded to rapid verbatim. The seed corpus the integration
+//     fuzz targets ship via f.Add encodes `dynamicSeedFor` /
+//     `staticSeedFor` outputs this way, so corpus entries replay the
+//     exact rapid bit stream the rapid oracle subtree already covers.
+//   - Anything else (including the empty input): hashed with fnv-64a
+//     into a single uint64 (see SeedFromBytes) and then forwarded to
+//     rapid as 8 little-endian bytes. The hashing layer is what lets
+//     short inputs like {1, 2, 3} and their zero-padded extension
+//     {1, 2, 3, 0, 0, 0, 0, 0} drive distinct rapid runs —
+//     rapid.MakeFuzz's own bytes→uint64 routine pads with zeros, so
+//     an unhashed path for non-8-byte inputs would collapse those two
+//     into the same bit stream.
+//
+// body runs once per fuzz invocation with the per-call *testing.T and
+// a rapid *rapid.T configured from the derived seed. rapid handles
+// its own Cleanup paths inside its checkOnce; the wrapping
+// testing.T's Cleanup runs after body returns.
 func MakeFuzz(f *testing.F, body func(*testing.T, *rapid.T)) {
 	f.Helper()
 	f.Fuzz(func(t *testing.T, raw []byte) {
-		seed := SeedFromBytes(raw)
+		var seed uint64
+		if len(raw) == 8 {
+			seed = binary.LittleEndian.Uint64(raw)
+		} else {
+			seed = SeedFromBytes(raw)
+		}
 		var encoded [8]byte
 		binary.LittleEndian.PutUint64(encoded[:], seed)
 		rapid.MakeFuzz(func(rt *rapid.T) {

--- a/adapters/common/codegen/bamlfuzz/fuzzbridge.go
+++ b/adapters/common/codegen/bamlfuzz/fuzzbridge.go
@@ -11,26 +11,35 @@ import (
 // MakeFuzz adapts rapid's bit-stream-driven generator model onto Go's
 // testing.F []byte-driven fuzz model.
 //
-// Two input shapes are recognised:
+// Each fuzz invocation becomes a single uint64 seed that drives a
+// PRNG-backed rapid bit stream; body then draws as many bits as it
+// needs without the input []byte capping draw count. Two input shapes
+// are recognised:
 //
-//   - Exactly 8 bytes: treated as a little-endian uint64 seed and
-//     forwarded to rapid verbatim. The seed corpus the integration
-//     fuzz targets ship via f.Add encodes `dynamicSeedFor` /
-//     `staticSeedFor` outputs this way, so corpus entries replay the
-//     exact rapid bit stream the rapid oracle subtree already covers.
+//   - Exactly 8 bytes: interpreted as a little-endian uint64 seed
+//     verbatim. The seed corpus the integration fuzz targets ship via
+//     f.Add encodes `dynamicSeedFor` / `staticSeedFor` outputs this way,
+//     so a corpus entry replays the same rapid stream as the rapid
+//     oracle subtree.
 //   - Anything else (including the empty input): hashed with fnv-64a
-//     into a single uint64 (see SeedFromBytes) and then forwarded to
-//     rapid as 8 little-endian bytes. The hashing layer is what lets
-//     short inputs like {1, 2, 3} and their zero-padded extension
-//     {1, 2, 3, 0, 0, 0, 0, 0} drive distinct rapid runs —
-//     rapid.MakeFuzz's own bytes→uint64 routine pads with zeros, so
-//     an unhashed path for non-8-byte inputs would collapse those two
-//     into the same bit stream.
+//     into a single uint64 (see SeedFromBytes). The hashing layer is
+//     what lets short inputs like {1, 2, 3} and their zero-padded
+//     extension {1, 2, 3, 0, 0, 0, 0, 0} drive distinct rapid runs;
+//     without it both prefixes would collapse to the same seed.
+//
+// The seed feeds rapid via `rapid.Custom(...).Example(int(seed))`,
+// matching the canonical seeded-draw mechanism integration/buildRapidCase
+// already uses. Unlike rapid.MakeFuzz — which converts the raw bytes
+// into a fixed buffer and panics with `invalidData("overrun")` once
+// draws exhaust it — Example installs a randomBitStream seeded from
+// the uint64, so the body gets unlimited draws; a multi-Draw property
+// then runs to completion where the buffer-backed path would skip on
+// the second draw.
 //
 // body runs once per fuzz invocation with the per-call *testing.T and
-// a rapid *rapid.T configured from the derived seed. rapid handles
-// its own Cleanup paths inside its checkOnce; the wrapping
-// testing.T's Cleanup runs after body returns.
+// a rapid *rapid.T configured from the derived seed. rapid handles its
+// own Cleanup paths inside Example; the wrapping testing.T's Cleanup
+// runs after body returns.
 func MakeFuzz(f *testing.F, body func(*testing.T, *rapid.T)) {
 	f.Helper()
 	f.Fuzz(func(t *testing.T, raw []byte) {
@@ -40,11 +49,10 @@ func MakeFuzz(f *testing.F, body func(*testing.T, *rapid.T)) {
 		} else {
 			seed = SeedFromBytes(raw)
 		}
-		var encoded [8]byte
-		binary.LittleEndian.PutUint64(encoded[:], seed)
-		rapid.MakeFuzz(func(rt *rapid.T) {
+		rapid.Custom(func(rt *rapid.T) struct{} {
 			body(t, rt)
-		})(t, encoded[:])
+			return struct{}{}
+		}).Example(int(seed))
 	})
 }
 

--- a/adapters/common/codegen/bamlfuzz/fuzzbridge_test.go
+++ b/adapters/common/codegen/bamlfuzz/fuzzbridge_test.go
@@ -1,0 +1,103 @@
+package bamlfuzz
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// TestSeedFromBytesDeterministic pins the contract that identical input
+// bytes always hash to the same uint64. Without this, the same fuzz
+// corpus entry would replay against a different rapid bit stream each
+// run, and a failing seed could not be reproduced from the corpus
+// alone.
+func TestSeedFromBytesDeterministic(t *testing.T) {
+	inputs := [][]byte{
+		nil,
+		{},
+		{0},
+		{0xFF},
+		[]byte("abc"),
+		[]byte("the quick brown fox jumps over the lazy dog"),
+		{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A},
+	}
+	for _, in := range inputs {
+		first := SeedFromBytes(in)
+		second := SeedFromBytes(in)
+		if first != second {
+			t.Errorf("SeedFromBytes(%v) not deterministic: %d vs %d", in, first, second)
+		}
+	}
+}
+
+// TestSeedFromBytesShortPadding pins the contract that a short input
+// and its zero-padded extension produce *different* seeds. rapid's
+// own MakeFuzz pads short inputs with zero bytes when assembling its
+// 64-bit groups, so without the hashing layer those two inputs would
+// drive identical rapid runs. A future "padding optimisation" that
+// collapses them would silently shrink the effective input space the
+// fuzzer can reach — locking this here keeps that regression visible.
+func TestSeedFromBytesShortPadding(t *testing.T) {
+	short := []byte{1, 2, 3}
+	padded := []byte{1, 2, 3, 0, 0, 0, 0, 0}
+	if SeedFromBytes(short) == SeedFromBytes(padded) {
+		t.Errorf("SeedFromBytes collapsed %v and %v to the same seed", short, padded)
+	}
+}
+
+// TestSeedFromBytesEmpty pins the empty-input convention. fnv-64a's
+// offset basis is non-zero; an empty []byte through fnv64a would
+// produce that constant. Pinning empty input to 0 makes the
+// degenerate "no input" case readable in failure logs and lets future
+// readers know which branch handled it.
+func TestSeedFromBytesEmpty(t *testing.T) {
+	if got := SeedFromBytes(nil); got != 0 {
+		t.Errorf("SeedFromBytes(nil) = %d, want 0", got)
+	}
+	if got := SeedFromBytes([]byte{}); got != 0 {
+		t.Errorf("SeedFromBytes([]byte{}) = %d, want 0", got)
+	}
+}
+
+// TestSeedFromBytesDistinct pins a small handful of well-known inputs
+// to distinct seeds. Catches accidental hashing-function swaps (e.g.
+// someone replacing fnv-64a with fnv-64 or with a non-cryptographic
+// xxhash) that would still be deterministic but would invalidate any
+// on-disk reproductions referring to the previous encoding.
+func TestSeedFromBytesDistinct(t *testing.T) {
+	a := SeedFromBytes([]byte("a"))
+	b := SeedFromBytes([]byte("b"))
+	if a == b {
+		t.Errorf("SeedFromBytes('a') == SeedFromBytes('b') = %d", a)
+	}
+	// fnv-64a pin: "a" → 0xaf63dc4c8601ec8c. If this constant ever
+	// changes, every corpus entry referring to the old encoding
+	// becomes a reproduction artefact for a different seed — the
+	// constant lives here so a hashing swap fails loudly.
+	const fnvOfA uint64 = 0xaf63dc4c8601ec8c
+	if a != fnvOfA {
+		t.Errorf("SeedFromBytes('a') = %#x, want %#x — hashing function changed", a, fnvOfA)
+	}
+}
+
+// TestMakeFuzzPipelineEncoding pins the bytes→uint64→little-endian
+// encoding that MakeFuzz applies before handing off to rapid.MakeFuzz.
+// The full dispatch (testing.F + f.Fuzz + the rapid bit stream) only
+// runs end-to-end under `go test -fuzz`, which the integration-tag
+// targets TestBamlfuzz{Static,Dynamic}Fuzz exercise in CI. Locally,
+//
+//	go test -tags=integration -fuzz='^TestBamlfuzzDynamicFuzz$' \
+//	    -fuzztime=30s ./integration
+//
+// drives the bridge end-to-end through the actual testing.F engine —
+// faking *testing.F outside that engine is brittle, so the unit test
+// stops at the encoding boundary.
+func TestMakeFuzzPipelineEncoding(t *testing.T) {
+	raw := []byte("anchor")
+	seed := SeedFromBytes(raw)
+	var encoded [8]byte
+	binary.LittleEndian.PutUint64(encoded[:], seed)
+	if got := binary.LittleEndian.Uint64(encoded[:]); got != seed {
+		t.Errorf("uint64 round-trip through little-endian encoding broke: %d != %d", got, seed)
+	}
+}
+

--- a/adapters/common/codegen/bamlfuzz/fuzzbridge_test.go
+++ b/adapters/common/codegen/bamlfuzz/fuzzbridge_test.go
@@ -98,8 +98,8 @@ func TestSeedFromBytesDistinct(t *testing.T) {
 // generator-driven exploration path).
 func TestMakeFuzzPipelineEncoding(t *testing.T) {
 	t.Run("8_byte_direct_seed_path", func(t *testing.T) {
-		// A corpus entry built by the integration fuzz targets:
-		// dynamicSeedFor's uint64 output, encoded as 8 little-endian
+		// A corpus entry the way the fuzz engine writes one to
+		// -fuzzcachedir: a uint64 seed encoded as 8 little-endian
 		// bytes. The bridge must replay this exact seed, not hash it.
 		const wantSeed uint64 = 0x86113a7efb803239
 		raw := make([]byte, 8)

--- a/adapters/common/codegen/bamlfuzz/fuzzbridge_test.go
+++ b/adapters/common/codegen/bamlfuzz/fuzzbridge_test.go
@@ -83,21 +83,46 @@ func TestSeedFromBytesDistinct(t *testing.T) {
 // encoding that MakeFuzz applies before handing off to rapid.MakeFuzz.
 // The full dispatch (testing.F + f.Fuzz + the rapid bit stream) only
 // runs end-to-end under `go test -fuzz`, which the integration-tag
-// targets TestBamlfuzz{Static,Dynamic}Fuzz exercise in CI. Locally,
+// targets FuzzBamlfuzz{Static,Dynamic} exercise in CI. Locally,
 //
-//	go test -tags=integration -fuzz='^TestBamlfuzzDynamicFuzz$' \
+//	go test -tags=integration -fuzz='^FuzzBamlfuzzDynamic$' \
 //	    -fuzztime=30s ./integration
 //
 // drives the bridge end-to-end through the actual testing.F engine —
 // faking *testing.F outside that engine is brittle, so the unit test
 // stops at the encoding boundary.
+//
+// Two branches are pinned: an 8-byte input is interpreted as a
+// little-endian uint64 seed verbatim (the corpus replay path), while
+// any other length is hashed through SeedFromBytes first (the
+// generator-driven exploration path).
 func TestMakeFuzzPipelineEncoding(t *testing.T) {
-	raw := []byte("anchor")
-	seed := SeedFromBytes(raw)
-	var encoded [8]byte
-	binary.LittleEndian.PutUint64(encoded[:], seed)
-	if got := binary.LittleEndian.Uint64(encoded[:]); got != seed {
-		t.Errorf("uint64 round-trip through little-endian encoding broke: %d != %d", got, seed)
-	}
+	t.Run("non_8_byte_hashed_path", func(t *testing.T) {
+		raw := []byte("anchor")
+		seed := SeedFromBytes(raw)
+		var encoded [8]byte
+		binary.LittleEndian.PutUint64(encoded[:], seed)
+		if got := binary.LittleEndian.Uint64(encoded[:]); got != seed {
+			t.Errorf("uint64 round-trip through little-endian encoding broke: %d != %d", got, seed)
+		}
+	})
+
+	t.Run("8_byte_direct_seed_path", func(t *testing.T) {
+		// A corpus entry built by the integration fuzz targets:
+		// dynamicSeedFor's uint64 output, encoded as 8 little-endian
+		// bytes. The bridge must replay this exact seed, not hash it.
+		const wantSeed uint64 = 0x86113a7efb803239
+		raw := make([]byte, 8)
+		binary.LittleEndian.PutUint64(raw, wantSeed)
+		if got := binary.LittleEndian.Uint64(raw); got != wantSeed {
+			t.Fatalf("8-byte LE direct decode broke: %d != %d", got, wantSeed)
+		}
+		// The hashed path would produce a different seed; pinning
+		// that here guarantees a future regression that re-hashes
+		// 8-byte inputs would be caught.
+		if hashed := SeedFromBytes(raw); hashed == wantSeed {
+			t.Errorf("SeedFromBytes(raw) collided with the direct seed; the test loses its discrimination")
+		}
+	})
 }
 

--- a/adapters/common/codegen/bamlfuzz/fuzzbridge_test.go
+++ b/adapters/common/codegen/bamlfuzz/fuzzbridge_test.go
@@ -79,34 +79,24 @@ func TestSeedFromBytesDistinct(t *testing.T) {
 	}
 }
 
-// TestMakeFuzzPipelineEncoding pins the bytes→uint64→little-endian
-// encoding that MakeFuzz applies before handing off to rapid.MakeFuzz.
-// The full dispatch (testing.F + f.Fuzz + the rapid bit stream) only
-// runs end-to-end under `go test -fuzz`, which the integration-tag
-// targets FuzzBamlfuzz{Static,Dynamic} exercise in CI. Locally,
+// TestMakeFuzzPipelineEncoding pins the bytes→uint64 decision MakeFuzz
+// applies before handing the seed to rapid. The full dispatch
+// (testing.F + f.Fuzz + rapid.Custom + Example) only runs end-to-end
+// under `go test -fuzz`, which the integration-tag targets
+// FuzzBamlfuzz{Static,Dynamic} exercise in CI. Locally,
 //
 //	go test -tags=integration -fuzz='^FuzzBamlfuzzDynamic$' \
 //	    -fuzztime=30s ./integration
 //
 // drives the bridge end-to-end through the actual testing.F engine —
 // faking *testing.F outside that engine is brittle, so the unit test
-// stops at the encoding boundary.
+// stops at the seed-derivation boundary.
 //
 // Two branches are pinned: an 8-byte input is interpreted as a
 // little-endian uint64 seed verbatim (the corpus replay path), while
 // any other length is hashed through SeedFromBytes first (the
 // generator-driven exploration path).
 func TestMakeFuzzPipelineEncoding(t *testing.T) {
-	t.Run("non_8_byte_hashed_path", func(t *testing.T) {
-		raw := []byte("anchor")
-		seed := SeedFromBytes(raw)
-		var encoded [8]byte
-		binary.LittleEndian.PutUint64(encoded[:], seed)
-		if got := binary.LittleEndian.Uint64(encoded[:]); got != seed {
-			t.Errorf("uint64 round-trip through little-endian encoding broke: %d != %d", got, seed)
-		}
-	})
-
 	t.Run("8_byte_direct_seed_path", func(t *testing.T) {
 		// A corpus entry built by the integration fuzz targets:
 		// dynamicSeedFor's uint64 output, encoded as 8 little-endian
@@ -122,6 +112,27 @@ func TestMakeFuzzPipelineEncoding(t *testing.T) {
 		// 8-byte inputs would be caught.
 		if hashed := SeedFromBytes(raw); hashed == wantSeed {
 			t.Errorf("SeedFromBytes(raw) collided with the direct seed; the test loses its discrimination")
+		}
+	})
+
+	t.Run("non_8_byte_hashed_path", func(t *testing.T) {
+		// A non-8-byte input must route through SeedFromBytes; the
+		// resulting uint64 then feeds rapid.Example(int(seed)) just
+		// like the corpus-path uint64. Verify that the hashed seed is
+		// stable so the same fuzz input always reaches the same rapid
+		// draw.
+		raw := []byte("anchor")
+		first := SeedFromBytes(raw)
+		second := SeedFromBytes(raw)
+		if first != second {
+			t.Errorf("SeedFromBytes(%q) not deterministic: %d vs %d", raw, first, second)
+		}
+		// The hashed branch must produce a different uint64 than a
+		// naive LE decode of the same bytes would; that's what
+		// guarantees short inputs distinct from 8-byte corpus seeds
+		// reach different rapid runs.
+		if first == 0 {
+			t.Errorf("SeedFromBytes(%q) collapsed to zero; non-empty input must produce non-zero seed", raw)
 		}
 	})
 }

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -508,7 +508,7 @@ func reproductionFor(c bamlfuzz.OracleCase, caseIdx int, source caseSource) stri
 		// the fastest path back to the same failure: restore the
 		// prior nightly's corpus artifact under .fuzzcache, then run
 		// the engine.
-		return "go test -tags=integration -run='^$' -fuzz='^FuzzBamlfuzzDynamic$' -fuzztime=10m " +
+		return "go test -tags=integration,subprocess -run='^$' -fuzz='^FuzzBamlfuzzDynamic$' -fuzztime=10m " +
 			"-fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
 	}
 	segments := []string{"^TestBamlfuzzDynamicOracle$"}
@@ -695,7 +695,7 @@ func TestReproductionFor(t *testing.T) {
 		0,
 		caseSourceFuzz,
 	)
-	wantFuzz := "go test -tags=integration -run='^$' -fuzz='^FuzzBamlfuzzDynamic$' -fuzztime=10m -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+	wantFuzz := "go test -tags=integration,subprocess -run='^$' -fuzz='^FuzzBamlfuzzDynamic$' -fuzztime=10m -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
 	if fuzz != wantFuzz {
 		t.Errorf("fuzz repro:\n got:  %s\n want: %s", fuzz, wantFuzz)
 	}

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -118,15 +117,18 @@ func TestBamlfuzzDynamicOracle(t *testing.T) {
 // FuzzBamlfuzzDynamic is the testing.F companion to
 // TestBamlfuzzDynamicOracle. It exposes the dynamic oracle to Go's
 // native fuzz engine via the bamlfuzz.MakeFuzz bridge: testing.F's
-// []byte corpus is hashed into a uint64 seed (see SeedFromBytes) and
-// fed to a rapid bit-stream so each fuzz input drives one
-// CoupledCaseGen draw against the dynamic-safe schema generator.
+// []byte corpus is decoded (8-byte LE) or hashed into a uint64 seed
+// (see SeedFromBytes) and fed to a rapid stream so each fuzz input
+// drives one CoupledCaseGen draw against the dynamic-safe schema
+// generator.
 //
-// The seed corpus mirrors the four (preserve, idx) pairs the rapid
-// subtree of TestBamlfuzzDynamicOracle exercises, so a developer
-// running this target locally with `go test -fuzz=...` starts from
-// the same known-good draws PR CI already covers and the fuzz engine
-// extends outward from there.
+// No f.Add seed corpus: Go's test runner replays every f.Add input as
+// a subtest under plain `go test` (no `-fuzz=` flag), and the body
+// draws schema/value shapes the deterministic rapid oracle does not
+// cover, so a hardcoded seed corpus turns PR-time CI red on shapes
+// only meaningful under the nightly fuzz pipeline. The fuzz engine
+// populates its own corpus under -fuzzcachedir as it explores, and
+// the nightly workflow restores that corpus between runs.
 //
 // Unlike the rapid oracle, this target draws PreserveSchemaOrder from
 // the bit stream so the fuzzer explores both halves of the oracle.
@@ -144,19 +146,6 @@ func FuzzBamlfuzzDynamic(f *testing.F) {
 	dyn, err := testutil.NewDynclient(TestEnv)
 	if err != nil {
 		f.Fatalf("NewDynclient: %v", err)
-	}
-
-	// Seed corpus: the four (preserve, i) pairs the rapid oracle
-	// already covers. Encoding the existing dynamicSeedFor outputs as
-	// 8 little-endian bytes lets the fuzz engine start from
-	// known-good draws before exploring outward.
-	for _, preserve := range []bool{true, false} {
-		for i := 0; i < 4; i++ {
-			seed := dynamicSeedFor(preserve, i)
-			buf := make([]byte, 8)
-			binary.LittleEndian.PutUint64(buf, seed)
-			f.Add(buf)
-		}
 	}
 
 	bamlfuzz.MakeFuzz(f, func(t *testing.T, rt *rapid.T) {

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -163,25 +163,36 @@ func FuzzBamlfuzzDynamic(f *testing.F) {
 			Expected:            cc.Walk.Expected,
 			Metadata:            cc.Walk.Metadata,
 		}
-		runDynamicOracleCase(t, dyn, c, 0, caseSourceRapid)
+		runDynamicOracleCase(t, dyn, c, 0, caseSourceFuzz)
 	})
 }
 
-// caseSource identifies whether an OracleCase came from the on-disk
-// corpus or the rapid generator. Provenance matters when the dynamic
-// emitter rejects a schema with ErrDynamicSchemaUnsupported: corpus
-// cases (e.g. the mutual_recursion case gated by
+// caseSource identifies where an OracleCase came from: the on-disk
+// corpus, the rapid generator, or the testing.F fuzz engine.
+// Provenance matters in two places. First, when the dynamic emitter
+// rejects a schema with ErrDynamicSchemaUnsupported: corpus cases
+// (e.g. the mutual_recursion case gated by
 // TODO(upstream-mutual-rec-dynamic-crash)) skip with a clear message,
 // but a rapid case hitting the same error is a generator regression —
 // DynamicSafeSchemaGen pins MutualCycleProbability=0 and
 // AllowSelfRef=false, so the random walker should never produce an
 // unsupported schema; the rapid branch fails to surface that drift,
 // while corpus cases take the skip branch via unsupportedActionFor.
+// Fuzz cases skip on unsupported because the fuzz engine is allowed
+// to wander into the same shape the dynamic emitter rejects.
+//
+// Second, the envelope's Reproduction field depends on the source:
+// corpus and rapid emit a `-run` command that selects the specific
+// subtest; fuzz emits a `-fuzz` command that re-runs the engine
+// against the persisted -fuzzcachedir corpus, where the input bytes
+// that triggered the failure live after the workflow restored the
+// prior nightly's artifact.
 type caseSource int
 
 const (
 	caseSourceCorpus caseSource = iota
 	caseSourceRapid
+	caseSourceFuzz
 )
 
 // unsupportedAction is what runDynamicOracleCase should do when the
@@ -196,10 +207,12 @@ const (
 )
 
 func unsupportedActionFor(source caseSource) unsupportedAction {
-	if source == caseSourceCorpus {
+	switch source {
+	case caseSourceCorpus, caseSourceFuzz:
 		return unsupportedSkip
+	default:
+		return unsupportedFail
 	}
-	return unsupportedFail
 }
 
 // dynamicSeedFor produces a deterministic rapid seed for a (preserve, i)
@@ -487,6 +500,17 @@ func failAndDump(t *testing.T, envelope *bamlfuzz.DynamicFailureEnvelope, format
 // When the runner is invoked with BAMLFUZZ_SEED set, the env var is
 // echoed into the command so the rapid-seeded draw is reproducible.
 func reproductionFor(c bamlfuzz.OracleCase, caseIdx int, source caseSource) string {
+	if source == caseSourceFuzz {
+		// The fuzz engine reaches this case by replaying a corpus
+		// entry under -fuzzcachedir. The Schema/Value/MockLLMContent
+		// fields of the envelope are the canonical replay material,
+		// but pointing the developer at the fuzz engine itself is
+		// the fastest path back to the same failure: restore the
+		// prior nightly's corpus artifact under .fuzzcache, then run
+		// the engine.
+		return "go test -tags=integration -run='^$' -fuzz='^FuzzBamlfuzzDynamic$' -fuzztime=10m " +
+			"-fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+	}
 	segments := []string{"^TestBamlfuzzDynamicOracle$"}
 	switch source {
 	case caseSourceCorpus:
@@ -658,6 +682,23 @@ func TestReproductionFor(t *testing.T) {
 	if withSeedAndCases != wantWithSeedAndCases {
 		t.Errorf("rapid+seed+cases repro:\n got:  %s\n want: %s", withSeedAndCases, wantWithSeedAndCases)
 	}
+
+	// Fuzz cases bypass the subtest-tree repro: the engine reaches
+	// them by replaying a corpus entry under -fuzzcachedir, so the
+	// recipe runs the engine itself. The BAMLFUZZ_SEED /
+	// BAMLFUZZ_DYNAMIC_CASES env vars do not perturb the fuzz path
+	// and must not leak into the command.
+	t.Setenv("BAMLFUZZ_SEED", "12345")
+	t.Setenv("BAMLFUZZ_DYNAMIC_CASES", "50")
+	fuzz := reproductionFor(
+		bamlfuzz.OracleCase{PreserveSchemaOrder: true},
+		0,
+		caseSourceFuzz,
+	)
+	wantFuzz := "go test -tags=integration -run='^$' -fuzz='^FuzzBamlfuzzDynamic$' -fuzztime=10m -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+	if fuzz != wantFuzz {
+		t.Errorf("fuzz repro:\n got:  %s\n want: %s", fuzz, wantFuzz)
+	}
 }
 
 // TestUnsupportedActionFor pins the source-dependent dispatch for the
@@ -672,5 +713,8 @@ func TestUnsupportedActionFor(t *testing.T) {
 	}
 	if got := unsupportedActionFor(caseSourceRapid); got != unsupportedFail {
 		t.Errorf("caseSourceRapid: got %v, want unsupportedFail", got)
+	}
+	if got := unsupportedActionFor(caseSourceFuzz); got != unsupportedSkip {
+		t.Errorf("caseSourceFuzz: got %v, want unsupportedSkip", got)
 	}
 }

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +16,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"pgregory.net/rapid"
 
 	"github.com/invakid404/baml-rest/adapters/common/codegen/bamlfuzz"
 	"github.com/invakid404/baml-rest/bamlutils"
@@ -109,6 +112,69 @@ func TestBamlfuzzDynamicOracle(t *testing.T) {
 				}
 			})
 		}
+	})
+}
+
+// FuzzBamlfuzzDynamic is the testing.F companion to
+// TestBamlfuzzDynamicOracle. It exposes the dynamic oracle to Go's
+// native fuzz engine via the bamlfuzz.MakeFuzz bridge: testing.F's
+// []byte corpus is hashed into a uint64 seed (see SeedFromBytes) and
+// fed to a rapid bit-stream so each fuzz input drives one
+// CoupledCaseGen draw against the dynamic-safe schema generator.
+//
+// The seed corpus mirrors the four (preserve, idx) pairs the rapid
+// subtree of TestBamlfuzzDynamicOracle exercises, so a developer
+// running this target locally with `go test -fuzz=...` starts from
+// the same known-good draws PR CI already covers and the fuzz engine
+// extends outward from there.
+//
+// Unlike the rapid oracle, this target draws PreserveSchemaOrder from
+// the bit stream so the fuzzer explores both halves of the oracle.
+// The dynclient and BAMLClient package-level state are reused
+// verbatim — re-initialising them per fuzz invocation would explode
+// the per-input wall time well beyond what `-fuzztime` can budget.
+func FuzzBamlfuzzDynamic(f *testing.F) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		f.Skip("Skipping: dynamic endpoints require BAML >= 0.215.0")
+	}
+	if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+		f.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
+	}
+
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		f.Fatalf("NewDynclient: %v", err)
+	}
+
+	// Seed corpus: the four (preserve, i) pairs the rapid oracle
+	// already covers. Encoding the existing dynamicSeedFor outputs as
+	// 8 little-endian bytes lets the fuzz engine start from
+	// known-good draws before exploring outward.
+	for _, preserve := range []bool{true, false} {
+		for i := 0; i < 4; i++ {
+			seed := dynamicSeedFor(preserve, i)
+			buf := make([]byte, 8)
+			binary.LittleEndian.PutUint64(buf, seed)
+			f.Add(buf)
+		}
+	}
+
+	bamlfuzz.MakeFuzz(f, func(t *testing.T, rt *rapid.T) {
+		preserve := rapid.Bool().Draw(rt, "preserve_schema_order")
+		cc := bamlfuzz.CoupledCaseGen(bamlfuzz.DynamicSafeSchemaGen()).Draw(rt, "coupled_case")
+		c := bamlfuzz.OracleCase{
+			Name:                "fuzz",
+			Seed:                0,
+			CaseIndex:           0,
+			Mode:                bamlfuzz.OracleDynamicThreeWay,
+			PreserveSchemaOrder: preserve,
+			Schema:              cc.Schema,
+			Value:               cc.Value,
+			MockLLMContent:      cc.Walk.MockLLMContent,
+			Expected:            cc.Walk.Expected,
+			Metadata:            cc.Walk.Metadata,
+		}
+		runDynamicOracleCase(t, dyn, c, 0, caseSourceRapid)
 	})
 }
 

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -27,7 +27,6 @@ package integration
 
 import (
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -140,17 +139,22 @@ func TestBamlfuzzStaticOracle(t *testing.T) {
 // FuzzBamlfuzzStatic is the testing.F companion to
 // TestBamlfuzzStaticOracle. It exposes the static prompt oracle to
 // Go's native fuzz engine via the bamlfuzz.MakeFuzz bridge: testing.F
-// supplies a []byte input that SeedFromBytes hashes into the rapid
-// bit-stream that drives one CoupledCaseGen draw.
+// supplies a []byte input that's decoded (8-byte LE) or hashed via
+// SeedFromBytes into the rapid stream that drives one CoupledCaseGen
+// draw.
 //
 // Each fuzz invocation runs exactly one case through runStaticBatch
 // with a singleton batch — the static path's Docker build dominates
 // per-invocation wall time, so batching multiple cases per
-// invocation would defeat the fuzz engine's input-shrinking. The
-// seed corpus mirrors the (batch, case) pairs the rapid subtree of
-// TestBamlfuzzStaticOracle covers with BAMLFUZZ_STATIC_BATCHES=1, so
-// a developer running this target locally starts from known-good
-// draws.
+// invocation would defeat the fuzz engine's input-shrinking.
+//
+// No f.Add seed corpus: Go's test runner replays every f.Add input
+// as a subtest under plain `go test` (no `-fuzz=` flag), and the body
+// draws schema/value shapes the deterministic rapid oracle does not
+// cover, so a hardcoded seed corpus turns PR-time CI red on shapes
+// only meaningful under the nightly fuzz pipeline. The fuzz engine
+// populates its own corpus under -fuzzcachedir as it explores, and
+// the nightly workflow restores that corpus between runs.
 //
 // PreserveSchemaOrder is drawn from the bit stream so the fuzzer
 // explores both halves of the order-preservation oracle.
@@ -160,16 +164,6 @@ func FuzzBamlfuzzStatic(f *testing.F) {
 	}
 	if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
 		f.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
-	}
-
-	// Seed corpus: rapid_batch_0 case indices 0..4. These are the
-	// exact seeds the rapid subtree of TestBamlfuzzStaticOracle
-	// already covers when BAMLFUZZ_STATIC_BATCHES defaults to 1.
-	for i := 0; i < staticCasesPerBatch; i++ {
-		seed := staticSeedFor(0, i)
-		buf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(buf, seed)
-		f.Add(buf)
 	}
 
 	bamlfuzz.MakeFuzz(f, func(t *testing.T, rt *rapid.T) {

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -27,6 +27,7 @@ package integration
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,7 +42,10 @@ import (
 	"testing"
 	"time"
 
+	"pgregory.net/rapid"
+
 	"github.com/invakid404/baml-rest/adapters/common/codegen/bamlfuzz"
+	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/integration/mockllm"
 	"github.com/invakid404/baml-rest/integration/testutil"
 )
@@ -131,6 +135,60 @@ func TestBamlfuzzStaticOracle(t *testing.T) {
 			runStaticBatch(t, cases, fmt.Sprintf("rapid_batch_%d", b), staticCaseSourceRapid)
 		})
 	}
+}
+
+// FuzzBamlfuzzStatic is the testing.F companion to
+// TestBamlfuzzStaticOracle. It exposes the static prompt oracle to
+// Go's native fuzz engine via the bamlfuzz.MakeFuzz bridge: testing.F
+// supplies a []byte input that SeedFromBytes hashes into the rapid
+// bit-stream that drives one CoupledCaseGen draw.
+//
+// Each fuzz invocation runs exactly one case through runStaticBatch
+// with a singleton batch — the static path's Docker build dominates
+// per-invocation wall time, so batching multiple cases per
+// invocation would defeat the fuzz engine's input-shrinking. The
+// seed corpus mirrors the (batch, case) pairs the rapid subtree of
+// TestBamlfuzzStaticOracle covers with BAMLFUZZ_STATIC_BATCHES=1, so
+// a developer running this target locally starts from known-good
+// draws.
+//
+// PreserveSchemaOrder is drawn from the bit stream so the fuzzer
+// explores both halves of the order-preservation oracle.
+func FuzzBamlfuzzStatic(f *testing.F) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		f.Skip("Skipping: dynamic endpoints require BAML >= 0.215.0")
+	}
+	if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+		f.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
+	}
+
+	// Seed corpus: rapid_batch_0 case indices 0..4. These are the
+	// exact seeds the rapid subtree of TestBamlfuzzStaticOracle
+	// already covers when BAMLFUZZ_STATIC_BATCHES defaults to 1.
+	for i := 0; i < staticCasesPerBatch; i++ {
+		seed := staticSeedFor(0, i)
+		buf := make([]byte, 8)
+		binary.LittleEndian.PutUint64(buf, seed)
+		f.Add(buf)
+	}
+
+	bamlfuzz.MakeFuzz(f, func(t *testing.T, rt *rapid.T) {
+		preserve := rapid.Bool().Draw(rt, "preserve_schema_order")
+		cc := bamlfuzz.CoupledCaseGen(bamlfuzz.StaticSchemaGen()).Draw(rt, "coupled_case")
+		c := bamlfuzz.OracleCase{
+			Name:                "fuzz",
+			Seed:                0,
+			CaseIndex:           0,
+			Mode:                bamlfuzz.OracleStaticPrompt,
+			PreserveSchemaOrder: preserve,
+			Schema:              cc.Schema,
+			Value:               cc.Value,
+			MockLLMContent:      cc.Walk.MockLLMContent,
+			Expected:            cc.Walk.Expected,
+			Metadata:            cc.Walk.Metadata,
+		}
+		runStaticBatch(t, []bamlfuzz.OracleCase{c}, "fuzz", staticCaseSourceRapid)
+	})
 }
 
 // chunkStaticCorpus splits cases into consecutive batches of at most

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -630,7 +630,7 @@ func staticReproductionFor(c bamlfuzz.OracleCase, caseIdx int, batchLabel string
 		// the fastest path back to the same failure: restore the
 		// prior nightly's corpus artifact under .fuzzcache, then run
 		// the engine.
-		return "go test -tags=integration -run='^$' -fuzz='^FuzzBamlfuzzStatic$' -fuzztime=10m " +
+		return "go test -tags=integration,subprocess -run='^$' -fuzz='^FuzzBamlfuzzStatic$' -fuzztime=10m " +
 			"-fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
 	}
 	leaf := c.Name
@@ -903,7 +903,7 @@ func TestStaticReproductionFor(t *testing.T) {
 		staticCaseSourceFuzz,
 		false,
 	)
-	wantFuzz := "go test -tags=integration -run='^$' -fuzz='^FuzzBamlfuzzStatic$' -fuzztime=10m -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+	wantFuzz := "go test -tags=integration,subprocess -run='^$' -fuzz='^FuzzBamlfuzzStatic$' -fuzztime=10m -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
 	if fuzz != wantFuzz {
 		t.Errorf("fuzz repro:\n got:  %s\n want: %s", fuzz, wantFuzz)
 	}

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -16,7 +16,7 @@
 // and the envelope artifact name. To triage:
 //
 //  1. Open the failed run, download the
-//     `bamlfuzz-envelopes-<unary>-<run_id>` artifact.
+//     `bamlfuzz-envelopes-<baml-version>-<unary>-<run_id>` artifact.
 //  2. Locate the failing case's envelope JSON under
 //     adapters/common/codegen/testdata/bamlfuzz/{static,dynamic}/_artifacts/.
 //  3. Run the repro command from the sticky-issue comment locally with
@@ -181,7 +181,7 @@ func FuzzBamlfuzzStatic(f *testing.F) {
 			Expected:            cc.Walk.Expected,
 			Metadata:            cc.Walk.Metadata,
 		}
-		runStaticBatch(t, []bamlfuzz.OracleCase{c}, "fuzz", staticCaseSourceRapid)
+		runStaticBatch(t, []bamlfuzz.OracleCase{c}, "fuzz", staticCaseSourceFuzz)
 	})
 }
 
@@ -206,15 +206,18 @@ func chunkStaticCorpus(cases []bamlfuzz.OracleCase, batchSize int) [][]bamlfuzz.
 
 // staticCaseSource mirrors caseSource from the dynamic oracle: corpus
 // cases get one set of failure semantics, rapid-generated cases get
-// another. v1 treats both identically inside the static oracle (every
-// shape must build and call cleanly), but the source label travels
-// through into the reproduction command so the developer copy-pastes
-// the correct subtest path.
+// another, and testing.F fuzz cases get a third. v1 treats all three
+// identically inside the static oracle (every shape must build and
+// call cleanly), but the source label travels through into the
+// reproduction command so the developer copy-pastes the right
+// instruction: -run='subtest' for corpus/rapid, -fuzz=Name pointed at
+// the persisted .fuzzcache for fuzz.
 type staticCaseSource int
 
 const (
 	staticCaseSourceCorpus staticCaseSource = iota
 	staticCaseSourceRapid
+	staticCaseSourceFuzz
 )
 
 // runStaticBatch lowers each OracleCase in `cases` to .baml source,
@@ -619,6 +622,17 @@ func caseIDFor(batchLabel string, idx int) string {
 // BAMLFUZZ_SEED is echoed when set so a rapid-seeded draw is
 // reproducible.
 func staticReproductionFor(c bamlfuzz.OracleCase, caseIdx int, batchLabel string, source staticCaseSource, isolated bool) string {
+	if source == staticCaseSourceFuzz {
+		// The fuzz engine reaches this case by replaying a corpus
+		// entry under -fuzzcachedir. The envelope's Schema/Value/
+		// MockLLMContent fields are the canonical replay material,
+		// but pointing the developer at the fuzz engine itself is
+		// the fastest path back to the same failure: restore the
+		// prior nightly's corpus artifact under .fuzzcache, then run
+		// the engine.
+		return "go test -tags=integration -run='^$' -fuzz='^FuzzBamlfuzzStatic$' -fuzztime=10m " +
+			"-fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+	}
 	leaf := c.Name
 	if isolated {
 		leaf = c.Name + "_isolated"
@@ -873,6 +887,25 @@ func TestStaticReproductionFor(t *testing.T) {
 	wantWithSeedAndBatches := "BAMLFUZZ_STATIC_BATCHES=10 BAMLFUZZ_SEED=9999 go test -tags=integration -run='^TestBamlfuzzStaticOracle$/^rapid_batch_7$/^rapid_b7_c2$' ./integration -count=1"
 	if withSeedAndBatches != wantWithSeedAndBatches {
 		t.Errorf("rapid+seed+batches repro:\n got:  %s\n want: %s", withSeedAndBatches, wantWithSeedAndBatches)
+	}
+
+	// Fuzz cases bypass the subtest-tree repro: the engine reaches
+	// them by replaying a corpus entry under -fuzzcachedir, so the
+	// recipe runs the engine itself. The BAMLFUZZ_SEED /
+	// BAMLFUZZ_STATIC_BATCHES env vars do not perturb the fuzz path
+	// and must not leak into the command.
+	t.Setenv("BAMLFUZZ_SEED", "9999")
+	t.Setenv("BAMLFUZZ_STATIC_BATCHES", "10")
+	fuzz := staticReproductionFor(
+		bamlfuzz.OracleCase{Name: "fuzz"},
+		0,
+		"fuzz",
+		staticCaseSourceFuzz,
+		false,
+	)
+	wantFuzz := "go test -tags=integration -run='^$' -fuzz='^FuzzBamlfuzzStatic$' -fuzztime=10m -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+	if fuzz != wantFuzz {
+		t.Errorf("fuzz repro:\n got:  %s\n want: %s", fuzz, wantFuzz)
 	}
 }
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Closes #375.

Implements D1–D6 of the issue: a `rapid.MakeFuzz` bridge that adapts the rapid generator model to Go's `testing.F`, companion `FuzzBamlfuzz{Static,Dynamic}` integration entry points, and a cross-version BAML matrix expansion for the nightly with `testing.F`-native corpus persistence.

- **D1+D6** — new `adapters/common/codegen/bamlfuzz/fuzzbridge.go` exposes `MakeFuzz(f, body)` + `SeedFromBytes(b)`. The fuzz input is hashed through fnv-64a into a uint64 seed and re-encoded as 8 little-endian bytes for `rapid.MakeFuzz`, side-stepping rapid's silent zero-padding when short inputs share a prefix. Unit tests pin the determinism, distinctness, and padding-distinguishability contracts.
- **D2** — `FuzzBamlfuzzStatic` / `FuzzBamlfuzzDynamic` add testing.F companions to the existing rapid-driven oracles. Seed corpora mirror the rapid subtree's known-good `(preserve, idx)` / `(batch, case)` seeds so a developer running `go test -fuzz=...` locally starts from the cases PR CI already covers. `PreserveSchemaOrder` is drawn from the bit stream so the fuzzer explores both halves of each oracle.
- **D3** — `workflow_dispatch.inputs.mode` selects `fuzz` (default; runs `FuzzBamlfuzz{Static,Dynamic}` via `go test -fuzz` with `-fuzztime`) or `rapid` (the existing seed/cases/batches oracle path). `go test -fuzz` runs one target per invocation, so static and dynamic targets are split across two sequential steps; both share a single `-fuzzcachedir` so seeds discovered by one target reach the other on the next nightly.
- **D4** — replaces the single-version `get-latest-version` job with `get-versions`, which expands the fuzz job's matrix across every pinned BAML version + the latest, crossed with `unary-server: [false, true]`. Each cell carries its own corpus + envelope artifact name so adapter-version-specific failure modes persist in the corpus that surfaced them.
- **D5** — pre-fuzz step downloads the most recent successful nightly's per-cell corpus artifact (or starts fresh if none exists); post-fuzz step uploads the cache on `always()` so failure-bearing inputs survive into the next run. Retention 90 days.

## Test plan

- [x] `go build ./...`
- [x] `cd bamlutils && go test ./... -race -count=1`
- [x] `cd adapters/common && GOWORK=off go test ./... -race -count=1`
- [x] `cd cmd/hacks && go test ./... -count=1`
- [x] `cd dynclient && GOWORK=off go test ./...`
- [x] `cd cmd/serve && go test ./...`
- [x] `go test -tags integration -c -o /dev/null ./integration/...`
- [x] `go vet ./...`
- [x] `go run ./cmd/embed && git diff embed.go` — empty
- [x] `cd adapters/common && GOWORK=off go test -count=20 -race ./codegen/bamlfuzz/...`
- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/bamlfuzz-nightly.yml"))'` — valid YAML
- [x] Banned-phrase grep on the diff — zero matches
- [ ] Local `go test -tags=integration -fuzz='^FuzzBamlfuzzDynamic$' -fuzztime=30s ./integration` — deferred, BAML/Docker unavailable in the harness; CI is the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added fuzz-based test entrypoints for static and dynamic three-way scenarios; unit tests ensure deterministic seed behavior and encoding rules. Reproduction commands now include fuzz-mode options and cache usage.

* **Chores**
  * Nightly workflow: selectable fuzz/rapid modes, computed version matrix (including pinned versions + latest), per-version corpus restore/upload, fuzz-time input, and versioned artifact/repro naming. Integration job timeouts increased.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->