### PR TITLE
feat(bamlfuzz): invalid-schema fuzzing — dynamic schema rejection + JSON coercion divergence

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -272,7 +272,7 @@ jobs:
             if [ "${MODE}" = "fuzz" ]; then
               echo "Corpus artifact: bamlfuzz-corpus-${BAML}-${UNARY}"
               echo
-              echo "Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/). \`go test -fuzz\` accepts only a single target per invocation, so run the static and dynamic targets sequentially. The \`-fuzzcachedir\` flag points the engine at the extracted corpus so the failing input is replayed:"
+              echo "Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/). \`go test -fuzz\` accepts only a single target per invocation, so run the static, dynamic, invalid-dynamic, and invalid-json-coercion targets sequentially. The \`-fuzzcachedir\` flag points the engine at the extracted corpus so the failing input is replayed:"
               echo
               echo '```'
               echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzStatic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -76,13 +76,21 @@ jobs:
   fuzz:
     needs: get-versions
     runs-on: ubuntu-latest
-    # Four sequential fuzz targets at the default 15m each = 60m of fuzz
-    # wall time; setup + image pull + corpus restore land around 10m on
-    # cold runners. The 120m cap leaves headroom for an operator-set
-    # FUZZTIME up to ~25m without breaching, and absorbs the
-    # invalid-* targets' slower per-exec rate when a draw lands on a
-    # mutation whose JSON re-encoding dominates the loop.
-    timeout-minutes: 120
+    # Four sequential fuzz targets, each its own `go test ./integration`
+    # invocation — so TestMain (the integration env Setup that boots
+    # the BAML REST container + mock LLM) runs FOUR TIMES, not once.
+    # Budget:
+    #   - fuzz: 4 × FUZZTIME (default 15m) = 60m
+    #   - setup: 4 × ~10m per invocation on cold runners = 40m
+    #   - corpus restore + Go install + safety margin = ~10m
+    #   Total at the FUZZTIME default: ~110m.
+    # The 180m cap absorbs cold-runner setup variance and supports an
+    # operator-set FUZZTIME up to ~25m (4 × 25m + 40m setup + 10m
+    # margin = 150m) without breaching. A future refactor that runs
+    # all four fuzz targets under a single `go test` invocation would
+    # collapse setup to ~10m total and shrink the budget back to the
+    # ~75m the prior two-target nightly used.
+    timeout-minutes: 180
     permissions:
       contents: read
       actions: read
@@ -285,7 +293,7 @@ jobs:
               echo "Repro:"
               echo
               echo '```'
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_DYNAMIC_CASES=${BAMLFUZZ_DYNAMIC_CASES} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} BAMLFUZZ_INVALID_CASES=${BAMLFUZZ_INVALID_CASES} go test -tags=integration -run='^TestBamlfuzz(Static|Dynamic)Oracle\$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)\$' ./integration -count=1"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_DYNAMIC_CASES=${BAMLFUZZ_DYNAMIC_CASES} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} BAMLFUZZ_INVALID_CASES=${BAMLFUZZ_INVALID_CASES} go test -tags=integration,subprocess -run='^TestBamlfuzz(Static|Dynamic)Oracle\$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)\$' ./integration -count=1"
               echo '```'
             fi
           } | gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file -

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -32,7 +32,7 @@ on:
         required: false
         default: "50"
       fuzztime:
-        description: Fuzz-mode duration per target (default 15m; total wall time roughly 2× this)
+        description: Fuzz-mode duration per target (default 15m; total wall time roughly 4× this — static + dynamic + invalid-dynamic + invalid-json-coercion run sequentially)
         type: string
         required: false
         default: "15m"
@@ -76,7 +76,13 @@ jobs:
   fuzz:
     needs: get-versions
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # Four sequential fuzz targets at the default 15m each = 60m of fuzz
+    # wall time; setup + image pull + corpus restore land around 10m on
+    # cold runners. The 120m cap leaves headroom for an operator-set
+    # FUZZTIME up to ~25m without breaching, and absorbs the
+    # invalid-* targets' slower per-exec rate when a draw lands on a
+    # mutation whose JSON re-encoding dominates the loop.
+    timeout-minutes: 120
     permissions:
       contents: read
       actions: read
@@ -136,22 +142,26 @@ jobs:
 
       - name: Run bamlfuzz nightly — static fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'fuzz' }}
-        # `go test -fuzz` runs ONE target per invocation, so the static
-        # and dynamic targets are split across sequential steps. Each
-        # gets half the configured fuzztime budget. The corpus dir is
-        # shared so seed inputs that the dynamic target discovered also
-        # influence the static target on the next nightly.
+        # `go test -fuzz` runs ONE target per invocation, so the four
+        # fuzz targets (static, dynamic, invalid-dynamic,
+        # invalid-json-coercion) are split across sequential steps.
+        # Each gets the full configured FUZZTIME budget. Total fuzz
+        # wall time is therefore 4 × FUZZTIME; the job's
+        # timeout-minutes block above caps the combined cost. The
+        # corpus dir is shared so seed inputs any target discovers
+        # also influence the others on the next nightly.
         #
         # `-run='^$'` matches no ordinary test name, which keeps the
-        # cranked-up TestBamlfuzz{Static,Dynamic}Oracle rapid runs from
-        # consuming the per-step budget before fuzzing starts.
+        # cranked-up TestBamlfuzz{Static,Dynamic,Invalid*} rapid runs
+        # from consuming the per-step budget before fuzzing starts.
         # BAMLFUZZ_KEEP_ARTIFACTS is forced off here; the success-path
         # envelope dump in the oracle bodies all writes to
         # _artifacts/fuzz.json (one filename per fuzz case), which races
         # under parallel fuzz workers and can overwrite a failure
         # envelope on the way out. Failures still dump unconditionally
-        # via failAndDump/failStaticAndDump, so the workflow's
-        # upload-on-failure step still captures the right artifact.
+        # via failAndDump / failStaticAndDump / failAndDumpInvalid, so
+        # the workflow's upload-on-failure step still captures the
+        # right artifact.
         env:
           BAMLFUZZ_KEEP_ARTIFACTS: ""
         run: |

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -26,6 +26,11 @@ on:
         type: string
         required: false
         default: "10"
+      invalid_cases:
+        description: Rapid-mode invalid-input cases per oracle (default 50)
+        type: string
+        required: false
+        default: "50"
       fuzztime:
         description: Fuzz-mode duration per target (default 15m; total wall time roughly 2× this)
         type: string
@@ -90,6 +95,7 @@ jobs:
       # via dispatch inputs so a manual run can mix-and-match.
       BAMLFUZZ_DYNAMIC_CASES: ${{ github.event.inputs.dynamic_cases || '50' }}
       BAMLFUZZ_STATIC_BATCHES: ${{ github.event.inputs.static_batches || '10' }}
+      BAMLFUZZ_INVALID_CASES: ${{ github.event.inputs.invalid_cases || '50' }}
       BAMLFUZZ_SEED: ${{ github.event.inputs.seed || github.run_id }}
     steps:
       - name: Checkout Repository
@@ -168,14 +174,38 @@ jobs:
             -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
             ./integration
 
+      - name: Run bamlfuzz nightly — invalid-schema fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
+        if: ${{ env.MODE == 'fuzz' }}
+        env:
+          BAMLFUZZ_KEEP_ARTIFACTS: ""
+        run: |
+          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
+            -run='^$' \
+            -fuzz='^FuzzBamlfuzzInvalidDynamic$' \
+            -fuzztime="${FUZZTIME}" \
+            -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
+            ./integration
+
+      - name: Run bamlfuzz nightly — invalid-JSON-coercion fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
+        if: ${{ env.MODE == 'fuzz' }}
+        env:
+          BAMLFUZZ_KEEP_ARTIFACTS: ""
+        run: |
+          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
+            -run='^$' \
+            -fuzz='^FuzzBamlfuzzInvalidJSONCoercion$' \
+            -fuzztime="${FUZZTIME}" \
+            -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
+            ./integration
+
       - name: Run bamlfuzz oracles — rapid mode (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'rapid' }}
         # `subprocess` matches the normal server deployment path (server +
         # cmd/worker go-plugin), same as integration-tests.yml. -p 1 keeps
-        # the integration env setup serial; the two oracles share state.
+        # the integration env setup serial; the oracles share state.
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
-            -run='^TestBamlfuzz(Static|Dynamic)Oracle$' ./integration/...
+            -run='^TestBamlfuzz(Static|Dynamic)Oracle$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)$' ./integration/...
 
       - name: Upload corpus for next nightly
         if: ${{ always() && env.MODE == 'fuzz' }}
@@ -237,13 +267,15 @@ jobs:
               echo '```'
               echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzStatic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
               echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzDynamic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzInvalidDynamic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzInvalidJSONCoercion\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
               echo '```'
             else
               echo
               echo "Repro:"
               echo
               echo '```'
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_DYNAMIC_CASES=${BAMLFUZZ_DYNAMIC_CASES} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} go test -tags=integration -run='^TestBamlfuzz(Static|Dynamic)Oracle\$' ./integration -count=1"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_DYNAMIC_CASES=${BAMLFUZZ_DYNAMIC_CASES} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} BAMLFUZZ_INVALID_CASES=${BAMLFUZZ_INVALID_CASES} go test -tags=integration -run='^TestBamlfuzz(Static|Dynamic)Oracle\$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)\$' ./integration -count=1"
               echo '```'
             fi
           } | gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file -

--- a/adapters/common/codegen/bamlfuzz/invalid_case.go
+++ b/adapters/common/codegen/bamlfuzz/invalid_case.go
@@ -95,16 +95,25 @@ const (
 // LowerInvalidToDynamicSchema; for Axis C the schema lowers cleanly and
 // the perturbation lives in MockLLMContent.
 type InvalidOracleCase struct {
-	Name            string            `json:"name"`
-	Seed            int64             `json:"seed"`
-	CaseIndex       int               `json:"case_index"`
-	Mode            InvalidOracleMode `json:"mode"`
-	Mutation        string            `json:"mutation"`
-	ExpectedOutcome ExpectedOutcome   `json:"expected_outcome"`
-	Schema          FuzzSchema        `json:"schema"`
-	Value           FuzzValue         `json:"value"`
-	MockLLMContent  json.RawMessage   `json:"mock_llm_content"`
-	Metadata        CaseMetadata      `json:"metadata"`
+	Name string `json:"name"`
+	Seed int64  `json:"seed"`
+	// CaseIndex is the position of the case within its rapid batch.
+	// Used to derive distinct artifact filenames per case.
+	CaseIndex int               `json:"case_index"`
+	Mode      InvalidOracleMode `json:"mode"`
+	Mutation  string            `json:"mutation"`
+	// PreserveSchemaOrder mirrors the dynamic /call/_dynamic
+	// preserve_schema_order request field. Axis C's success quadrant
+	// runs the schema-aware key-order oracle when true; both axes pass
+	// the value through verbatim to dynclient.Request so the surface
+	// pipeline exercises whatever order-emission code path the bit
+	// selects.
+	PreserveSchemaOrder bool            `json:"preserve_schema_order"`
+	ExpectedOutcome     ExpectedOutcome `json:"expected_outcome"`
+	Schema              FuzzSchema      `json:"schema"`
+	Value               FuzzValue       `json:"value"`
+	MockLLMContent      json.RawMessage `json:"mock_llm_content"`
+	Metadata            CaseMetadata    `json:"metadata"`
 }
 
 // InvalidFailureEnvelope captures the full context around an oracle
@@ -112,29 +121,31 @@ type InvalidOracleCase struct {
 // each surface actually did (succeed / error) so a developer reading
 // the artifact can see the divergence without re-running the case.
 type InvalidFailureEnvelope struct {
-	GeneratorVersion  string                         `json:"generator_version"`
-	GeneratedAt       string                         `json:"generated_at"`
-	RapidSeed         int64                          `json:"rapid_seed"`
-	CaseIndex         int                            `json:"case_index"`
-	CaseName          string                         `json:"case_name"`
-	OracleMode        InvalidOracleMode              `json:"oracle_mode"`
-	Mutation          string                         `json:"mutation"`
-	ExpectedOutcome   ExpectedOutcome                `json:"expected_outcome"`
-	Schema            FuzzSchema                     `json:"schema"`
-	DynamicSchema     *bamlutils.DynamicOutputSchema `json:"dynamic_schema,omitempty"`
-	LoweringError     string                         `json:"lowering_error,omitempty"`
-	MockLLMScenarioID string                         `json:"mockllm_scenario_id,omitempty"`
-	MockLLMContent    json.RawMessage                `json:"mock_llm_content,omitempty"`
-	DynclientOutput   json.RawMessage                `json:"dynclient_output,omitempty"`
-	DynclientError    string                         `json:"dynclient_error,omitempty"`
-	RESTStatus        int                            `json:"rest_status,omitempty"`
-	RESTBody          json.RawMessage                `json:"rest_body,omitempty"`
-	RESTError         string                         `json:"rest_error,omitempty"`
-	SemanticDiff      []SemanticDiffEntry            `json:"semantic_diff,omitempty"`
-	ActualOutcome     string                         `json:"actual_outcome,omitempty"`
-	ReplayPath        string                         `json:"replay_path"`
-	Reproduction      string                         `json:"reproduction"`
-	Metadata          CaseMetadata                   `json:"metadata"`
+	GeneratorVersion    string                         `json:"generator_version"`
+	GeneratedAt         string                         `json:"generated_at"`
+	RapidSeed           int64                          `json:"rapid_seed"`
+	CaseIndex           int                            `json:"case_index"`
+	CaseName            string                         `json:"case_name"`
+	OracleMode          InvalidOracleMode              `json:"oracle_mode"`
+	Mutation            string                         `json:"mutation"`
+	PreserveSchemaOrder bool                           `json:"preserve_schema_order"`
+	ExpectedOutcome     ExpectedOutcome                `json:"expected_outcome"`
+	Schema              FuzzSchema                     `json:"schema"`
+	DynamicSchema       *bamlutils.DynamicOutputSchema `json:"dynamic_schema,omitempty"`
+	LoweringError       string                         `json:"lowering_error,omitempty"`
+	MockLLMScenarioID   string                         `json:"mockllm_scenario_id,omitempty"`
+	MockLLMContent      json.RawMessage                `json:"mock_llm_content,omitempty"`
+	DynclientOutput     json.RawMessage                `json:"dynclient_output,omitempty"`
+	DynclientError      string                         `json:"dynclient_error,omitempty"`
+	RESTStatus          int                            `json:"rest_status,omitempty"`
+	RESTBody            json.RawMessage                `json:"rest_body,omitempty"`
+	RESTError           string                         `json:"rest_error,omitempty"`
+	SemanticDiff        []SemanticDiffEntry            `json:"semantic_diff,omitempty"`
+	OrderWarning        []string                       `json:"order_warning,omitempty"`
+	ActualOutcome       string                         `json:"actual_outcome,omitempty"`
+	ReplayPath          string                         `json:"replay_path"`
+	Reproduction        string                         `json:"reproduction"`
+	Metadata            CaseMetadata                   `json:"metadata"`
 }
 
 // WriteInvalidReplayArtifact writes the invalid-case failure envelope

--- a/adapters/common/codegen/bamlfuzz/invalid_case.go
+++ b/adapters/common/codegen/bamlfuzz/invalid_case.go
@@ -1,0 +1,169 @@
+package bamlfuzz
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// InvalidOracleMode names the invalid-input oracle the test harness
+// runs against an InvalidOracleCase. v1 covers two axes; both share the
+// dynamic /call/_dynamic surface and the dynclient in-process path.
+type InvalidOracleMode string
+
+const (
+	// InvalidDynamicSchema (Axis B): a valid base schema is lowered
+	// then perturbed via one targeted mutation so the resulting
+	// dynamic output_schema should be rejected by both dynclient and
+	// REST. The oracle is OutcomeBothReject.
+	InvalidDynamicSchema InvalidOracleMode = "invalid_dynamic_schema"
+	// InvalidJSONCoercion (Axis C): a valid base schema, valid lowered
+	// dynamic output_schema, but the mock LLM JSON response is
+	// perturbed with one targeted edit. The oracle is OutcomeConditional:
+	// both surfaces succeed → SemanticDiff empty; at least one errors
+	// → both must error. Error text is not compared (the pre-flight
+	// determinism check showed dynclient and REST emit divergent
+	// surface-layer prefixes around an identical BAML diagnostic core).
+	InvalidJSONCoercion InvalidOracleMode = "invalid_json_coercion"
+)
+
+// ExpectedOutcome describes the assertion shape the oracle applies to a
+// case. Kept small — finer-grained classifications (RejectAtValidate vs
+// RejectAtRuntime) are tempting but would require BAML to expose a
+// stable error-class taxonomy, which it does not.
+type ExpectedOutcome string
+
+const (
+	// OutcomeBothReject: both dynclient and REST must return a non-nil
+	// error (REST: status >= 400). Used by Axis B.
+	OutcomeBothReject ExpectedOutcome = "both_reject"
+	// OutcomeConditional: when both surfaces succeed the two outputs
+	// must SemanticDiff equal; when at least one errors both must
+	// error. Used by Axis C, where lenient coercion may legitimately
+	// turn a perturbed mock into a valid parse on both surfaces.
+	OutcomeConditional ExpectedOutcome = "conditional"
+)
+
+// Invalid-schema mutation kinds applied to a valid lowered
+// DynamicOutputSchema. Each kind names one targeted edit to one root
+// property; the rest of the schema stays untouched so the rapid
+// shrinker can isolate the offending mutation when a regression
+// surfaces.
+//
+// MutationUnknownRef from the scoping catalogue is intentionally
+// absent: empirical validation at BAML 0.222.0 shows that swapping a
+// root property's ref for an undeclared name does NOT trigger
+// rejection. Both dynclient and REST consistently return `{}` (the
+// runtime treats the unresolved ref as a vacuous class), which makes
+// the input invalid by intent but not by behaviour — incompatible
+// with Axis B's both-reject oracle. Routing unknown-ref into a
+// different oracle (no-crash + body-parity) is a follow-up worth
+// considering.
+const (
+	MutationBothTypeAndRef = "both_type_and_ref"
+	MutationMisspelledType = "misspelled_type"
+	MutationDropItems      = "drop_items"
+	MutationDropInner      = "drop_inner"
+	MutationDropKeysValues = "drop_keys_values"
+	MutationDropOneOf      = "drop_oneof"
+	MutationOverDepth      = "over_depth"
+)
+
+// JSON mutation kinds applied to a mock LLM response (Axis C). Each
+// kind names one targeted edit to the JSON object the mockllm replays
+// as the LLM's textual response.
+const (
+	JSONMutationDropKey       = "drop_key"
+	JSONMutationRetypeScalar  = "retype_scalar"
+	JSONMutationAddUnknownKey = "add_unknown_key"
+	JSONMutationSwapEnum      = "swap_enum"
+	JSONMutationWrapInArray   = "wrap_in_array"
+)
+
+// InvalidOracleCase is the materialized fuzz case for the invalid-input
+// oracles. Parallel to OracleCase (case.go) but drops the Expected
+// parsed-answer field (there is no "right" answer for invalid input)
+// and carries the mutation descriptor + expected outcome the oracle
+// asserts.
+//
+// Schema + Value describe the valid base from which the case was
+// derived. For Axis B the mutation is applied during lowering by
+// LowerInvalidToDynamicSchema; for Axis C the schema lowers cleanly and
+// the perturbation lives in MockLLMContent.
+type InvalidOracleCase struct {
+	Name            string            `json:"name"`
+	Seed            int64             `json:"seed"`
+	CaseIndex       int               `json:"case_index"`
+	Mode            InvalidOracleMode `json:"mode"`
+	Mutation        string            `json:"mutation"`
+	ExpectedOutcome ExpectedOutcome   `json:"expected_outcome"`
+	Schema          FuzzSchema        `json:"schema"`
+	Value           FuzzValue         `json:"value"`
+	MockLLMContent  json.RawMessage   `json:"mock_llm_content"`
+	Metadata        CaseMetadata      `json:"metadata"`
+}
+
+// InvalidFailureEnvelope captures the full context around an oracle
+// disagreement for an InvalidOracleCase. ActualOutcome records what
+// each surface actually did (succeed / error) so a developer reading
+// the artifact can see the divergence without re-running the case.
+type InvalidFailureEnvelope struct {
+	GeneratorVersion  string                         `json:"generator_version"`
+	GeneratedAt       string                         `json:"generated_at"`
+	RapidSeed         int64                          `json:"rapid_seed"`
+	CaseIndex         int                            `json:"case_index"`
+	CaseName          string                         `json:"case_name"`
+	OracleMode        InvalidOracleMode              `json:"oracle_mode"`
+	Mutation          string                         `json:"mutation"`
+	ExpectedOutcome   ExpectedOutcome                `json:"expected_outcome"`
+	Schema            FuzzSchema                     `json:"schema"`
+	DynamicSchema     *bamlutils.DynamicOutputSchema `json:"dynamic_schema,omitempty"`
+	LoweringError     string                         `json:"lowering_error,omitempty"`
+	MockLLMScenarioID string                         `json:"mockllm_scenario_id,omitempty"`
+	MockLLMContent    json.RawMessage                `json:"mock_llm_content,omitempty"`
+	DynclientOutput   json.RawMessage                `json:"dynclient_output,omitempty"`
+	DynclientError    string                         `json:"dynclient_error,omitempty"`
+	RESTStatus        int                            `json:"rest_status,omitempty"`
+	RESTBody          json.RawMessage                `json:"rest_body,omitempty"`
+	RESTError         string                         `json:"rest_error,omitempty"`
+	SemanticDiff      []SemanticDiffEntry            `json:"semantic_diff,omitempty"`
+	ActualOutcome     string                         `json:"actual_outcome,omitempty"`
+	ReplayPath        string                         `json:"replay_path"`
+	Reproduction      string                         `json:"reproduction"`
+	Metadata          CaseMetadata                   `json:"metadata"`
+}
+
+// WriteInvalidReplayArtifact writes the invalid-case failure envelope
+// to `dir` as a JSON file and returns the resulting path. Mirrors the
+// dynamic / static writers in envelope.go — same basename sanitisation,
+// same 2-space-indent layout, ReplayPath stamped in place so the
+// failure message can point at the artifact.
+func WriteInvalidReplayArtifact(dir string, envelope *InvalidFailureEnvelope) (string, error) {
+	if envelope == nil {
+		return "", fmt.Errorf("bamlfuzz: nil envelope")
+	}
+	if envelope.GeneratorVersion == "" {
+		envelope.GeneratorVersion = GeneratorVersion
+	}
+	if envelope.GeneratedAt == "" {
+		envelope.GeneratedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("bamlfuzz: mkdir %s: %w", dir, err)
+	}
+	name := sanitizeArtifactBasename(envelope.CaseName, envelope.CaseIndex)
+	path := filepath.Join(dir, name+".json")
+	envelope.ReplayPath = path
+	buf, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("bamlfuzz: marshal envelope: %w", err)
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		return "", fmt.Errorf("bamlfuzz: write %s: %w", path, err)
+	}
+	return path, nil
+}

--- a/adapters/common/codegen/bamlfuzz/invalid_gen.go
+++ b/adapters/common/codegen/bamlfuzz/invalid_gen.go
@@ -78,9 +78,9 @@ func InvalidJSONCoercionGen() *rapid.Generator[InvalidOracleCase] {
 		cc := CoupledCaseGen(DynamicSafeSchemaGen()).Draw(t, "coupled_case")
 		idx := rapid.IntRange(0, len(invalidJSONMutationKinds)-1).Draw(t, "json_mutation_kind")
 		kind := invalidJSONMutationKinds[idx]
-		mutated, err := applyJSONMutation(cc.Walk.MockLLMContent, kind)
+		mutated, err := applyJSONMutation(cc.Schema, cc.Walk.MockLLMContent, kind)
 		if err != nil {
-			fallback, ferr := applyJSONMutation(cc.Walk.MockLLMContent, JSONMutationAddUnknownKey)
+			fallback, ferr := applyJSONMutation(cc.Schema, cc.Walk.MockLLMContent, JSONMutationAddUnknownKey)
 			if ferr != nil {
 				t.Fatalf("bamlfuzz: fallback JSON mutation failed: %v (original kind=%q err=%v)", ferr, kind, err)
 			}

--- a/adapters/common/codegen/bamlfuzz/invalid_gen.go
+++ b/adapters/common/codegen/bamlfuzz/invalid_gen.go
@@ -1,0 +1,101 @@
+package bamlfuzz
+
+import (
+	"fmt"
+
+	"pgregory.net/rapid"
+)
+
+// invalidSchemaMutationKinds enumerates the Axis B mutation catalogue
+// the generator picks from. Kept as a stable ordered slice so the
+// rapid bit that selects an index has predictable shrink behaviour
+// (lower indices = earlier kinds, which rapid biases toward).
+var invalidSchemaMutationKinds = []string{
+	MutationBothTypeAndRef,
+	MutationMisspelledType,
+	MutationDropItems,
+	MutationDropInner,
+	MutationDropKeysValues,
+	MutationDropOneOf,
+	MutationOverDepth,
+}
+
+// invalidJSONMutationKinds enumerates the Axis C JSON mutation
+// catalogue. Same ordering rationale as invalidSchemaMutationKinds.
+var invalidJSONMutationKinds = []string{
+	JSONMutationDropKey,
+	JSONMutationRetypeScalar,
+	JSONMutationAddUnknownKey,
+	JSONMutationSwapEnum,
+	JSONMutationWrapInArray,
+}
+
+// InvalidDynamicSchemaGen returns a rapid generator for InvalidOracleCase
+// values that drive Axis B: a valid base schema drawn from
+// DynamicSafeSchemaGen, paired with a Mutation descriptor describing
+// one targeted edit the lowering helper applies to the first root
+// property. ExpectedOutcome is OutcomeBothReject — both dynclient and
+// REST surfaces must error on the resulting dynamic output_schema.
+//
+// The schema mutation lives on the lowered DynamicOutputSchema, not on
+// the FuzzSchema IR: the IR's pointer-fielded composites can't express
+// shapes like "list with no items" cleanly, while the lowered form's
+// raw nullable fields can. The case carries the valid base schema +
+// the mutation kind; LowerInvalidToDynamicSchema rebuilds the
+// post-mutation lowered form deterministically.
+func InvalidDynamicSchemaGen() *rapid.Generator[InvalidOracleCase] {
+	return rapid.Custom(func(t *rapid.T) InvalidOracleCase {
+		cc := CoupledCaseGen(DynamicSafeSchemaGen()).Draw(t, "coupled_case")
+		idx := rapid.IntRange(0, len(invalidSchemaMutationKinds)-1).Draw(t, "schema_mutation_kind")
+		kind := invalidSchemaMutationKinds[idx]
+		return InvalidOracleCase{
+			Name:            fmt.Sprintf("invalid_dyn_%s", kind),
+			Mode:            InvalidDynamicSchema,
+			Mutation:        kind,
+			ExpectedOutcome: OutcomeBothReject,
+			Schema:          cc.Schema,
+			Value:           cc.Value,
+			MockLLMContent:  cc.Walk.MockLLMContent,
+			Metadata:        cc.Walk.Metadata,
+		}
+	})
+}
+
+// InvalidJSONCoercionGen returns a rapid generator for InvalidOracleCase
+// values that drive Axis C: a valid base schema + valid value, with the
+// walker-emitted mock LLM JSON perturbed via one targeted JSON-aware
+// edit. ExpectedOutcome is OutcomeConditional — when both surfaces
+// succeed they must agree on semantic equality; when at least one
+// errors both must error.
+//
+// When the chosen mutation can't apply to the drawn mock (e.g.,
+// drop_key on a zero-key object), the generator falls back to
+// add_unknown_key — a universal mutation that always perturbs the
+// payload meaningfully. Without the fallback the case would
+// degenerate to a no-op pass that the oracle silently accepts.
+func InvalidJSONCoercionGen() *rapid.Generator[InvalidOracleCase] {
+	return rapid.Custom(func(t *rapid.T) InvalidOracleCase {
+		cc := CoupledCaseGen(DynamicSafeSchemaGen()).Draw(t, "coupled_case")
+		idx := rapid.IntRange(0, len(invalidJSONMutationKinds)-1).Draw(t, "json_mutation_kind")
+		kind := invalidJSONMutationKinds[idx]
+		mutated, err := applyJSONMutation(cc.Walk.MockLLMContent, kind)
+		if err != nil {
+			fallback, ferr := applyJSONMutation(cc.Walk.MockLLMContent, JSONMutationAddUnknownKey)
+			if ferr != nil {
+				t.Fatalf("bamlfuzz: fallback JSON mutation failed: %v (original kind=%q err=%v)", ferr, kind, err)
+			}
+			mutated = fallback
+			kind = JSONMutationAddUnknownKey
+		}
+		return InvalidOracleCase{
+			Name:            fmt.Sprintf("invalid_json_%s", kind),
+			Mode:            InvalidJSONCoercion,
+			Mutation:        kind,
+			ExpectedOutcome: OutcomeConditional,
+			Schema:          cc.Schema,
+			Value:           cc.Value,
+			MockLLMContent:  mutated,
+			Metadata:        cc.Walk.Metadata,
+		}
+	})
+}

--- a/adapters/common/codegen/bamlfuzz/invalid_lower.go
+++ b/adapters/common/codegen/bamlfuzz/invalid_lower.go
@@ -1,0 +1,36 @@
+package bamlfuzz
+
+import (
+	"fmt"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// LowerInvalidToDynamicSchema lowers c.Schema to a DynamicOutputSchema
+// and, for InvalidDynamicSchema (Axis B), applies c.Mutation to the
+// lowered shape's first root property. For InvalidJSONCoercion (Axis C)
+// the schema lowers cleanly — the perturbation lives in c.MockLLMContent
+// and reaches the surfaces through the mockllm scenario; the schema
+// itself stays untouched.
+//
+// Errors from the base lowering (ErrDynamicSchemaUnsupported and
+// friends) bubble up unchanged so the caller can apply the same
+// skip-vs-fail dispatch the dynamic oracle uses (corpus/fuzz cases
+// skip, rapid cases fail — rapid draws from DynamicSafeSchemaGen which
+// excludes unsupported shapes by construction).
+func LowerInvalidToDynamicSchema(c InvalidOracleCase) (bamlutils.DynamicOutputSchema, error) {
+	lowered, err := LowerToDynamicSchema(c.Schema)
+	if err != nil {
+		return bamlutils.DynamicOutputSchema{}, err
+	}
+	switch c.Mode {
+	case InvalidJSONCoercion:
+		return lowered, nil
+	case InvalidDynamicSchema:
+		if err := applyInvalidSchemaMutation(&lowered, c.Mutation); err != nil {
+			return bamlutils.DynamicOutputSchema{}, fmt.Errorf("apply mutation %q: %w", c.Mutation, err)
+		}
+		return lowered, nil
+	}
+	return bamlutils.DynamicOutputSchema{}, fmt.Errorf("unknown invalid oracle mode %q", c.Mode)
+}

--- a/adapters/common/codegen/bamlfuzz/mutate.go
+++ b/adapters/common/codegen/bamlfuzz/mutate.go
@@ -79,7 +79,15 @@ func buildInvalidProperty(kind string) (*bamlutils.DynamicProperty, error) {
 // order modulo the specific key the mutation touched (drop_key
 // removes one in place; retype/swap_enum/wrap_in_array replace one
 // in place; add_unknown_key appends at the end).
-func applyJSONMutation(content json.RawMessage, kind string) (json.RawMessage, error) {
+//
+// `schema` is consulted by schema-aware mutations: JSONMutationSwapEnum
+// scans the root class for a property of enum type so the replacement
+// actually exercises an enum-coercion code path; a generic first-field
+// replacement would only swap a string for a string when the first
+// field is non-enum, defeating the mutation's intent. When no enum
+// field exists in the schema the mutation returns an error and the
+// caller's fallback (typically JSONMutationAddUnknownKey) takes over.
+func applyJSONMutation(schema FuzzSchema, content json.RawMessage, kind string) (json.RawMessage, error) {
 	var obj bamlutils.OrderedMap[json.RawMessage]
 	if err := obj.UnmarshalJSON(content); err != nil {
 		return nil, fmt.Errorf("unmarshal mock content: %w", err)
@@ -110,10 +118,18 @@ func applyJSONMutation(content json.RawMessage, kind string) (json.RawMessage, e
 			return nil, fmt.Errorf("retype_scalar: %w", err)
 		}
 	case JSONMutationSwapEnum:
-		if len(keys) == 0 {
-			return nil, fmt.Errorf("no keys for swap_enum")
+		target, ok := findRootEnumFieldName(schema)
+		if !ok {
+			return nil, fmt.Errorf("swap_enum: schema has no root-class enum field")
 		}
-		if err := obj.Replace(keys[0], json.RawMessage(`"_invalid_enum_variant"`)); err != nil {
+		if !obj.Has(target) {
+			// The walker is supposed to render every root-class field
+			// into the mock; a missing key here would be a generator
+			// integrity bug. Surface as a hard error so the caller's
+			// fallback handles it deterministically.
+			return nil, fmt.Errorf("swap_enum: enum field %q absent from mock content", target)
+		}
+		if err := obj.Replace(target, json.RawMessage(`"_invalid_enum_variant"`)); err != nil {
 			return nil, fmt.Errorf("swap_enum: %w", err)
 		}
 	case JSONMutationWrapInArray:
@@ -134,6 +150,41 @@ func applyJSONMutation(content json.RawMessage, kind string) (json.RawMessage, e
 		return nil, fmt.Errorf("marshal mutated mock: %w", err)
 	}
 	return out, nil
+}
+
+// findRootEnumFieldName scans the root class for a property typed as
+// an enum reference. Walks through KindOptional and KindUnion
+// wrappers so an optional<enum> or a union arm naming an enum still
+// counts. Returns the property name plus a found flag.
+func findRootEnumFieldName(schema FuzzSchema) (string, bool) {
+	rootCls, ok := schema.FindClass(schema.RootClass)
+	if !ok {
+		return "", false
+	}
+	for _, prop := range rootCls.Properties {
+		if typeReachesEnum(prop.Type) {
+			return prop.Name, true
+		}
+	}
+	return "", false
+}
+
+func typeReachesEnum(t FuzzType) bool {
+	switch t.Kind {
+	case KindEnumRef:
+		return true
+	case KindOptional:
+		if t.Inner != nil {
+			return typeReachesEnum(*t.Inner)
+		}
+	case KindUnion:
+		for _, v := range t.Variants {
+			if typeReachesEnum(v) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // retypeScalarValue produces a value of a different JSON type than

--- a/adapters/common/codegen/bamlfuzz/mutate.go
+++ b/adapters/common/codegen/bamlfuzz/mutate.go
@@ -1,0 +1,145 @@
+package bamlfuzz
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// applyInvalidSchemaMutation replaces the first root property of `out`
+// with a tailored-but-invalid DynamicProperty matching `kind`. The
+// other properties and any nested classes/enums stay untouched so the
+// resulting schema is "almost valid" with one localized fault — the
+// shape the rapid shrinker can isolate to a minimal repro.
+func applyInvalidSchemaMutation(out *bamlutils.DynamicOutputSchema, kind string) error {
+	keys := out.Properties.Keys()
+	if len(keys) == 0 {
+		return fmt.Errorf("output schema has no properties to mutate")
+	}
+	target := keys[0]
+	prop, err := buildInvalidProperty(kind)
+	if err != nil {
+		return err
+	}
+	if err := out.Properties.Replace(target, prop); err != nil {
+		return fmt.Errorf("replace property %q: %w", target, err)
+	}
+	return nil
+}
+
+// buildInvalidProperty returns a DynamicProperty whose shape violates
+// DynamicTypes.Validate (interfaces.go:688), per the mutation kind.
+// Each shape exercises one rejection path:
+//
+//   - both_type_and_ref: validateTypeRef rejects properties carrying both
+//     "type" and "ref" (interfaces.go:754).
+//   - misspelled_type: an unknown type string lands on the default arm
+//     (interfaces.go:832).
+//   - drop_items / drop_inner / drop_keys_values / drop_oneof: each
+//     composite kind requires its companion field (interfaces.go:772+).
+//   - over_depth: 70 nested optional wrappers exceeds maxTypeDepth (64).
+func buildInvalidProperty(kind string) (*bamlutils.DynamicProperty, error) {
+	switch kind {
+	case MutationBothTypeAndRef:
+		return &bamlutils.DynamicProperty{Type: "string", Ref: "Nonexistent"}, nil
+	case MutationMisspelledType:
+		return &bamlutils.DynamicProperty{Type: "strin"}, nil
+	case MutationDropItems:
+		return &bamlutils.DynamicProperty{Type: "list"}, nil
+	case MutationDropInner:
+		return &bamlutils.DynamicProperty{Type: "optional"}, nil
+	case MutationDropKeysValues:
+		return &bamlutils.DynamicProperty{Type: "map"}, nil
+	case MutationDropOneOf:
+		return &bamlutils.DynamicProperty{Type: "union"}, nil
+	case MutationOverDepth:
+		inner := &bamlutils.DynamicTypeSpec{Type: "string"}
+		for i := 0; i < 70; i++ {
+			inner = &bamlutils.DynamicTypeSpec{Type: "optional", Inner: inner}
+		}
+		return &bamlutils.DynamicProperty{Type: "optional", Inner: inner}, nil
+	}
+	return nil, fmt.Errorf("unknown invalid schema mutation %q", kind)
+}
+
+// applyJSONMutation perturbs the mock LLM JSON response with one
+// targeted edit. Returns the mutated bytes. The mock content the
+// walker emits at the dynamic-safe root is always a JSON object whose
+// keys are the class's properties, so a flat map[string]json.RawMessage
+// decode is sufficient — every mutation kind operates on a top-level
+// key.
+//
+// Decode goes through encoding/json so the JSON wire-order may
+// scramble across the mutation; the Axis C oracle compares semantic
+// equality only, not source-order, so the reorder is invisible to the
+// assertion.
+func applyJSONMutation(content json.RawMessage, kind string) (json.RawMessage, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(content, &obj); err != nil {
+		return nil, fmt.Errorf("unmarshal mock content: %w", err)
+	}
+	if obj == nil {
+		obj = make(map[string]json.RawMessage)
+	}
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	switch kind {
+	case JSONMutationDropKey:
+		if len(keys) == 0 {
+			return nil, fmt.Errorf("no keys to drop")
+		}
+		delete(obj, keys[0])
+	case JSONMutationAddUnknownKey:
+		obj["_invalid_unknown_key"] = json.RawMessage(`"unknown"`)
+	case JSONMutationRetypeScalar:
+		if len(keys) == 0 {
+			return nil, fmt.Errorf("no keys to retype")
+		}
+		obj[keys[0]] = retypeScalarValue(obj[keys[0]])
+	case JSONMutationSwapEnum:
+		if len(keys) == 0 {
+			return nil, fmt.Errorf("no keys for swap_enum")
+		}
+		obj[keys[0]] = json.RawMessage(`"_invalid_enum_variant"`)
+	case JSONMutationWrapInArray:
+		if len(keys) == 0 {
+			return nil, fmt.Errorf("no keys for wrap_in_array")
+		}
+		target := keys[0]
+		obj[target] = json.RawMessage("[" + string(obj[target]) + "]")
+	default:
+		return nil, fmt.Errorf("unknown json mutation %q", kind)
+	}
+
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("marshal mutated mock: %w", err)
+	}
+	return out, nil
+}
+
+// retypeScalarValue produces a value of a different JSON type than
+// `raw`. Dispatched on the first non-whitespace byte: bool → string,
+// string → number, number → string, otherwise number. Composite values
+// (arrays, objects, null) collapse to a number — the goal is "wrong
+// type at this slot", not a faithful type-swap matrix.
+func retypeScalarValue(raw json.RawMessage) json.RawMessage {
+	s := strings.TrimSpace(string(raw))
+	switch {
+	case s == "true" || s == "false":
+		return json.RawMessage(`"yes"`)
+	case len(s) > 0 && s[0] == '"':
+		return json.RawMessage("42")
+	case len(s) > 0 && (s[0] == '-' || (s[0] >= '0' && s[0] <= '9')):
+		return json.RawMessage(`"twelve"`)
+	default:
+		return json.RawMessage("42")
+	}
+}

--- a/adapters/common/codegen/bamlfuzz/mutate.go
+++ b/adapters/common/codegen/bamlfuzz/mutate.go
@@ -3,7 +3,6 @@ package bamlfuzz
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/invakid404/baml-rest/bamlutils"
@@ -68,57 +67,69 @@ func buildInvalidProperty(kind string) (*bamlutils.DynamicProperty, error) {
 // applyJSONMutation perturbs the mock LLM JSON response with one
 // targeted edit. Returns the mutated bytes. The mock content the
 // walker emits at the dynamic-safe root is always a JSON object whose
-// keys are the class's properties, so a flat map[string]json.RawMessage
-// decode is sufficient — every mutation kind operates on a top-level
-// key.
+// keys are the class's properties; every mutation operates on the
+// top-level wire shape.
 //
-// Decode goes through encoding/json so the JSON wire-order may
-// scramble across the mutation; the Axis C oracle compares semantic
-// equality only, not source-order, so the reorder is invisible to the
-// assertion.
+// Decode/re-encode goes through bamlutils.OrderedMap so wire-order is
+// preserved across the mutation. The Axis C order oracle compares
+// dynclient vs REST key order at every class node via
+// SchemaOrderDiffWithChoices, so scrambling the mock's input order
+// here would corrupt the assertion's expected behaviour: a mock with
+// keys [a, b, c] must come out of the mutation in the same [a, b, c]
+// order modulo the specific key the mutation touched (drop_key
+// removes one in place; retype/swap_enum/wrap_in_array replace one
+// in place; add_unknown_key appends at the end).
 func applyJSONMutation(content json.RawMessage, kind string) (json.RawMessage, error) {
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(content, &obj); err != nil {
+	var obj bamlutils.OrderedMap[json.RawMessage]
+	if err := obj.UnmarshalJSON(content); err != nil {
 		return nil, fmt.Errorf("unmarshal mock content: %w", err)
 	}
-	if obj == nil {
-		obj = make(map[string]json.RawMessage)
-	}
-	keys := make([]string, 0, len(obj))
-	for k := range obj {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	keys := obj.Keys()
 
 	switch kind {
 	case JSONMutationDropKey:
 		if len(keys) == 0 {
 			return nil, fmt.Errorf("no keys to drop")
 		}
-		delete(obj, keys[0])
+		obj.Delete(keys[0])
 	case JSONMutationAddUnknownKey:
-		obj["_invalid_unknown_key"] = json.RawMessage(`"unknown"`)
+		// Set returns an error on duplicate key. The reserved
+		// "_invalid_unknown_key" name is namespaced so it cannot
+		// collide with the generator's Fuzz_field_N convention; a
+		// duplicate here would mean a caller wired the same case
+		// twice, which is an integrity bug worth surfacing.
+		if err := obj.Set("_invalid_unknown_key", json.RawMessage(`"unknown"`)); err != nil {
+			return nil, fmt.Errorf("add_unknown_key: %w", err)
+		}
 	case JSONMutationRetypeScalar:
 		if len(keys) == 0 {
 			return nil, fmt.Errorf("no keys to retype")
 		}
-		obj[keys[0]] = retypeScalarValue(obj[keys[0]])
+		cur, _ := obj.Get(keys[0])
+		if err := obj.Replace(keys[0], retypeScalarValue(cur)); err != nil {
+			return nil, fmt.Errorf("retype_scalar: %w", err)
+		}
 	case JSONMutationSwapEnum:
 		if len(keys) == 0 {
 			return nil, fmt.Errorf("no keys for swap_enum")
 		}
-		obj[keys[0]] = json.RawMessage(`"_invalid_enum_variant"`)
+		if err := obj.Replace(keys[0], json.RawMessage(`"_invalid_enum_variant"`)); err != nil {
+			return nil, fmt.Errorf("swap_enum: %w", err)
+		}
 	case JSONMutationWrapInArray:
 		if len(keys) == 0 {
 			return nil, fmt.Errorf("no keys for wrap_in_array")
 		}
-		target := keys[0]
-		obj[target] = json.RawMessage("[" + string(obj[target]) + "]")
+		cur, _ := obj.Get(keys[0])
+		wrapped := json.RawMessage("[" + string(cur) + "]")
+		if err := obj.Replace(keys[0], wrapped); err != nil {
+			return nil, fmt.Errorf("wrap_in_array: %w", err)
+		}
 	default:
 		return nil, fmt.Errorf("unknown json mutation %q", kind)
 	}
 
-	out, err := json.Marshal(obj)
+	out, err := obj.MarshalJSON()
 	if err != nil {
 		return nil, fmt.Errorf("marshal mutated mock: %w", err)
 	}

--- a/integration/bamlfuzz_invalid_test.go
+++ b/integration/bamlfuzz_invalid_test.go
@@ -1,0 +1,443 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/bamlfuzz"
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/dynclient"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// invalidDynamicArtifactDir is where envelope artifacts land on Axis B
+// failure (or with BAMLFUZZ_KEEP_ARTIFACTS=1). Mirrors the existing
+// dynamic / static directory split so CI artifact collection picks up
+// every oracle from one glob.
+const invalidDynamicArtifactDir = "../adapters/common/codegen/testdata/bamlfuzz/invalid_dynamic/_artifacts"
+
+// invalidJSONCoercionArtifactDir is where envelope artifacts land on
+// Axis C failure.
+const invalidJSONCoercionArtifactDir = "../adapters/common/codegen/testdata/bamlfuzz/invalid_json_coercion/_artifacts"
+
+// invalidCasesPerRun controls how many random invalid-input cases run
+// per oracle invocation. Sized for PR CI wall time; nightly fuzz can
+// crank it via BAMLFUZZ_INVALID_CASES so a scheduled run explores a
+// broader slice of the mutation × schema space.
+func invalidCasesPerRun() int {
+	return envIntDefault("BAMLFUZZ_INVALID_CASES", 16)
+}
+
+// TestBamlfuzzInvalidDynamic drives Axis B of the invalid-input oracles:
+// a valid base FuzzSchema is lowered, then perturbed with one targeted
+// mutation (drop a required composite field, set both type and ref on
+// a property, etc.) so the resulting DynamicOutputSchema should be
+// rejected. The oracle asserts both dynclient.Client.DynamicCall and
+// the REST /call/_dynamic endpoint return an error — error text is
+// not compared (the pre-flight check found dynclient and REST emit
+// divergent surface-layer prefixes even when the BAML diagnostic core
+// is identical).
+func TestBamlfuzzInvalidDynamic(t *testing.T) {
+	dynclientCallGate(t)
+
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		t.Fatalf("NewDynclient: %v", err)
+	}
+
+	t.Run("rapid", func(t *testing.T) {
+		cases := invalidCasesPerRun()
+		for i := 0; i < cases; i++ {
+			i := i
+			seed := invalidSeedFor("invalid_dynamic", i)
+			t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+				c := buildRapidInvalidDynamicCase(t, seed, i)
+				runInvalidOracleCase(t, dyn, c, i, caseSourceRapid)
+			})
+		}
+	})
+}
+
+// FuzzBamlfuzzInvalidDynamic is the testing.F companion to
+// TestBamlfuzzInvalidDynamic. It exposes the Axis B oracle to Go's
+// native fuzz engine via the bamlfuzz.MakeFuzz bridge: testing.F's
+// []byte corpus is decoded (8-byte LE) or hashed via SeedFromBytes
+// into a uint64 seed that drives one InvalidDynamicSchemaGen draw.
+//
+// One f.Add seed is registered so plain `go test` (no `-fuzz=`) runs
+// the target with a deterministic input. The seed is derived FNV-64a
+// from a stable label so the same case replays across runs.
+func FuzzBamlfuzzInvalidDynamic(f *testing.F) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		f.Skip("Skipping: dynamic endpoints require BAML >= 0.215.0")
+	}
+	if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+		f.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
+	}
+
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		f.Fatalf("NewDynclient: %v", err)
+	}
+
+	f.Add(invalidFuzzSeedBytes("invalid_dynamic", 0))
+
+	bamlfuzz.MakeFuzz(f, func(t *testing.T, rt *rapid.T) {
+		c := bamlfuzz.InvalidDynamicSchemaGen().Draw(rt, "invalid_dynamic_case")
+		c.Name = "fuzz_" + c.Mutation
+		runInvalidOracleCase(t, dyn, c, 0, caseSourceFuzz)
+	})
+}
+
+// TestBamlfuzzInvalidJSONCoercion drives Axis C: a valid schema with a
+// perturbed mock LLM JSON response. The oracle is conditional — when
+// both surfaces parse successfully the two outputs must SemanticDiff
+// equal (so a lenient-coercion divergence between dynclient and REST
+// surfaces); when at least one surface errors both must error (no
+// error-text comparison; see pre-flight finding).
+func TestBamlfuzzInvalidJSONCoercion(t *testing.T) {
+	dynclientCallGate(t)
+
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		t.Fatalf("NewDynclient: %v", err)
+	}
+
+	t.Run("rapid", func(t *testing.T) {
+		cases := invalidCasesPerRun()
+		for i := 0; i < cases; i++ {
+			i := i
+			seed := invalidSeedFor("invalid_json_coercion", i)
+			t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+				c := buildRapidInvalidJSONCase(t, seed, i)
+				runInvalidOracleCase(t, dyn, c, i, caseSourceRapid)
+			})
+		}
+	})
+}
+
+// FuzzBamlfuzzInvalidJSONCoercion is the testing.F companion to
+// TestBamlfuzzInvalidJSONCoercion. Same bridge / seed pattern as
+// FuzzBamlfuzzInvalidDynamic.
+func FuzzBamlfuzzInvalidJSONCoercion(f *testing.F) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		f.Skip("Skipping: dynamic endpoints require BAML >= 0.215.0")
+	}
+	if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+		f.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
+	}
+
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		f.Fatalf("NewDynclient: %v", err)
+	}
+
+	f.Add(invalidFuzzSeedBytes("invalid_json_coercion", 0))
+
+	bamlfuzz.MakeFuzz(f, func(t *testing.T, rt *rapid.T) {
+		c := bamlfuzz.InvalidJSONCoercionGen().Draw(rt, "invalid_json_case")
+		c.Name = "fuzz_" + c.Mutation
+		runInvalidOracleCase(t, dyn, c, 0, caseSourceFuzz)
+	})
+}
+
+// invalidSeedFor derives a deterministic uint64 rapid seed for an
+// invalid-case (mode, idx) pair. Tests are deterministic across runs
+// unless BAMLFUZZ_SEED is set; BAMLFUZZ_SEED XORs into the per-case
+// seed so a single env var perturbs the entire matrix at once. Same
+// convention as dynamicSeedFor for the valid-case oracle.
+func invalidSeedFor(label string, idx int) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(label))
+	fmt.Fprintf(h, ":%d", idx)
+	base := h.Sum64()
+	if v := os.Getenv("BAMLFUZZ_SEED"); v != "" {
+		base ^= fnv64aInvalidString(v)
+	}
+	return base
+}
+
+func fnv64aInvalidString(s string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(s))
+	return h.Sum64()
+}
+
+// invalidFuzzSeedBytes encodes invalidSeedFor's uint64 output as 8
+// little-endian bytes — the exact wire shape bamlfuzz.MakeFuzz
+// recognizes as a verbatim seed (fuzzbridge.go).
+func invalidFuzzSeedBytes(label string, idx int) []byte {
+	seed := invalidSeedFor(label, idx)
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, seed)
+	return b
+}
+
+// buildRapidInvalidDynamicCase synthesizes one Axis B case
+// deterministically from seed.
+func buildRapidInvalidDynamicCase(t *testing.T, seed uint64, idx int) bamlfuzz.InvalidOracleCase {
+	t.Helper()
+	c := bamlfuzz.InvalidDynamicSchemaGen().Example(int(seed))
+	c.Name = fmt.Sprintf("rapid_%d_%s", idx, c.Mutation)
+	c.Seed = int64(seed)
+	c.CaseIndex = idx
+	return c
+}
+
+// buildRapidInvalidJSONCase synthesizes one Axis C case
+// deterministically from seed.
+func buildRapidInvalidJSONCase(t *testing.T, seed uint64, idx int) bamlfuzz.InvalidOracleCase {
+	t.Helper()
+	c := bamlfuzz.InvalidJSONCoercionGen().Example(int(seed))
+	c.Name = fmt.Sprintf("rapid_%d_%s", idx, c.Mutation)
+	c.Seed = int64(seed)
+	c.CaseIndex = idx
+	return c
+}
+
+// invalidArtifactDirFor selects the artifact directory matching c.Mode.
+// Keeping the two axes in sibling directories means CI artifact
+// collection (the nightly's `_artifacts/` glob) picks up failures from
+// both with no workflow change.
+func invalidArtifactDirFor(mode bamlfuzz.InvalidOracleMode) string {
+	switch mode {
+	case bamlfuzz.InvalidDynamicSchema:
+		return invalidDynamicArtifactDir
+	case bamlfuzz.InvalidJSONCoercion:
+		return invalidJSONCoercionArtifactDir
+	}
+	return invalidDynamicArtifactDir
+}
+
+// runInvalidOracleCase executes one InvalidOracleCase end-to-end and
+// applies c.ExpectedOutcome. Dumps an envelope artifact on any oracle
+// disagreement; success-path artifacts dump only when
+// BAMLFUZZ_KEEP_ARTIFACTS=1, matching the valid-case oracle's
+// behaviour.
+func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.InvalidOracleCase, caseIdx int, source caseSource) {
+	t.Helper()
+
+	artifactDir := invalidArtifactDirFor(c.Mode)
+	envelope := &bamlfuzz.InvalidFailureEnvelope{
+		GeneratorVersion: bamlfuzz.GeneratorVersion,
+		RapidSeed:        c.Seed,
+		CaseIndex:        caseIdx,
+		CaseName:         c.Name,
+		OracleMode:       c.Mode,
+		Mutation:         c.Mutation,
+		ExpectedOutcome:  c.ExpectedOutcome,
+		Schema:           c.Schema,
+		MockLLMContent:   c.MockLLMContent,
+		Metadata:         c.Metadata,
+		Reproduction:     reproductionForInvalid(c, caseIdx, source),
+	}
+
+	lowered, err := bamlfuzz.LowerInvalidToDynamicSchema(c)
+	if errors.Is(err, bamlfuzz.ErrDynamicSchemaUnsupported) {
+		switch unsupportedActionFor(source) {
+		case unsupportedSkip:
+			t.Skipf("dynamic emitter skipped schema: %v", err)
+			return
+		case unsupportedFail:
+			envelope.LoweringError = err.Error()
+			failAndDumpInvalid(t, artifactDir, envelope, "rapid generator produced unsupported base schema: %v", err)
+			return
+		}
+	}
+	if err != nil {
+		envelope.LoweringError = err.Error()
+		failAndDumpInvalid(t, artifactDir, envelope, "LowerInvalidToDynamicSchema failed: %v", err)
+		return
+	}
+	envelope.DynamicSchema = &lowered
+
+	scenarioID := fmt.Sprintf("bamlfuzz-invalid-%s", scenarioSafe(c.Name))
+	envelope.MockLLMScenarioID = scenarioID
+	registerCtx, registerCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer registerCancel()
+	scenario := &mockllm.Scenario{
+		ID:             scenarioID,
+		Provider:       "openai",
+		Content:        string(c.MockLLMContent),
+		ChunkSize:      0,
+		InitialDelayMs: 0,
+	}
+	if err := MockClient.RegisterScenario(registerCtx, scenario); err != nil {
+		failAndDumpInvalid(t, artifactDir, envelope, "register scenario: %v", err)
+		return
+	}
+
+	clientReg := testutil.CreateTestClient(TestEnv.MockLLMInternal, scenarioID)
+
+	callCtx, callCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer callCancel()
+
+	hello := "Return the dynamic fuzz value."
+	libReq := dynclient.Request{
+		Messages: []dynclient.Message{
+			{Role: "system", PartsContent: []dynclient.ContentPart{
+				{Type: "text", Text: &hello},
+				{Type: "output_format"},
+			}},
+			{Role: "user", TextContent: &hello},
+		},
+		ClientRegistry: testutil.DynRegistry(clientReg),
+		OutputSchema:   &lowered,
+	}
+
+	libResp, libErr := dyn.DynamicCall(callCtx, libReq)
+	var dynSuccess bool
+	switch {
+	case libErr != nil:
+		envelope.DynclientError = libErr.Error()
+	case libResp == nil:
+		envelope.DynclientError = "nil response from dyn.DynamicCall"
+		failAndDumpInvalid(t, artifactDir, envelope, "dynclient returned nil response without an error")
+		return
+	default:
+		envelope.DynclientOutput = libResp.Data
+		dynSuccess = true
+	}
+
+	restBody, err := buildDynamicCallBody(libReq, &lowered)
+	if err != nil {
+		failAndDumpInvalid(t, artifactDir, envelope, "build REST body: %v", err)
+		return
+	}
+	restResp, err := BAMLClient.DynamicCallJSON(callCtx, restBody)
+	var restSuccess bool
+	switch {
+	case err != nil:
+		envelope.RESTError = err.Error()
+	case restResp == nil:
+		envelope.RESTError = "nil response from BAMLClient.DynamicCallJSON"
+		failAndDumpInvalid(t, artifactDir, envelope, "REST client returned nil response without an error")
+		return
+	default:
+		envelope.RESTStatus = restResp.StatusCode
+		if restResp.StatusCode >= 400 {
+			envelope.RESTError = restResp.Error
+		} else {
+			envelope.RESTBody = restResp.Body
+			restSuccess = true
+		}
+	}
+
+	envelope.ActualOutcome = formatActualOutcome(dynSuccess, restSuccess)
+
+	switch c.ExpectedOutcome {
+	case bamlfuzz.OutcomeBothReject:
+		var failures []string
+		if dynSuccess {
+			failures = append(failures, "dynclient unexpectedly succeeded")
+		}
+		if restSuccess {
+			failures = append(failures, "REST unexpectedly succeeded")
+		}
+		if len(failures) > 0 {
+			failAndDumpInvalid(t, artifactDir, envelope, "axis B both-reject violated (mutation=%s): %s", c.Mutation, strings.Join(failures, "; "))
+			return
+		}
+	case bamlfuzz.OutcomeConditional:
+		switch {
+		case dynSuccess && restSuccess:
+			diffs, derr := bamlfuzz.SemanticDiff("dynclient_vs_rest", envelope.DynclientOutput, envelope.RESTBody)
+			if derr != nil {
+				failAndDumpInvalid(t, artifactDir, envelope, "axis C diff decode (mutation=%s): %v", c.Mutation, derr)
+				return
+			}
+			if len(diffs) > 0 {
+				envelope.SemanticDiff = diffs
+				failAndDumpInvalid(t, artifactDir, envelope, "axis C both-success but dynclient ≠ REST body (mutation=%s)", c.Mutation)
+				return
+			}
+		case !dynSuccess && !restSuccess:
+			// Both errored: pass — error-text divergence is intentional
+			// per the pre-flight finding.
+		default:
+			failAndDumpInvalid(t, artifactDir, envelope, "axis C succeed-vs-reject parity violated (mutation=%s): %s", c.Mutation, envelope.ActualOutcome)
+			return
+		}
+	default:
+		failAndDumpInvalid(t, artifactDir, envelope, "unknown expected outcome %q", c.ExpectedOutcome)
+		return
+	}
+
+	if os.Getenv("BAMLFUZZ_KEEP_ARTIFACTS") == "1" {
+		if path, err := bamlfuzz.WriteInvalidReplayArtifact(artifactDir, envelope); err == nil {
+			t.Logf("kept replay artifact (success): %s", path)
+		}
+	}
+}
+
+// failAndDumpInvalid writes the invalid-case envelope to dir and fails
+// the test with a message pointing at the replay path. Parallel to
+// failAndDump for the valid-case oracle.
+func failAndDumpInvalid(t *testing.T, dir string, envelope *bamlfuzz.InvalidFailureEnvelope, format string, args ...any) {
+	t.Helper()
+	path, err := bamlfuzz.WriteInvalidReplayArtifact(dir, envelope)
+	msg := fmt.Sprintf(format, args...)
+	if err != nil {
+		t.Errorf("write replay artifact: %v", err)
+		t.Errorf("%s", msg)
+		return
+	}
+	t.Errorf("%s\nreplay: %s\nrepro: %s", msg, path, envelope.Reproduction)
+}
+
+// formatActualOutcome describes which surfaces succeeded vs errored,
+// in a form the envelope's ActualOutcome field can carry verbatim.
+func formatActualOutcome(dynSuccess, restSuccess bool) string {
+	dyn := "error"
+	if dynSuccess {
+		dyn = "success"
+	}
+	rest := "error"
+	if restSuccess {
+		rest = "success"
+	}
+	return fmt.Sprintf("dynclient=%s rest=%s", dyn, rest)
+}
+
+// reproductionForInvalid returns the canonical command to re-run a
+// failing invalid-case in isolation, embedded in the envelope so a
+// developer can copy-paste it from the failure log. Mirrors
+// reproductionFor's source dispatch: fuzz cases re-run the engine
+// against the persisted -fuzzcachedir; rapid cases re-run a single
+// subtest under -run.
+func reproductionForInvalid(c bamlfuzz.InvalidOracleCase, caseIdx int, source caseSource) string {
+	var testName, fuzzName string
+	switch c.Mode {
+	case bamlfuzz.InvalidDynamicSchema:
+		testName = "TestBamlfuzzInvalidDynamic"
+		fuzzName = "FuzzBamlfuzzInvalidDynamic"
+	case bamlfuzz.InvalidJSONCoercion:
+		testName = "TestBamlfuzzInvalidJSONCoercion"
+		fuzzName = "FuzzBamlfuzzInvalidJSONCoercion"
+	}
+	if source == caseSourceFuzz {
+		return "go test -tags=integration,subprocess -run='^$' -fuzz='^" + fuzzName +
+			"$' -fuzztime=10m -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+	}
+	cmd := fmt.Sprintf("go test -tags=integration -run='^%s$/^rapid$/^case_%d$' ./integration -count=1",
+		testName, caseIdx)
+	if seed := os.Getenv("BAMLFUZZ_SEED"); seed != "" {
+		cmd = "BAMLFUZZ_SEED=" + seed + " " + cmd
+	}
+	if cases := os.Getenv("BAMLFUZZ_INVALID_CASES"); cases != "" {
+		cmd = "BAMLFUZZ_INVALID_CASES=" + cases + " " + cmd
+	}
+	return cmd
+}

--- a/integration/bamlfuzz_invalid_test.go
+++ b/integration/bamlfuzz_invalid_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -184,15 +185,14 @@ func invalidSeedFor(label string, idx int) uint64 {
 	fmt.Fprintf(h, ":%d", idx)
 	base := h.Sum64()
 	if v := os.Getenv("BAMLFUZZ_SEED"); v != "" {
-		base ^= fnv64aInvalidString(v)
+		// Reuse fnv64aString from bamlfuzz_dynamic_test.go (same
+		// package, same build tag). The static-test variant
+		// fnv64aStaticString is a deliberate duplicate left in
+		// place — same cleanup opportunity, but in an out-of-scope
+		// file.
+		base ^= fnv64aString(v)
 	}
 	return base
-}
-
-func fnv64aInvalidString(s string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte(s))
-	return h.Sum64()
 }
 
 // invalidFuzzSeedBytes derives a deterministic 8-byte fuzz-corpus seed
@@ -325,8 +325,16 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 
 	clientReg := testutil.CreateTestClient(TestEnv.MockLLMInternal, scenarioID)
 
-	callCtx, callCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer callCancel()
+	// Independent contexts per surface. Sharing one context across
+	// dynclient and REST lets a dynclient hang / cancellation drain
+	// the deadline before REST runs, so REST returns context.Canceled
+	// without ever hitting the server. The oracle would then see
+	// "both error" and pass the case — masking a one-sided failure.
+	// A common parentCtx still allows test-level cancellation to abort
+	// both surfaces together; per-surface child contexts isolate the
+	// 30s budget so each call gets its own clock.
+	parentCtx, parentCancel := context.WithCancel(context.Background())
+	defer parentCancel()
 
 	hello := "Return the dynamic fuzz value."
 	preserve := c.PreserveSchemaOrder
@@ -343,7 +351,16 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 		PreserveSchemaOrder: &preserve,
 	}
 
-	libResp, libErr := dyn.DynamicCall(callCtx, libReq)
+	dynCtx, dynCancel := context.WithTimeout(parentCtx, 30*time.Second)
+	defer dynCancel()
+	libResp, libErr := dyn.DynamicCall(dynCtx, libReq)
+	if libErr != nil && (errors.Is(libErr, context.Canceled) || errors.Is(libErr, context.DeadlineExceeded)) {
+		// Context-derived dynclient error is a harness failure, not an
+		// oracle signal — the BAML pipeline never produced a verdict.
+		// Treating it as a rejection would let an outright timeout pass
+		// the both-reject oracle.
+		t.Fatalf("harness failure: dynclient context (case=%s mutation=%s): %v", c.Name, c.Mutation, libErr)
+	}
 	var dynSuccess bool
 	switch {
 	case libErr != nil:
@@ -362,23 +379,28 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 		failAndDumpInvalid(t, artifactDir, envelope, "build REST body: %v", err)
 		return
 	}
-	restResp, err := BAMLClient.DynamicCallJSON(callCtx, restBody)
-	var restSuccess bool
-	switch {
-	case err != nil:
-		envelope.RESTError = err.Error()
-	case restResp == nil:
+	restCtx, restCancel := context.WithTimeout(parentCtx, 30*time.Second)
+	defer restCancel()
+	restResp, err := BAMLClient.DynamicCallJSON(restCtx, restBody)
+	if err != nil {
+		// BAMLClient.DynamicCallJSON wraps the HTTP transport layer;
+		// 4xx/5xx responses come back through restResp.StatusCode +
+		// restResp.Error, not through err. A non-nil err here is a
+		// transport or context failure — harness, not oracle signal.
+		t.Fatalf("harness failure: REST transport (case=%s mutation=%s): %v", c.Name, c.Mutation, err)
+	}
+	if restResp == nil {
 		envelope.RESTError = "nil response from BAMLClient.DynamicCallJSON"
 		failAndDumpInvalid(t, artifactDir, envelope, "REST client returned nil response without an error")
 		return
-	default:
-		envelope.RESTStatus = restResp.StatusCode
-		if restResp.StatusCode >= 400 {
-			envelope.RESTError = restResp.Error
-		} else {
-			envelope.RESTBody = restResp.Body
-			restSuccess = true
-		}
+	}
+	var restSuccess bool
+	envelope.RESTStatus = restResp.StatusCode
+	if restResp.StatusCode >= 400 {
+		envelope.RESTError = restResp.Error
+	} else {
+		envelope.RESTBody = restResp.Body
+		restSuccess = true
 	}
 
 	envelope.ActualOutcome = formatActualOutcome(dynSuccess, restSuccess)
@@ -596,24 +618,96 @@ func deriveChoicesAt(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any, pat
 	}
 }
 
-// pickUnionArm returns the index of the first variant whose shape
-// matches the observed value v, or -1 if no arm matches.
+// defaultMatchDepth caps the structural-match recursion in
+// variantMatchesValue. The v1 schema generator bounds nesting at
+// bamlfuzz.MaxTypeDepth=4, so 16 is comfortable headroom; the cap
+// exists to keep a future grammar widening from blowing the stack.
+const defaultMatchDepth = 16
+
+// pickUnionArm picks the variant index whose structural matcher
+// accepts v, choosing narrow shapes before broad ones. The previous
+// implementation took the first shallow Kind match in declaration
+// order, which let a `union<map<string, T>, class Foo>` with a value
+// shaped like a `Foo` instance silently dispatch to the map arm
+// (KindMap accepts any object) — and the order walker then skipped
+// the nested class-level order check, defeating the very assertion
+// PreserveSchemaOrder=true was meant to run.
+//
+// Narrowness order: literal → null/bool → enum ref → class ref →
+// list → map → numeric → string → optional/union → catch-all. Within
+// a tier, original declaration order is preserved (stable sort) so a
+// schema's variant ordering still influences the pick when multiple
+// arms are equally narrow.
+//
+// Returns -1 if no variant matches the value.
 func pickUnionArm(schema bamlfuzz.FuzzSchema, variants []bamlfuzz.FuzzType, v any) int {
-	for i, variant := range variants {
-		if variantMatchesValue(schema, variant, v) {
-			return i
+	indices := make([]int, len(variants))
+	for i := range variants {
+		indices[i] = i
+	}
+	sort.SliceStable(indices, func(a, b int) bool {
+		return variantNarrowness(variants[indices[a]]) < variantNarrowness(variants[indices[b]])
+	})
+	for _, idx := range indices {
+		if variantMatchesValue(schema, variants[idx], v, defaultMatchDepth) {
+			return idx
 		}
 	}
 	return -1
 }
 
-// variantMatchesValue reports whether variant's Kind can plausibly
-// hold v. Literal kinds require byte-equal content; enum refs require
-// v to be one of the enum's declared values; class refs require v's
-// JSON object keys to be a subset of the class's property names so
-// classref-vs-map ambiguity resolves toward the class arm when keys
-// look like class properties.
-func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any) bool {
+// variantNarrowness ranks variant kinds from narrowest (lowest score)
+// to broadest. Lower wins in pickUnionArm. KindOptional unwraps to
+// its inner type so optional<class> sorts with class, not with the
+// broad fallback.
+func variantNarrowness(t bamlfuzz.FuzzType) int {
+	switch t.Kind {
+	case bamlfuzz.KindLiteral:
+		return 0
+	case bamlfuzz.KindNull:
+		return 1
+	case bamlfuzz.KindBool:
+		return 2
+	case bamlfuzz.KindEnumRef:
+		return 3
+	case bamlfuzz.KindClassRef:
+		return 4
+	case bamlfuzz.KindList:
+		return 5
+	case bamlfuzz.KindMap:
+		return 6
+	case bamlfuzz.KindInt, bamlfuzz.KindFloat:
+		return 7
+	case bamlfuzz.KindString:
+		return 8
+	case bamlfuzz.KindOptional:
+		if t.Inner != nil {
+			return variantNarrowness(*t.Inner)
+		}
+		return 9
+	case bamlfuzz.KindUnion:
+		return 9
+	}
+	return 10
+}
+
+// variantMatchesValue reports whether v structurally conforms to t.
+// Class refs require the observed object's keys to be a subset of
+// declared properties AND every required (non-optional) property to
+// be present — the previous "any key-subset matches" rule let any
+// JSON object that happened to use a class's property names slip
+// through, even when missing required fields. List<T> and
+// ClassRef<T> recurse into elements so nested narrowness is checked
+// too, depth-limited to keep a degenerate cycle from blowing the
+// stack.
+func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any, depth int) bool {
+	if depth <= 0 {
+		// Out of depth budget: accept on top-level shape only. The
+		// v1 grammar bounds nesting at bamlfuzz.MaxTypeDepth=4, so
+		// random generation never lands here; the guard exists to
+		// prevent a future widening from stack-blowing.
+		return shallowKindMatch(t, v)
+	}
 	switch t.Kind {
 	case bamlfuzz.KindNull:
 		return v == nil
@@ -658,11 +752,33 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any)
 		}
 		return false
 	case bamlfuzz.KindList:
-		_, ok := v.([]any)
-		return ok
+		arr, ok := v.([]any)
+		if !ok {
+			return false
+		}
+		if t.Inner == nil {
+			return true
+		}
+		for _, item := range arr {
+			if !variantMatchesValue(schema, *t.Inner, item, depth-1) {
+				return false
+			}
+		}
+		return true
 	case bamlfuzz.KindMap:
-		_, ok := v.(map[string]any)
-		return ok
+		obj, ok := v.(map[string]any)
+		if !ok {
+			return false
+		}
+		if t.Inner == nil {
+			return true
+		}
+		for _, val := range obj {
+			if !variantMatchesValue(schema, *t.Inner, val, depth-1) {
+				return false
+			}
+		}
+		return true
 	case bamlfuzz.KindClassRef:
 		obj, ok := v.(map[string]any)
 		if !ok {
@@ -672,12 +788,29 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any)
 		if !found {
 			return false
 		}
-		propNames := make(map[string]struct{}, len(cls.Properties))
+		propByName := make(map[string]bamlfuzz.FuzzType, len(cls.Properties))
 		for _, p := range cls.Properties {
-			propNames[p.Name] = struct{}{}
+			propByName[p.Name] = p.Type
 		}
 		for k := range obj {
-			if _, ok := propNames[k]; !ok {
+			if _, ok := propByName[k]; !ok {
+				return false
+			}
+		}
+		for _, p := range cls.Properties {
+			if p.Type.Kind == bamlfuzz.KindOptional {
+				continue
+			}
+			if _, present := obj[p.Name]; !present {
+				return false
+			}
+		}
+		for name, fieldType := range propByName {
+			fv, present := obj[name]
+			if !present {
+				continue
+			}
+			if !variantMatchesValue(schema, fieldType, fv, depth-1) {
 				return false
 			}
 		}
@@ -687,16 +820,48 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any)
 			return true
 		}
 		if t.Inner != nil {
-			return variantMatchesValue(schema, *t.Inner, v)
+			return variantMatchesValue(schema, *t.Inner, v, depth-1)
 		}
 		return false
 	case bamlfuzz.KindUnion:
 		for _, variant := range t.Variants {
-			if variantMatchesValue(schema, variant, v) {
+			if variantMatchesValue(schema, variant, v, depth-1) {
 				return true
 			}
 		}
 		return false
+	}
+	return false
+}
+
+// shallowKindMatch is the depth-exhausted fallback: top-level
+// shape compatibility only. Class refs degrade to "is an object";
+// no key-set or required-field check.
+func shallowKindMatch(t bamlfuzz.FuzzType, v any) bool {
+	switch t.Kind {
+	case bamlfuzz.KindNull:
+		return v == nil
+	case bamlfuzz.KindString, bamlfuzz.KindEnumRef:
+		_, ok := v.(string)
+		return ok
+	case bamlfuzz.KindInt, bamlfuzz.KindFloat:
+		_, ok := v.(float64)
+		return ok
+	case bamlfuzz.KindBool:
+		_, ok := v.(bool)
+		return ok
+	case bamlfuzz.KindList:
+		_, ok := v.([]any)
+		return ok
+	case bamlfuzz.KindMap, bamlfuzz.KindClassRef:
+		_, ok := v.(map[string]any)
+		return ok
+	case bamlfuzz.KindLiteral:
+		return true
+	case bamlfuzz.KindOptional:
+		return true
+	case bamlfuzz.KindUnion:
+		return true
 	}
 	return false
 }
@@ -712,6 +877,17 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any)
 // preserve_on) under "rapid"; the repro path reflects this when the
 // case carries the mode in c.PreserveSchemaOrder so the printed
 // command targets the exact failing subtest.
+//
+// Both the fuzz and rapid repros hardcode `-tags=integration,subprocess`
+// because the nightly invokes the test binary under those tags
+// (subprocess routes through the cmd/worker go-plugin, inprocess uses
+// the in-binary worker — they exercise different code paths in the
+// worker pool). Replaying with `-tags=integration` alone would run the
+// inprocess worker and potentially mask a failure that only reproduces
+// on the subprocess path. NB: the existing TestBamlfuzz{Static,Dynamic}Oracle
+// repro emitters in bamlfuzz_{static,dynamic}_test.go still emit
+// `-tags=integration` for their rapid branch; that's the same bug in
+// out-of-scope files, worth a future cleanup but left alone here.
 func reproductionForInvalid(c bamlfuzz.InvalidOracleCase, caseIdx int, source caseSource) string {
 	var testName, fuzzName string
 	switch c.Mode {
@@ -737,7 +913,7 @@ func reproductionForInvalid(c bamlfuzz.InvalidOracleCase, caseIdx int, source ca
 	default:
 		runPath = fmt.Sprintf("^%s$/^rapid$/^case_%d$", testName, caseIdx)
 	}
-	cmd := fmt.Sprintf("go test -tags=integration -run='%s' ./integration -count=1", runPath)
+	cmd := fmt.Sprintf("go test -tags=integration,subprocess -run='%s' ./integration -count=1", runPath)
 	if seed := os.Getenv("BAMLFUZZ_SEED"); seed != "" {
 		cmd = "BAMLFUZZ_SEED=" + seed + " " + cmd
 	}

--- a/integration/bamlfuzz_invalid_test.go
+++ b/integration/bamlfuzz_invalid_test.go
@@ -468,25 +468,237 @@ func formatActualOutcome(dynSuccess, restSuccess bool) string {
 
 // checkInvalidOrderC runs the schema-aware key-order assertion on the
 // (dynclient.Data, REST.Body) pair for an Axis C case in the success
-// quadrant. Returns a non-empty diagnostic when the surfaces disagree
-// on key order at any class node OR when the order walker bails. The
-// second return reports whether the call site should treat the result
-// as a hard failure: a real order mismatch is hard fail; an
-// ErrSchemaOrderUnsupported result (the walker hit a union node
-// without a recorded choice) downgrades to a soft warning because the
-// post-mutation surface output may legitimately exercise union arms
-// the original walker did not visit.
+// quadrant. Returns (diagnostic, hardFail) — a non-empty diagnostic
+// always indicates the check found something worth reporting; the
+// second return reports whether the call site should fail the test.
+//
+// The order walker's UnionChoices contract requires a recorded choice
+// for every union path it visits. The walker built CaseMetadata.UnionChoices
+// from the pre-mutation FuzzValue, but the mock LLM JSON has been
+// perturbed since: a mutation can flip the surfaces into a union arm
+// the pre-mutation walk never recorded, leaving the order walker no
+// way to dispatch at that node. To keep the order assertion runnable
+// in that case, derive a fresh choices map from the actual parsed
+// dynclient output (which SemanticDiff already proved equals the REST
+// body at this point), then feed THAT into the walker. Derivation
+// covers every union path in the schema reachable through the parsed
+// JSON, so the walker should always have a choice and never bail.
+//
+// ErrSchemaOrderUnsupported after derivation is a hard fail: it means
+// either (a) the parsed value at a union path has a shape no arm
+// matches (a real schema-vs-output divergence the oracle should
+// surface), or (b) the derivation itself is buggy. Both are worth
+// failing on.
 func checkInvalidOrderC(c bamlfuzz.InvalidOracleCase, dyn, rest json.RawMessage) (string, bool) {
-	diffs, err := bamlfuzz.SchemaOrderDiffWithChoices("dynclient_vs_rest_order", c.Schema, dyn, rest, c.Metadata.UnionChoices)
+	choices, err := deriveUnionChoicesFromParsed(c.Schema, dyn)
+	if err != nil {
+		return fmt.Sprintf("axis C order check: derive union choices: %v", err), true
+	}
+	diffs, err := bamlfuzz.SchemaOrderDiffWithChoices("dynclient_vs_rest_order", c.Schema, dyn, rest, choices)
 	switch {
 	case errors.Is(err, bamlfuzz.ErrSchemaOrderUnsupported):
-		return fmt.Sprintf("axis C order check: %v (soft-skip on union arm metadata)", err), false
+		return fmt.Sprintf("axis C order check: %v (derivation did not cover every union path; treat as hard fail per F1 contract)", err), true
 	case err != nil:
 		return fmt.Sprintf("axis C order check: %v", err), true
 	case len(diffs) > 0:
 		return strings.Join(bamlfuzz.FormatSchemaOrderDiffs(diffs), "; "), true
 	}
 	return "", false
+}
+
+// deriveUnionChoicesFromParsed walks the schema in parallel with the
+// parsed JSON, recording a UnionChoice at every union path. The path
+// scheme matches the walker's CaseMetadata.UnionChoices convention
+// exactly: paths start at "" (no leading "$"); class fields append
+// ".<name>"; list elements append "[<idx>]"; map values append
+// "[<quoted-key>]"; union variant arms append ":v". The order walker
+// (order.go's walkType) strips the leading "$" before consulting
+// choices, so a "" start here lands on the same key the walker
+// queries.
+//
+// The variant picked at each union is the first arm whose Kind shape
+// matches the parsed value. Ambiguous arms (e.g., KindString vs
+// KindEnumRef vs KindLiteralString — all produce JSON strings) are
+// disambiguated by content match where possible (KindLiteralString
+// requires byte-equal value; KindEnumRef requires the string to be
+// one of the enum's declared values), with KindString as the
+// catch-all fallback. A union with no matching arm leaves the node
+// unrecorded; the order walker then surfaces ErrSchemaOrderUnsupported,
+// which checkInvalidOrderC treats as a hard failure.
+func deriveUnionChoicesFromParsed(schema bamlfuzz.FuzzSchema, parsed json.RawMessage) (map[string]bamlfuzz.UnionChoice, error) {
+	var v any
+	if err := json.Unmarshal(parsed, &v); err != nil {
+		return nil, err
+	}
+	choices := make(map[string]bamlfuzz.UnionChoice)
+	deriveChoicesAt(schema, schema.EffectiveRoot(), v, "", choices)
+	return choices, nil
+}
+
+func deriveChoicesAt(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any, path string, choices map[string]bamlfuzz.UnionChoice) {
+	switch t.Kind {
+	case bamlfuzz.KindUnion:
+		idx := pickUnionArm(schema, t.Variants, v)
+		if idx < 0 || idx >= len(t.Variants) {
+			return
+		}
+		selected := t.Variants[idx]
+		choices[path] = bamlfuzz.UnionChoice{
+			Index:        idx,
+			Kind:         selected.Kind,
+			Ref:          selected.Ref,
+			VariantCount: len(t.Variants),
+		}
+		deriveChoicesAt(schema, selected, v, path+":v", choices)
+	case bamlfuzz.KindOptional:
+		if t.Inner == nil || v == nil {
+			return
+		}
+		deriveChoicesAt(schema, *t.Inner, v, path, choices)
+	case bamlfuzz.KindList:
+		if t.Inner == nil {
+			return
+		}
+		arr, ok := v.([]any)
+		if !ok {
+			return
+		}
+		for i, item := range arr {
+			deriveChoicesAt(schema, *t.Inner, item, fmt.Sprintf("%s[%d]", path, i), choices)
+		}
+	case bamlfuzz.KindMap:
+		if t.Inner == nil {
+			return
+		}
+		obj, ok := v.(map[string]any)
+		if !ok {
+			return
+		}
+		for k, val := range obj {
+			deriveChoicesAt(schema, *t.Inner, val, fmt.Sprintf("%s[%q]", path, k), choices)
+		}
+	case bamlfuzz.KindClassRef:
+		obj, ok := v.(map[string]any)
+		if !ok {
+			return
+		}
+		cls, found := schema.FindClass(t.Ref)
+		if !found {
+			return
+		}
+		for _, prop := range cls.Properties {
+			fv, present := obj[prop.Name]
+			if !present {
+				continue
+			}
+			deriveChoicesAt(schema, prop.Type, fv, path+"."+prop.Name, choices)
+		}
+	}
+}
+
+// pickUnionArm returns the index of the first variant whose shape
+// matches the observed value v, or -1 if no arm matches.
+func pickUnionArm(schema bamlfuzz.FuzzSchema, variants []bamlfuzz.FuzzType, v any) int {
+	for i, variant := range variants {
+		if variantMatchesValue(schema, variant, v) {
+			return i
+		}
+	}
+	return -1
+}
+
+// variantMatchesValue reports whether variant's Kind can plausibly
+// hold v. Literal kinds require byte-equal content; enum refs require
+// v to be one of the enum's declared values; class refs require v's
+// JSON object keys to be a subset of the class's property names so
+// classref-vs-map ambiguity resolves toward the class arm when keys
+// look like class properties.
+func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any) bool {
+	switch t.Kind {
+	case bamlfuzz.KindNull:
+		return v == nil
+	case bamlfuzz.KindString:
+		_, ok := v.(string)
+		return ok
+	case bamlfuzz.KindInt, bamlfuzz.KindFloat:
+		_, ok := v.(float64)
+		return ok
+	case bamlfuzz.KindBool:
+		_, ok := v.(bool)
+		return ok
+	case bamlfuzz.KindLiteral:
+		if t.Literal == nil {
+			return false
+		}
+		switch t.Literal.Kind {
+		case bamlfuzz.LiteralString:
+			s, ok := v.(string)
+			return ok && s == t.Literal.String
+		case bamlfuzz.LiteralInt:
+			n, ok := v.(float64)
+			return ok && n == float64(t.Literal.Int)
+		case bamlfuzz.LiteralBool:
+			b, ok := v.(bool)
+			return ok && b == t.Literal.Bool
+		}
+		return false
+	case bamlfuzz.KindEnumRef:
+		s, ok := v.(string)
+		if !ok {
+			return false
+		}
+		enum, found := schema.FindEnum(t.Ref)
+		if !found {
+			return false
+		}
+		for _, val := range enum.Values {
+			if val == s {
+				return true
+			}
+		}
+		return false
+	case bamlfuzz.KindList:
+		_, ok := v.([]any)
+		return ok
+	case bamlfuzz.KindMap:
+		_, ok := v.(map[string]any)
+		return ok
+	case bamlfuzz.KindClassRef:
+		obj, ok := v.(map[string]any)
+		if !ok {
+			return false
+		}
+		cls, found := schema.FindClass(t.Ref)
+		if !found {
+			return false
+		}
+		propNames := make(map[string]struct{}, len(cls.Properties))
+		for _, p := range cls.Properties {
+			propNames[p.Name] = struct{}{}
+		}
+		for k := range obj {
+			if _, ok := propNames[k]; !ok {
+				return false
+			}
+		}
+		return true
+	case bamlfuzz.KindOptional:
+		if v == nil {
+			return true
+		}
+		if t.Inner != nil {
+			return variantMatchesValue(schema, *t.Inner, v)
+		}
+		return false
+	case bamlfuzz.KindUnion:
+		for _, variant := range t.Variants {
+			if variantMatchesValue(schema, variant, v) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
 // reproductionForInvalid returns the canonical command to re-run a

--- a/integration/bamlfuzz_invalid_test.go
+++ b/integration/bamlfuzz_invalid_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -107,6 +108,13 @@ func FuzzBamlfuzzInvalidDynamic(f *testing.F) {
 // equal (so a lenient-coercion divergence between dynclient and REST
 // surfaces); when at least one surface errors both must error (no
 // error-text comparison; see pre-flight finding).
+//
+// The rapid loop iterates both preserve_schema_order modes so the Axis
+// C oracle exercises the ordered-fields code path under
+// preserve_schema_order=true. The order assertion (success quadrant
+// only) compares dynclient vs REST key order at every class node via
+// SchemaOrderDiffWithChoices — the same machinery the valid-case
+// dynamic oracle uses.
 func TestBamlfuzzInvalidJSONCoercion(t *testing.T) {
 	dynclientCallGate(t)
 
@@ -117,12 +125,22 @@ func TestBamlfuzzInvalidJSONCoercion(t *testing.T) {
 
 	t.Run("rapid", func(t *testing.T) {
 		cases := invalidCasesPerRun()
-		for i := 0; i < cases; i++ {
-			i := i
-			seed := invalidSeedFor("invalid_json_coercion", i)
-			t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-				c := buildRapidInvalidJSONCase(t, seed, i)
-				runInvalidOracleCase(t, dyn, c, i, caseSourceRapid)
+		modes := []bool{true, false}
+		for _, preserve := range modes {
+			preserve := preserve
+			label := "preserve_off"
+			if preserve {
+				label = "preserve_on"
+			}
+			t.Run(label, func(t *testing.T) {
+				for i := 0; i < cases; i++ {
+					i := i
+					seed := invalidSeedFor(fmt.Sprintf("invalid_json_coercion:%s", label), i)
+					t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+						c := buildRapidInvalidJSONCase(t, seed, i, preserve)
+						runInvalidOracleCase(t, dyn, c, i, caseSourceRapid)
+					})
+				}
 			})
 		}
 	})
@@ -147,7 +165,9 @@ func FuzzBamlfuzzInvalidJSONCoercion(f *testing.F) {
 	f.Add(invalidFuzzSeedBytes("invalid_json_coercion", 0))
 
 	bamlfuzz.MakeFuzz(f, func(t *testing.T, rt *rapid.T) {
+		preserve := rapid.Bool().Draw(rt, "preserve_schema_order")
 		c := bamlfuzz.InvalidJSONCoercionGen().Draw(rt, "invalid_json_case")
+		c.PreserveSchemaOrder = preserve
 		c.Name = "fuzz_" + c.Mutation
 		runInvalidOracleCase(t, dyn, c, 0, caseSourceFuzz)
 	})
@@ -175,11 +195,27 @@ func fnv64aInvalidString(s string) uint64 {
 	return h.Sum64()
 }
 
-// invalidFuzzSeedBytes encodes invalidSeedFor's uint64 output as 8
-// little-endian bytes — the exact wire shape bamlfuzz.MakeFuzz
-// recognizes as a verbatim seed (fuzzbridge.go).
+// invalidFuzzSeedBytes derives a deterministic 8-byte fuzz-corpus seed
+// from (label, idx). The output is the exact wire shape
+// bamlfuzz.MakeFuzz recognizes as a verbatim uint64 (fuzzbridge.go).
+//
+// BAMLFUZZ_SEED is intentionally NOT folded in here, even though the
+// rapid path's invalidSeedFor does fold it in. Reason: the nightly's
+// fuzz mode runs with BAMLFUZZ_SEED=github.run_id set in the job env,
+// and the fuzz-mode repro command emitted on failure does not echo
+// BAMLFUZZ_SEED back (only the corpus bytes under -fuzzcachedir
+// identify the failing input). Folding the env var into the corpus
+// seed bytes would make every nightly's seed bytes different from the
+// developer-machine bytes under the same f.Add(label, idx) call, so a
+// failed run's "go test -fuzz=..." command would replay a different
+// case than the one that triggered the failure. Keeping the corpus
+// bytes pure ensures f.Add(label, 0) is byte-identical across all
+// environments.
 func invalidFuzzSeedBytes(label string, idx int) []byte {
-	seed := invalidSeedFor(label, idx)
+	h := fnv.New64a()
+	h.Write([]byte(label))
+	fmt.Fprintf(h, ":%d", idx)
+	seed := h.Sum64()
 	b := make([]byte, 8)
 	binary.LittleEndian.PutUint64(b, seed)
 	return b
@@ -197,13 +233,20 @@ func buildRapidInvalidDynamicCase(t *testing.T, seed uint64, idx int) bamlfuzz.I
 }
 
 // buildRapidInvalidJSONCase synthesizes one Axis C case
-// deterministically from seed.
-func buildRapidInvalidJSONCase(t *testing.T, seed uint64, idx int) bamlfuzz.InvalidOracleCase {
+// deterministically from seed. PreserveSchemaOrder is set explicitly
+// by the caller's preserve-mode iterator and is encoded into the case
+// name so per-mode artifact paths don't collide.
+func buildRapidInvalidJSONCase(t *testing.T, seed uint64, idx int, preserve bool) bamlfuzz.InvalidOracleCase {
 	t.Helper()
 	c := bamlfuzz.InvalidJSONCoercionGen().Example(int(seed))
-	c.Name = fmt.Sprintf("rapid_%d_%s", idx, c.Mutation)
+	mode := "preserve_off"
+	if preserve {
+		mode = "preserve_on"
+	}
+	c.Name = fmt.Sprintf("rapid_%s_%d_%s", mode, idx, c.Mutation)
 	c.Seed = int64(seed)
 	c.CaseIndex = idx
+	c.PreserveSchemaOrder = preserve
 	return c
 }
 
@@ -231,17 +274,18 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 
 	artifactDir := invalidArtifactDirFor(c.Mode)
 	envelope := &bamlfuzz.InvalidFailureEnvelope{
-		GeneratorVersion: bamlfuzz.GeneratorVersion,
-		RapidSeed:        c.Seed,
-		CaseIndex:        caseIdx,
-		CaseName:         c.Name,
-		OracleMode:       c.Mode,
-		Mutation:         c.Mutation,
-		ExpectedOutcome:  c.ExpectedOutcome,
-		Schema:           c.Schema,
-		MockLLMContent:   c.MockLLMContent,
-		Metadata:         c.Metadata,
-		Reproduction:     reproductionForInvalid(c, caseIdx, source),
+		GeneratorVersion:    bamlfuzz.GeneratorVersion,
+		RapidSeed:           c.Seed,
+		CaseIndex:           caseIdx,
+		CaseName:            c.Name,
+		OracleMode:          c.Mode,
+		Mutation:            c.Mutation,
+		PreserveSchemaOrder: c.PreserveSchemaOrder,
+		ExpectedOutcome:     c.ExpectedOutcome,
+		Schema:              c.Schema,
+		MockLLMContent:      c.MockLLMContent,
+		Metadata:            c.Metadata,
+		Reproduction:        reproductionForInvalid(c, caseIdx, source),
 	}
 
 	lowered, err := bamlfuzz.LowerInvalidToDynamicSchema(c)
@@ -285,6 +329,7 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 	defer callCancel()
 
 	hello := "Return the dynamic fuzz value."
+	preserve := c.PreserveSchemaOrder
 	libReq := dynclient.Request{
 		Messages: []dynclient.Message{
 			{Role: "system", PartsContent: []dynclient.ContentPart{
@@ -293,8 +338,9 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 			}},
 			{Role: "user", TextContent: &hello},
 		},
-		ClientRegistry: testutil.DynRegistry(clientReg),
-		OutputSchema:   &lowered,
+		ClientRegistry:      testutil.DynRegistry(clientReg),
+		OutputSchema:        &lowered,
+		PreserveSchemaOrder: &preserve,
 	}
 
 	libResp, libErr := dyn.DynamicCall(callCtx, libReq)
@@ -363,6 +409,15 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 				failAndDumpInvalid(t, artifactDir, envelope, "axis C both-success but dynclient ≠ REST body (mutation=%s)", c.Mutation)
 				return
 			}
+			if c.PreserveSchemaOrder {
+				if msg, fail := checkInvalidOrderC(c, envelope.DynclientOutput, envelope.RESTBody); msg != "" {
+					envelope.OrderWarning = append(envelope.OrderWarning, msg)
+					if fail {
+						failAndDumpInvalid(t, artifactDir, envelope, "axis C dynclient ≠ REST key order (mutation=%s)", c.Mutation)
+						return
+					}
+				}
+			}
 		case !dynSuccess && !restSuccess:
 			// Both errored: pass — error-text divergence is intentional
 			// per the pre-flight finding.
@@ -411,12 +466,40 @@ func formatActualOutcome(dynSuccess, restSuccess bool) string {
 	return fmt.Sprintf("dynclient=%s rest=%s", dyn, rest)
 }
 
+// checkInvalidOrderC runs the schema-aware key-order assertion on the
+// (dynclient.Data, REST.Body) pair for an Axis C case in the success
+// quadrant. Returns a non-empty diagnostic when the surfaces disagree
+// on key order at any class node OR when the order walker bails. The
+// second return reports whether the call site should treat the result
+// as a hard failure: a real order mismatch is hard fail; an
+// ErrSchemaOrderUnsupported result (the walker hit a union node
+// without a recorded choice) downgrades to a soft warning because the
+// post-mutation surface output may legitimately exercise union arms
+// the original walker did not visit.
+func checkInvalidOrderC(c bamlfuzz.InvalidOracleCase, dyn, rest json.RawMessage) (string, bool) {
+	diffs, err := bamlfuzz.SchemaOrderDiffWithChoices("dynclient_vs_rest_order", c.Schema, dyn, rest, c.Metadata.UnionChoices)
+	switch {
+	case errors.Is(err, bamlfuzz.ErrSchemaOrderUnsupported):
+		return fmt.Sprintf("axis C order check: %v (soft-skip on union arm metadata)", err), false
+	case err != nil:
+		return fmt.Sprintf("axis C order check: %v", err), true
+	case len(diffs) > 0:
+		return strings.Join(bamlfuzz.FormatSchemaOrderDiffs(diffs), "; "), true
+	}
+	return "", false
+}
+
 // reproductionForInvalid returns the canonical command to re-run a
 // failing invalid-case in isolation, embedded in the envelope so a
 // developer can copy-paste it from the failure log. Mirrors
 // reproductionFor's source dispatch: fuzz cases re-run the engine
 // against the persisted -fuzzcachedir; rapid cases re-run a single
 // subtest under -run.
+//
+// The Axis C rapid subtree has a per-mode layer (preserve_off /
+// preserve_on) under "rapid"; the repro path reflects this when the
+// case carries the mode in c.PreserveSchemaOrder so the printed
+// command targets the exact failing subtest.
 func reproductionForInvalid(c bamlfuzz.InvalidOracleCase, caseIdx int, source caseSource) string {
 	var testName, fuzzName string
 	switch c.Mode {
@@ -431,8 +514,18 @@ func reproductionForInvalid(c bamlfuzz.InvalidOracleCase, caseIdx int, source ca
 		return "go test -tags=integration,subprocess -run='^$' -fuzz='^" + fuzzName +
 			"$' -fuzztime=10m -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
 	}
-	cmd := fmt.Sprintf("go test -tags=integration -run='^%s$/^rapid$/^case_%d$' ./integration -count=1",
-		testName, caseIdx)
+	var runPath string
+	switch c.Mode {
+	case bamlfuzz.InvalidJSONCoercion:
+		mode := "preserve_off"
+		if c.PreserveSchemaOrder {
+			mode = "preserve_on"
+		}
+		runPath = fmt.Sprintf("^%s$/^rapid$/^%s$/^case_%d$", testName, mode, caseIdx)
+	default:
+		runPath = fmt.Sprintf("^%s$/^rapid$/^case_%d$", testName, caseIdx)
+	}
+	cmd := fmt.Sprintf("go test -tags=integration -run='%s' ./integration -count=1", runPath)
 	if seed := os.Getenv("BAMLFUZZ_SEED"); seed != "" {
 		cmd = "BAMLFUZZ_SEED=" + seed + " " + cmd
 	}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Wires two new axes of property-style fuzzing onto the dynamic
`/call/_dynamic` surface, sharing a single `InvalidOracleCase` +
`InvalidFailureEnvelope` pair under `adapters/common/codegen/bamlfuzz/`
and one new test file under `integration/`.

### Axis B — Invalid dynamic `output_schema`

`InvalidDynamicSchemaGen` draws a valid base schema from
`DynamicSafeSchemaGen`, lowers it to a `DynamicOutputSchema`, and
applies one targeted mutation to the first root property:

- `both_type_and_ref` — set both `type` and `ref` on the property
- `misspelled_type` — `\"strin\"` lands on the unknown-type default arm
- `drop_items` / `drop_inner` / `drop_keys_values` / `drop_oneof` — each
  composite kind requires its companion field
- `over_depth` — 70 nested `optional` wrappers exceeds `maxTypeDepth`

The oracle (`OutcomeBothReject`) asserts both `dynclient.DynamicCall`
and the REST `/call/_dynamic` endpoint error. Error text is not
compared.

### Axis C — Lenient-coercion divergence

`InvalidJSONCoercionGen` lowers a valid schema cleanly and perturbs the
walker-emitted mock LLM JSON with one targeted edit:

- `drop_key`, `add_unknown_key`, `retype_scalar`, `swap_enum`,
  `wrap_in_array`

The oracle (`OutcomeConditional`) is split:

1. **Both surfaces succeed**: `SemanticDiff(dynclient.Data, REST.Body)`
   must be empty.
2. **At least one errors**: both must error (no error-text comparison).

The conditional shape comes from the pre-flight determinism check: the
two surfaces emit divergent error-wrapper prefixes (`dynclient: dynamic
call:` vs `status 500:`) around an identical BAML diagnostic core, so
an unconditional byte-equality oracle would flake on the error path
even though the underlying behaviour is identical.

## File layout

```
adapters/common/codegen/bamlfuzz/
  invalid_case.go    — InvalidOracleCase, InvalidFailureEnvelope, WriteInvalidReplayArtifact
  invalid_gen.go     — InvalidDynamicSchemaGen, InvalidJSONCoercionGen
  invalid_lower.go   — LowerInvalidToDynamicSchema
  mutate.go          — schema mutation dispatch + JSON mutation dispatch
integration/
  bamlfuzz_invalid_test.go  — TestBamlfuzz{InvalidDynamic,InvalidJSONCoercion}
                              + FuzzBamlfuzz{InvalidDynamic,InvalidJSONCoercion}
.github/workflows/bamlfuzz-nightly.yml — two new fuzz steps + extended rapid -run
```

## Validation

Local at BAML 0.222.0:

- `go build ./...` clean
- `go vet ./...` clean
- `go test -tags=integration -c -o /dev/null ./integration/...` clean
- Rapid oracle (16 cases × 2 axes):

  ```
  --- PASS: TestBamlfuzzInvalidDynamic (0.27s)
  --- PASS: TestBamlfuzzInvalidJSONCoercion (0.33s)
  ```
- Fuzz mode 10s smoke per target:
  - `FuzzBamlfuzzInvalidDynamic`: 15658 execs, 50 interesting, PASS
  - `FuzzBamlfuzzInvalidJSONCoercion`: 1494 execs, 6 interesting, PASS

## Implementation notes

The scoping report listed `unknown_ref` as a candidate Axis B
mutation. Empirical validation at BAML 0.222.0 showed BAML's runtime
silently returns `{}` from both surfaces when a property's ref names an
undeclared class — so the input is invalid by intent but consistent by
behaviour, which does not satisfy `OutcomeBothReject`. The catalogue
omits `unknown_ref`; routing it to a no-crash + body-parity oracle is
a future option worth considering and out of scope here.

Mutations are applied at the lowered `DynamicOutputSchema` layer
because the `FuzzSchema` IR's pointer-fielded composites cannot
naturally express shapes like \"list with no items\". The case carries
the valid base schema + a `Mutation` descriptor;
`LowerInvalidToDynamicSchema` rebuilds the post-mutation lowered form
deterministically so envelope replays reproduce.

## References

Partial v2+ progress on the bamlfuzz roadmap: #349.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added invalid-input fuzz axes (dynamic-schema and JSON-coercion) with rapid and fuzz entrypoints, deterministic seeds, semantic-equality and ordering checks, replay artifacts on failures, optional artifact retention, and reproducible commands that include the invalid-case env var.

* **Chores**
  * CI workflow updated to run the new invalid-input fuzz/rapid jobs, increased fuzz timeout, added configurable invalid-case count, and expanded rapid/fuzz runs to cover all invalid targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->