### PR TITLE
feat(bamlfuzz): streaming oracle — final-value equivalence on /stream/_dynamic

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -31,8 +31,13 @@ on:
         type: string
         required: false
         default: "50"
+      streaming_cases:
+        description: Rapid-mode streaming cases per preserve mode (default 50)
+        type: string
+        required: false
+        default: "50"
       fuzztime:
-        description: Fuzz-mode duration per target (default 15m; total wall time roughly 4× this — static + dynamic + invalid-dynamic + invalid-json-coercion run sequentially)
+        description: Fuzz-mode duration per target (default 15m; total wall time roughly 5× this — static + dynamic + invalid-dynamic + invalid-json-coercion + streaming run sequentially)
         type: string
         required: false
         default: "15m"
@@ -76,21 +81,21 @@ jobs:
   fuzz:
     needs: get-versions
     runs-on: ubuntu-latest
-    # Four sequential fuzz targets, each its own `go test ./integration`
+    # Five sequential fuzz targets, each its own `go test ./integration`
     # invocation — so TestMain (the integration env Setup that boots
-    # the BAML REST container + mock LLM) runs FOUR TIMES, not once.
+    # the BAML REST container + mock LLM) runs FIVE TIMES, not once.
     # Budget:
-    #   - fuzz: 4 × FUZZTIME (default 15m) = 60m
-    #   - setup: 4 × ~10m per invocation on cold runners = 40m
+    #   - fuzz: 5 × FUZZTIME (default 15m) = 75m
+    #   - setup: 5 × ~10m per invocation on cold runners = 50m
     #   - corpus restore + Go install + safety margin = ~10m
-    #   Total at the FUZZTIME default: ~110m.
-    # The 180m cap absorbs cold-runner setup variance and supports an
-    # operator-set FUZZTIME up to ~25m (4 × 25m + 40m setup + 10m
-    # margin = 150m) without breaching. A future refactor that runs
-    # all four fuzz targets under a single `go test` invocation would
+    #   Total at the FUZZTIME default: ~135m.
+    # The 210m cap absorbs cold-runner setup variance and supports an
+    # operator-set FUZZTIME up to ~30m (5 × 30m + 50m setup + 10m
+    # margin = 210m) without breaching. A future refactor that runs
+    # all five fuzz targets under a single `go test` invocation would
     # collapse setup to ~10m total and shrink the budget back to the
-    # ~75m the prior two-target nightly used.
-    timeout-minutes: 180
+    # ~85m a single-setup run would need.
+    timeout-minutes: 210
     permissions:
       contents: read
       actions: read
@@ -110,6 +115,7 @@ jobs:
       BAMLFUZZ_DYNAMIC_CASES: ${{ github.event.inputs.dynamic_cases || '50' }}
       BAMLFUZZ_STATIC_BATCHES: ${{ github.event.inputs.static_batches || '10' }}
       BAMLFUZZ_INVALID_CASES: ${{ github.event.inputs.invalid_cases || '50' }}
+      BAMLFUZZ_STREAMING_CASES: ${{ github.event.inputs.streaming_cases || '50' }}
       BAMLFUZZ_SEED: ${{ github.event.inputs.seed || github.run_id }}
     steps:
       - name: Checkout Repository
@@ -150,11 +156,11 @@ jobs:
 
       - name: Run bamlfuzz nightly — static fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'fuzz' }}
-        # `go test -fuzz` runs ONE target per invocation, so the four
+        # `go test -fuzz` runs ONE target per invocation, so the five
         # fuzz targets (static, dynamic, invalid-dynamic,
-        # invalid-json-coercion) are split across sequential steps.
-        # Each gets the full configured FUZZTIME budget. Total fuzz
-        # wall time is therefore 4 × FUZZTIME; the job's
+        # invalid-json-coercion, streaming) are split across sequential
+        # steps. Each gets the full configured FUZZTIME budget. Total
+        # fuzz wall time is therefore 5 × FUZZTIME; the job's
         # timeout-minutes block above caps the combined cost. The
         # corpus dir is shared so seed inputs any target discovers
         # also influence the others on the next nightly.
@@ -216,6 +222,18 @@ jobs:
             -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
             ./integration
 
+      - name: Run bamlfuzz nightly — streaming fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
+        if: ${{ env.MODE == 'fuzz' }}
+        env:
+          BAMLFUZZ_KEEP_ARTIFACTS: ""
+        run: |
+          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
+            -run='^$' \
+            -fuzz='^FuzzBamlfuzzStreaming$' \
+            -fuzztime="${FUZZTIME}" \
+            -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
+            ./integration
+
       - name: Run bamlfuzz oracles — rapid mode (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'rapid' }}
         # `subprocess` matches the normal server deployment path (server +
@@ -228,7 +246,7 @@ jobs:
         # bamlfuzz-package-stress job instead.
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
-            -run='^TestBamlfuzz(Static|Dynamic)Oracle$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)$' ./integration/...
+            -run='^TestBamlfuzz(Static|Dynamic|Streaming)Oracle$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)$' ./integration/...
 
       - name: Upload corpus for next nightly
         if: ${{ always() && env.MODE == 'fuzz' }}
@@ -285,20 +303,21 @@ jobs:
             if [ "${MODE}" = "fuzz" ]; then
               echo "Corpus artifact: bamlfuzz-corpus-${BAML}-${UNARY}"
               echo
-              echo "Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/). \`go test -fuzz\` accepts only a single target per invocation, so run the static, dynamic, invalid-dynamic, and invalid-json-coercion targets sequentially. The \`-fuzzcachedir\` flag points the engine at the extracted corpus so the failing input is replayed:"
+              echo "Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/). \`go test -fuzz\` accepts only a single target per invocation, so run the static, dynamic, invalid-dynamic, invalid-json-coercion, and streaming targets sequentially. The \`-fuzzcachedir\` flag points the engine at the extracted corpus so the failing input is replayed:"
               echo
               echo '```'
               echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzStatic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
               echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzDynamic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
               echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzInvalidDynamic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
               echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzInvalidJSONCoercion\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzStreaming\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
               echo '```'
             else
               echo
               echo "Repro:"
               echo
               echo '```'
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_DYNAMIC_CASES=${BAMLFUZZ_DYNAMIC_CASES} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} BAMLFUZZ_INVALID_CASES=${BAMLFUZZ_INVALID_CASES} go test -tags=integration,subprocess -run='^TestBamlfuzz(Static|Dynamic)Oracle\$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)\$' ./integration -count=1"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_DYNAMIC_CASES=${BAMLFUZZ_DYNAMIC_CASES} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} BAMLFUZZ_INVALID_CASES=${BAMLFUZZ_INVALID_CASES} BAMLFUZZ_STREAMING_CASES=${BAMLFUZZ_STREAMING_CASES} go test -tags=integration,subprocess -run='^TestBamlfuzz(Static|Dynamic|Streaming)Oracle\$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)\$' ./integration -count=1"
               echo '```'
             fi
           } | gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file -

--- a/adapters/common/codegen/bamlfuzz/case.go
+++ b/adapters/common/codegen/bamlfuzz/case.go
@@ -3,8 +3,8 @@ package bamlfuzz
 import "encoding/json"
 
 // OracleMode names the oracle the test harness runs against an
-// OracleCase. The two modes correspond to the two emission paths in
-// the v1 plan.
+// OracleCase. Each mode corresponds to one emission/transport path the
+// same generated case is driven through.
 type OracleMode string
 
 const (
@@ -18,6 +18,13 @@ const (
 	// drive REST /call/<GeneratedFunction>, and diff against the
 	// walker's expected JSON.
 	OracleStaticPrompt OracleMode = "static_prompt"
+	// OracleDynamicStreaming: drive the same lowered dynamic case
+	// through the streaming surfaces (dynclient DynamicStream iterator
+	// + REST /stream/_dynamic over SSE and NDJSON), collect each leg's
+	// final frame, and assert it equals the walker's expected JSON and
+	// the unary parse. Partial frames are not asserted on in v1 — only
+	// the terminal frame, which is chunk-timing invariant.
+	OracleDynamicStreaming OracleMode = "dynamic_streaming"
 )
 
 // CaseMetadata is per-case provenance that's useful to a developer

--- a/adapters/common/codegen/bamlfuzz/envelope_streaming.go
+++ b/adapters/common/codegen/bamlfuzz/envelope_streaming.go
@@ -1,0 +1,116 @@
+package bamlfuzz
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// StreamingFailureEnvelope captures the full context around a
+// disagreement on the streaming dynamic oracle. It mirrors
+// DynamicFailureEnvelope's header fields and adds streaming-specific
+// capture: the ordered partial sequence and final frame from each leg
+// (dynclient iterator, REST /stream/_dynamic over SSE, REST
+// /stream/_dynamic over NDJSON), the unary parse used for the
+// streaming-vs-unary cross-check, the per-leg event-kind sequences, the
+// chunk size mockllm paged the response with, and whether any leg saw a
+// reset frame. The partial sequences are the evidence a developer needs
+// to reconstruct how a final diverged, so they travel even though v1
+// only asserts on the final frame.
+//
+// Release gates match the unary dynamic oracle: semantic equality of
+// every final pairing always, and schema-aware key order on each leg's
+// final frame when PreserveSchemaOrder is true. Order diagnostics land
+// on OrderWarning before the envelope is dumped.
+type StreamingFailureEnvelope struct {
+	GeneratorVersion    string                         `json:"generator_version"`
+	GeneratedAt         string                         `json:"generated_at"`
+	RapidSeed           int64                          `json:"rapid_seed"`
+	CaseIndex           int                            `json:"case_index"`
+	CaseName            string                         `json:"case_name"`
+	OracleMode          OracleMode                     `json:"oracle_mode"`
+	PreserveSchemaOrder bool                           `json:"preserve_schema_order"`
+	Schema              FuzzSchema                     `json:"schema"`
+	DynamicSchema       *bamlutils.DynamicOutputSchema `json:"dynamic_schema,omitempty"`
+	DynamicSkipReason   string                         `json:"dynamic_skip_reason,omitempty"`
+	MockLLMScenarioID   string                         `json:"mockllm_scenario_id"`
+	MockLLMContent      json.RawMessage                `json:"mockllm_content"`
+	Expected            json.RawMessage                `json:"expected"`
+
+	// ChunkSize is the mockllm per-chunk byte width used for this case.
+	// >0 so the streaming/partial code path is genuinely exercised.
+	ChunkSize int `json:"chunk_size"`
+
+	// Per-leg partial sequences (full snapshots with placeholder nulls,
+	// not deltas) captured in arrival order.
+	DynclientPartials  []json.RawMessage `json:"dynclient_partials,omitempty"`
+	RESTPartialsSSE    []json.RawMessage `json:"rest_partials_sse,omitempty"`
+	RESTPartialsNDJSON []json.RawMessage `json:"rest_partials_ndjson,omitempty"`
+
+	// Per-leg terminal frames + the unary parse the streaming finals
+	// are cross-checked against.
+	DynclientFinal  json.RawMessage `json:"dynclient_final,omitempty"`
+	RESTFinalSSE    json.RawMessage `json:"rest_final_sse,omitempty"`
+	RESTFinalNDJSON json.RawMessage `json:"rest_final_ndjson,omitempty"`
+	UnaryParse      json.RawMessage `json:"unary_parse,omitempty"`
+
+	// Ordered event-kind sequence per leg ("partial"/"final"/"reset"/
+	// "metadata"/"error"). The "single clean final" check reads these.
+	DynclientKinds  []string `json:"dynclient_kinds,omitempty"`
+	RESTKindsSSE    []string `json:"rest_kinds_sse,omitempty"`
+	RESTKindsNDJSON []string `json:"rest_kinds_ndjson,omitempty"`
+
+	// SawReset is true when any leg emitted a reset frame. With the
+	// deterministic single-attempt mock a reset is unexpected and
+	// recorded as a finding.
+	SawReset bool `json:"saw_reset,omitempty"`
+
+	// Per-leg surface errors. Context/transport errors are harness
+	// failures and never reach the envelope; these capture stream-level
+	// or HTTP-status errors that are oracle signal.
+	DynclientError  string `json:"dynclient_error,omitempty"`
+	RESTErrorSSE    string `json:"rest_error_sse,omitempty"`
+	RESTErrorNDJSON string `json:"rest_error_ndjson,omitempty"`
+	UnaryError      string `json:"unary_error,omitempty"`
+
+	SemanticDiff []SemanticDiffEntry `json:"semantic_diff,omitempty"`
+	OrderWarning []string            `json:"order_warning,omitempty"`
+	ReplayPath   string              `json:"replay_path"`
+	Reproduction string              `json:"reproduction"`
+	Metadata     CaseMetadata        `json:"metadata"`
+}
+
+// WriteStreamingReplayArtifact writes a StreamingFailureEnvelope to
+// `dir` as a JSON file. Same on-disk format as WriteReplayArtifact
+// (2-space indent, deterministic basename via sanitizeArtifactBasename);
+// envelope.ReplayPath is stamped with the resulting path so the
+// t.Errorf message can point at the artifact.
+func WriteStreamingReplayArtifact(dir string, envelope *StreamingFailureEnvelope) (string, error) {
+	if envelope == nil {
+		return "", fmt.Errorf("bamlfuzz: nil envelope")
+	}
+	if envelope.GeneratorVersion == "" {
+		envelope.GeneratorVersion = GeneratorVersion
+	}
+	if envelope.GeneratedAt == "" {
+		envelope.GeneratedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("bamlfuzz: mkdir %s: %w", dir, err)
+	}
+	name := sanitizeArtifactBasename(envelope.CaseName, envelope.CaseIndex)
+	path := filepath.Join(dir, name+".json")
+	envelope.ReplayPath = path
+	buf, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("bamlfuzz: marshal envelope: %w", err)
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		return "", fmt.Errorf("bamlfuzz: write %s: %w", path, err)
+	}
+	return path, nil
+}

--- a/integration/bamlfuzz_streaming_clean_final_test.go
+++ b/integration/bamlfuzz_streaming_clean_final_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestCheckSingleCleanFinalEmptyPayload is the ad-hoc sanity check for the
+// non-empty-final-payload guard in checkSingleCleanFinal. It isolates the
+// helper from the live streaming legs and drives two synthetic leg-results
+// directly:
+//
+//   - a single terminal final whose Data is empty must FAIL (the
+//     vacuous-pass hole: diffAndRecord skips len==0 sides, so an empty
+//     final would otherwise clear every equivalence assertion);
+//   - a canonical single terminal final whose Data is non-empty must PASS.
+//
+// Mirrors the terminality reasoning of the broader assertion 5 without
+// needing the mock-LLM subprocess or network.
+func TestCheckSingleCleanFinalEmptyPayload(t *testing.T) {
+	t.Run("empty final fails", func(t *testing.T) {
+		var failures []string
+		kinds := []string{"partial", "final"}
+		sawReset := checkSingleCleanFinal("synthetic", kinds, json.RawMessage(nil), &failures)
+		if sawReset {
+			t.Fatalf("did not expect a reset, got sawReset=true")
+		}
+		if len(failures) == 0 {
+			t.Fatalf("expected a failure for an empty final payload, got none (kinds=%v)", kinds)
+		}
+		var sawEmpty bool
+		for _, f := range failures {
+			if strings.Contains(f, "empty Data") {
+				sawEmpty = true
+			}
+		}
+		if !sawEmpty {
+			t.Fatalf("expected an empty-Data failure, got: %v", failures)
+		}
+	})
+
+	t.Run("canonical non-empty final passes", func(t *testing.T) {
+		var failures []string
+		kinds := []string{"partial", "final"}
+		sawReset := checkSingleCleanFinal("synthetic", kinds, json.RawMessage(`{"k":"v"}`), &failures)
+		if sawReset {
+			t.Fatalf("did not expect a reset, got sawReset=true")
+		}
+		if len(failures) != 0 {
+			t.Fatalf("expected a clean pass for a non-empty terminal final, got: %v", failures)
+		}
+	})
+}

--- a/integration/bamlfuzz_streaming_test.go
+++ b/integration/bamlfuzz_streaming_test.go
@@ -458,17 +458,20 @@ func checkStreamFinalOrder(t *testing.T, c bamlfuzz.OracleCase, envelope *bamlfu
 }
 
 // checkSingleCleanFinal applies assertion 5 to one leg's event-kind
-// sequence: exactly one final, no error event, no reset. Returns whether
-// a reset was seen so the caller can aggregate SawReset across legs. A
-// reset is a finding (not a silent pass) because the rapid generator's
-// mock scenarios are deterministic single-attempt, so the orchestrator
-// never retries.
+// sequence: exactly one final, no error event, no reset, and the final
+// is terminal (the last non-metadata event). Returns whether a reset was
+// seen so the caller can aggregate SawReset across legs. A reset is a
+// finding (not a silent pass) because the rapid generator's mock
+// scenarios are deterministic single-attempt, so the orchestrator never
+// retries.
 func checkSingleCleanFinal(leg string, kinds []string, failures *[]string) (sawReset bool) {
 	finals := 0
-	for _, k := range kinds {
+	finalIdx := -1
+	for i, k := range kinds {
 		switch k {
 		case "final":
 			finals++
+			finalIdx = i
 		case "reset":
 			sawReset = true
 		case "error":
@@ -476,10 +479,23 @@ func checkSingleCleanFinal(leg string, kinds []string, failures *[]string) (sawR
 		}
 	}
 	if finals != 1 {
-		*failures = append(*failures, fmt.Sprintf("%s: expected exactly one final frame, saw %d", leg, finals))
+		*failures = append(*failures, fmt.Sprintf("%s: expected exactly one final frame, saw %d (kinds=%v)", leg, finals, kinds))
 	}
 	if sawReset {
 		*failures = append(*failures, fmt.Sprintf("%s: unexpected reset frame (deterministic single-attempt mock)", leg))
+	}
+	// With exactly one final, require it to be terminal: no non-metadata
+	// event may follow it. A sequence like [partial, final, partial] has
+	// one final and no error/reset but did not terminate at the final
+	// frame, which is a spec violation.
+	if finals == 1 {
+		for i := finalIdx + 1; i < len(kinds); i++ {
+			if kinds[i] == "metadata" {
+				continue
+			}
+			*failures = append(*failures, fmt.Sprintf("%s: non-metadata event after final at index %d (kind=%s, kinds=%v)", leg, i, kinds[i], kinds))
+			break
+		}
 	}
 	return sawReset
 }

--- a/integration/bamlfuzz_streaming_test.go
+++ b/integration/bamlfuzz_streaming_test.go
@@ -376,9 +376,9 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 	// no error event, no unexpected reset. Run first so a degenerate
 	// stream (no final) is reported even when the equivalence diffs
 	// below short-circuit on an empty payload.
-	dynReset := checkSingleCleanFinal("dynclient", envelope.DynclientKinds, &failures)
-	sseReset := checkSingleCleanFinal("rest_sse", envelope.RESTKindsSSE, &failures)
-	ndjsonReset := checkSingleCleanFinal("rest_ndjson", envelope.RESTKindsNDJSON, &failures)
+	dynReset := checkSingleCleanFinal("dynclient", envelope.DynclientKinds, envelope.DynclientFinal, &failures)
+	sseReset := checkSingleCleanFinal("rest_sse", envelope.RESTKindsSSE, envelope.RESTFinalSSE, &failures)
+	ndjsonReset := checkSingleCleanFinal("rest_ndjson", envelope.RESTKindsNDJSON, envelope.RESTFinalNDJSON, &failures)
 	envelope.SawReset = dynReset || sseReset || ndjsonReset
 
 	// Assertion 1 — three-way final equivalence: dynclient final ≡ REST
@@ -458,13 +458,21 @@ func checkStreamFinalOrder(t *testing.T, c bamlfuzz.OracleCase, envelope *bamlfu
 }
 
 // checkSingleCleanFinal applies assertion 5 to one leg's event-kind
-// sequence: exactly one final, no error event, no reset, and the final
-// is terminal (the last non-metadata event). Returns whether a reset was
-// seen so the caller can aggregate SawReset across legs. A reset is a
-// finding (not a silent pass) because the rapid generator's mock
-// scenarios are deterministic single-attempt, so the orchestrator never
-// retries.
-func checkSingleCleanFinal(leg string, kinds []string, failures *[]string) (sawReset bool) {
+// sequence: exactly one final, no error event, no reset, the final is
+// terminal (the last non-metadata event), and the final frame carries a
+// non-empty payload. Returns whether a reset was seen so the caller can
+// aggregate SawReset across legs. A reset is a finding (not a silent
+// pass) because the rapid generator's mock scenarios are deterministic
+// single-attempt, so the orchestrator never retries.
+//
+// The non-empty-payload check closes a vacuous-pass hole: diffAndRecord
+// skips any SemanticDiff when either side has len == 0, so a leg that
+// emits exactly one final frame with empty/nil Data would clear the
+// terminality, order, and (skipped) equivalence checks while silently
+// violating final equivalence. Requiring a non-empty final here turns
+// that empty payload into a hard failure at the leg where it was
+// observed.
+func checkSingleCleanFinal(leg string, kinds []string, finalData json.RawMessage, failures *[]string) (sawReset bool) {
 	finals := 0
 	finalIdx := -1
 	for i, k := range kinds {
@@ -489,6 +497,9 @@ func checkSingleCleanFinal(leg string, kinds []string, failures *[]string) (sawR
 	// one final and no error/reset but did not terminate at the final
 	// frame, which is a spec violation.
 	if finals == 1 {
+		if len(finalData) == 0 {
+			*failures = append(*failures, fmt.Sprintf("%s: final frame has empty Data (kinds=%v) — vacuous pass would slip every equivalence assertion through", leg, kinds))
+		}
 		for i := finalIdx + 1; i < len(kinds); i++ {
 			if kinds[i] == "metadata" {
 				continue

--- a/integration/bamlfuzz_streaming_test.go
+++ b/integration/bamlfuzz_streaming_test.go
@@ -1,0 +1,597 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/bamlfuzz"
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/dynclient"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// streamingOracleArtifactDir is where streaming-oracle envelope artifacts
+// land on failure or with BAMLFUZZ_KEEP_ARTIFACTS=1. Sibling to the
+// dynamic / invalid dirs so the nightly's `_artifacts/` glob collects it
+// with no workflow change.
+const streamingOracleArtifactDir = "../adapters/common/codegen/testdata/bamlfuzz/streaming/_artifacts"
+
+// streamingCasesPerMode controls how many random streaming cases run per
+// preserve mode. Sized for PR CI wall time (each case drives four calls:
+// dynclient stream, REST SSE stream, REST NDJSON stream, unary
+// cross-check); the nightly fuzz workflow cranks it via
+// BAMLFUZZ_STREAMING_CASES so a scheduled run explores a broader slice
+// of the schema space.
+func streamingCasesPerMode() int {
+	return envIntDefault("BAMLFUZZ_STREAMING_CASES", 16)
+}
+
+// TestBamlfuzzStreamingOracle drives the streaming dynamic oracle: for
+// each fuzz case it lowers the schema through the dynamic emitter, then
+// drives the same case through the streaming surfaces and asserts on the
+// terminal frame:
+//
+//  1. three-way final equivalence — dynclient stream final ≡ REST SSE
+//     stream final ≡ walker Expected;
+//  2. final-frame key order on each leg when PreserveSchemaOrder is true;
+//  3. streaming final ≡ unary parse (streaming-vs-unary divergence);
+//  4. SSE final ≡ NDJSON final (transport parity);
+//  5. each leg terminates in exactly one final, no error event, and no
+//     unexpected reset.
+//
+// Only the terminal frame is asserted on. Partial frames are full
+// snapshots with placeholder nulls and are not reordered, so a key-order
+// assertion on a partial would spuriously fail; the final frame is the
+// only one with a contract-shaped key order and is chunk-timing
+// invariant.
+func TestBamlfuzzStreamingOracle(t *testing.T) {
+	dynclientCallGate(t)
+
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		t.Fatalf("NewDynclient: %v", err)
+	}
+
+	t.Run("rapid", func(t *testing.T) {
+		modes := []bool{true, false}
+		for _, preserve := range modes {
+			preserve := preserve
+			label := "preserve_off"
+			if preserve {
+				label = "preserve_on"
+			}
+			t.Run(label, func(t *testing.T) {
+				cases := streamingCasesPerMode()
+				for i := 0; i < cases; i++ {
+					i := i
+					seed := streamingSeedFor(preserve, i)
+					t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+						c := buildStreamingRapidCase(t, seed, preserve, i)
+						runStreamingOracleCase(t, dyn, c, i, caseSourceRapid)
+					})
+				}
+			})
+		}
+	})
+}
+
+// FuzzBamlfuzzStreaming is the testing.F companion to
+// TestBamlfuzzStreamingOracle. It exposes the streaming oracle to Go's
+// native fuzz engine via the bamlfuzz.MakeFuzz bridge: testing.F's
+// []byte corpus is decoded (8-byte LE) or hashed via SeedFromBytes into
+// a uint64 seed that drives one CoupledCaseGen draw against the
+// dynamic-safe schema generator. PreserveSchemaOrder is drawn from the
+// bit stream so the fuzzer explores both halves of the oracle.
+//
+// One f.Add seed is registered so plain `go test` (no `-fuzz=`) runs the
+// target with a deterministic input. The seed is derived FNV-64a from a
+// stable label and is NOT folded with BAMLFUZZ_SEED — the nightly's fuzz
+// mode sets BAMLFUZZ_SEED=github.run_id in the job env, but the fuzz
+// repro command does not echo it back (only the corpus bytes under
+// -fuzzcachedir identify the failing input), so folding it in would make
+// f.Add bytes differ between the nightly and a developer machine and
+// break replay.
+func FuzzBamlfuzzStreaming(f *testing.F) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		f.Skip("Skipping: dynamic endpoints require BAML >= 0.215.0")
+	}
+	if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+		f.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
+	}
+
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		f.Fatalf("NewDynclient: %v", err)
+	}
+
+	f.Add(streamingFuzzSeedBytes("streaming"))
+
+	bamlfuzz.MakeFuzz(f, func(t *testing.T, rt *rapid.T) {
+		preserve := rapid.Bool().Draw(rt, "preserve_schema_order")
+		cc := bamlfuzz.CoupledCaseGen(bamlfuzz.DynamicSafeSchemaGen()).Draw(rt, "coupled_case")
+		c := bamlfuzz.OracleCase{
+			Name:                "fuzz",
+			Seed:                0,
+			CaseIndex:           0,
+			Mode:                bamlfuzz.OracleDynamicStreaming,
+			PreserveSchemaOrder: preserve,
+			Schema:              cc.Schema,
+			Value:               cc.Value,
+			MockLLMContent:      cc.Walk.MockLLMContent,
+			Expected:            cc.Walk.Expected,
+			Metadata:            cc.Walk.Metadata,
+		}
+		runStreamingOracleCase(t, dyn, c, 0, caseSourceFuzz)
+	})
+}
+
+// streamingSeedFor produces a deterministic rapid seed for a (preserve,
+// i) pair. Tests are deterministic across runs unless BAMLFUZZ_SEED is
+// set; BAMLFUZZ_SEED, when present, XORs into the per-case seed so a
+// single env var perturbs the entire matrix at once. Same convention as
+// dynamicSeedFor.
+func streamingSeedFor(preserve bool, i int) uint64 {
+	label := "streaming_preserve_off"
+	if preserve {
+		label = "streaming_preserve_on"
+	}
+	base := fnv64aString(fmt.Sprintf("%s:%d", label, i))
+	if v := os.Getenv("BAMLFUZZ_SEED"); v != "" {
+		base ^= fnv64aString(v)
+	}
+	return base
+}
+
+// streamingFuzzSeedBytes derives the deterministic 8-byte fuzz-corpus
+// seed for the f.Add input from a stable label. The output is the exact
+// wire shape bamlfuzz.MakeFuzz recognizes as a verbatim uint64. The
+// label-only derivation (no BAMLFUZZ_SEED fold) keeps the f.Add bytes
+// byte-identical across every environment so a failed nightly's
+// `go test -fuzz` command replays the same case it failed on.
+func streamingFuzzSeedBytes(label string) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, fnv64aString(label))
+	return b
+}
+
+// buildStreamingRapidCase synthesizes one streaming OracleCase
+// deterministically from seed. Uses CoupledCaseGen so the value
+// generator's union-choice metadata + the shrink-biased collapse pass
+// land on the case together — the same draw the dynamic oracle uses,
+// driven through the streaming path instead.
+func buildStreamingRapidCase(t *testing.T, seed uint64, preserve bool, idx int) bamlfuzz.OracleCase {
+	t.Helper()
+	cc := bamlfuzz.CoupledCaseGen(bamlfuzz.DynamicSafeSchemaGen()).Example(int(seed))
+	return bamlfuzz.OracleCase{
+		Name:                fmt.Sprintf("streaming_rapid_%t_%d", preserve, idx),
+		Seed:                int64(seed),
+		CaseIndex:           idx,
+		Mode:                bamlfuzz.OracleDynamicStreaming,
+		PreserveSchemaOrder: preserve,
+		Schema:              cc.Schema,
+		Value:               cc.Value,
+		MockLLMContent:      cc.Walk.MockLLMContent,
+		Expected:            cc.Walk.Expected,
+		Metadata:            cc.Walk.Metadata,
+	}
+}
+
+// streamChunkSizeFor derives the mockllm per-chunk byte width from the
+// case seed, bounded to [8, 32]. >0 so mockllm genuinely pages the
+// response across frames and exercises the streaming/partial code path;
+// ChunkSize 0 would emit a single blob and skip it. v1 asserts only on
+// the final frame, which the pre-flight proved is identical regardless
+// of chunk granularity, so the exact size does not affect the verdict —
+// it just varies which byte boundaries the partial sequence splits on
+// across cases.
+func streamChunkSizeFor(seed int64) int {
+	return 8 + int(uint64(seed)%25)
+}
+
+// runStreamingOracleCase drives one OracleCase through the streaming
+// surfaces and applies the five v1 assertions, capturing all relevant
+// context into a StreamingFailureEnvelope when any leg disagrees.
+func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.OracleCase, caseIdx int, source caseSource) {
+	t.Helper()
+
+	chunkSize := streamChunkSizeFor(c.Seed)
+	envelope := &bamlfuzz.StreamingFailureEnvelope{
+		GeneratorVersion:    bamlfuzz.GeneratorVersion,
+		RapidSeed:           c.Seed,
+		CaseIndex:           caseIdx,
+		CaseName:            c.Name,
+		OracleMode:          bamlfuzz.OracleDynamicStreaming,
+		PreserveSchemaOrder: c.PreserveSchemaOrder,
+		Schema:              c.Schema,
+		MockLLMContent:      c.MockLLMContent,
+		Expected:            c.Expected,
+		Metadata:            c.Metadata,
+		ChunkSize:           chunkSize,
+		Reproduction:        reproductionForStreaming(c, caseIdx, source),
+	}
+
+	lowered, err := bamlfuzz.LowerToDynamicSchema(c.Schema)
+	if errors.Is(err, bamlfuzz.ErrDynamicSchemaUnsupported) {
+		switch unsupportedActionFor(source) {
+		case unsupportedSkip:
+			t.Skipf("dynamic emitter skipped schema: %v", err)
+			return
+		case unsupportedFail:
+			envelope.DynamicSkipReason = err.Error()
+			failAndDumpStreaming(t, envelope, "rapid generator produced unsupported schema: %v", err)
+			return
+		}
+	}
+	if err != nil {
+		envelope.DynamicSkipReason = err.Error()
+		failAndDumpStreaming(t, envelope, "LowerToDynamicSchema failed: %v", err)
+		return
+	}
+	envelope.DynamicSchema = &lowered
+
+	scenarioID := fmt.Sprintf("bamlfuzz-stream-%s", scenarioSafe(c.Name))
+	envelope.MockLLMScenarioID = scenarioID
+	registerCtx, registerCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer registerCancel()
+	scenario := &mockllm.Scenario{
+		ID:             scenarioID,
+		Provider:       "openai",
+		Content:        string(c.MockLLMContent),
+		ChunkSize:      chunkSize,
+		ChunkDelayMs:   0,
+		InitialDelayMs: 0,
+	}
+	if err := MockClient.RegisterScenario(registerCtx, scenario); err != nil {
+		failAndDumpStreaming(t, envelope, "register scenario: %v", err)
+		return
+	}
+
+	clientReg := testutil.CreateTestClient(TestEnv.MockLLMInternal, scenarioID)
+
+	preserve := c.PreserveSchemaOrder
+	hello := "Return the dynamic fuzz value."
+	libReq := dynclient.Request{
+		Messages: []dynclient.Message{
+			{Role: "system", PartsContent: []dynclient.ContentPart{
+				{Type: "text", Text: &hello},
+				{Type: "output_format"},
+			}},
+			{Role: "user", TextContent: &hello},
+		},
+		ClientRegistry:      testutil.DynRegistry(clientReg),
+		OutputSchema:        &lowered,
+		PreserveSchemaOrder: &preserve,
+	}
+
+	// REST legs are driven with a body built via bamlutils so the
+	// OrderedMap insertion order survives the wire; the map-backed
+	// testutil.DynamicOutputSchema would scramble property order and
+	// defeat the final-frame key-order assertion.
+	restBody, err := buildDynamicCallBody(libReq, &lowered)
+	if err != nil {
+		failAndDumpStreaming(t, envelope, "build REST body: %v", err)
+		return
+	}
+
+	// Independent contexts per surface, derived from a shared parent.
+	// A shared deadline would let one surface draining the clock mask
+	// another's failure; per-surface child contexts give each of the
+	// four calls its own budget, while the common parent still lets a
+	// test-level cancellation abort all of them together.
+	parentCtx, parentCancel := context.WithCancel(context.Background())
+	defer parentCancel()
+
+	var failures []string
+
+	// --- dynclient streaming leg ---
+	dynCtx, dynCancel := context.WithTimeout(parentCtx, 30*time.Second)
+	defer dynCancel()
+	stream, openErr := dyn.DynamicStream(dynCtx, libReq)
+	if openErr != nil {
+		if isContextErr(openErr) {
+			t.Fatalf("harness failure: dynclient stream open (case=%s): %v", c.Name, openErr)
+		}
+		envelope.DynclientError = openErr.Error()
+		failures = append(failures, fmt.Sprintf("dynclient stream open: %v", openErr))
+	} else {
+		dynPartials, dynFinal, dynKinds, drainErr := drainDynclientStream(stream)
+		stream.Close()
+		envelope.DynclientPartials = dynPartials
+		envelope.DynclientFinal = dynFinal
+		envelope.DynclientKinds = dynKinds
+		if drainErr != nil {
+			if isContextErr(drainErr) {
+				t.Fatalf("harness failure: dynclient stream drain (case=%s): %v", c.Name, drainErr)
+			}
+			envelope.DynclientError = drainErr.Error()
+			failures = append(failures, fmt.Sprintf("dynclient stream errored: %v", drainErr))
+		}
+	}
+
+	// --- REST SSE streaming leg ---
+	sseCtx, sseCancel := context.WithTimeout(parentCtx, 30*time.Second)
+	defer sseCancel()
+	sseEvents, sseErrs := BAMLClient.DynamicStreamBody(sseCtx, restBody)
+	ssePartials, sseFinal, sseKinds, sseErr := drainRESTStream(sseEvents, sseErrs)
+	envelope.RESTPartialsSSE = ssePartials
+	envelope.RESTFinalSSE = sseFinal
+	envelope.RESTKindsSSE = sseKinds
+	if sseErr != nil {
+		if isContextErr(sseErr) {
+			t.Fatalf("harness failure: REST SSE stream (case=%s): %v", c.Name, sseErr)
+		}
+		envelope.RESTErrorSSE = sseErr.Error()
+		failures = append(failures, fmt.Sprintf("REST SSE stream errored: %v", sseErr))
+	}
+
+	// --- REST NDJSON streaming leg ---
+	ndjsonCtx, ndjsonCancel := context.WithTimeout(parentCtx, 30*time.Second)
+	defer ndjsonCancel()
+	ndjsonEvents, ndjsonErrs := BAMLClient.DynamicStreamNDJSONBody(ndjsonCtx, restBody)
+	ndjsonPartials, ndjsonFinal, ndjsonKinds, ndjsonErr := drainRESTStream(ndjsonEvents, ndjsonErrs)
+	envelope.RESTPartialsNDJSON = ndjsonPartials
+	envelope.RESTFinalNDJSON = ndjsonFinal
+	envelope.RESTKindsNDJSON = ndjsonKinds
+	if ndjsonErr != nil {
+		if isContextErr(ndjsonErr) {
+			t.Fatalf("harness failure: REST NDJSON stream (case=%s): %v", c.Name, ndjsonErr)
+		}
+		envelope.RESTErrorNDJSON = ndjsonErr.Error()
+		failures = append(failures, fmt.Sprintf("REST NDJSON stream errored: %v", ndjsonErr))
+	}
+
+	// --- unary cross-check leg ---
+	unaryCtx, unaryCancel := context.WithTimeout(parentCtx, 30*time.Second)
+	defer unaryCancel()
+	unaryResp, unaryErr := dyn.DynamicCall(unaryCtx, libReq)
+	switch {
+	case unaryErr != nil:
+		if isContextErr(unaryErr) {
+			t.Fatalf("harness failure: unary cross-check (case=%s): %v", c.Name, unaryErr)
+		}
+		envelope.UnaryError = unaryErr.Error()
+		failures = append(failures, fmt.Sprintf("unary cross-check errored: %v", unaryErr))
+	case unaryResp == nil:
+		envelope.UnaryError = "nil response from dyn.DynamicCall"
+		failAndDumpStreaming(t, envelope, "unary cross-check returned nil response without an error")
+		return
+	default:
+		envelope.UnaryParse = unaryResp.Data
+	}
+
+	// Assertion 5 — each streaming leg terminates in exactly one final,
+	// no error event, no unexpected reset. Run first so a degenerate
+	// stream (no final) is reported even when the equivalence diffs
+	// below short-circuit on an empty payload.
+	dynReset := checkSingleCleanFinal("dynclient", envelope.DynclientKinds, &failures)
+	sseReset := checkSingleCleanFinal("rest_sse", envelope.RESTKindsSSE, &failures)
+	ndjsonReset := checkSingleCleanFinal("rest_ndjson", envelope.RESTKindsNDJSON, &failures)
+	envelope.SawReset = dynReset || sseReset || ndjsonReset
+
+	// Assertion 1 — three-way final equivalence: dynclient final ≡ REST
+	// SSE final ≡ Expected.
+	diffAndRecord(envelope, &failures, "expected_vs_dynclient_final", c.Expected, envelope.DynclientFinal)
+	diffAndRecord(envelope, &failures, "expected_vs_rest_sse_final", c.Expected, envelope.RESTFinalSSE)
+	diffAndRecord(envelope, &failures, "dynclient_vs_rest_sse_final", envelope.DynclientFinal, envelope.RESTFinalSSE)
+
+	// Assertion 3 — streaming final ≡ unary parse. Directly probes a
+	// streaming-vs-unary parser divergence.
+	diffAndRecord(envelope, &failures, "dynclient_final_vs_unary", envelope.DynclientFinal, envelope.UnaryParse)
+
+	// Assertion 4 — transport parity: SSE final ≡ NDJSON final.
+	diffAndRecord(envelope, &failures, "rest_sse_vs_ndjson_final", envelope.RESTFinalSSE, envelope.RESTFinalNDJSON)
+
+	// Assertion 2 — final-frame key order on each leg (preserve only).
+	checkStreamFinalOrder(t, c, envelope, &failures, "dynclient_final_order", envelope.DynclientFinal)
+	checkStreamFinalOrder(t, c, envelope, &failures, "rest_sse_final_order", envelope.RESTFinalSSE)
+	checkStreamFinalOrder(t, c, envelope, &failures, "rest_ndjson_final_order", envelope.RESTFinalNDJSON)
+
+	if len(failures) == 0 {
+		if os.Getenv("BAMLFUZZ_KEEP_ARTIFACTS") == "1" {
+			if path, err := bamlfuzz.WriteStreamingReplayArtifact(streamingOracleArtifactDir, envelope); err == nil {
+				t.Logf("kept replay artifact (success): %s", path)
+			}
+		}
+		return
+	}
+	failAndDumpStreaming(t, envelope, "%s", strings.Join(failures, "; "))
+}
+
+// diffAndRecord runs a SemanticDiff for one leg pairing and records any
+// disagreement on the envelope + failures list. A missing operand
+// (empty payload) is skipped here — the absent final is reported by the
+// single-clean-final check, so re-flagging it as a decode error would
+// just duplicate the signal.
+func diffAndRecord(envelope *bamlfuzz.StreamingFailureEnvelope, failures *[]string, side string, a, b json.RawMessage) {
+	if len(a) == 0 || len(b) == 0 {
+		return
+	}
+	diff, err := bamlfuzz.SemanticDiff(side, a, b)
+	if err != nil {
+		*failures = append(*failures, fmt.Sprintf("%s diff: %v", side, err))
+		return
+	}
+	if len(diff) > 0 {
+		envelope.SemanticDiff = append(envelope.SemanticDiff, diff...)
+		*failures = append(*failures, side+" mismatch")
+	}
+}
+
+// checkStreamFinalOrder runs the strict schema-aware key-order assertion
+// on one leg's final frame against the walker's Expected when the case
+// opts into PreserveSchemaOrder. Mirrors the unary oracle's
+// checkSchemaOrder: ErrSchemaOrderUnsupported is a hard failure (a
+// missing union choice is an integrity bug), and an order mismatch
+// records the diagnostic on OrderWarning before appending a failure.
+// Final frames are reordered (partials are not), so the order contract
+// applies only here.
+func checkStreamFinalOrder(t *testing.T, c bamlfuzz.OracleCase, envelope *bamlfuzz.StreamingFailureEnvelope, failures *[]string, label string, finalData json.RawMessage) {
+	t.Helper()
+	if !c.PreserveSchemaOrder || len(finalData) == 0 {
+		return
+	}
+	diffs, err := bamlfuzz.SchemaOrderDiffWithChoices(label, c.Schema, c.Expected, finalData, c.Metadata.UnionChoices)
+	switch {
+	case errors.Is(err, bamlfuzz.ErrSchemaOrderUnsupported):
+		envelope.OrderWarning = append(envelope.OrderWarning, fmt.Sprintf("%s: %v", label, err))
+		*failures = append(*failures, fmt.Sprintf("%s schema order unsupported: %v", label, err))
+	case err != nil:
+		envelope.OrderWarning = append(envelope.OrderWarning, fmt.Sprintf("%s: %v", label, err))
+		*failures = append(*failures, fmt.Sprintf("%s schema order: %v", label, err))
+	case len(diffs) > 0:
+		envelope.OrderWarning = append(envelope.OrderWarning, bamlfuzz.FormatSchemaOrderDiffs(diffs)...)
+		*failures = append(*failures, fmt.Sprintf("%s: schema key order mismatch", label))
+	}
+}
+
+// checkSingleCleanFinal applies assertion 5 to one leg's event-kind
+// sequence: exactly one final, no error event, no reset. Returns whether
+// a reset was seen so the caller can aggregate SawReset across legs. A
+// reset is a finding (not a silent pass) because the rapid generator's
+// mock scenarios are deterministic single-attempt, so the orchestrator
+// never retries.
+func checkSingleCleanFinal(leg string, kinds []string, failures *[]string) (sawReset bool) {
+	finals := 0
+	for _, k := range kinds {
+		switch k {
+		case "final":
+			finals++
+		case "reset":
+			sawReset = true
+		case "error":
+			*failures = append(*failures, fmt.Sprintf("%s: error event in stream", leg))
+		}
+	}
+	if finals != 1 {
+		*failures = append(*failures, fmt.Sprintf("%s: expected exactly one final frame, saw %d", leg, finals))
+	}
+	if sawReset {
+		*failures = append(*failures, fmt.Sprintf("%s: unexpected reset frame (deterministic single-attempt mock)", leg))
+	}
+	return sawReset
+}
+
+// drainDynclientStream consumes a dynclient streaming iterator to
+// completion, returning the ordered partial snapshots, the final frame,
+// the ordered event-kind sequence, and the terminal error (nil on clean
+// io.EOF). Mid-stream worker errors surface as the returned error rather
+// than an "error" kind. Payloads are copied off the pooled byte slices.
+func drainDynclientStream(s *dynclient.Stream) (partials []json.RawMessage, final json.RawMessage, kinds []string, err error) {
+	for {
+		ev, e := s.Next()
+		if errors.Is(e, io.EOF) {
+			return partials, final, kinds, nil
+		}
+		if e != nil {
+			return partials, final, kinds, e
+		}
+		switch ev.Kind {
+		case dynclient.EventPartial:
+			kinds = append(kinds, "partial")
+			partials = append(partials, append(json.RawMessage(nil), ev.Data...))
+		case dynclient.EventFinal:
+			kinds = append(kinds, "final")
+			final = append(json.RawMessage(nil), ev.Data...)
+		case dynclient.EventReset:
+			kinds = append(kinds, "reset")
+		case dynclient.EventMetadata:
+			kinds = append(kinds, "metadata")
+		}
+	}
+}
+
+// drainRESTStream consumes a REST streaming event channel (SSE or
+// NDJSON) to completion, returning the ordered partial snapshots, the
+// final frame, the ordered event-kind sequence, and the transport-level
+// error (nil on clean completion). An "error" event in the stream is
+// recorded as an "error" kind, not as the returned error — the returned
+// error is reserved for transport / parse / HTTP-status failures
+// surfaced on the error channel.
+func drainRESTStream(events <-chan testutil.StreamEvent, errs <-chan error) (partials []json.RawMessage, final json.RawMessage, kinds []string, err error) {
+	for ev := range events {
+		switch {
+		case ev.IsFinal():
+			kinds = append(kinds, "final")
+			final = append(json.RawMessage(nil), ev.Data...)
+		case ev.IsReset():
+			kinds = append(kinds, "reset")
+		case ev.IsError():
+			kinds = append(kinds, "error")
+		case ev.IsMetadata():
+			kinds = append(kinds, "metadata")
+		case ev.IsPartialData():
+			kinds = append(kinds, "partial")
+			partials = append(partials, append(json.RawMessage(nil), ev.Data...))
+		}
+	}
+	// The producer buffers the error and closes errs before closing
+	// events, so by the time the range above exits the error (if any)
+	// is already queued.
+	if e, ok := <-errs; ok && e != nil {
+		err = e
+	}
+	return partials, final, kinds, err
+}
+
+// isContextErr reports whether err is a context cancellation or deadline
+// error. Context (and transport) errors mean the call never produced a
+// verdict, so the oracle treats them as harness failures (t.Fatal), not
+// oracle rejections — letting an outright timeout pass an equivalence
+// check would mask a real divergence.
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// failAndDumpStreaming writes the streaming envelope to the artifact dir
+// and fails the test with a message pointing at the replay path. Mirrors
+// failAndDump for the unary dynamic oracle.
+func failAndDumpStreaming(t *testing.T, envelope *bamlfuzz.StreamingFailureEnvelope, format string, args ...any) {
+	t.Helper()
+	path, err := bamlfuzz.WriteStreamingReplayArtifact(streamingOracleArtifactDir, envelope)
+	if err != nil {
+		t.Errorf("write replay artifact: %v", err)
+		t.Errorf(format, args...)
+		return
+	}
+	msg := fmt.Sprintf(format, args...)
+	t.Errorf("%s\nreplay: %s\nrepro: %s", msg, path, envelope.Reproduction)
+}
+
+// reproductionForStreaming returns the canonical command to re-run a
+// failing streaming case in isolation, embedded in the envelope. Mirrors
+// reproductionForInvalid's source dispatch: fuzz cases re-run the engine
+// against the persisted -fuzzcachedir; rapid cases re-run a single
+// subtest under -run. Both pin -tags=integration,subprocess so the
+// replay routes through the cmd/worker go-plugin path the nightly uses.
+func reproductionForStreaming(c bamlfuzz.OracleCase, caseIdx int, source caseSource) string {
+	if source == caseSourceFuzz {
+		return "go test -tags=integration,subprocess -run='^$' -fuzz='^FuzzBamlfuzzStreaming$' -fuzztime=10m " +
+			"-fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+	}
+	mode := "preserve_off"
+	if c.PreserveSchemaOrder {
+		mode = "preserve_on"
+	}
+	runPath := fmt.Sprintf("^TestBamlfuzzStreamingOracle$/^rapid$/^%s$/^case_%d$", mode, caseIdx)
+	cmd := fmt.Sprintf("go test -tags=integration,subprocess -run='%s' ./integration -count=1", runPath)
+	if seed := os.Getenv("BAMLFUZZ_SEED"); seed != "" {
+		cmd = "BAMLFUZZ_SEED=" + seed + " " + cmd
+	}
+	if cases := os.Getenv("BAMLFUZZ_STREAMING_CASES"); cases != "" {
+		cmd = "BAMLFUZZ_STREAMING_CASES=" + cases + " " + cmd
+	}
+	return cmd
+}

--- a/integration/mockllm/streaming.go
+++ b/integration/mockllm/streaming.go
@@ -90,9 +90,7 @@ func StreamResponse(ctx context.Context, w *bufio.Writer, scenario *Scenario, pr
 		// Snap the boundary forward to the next rune start: a real LLM SSE
 		// server never emits a frame that splits a multi-byte UTF-8 rune,
 		// and the stream transport rejects invalid-UTF-8 frames.
-		for end < len(content) && !utf8.RuneStart(content[end]) {
-			end++
-		}
+		end = snapChunkEndToRuneStart(content, end)
 		chunk := content[i:end]
 
 		// Check for failure injection
@@ -199,11 +197,15 @@ func streamAnthropicBlock(
 		}
 		*deltaIndex++
 	} else {
-		for i := 0; i < len(content); i += chunkSize {
+		// Advance by the snapped `end` (not a fixed stride) so a multi-byte
+		// rune is never split across two deltas — same contract as the
+		// default StreamResponse path.
+		for i := 0; i < len(content); {
 			end := i + chunkSize
 			if end > len(content) {
 				end = len(content)
 			}
+			end = snapChunkEndToRuneStart(content, end)
 			chunk := content[i:end]
 
 			if scenario.FailAfter > 0 && *deltaIndex >= scenario.FailAfter {
@@ -231,6 +233,8 @@ func streamAnthropicBlock(
 					}
 				}
 			}
+
+			i = end
 		}
 	}
 
@@ -238,6 +242,17 @@ func streamAnthropicBlock(
 		return err
 	}
 	return w.Flush()
+}
+
+// snapChunkEndToRuneStart advances end forward until it lands on a UTF-8
+// rune boundary (or the end of content), so a chunk never splits a
+// multi-byte rune. A real LLM SSE server never emits a frame that splits
+// a rune, and the stream transport rejects invalid-UTF-8 frames.
+func snapChunkEndToRuneStart(content string, end int) int {
+	for end < len(content) && !utf8.RuneStart(content[end]) {
+		end++
+	}
+	return end
 }
 
 func handleFailure(ctx context.Context, scenario *Scenario) error {

--- a/integration/mockllm/streaming.go
+++ b/integration/mockllm/streaming.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"math/rand"
 	"time"
+	"unicode/utf8"
 )
 
 // StreamWriter handles writing SSE chunks with timing.
@@ -78,10 +79,19 @@ func StreamResponse(ctx context.Context, w *bufio.Writer, scenario *Scenario, pr
 	}
 
 	chunkIndex := 0
-	for i := 0; i < len(content); i += chunkSize {
+	// Advance by the snapped `end` (not a fixed stride): when the rune
+	// boundary pushes `end` past i+chunkSize, the next chunk must resume
+	// there so bytes are neither re-sent nor restarted mid-rune.
+	for i := 0; i < len(content); {
 		end := i + chunkSize
 		if end > len(content) {
 			end = len(content)
+		}
+		// Snap the boundary forward to the next rune start: a real LLM SSE
+		// server never emits a frame that splits a multi-byte UTF-8 rune,
+		// and the stream transport rejects invalid-UTF-8 frames.
+		for end < len(content) && !utf8.RuneStart(content[end]) {
+			end++
 		}
 		chunk := content[i:end]
 
@@ -109,6 +119,8 @@ func StreamResponse(ctx context.Context, w *bufio.Writer, scenario *Scenario, pr
 				}
 			}
 		}
+
+		i = end
 	}
 
 	// Send final chunk with finish_reason: "stop"

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -1328,18 +1328,58 @@ func (c *BAMLRestClient) DynamicStreamWithRawNDJSON(ctx context.Context, req Dyn
 }
 
 func (c *BAMLRestClient) dynamicStreamRequest(ctx context.Context, url string, req DynamicRequest, expectRawEnvelope bool) (<-chan StreamEvent, <-chan error) {
+	body, err := sonic.Marshal(req)
+	if err != nil {
+		return closedStreamWithError(err)
+	}
+	return c.dynamicStreamRequestBody(ctx, url, body, expectRawEnvelope)
+}
+
+func (c *BAMLRestClient) dynamicStreamRequestNDJSON(ctx context.Context, url string, req DynamicRequest) (<-chan StreamEvent, <-chan error) {
+	body, err := sonic.Marshal(req)
+	if err != nil {
+		return closedStreamWithError(err)
+	}
+	return c.dynamicStreamRequestBodyNDJSON(ctx, url, body)
+}
+
+// DynamicStreamBody executes a /stream/_dynamic SSE request with a
+// caller-provided JSON body. Like DynamicCallJSON, this lets tests build
+// the body via bamlutils-ordered types so property / class / enum
+// declaration order survives end-to-end; the DynamicRequest-based
+// DynamicStream helper marshals a map-backed DynamicOutputSchema, which
+// cannot carry declaration order and would defeat a final-frame key-order
+// assertion.
+func (c *BAMLRestClient) DynamicStreamBody(ctx context.Context, body []byte) (<-chan StreamEvent, <-chan error) {
+	return c.dynamicStreamRequestBody(ctx, fmt.Sprintf("%s/stream/_dynamic", c.baseURL), body, false)
+}
+
+// DynamicStreamNDJSONBody executes a /stream/_dynamic NDJSON request with
+// a caller-provided JSON body. NDJSON-transport analogue of
+// DynamicStreamBody; same order-preservation rationale.
+func (c *BAMLRestClient) DynamicStreamNDJSONBody(ctx context.Context, body []byte) (<-chan StreamEvent, <-chan error) {
+	return c.dynamicStreamRequestBodyNDJSON(ctx, fmt.Sprintf("%s/stream/_dynamic", c.baseURL), body)
+}
+
+// closedStreamWithError returns a stream pair that immediately reports a
+// single error and is closed, matching the channel contract of the live
+// streaming paths (buffered errs, both channels closed).
+func closedStreamWithError(err error) (<-chan StreamEvent, <-chan error) {
+	events := make(chan StreamEvent)
+	errs := make(chan error, 1)
+	errs <- err
+	close(events)
+	close(errs)
+	return events, errs
+}
+
+func (c *BAMLRestClient) dynamicStreamRequestBody(ctx context.Context, url string, body []byte, expectRawEnvelope bool) (<-chan StreamEvent, <-chan error) {
 	events := make(chan StreamEvent)
 	errs := make(chan error, 1)
 
 	go func() {
 		defer close(events)
 		defer close(errs)
-
-		body, err := sonic.Marshal(req)
-		if err != nil {
-			errs <- err
-			return
-		}
 
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
 		if err != nil {
@@ -1357,8 +1397,8 @@ func (c *BAMLRestClient) dynamicStreamRequest(ctx context.Context, url string, r
 		defer resp.Body.Close()
 
 		if resp.StatusCode >= 400 {
-			body, _ := io.ReadAll(resp.Body)
-			errs <- fmt.Errorf("HTTP %d: %s", resp.StatusCode, extractErrorMessage(body))
+			respBody, _ := io.ReadAll(resp.Body)
+			errs <- fmt.Errorf("HTTP %d: %s", resp.StatusCode, extractErrorMessage(respBody))
 			return
 		}
 
@@ -1370,19 +1410,13 @@ func (c *BAMLRestClient) dynamicStreamRequest(ctx context.Context, url string, r
 	return events, errs
 }
 
-func (c *BAMLRestClient) dynamicStreamRequestNDJSON(ctx context.Context, url string, req DynamicRequest) (<-chan StreamEvent, <-chan error) {
+func (c *BAMLRestClient) dynamicStreamRequestBodyNDJSON(ctx context.Context, url string, body []byte) (<-chan StreamEvent, <-chan error) {
 	events := make(chan StreamEvent)
 	errs := make(chan error, 1)
 
 	go func() {
 		defer close(events)
 		defer close(errs)
-
-		body, err := sonic.Marshal(req)
-		if err != nil {
-			errs <- err
-			return
-		}
 
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
 		if err != nil {
@@ -1400,8 +1434,8 @@ func (c *BAMLRestClient) dynamicStreamRequestNDJSON(ctx context.Context, url str
 		defer resp.Body.Close()
 
 		if resp.StatusCode >= 400 {
-			body, _ := io.ReadAll(resp.Body)
-			errs <- fmt.Errorf("HTTP %d: %s", resp.StatusCode, extractErrorMessage(body))
+			respBody, _ := io.ReadAll(resp.Body)
+			errs <- fmt.Errorf("HTTP %d: %s", resp.StatusCode, extractErrorMessage(respBody))
 			return
 		}
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Summary

Adds a v1 **streaming oracle** for baml-rest's `/stream/_dynamic` surface. It drives the same generated dynamic cases the unary oracle uses, but through the streaming path (dynclient `DynamicStream` iterator + REST `/stream/_dynamic` over SSE and NDJSON), and asserts on the **final frame**.

Part of the bamlfuzz v2+ roadmap. Refs #349 (umbrella).

### The five assertions (all chunk-timing-insensitive — terminal frame only)

1. **Three-way final equivalence** — `final_dynclient ≡ final_REST(SSE) ≡ c.Expected` via `bamlfuzz.SemanticDiff` (all three pairings empty). `runStreamingOracleCase`.
2. **Final-frame key order** — when `PreserveSchemaOrder` is true, `SchemaOrderDiffWithChoices` runs on each leg's final frame (dynclient, SSE, NDJSON), fed `Metadata.UnionChoices`; `ErrSchemaOrderUnsupported` is a hard failure (matches the unary oracle's `checkSchemaOrder`). `checkStreamFinalOrder`.
3. **Final-vs-unary cross-check** — streaming final ≡ `dyn.DynamicCall` unary parse — a direct probe of streaming-vs-unary parser divergence.
4. **SSE/NDJSON transport parity** — both `Accept` types' finals must SemanticDiff-equal.
5. **Strict single-clean-final parity** — each leg must satisfy *all* of:
   - exactly one `final` event, no `error` / no `reset` (metadata tolerated)
   - `final` is the **last** non-metadata event in the kind sequence (terminality — closes the `[partial, final, partial]` vacuous-pass)
   - the final payload is non-empty (`len(Data) > 0` — closes the empty-`Data` vacuous-pass where `diffAndRecord` would otherwise skip every SemanticDiff)

   `checkSingleCleanFinal`.

### Why final-frame only

Partial frames are full snapshots with `null` placeholders and are **not** reordered by the streaming path, so a key-order assertion on a partial would spuriously fail. Only the final frame carries a contract-shaped key order, and the pre-flight confirmed (BAML 0.222.0) that the final is identical whether content arrives in one blob or many chunks.

### Deferred (not in this PR)

Monotonic partial-state consistency, strong ordered partial-sequence parity, raw/reasoning streaming, mid-stream failure injection. These flake under byte-index chunking + transport coalescing and need a prefix-state comparator that does not yet exist.

### File layout

- `adapters/common/codegen/bamlfuzz/case.go` — new `OracleDynamicStreaming` mode (reuses `OracleCase`; no parallel case type).
- `adapters/common/codegen/bamlfuzz/envelope_streaming.go` — `StreamingFailureEnvelope` + `WriteStreamingReplayArtifact` (captures per-leg partial sequences, finals, event kinds, chunk width, `SawReset`).
- `integration/bamlfuzz_streaming_test.go` — `TestBamlfuzzStreamingOracle` (rapid, preserve_off/on split), `FuzzBamlfuzzStreaming` (testing.F bridge), `runStreamingOracleCase`, drain helpers.
- `integration/bamlfuzz_streaming_clean_final_test.go` — focused unit test for the tightened `checkSingleCleanFinal` (empty-final fails; canonical passes).
- `integration/testutil/client.go` — `DynamicStreamBody` / `DynamicStreamNDJSONBody`: raw-body streaming helpers so REST requests carry property declaration order (the map-backed `DynamicOutputSchema` scrambles it; same shape as the unary oracle's `DynamicCallJSON`). The existing `DynamicStream`/`DynamicStreamNDJSON` share the body core.
- `integration/mockllm/streaming.go` — **rune-safe chunking** (see below).
- `.github/workflows/bamlfuzz-nightly.yml` — fifth fuzz target wired; `timeout-minutes` 180 → 210; `BAMLFUZZ_STREAMING_CASES` knob; rapid regex + repro list + sticky-issue prose enumerate the streaming target.

### ChunkSize decision

Derived deterministically from `c.Seed` (8..32, `ChunkDelayMs=0`) — keeps the `OracleCase` schema unchanged and replay reproducible while genuinely exercising the partial path (`ChunkSize=0` would degenerate to one blob). v1 does not assert on partial counts, so no inter-chunk delay is needed.

### Workflow timeout recalc (4 → 5 targets)

- fuzz: 5 × FUZZTIME (75m at the 15m default)
- setup: 5 × ~10m cold-runner = 50m
- corpus restore + Go install + margin = ~10m
- total at default ≈ 135m; **210m** cap supports operator FUZZTIME up to ~30m (5×30 + 50 + 10 = 210).

## Rune-safe mockllm chunking

mockllm previously sliced stream content by **byte index**, so a chunk width landing inside a multi-byte rune emitted an invalid-UTF-8 SSE frame and BAML's stream transport hard-errored (`Utf8(FromUtf8Error{...})`). The streaming oracle hit this the moment the fuzzer fed it arbitrary-Unicode content.

The fix is a shared helper `snapChunkEndToRuneStart(content, end) int` applied to **both** chunking loops:

- `StreamResponse` — the default OpenAI / Google / OpenAI-Responses path.
- `streamAnthropicBlock` — the Anthropic thinking-block path. It also chunked by byte index; flagged independently by Codex review and CodeRabbit and now uses the same helper + `i = end` advance pattern.

Both loops advance via `i = end` from the snapped boundary (no re-sent / mid-rune bytes); behavior-preserving for ASCII. A real LLM SSE server never splits a rune across frames, so this makes the mock faithful and lets the oracle exercise the partial path on the full Unicode input space.

**Confirmed:** the previously-failing multi-byte seed now passes; a 45s fuzz run produces no UTF-8 transport error; a 15s fuzz smoke after the Anthropic-block extension ran 85k execs with 0 crashes.

## Hardening from review

Findings landed during the Codex review cycle (cold first-reads) + CodeRabbit:

- **Anthropic-block rune-safe chunking** — Codex r1 + CodeRabbit independently flagged that the rune-safe fix had been applied only to `StreamResponse`; the helper is now shared with `streamAnthropicBlock`.
- **Terminality** — `checkSingleCleanFinal` previously counted the `final` event kind without requiring it to be terminal. Now requires the last non-metadata kind in the sequence to be `final`. A `[partial, final, partial]` leg fails the assertion.
- **Empty-final-payload close** — `diffAndRecord` skips SemanticDiff on `len == 0` sides. Combined with the loose single-final check, a leg emitting `final` with empty `Data` slipped every assertion. `checkSingleCleanFinal` now also requires `len(finalData) > 0`.

Codex's final pass (r3) on the tightened tip: `APPROVE — zero findings`.

## Validation

- `go build ./...` / `go vet ./...` (+ `-tags integration`) — OK
- `go test -tags integration -c -o /dev/null ./integration/...` — compiles
- `BAML_VERSION=0.222.0 ... -run='^TestBamlfuzzStreamingOracle$' ... -timeout=20m` — **32/32 rapid cases PASS** (16 × 2 preserve modes), 0 fail/skip
- `... -fuzz='^FuzzBamlfuzzStreaming$' -fuzztime=15s` — clean (85k execs, 0 crashes after the Anthropic-block extension)
- `TestCheckSingleCleanFinalEmptyPayload` — empty-final fails; canonical passes
- Banned-phrase grep over diff + commit messages + PR body — clean

## Test plan

- [x] Rapid oracle green at BAML 0.222.0 (subprocess server), 32/32
- [x] Build / vet / integration-compile green
- [x] Rune-safe chunking resolves the multi-byte UTF-8 transport error (both `StreamResponse` and `streamAnthropicBlock`)
- [x] Walker-`Expected` vs BAML `{field:null}` divergence — resolved on master; this branch is rebased on top
- [x] Codex review — `APPROVE — zero findings` on the final tip
- [ ] Nightly fuzz run picks up `FuzzBamlfuzzStreaming` across the version matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a streaming oracle mode and included streaming cases in nightly fuzz runs
  * Exposed streaming request methods that accept caller-provided request bodies
  * Nightly workflow gains a streaming-case input (default 50) and increases fuzz job timeout

* **Bug Fixes**
  * Fixed UTF‑8 rune boundary handling in streaming chunking
  * Improved HTTP streaming error reporting

* **Tests**
  * Added integration tests and fuzz entrypoints for streaming; writes streaming replay artifacts on failure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
