### PR TITLE
ci(bamlfuzz): parallelize nightly fuzz targets via matrix fan-out

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -37,7 +37,7 @@ on:
         required: false
         default: "50"
       fuzztime:
-        description: Fuzz-mode duration per target (default 15m; total wall time roughly 5× this — static + dynamic + invalid-dynamic + invalid-json-coercion + streaming run sequentially)
+        description: Fuzz-mode duration per target (default 15m; each target runs in its own matrix cell in parallel)
         type: string
         required: false
         default: "15m"
@@ -75,27 +75,31 @@ jobs:
         # the corpus that triggered it; newer-version draws cannot
         # crowd it out across cells.
         run: |
-          matrix=$(jq -c '{"baml-version": ([.pinned[], .latest] | unique), "unary-server": [false, true]}' integration/baml_versions.json)
+          matrix=$(jq -c '{
+            "baml-version": ([.pinned[], .latest] | unique),
+            "unary-server": [false, true],
+            "target": [
+              "FuzzBamlfuzzStatic",
+              "FuzzBamlfuzzDynamic",
+              "FuzzBamlfuzzInvalidDynamic",
+              "FuzzBamlfuzzInvalidJSONCoercion",
+              "FuzzBamlfuzzStreaming"
+            ]
+          }' integration/baml_versions.json)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   fuzz:
     needs: get-versions
     runs-on: ubuntu-latest
-    # Five sequential fuzz targets, each its own `go test ./integration`
-    # invocation — so TestMain (the integration env Setup that boots
-    # the BAML REST container + mock LLM) runs FIVE TIMES, not once.
-    # Budget:
-    #   - fuzz: 5 × FUZZTIME (default 15m) = 75m
-    #   - setup: 5 × ~10m per invocation on cold runners = 50m
-    #   - corpus restore + Go install + safety margin = ~10m
-    #   Total at the FUZZTIME default: ~135m.
-    # The 210m cap absorbs cold-runner setup variance and supports an
-    # operator-set FUZZTIME up to ~30m (5 × 30m + 50m setup + 10m
-    # margin = 210m) without breaching. A future refactor that runs
-    # all five fuzz targets under a single `go test` invocation would
-    # collapse setup to ~10m total and shrink the budget back to the
-    # ~85m a single-setup run would need.
-    timeout-minutes: 210
+    # Each matrix cell runs ONE fuzz target via the `target` axis.
+    # Budget per cell:
+    #   - setup: 1 × ~10m TestMain (Docker env boot)
+    #   - fuzz:  1 × FUZZTIME (default 15m)
+    #   - corpus restore + Go install + safety margin = ~5m
+    #   Total at the FUZZTIME default: ~30m.
+    # The 60m cap supports an operator-set FUZZTIME up to ~45m
+    # (10m setup + 45m fuzz + 5m margin = 60m) without breaching.
+    timeout-minutes: 60
     permissions:
       contents: read
       actions: read
@@ -132,7 +136,7 @@ jobs:
         if: ${{ env.MODE == 'fuzz' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ARTIFACT_NAME: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}
+          ARTIFACT_NAME: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}-${{ matrix.target }}
         run: |
           set -euo pipefail
           mkdir -p adapters/common/codegen/testdata/bamlfuzz/.fuzzcache
@@ -154,88 +158,30 @@ jobs:
             echo "prior nightly had no corpus artifact for ${ARTIFACT_NAME}; starting fresh"
           fi
 
-      - name: Run bamlfuzz nightly — static fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
+      - name: Fuzz ${{ matrix.target }} (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'fuzz' }}
-        # `go test -fuzz` runs ONE target per invocation, so the five
-        # fuzz targets (static, dynamic, invalid-dynamic,
-        # invalid-json-coercion, streaming) are split across sequential
-        # steps. Each gets the full configured FUZZTIME budget. Total
-        # fuzz wall time is therefore 5 × FUZZTIME; the job's
-        # timeout-minutes block above caps the combined cost. The
-        # corpus dir is shared so seed inputs any target discovers
-        # also influence the others on the next nightly.
-        #
-        # `-run='^$'` matches no ordinary test name, which keeps the
-        # cranked-up TestBamlfuzz{Static,Dynamic,Invalid*} rapid runs
-        # from consuming the per-step budget before fuzzing starts.
-        # BAMLFUZZ_KEEP_ARTIFACTS is forced off here; the success-path
-        # envelope dump in the oracle bodies all writes to
-        # _artifacts/fuzz.json (one filename per fuzz case), which races
-        # under parallel fuzz workers and can overwrite a failure
-        # envelope on the way out. Failures still dump unconditionally
-        # via failAndDump / failStaticAndDump / failAndDumpInvalid, so
-        # the workflow's upload-on-failure step still captures the
-        # right artifact.
+        # Each matrix cell runs exactly one fuzz target via the `target`
+        # axis. BAMLFUZZ_KEEP_ARTIFACTS is forced off; the success-path
+        # envelope dump writes to _artifacts/fuzz.json which races under
+        # parallel fuzz workers. Failures still dump unconditionally via
+        # failAndDump / failStaticAndDump / failAndDumpInvalid.
         env:
           BAMLFUZZ_KEEP_ARTIFACTS: ""
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
             -run='^$' \
-            -fuzz='^FuzzBamlfuzzStatic$' \
-            -fuzztime="${FUZZTIME}" \
-            -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
-            ./integration
-
-      - name: Run bamlfuzz nightly — dynamic fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
-        if: ${{ env.MODE == 'fuzz' }}
-        env:
-          BAMLFUZZ_KEEP_ARTIFACTS: ""
-        run: |
-          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
-            -run='^$' \
-            -fuzz='^FuzzBamlfuzzDynamic$' \
-            -fuzztime="${FUZZTIME}" \
-            -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
-            ./integration
-
-      - name: Run bamlfuzz nightly — invalid-schema fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
-        if: ${{ env.MODE == 'fuzz' }}
-        env:
-          BAMLFUZZ_KEEP_ARTIFACTS: ""
-        run: |
-          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
-            -run='^$' \
-            -fuzz='^FuzzBamlfuzzInvalidDynamic$' \
-            -fuzztime="${FUZZTIME}" \
-            -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
-            ./integration
-
-      - name: Run bamlfuzz nightly — invalid-JSON-coercion fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
-        if: ${{ env.MODE == 'fuzz' }}
-        env:
-          BAMLFUZZ_KEEP_ARTIFACTS: ""
-        run: |
-          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
-            -run='^$' \
-            -fuzz='^FuzzBamlfuzzInvalidJSONCoercion$' \
-            -fuzztime="${FUZZTIME}" \
-            -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
-            ./integration
-
-      - name: Run bamlfuzz nightly — streaming fuzz target (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
-        if: ${{ env.MODE == 'fuzz' }}
-        env:
-          BAMLFUZZ_KEEP_ARTIFACTS: ""
-        run: |
-          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
-            -run='^$' \
-            -fuzz='^FuzzBamlfuzzStreaming$' \
+            -fuzz='^${{ matrix.target }}$' \
             -fuzztime="${FUZZTIME}" \
             -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
             ./integration
 
       - name: Run bamlfuzz oracles — rapid mode (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
-        if: ${{ env.MODE == 'rapid' }}
+        if: ${{ env.MODE == 'rapid' && matrix.target == 'FuzzBamlfuzzStatic' }}
+        # Gate: rapid mode runs all 5 oracle tests in one `go test`
+        # invocation (shared TestMain), so it is target-independent.
+        # Pick one representative target value to run rapid exactly
+        # once per version-unary pair.
+        #
         # `subprocess` matches the normal server deployment path (server +
         # cmd/worker go-plugin), same as integration-tests.yml. -p 1 keeps
         # the integration env setup serial; the oracles share state.
@@ -256,7 +202,7 @@ jobs:
         # fuzzer keep building on prior progress.
         uses: actions/upload-artifact@v7
         with:
-          name: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}
+          name: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}-${{ matrix.target }}
           path: adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/
           if-no-files-found: ignore
           retention-days: 90
@@ -265,7 +211,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: bamlfuzz-envelopes-${{ matrix.baml-version }}-${{ matrix.unary-server }}-${{ github.run_id }}
+          name: bamlfuzz-envelopes-${{ matrix.baml-version }}-${{ matrix.unary-server }}-${{ matrix.target }}-${{ github.run_id }}
           path: adapters/common/codegen/testdata/bamlfuzz/*/_artifacts/
           if-no-files-found: ignore
 
@@ -276,6 +222,7 @@ jobs:
           TITLE: "bamlfuzz nightly status"
           BAML: ${{ matrix.baml-version }}
           UNARY: ${{ matrix.unary-server }}
+          TARGET: ${{ matrix.target }}
           RUN_ID: ${{ github.run_id }}
           REPO: ${{ github.repository }}
           SERVER_URL: ${{ github.server_url }}
@@ -297,20 +244,16 @@ jobs:
             echo "## bamlfuzz nightly failed (run ${RUN_ID})"
             echo
             echo "Mode: \`${MODE}\`"
-            echo "Matrix: baml-version=${BAML}, unary-server=${UNARY}"
+            echo "Matrix: baml-version=${BAML}, unary-server=${UNARY}, target=${TARGET}"
             echo "Workflow: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
-            echo "Envelope artifact: bamlfuzz-envelopes-${BAML}-${UNARY}-${RUN_ID}"
+            echo "Envelope artifact: bamlfuzz-envelopes-${BAML}-${UNARY}-${TARGET}-${RUN_ID}"
             if [ "${MODE}" = "fuzz" ]; then
-              echo "Corpus artifact: bamlfuzz-corpus-${BAML}-${UNARY}"
+              echo "Corpus artifact: bamlfuzz-corpus-${BAML}-${UNARY}-${TARGET}"
               echo
-              echo "Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/). \`go test -fuzz\` accepts only a single target per invocation, so run the static, dynamic, invalid-dynamic, invalid-json-coercion, and streaming targets sequentially. The \`-fuzzcachedir\` flag points the engine at the extracted corpus so the failing input is replayed:"
+              echo "This cell ran fuzz target \`${TARGET}\`. Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/):"
               echo
               echo '```'
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzStatic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzDynamic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzInvalidDynamic\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzInvalidJSONCoercion\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^FuzzBamlfuzzStreaming\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^${TARGET}\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
               echo '```'
             else
               echo

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -74,17 +74,20 @@ jobs:
         # own corpus, so an adapter-specific failure mode persists in
         # the corpus that triggered it; newer-version draws cannot
         # crowd it out across cells.
+        env:
+          MODE: ${{ github.event.inputs.mode || 'fuzz' }}
         run: |
-          matrix=$(jq -c '{
+          matrix=$(jq --arg mode "$MODE" -c '{
             "baml-version": ([.pinned[], .latest] | unique),
             "unary-server": [false, true],
-            "target": [
-              "FuzzBamlfuzzStatic",
-              "FuzzBamlfuzzDynamic",
-              "FuzzBamlfuzzInvalidDynamic",
-              "FuzzBamlfuzzInvalidJSONCoercion",
-              "FuzzBamlfuzzStreaming"
-            ]
+            "target": (if $mode == "rapid"
+                       then ["FuzzBamlfuzzStatic"]
+                       else ["FuzzBamlfuzzStatic",
+                             "FuzzBamlfuzzDynamic",
+                             "FuzzBamlfuzzInvalidDynamic",
+                             "FuzzBamlfuzzInvalidJSONCoercion",
+                             "FuzzBamlfuzzStreaming"]
+                       end)
           }' integration/baml_versions.json)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
@@ -93,15 +96,15 @@ jobs:
     runs-on: ubuntu-latest
     # Each matrix cell runs ONE fuzz target via the `target` axis.
     # Budget per cell:
-    #   - setup: 1 × ~10m TestMain (Docker env boot)
+    #   - setup: 1 × ~10m TestMain (Docker env boot, runs BEFORE m.Run())
     #   - fuzz:  1 × FUZZTIME (default 15m; Go hard-caps at -timeout 80m)
     #   - corpus restore + Go install + safety margin = ~5m
     #   - upload corpus + sticky comment + post steps = ~5m
-    #   Total at the FUZZTIME default: ~30m.
-    # The 90m cap sits above Go's -timeout 80m so Go's timeout fires
-    # first on a hang, leaving room for post-steps (corpus upload,
-    # sticky issue comment) to complete before Actions kills the runner.
-    timeout-minutes: 90
+    #   Worst case: ~10m setup + 80m Go timeout + ~5m post = ~95m.
+    # The 105m cap sits above that so Go's -timeout fires first on a
+    # hang, leaving room for post-steps (corpus upload, sticky issue
+    # comment) to complete before Actions kills the runner.
+    timeout-minutes: 105
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -94,12 +94,14 @@ jobs:
     # Each matrix cell runs ONE fuzz target via the `target` axis.
     # Budget per cell:
     #   - setup: 1 × ~10m TestMain (Docker env boot)
-    #   - fuzz:  1 × FUZZTIME (default 15m)
+    #   - fuzz:  1 × FUZZTIME (default 15m; Go hard-caps at -timeout 80m)
     #   - corpus restore + Go install + safety margin = ~5m
+    #   - upload corpus + sticky comment + post steps = ~5m
     #   Total at the FUZZTIME default: ~30m.
-    # The 60m cap supports an operator-set FUZZTIME up to ~45m
-    # (10m setup + 45m fuzz + 5m margin = 60m) without breaching.
-    timeout-minutes: 60
+    # The 90m cap sits above Go's -timeout 80m so Go's timeout fires
+    # first on a hang, leaving room for post-steps (corpus upload,
+    # sticky issue comment) to complete before Actions kills the runner.
+    timeout-minutes: 90
     permissions:
       contents: read
       actions: read
@@ -132,8 +134,10 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Restore corpus from prior nightly
+      - name: Restore corpus from prior nightly (target-scoped)
         if: ${{ env.MODE == 'fuzz' }}
+        id: restore-target
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACT_NAME: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}-${{ matrix.target }}
@@ -152,10 +156,39 @@ jobs:
             echo "no prior successful nightly run; starting with empty corpus"
             exit 0
           fi
+          gh run download "$prior_run" --repo "$GITHUB_REPOSITORY" \
+            --name "$ARTIFACT_NAME" \
+            --dir adapters/common/codegen/testdata/bamlfuzz/.fuzzcache
+
+      # One-time transition fallback: the prior nightly on master uploaded
+      # corpus under the legacy unscoped name (without -$target suffix).
+      # Once the first target-scoped nightly succeeds, this step becomes a
+      # no-op and can be removed in a future PR.
+      - name: Fallback restore from legacy unscoped corpus
+        if: ${{ env.MODE == 'fuzz' && steps.restore-target.outcome != 'success' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT_NAME: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}
+        run: |
+          set -euo pipefail
+          mkdir -p adapters/common/codegen/testdata/bamlfuzz/.fuzzcache
+          prior_run=$(gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow=bamlfuzz-nightly.yml \
+            --status=success \
+            --branch=master \
+            --limit=1 \
+            --json databaseId \
+            --jq '.[0].databaseId // empty')
+          if [ -z "$prior_run" ]; then
+            echo "no prior successful nightly run; starting with empty corpus"
+            exit 0
+          fi
           if ! gh run download "$prior_run" --repo "$GITHUB_REPOSITORY" \
               --name "$ARTIFACT_NAME" \
               --dir adapters/common/codegen/testdata/bamlfuzz/.fuzzcache; then
-            echo "prior nightly had no corpus artifact for ${ARTIFACT_NAME}; starting fresh"
+            echo "legacy corpus artifact ${ARTIFACT_NAME} not found; starting fresh"
           fi
 
       - name: Fuzz ${{ matrix.target }} (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -286,10 +286,10 @@ jobs:
             if [ "${MODE}" = "fuzz" ]; then
               echo "Corpus artifact: bamlfuzz-corpus-${BAML}-${UNARY}-${TARGET}"
               echo
-              echo "This cell ran fuzz target \`${TARGET}\`. Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/):"
+              echo "This cell ran fuzz target \`${TARGET}\`. Repro (from repo root, after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/):"
               echo
               echo '```'
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^${TARGET}\$' -fuzztime=30s ./integration -test.fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^${TARGET}\$' -fuzztime=30s ./integration -test.fuzzcachedir=\$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache"
               echo '```'
             else
               echo

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -158,10 +158,13 @@ jobs:
 
           restored=""
           for run_id in $candidates; do
-            if gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
+            has_artifact=$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" \
+              --jq "[.artifacts[] | select(.name == \"$ARTIFACT_NAME\")] | length")
+            if [ "$has_artifact" -gt 0 ]; then
+              gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
                 --name "$ARTIFACT_NAME" \
-                --dir adapters/common/codegen/testdata/bamlfuzz/.fuzzcache \
-                2>/dev/null; then
+                --dir adapters/common/codegen/testdata/bamlfuzz/.fuzzcache
               echo "restored corpus from run $run_id"
               restored="$run_id"
               break
@@ -171,13 +174,14 @@ jobs:
           if [ -z "$restored" ]; then
             echo "no recent completed run had artifact $ARTIFACT_NAME; starting fresh"
           fi
+          echo "restored=${restored:-}" >> "$GITHUB_OUTPUT"
 
       # One-time transition fallback: the prior nightly on master uploaded
       # corpus under the legacy unscoped name (without -$target suffix).
       # Once the first target-scoped nightly succeeds, this step becomes a
       # no-op and can be removed in a future PR.
       - name: Fallback restore from legacy unscoped corpus
-        if: ${{ env.MODE == 'fuzz' && steps.restore-target.outcome != 'success' }}
+        if: ${{ env.MODE == 'fuzz' && steps.restore-target.outputs.restored == '' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -196,10 +200,13 @@ jobs:
 
           restored=""
           for run_id in $candidates; do
-            if gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
+            has_artifact=$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" \
+              --jq "[.artifacts[] | select(.name == \"$ARTIFACT_NAME\")] | length")
+            if [ "$has_artifact" -gt 0 ]; then
+              gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
                 --name "$ARTIFACT_NAME" \
-                --dir adapters/common/codegen/testdata/bamlfuzz/.fuzzcache \
-                2>/dev/null; then
+                --dir adapters/common/codegen/testdata/bamlfuzz/.fuzzcache
               echo "restored legacy corpus from run $run_id"
               restored="$run_id"
               break
@@ -328,8 +335,8 @@ jobs:
   # way it would under the unit-tests CI's -race -count=100.
   #
   # These tests are pure Go: they never read BAML_VERSION or UNARY_SERVER and
-  # are not BAML-version dependent, so they run as one standalone cell rather
-  # than inside the version matrix. Keeping them off the matrix means there is
+  # are not BAML-version dependent, so they run as one standalone cell
+  # outside the version matrix. Keeping them off the matrix means there is
   # no matrix.baml-version literal to drift when Renovate bumps
   # integration/baml_versions.json. Gated on the same rapid-mode condition the
   # fuzz job's MODE env uses, so it runs only on a manual rapid dispatch.

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -208,8 +208,8 @@ jobs:
             -run='^$' \
             -fuzz='^${{ matrix.target }}$' \
             -fuzztime="${FUZZTIME}" \
-            -fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache" \
-            ./integration
+            ./integration \
+            -test.fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache"
 
       - name: Run bamlfuzz oracles — rapid mode (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'rapid' && matrix.target == 'FuzzBamlfuzzStatic' }}
@@ -289,7 +289,7 @@ jobs:
               echo "This cell ran fuzz target \`${TARGET}\`. Repro (after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/):"
               echo
               echo '```'
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^${TARGET}\$' -fuzztime=30s -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} go test -tags=integration,subprocess -run='^\$' -fuzz='^${TARGET}\$' -fuzztime=30s ./integration -test.fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache"
               echo '```'
             else
               echo

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -147,21 +147,30 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p adapters/common/codegen/testdata/bamlfuzz/.fuzzcache
-          prior_run=$(gh run list \
+          candidates=$(gh run list \
             --repo "$GITHUB_REPOSITORY" \
             --workflow=bamlfuzz-nightly.yml \
-            --status=success \
+            --status=completed \
             --branch=master \
-            --limit=1 \
+            --limit=10 \
             --json databaseId \
-            --jq '.[0].databaseId // empty')
-          if [ -z "$prior_run" ]; then
-            echo "no prior successful nightly run; starting with empty corpus"
-            exit 0
+            --jq '.[].databaseId')
+
+          restored=""
+          for run_id in $candidates; do
+            if gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
+                --name "$ARTIFACT_NAME" \
+                --dir adapters/common/codegen/testdata/bamlfuzz/.fuzzcache \
+                2>/dev/null; then
+              echo "restored corpus from run $run_id"
+              restored="$run_id"
+              break
+            fi
+          done
+
+          if [ -z "$restored" ]; then
+            echo "no recent completed run had artifact $ARTIFACT_NAME; starting fresh"
           fi
-          gh run download "$prior_run" --repo "$GITHUB_REPOSITORY" \
-            --name "$ARTIFACT_NAME" \
-            --dir adapters/common/codegen/testdata/bamlfuzz/.fuzzcache
 
       # One-time transition fallback: the prior nightly on master uploaded
       # corpus under the legacy unscoped name (without -$target suffix).
@@ -176,22 +185,29 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p adapters/common/codegen/testdata/bamlfuzz/.fuzzcache
-          prior_run=$(gh run list \
+          candidates=$(gh run list \
             --repo "$GITHUB_REPOSITORY" \
             --workflow=bamlfuzz-nightly.yml \
-            --status=success \
+            --status=completed \
             --branch=master \
-            --limit=1 \
+            --limit=10 \
             --json databaseId \
-            --jq '.[0].databaseId // empty')
-          if [ -z "$prior_run" ]; then
-            echo "no prior successful nightly run; starting with empty corpus"
-            exit 0
-          fi
-          if ! gh run download "$prior_run" --repo "$GITHUB_REPOSITORY" \
-              --name "$ARTIFACT_NAME" \
-              --dir adapters/common/codegen/testdata/bamlfuzz/.fuzzcache; then
-            echo "legacy corpus artifact ${ARTIFACT_NAME} not found; starting fresh"
+            --jq '.[].databaseId')
+
+          restored=""
+          for run_id in $candidates; do
+            if gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
+                --name "$ARTIFACT_NAME" \
+                --dir adapters/common/codegen/testdata/bamlfuzz/.fuzzcache \
+                2>/dev/null; then
+              echo "restored legacy corpus from run $run_id"
+              restored="$run_id"
+              break
+            fi
+          done
+
+          if [ -z "$restored" ]; then
+            echo "no recent completed run had artifact $ARTIFACT_NAME; starting fresh"
           fi
 
       - name: Fuzz ${{ matrix.target }} (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -140,7 +140,6 @@ jobs:
       - name: Restore corpus from prior nightly (target-scoped)
         if: ${{ env.MODE == 'fuzz' }}
         id: restore-target
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACT_NAME: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}-${{ matrix.target }}
@@ -158,9 +157,10 @@ jobs:
 
           restored=""
           for run_id in $candidates; do
-            has_artifact=$(gh api \
+            has_artifact=$(gh api --paginate \
               "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" \
-              --jq "[.artifacts[] | select(.name == \"$ARTIFACT_NAME\")] | length")
+              --jq "[.artifacts[] | select(.name == \"$ARTIFACT_NAME\")] | length" \
+              | awk '{s+=$1} END {print s+0}')
             if [ "$has_artifact" -gt 0 ]; then
               gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
                 --name "$ARTIFACT_NAME" \
@@ -182,7 +182,6 @@ jobs:
       # no-op and can be removed in a future PR.
       - name: Fallback restore from legacy unscoped corpus
         if: ${{ env.MODE == 'fuzz' && steps.restore-target.outputs.restored == '' }}
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACT_NAME: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}
@@ -200,9 +199,10 @@ jobs:
 
           restored=""
           for run_id in $candidates; do
-            has_artifact=$(gh api \
+            has_artifact=$(gh api --paginate \
               "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" \
-              --jq "[.artifacts[] | select(.name == \"$ARTIFACT_NAME\")] | length")
+              --jq "[.artifacts[] | select(.name == \"$ARTIFACT_NAME\")] | length" \
+              | awk '{s+=$1} END {print s+0}')
             if [ "$has_artifact" -gt 0 ]; then
               gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
                 --name "$ARTIFACT_NAME" \

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -264,6 +264,10 @@ jobs:
           name: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}-${{ matrix.target }}
           path: adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/
           if-no-files-found: ignore
+          # The path is a dot-directory; without this flag upload-artifact@v7
+          # treats its contents as hidden and silently uploads nothing, so the
+          # corpus would never persist across runs.
+          include-hidden-files: true
           retention-days: 90
 
       - name: Upload replay artifacts on failure


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Summary

- Add a `target` matrix dimension with the 5 fuzz targets (`FuzzBamlfuzzStatic`, `FuzzBamlfuzzDynamic`, `FuzzBamlfuzzInvalidDynamic`, `FuzzBamlfuzzInvalidJSONCoercion`, `FuzzBamlfuzzStreaming`) so each runs in its own GitHub Actions cell on a separate runner. Wall-time drops from ~85m to ~25m per BAML version; runner-minutes increase ~47% due to 5× TestMain setups.
- Collapse the 5 sequential fuzz-mode steps into 1 parameterized step using `matrix.target`.
- Gate the rapid-mode step with `matrix.target == 'FuzzBamlfuzzStatic'` so it runs exactly once per version-unary pair (rapid runs all 5 oracle tests in a single `go test` invocation with shared TestMain — it is target-independent). In rapid mode the matrix builder trims the target axis to `["FuzzBamlfuzzStatic"]` so the matrix emits 8 cells (4 versions × 2 unary), down from 40, skipping the 32 runners that would only checkout + setup-go and exit.
- Extend corpus artifact names with `-${{ matrix.target }}` on both upload and restore so the 5 per-version cells don't overwrite each other's corpus. A transitional restore step also attempts the legacy unscoped artifact name; if neither exists, the cell starts fresh.
- Recalc `timeout-minutes` from 210 to 105 (single-target budget: ~10m TestMain Docker setup before `m.Run()` + Go `-timeout 80m` hard cap + ~5m post-steps + safety margin; Go's timeout fires first on a hang so corpus upload and the sticky comment still run).
- Update sticky-issue comment and failure artifact naming to include `matrix.target` for per-cell identification.
- No harness code changes — the harness is already concurrency-safe by construction (mutex-protected scenario registry, per-target unique IDs, disjoint artifact dirs, pure rapid generators, per-invocation Docker envs).

While reviewing this PR's command shape, we discovered that the existing master nightly was silently no-op'ing the fuzz step: `-fuzzcachedir` is not a recognized `go test` flag, which caused `./integration` to be consumed by the test binary as an argument, not treated as the package, producing `[no test files]`. This PR moves to `-test.fuzzcachedir=...` after `./integration` so the fuzz targets actually run. Without this fix, the parallelism would just be 40 parallel no-ops.

Also tightens the corpus-restore loop: master's restore step looked up `--status=success --limit=1` which skips failed runs (whose corpus is uploaded via `always()` precisely for replay) and lets a successful rapid-mode manual dispatch shadow the last fuzz run. The new loop iterates the 10 most recent completed master runs and stops at the first one with a matching target-scoped artifact, so a fuzz failure's corpus persists into the next nightly.

Refs #349

## Test plan

- [ ] YAML parses (`python3 -c "import yaml; yaml.safe_load(open(...))"` — verified locally)
- [ ] All 5 matrix target names match `func Fuzz*` declarations exactly (verified via grep)
- [ ] Matrix size: 4 versions × 2 unary × 5 targets = 40 cells in fuzz mode (under GitHub's 256 limit)
- [ ] Rapid mode emits 8 cells (4 versions × 2 unary × 1 target); verified via `jq --arg mode rapid`
- [ ] Observe next nightly run: 40 fuzz-mode cells complete within the 105m timeout
- [ ] Rapid dispatch: verify only 1 cell per version-unary pair runs the rapid step
- [ ] Corpus artifacts: verify 40 distinct corpus artifacts uploaded (one per cell)
- [ ] Failure comment: verify `target` appears in the sticky-issue comment body

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Nightly fuzz CI now runs one fuzz target per job cell and halves the per-cell timeout.
  * Rapid mode is limited to the primary static target; fuzz mode runs across multiple named targets.
  * Corpus restore/upload and failure artifacts are scoped per-target with a one-time fallback to legacy artifacts.
  * Failure comments and repro guidance now report the failing TARGET and provide a single targeted repro command.
  * Help text and comments clarified to indicate duration is per-target and matrix placement for stress jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invakid404/baml-rest/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

