### PR TITLE
fix(bamlfuzz): forbid zero-length map for union arm with class-reachable sibling

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -230,8 +230,8 @@ jobs:
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
             -run='^TestBamlfuzz(Static|Dynamic)Oracle$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)$' ./integration/...
 
-      - name: Run bamlfuzz package stress invariants (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
-        if: ${{ env.MODE == 'rapid' }}
+      - name: Run bamlfuzz package stress invariants
+        if: ${{ env.MODE == 'rapid' && matrix.baml-version == '0.222.0' && matrix.unary-server == false }}
         # raiseRapidChecksFloor (adapters/common/codegen/bamlfuzz/
         # union_test.go) is opt-in via BAMLFUZZ_RAPID_STRESS and lives in
         # the bamlfuzz PACKAGE, not ./integration — so the rapid-mode
@@ -243,11 +243,16 @@ jobs:
         # -count=1, so the floor does not compound the way it would under
         # the unit-tests CI's `-race -count=100` (which is exactly why
         # that job leaves this env unset).
+        #
+        # Runs on one representative rapid cell — the bamlfuzz package
+        # tests are pure-Go and not BAML-version-dependent (they never
+        # read BAML_VERSION or UNARY_SERVER), so the matrix fan-out would
+        # just re-run identical work.
         env:
           BAMLFUZZ_RAPID_STRESS: "1"
         working-directory: adapters/common
         run: |
-          GOWORK=off go test -count=1 ./codegen/bamlfuzz/...
+          GOWORK=off go test -count=1 -timeout 80m ./codegen/bamlfuzz/...
 
       - name: Upload corpus for next nightly
         if: ${{ always() && env.MODE == 'fuzz' }}

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -225,34 +225,10 @@ jobs:
         # BAMLFUZZ_RAPID_STRESS does NOT belong here: raiseRapidChecksFloor
         # lives in the adapters/common/codegen/bamlfuzz package, which this
         # integration step never invokes. The env is set on the dedicated
-        # package-stress step below instead.
+        # bamlfuzz-package-stress job instead.
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
             -run='^TestBamlfuzz(Static|Dynamic)Oracle$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)$' ./integration/...
-
-      - name: Run bamlfuzz package stress invariants
-        if: ${{ env.MODE == 'rapid' && matrix.baml-version == '0.222.0' && matrix.unary-server == false }}
-        # raiseRapidChecksFloor (adapters/common/codegen/bamlfuzz/
-        # union_test.go) is opt-in via BAMLFUZZ_RAPID_STRESS and lives in
-        # the bamlfuzz PACKAGE, not ./integration — so the rapid-mode
-        # integration step above can never trip it. Running the package's
-        # union tests here under the gated 5000-check floor surfaces
-        # generator regressions like the recursion-cap fallback Codex
-        # found at 1315 cases. The floor's defer-restore of the rapid
-        # checks count is package-local, and this step is non-race with
-        # -count=1, so the floor does not compound the way it would under
-        # the unit-tests CI's `-race -count=100` (which is exactly why
-        # that job leaves this env unset).
-        #
-        # Runs on one representative rapid cell — the bamlfuzz package
-        # tests are pure-Go and not BAML-version-dependent (they never
-        # read BAML_VERSION or UNARY_SERVER), so the matrix fan-out would
-        # just re-run identical work.
-        env:
-          BAMLFUZZ_RAPID_STRESS: "1"
-        working-directory: adapters/common
-        run: |
-          GOWORK=off go test -count=1 -timeout 80m ./codegen/bamlfuzz/...
 
       - name: Upload corpus for next nightly
         if: ${{ always() && env.MODE == 'fuzz' }}
@@ -326,3 +302,42 @@ jobs:
               echo '```'
             fi
           } | gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file -
+
+  # Stress invariants for the bamlfuzz Go package itself. raiseRapidChecksFloor
+  # (adapters/common/codegen/bamlfuzz/union_test.go) is opt-in via
+  # BAMLFUZZ_RAPID_STRESS and lives in the bamlfuzz PACKAGE, not ./integration,
+  # so the rapid-mode integration step in the fuzz job can never trip it.
+  # Running the package's union tests under the gated 5000-check floor surfaces
+  # generator regressions like the recursion-cap fallback Codex found at 1315
+  # cases. The floor's defer-restore of the rapid checks count is package-local
+  # and this run is non-race with -count=1, so the floor does not compound the
+  # way it would under the unit-tests CI's -race -count=100.
+  #
+  # These tests are pure Go: they never read BAML_VERSION or UNARY_SERVER and
+  # are not BAML-version dependent, so they run as one standalone cell rather
+  # than inside the version matrix. Keeping them off the matrix means there is
+  # no matrix.baml-version literal to drift when Renovate bumps
+  # integration/baml_versions.json. Gated on the same rapid-mode condition the
+  # fuzz job's MODE env uses, so it runs only on a manual rapid dispatch.
+  bamlfuzz-package-stress:
+    name: bamlfuzz package stress invariants
+    if: ${{ (github.event.inputs.mode || 'fuzz') == 'rapid' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run bamlfuzz package stress invariants
+        env:
+          BAMLFUZZ_RAPID_STRESS: "1"
+        working-directory: adapters/common
+        run: |
+          GOWORK=off go test -count=1 -timeout 80m ./codegen/bamlfuzz/...

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -221,6 +221,16 @@ jobs:
         # `subprocess` matches the normal server deployment path (server +
         # cmd/worker go-plugin), same as integration-tests.yml. -p 1 keeps
         # the integration env setup serial; the oracles share state.
+        #
+        # BAMLFUZZ_RAPID_STRESS lifts the rapid check budget for the
+        # high-budget union invariants to their 5000-check floor. It is
+        # scoped to this step only: the fuzz-mode steps run each target
+        # once per -fuzztime so the floor never compounds there, and no
+        # race-instrumented step carries it (the floor × -race ×
+        # -count=100 compounding is exactly what the unit-tests job
+        # avoids by leaving this env unset).
+        env:
+          BAMLFUZZ_RAPID_STRESS: "1"
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
             -run='^TestBamlfuzz(Static|Dynamic)Oracle$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)$' ./integration/...

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -222,18 +222,32 @@ jobs:
         # cmd/worker go-plugin), same as integration-tests.yml. -p 1 keeps
         # the integration env setup serial; the oracles share state.
         #
-        # BAMLFUZZ_RAPID_STRESS lifts the rapid check budget for the
-        # high-budget union invariants to their 5000-check floor. It is
-        # scoped to this step only: the fuzz-mode steps run each target
-        # once per -fuzztime so the floor never compounds there, and no
-        # race-instrumented step carries it (the floor × -race ×
-        # -count=100 compounding is exactly what the unit-tests job
-        # avoids by leaving this env unset).
-        env:
-          BAMLFUZZ_RAPID_STRESS: "1"
+        # BAMLFUZZ_RAPID_STRESS does NOT belong here: raiseRapidChecksFloor
+        # lives in the adapters/common/codegen/bamlfuzz package, which this
+        # integration step never invokes. The env is set on the dedicated
+        # package-stress step below instead.
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
             -run='^TestBamlfuzz(Static|Dynamic)Oracle$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)$' ./integration/...
+
+      - name: Run bamlfuzz package stress invariants (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
+        if: ${{ env.MODE == 'rapid' }}
+        # raiseRapidChecksFloor (adapters/common/codegen/bamlfuzz/
+        # union_test.go) is opt-in via BAMLFUZZ_RAPID_STRESS and lives in
+        # the bamlfuzz PACKAGE, not ./integration — so the rapid-mode
+        # integration step above can never trip it. Running the package's
+        # union tests here under the gated 5000-check floor surfaces
+        # generator regressions like the recursion-cap fallback Codex
+        # found at 1315 cases. The floor's defer-restore of the rapid
+        # checks count is package-local, and this step is non-race with
+        # -count=1, so the floor does not compound the way it would under
+        # the unit-tests CI's `-race -count=100` (which is exactly why
+        # that job leaves this env unset).
+        env:
+          BAMLFUZZ_RAPID_STRESS: "1"
+        working-directory: adapters/common
+        run: |
+          GOWORK=off go test -count=1 ./codegen/bamlfuzz/...
 
       - name: Upload corpus for next nightly
         if: ${{ always() && env.MODE == 'fuzz' }}

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -491,23 +491,9 @@ func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValu
 	if len(ft.Variants) == 0 {
 		t.Fatalf("bamlfuzz: union has no variants (label=%s); schema is malformed", label)
 	}
-	safe := make([]int, 0, len(ft.Variants))
-	for i := range ft.Variants {
-		v := ft.Variants[i]
-		if !c.wouldExceedDepth(&v) {
-			safe = append(safe, i)
-		}
-	}
-	if len(safe) == 0 {
-		// Every arm reaches an already-exhausted class. Fall through
-		// to the full index range — the inner draw still enforces
-		// termination at the next optional/list/map wrapper.
-		for i := range ft.Variants {
-			safe = append(safe, i)
-		}
-	}
-	pick := rapid.IntRange(0, len(safe)-1).Draw(t, label+":variant_pick")
-	idx := safe[pick]
+	candidates := c.unionDrawCandidates(ft)
+	pick := rapid.IntRange(0, len(candidates)-1).Draw(t, label+":variant_pick")
+	idx := candidates[pick]
 	arm := ft.Variants[idx]
 	armLabel := fmt.Sprintf("%s:variant_%d", label, idx)
 	var inner FuzzValue
@@ -521,6 +507,105 @@ func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValu
 		VariantIndex: idx,
 		Variant:      &inner,
 	}
+}
+
+// unionDrawCandidates returns the variant indices a union draw may
+// pick from, shared by drawUnion and the ensure-non-empty union
+// branch so both apply the same two filters. Arms whose realisation
+// would blow the per-class recursion cap are dropped first, biasing
+// the rapid bitstream toward terminating arms; when every arm is
+// over the cap the full index range is the base set (the inner draw
+// still enforces optional/list/map termination at the next wrapper).
+//
+// The second filter closes the recursion-cap back-door Codex found:
+// when the base set falls back to over-cap arms and the union has a
+// class-reachable arm, a map-reaching arm is forced to render the
+// depth-clamped empty map `{}` (drawMap clamps minLen=1 to 0 once
+// wouldExceedDepth holds). That `{}` is byte-identical to a null-
+// materialized class instance, which BAML's resolver coerces to the
+// class arm — diverging from the walker's recorded map choice. Such
+// arms are dropped so the pick lands on a sibling that resolves
+// unambiguously (a class_ref or scalar arm). The filter is a no-op
+// on the non-fallback base set, where over-cap map arms are already
+// excluded, and is skipped if it would empty the candidate set.
+func (c *valueDrawCtx) unionDrawCandidates(ft FuzzType) []int {
+	base := make([]int, 0, len(ft.Variants))
+	for i := range ft.Variants {
+		v := ft.Variants[i]
+		if !c.wouldExceedDepth(&v) {
+			base = append(base, i)
+		}
+	}
+	if len(base) == 0 {
+		for i := range ft.Variants {
+			base = append(base, i)
+		}
+	}
+	if !unionHasClassReachableArm(ft) {
+		return base
+	}
+	pruned := make([]int, 0, len(base))
+	for _, i := range base {
+		if c.armForcesEmptyMap(ft.Variants[i], 0) {
+			continue
+		}
+		pruned = append(pruned, i)
+	}
+	if len(pruned) == 0 {
+		return base
+	}
+	return pruned
+}
+
+// armForcesEmptyMap reports whether picking `arm` along the ensure-
+// non-empty draw is forced to render a depth-clamped empty map at the
+// transparent leaf — the case that collides with a class-reachable
+// sibling. A direct map arm is forced exactly when its inner type
+// would blow the recursion cap, so drawMap clamps the length to 0. An
+// optional is never forced: the ensure-non-empty draw terminates it
+// as absent/null (emitting no map) whenever its inner would clamp. A
+// union is forced only when every arm it could pick is itself forced;
+// if any arm can avoid the clamp, the candidate filter steers the
+// nested draw to it. Bounded by MaxTypeDepth + 1 so a malformed cyclic
+// union literal cannot loop the walk.
+func (c *valueDrawCtx) armForcesEmptyMap(arm FuzzType, depth int) bool {
+	if depth > MaxTypeDepth {
+		return false
+	}
+	switch arm.Kind {
+	case KindMap:
+		return c.wouldExceedDepth(arm.Inner)
+	case KindOptional:
+		return false
+	case KindUnion:
+		if len(arm.Variants) == 0 {
+			return false
+		}
+		for _, v := range arm.Variants {
+			if !c.armForcesEmptyMap(v, depth+1) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// unionHasClassReachableArm reports whether any variant of `union` is,
+// or reaches via nested unions and optional wrappers, a KindClassRef.
+// It mirrors unionHasClassReachableSibling with no excluded index: the
+// candidate filter only needs to know whether the empty-map ambiguity
+// is possible at all before deciding to drop a forced map arm.
+func unionHasClassReachableArm(union FuzzType) bool {
+	if union.Kind != KindUnion {
+		return false
+	}
+	for _, v := range union.Variants {
+		if typeReachesClassRef(v, 0) {
+			return true
+		}
+	}
+	return false
 }
 
 // pickedArmReachesMapThroughTransparent reports whether `arm` is
@@ -593,20 +678,9 @@ func (c *valueDrawCtx) drawArmEnsuringMapNonEmpty(t *rapid.T, arm FuzzType, labe
 		if len(arm.Variants) == 0 {
 			t.Fatalf("bamlfuzz: nested union has no variants (label=%s); schema is malformed", label)
 		}
-		safe := make([]int, 0, len(arm.Variants))
-		for i := range arm.Variants {
-			v := arm.Variants[i]
-			if !c.wouldExceedDepth(&v) {
-				safe = append(safe, i)
-			}
-		}
-		if len(safe) == 0 {
-			for i := range arm.Variants {
-				safe = append(safe, i)
-			}
-		}
-		pick := rapid.IntRange(0, len(safe)-1).Draw(t, label+":variant_pick")
-		idx := safe[pick]
+		candidates := c.unionDrawCandidates(arm)
+		pick := rapid.IntRange(0, len(candidates)-1).Draw(t, label+":variant_pick")
+		idx := candidates[pick]
 		innerArm := arm.Variants[idx]
 		innerLabel := fmt.Sprintf("%s:variant_%d", label, idx)
 		innerVal := c.drawArmEnsuringMapNonEmpty(t, innerArm, innerLabel)

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -476,15 +476,17 @@ func (c *valueDrawCtx) drawValueForType(t *rapid.T, ft FuzzType, label string) F
 // optional/list/map termination); this is a defensive branch the
 // schema generator's depth bounds make unreachable.
 //
-// When the picked arm's effective kind (after unwrapping any
-// KindOptional wrappers) is KindMap and a sibling arm reaches a
-// class_ref (directly or through nested unions/optional wrappers), any
-// map drawn at the leaf carries len >= 1. An empty map renders as the
-// wire bytes `{}`, which BAML's union resolver coerces to the class arm
-// with null-materialized fields — diverging from the walker's
-// prediction. Forcing the map to carry at least one entry keeps the
-// walker's recorded arm choice the one BAML lands on, including for
-// the optional<map> shape where the optional draws as present.
+// When the picked arm reaches KindMap through transparent wrappers
+// (nested KindUnion / KindOptional) and a sibling arm reaches a
+// class_ref, any map drawn along the picked path carries len >= 1.
+// An empty map renders as the wire bytes `{}`, which BAML's union
+// resolver coerces to the class arm with null-materialized fields —
+// diverging from the walker's prediction. The transparent-wrapper
+// reach check mirrors the sibling-side helper (typeReachesClassRef
+// descends through optionals and nested unions), so a shape like
+// `union[union[map<string,int>, string], class_ref X]` triggers the
+// non-empty-map constraint when the inner union picks the map arm
+// even though the inner union's own sibling set is class-free.
 func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValue {
 	if len(ft.Variants) == 0 {
 		t.Fatalf("bamlfuzz: union has no variants (label=%s); schema is malformed", label)
@@ -509,7 +511,7 @@ func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValu
 	arm := ft.Variants[idx]
 	armLabel := fmt.Sprintf("%s:variant_%d", label, idx)
 	var inner FuzzValue
-	if pickedArmEffectiveKindIsMap(arm) && unionHasClassReachableSibling(ft, idx) {
+	if pickedArmReachesMapThroughTransparent(arm, 0) && unionHasClassReachableSibling(ft, idx) {
 		inner = c.drawArmEnsuringMapNonEmpty(t, arm, armLabel)
 	} else {
 		inner = c.drawValueForType(t, arm, armLabel)
@@ -521,31 +523,50 @@ func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValu
 	}
 }
 
-// pickedArmEffectiveKindIsMap reports whether `arm` is KindMap directly
-// or resolves to KindMap after stripping nested KindOptional wrappers.
-// The picked-arm dispatch mirrors the sibling-side reach helper
-// (typeReachesClassRef descends through optionals), so a union shape
-// like `optional<map<string, T>> | class_ref X` triggers the
-// non-empty-map constraint when the optional draws as present — the
-// asymmetric direct-KindMap check skipped these and emitted `{}` at
-// the leaf, which BAML coerces to the class sibling.
-func pickedArmEffectiveKindIsMap(arm FuzzType) bool {
-	cur := arm
-	for cur.Kind == KindOptional && cur.Inner != nil {
-		cur = *cur.Inner
+// pickedArmReachesMapThroughTransparent reports whether `arm` is
+// KindMap directly or resolves to KindMap after descending through
+// nested KindOptional and KindUnion wrappers. These are the only
+// kinds whose drawn value can render as the leaf wire bytes `{}` of
+// a sibling arm's path; KindList wraps in `[...]`, KindClassRef in
+// named fields, neither colliding with the empty-map encoding.
+// Bounded by MaxTypeDepth + 1 so a malformed cyclic union literal
+// cannot loop the walk.
+func pickedArmReachesMapThroughTransparent(arm FuzzType, depth int) bool {
+	if depth > MaxTypeDepth {
+		return false
 	}
-	return cur.Kind == KindMap
+	switch arm.Kind {
+	case KindMap:
+		return true
+	case KindOptional:
+		if arm.Inner == nil {
+			return false
+		}
+		return pickedArmReachesMapThroughTransparent(*arm.Inner, depth+1)
+	case KindUnion:
+		for _, v := range arm.Variants {
+			if pickedArmReachesMapThroughTransparent(v, depth+1) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
-// drawArmEnsuringMapNonEmpty draws the value for a union arm whose
-// effective kind (after unwrapping KindOptional wrappers) is KindMap.
-// At every optional wrapper the helper mirrors drawOptional's
-// shape draw (present/absent/null with the same termination-on-
-// depth-exhaustion semantics); only the present branch forwards the
-// non-empty-map constraint, so absent / null draws are unaffected.
-// When the leaf KindMap is reached, drawMap is invoked with minLen=1
-// (drawMap itself clamps minLen down when wouldExceedDepth forces
-// maxLen=0; termination still beats the non-emptiness preference).
+// drawArmEnsuringMapNonEmpty draws the value for a union arm reached
+// through transparent wrappers (nested KindUnion / KindOptional) from
+// a class-ambiguous outer union. At every transparent wrapper the
+// helper mirrors the corresponding draw (drawOptional's shape split,
+// drawUnion's safe-arm pick) so the bitstream layout stays unchanged
+// from the unconstrained path; only the recursive value draw forwards
+// the non-empty-map constraint. KindMap leaves are drawn via drawMap
+// with minLen=1 — drawMap itself clamps minLen down when
+// wouldExceedDepth forces maxLen=0, so termination still beats the
+// non-emptiness preference. Non-transparent kinds (KindList,
+// KindClassRef, scalars) cannot render as `{}` at the leaf and so
+// don't propagate the constraint — the default branch hands them off
+// to drawValueForType for the standard draw.
 func (c *valueDrawCtx) drawArmEnsuringMapNonEmpty(t *rapid.T, arm FuzzType, label string) FuzzValue {
 	switch arm.Kind {
 	case KindMap:
@@ -568,11 +589,36 @@ func (c *valueDrawCtx) drawArmEnsuringMapNonEmpty(t *rapid.T, arm FuzzType, labe
 			OptionalShape: OptionalPresent,
 			Inner:         &inner,
 		}
+	case KindUnion:
+		if len(arm.Variants) == 0 {
+			t.Fatalf("bamlfuzz: nested union has no variants (label=%s); schema is malformed", label)
+		}
+		safe := make([]int, 0, len(arm.Variants))
+		for i := range arm.Variants {
+			v := arm.Variants[i]
+			if !c.wouldExceedDepth(&v) {
+				safe = append(safe, i)
+			}
+		}
+		if len(safe) == 0 {
+			for i := range arm.Variants {
+				safe = append(safe, i)
+			}
+		}
+		pick := rapid.IntRange(0, len(safe)-1).Draw(t, label+":variant_pick")
+		idx := safe[pick]
+		innerArm := arm.Variants[idx]
+		innerLabel := fmt.Sprintf("%s:variant_%d", label, idx)
+		innerVal := c.drawArmEnsuringMapNonEmpty(t, innerArm, innerLabel)
+		return FuzzValue{
+			Kind:         KindUnion,
+			VariantIndex: idx,
+			Variant:      &innerVal,
+		}
 	default:
-		// Defensive: pickedArmEffectiveKindIsMap pins this helper to
-		// KindMap / KindOptional<...<KindMap>> arms only. Any other
-		// kind here means a caller is misusing the helper; fall back
-		// to the standard draw so the value still type-checks.
+		// Non-transparent leaf kind: cannot render as `{}`, so the
+		// ambient class-ambiguity constraint is a no-op. Hand off to
+		// the standard draw.
 		return c.drawValueForType(t, arm, label)
 	}
 }

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -491,7 +491,7 @@ func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValu
 	if len(ft.Variants) == 0 {
 		t.Fatalf("bamlfuzz: union has no variants (label=%s); schema is malformed", label)
 	}
-	candidates := c.unionDrawCandidates(ft)
+	candidates := c.unionDrawCandidates(ft, false)
 	pick := rapid.IntRange(0, len(candidates)-1).Draw(t, label+":variant_pick")
 	idx := candidates[pick]
 	arm := ft.Variants[idx]
@@ -518,17 +518,30 @@ func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValu
 // still enforces optional/list/map termination at the next wrapper).
 //
 // The second filter closes the recursion-cap back-door Codex found:
-// when the base set falls back to over-cap arms and the union has a
-// class-reachable arm, a map-reaching arm is forced to render the
-// depth-clamped empty map `{}` (drawMap clamps minLen=1 to 0 once
-// wouldExceedDepth holds). That `{}` is byte-identical to a null-
-// materialized class instance, which BAML's resolver coerces to the
-// class arm — diverging from the walker's recorded map choice. Such
-// arms are dropped so the pick lands on a sibling that resolves
-// unambiguously (a class_ref or scalar arm). The filter is a no-op
-// on the non-fallback base set, where over-cap map arms are already
+// when the base set falls back to over-cap arms and a class is
+// reachable, a map-reaching arm is forced to render the depth-clamped
+// empty map `{}` (drawMap clamps minLen=1 to 0 once wouldExceedDepth
+// holds). That `{}` is byte-identical to a null-materialized class
+// instance, which BAML's resolver coerces to the class arm —
+// diverging from the walker's recorded map choice. Such arms are
+// dropped so the pick lands on a sibling that resolves unambiguously
+// (a class_ref or scalar arm). The filter is a no-op on the
+// non-fallback base set, where over-cap map arms are already
 // excluded, and is skipped if it would empty the candidate set.
-func (c *valueDrawCtx) unionDrawCandidates(ft FuzzType) []int {
+//
+// classReachable folds two sources of that ambiguity. The LOCAL one
+// this union owns — a class_ref among its own arms — is what gates
+// pruning at the top level. The AMBIENT one is established by an outer
+// union before the recursion descends here: drawArmEnsuringMapNonEmpty
+// only recurses into a nested union after the outer union already
+// proved a class-reachable sibling, so a depth-clamped `{}` at this
+// nested leaf is still ambiguous with that outer class even when the
+// nested union carries no class arm of its own. Passing
+// ambientHasClassSibling=true from that path keeps the prune on for
+// the nested union, independent of its local arms; drawUnion enters at
+// the top level with ambientHasClassSibling=false, so the local check
+// alone decides and the existing top-level behaviour is unchanged.
+func (c *valueDrawCtx) unionDrawCandidates(ft FuzzType, ambientHasClassSibling bool) []int {
 	base := make([]int, 0, len(ft.Variants))
 	for i := range ft.Variants {
 		v := ft.Variants[i]
@@ -541,7 +554,8 @@ func (c *valueDrawCtx) unionDrawCandidates(ft FuzzType) []int {
 			base = append(base, i)
 		}
 	}
-	if !unionHasClassReachableArm(ft) {
+	classReachable := ambientHasClassSibling || unionHasClassReachableArm(ft)
+	if !classReachable {
 		return base
 	}
 	pruned := make([]int, 0, len(base))
@@ -678,7 +692,11 @@ func (c *valueDrawCtx) drawArmEnsuringMapNonEmpty(t *rapid.T, arm FuzzType, labe
 		if len(arm.Variants) == 0 {
 			t.Fatalf("bamlfuzz: nested union has no variants (label=%s); schema is malformed", label)
 		}
-		candidates := c.unionDrawCandidates(arm)
+		// ambientHasClassSibling=true: drawArmEnsuringMapNonEmpty only
+		// reaches this nested union after an outer union proved a
+		// class-reachable sibling, so the prune must run here whether or
+		// not this nested union owns a class arm.
+		candidates := c.unionDrawCandidates(arm, true)
 		pick := rapid.IntRange(0, len(candidates)-1).Draw(t, label+":variant_pick")
 		idx := candidates[pick]
 		innerArm := arm.Variants[idx]

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -476,13 +476,15 @@ func (c *valueDrawCtx) drawValueForType(t *rapid.T, ft FuzzType, label string) F
 // optional/list/map termination); this is a defensive branch the
 // schema generator's depth bounds make unreachable.
 //
-// When the picked arm is a direct KindMap and a sibling arm reaches a
-// class_ref (directly or through nested unions/optional wrappers), the
-// map is drawn with len >= 1. An empty map renders as the wire bytes
-// `{}`, which BAML's union resolver coerces to the class arm with
-// null-materialized fields — diverging from the walker's prediction.
-// Forcing the map to carry at least one entry keeps the walker's
-// recorded arm choice the one BAML lands on.
+// When the picked arm's effective kind (after unwrapping any
+// KindOptional wrappers) is KindMap and a sibling arm reaches a
+// class_ref (directly or through nested unions/optional wrappers), any
+// map drawn at the leaf carries len >= 1. An empty map renders as the
+// wire bytes `{}`, which BAML's union resolver coerces to the class arm
+// with null-materialized fields — diverging from the walker's
+// prediction. Forcing the map to carry at least one entry keeps the
+// walker's recorded arm choice the one BAML lands on, including for
+// the optional<map> shape where the optional draws as present.
 func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValue {
 	if len(ft.Variants) == 0 {
 		t.Fatalf("bamlfuzz: union has no variants (label=%s); schema is malformed", label)
@@ -507,8 +509,8 @@ func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValu
 	arm := ft.Variants[idx]
 	armLabel := fmt.Sprintf("%s:variant_%d", label, idx)
 	var inner FuzzValue
-	if arm.Kind == KindMap && unionHasClassReachableSibling(ft, idx) {
-		inner = c.drawMap(t, arm, 1, armLabel)
+	if pickedArmEffectiveKindIsMap(arm) && unionHasClassReachableSibling(ft, idx) {
+		inner = c.drawArmEnsuringMapNonEmpty(t, arm, armLabel)
 	} else {
 		inner = c.drawValueForType(t, arm, armLabel)
 	}
@@ -516,6 +518,62 @@ func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValu
 		Kind:         KindUnion,
 		VariantIndex: idx,
 		Variant:      &inner,
+	}
+}
+
+// pickedArmEffectiveKindIsMap reports whether `arm` is KindMap directly
+// or resolves to KindMap after stripping nested KindOptional wrappers.
+// The picked-arm dispatch mirrors the sibling-side reach helper
+// (typeReachesClassRef descends through optionals), so a union shape
+// like `optional<map<string, T>> | class_ref X` triggers the
+// non-empty-map constraint when the optional draws as present — the
+// asymmetric direct-KindMap check skipped these and emitted `{}` at
+// the leaf, which BAML coerces to the class sibling.
+func pickedArmEffectiveKindIsMap(arm FuzzType) bool {
+	cur := arm
+	for cur.Kind == KindOptional && cur.Inner != nil {
+		cur = *cur.Inner
+	}
+	return cur.Kind == KindMap
+}
+
+// drawArmEnsuringMapNonEmpty draws the value for a union arm whose
+// effective kind (after unwrapping KindOptional wrappers) is KindMap.
+// At every optional wrapper the helper mirrors drawOptional's
+// shape draw (present/absent/null with the same termination-on-
+// depth-exhaustion semantics); only the present branch forwards the
+// non-empty-map constraint, so absent / null draws are unaffected.
+// When the leaf KindMap is reached, drawMap is invoked with minLen=1
+// (drawMap itself clamps minLen down when wouldExceedDepth forces
+// maxLen=0; termination still beats the non-emptiness preference).
+func (c *valueDrawCtx) drawArmEnsuringMapNonEmpty(t *rapid.T, arm FuzzType, label string) FuzzValue {
+	switch arm.Kind {
+	case KindMap:
+		return c.drawMap(t, arm, 1, label)
+	case KindOptional:
+		if c.wouldExceedDepth(arm.Inner) {
+			shape := OptionalAbsent
+			if rapid.Bool().Draw(t, label+":term_shape") {
+				shape = OptionalNull
+			}
+			return FuzzValue{Kind: KindOptional, OptionalShape: shape}
+		}
+		shape := drawOptionalShape(t, label)
+		if shape != OptionalPresent {
+			return FuzzValue{Kind: KindOptional, OptionalShape: shape}
+		}
+		inner := c.drawArmEnsuringMapNonEmpty(t, *arm.Inner, label+":opt_present")
+		return FuzzValue{
+			Kind:          KindOptional,
+			OptionalShape: OptionalPresent,
+			Inner:         &inner,
+		}
+	default:
+		// Defensive: pickedArmEffectiveKindIsMap pins this helper to
+		// KindMap / KindOptional<...<KindMap>> arms only. Any other
+		// kind here means a caller is misusing the helper; fall back
+		// to the standard draw so the value still type-checks.
+		return c.drawValueForType(t, arm, label)
 	}
 }
 

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -452,7 +452,7 @@ func (c *valueDrawCtx) drawValueForType(t *rapid.T, ft FuzzType, label string) F
 	case KindList:
 		return c.drawList(t, ft, label)
 	case KindMap:
-		return c.drawMap(t, ft, label)
+		return c.drawMap(t, ft, 0, label)
 	case KindClassRef:
 		// Required class ref: if recursion budget for the target
 		// is exhausted, this shape is unreachable from the
@@ -475,6 +475,14 @@ func (c *valueDrawCtx) drawValueForType(t *rapid.T, ft FuzzType, label string) F
 // the helper falls back to any arm (the inner draw still enforces
 // optional/list/map termination); this is a defensive branch the
 // schema generator's depth bounds make unreachable.
+//
+// When the picked arm is a direct KindMap and a sibling arm reaches a
+// class_ref (directly or through nested unions/optional wrappers), the
+// map is drawn with len >= 1. An empty map renders as the wire bytes
+// `{}`, which BAML's union resolver coerces to the class arm with
+// null-materialized fields — diverging from the walker's prediction.
+// Forcing the map to carry at least one entry keeps the walker's
+// recorded arm choice the one BAML lands on.
 func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValue {
 	if len(ft.Variants) == 0 {
 		t.Fatalf("bamlfuzz: union has no variants (label=%s); schema is malformed", label)
@@ -496,12 +504,66 @@ func (c *valueDrawCtx) drawUnion(t *rapid.T, ft FuzzType, label string) FuzzValu
 	}
 	pick := rapid.IntRange(0, len(safe)-1).Draw(t, label+":variant_pick")
 	idx := safe[pick]
-	inner := c.drawValueForType(t, ft.Variants[idx], fmt.Sprintf("%s:variant_%d", label, idx))
+	arm := ft.Variants[idx]
+	armLabel := fmt.Sprintf("%s:variant_%d", label, idx)
+	var inner FuzzValue
+	if arm.Kind == KindMap && unionHasClassReachableSibling(ft, idx) {
+		inner = c.drawMap(t, arm, 1, armLabel)
+	} else {
+		inner = c.drawValueForType(t, arm, armLabel)
+	}
 	return FuzzValue{
 		Kind:         KindUnion,
 		VariantIndex: idx,
 		Variant:      &inner,
 	}
+}
+
+// unionHasClassReachableSibling reports whether any variant of `union`
+// at an index other than `excludeIdx` is, or reaches via nested unions
+// and optional wrappers, a KindClassRef. The check exists so the
+// value generator can avoid producing an empty map `{}` for a union's
+// direct map arm when a class is reachable through a sibling: an
+// empty `{}` is byte-identical to an empty class instance, and BAML's
+// union resolver prefers the class — null-materializing its declared
+// fields — over the empty map. Recursion is bounded by MaxTypeDepth +
+// 1 so a malformed cyclic union literal cannot loop the walk.
+func unionHasClassReachableSibling(union FuzzType, excludeIdx int) bool {
+	if union.Kind != KindUnion {
+		return false
+	}
+	for i, v := range union.Variants {
+		if i == excludeIdx {
+			continue
+		}
+		if typeReachesClassRef(v, 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func typeReachesClassRef(t FuzzType, depth int) bool {
+	if depth > MaxTypeDepth {
+		return false
+	}
+	switch t.Kind {
+	case KindClassRef:
+		return true
+	case KindOptional:
+		if t.Inner == nil {
+			return false
+		}
+		return typeReachesClassRef(*t.Inner, depth+1)
+	case KindUnion:
+		for _, v := range t.Variants {
+			if typeReachesClassRef(v, depth+1) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
 func (c *valueDrawCtx) drawOptional(t *rapid.T, ft FuzzType, label string) FuzzValue {
@@ -557,12 +619,21 @@ func (c *valueDrawCtx) drawList(t *rapid.T, ft FuzzType, label string) FuzzValue
 	return FuzzValue{Kind: KindList, Items: items}
 }
 
-func (c *valueDrawCtx) drawMap(t *rapid.T, ft FuzzType, label string) FuzzValue {
+// drawMap draws a KindMap value with length in [minLen, MaxMapLen].
+// When recursion budget is exhausted for the inner type the cap drops
+// to 0 and a minLen > 0 is clamped down with it — termination beats
+// the non-emptiness preference. Callers that want the standard "may
+// be empty" behaviour pass minLen = 0; the union-ambiguity branch in
+// drawUnion passes minLen = 1.
+func (c *valueDrawCtx) drawMap(t *rapid.T, ft FuzzType, minLen int, label string) FuzzValue {
 	maxLen := MaxMapLen
 	if c.wouldExceedDepth(ft.Inner) {
 		maxLen = 0
 	}
-	length := rapid.IntRange(0, maxLen).Draw(t, label+":map_len")
+	if minLen > maxLen {
+		minLen = maxLen
+	}
+	length := rapid.IntRange(minLen, maxLen).Draw(t, label+":map_len")
 	used := make(map[string]struct{}, length)
 	entries := make([]FuzzMapEntry, 0, length)
 	for i := 0; i < length; i++ {

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -1636,6 +1636,275 @@ func TestValueGenOptionalMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	})
 }
 
+// fixtureSchemaNestedUnionMapVsClassSibling pins the nested-union
+// shape: the outer union has a nested-union arm `[map<string,int>,
+// string]` and a class-reachable arm. When the outer pick lands on
+// the nested union AND the nested union picks its own map arm, the
+// drawn `{}` is byte-identical to a null-materialized Inner — the
+// outer union's class-reachable sibling is what BAML's resolver
+// uses to disambiguate, not the inner union's siblings. The picked-
+// arm dispatch must descend through nested unions and apply the
+// non-empty-map constraint at the leaf.
+func fixtureSchemaNestedUnionMapVsClassSibling() FuzzSchema {
+	keyT := FuzzType{Kind: KindString}
+	intT := FuzzType{Kind: KindInt}
+	innerUnion := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindMap, Key: &keyT, Inner: &intT},
+			{Kind: KindString},
+		},
+	}
+	inner := FuzzClass{
+		Name: "Inner",
+		Properties: []FuzzProperty{
+			{Name: "Fuzz_field_0", Type: FuzzType{Kind: KindInt}},
+		},
+	}
+	outer := FuzzClass{
+		Name: "Outer",
+		Properties: []FuzzProperty{
+			{Name: "f", Type: FuzzType{
+				Kind: KindUnion,
+				Variants: []FuzzType{
+					innerUnion,
+					{Kind: KindClassRef, Ref: "Inner"},
+				},
+			}},
+		},
+	}
+	return AnalyzeGraph(FuzzSchema{
+		Classes:   []FuzzClass{outer, inner},
+		RootClass: "Outer",
+	})
+}
+
+// TestValueGenNestedUnionMapArmWithClassSiblingNeverEmpty exercises
+// the nested-union case. The outer union picks the nested-union arm
+// and the nested union picks its map arm — the leaf map must be
+// non-empty so the wire bytes don't coerce to the outer's class-
+// reachable sibling.
+func TestValueGenNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.T) {
+	schema := fixtureSchemaNestedUnionMapVsClassSibling()
+	var exercised bool
+	rapid.Check(t, func(rt *rapid.T) {
+		v := ValueGen(schema).Draw(rt, "v")
+		fv, ok := v.LookupField("f")
+		if !ok {
+			rt.Fatalf("outer instance missing field f")
+		}
+		if fv.Kind != KindUnion || fv.Variant == nil {
+			rt.Fatalf("field f expected union value, got %v", fv.Kind)
+		}
+		if fv.VariantIndex != 0 {
+			return
+		}
+		if fv.Variant.Kind != KindUnion {
+			rt.Fatalf("outer arm 0 expected to be a nested union value, got %v", fv.Variant.Kind)
+		}
+		if fv.Variant.Variant == nil {
+			rt.Fatalf("nested union missing Variant")
+		}
+		if fv.Variant.VariantIndex != 0 {
+			return
+		}
+		if fv.Variant.Variant.Kind != KindMap {
+			rt.Fatalf("nested union arm 0 expected to be a map value, got %v", fv.Variant.Variant.Kind)
+		}
+		exercised = true
+		if len(fv.Variant.Variant.MapEntries) == 0 {
+			rt.Fatalf("nested-union map arm produced an empty map — ambiguous with outer class sibling under BAML coercion")
+		}
+	})
+	if !exercised {
+		t.Fatalf("rapid budget never reached nested-union map leaf — coverage sentinel never fired; non-empty-map invariant unverified")
+	}
+}
+
+// fixtureSchemaOptionalNestedUnionMapVsClassSibling layers an
+// optional over the nested union: `union[ optional<union[map, string]>,
+// class_ref Inner ]`. The picked-arm dispatch must descend through
+// the optional (present branch) and into the nested union before
+// applying the constraint at the map leaf. Bounded composition of
+// the two transparent wrappers the helper already handles in
+// isolation.
+func fixtureSchemaOptionalNestedUnionMapVsClassSibling() FuzzSchema {
+	keyT := FuzzType{Kind: KindString}
+	intT := FuzzType{Kind: KindInt}
+	innerUnion := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindMap, Key: &keyT, Inner: &intT},
+			{Kind: KindString},
+		},
+	}
+	optInnerUnion := FuzzType{Kind: KindOptional, Inner: &innerUnion}
+	inner := FuzzClass{
+		Name: "Inner",
+		Properties: []FuzzProperty{
+			{Name: "Fuzz_field_0", Type: FuzzType{Kind: KindInt}},
+		},
+	}
+	outer := FuzzClass{
+		Name: "Outer",
+		Properties: []FuzzProperty{
+			{Name: "f", Type: FuzzType{
+				Kind: KindUnion,
+				Variants: []FuzzType{
+					optInnerUnion,
+					{Kind: KindClassRef, Ref: "Inner"},
+				},
+			}},
+		},
+	}
+	return AnalyzeGraph(FuzzSchema{
+		Classes:   []FuzzClass{outer, inner},
+		RootClass: "Outer",
+	})
+}
+
+// TestValueGenOptionalNestedUnionMapArmWithClassSiblingNeverEmpty
+// exercises the optional + nested-union compound: the outer pick
+// lands on the optional<nested-union>, the optional draws present,
+// the nested union picks its map arm. The leaf map must be non-
+// empty.
+func TestValueGenOptionalNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.T) {
+	schema := fixtureSchemaOptionalNestedUnionMapVsClassSibling()
+	var exercised bool
+	rapid.Check(t, func(rt *rapid.T) {
+		v := ValueGen(schema).Draw(rt, "v")
+		fv, ok := v.LookupField("f")
+		if !ok {
+			rt.Fatalf("outer instance missing field f")
+		}
+		if fv.Kind != KindUnion || fv.Variant == nil {
+			rt.Fatalf("field f expected union value, got %v", fv.Kind)
+		}
+		if fv.VariantIndex != 0 {
+			return
+		}
+		if fv.Variant.Kind != KindOptional {
+			rt.Fatalf("outer arm 0 expected to be an optional value, got %v", fv.Variant.Kind)
+		}
+		if fv.Variant.OptionalShape != OptionalPresent {
+			return
+		}
+		if fv.Variant.Inner == nil {
+			rt.Fatalf("present optional missing Inner")
+		}
+		if fv.Variant.Inner.Kind != KindUnion {
+			rt.Fatalf("optional<nested-union> expected union value, got %v", fv.Variant.Inner.Kind)
+		}
+		if fv.Variant.Inner.Variant == nil {
+			rt.Fatalf("nested union missing Variant")
+		}
+		if fv.Variant.Inner.VariantIndex != 0 {
+			return
+		}
+		if fv.Variant.Inner.Variant.Kind != KindMap {
+			rt.Fatalf("nested union arm 0 expected to be a map value, got %v", fv.Variant.Inner.Variant.Kind)
+		}
+		exercised = true
+		if len(fv.Variant.Inner.Variant.MapEntries) == 0 {
+			rt.Fatalf("optional+nested-union map arm produced an empty map — ambiguous with outer class sibling under BAML coercion")
+		}
+	})
+	if !exercised {
+		t.Fatalf("rapid budget never reached optional+nested-union map leaf — coverage sentinel never fired; non-empty-map invariant unverified")
+	}
+}
+
+// fixtureSchemaDeepNestedUnionMapVsClassSibling stacks two levels of
+// nested union: `union[ union[ union[map, T], string ], class_ref
+// Inner ]`. Pins arbitrary-depth propagation of the constraint
+// through transparent wrappers, bounded by MaxTypeDepth.
+func fixtureSchemaDeepNestedUnionMapVsClassSibling() FuzzSchema {
+	keyT := FuzzType{Kind: KindString}
+	intT := FuzzType{Kind: KindInt}
+	innermost := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindMap, Key: &keyT, Inner: &intT},
+			{Kind: KindInt},
+		},
+	}
+	middle := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			innermost,
+			{Kind: KindString},
+		},
+	}
+	inner := FuzzClass{
+		Name: "Inner",
+		Properties: []FuzzProperty{
+			{Name: "Fuzz_field_0", Type: FuzzType{Kind: KindInt}},
+		},
+	}
+	outer := FuzzClass{
+		Name: "Outer",
+		Properties: []FuzzProperty{
+			{Name: "f", Type: FuzzType{
+				Kind: KindUnion,
+				Variants: []FuzzType{
+					middle,
+					{Kind: KindClassRef, Ref: "Inner"},
+				},
+			}},
+		},
+	}
+	return AnalyzeGraph(FuzzSchema{
+		Classes:   []FuzzClass{outer, inner},
+		RootClass: "Outer",
+	})
+}
+
+// TestValueGenDeepNestedUnionMapArmWithClassSiblingNeverEmpty walks
+// the two-level nested union case. When the picked path traverses
+// outer → middle → innermost → map, the leaf map must be non-empty.
+func TestValueGenDeepNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.T) {
+	schema := fixtureSchemaDeepNestedUnionMapVsClassSibling()
+	var exercised bool
+	rapid.Check(t, func(rt *rapid.T) {
+		v := ValueGen(schema).Draw(rt, "v")
+		fv, ok := v.LookupField("f")
+		if !ok {
+			rt.Fatalf("outer instance missing field f")
+		}
+		if fv.Kind != KindUnion || fv.Variant == nil {
+			rt.Fatalf("field f expected union value, got %v", fv.Kind)
+		}
+		if fv.VariantIndex != 0 {
+			return
+		}
+		mid := fv.Variant
+		if mid.Kind != KindUnion || mid.Variant == nil {
+			rt.Fatalf("outer arm 0 expected middle union value, got %v", mid.Kind)
+		}
+		if mid.VariantIndex != 0 {
+			return
+		}
+		innermost := mid.Variant
+		if innermost.Kind != KindUnion || innermost.Variant == nil {
+			rt.Fatalf("middle arm 0 expected innermost union value, got %v", innermost.Kind)
+		}
+		if innermost.VariantIndex != 0 {
+			return
+		}
+		leaf := innermost.Variant
+		if leaf.Kind != KindMap {
+			rt.Fatalf("innermost arm 0 expected map value, got %v", leaf.Kind)
+		}
+		exercised = true
+		if len(leaf.MapEntries) == 0 {
+			rt.Fatalf("deep-nested map arm produced an empty map — ambiguous with outermost class sibling under BAML coercion")
+		}
+	})
+	if !exercised {
+		t.Fatalf("rapid budget never reached deep-nested map leaf — coverage sentinel never fired; non-empty-map invariant unverified")
+	}
+}
+
 // TestValueGenMapArmWithoutClassSiblingMayBeEmpty pins the fix's
 // targeting: when no sibling reaches a class, the map arm is allowed
 // to draw as empty. Asserted by observing at least one empty-map
@@ -1703,11 +1972,12 @@ func TestValueGenStaticSchemaUnionMapArmInvariant(t *testing.T) {
 }
 
 // assertPickedArmLeafMapNonEmpty walks a (type, value) pair whose
-// effective leaf type is KindMap, descending through KindOptional
-// wrappers on the value side. At every present optional it recurses;
-// when it reaches KindMap it asserts the entry list is non-empty.
-// Absent/null optional shapes terminate the walk without an assertion
-// (no `{}` is emitted in those cases).
+// effective leaf type reaches KindMap through transparent wrappers
+// (KindOptional and nested KindUnion). At every present optional and
+// at every union it descends into the picked subtype/subvalue; when
+// it reaches KindMap it asserts the entry list is non-empty. Absent
+// /null optional shapes terminate the walk without an assertion (no
+// `{}` is emitted in those cases).
 func assertPickedArmLeafMapNonEmpty(rt *rapid.T, t FuzzType, v FuzzValue) {
 	switch t.Kind {
 	case KindMap:
@@ -1715,7 +1985,7 @@ func assertPickedArmLeafMapNonEmpty(rt *rapid.T, t FuzzType, v FuzzValue) {
 			rt.Fatalf("expected map value at leaf, got %v", v.Kind)
 		}
 		if len(v.MapEntries) == 0 {
-			rt.Fatalf("map arm produced empty map with class-reachable sibling (leaf under %d optional wrappers)", 0)
+			rt.Fatalf("map arm produced empty map with class-reachable sibling")
 		}
 	case KindOptional:
 		if v.Kind != KindOptional {
@@ -1724,6 +1994,17 @@ func assertPickedArmLeafMapNonEmpty(rt *rapid.T, t FuzzType, v FuzzValue) {
 		if v.OptionalShape == OptionalPresent && v.Inner != nil && t.Inner != nil {
 			assertPickedArmLeafMapNonEmpty(rt, *t.Inner, *v.Inner)
 		}
+	case KindUnion:
+		if v.Kind != KindUnion {
+			rt.Fatalf("expected union value, got %v", v.Kind)
+		}
+		if v.Variant == nil {
+			rt.Fatalf("union value missing Variant")
+		}
+		if v.VariantIndex < 0 || v.VariantIndex >= len(t.Variants) {
+			rt.Fatalf("union value VariantIndex %d out of range (arms=%d)", v.VariantIndex, len(t.Variants))
+		}
+		assertPickedArmLeafMapNonEmpty(rt, t.Variants[v.VariantIndex], *v.Variant)
 	}
 }
 
@@ -1737,7 +2018,7 @@ func walkValueForMapArmAmbiguity(rt *rapid.T, t FuzzType, v FuzzValue, schema Fu
 			return
 		}
 		arm := t.Variants[v.VariantIndex]
-		if pickedArmEffectiveKindIsMap(arm) && unionHasClassReachableSibling(t, v.VariantIndex) {
+		if pickedArmReachesMapThroughTransparent(arm, 0) && unionHasClassReachableSibling(t, v.VariantIndex) {
 			assertPickedArmLeafMapNonEmpty(rt, arm, *v.Variant)
 		}
 		walkValueForMapArmAmbiguity(rt, arm, *v.Variant, schema)

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -2193,3 +2193,120 @@ func walkValueForMapArmAmbiguity(rt *rapid.T, t FuzzType, v FuzzValue, schema Fu
 		}
 	}
 }
+
+// fixtureSchemaNestedUnionAmbientClampClassSibling builds the nested
+// analogue of fixtureSchemaRecursiveUnionMapClampClassSibling: the map
+// arm Codex's r4 finding names lives inside an INNER union whose own
+// arms reach no class, while the OUTER union holds the class_ref
+// sibling. `A → union[ union[map<string,A>, list<A>], class_ref B ]`,
+// `B → optional<class_ref A>`.
+//
+// Entering A twice exhausts its per-class budget. At the depth-2 A the
+// outer union's both arms sit over the cap (the inner-union arm reaches
+// A through its map/list, the class_ref B arm reaches A through B's
+// optional), so the safe-arm set empties and the outer falls back —
+// then prunes to the class-ambiguity-safe set and may still pick the
+// inner-union arm, whose list sibling keeps it off the forced-empty
+// list. Descending into that inner union, the local class check is
+// false: its only arms are map<string,A> and list<A>, neither a direct
+// class_ref. Before threading the ambient flag the nested
+// unionDrawCandidates therefore skipped the prune and could pick the
+// over-cap map arm, where drawMap clamps minLen=1 down to 0 and emits
+// `{}` — byte-identical to a null-materialized A and coerced by BAML to
+// the outer's class_ref B sibling. With the ambient flag on, the
+// nested prune drops the forced map arm and the pick lands on list<A>,
+// which clamps to `[]` (unambiguous) at the cap.
+func fixtureSchemaNestedUnionAmbientClampClassSibling() FuzzSchema {
+	keyT := FuzzType{Kind: KindString}
+	mapValT := FuzzType{Kind: KindClassRef, Ref: "A"}
+	listValT := FuzzType{Kind: KindClassRef, Ref: "A"}
+	innerUnion := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindMap, Key: &keyT, Inner: &mapValT},
+			{Kind: KindList, Inner: &listValT},
+		},
+	}
+	a := FuzzClass{
+		Name: "A",
+		Properties: []FuzzProperty{
+			{Name: "f", Type: FuzzType{
+				Kind: KindUnion,
+				Variants: []FuzzType{
+					innerUnion,
+					{Kind: KindClassRef, Ref: "B"},
+				},
+			}},
+		},
+	}
+	bOptInner := FuzzType{Kind: KindClassRef, Ref: "A"}
+	b := FuzzClass{
+		Name: "B",
+		Properties: []FuzzProperty{
+			{Name: "g", Type: FuzzType{Kind: KindOptional, Inner: &bOptInner}},
+		},
+	}
+	return AnalyzeGraph(FuzzSchema{
+		Classes:   []FuzzClass{a, b},
+		RootClass: "A",
+	})
+}
+
+// nestedAmbientFallbackExercised reports whether the draw populated the
+// depth-1 inner-union map arm: the outer union picked its inner-union
+// arm (index 0) and the inner union picked its map arm (index 0) with
+// at least one entry. Each entry is a depth-2 A instance whose own
+// outer union sits over the recursion cap on both arms — the fallback
+// path the regression guards. A non-empty depth-1 inner map therefore
+// proves the depth-2 nested fallback was reached, so the leaf assertion
+// below actually covered it. The sentinel holds on both the pre-fix
+// (clamped `{}` at depth 2) and post-fix (list arm at depth 2) runs:
+// the depth-1 map is never clamped, so it stays the stable coverage
+// proof.
+func nestedAmbientFallbackExercised(v FuzzValue) bool {
+	fv, ok := v.LookupField("f")
+	if !ok || fv.Kind != KindUnion || fv.Variant == nil {
+		return false
+	}
+	if fv.VariantIndex != 0 {
+		return false
+	}
+	inner := fv.Variant
+	if inner.Kind != KindUnion || inner.Variant == nil {
+		return false
+	}
+	if inner.VariantIndex != 0 || inner.Variant.Kind != KindMap {
+		return false
+	}
+	return len(inner.Variant.MapEntries) > 0
+}
+
+// TestValueGenNestedUnionAmbientConstraintNeverEmpty is the
+// deterministic regression for the nested-union ensure path Codex's r4
+// review found. drawArmEnsuringMapNonEmpty reuses unionDrawCandidates
+// for nested unions; before the ambient flag that helper pruned
+// forced-empty map arms only when the nested union had its own
+// class-reachable arm. The shape here
+// (`union[ union[map<string,A>, list<A>], class_ref B ]` at the cap)
+// has the class sibling on the OUTER union, so the nested prune was
+// skipped and the over-cap map arm rendered an ambiguous `{}`. The
+// ambient flag carries the outer union's class-reachability into the
+// nested candidate filter, so the forced map arm is dropped and the
+// pick lands on the list arm. The wide-net
+// TestValueGenStaticSchemaUnionMapArmInvariant catches this shape
+// transitively; this fixture pins it directly.
+func TestValueGenNestedUnionAmbientConstraintNeverEmpty(t *testing.T) {
+	defer raiseRapidChecksFloor(t, 5000)()
+	schema := fixtureSchemaNestedUnionAmbientClampClassSibling()
+	var exercised bool
+	rapid.Check(t, func(rt *rapid.T) {
+		v := ValueGen(schema).Draw(rt, "v")
+		if nestedAmbientFallbackExercised(v) {
+			exercised = true
+		}
+		walkValueForMapArmAmbiguity(rt, schema.EffectiveRoot(), v, schema)
+	})
+	if !exercised {
+		t.Fatalf("rapid budget never reached the depth-clamped nested fallback union — coverage sentinel never fired; regression unverified")
+	}
+}

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -1559,6 +1559,83 @@ func TestValueGenMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	})
 }
 
+// fixtureSchemaOptionalMapVsClassSiblingUnion mirrors
+// fixtureSchemaMapVsClassSiblingUnion but the map arm sits under an
+// optional wrapper. The picked-arm dispatch must descend through the
+// optional and apply the non-empty-map constraint at the leaf when the
+// optional draws as present, matching the sibling-side reach helper
+// (which descends through optionals).
+func fixtureSchemaOptionalMapVsClassSiblingUnion() FuzzSchema {
+	keyT := FuzzType{Kind: KindString}
+	intT := FuzzType{Kind: KindInt}
+	mapT := FuzzType{Kind: KindMap, Key: &keyT, Inner: &intT}
+	optMap := FuzzType{Kind: KindOptional, Inner: &mapT}
+	inner := FuzzClass{
+		Name: "Inner",
+		Properties: []FuzzProperty{
+			{Name: "Fuzz_field_0", Type: FuzzType{Kind: KindInt}},
+		},
+	}
+	outer := FuzzClass{
+		Name: "Outer",
+		Properties: []FuzzProperty{
+			{Name: "f", Type: FuzzType{
+				Kind: KindUnion,
+				Variants: []FuzzType{
+					optMap,
+					{Kind: KindClassRef, Ref: "Inner"},
+				},
+			}},
+		},
+	}
+	return AnalyzeGraph(FuzzSchema{
+		Classes:   []FuzzClass{outer, inner},
+		RootClass: "Outer",
+	})
+}
+
+// TestValueGenOptionalMapArmWithClassSiblingNeverEmpty is the
+// regression guard for the picked-arm/sibling-side asymmetry: when a
+// union arm is `optional<map<...>>` and a sibling reaches a class_ref,
+// a present optional must not draw an empty map. An empty `{}` is byte-
+// identical to a null-materialized class instance, which BAML coerces
+// to the class arm — diverging from the walker's recorded choice.
+// The companion direct-arm guard
+// (TestValueGenMapArmWithClassSiblingNeverEmpty) pins the same property
+// for the no-wrapper shape; both must hold for the union resolver's
+// coercion to remain unambiguous.
+func TestValueGenOptionalMapArmWithClassSiblingNeverEmpty(t *testing.T) {
+	schema := fixtureSchemaOptionalMapVsClassSiblingUnion()
+	rapid.Check(t, func(rt *rapid.T) {
+		v := ValueGen(schema).Draw(rt, "v")
+		fv, ok := v.LookupField("f")
+		if !ok {
+			rt.Fatalf("outer instance missing field f")
+		}
+		if fv.Kind != KindUnion || fv.Variant == nil {
+			rt.Fatalf("field f expected union value, got %v", fv.Kind)
+		}
+		if fv.VariantIndex != 0 {
+			return
+		}
+		if fv.Variant.Kind != KindOptional {
+			rt.Fatalf("union arm 0 expected to be an optional value, got %v", fv.Variant.Kind)
+		}
+		if fv.Variant.OptionalShape != OptionalPresent {
+			return
+		}
+		if fv.Variant.Inner == nil {
+			rt.Fatalf("present optional missing Inner")
+		}
+		if fv.Variant.Inner.Kind != KindMap {
+			rt.Fatalf("present optional expected map at leaf, got %v", fv.Variant.Inner.Kind)
+		}
+		if len(fv.Variant.Inner.MapEntries) == 0 {
+			rt.Fatalf("present optional<map> drew empty map — ambiguous with class sibling under BAML coercion")
+		}
+	})
+}
+
 // TestValueGenMapArmWithoutClassSiblingMayBeEmpty pins the fix's
 // targeting: when no sibling reaches a class, the map arm is allowed
 // to draw as empty. Asserted by observing at least one empty-map
@@ -1612,16 +1689,42 @@ func TestValueGenMapArmWithoutClassSiblingMayBeEmpty(t *testing.T) {
 
 // TestValueGenStaticSchemaUnionMapArmInvariant is the wide-net
 // invariant: across StaticSchemaGen, every drawn (schema, value) pair
-// whose union picks a direct map arm with a class-reachable sibling
-// must carry a non-empty map. Backstops the targeted fixture test
-// against future generator paths that could re-introduce the empty-
-// map draw.
+// whose union picks a direct or optional-wrapped map arm with a
+// class-reachable sibling must carry a non-empty map at the leaf when
+// any wrapping optionals drew present. Backstops the targeted fixture
+// tests against future generator paths that could re-introduce the
+// empty-map draw at either the direct or the optional<map> arm shape.
 func TestValueGenStaticSchemaUnionMapArmInvariant(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		schema := StaticSchemaGen().Draw(rt, "schema")
 		value := ValueGen(schema).Draw(rt, "value")
 		walkValueForMapArmAmbiguity(rt, schema.EffectiveRoot(), value, schema)
 	})
+}
+
+// assertPickedArmLeafMapNonEmpty walks a (type, value) pair whose
+// effective leaf type is KindMap, descending through KindOptional
+// wrappers on the value side. At every present optional it recurses;
+// when it reaches KindMap it asserts the entry list is non-empty.
+// Absent/null optional shapes terminate the walk without an assertion
+// (no `{}` is emitted in those cases).
+func assertPickedArmLeafMapNonEmpty(rt *rapid.T, t FuzzType, v FuzzValue) {
+	switch t.Kind {
+	case KindMap:
+		if v.Kind != KindMap {
+			rt.Fatalf("expected map value at leaf, got %v", v.Kind)
+		}
+		if len(v.MapEntries) == 0 {
+			rt.Fatalf("map arm produced empty map with class-reachable sibling (leaf under %d optional wrappers)", 0)
+		}
+	case KindOptional:
+		if v.Kind != KindOptional {
+			rt.Fatalf("expected optional value, got %v", v.Kind)
+		}
+		if v.OptionalShape == OptionalPresent && v.Inner != nil && t.Inner != nil {
+			assertPickedArmLeafMapNonEmpty(rt, *t.Inner, *v.Inner)
+		}
+	}
 }
 
 func walkValueForMapArmAmbiguity(rt *rapid.T, t FuzzType, v FuzzValue, schema FuzzSchema) {
@@ -1634,13 +1737,8 @@ func walkValueForMapArmAmbiguity(rt *rapid.T, t FuzzType, v FuzzValue, schema Fu
 			return
 		}
 		arm := t.Variants[v.VariantIndex]
-		if arm.Kind == KindMap && unionHasClassReachableSibling(t, v.VariantIndex) {
-			if v.Variant.Kind != KindMap {
-				rt.Fatalf("union picked map arm but value is %v", v.Variant.Kind)
-			}
-			if len(v.Variant.MapEntries) == 0 {
-				rt.Fatalf("map arm produced empty map with class-reachable sibling")
-			}
+		if pickedArmEffectiveKindIsMap(arm) && unionHasClassReachableSibling(t, v.VariantIndex) {
+			assertPickedArmLeafMapNonEmpty(rt, arm, *v.Variant)
 		}
 		walkValueForMapArmAmbiguity(rt, arm, *v.Variant, schema)
 	case KindOptional:

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -2099,10 +2099,11 @@ func raiseRapidChecksFloor(t *testing.T, floor int) func() {
 // tests against future generator paths that could re-introduce the
 // empty-map draw at either the direct or the optional<map> arm shape.
 //
-// The check budget is floored at 5000: the default 100 did not surface
-// the recursion-cap fallback Codex hit at 1315 cases under seed
-// 12166613081859382899, and 5000 covers that class of generator
-// regression in well under a second.
+// In BAMLFUZZ_RAPID_STRESS=1 runs, the check budget is floored at
+// 5000: rapid's default budget did not surface the recursion-cap
+// fallback Codex hit at 1315 cases under seed 12166613081859382899,
+// and 5000 covers that class of generator regression. Default runs
+// keep rapid's standard budget.
 func TestValueGenStaticSchemaUnionMapArmInvariant(t *testing.T) {
 	defer raiseRapidChecksFloor(t, 5000)()
 	rapid.Check(t, func(rt *rapid.T) {

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -1411,3 +1411,270 @@ func valueDumpJSON(v FuzzValue) string {
 	}
 	return string(b)
 }
+
+// --- Regression coverage for issue #349: union-arm coercion ambiguity.
+//
+// An empty map `{}` rendered for a union's direct map arm is byte-
+// identical to an empty/null-materialized class instance, and BAML's
+// union resolver coerces such `{}` to the class arm whenever a class
+// is reachable through a sibling arm — diverging from the walker's
+// prediction. The generator therefore forbids a zero-length map for
+// such direct map arms.
+
+func TestUnionHasClassReachableSibling_Direct(t *testing.T) {
+	keyT := FuzzType{Kind: KindString}
+	intT := FuzzType{Kind: KindInt}
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindMap, Key: &keyT, Inner: &intT},
+			{Kind: KindClassRef, Ref: "X"},
+		},
+	}
+	if !unionHasClassReachableSibling(uni, 0) {
+		t.Fatalf("direct class_ref sibling not detected")
+	}
+	if unionHasClassReachableSibling(uni, 1) {
+		t.Fatalf("excluded sibling falsely reported as class-reachable")
+	}
+}
+
+func TestUnionHasClassReachableSibling_NestedUnion(t *testing.T) {
+	keyT := FuzzType{Kind: KindString}
+	intT := FuzzType{Kind: KindInt}
+	inner := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindClassRef, Ref: "X"},
+		},
+	}
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			inner,
+			{Kind: KindMap, Key: &keyT, Inner: &intT},
+		},
+	}
+	if !unionHasClassReachableSibling(uni, 1) {
+		t.Fatalf("class_ref through nested union not detected")
+	}
+}
+
+func TestUnionHasClassReachableSibling_OptionalWrap(t *testing.T) {
+	cls := FuzzType{Kind: KindClassRef, Ref: "X"}
+	opt := FuzzType{Kind: KindOptional, Inner: &cls}
+	keyT := FuzzType{Kind: KindString}
+	intT := FuzzType{Kind: KindInt}
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindMap, Key: &keyT, Inner: &intT},
+			opt,
+		},
+	}
+	if !unionHasClassReachableSibling(uni, 0) {
+		t.Fatalf("class_ref through optional wrapper not detected")
+	}
+}
+
+func TestUnionHasClassReachableSibling_NoClass(t *testing.T) {
+	keyT := FuzzType{Kind: KindString}
+	intT := FuzzType{Kind: KindInt}
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindMap, Key: &keyT, Inner: &intT},
+			{Kind: KindString},
+			{Kind: KindInt},
+		},
+	}
+	if unionHasClassReachableSibling(uni, 0) {
+		t.Fatalf("class-free union falsely reported as class-reachable")
+	}
+}
+
+func TestUnionHasClassReachableSibling_NonUnionInput(t *testing.T) {
+	if unionHasClassReachableSibling(FuzzType{Kind: KindMap}, 0) {
+		t.Fatalf("non-union input must report false")
+	}
+}
+
+// fixtureSchemaMapVsClassSiblingUnion is the minimal reproduction of
+// the envelope shape: a class whose single field is a union with a
+// direct map arm and a class_ref arm. Used by the regression rapid
+// check below.
+func fixtureSchemaMapVsClassSiblingUnion() FuzzSchema {
+	keyT := FuzzType{Kind: KindString}
+	intT := FuzzType{Kind: KindInt}
+	inner := FuzzClass{
+		Name: "Inner",
+		Properties: []FuzzProperty{
+			{Name: "Fuzz_field_0", Type: FuzzType{Kind: KindInt}},
+		},
+	}
+	outer := FuzzClass{
+		Name: "Outer",
+		Properties: []FuzzProperty{
+			{Name: "f", Type: FuzzType{
+				Kind: KindUnion,
+				Variants: []FuzzType{
+					{Kind: KindMap, Key: &keyT, Inner: &intT},
+					{Kind: KindClassRef, Ref: "Inner"},
+				},
+			}},
+		},
+	}
+	return AnalyzeGraph(FuzzSchema{
+		Classes:   []FuzzClass{outer, inner},
+		RootClass: "Outer",
+	})
+}
+
+// TestValueGenMapArmWithClassSiblingNeverEmpty is the durable
+// regression guard. With a union whose map arm has a class-reachable
+// sibling, ValueGen must never produce an empty map for the picked
+// map arm — otherwise the walker's Expected (`{}`) diverges from BAML
+// (which coerces `{}` to the class arm with null-filled fields).
+func TestValueGenMapArmWithClassSiblingNeverEmpty(t *testing.T) {
+	schema := fixtureSchemaMapVsClassSiblingUnion()
+	rapid.Check(t, func(rt *rapid.T) {
+		v := ValueGen(schema).Draw(rt, "v")
+		fv, ok := v.LookupField("f")
+		if !ok {
+			rt.Fatalf("outer instance missing field f")
+		}
+		if fv.Kind != KindUnion || fv.Variant == nil {
+			rt.Fatalf("field f expected union value, got %v", fv.Kind)
+		}
+		if fv.VariantIndex != 0 {
+			return
+		}
+		if fv.Variant.Kind != KindMap {
+			rt.Fatalf("union arm 0 expected to be a map value, got %v", fv.Variant.Kind)
+		}
+		if len(fv.Variant.MapEntries) == 0 {
+			rt.Fatalf("map arm produced an empty map — ambiguous with class sibling under BAML coercion")
+		}
+	})
+}
+
+// TestValueGenMapArmWithoutClassSiblingMayBeEmpty pins the fix's
+// targeting: when no sibling reaches a class, the map arm is allowed
+// to draw as empty. Asserted by observing at least one empty-map
+// draw across the rapid sample budget. Without this guard the fix
+// could over-trigger and shift the corpus more than needed.
+func TestValueGenMapArmWithoutClassSiblingMayBeEmpty(t *testing.T) {
+	keyT := FuzzType{Kind: KindString}
+	intT := FuzzType{Kind: KindInt}
+	outer := FuzzClass{
+		Name: "Outer",
+		Properties: []FuzzProperty{
+			{Name: "f", Type: FuzzType{
+				Kind: KindUnion,
+				Variants: []FuzzType{
+					{Kind: KindMap, Key: &keyT, Inner: &intT},
+					{Kind: KindString},
+					{Kind: KindInt},
+				},
+			}},
+		},
+	}
+	schema := AnalyzeGraph(FuzzSchema{
+		Classes:   []FuzzClass{outer},
+		RootClass: "Outer",
+	})
+	var sawEmpty, sawMapPick bool
+	rapid.Check(t, func(rt *rapid.T) {
+		v := ValueGen(schema).Draw(rt, "v")
+		fv, ok := v.LookupField("f")
+		if !ok {
+			rt.Fatalf("outer instance missing field f")
+		}
+		if fv.Kind != KindUnion || fv.Variant == nil {
+			rt.Fatalf("field f expected union value, got %v", fv.Kind)
+		}
+		if fv.VariantIndex != 0 {
+			return
+		}
+		sawMapPick = true
+		if len(fv.Variant.MapEntries) == 0 {
+			sawEmpty = true
+		}
+	})
+	if !sawMapPick {
+		t.Skip("rapid budget did not pick the map arm — sample-size flake; rerun")
+	}
+	if !sawEmpty {
+		t.Fatalf("empty-map draw never observed for class-free sibling union — fix is over-triggering")
+	}
+}
+
+// TestValueGenStaticSchemaUnionMapArmInvariant is the wide-net
+// invariant: across StaticSchemaGen, every drawn (schema, value) pair
+// whose union picks a direct map arm with a class-reachable sibling
+// must carry a non-empty map. Backstops the targeted fixture test
+// against future generator paths that could re-introduce the empty-
+// map draw.
+func TestValueGenStaticSchemaUnionMapArmInvariant(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		schema := StaticSchemaGen().Draw(rt, "schema")
+		value := ValueGen(schema).Draw(rt, "value")
+		walkValueForMapArmAmbiguity(rt, schema.EffectiveRoot(), value, schema)
+	})
+}
+
+func walkValueForMapArmAmbiguity(rt *rapid.T, t FuzzType, v FuzzValue, schema FuzzSchema) {
+	switch t.Kind {
+	case KindUnion:
+		if v.Kind != KindUnion || v.Variant == nil {
+			return
+		}
+		if v.VariantIndex < 0 || v.VariantIndex >= len(t.Variants) {
+			return
+		}
+		arm := t.Variants[v.VariantIndex]
+		if arm.Kind == KindMap && unionHasClassReachableSibling(t, v.VariantIndex) {
+			if v.Variant.Kind != KindMap {
+				rt.Fatalf("union picked map arm but value is %v", v.Variant.Kind)
+			}
+			if len(v.Variant.MapEntries) == 0 {
+				rt.Fatalf("map arm produced empty map with class-reachable sibling")
+			}
+		}
+		walkValueForMapArmAmbiguity(rt, arm, *v.Variant, schema)
+	case KindOptional:
+		if v.OptionalShape == OptionalPresent && v.Inner != nil && t.Inner != nil {
+			walkValueForMapArmAmbiguity(rt, *t.Inner, *v.Inner, schema)
+		}
+	case KindList:
+		if t.Inner == nil {
+			return
+		}
+		for _, item := range v.Items {
+			walkValueForMapArmAmbiguity(rt, *t.Inner, item, schema)
+		}
+	case KindMap:
+		if t.Inner == nil {
+			return
+		}
+		for _, e := range v.MapEntries {
+			walkValueForMapArmAmbiguity(rt, *t.Inner, e.Value, schema)
+		}
+	case KindClassRef:
+		if v.Kind != KindClassRef {
+			return
+		}
+		cls, ok := schema.FindClass(v.ClassName)
+		if !ok {
+			return
+		}
+		for _, prop := range cls.Properties {
+			fv, ok := v.LookupField(prop.Name)
+			if !ok {
+				continue
+			}
+			walkValueForMapArmAmbiguity(rt, prop.Type, fv, schema)
+		}
+	}
+}

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -3,7 +3,9 @@ package bamlfuzz
 import (
 	"encoding/json"
 	"errors"
+	"flag"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1966,6 +1968,117 @@ func TestValueGenMapArmWithoutClassSiblingMayBeEmpty(t *testing.T) {
 	}
 }
 
+// fixtureSchemaRecursiveUnionMapClampClassSibling builds the mutual-
+// cycle shape Codex's r3 stress run reduced to: a union whose direct
+// map arm and class_ref sibling BOTH reach the recursion cap at the
+// same point, so the safe-arm filter empties and the draw falls back
+// to the over-cap arms. There drawMap clamps the map length to 0,
+// which previously rendered the ambiguous empty map `{}` against the
+// class sibling. `A → union[map<string,A>, class_ref B]`, `B →
+// optional<class_ref A>`: entering A twice exhausts its budget, at
+// which point the map arm (reaches A, over cap) and the class_ref B
+// arm (B reaches A, over cap) are both pruned from the safe set. The
+// fix steers the fallback pick to the class_ref B arm, whose only
+// field is an optional that terminates as absent/null at the cap.
+func fixtureSchemaRecursiveUnionMapClampClassSibling() FuzzSchema {
+	keyT := FuzzType{Kind: KindString}
+	mapValT := FuzzType{Kind: KindClassRef, Ref: "A"}
+	mapAA := FuzzType{Kind: KindMap, Key: &keyT, Inner: &mapValT}
+	a := FuzzClass{
+		Name: "A",
+		Properties: []FuzzProperty{
+			{Name: "f", Type: FuzzType{
+				Kind: KindUnion,
+				Variants: []FuzzType{
+					mapAA,
+					{Kind: KindClassRef, Ref: "B"},
+				},
+			}},
+		},
+	}
+	bOptInner := FuzzType{Kind: KindClassRef, Ref: "A"}
+	b := FuzzClass{
+		Name: "B",
+		Properties: []FuzzProperty{
+			{Name: "g", Type: FuzzType{Kind: KindOptional, Inner: &bOptInner}},
+		},
+	}
+	return AnalyzeGraph(FuzzSchema{
+		Classes:   []FuzzClass{a, b},
+		RootClass: "A",
+	})
+}
+
+// recursiveFallbackExercised reports whether the draw populated the
+// root union's map arm. Each map entry is a depth-2 A instance whose
+// own union sits over the recursion cap on both arms — the fallback
+// the regression guards. A non-empty root map therefore proves the
+// clamp path was reached, so the assertion below actually covered it.
+func recursiveFallbackExercised(v FuzzValue) bool {
+	fv, ok := v.LookupField("f")
+	if !ok || fv.Kind != KindUnion || fv.Variant == nil {
+		return false
+	}
+	if fv.VariantIndex != 0 || fv.Variant.Kind != KindMap {
+		return false
+	}
+	return len(fv.Variant.MapEntries) > 0
+}
+
+// TestValueGenRecursiveFallbackMapArmWithClassSiblingNeverEmpty is the
+// deterministic regression for the recursion-cap fallback Codex found
+// in r3. When the union's safe-arm set empties (every arm over the
+// cap) and a class_ref sibling is present, the draw must not fall back
+// to the map arm and render a depth-clamped `{}` — BAML coerces that
+// empty map to the class sibling, diverging from the walker's recorded
+// map choice. Before the picker-level fix this fixture draws empty
+// ambiguous maps at the depth-2 union; after it, the fallback picks
+// the terminating class_ref arm and the leaf invariant holds.
+func TestValueGenRecursiveFallbackMapArmWithClassSiblingNeverEmpty(t *testing.T) {
+	schema := fixtureSchemaRecursiveUnionMapClampClassSibling()
+	var exercised bool
+	rapid.Check(t, func(rt *rapid.T) {
+		v := ValueGen(schema).Draw(rt, "v")
+		if recursiveFallbackExercised(v) {
+			exercised = true
+		}
+		walkValueForMapArmAmbiguity(rt, schema.EffectiveRoot(), v, schema)
+	})
+	if !exercised {
+		t.Fatalf("rapid budget never reached the depth-clamped fallback union — coverage sentinel never fired; regression unverified")
+	}
+}
+
+// raiseRapidChecksFloor lifts the rapid check budget for the calling
+// test to at least floor, returning a restore func. An explicit
+// -rapid.checks above floor on the command line is left untouched —
+// the floor only raises the default. Package tests are sequential
+// (none call t.Parallel), so the global flag mutation is safe across
+// the test's lifetime.
+func raiseRapidChecksFloor(t *testing.T, floor int) func() {
+	t.Helper()
+	f := flag.Lookup("rapid.checks")
+	if f == nil {
+		return func() {}
+	}
+	getter, ok := f.Value.(flag.Getter)
+	if !ok {
+		return func() {}
+	}
+	prev, ok := getter.Get().(int)
+	if !ok {
+		return func() {}
+	}
+	if prev >= floor {
+		return func() {}
+	}
+	prevStr := f.Value.String()
+	if err := flag.Set("rapid.checks", strconv.Itoa(floor)); err != nil {
+		return func() {}
+	}
+	return func() { _ = flag.Set("rapid.checks", prevStr) }
+}
+
 // TestValueGenStaticSchemaUnionMapArmInvariant is the wide-net
 // invariant: across StaticSchemaGen, every drawn (schema, value) pair
 // whose union picks a direct or optional-wrapped map arm with a
@@ -1973,7 +2086,13 @@ func TestValueGenMapArmWithoutClassSiblingMayBeEmpty(t *testing.T) {
 // any wrapping optionals drew present. Backstops the targeted fixture
 // tests against future generator paths that could re-introduce the
 // empty-map draw at either the direct or the optional<map> arm shape.
+//
+// The check budget is floored at 5000: the default 100 did not surface
+// the recursion-cap fallback Codex hit at 1315 cases under seed
+// 12166613081859382899, and 5000 covers that class of generator
+// regression in well under a second.
 func TestValueGenStaticSchemaUnionMapArmInvariant(t *testing.T) {
+	defer raiseRapidChecksFloor(t, 5000)()
 	rapid.Check(t, func(rt *rapid.T) {
 		schema := StaticSchemaGen().Draw(rt, "schema")
 		value := ValueGen(schema).Draw(rt, "value")

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -1961,7 +1962,7 @@ func TestValueGenMapArmWithoutClassSiblingMayBeEmpty(t *testing.T) {
 		}
 	})
 	if !sawMapPick {
-		t.Skip("rapid budget did not pick the map arm — sample-size flake; rerun")
+		t.Fatalf("rapid budget never picked the map arm — targeting guard never exercised; regression unverified")
 	}
 	if !sawEmpty {
 		t.Fatalf("empty-map draw never observed for class-free sibling union — fix is over-triggering")
@@ -2055,8 +2056,19 @@ func TestValueGenRecursiveFallbackMapArmWithClassSiblingNeverEmpty(t *testing.T)
 // the floor only raises the default. Package tests are sequential
 // (none call t.Parallel), so the global flag mutation is safe across
 // the test's lifetime.
+//
+// The floor is opt-in via BAMLFUZZ_RAPID_STRESS=1. By default it is a
+// no-op so the package runs at rapid's standard budget; the default
+// unit-tests CI job invokes `go test -race -count=100`, where a high
+// floor compounds across the 100 iterations and the race instrument
+// into a multi-minute-per-test cost that blows the package timeout.
+// The nightly stress job sets BAMLFUZZ_RAPID_STRESS=1 to exercise the
+// higher budget that surfaced the recursion-cap regression.
 func raiseRapidChecksFloor(t *testing.T, floor int) func() {
 	t.Helper()
+	if os.Getenv("BAMLFUZZ_RAPID_STRESS") != "1" {
+		return func() {}
+	}
 	f := flag.Lookup("rapid.checks")
 	if f == nil {
 		return func() {}

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -2252,17 +2252,22 @@ func fixtureSchemaNestedUnionAmbientClampClassSibling() FuzzSchema {
 	})
 }
 
-// nestedAmbientFallbackExercised reports whether the draw populated the
-// depth-1 inner-union map arm: the outer union picked its inner-union
-// arm (index 0) and the inner union picked its map arm (index 0) with
-// at least one entry. Each entry is a depth-2 A instance whose own
-// outer union sits over the recursion cap on both arms — the fallback
-// path the regression guards. A non-empty depth-1 inner map therefore
-// proves the depth-2 nested fallback was reached, so the leaf assertion
-// below actually covered it. The sentinel holds on both the pre-fix
-// (clamped `{}` at depth 2) and post-fix (list arm at depth 2) runs:
-// the depth-1 map is never clamped, so it stays the stable coverage
-// proof.
+// nestedAmbientFallbackExercised reports whether the draw actually
+// descended into the depth-2 nested-union arm — the only path that
+// exercises the ambient prune. The depth-1 frame must pick the outer
+// union's inner-union arm (index 0), then the inner union's map arm
+// (index 0). A non-empty depth-1 map alone is insufficient: those
+// entries are depth-2 A instances that could each pick the outer
+// union's class_ref B sibling, leaving the ambient-pruned nested union
+// (`drawArmEnsuringMapNonEmpty` → nested KindUnion →
+// `unionDrawCandidates(arm, true)`) untouched. So we require at least
+// one depth-1 map entry whose value is an A whose own `f` field picked
+// the outer nested-union arm (VariantIndex == 0, wrapping a KindUnion).
+// That is the depth-2 nested-union pick that drives the ambient
+// fallback the regression guards. The sentinel holds on both the
+// pre-fix (clamped `{}` at the depth-2 leaf) and post-fix (list arm at
+// the depth-2 leaf) runs: it keys off the depth-2 union choice, which
+// is taken in both, not off the leaf's clamped shape.
 func nestedAmbientFallbackExercised(v FuzzValue) bool {
 	fv, ok := v.LookupField("f")
 	if !ok || fv.Kind != KindUnion || fv.Variant == nil {
@@ -2278,7 +2283,19 @@ func nestedAmbientFallbackExercised(v FuzzValue) bool {
 	if inner.VariantIndex != 0 || inner.Variant.Kind != KindMap {
 		return false
 	}
-	return len(inner.Variant.MapEntries) > 0
+	for _, entry := range inner.Variant.MapEntries {
+		if entry.Value.Kind != KindClassRef || entry.Value.ClassName != "A" {
+			continue
+		}
+		depth2f, ok := entry.Value.LookupField("f")
+		if !ok || depth2f.Kind != KindUnion || depth2f.Variant == nil {
+			continue
+		}
+		if depth2f.VariantIndex == 0 && depth2f.Variant.Kind == KindUnion {
+			return true
+		}
+	}
+	return false
 }
 
 // TestValueGenNestedUnionAmbientConstraintNeverEmpty is the

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -2157,14 +2157,26 @@ func assertPickedArmLeafMapNonEmpty(rt *rapid.T, t FuzzType, v FuzzValue) {
 	}
 }
 
+// walkValueForMapArmAmbiguity fails closed on malformed type/value
+// shapes. The walker drives generated values against the type IR
+// they were produced from, so a kind mismatch, an out-of-range
+// variant index, a nil Inner, or a missing class field signals a
+// generator regression. A silent `return` would let such a
+// regression slip past the map-arm-ambiguity assertions
+// undetected. Same fail-closed posture as assertPickedArmLeafMapNonEmpty;
+// rt.Fatalf propagates through rapid.Check's shrinker so the minimal
+// reproducer surfaces.
 func walkValueForMapArmAmbiguity(rt *rapid.T, t FuzzType, v FuzzValue, schema FuzzSchema) {
 	switch t.Kind {
 	case KindUnion:
-		if v.Kind != KindUnion || v.Variant == nil {
-			return
+		if v.Kind != KindUnion {
+			rt.Fatalf("walker: union type expected union value, got %v", v.Kind)
+		}
+		if v.Variant == nil {
+			rt.Fatalf("walker: union value missing Variant (value kind=%v)", v.Kind)
 		}
 		if v.VariantIndex < 0 || v.VariantIndex >= len(t.Variants) {
-			return
+			rt.Fatalf("walker: union value VariantIndex %d out of range (arms=%d)", v.VariantIndex, len(t.Variants))
 		}
 		arm := t.Variants[v.VariantIndex]
 		if pickedArmReachesMapThroughTransparent(arm, 0) && unionHasClassReachableSibling(t, v.VariantIndex) {
@@ -2172,35 +2184,50 @@ func walkValueForMapArmAmbiguity(rt *rapid.T, t FuzzType, v FuzzValue, schema Fu
 		}
 		walkValueForMapArmAmbiguity(rt, arm, *v.Variant, schema)
 	case KindOptional:
-		if v.OptionalShape == OptionalPresent && v.Inner != nil && t.Inner != nil {
+		if v.OptionalShape == OptionalPresent {
+			if v.Inner == nil {
+				rt.Fatalf("walker: present optional value missing Inner")
+			}
+			if t.Inner == nil {
+				rt.Fatalf("walker: optional type missing Inner")
+			}
 			walkValueForMapArmAmbiguity(rt, *t.Inner, *v.Inner, schema)
 		}
 	case KindList:
+		if v.Kind != KindList {
+			rt.Fatalf("walker: list type expected list value, got %v", v.Kind)
+		}
 		if t.Inner == nil {
-			return
+			rt.Fatalf("walker: list type missing Inner")
 		}
 		for _, item := range v.Items {
 			walkValueForMapArmAmbiguity(rt, *t.Inner, item, schema)
 		}
 	case KindMap:
+		if v.Kind != KindMap {
+			rt.Fatalf("walker: map type expected map value, got %v", v.Kind)
+		}
 		if t.Inner == nil {
-			return
+			rt.Fatalf("walker: map type missing Inner")
 		}
 		for _, e := range v.MapEntries {
 			walkValueForMapArmAmbiguity(rt, *t.Inner, e.Value, schema)
 		}
 	case KindClassRef:
 		if v.Kind != KindClassRef {
-			return
+			rt.Fatalf("walker: class_ref type %q expected class_ref value, got %v", t.Ref, v.Kind)
 		}
-		cls, ok := schema.FindClass(v.ClassName)
+		if v.ClassName != t.Ref {
+			rt.Fatalf("walker: class_ref value class %q drifts from type ref %q", v.ClassName, t.Ref)
+		}
+		cls, ok := schema.FindClass(t.Ref)
 		if !ok {
-			return
+			rt.Fatalf("walker: class_ref type ref %q not found in schema", t.Ref)
 		}
 		for _, prop := range cls.Properties {
 			fv, ok := v.LookupField(prop.Name)
 			if !ok {
-				continue
+				rt.Fatalf("walker: class %q value missing field %q", t.Ref, prop.Name)
 			}
 			walkValueForMapArmAmbiguity(rt, prop.Type, fv, schema)
 		}

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -2184,12 +2184,15 @@ func walkValueForMapArmAmbiguity(rt *rapid.T, t FuzzType, v FuzzValue, schema Fu
 		}
 		walkValueForMapArmAmbiguity(rt, arm, *v.Variant, schema)
 	case KindOptional:
+		if v.Kind != KindOptional {
+			rt.Fatalf("walker: optional type expected optional value, got %v", v.Kind)
+		}
+		if t.Inner == nil {
+			rt.Fatalf("walker: optional type missing Inner")
+		}
 		if v.OptionalShape == OptionalPresent {
 			if v.Inner == nil {
 				rt.Fatalf("walker: present optional value missing Inner")
-			}
-			if t.Inner == nil {
-				rt.Fatalf("walker: optional type missing Inner")
 			}
 			walkValueForMapArmAmbiguity(rt, *t.Inner, *v.Inner, schema)
 		}

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -1538,6 +1538,7 @@ func fixtureSchemaMapVsClassSiblingUnion() FuzzSchema {
 // (which coerces `{}` to the class arm with null-filled fields).
 func TestValueGenMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	schema := fixtureSchemaMapVsClassSiblingUnion()
+	var exercised bool
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
 		fv, ok := v.LookupField("f")
@@ -1553,10 +1554,14 @@ func TestValueGenMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 		if fv.Variant.Kind != KindMap {
 			rt.Fatalf("union arm 0 expected to be a map value, got %v", fv.Variant.Kind)
 		}
+		exercised = true
 		if len(fv.Variant.MapEntries) == 0 {
 			rt.Fatalf("map arm produced an empty map — ambiguous with class sibling under BAML coercion")
 		}
 	})
+	if !exercised {
+		t.Fatalf("rapid budget never picked the direct map arm — coverage sentinel never fired; non-empty-map invariant unverified")
+	}
 }
 
 // fixtureSchemaOptionalMapVsClassSiblingUnion mirrors
@@ -1606,6 +1611,7 @@ func fixtureSchemaOptionalMapVsClassSiblingUnion() FuzzSchema {
 // coercion to remain unambiguous.
 func TestValueGenOptionalMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	schema := fixtureSchemaOptionalMapVsClassSiblingUnion()
+	var exercised bool
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
 		fv, ok := v.LookupField("f")
@@ -1630,10 +1636,14 @@ func TestValueGenOptionalMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 		if fv.Variant.Inner.Kind != KindMap {
 			rt.Fatalf("present optional expected map at leaf, got %v", fv.Variant.Inner.Kind)
 		}
+		exercised = true
 		if len(fv.Variant.Inner.MapEntries) == 0 {
 			rt.Fatalf("present optional<map> drew empty map — ambiguous with class sibling under BAML coercion")
 		}
 	})
+	if !exercised {
+		t.Fatalf("rapid budget never reached present-optional<map> leaf — coverage sentinel never fired; non-empty-map invariant unverified")
+	}
 }
 
 // fixtureSchemaNestedUnionMapVsClassSibling pins the nested-union
@@ -1991,9 +2001,16 @@ func assertPickedArmLeafMapNonEmpty(rt *rapid.T, t FuzzType, v FuzzValue) {
 		if v.Kind != KindOptional {
 			rt.Fatalf("expected optional value, got %v", v.Kind)
 		}
-		if v.OptionalShape == OptionalPresent && v.Inner != nil && t.Inner != nil {
-			assertPickedArmLeafMapNonEmpty(rt, *t.Inner, *v.Inner)
+		if v.OptionalShape != OptionalPresent {
+			return
 		}
+		if t.Inner == nil {
+			rt.Fatalf("present optional map-arm type missing Inner")
+		}
+		if v.Inner == nil {
+			rt.Fatalf("present optional map-arm value missing Inner")
+		}
+		assertPickedArmLeafMapNonEmpty(rt, *t.Inner, *v.Inner)
 	case KindUnion:
 		if v.Kind != KindUnion {
 			rt.Fatalf("expected union value, got %v", v.Kind)


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## What

The shared bamlfuzz walker (Walk / CoupledCaseGen) emitted `{}` as the
Expected JSON wherever the value generator picked a direct map arm of
a union and drew the map zero-length. BAML, fed the same `{}`, never
keeps it as an empty map: its union resolver coerces `{}` to a class
arm reachable through a sibling and null-materializes the class's
declared fields. All four real surfaces (dynclient, REST SSE, REST
NDJSON, unary parse) agreed on the class shape — only the walker's
Expected was the outlier. Concretely, at `$.Fuzz_field_2.Fuzz_field_1`
of the captured envelope: walker Expected = `{}`; every surface =
`{"Fuzz_field_0": null}`.

This is a generator-soundness issue, not a render bug. `renderClass`
`Expected` already materializes a union-arm-selected class with every
declared field in declaration order, with `null` for absent fields —
verified by a focused unit test before changing anything.

## Fix

Generator-side, in `adapters/common/codegen/bamlfuzz/value.go`:

- `unionHasClassReachableSibling(union, excludeIdx)` walks the sibling
  arms of a union recursively through nested unions and optional
  wrappers, bounded by `MaxTypeDepth`, looking for any `KindClassRef`.
- `drawMap` takes a `minLen int`; the standard call site passes `0`.
- `drawUnion`, when the picked arm is `KindMap` and a sibling reaches
  a class, draws the map with `minLen = 1`. A non-empty map with the
  generator's `k0/k1/...` keys is unambiguous (those keys never match
  a `Fuzz_field_N` class field), so BAML keeps it a map and the
  walker's recorded arm survives the round-trip.

Render and normalize paths are untouched.

## Regression tests

In `adapters/common/codegen/bamlfuzz/union_test.go`:

- Unit tests for the new sibling-reach helper covering direct,
  nested-union, optional-wrapped, class-free, and non-union inputs.
- `TestValueGenMapArmWithClassSiblingNeverEmpty` — durable rapid
  invariant against the minimal repro schema (`Outer.f : union[map<string,int>, class_ref Inner]`): when the value picks the map arm, the map is never empty.
- `TestValueGenMapArmWithoutClassSiblingMayBeEmpty` — pins targeting:
  with a class-free sibling set, the empty-map draw is still observed
  across the rapid sample.
- `TestValueGenStaticSchemaUnionMapArmInvariant` — wide-net invariant
  on `StaticSchemaGen`: anywhere in the drawn (schema, value) pair, a
  picked direct map arm with a class-reachable sibling never carries
  an empty map.

## Validation

- `go build ./...` — OK
- `go vet ./...` — OK
- `go test -tags integration -c -o /dev/null ./integration/...` — OK
- `GOWORK=off go test -count=1 ./codegen/bamlfuzz/...` — `ok` (incl.
  the new regression tests, all green).
- `BAML_VERSION=0.222.0 go test -tags=integration,subprocess -v -run='^TestBamlfuzzDynamicOracle$|^TestBamlfuzzInvalidDynamic$|^TestBamlfuzzInvalidJSONCoercion$' ./integration -count=1 -timeout=30m` — PASS, 83 subtests, 0 failures. The dynamic + invalid rapid suites that share this walker stay green.

## Bitstream-shift caveat

The fix narrows the value-generator's draw space (zero-length maps are
forbidden in the narrow union-ambiguity context). Seed-pinned tests
exercise different cases under the same rapid seeds, but the oracle
assertions are unchanged and stay green.

Refs #349.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an ambiguity so generated map values are not empty when a sibling choice can materialize as a class.

* **Refactor**
  * Map generation accepts a minimum length while honoring termination/clamping.
  * Union selection now prunes candidates and enforces depth-safety to avoid ambiguous picks.

* **Tests**
  * Added regression and stress tests for union/class reachability, nested wrappers, and recursion fallbacks.

* **CI**
  * Nightly rapid workflow runs package-level stress invariants with an enabled env flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->