### PR TITLE
test(bamlfuzz): recover from dynclient panics with stack-trace envelope

### DIFF
--- a/adapters/common/codegen/bamlfuzz/envelope.go
+++ b/adapters/common/codegen/bamlfuzz/envelope.go
@@ -105,6 +105,8 @@ type StaticFailureEnvelope struct {
 	RESTStatus          int                 `json:"rest_status,omitempty"`
 	RESTBody            json.RawMessage     `json:"rest_body,omitempty"`
 	RESTError           string              `json:"rest_error,omitempty"`
+	RESTPanic           string              `json:"rest_panic,omitempty"`
+	RESTPanicStack      string              `json:"rest_panic_stack,omitempty"`
 	SemanticDiff        []SemanticDiffEntry `json:"semantic_diff,omitempty"`
 	OrderWarning        []string            `json:"order_warning,omitempty"`
 	ReplayPath          string              `json:"replay_path"`

--- a/adapters/common/codegen/bamlfuzz/envelope.go
+++ b/adapters/common/codegen/bamlfuzz/envelope.go
@@ -46,9 +46,13 @@ type DynamicFailureEnvelope struct {
 	Expected            json.RawMessage                `json:"expected"`
 	DynclientOutput     json.RawMessage                `json:"dynclient_output,omitempty"`
 	DynclientError      string                         `json:"dynclient_error,omitempty"`
+	DynclientPanic      string                         `json:"dynclient_panic,omitempty"`
+	DynclientPanicStack string                         `json:"dynclient_panic_stack,omitempty"`
 	RESTStatus          int                            `json:"rest_status,omitempty"`
 	RESTBody            json.RawMessage                `json:"rest_body,omitempty"`
 	RESTError           string                         `json:"rest_error,omitempty"`
+	RESTPanic           string                         `json:"rest_panic,omitempty"`
+	RESTPanicStack      string                         `json:"rest_panic_stack,omitempty"`
 	SemanticDiff        []SemanticDiffEntry            `json:"semantic_diff,omitempty"`
 	OrderWarning        []string                       `json:"order_warning,omitempty"`
 	ReplayPath          string                         `json:"replay_path"`

--- a/adapters/common/codegen/bamlfuzz/envelope_streaming.go
+++ b/adapters/common/codegen/bamlfuzz/envelope_streaming.go
@@ -72,10 +72,18 @@ type StreamingFailureEnvelope struct {
 	// Per-leg surface errors. Context/transport errors are harness
 	// failures and never reach the envelope; these capture stream-level
 	// or HTTP-status errors that are oracle signal.
-	DynclientError  string `json:"dynclient_error,omitempty"`
-	RESTErrorSSE    string `json:"rest_error_sse,omitempty"`
-	RESTErrorNDJSON string `json:"rest_error_ndjson,omitempty"`
-	UnaryError      string `json:"unary_error,omitempty"`
+	DynclientError      string `json:"dynclient_error,omitempty"`
+	DynclientPanic      string `json:"dynclient_panic,omitempty"`
+	DynclientPanicStack string `json:"dynclient_panic_stack,omitempty"`
+	RESTErrorSSE        string `json:"rest_error_sse,omitempty"`
+	RESTPanicSSE        string `json:"rest_panic_sse,omitempty"`
+	RESTPanicStackSSE   string `json:"rest_panic_stack_sse,omitempty"`
+	RESTErrorNDJSON     string `json:"rest_error_ndjson,omitempty"`
+	RESTPanicNDJSON     string `json:"rest_panic_ndjson,omitempty"`
+	RESTPanicStackNDJSON string `json:"rest_panic_stack_ndjson,omitempty"`
+	UnaryError          string `json:"unary_error,omitempty"`
+	UnaryPanic          string `json:"unary_panic,omitempty"`
+	UnaryPanicStack     string `json:"unary_panic_stack,omitempty"`
 
 	SemanticDiff []SemanticDiffEntry `json:"semantic_diff,omitempty"`
 	OrderWarning []string            `json:"order_warning,omitempty"`

--- a/adapters/common/codegen/bamlfuzz/envelope_streaming.go
+++ b/adapters/common/codegen/bamlfuzz/envelope_streaming.go
@@ -72,18 +72,18 @@ type StreamingFailureEnvelope struct {
 	// Per-leg surface errors. Context/transport errors are harness
 	// failures and never reach the envelope; these capture stream-level
 	// or HTTP-status errors that are oracle signal.
-	DynclientError      string `json:"dynclient_error,omitempty"`
-	DynclientPanic      string `json:"dynclient_panic,omitempty"`
-	DynclientPanicStack string `json:"dynclient_panic_stack,omitempty"`
-	RESTErrorSSE        string `json:"rest_error_sse,omitempty"`
-	RESTPanicSSE        string `json:"rest_panic_sse,omitempty"`
-	RESTPanicStackSSE   string `json:"rest_panic_stack_sse,omitempty"`
-	RESTErrorNDJSON     string `json:"rest_error_ndjson,omitempty"`
-	RESTPanicNDJSON     string `json:"rest_panic_ndjson,omitempty"`
+	DynclientError       string `json:"dynclient_error,omitempty"`
+	DynclientPanic       string `json:"dynclient_panic,omitempty"`
+	DynclientPanicStack  string `json:"dynclient_panic_stack,omitempty"`
+	RESTErrorSSE         string `json:"rest_error_sse,omitempty"`
+	RESTPanicSSE         string `json:"rest_panic_sse,omitempty"`
+	RESTPanicStackSSE    string `json:"rest_panic_stack_sse,omitempty"`
+	RESTErrorNDJSON      string `json:"rest_error_ndjson,omitempty"`
+	RESTPanicNDJSON      string `json:"rest_panic_ndjson,omitempty"`
 	RESTPanicStackNDJSON string `json:"rest_panic_stack_ndjson,omitempty"`
-	UnaryError          string `json:"unary_error,omitempty"`
-	UnaryPanic          string `json:"unary_panic,omitempty"`
-	UnaryPanicStack     string `json:"unary_panic_stack,omitempty"`
+	UnaryError           string `json:"unary_error,omitempty"`
+	UnaryPanic           string `json:"unary_panic,omitempty"`
+	UnaryPanicStack      string `json:"unary_panic_stack,omitempty"`
 
 	SemanticDiff []SemanticDiffEntry `json:"semantic_diff,omitempty"`
 	OrderWarning []string            `json:"order_warning,omitempty"`

--- a/adapters/common/codegen/bamlfuzz/invalid_case.go
+++ b/adapters/common/codegen/bamlfuzz/invalid_case.go
@@ -137,9 +137,13 @@ type InvalidFailureEnvelope struct {
 	MockLLMContent      json.RawMessage                `json:"mock_llm_content,omitempty"`
 	DynclientOutput     json.RawMessage                `json:"dynclient_output,omitempty"`
 	DynclientError      string                         `json:"dynclient_error,omitempty"`
+	DynclientPanic      string                         `json:"dynclient_panic,omitempty"`
+	DynclientPanicStack string                         `json:"dynclient_panic_stack,omitempty"`
 	RESTStatus          int                            `json:"rest_status,omitempty"`
 	RESTBody            json.RawMessage                `json:"rest_body,omitempty"`
 	RESTError           string                         `json:"rest_error,omitempty"`
+	RESTPanic           string                         `json:"rest_panic,omitempty"`
+	RESTPanicStack      string                         `json:"rest_panic_stack,omitempty"`
 	SemanticDiff        []SemanticDiffEntry            `json:"semantic_diff,omitempty"`
 	OrderWarning        []string                       `json:"order_warning,omitempty"`
 	ActualOutcome       string                         `json:"actual_outcome,omitempty"`

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -353,17 +353,23 @@ func runDynamicOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Oracle
 		OutputSchema:        &lowered,
 		PreserveSchemaOrder: preservePtr,
 	}
-	libResp, libErr := dyn.DynamicCall(callCtx, libReq)
+	var (
+		libResp *dynclient.CallResult
+		libErr  error
+	)
+	panicVal, panicStack := callWithRecover(func() {
+		libResp, libErr = dyn.DynamicCall(callCtx, libReq)
+	})
+	if panicVal != nil {
+		envelope.DynclientPanic = fmt.Sprintf("%v", panicVal)
+		envelope.DynclientPanicStack = string(panicStack)
+		failAndDump(t, envelope, "dyn.DynamicCall panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
 	switch {
 	case libErr != nil:
 		envelope.DynclientError = libErr.Error()
 	case libResp == nil:
-		// Defensive contract check: dynclient.Client.DynamicCall today
-		// always returns a non-nil response on the nil-error path. A
-		// future client regression returning (nil, nil) would otherwise
-		// flow through as a successful empty response and silently
-		// equate two legs. Surface as a hard failure with the envelope
-		// noting which side went nil.
 		envelope.DynclientError = "nil response from dyn.DynamicCall"
 		failAndDump(t, envelope, "dynclient returned nil response without an error")
 		return
@@ -379,15 +385,20 @@ func runDynamicOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Oracle
 		failAndDump(t, envelope, "build REST body: %v", err)
 		return
 	}
-	restResp, err := BAMLClient.DynamicCallJSON(callCtx, restBody)
+	var restResp *testutil.DynamicCallResponse
+	panicVal, panicStack = callWithRecover(func() {
+		restResp, err = BAMLClient.DynamicCallJSON(callCtx, restBody)
+	})
+	if panicVal != nil {
+		envelope.RESTPanic = fmt.Sprintf("%v", panicVal)
+		envelope.RESTPanicStack = string(panicStack)
+		failAndDump(t, envelope, "BAMLClient.DynamicCallJSON panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
 	switch {
 	case err != nil:
 		envelope.RESTError = err.Error()
 	case restResp == nil:
-		// Defensive contract check: see the dynclient branch above.
-		// DynamicCallJSON today always allocates a response on the
-		// nil-error path; this guard turns a future regression into a
-		// hard failure with the envelope noting the source leg.
 		envelope.RESTError = "nil response from BAMLClient.DynamicCallJSON"
 		failAndDump(t, envelope, "REST client returned nil response without an error")
 		return

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -357,10 +357,10 @@ func runDynamicOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Oracle
 		libResp *dynclient.CallResult
 		libErr  error
 	)
-	panicVal, panicStack := callWithRecover(func() {
+	panicked, panicVal, panicStack := callWithRecover(func() {
 		libResp, libErr = dyn.DynamicCall(callCtx, libReq)
 	})
-	if panicVal != nil {
+	if panicked {
 		envelope.DynclientPanic = fmt.Sprintf("%v", panicVal)
 		envelope.DynclientPanicStack = string(panicStack)
 		failAndDump(t, envelope, "dyn.DynamicCall panicked: %v\n%s", panicVal, panicStack)
@@ -386,10 +386,10 @@ func runDynamicOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Oracle
 		return
 	}
 	var restResp *testutil.DynamicCallResponse
-	panicVal, panicStack = callWithRecover(func() {
+	panicked, panicVal, panicStack = callWithRecover(func() {
 		restResp, err = BAMLClient.DynamicCallJSON(callCtx, restBody)
 	})
-	if panicVal != nil {
+	if panicked {
 		envelope.RESTPanic = fmt.Sprintf("%v", panicVal)
 		envelope.RESTPanicStack = string(panicStack)
 		failAndDump(t, envelope, "BAMLClient.DynamicCallJSON panicked: %v\n%s", panicVal, panicStack)

--- a/integration/bamlfuzz_invalid_test.go
+++ b/integration/bamlfuzz_invalid_test.go
@@ -357,10 +357,10 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 		libResp *dynclient.CallResult
 		libErr  error
 	)
-	panicVal, panicStack := callWithRecover(func() {
+	panicked, panicVal, panicStack := callWithRecover(func() {
 		libResp, libErr = dyn.DynamicCall(dynCtx, libReq)
 	})
-	if panicVal != nil {
+	if panicked {
 		envelope.DynclientPanic = fmt.Sprintf("%v", panicVal)
 		envelope.DynclientPanicStack = string(panicStack)
 		failAndDumpInvalid(t, artifactDir, envelope, "dyn.DynamicCall panicked: %v\n%s", panicVal, panicStack)
@@ -390,10 +390,10 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 	restCtx, restCancel := context.WithTimeout(parentCtx, 30*time.Second)
 	defer restCancel()
 	var restResp *testutil.DynamicCallResponse
-	panicVal, panicStack = callWithRecover(func() {
+	panicked, panicVal, panicStack = callWithRecover(func() {
 		restResp, err = BAMLClient.DynamicCallJSON(restCtx, restBody)
 	})
-	if panicVal != nil {
+	if panicked {
 		envelope.RESTPanic = fmt.Sprintf("%v", panicVal)
 		envelope.RESTPanicStack = string(panicStack)
 		failAndDumpInvalid(t, artifactDir, envelope, "BAMLClient.DynamicCallJSON panicked: %v\n%s", panicVal, panicStack)

--- a/integration/bamlfuzz_invalid_test.go
+++ b/integration/bamlfuzz_invalid_test.go
@@ -353,12 +353,20 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 
 	dynCtx, dynCancel := context.WithTimeout(parentCtx, 30*time.Second)
 	defer dynCancel()
-	libResp, libErr := dyn.DynamicCall(dynCtx, libReq)
+	var (
+		libResp *dynclient.CallResult
+		libErr  error
+	)
+	panicVal, panicStack := callWithRecover(func() {
+		libResp, libErr = dyn.DynamicCall(dynCtx, libReq)
+	})
+	if panicVal != nil {
+		envelope.DynclientPanic = fmt.Sprintf("%v", panicVal)
+		envelope.DynclientPanicStack = string(panicStack)
+		failAndDumpInvalid(t, artifactDir, envelope, "dyn.DynamicCall panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
 	if libErr != nil && (errors.Is(libErr, context.Canceled) || errors.Is(libErr, context.DeadlineExceeded)) {
-		// Context-derived dynclient error is a harness failure, not an
-		// oracle signal — the BAML pipeline never produced a verdict.
-		// Treating it as a rejection would let an outright timeout pass
-		// the both-reject oracle.
 		t.Fatalf("harness failure: dynclient context (case=%s mutation=%s): %v", c.Name, c.Mutation, libErr)
 	}
 	var dynSuccess bool
@@ -381,12 +389,17 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 	}
 	restCtx, restCancel := context.WithTimeout(parentCtx, 30*time.Second)
 	defer restCancel()
-	restResp, err := BAMLClient.DynamicCallJSON(restCtx, restBody)
+	var restResp *testutil.DynamicCallResponse
+	panicVal, panicStack = callWithRecover(func() {
+		restResp, err = BAMLClient.DynamicCallJSON(restCtx, restBody)
+	})
+	if panicVal != nil {
+		envelope.RESTPanic = fmt.Sprintf("%v", panicVal)
+		envelope.RESTPanicStack = string(panicStack)
+		failAndDumpInvalid(t, artifactDir, envelope, "BAMLClient.DynamicCallJSON panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
 	if err != nil {
-		// BAMLClient.DynamicCallJSON wraps the HTTP transport layer;
-		// 4xx/5xx responses come back through restResp.StatusCode +
-		// restResp.Error, not through err. A non-nil err here is a
-		// transport or context failure — harness, not oracle signal.
 		t.Fatalf("harness failure: REST transport (case=%s mutation=%s): %v", c.Name, c.Mutation, err)
 	}
 	if restResp == nil {

--- a/integration/bamlfuzz_recover_test.go
+++ b/integration/bamlfuzz_recover_test.go
@@ -5,15 +5,19 @@ package integration
 import "runtime/debug"
 
 // callWithRecover invokes fn and converts any panic into a returned
-// (panicValue, stack) pair. runtime.Goexit (from t.FailNow/Fatalf)
-// is not recovered, so legitimate test failures propagate normally.
-func callWithRecover(fn func()) (recovered any, stack []byte) {
+// (panicked, panicValue, stack) triple. The bool sentinel handles
+// panic(nil) correctly: panicked is set true before fn runs and
+// cleared only on normal return, so recover() is called
+// unconditionally when fn panics.
+func callWithRecover(fn func()) (panicked bool, recovered any, stack []byte) {
+	panicked = true
 	defer func() {
-		if r := recover(); r != nil {
-			recovered = r
+		if panicked {
+			recovered = recover()
 			stack = debug.Stack()
 		}
 	}()
 	fn()
-	return nil, nil
+	panicked = false
+	return
 }

--- a/integration/bamlfuzz_recover_test.go
+++ b/integration/bamlfuzz_recover_test.go
@@ -1,0 +1,19 @@
+//go:build integration
+
+package integration
+
+import "runtime/debug"
+
+// callWithRecover invokes fn and converts any panic into a returned
+// (panicValue, stack) pair. runtime.Goexit (from t.FailNow/Fatalf)
+// is not recovered, so legitimate test failures propagate normally.
+func callWithRecover(fn func()) (recovered any, stack []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			recovered = r
+			stack = debug.Stack()
+		}
+	}()
+	fn()
+	return nil, nil
+}

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -329,11 +329,23 @@ func runOneStaticCase(t *testing.T, env *testutil.TestEnvironment, mockClient *m
 
 	callCtx, callCancel := context.WithTimeout(context.Background(), staticCallTimeout)
 	defer callCancel()
-	resp, err := bamlClient.Call(callCtx, testutil.CallRequest{
-		Method:  lc.Source.FunctionName,
-		Input:   map[string]any{"input": "Static fuzz call."},
-		Options: &testutil.BAMLOptions{ClientRegistry: clientReg},
+	var (
+		resp *testutil.CallResponse
+		err  error
+	)
+	panicked, panicVal, panicStack := callWithRecover(func() {
+		resp, err = bamlClient.Call(callCtx, testutil.CallRequest{
+			Method:  lc.Source.FunctionName,
+			Input:   map[string]any{"input": "Static fuzz call."},
+			Options: &testutil.BAMLOptions{ClientRegistry: clientReg},
+		})
 	})
+	if panicked {
+		envelope.RESTPanic = fmt.Sprintf("%v", panicVal)
+		envelope.RESTPanicStack = string(panicStack)
+		failStaticAndDump(t, envelope, "bamlClient.Call panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
 	switch {
 	case err != nil:
 		envelope.RESTError = err.Error()

--- a/integration/bamlfuzz_streaming_test.go
+++ b/integration/bamlfuzz_streaming_test.go
@@ -299,7 +299,19 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 	// --- dynclient streaming leg ---
 	dynCtx, dynCancel := context.WithTimeout(parentCtx, 30*time.Second)
 	defer dynCancel()
-	stream, openErr := dyn.DynamicStream(dynCtx, libReq)
+	var (
+		stream  *dynclient.Stream
+		openErr error
+	)
+	panicVal, panicStack := callWithRecover(func() {
+		stream, openErr = dyn.DynamicStream(dynCtx, libReq)
+	})
+	if panicVal != nil {
+		envelope.DynclientPanic = fmt.Sprintf("%v", panicVal)
+		envelope.DynclientPanicStack = string(panicStack)
+		failAndDumpStreaming(t, envelope, "dyn.DynamicStream panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
 	if openErr != nil {
 		if isContextErr(openErr) {
 			t.Fatalf("harness failure: dynclient stream open (case=%s): %v", c.Name, openErr)
@@ -324,7 +336,19 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 	// --- REST SSE streaming leg ---
 	sseCtx, sseCancel := context.WithTimeout(parentCtx, 30*time.Second)
 	defer sseCancel()
-	sseEvents, sseErrs := BAMLClient.DynamicStreamBody(sseCtx, restBody)
+	var (
+		sseEvents <-chan testutil.StreamEvent
+		sseErrs   <-chan error
+	)
+	panicVal, panicStack = callWithRecover(func() {
+		sseEvents, sseErrs = BAMLClient.DynamicStreamBody(sseCtx, restBody)
+	})
+	if panicVal != nil {
+		envelope.RESTPanicSSE = fmt.Sprintf("%v", panicVal)
+		envelope.RESTPanicStackSSE = string(panicStack)
+		failAndDumpStreaming(t, envelope, "BAMLClient.DynamicStreamBody panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
 	ssePartials, sseFinal, sseKinds, sseErr := drainRESTStream(sseEvents, sseErrs)
 	envelope.RESTPartialsSSE = ssePartials
 	envelope.RESTFinalSSE = sseFinal
@@ -340,7 +364,19 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 	// --- REST NDJSON streaming leg ---
 	ndjsonCtx, ndjsonCancel := context.WithTimeout(parentCtx, 30*time.Second)
 	defer ndjsonCancel()
-	ndjsonEvents, ndjsonErrs := BAMLClient.DynamicStreamNDJSONBody(ndjsonCtx, restBody)
+	var (
+		ndjsonEvents <-chan testutil.StreamEvent
+		ndjsonErrs   <-chan error
+	)
+	panicVal, panicStack = callWithRecover(func() {
+		ndjsonEvents, ndjsonErrs = BAMLClient.DynamicStreamNDJSONBody(ndjsonCtx, restBody)
+	})
+	if panicVal != nil {
+		envelope.RESTPanicNDJSON = fmt.Sprintf("%v", panicVal)
+		envelope.RESTPanicStackNDJSON = string(panicStack)
+		failAndDumpStreaming(t, envelope, "BAMLClient.DynamicStreamNDJSONBody panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
 	ndjsonPartials, ndjsonFinal, ndjsonKinds, ndjsonErr := drainRESTStream(ndjsonEvents, ndjsonErrs)
 	envelope.RESTPartialsNDJSON = ndjsonPartials
 	envelope.RESTFinalNDJSON = ndjsonFinal
@@ -356,7 +392,19 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 	// --- unary cross-check leg ---
 	unaryCtx, unaryCancel := context.WithTimeout(parentCtx, 30*time.Second)
 	defer unaryCancel()
-	unaryResp, unaryErr := dyn.DynamicCall(unaryCtx, libReq)
+	var (
+		unaryResp *dynclient.CallResult
+		unaryErr  error
+	)
+	panicVal, panicStack = callWithRecover(func() {
+		unaryResp, unaryErr = dyn.DynamicCall(unaryCtx, libReq)
+	})
+	if panicVal != nil {
+		envelope.UnaryPanic = fmt.Sprintf("%v", panicVal)
+		envelope.UnaryPanicStack = string(panicStack)
+		failAndDumpStreaming(t, envelope, "dyn.DynamicCall (unary cross-check) panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
 	switch {
 	case unaryErr != nil:
 		if isContextErr(unaryErr) {

--- a/integration/bamlfuzz_streaming_test.go
+++ b/integration/bamlfuzz_streaming_test.go
@@ -303,10 +303,10 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 		stream  *dynclient.Stream
 		openErr error
 	)
-	panicVal, panicStack := callWithRecover(func() {
+	panicked, panicVal, panicStack := callWithRecover(func() {
 		stream, openErr = dyn.DynamicStream(dynCtx, libReq)
 	})
-	if panicVal != nil {
+	if panicked {
 		envelope.DynclientPanic = fmt.Sprintf("%v", panicVal)
 		envelope.DynclientPanicStack = string(panicStack)
 		failAndDumpStreaming(t, envelope, "dyn.DynamicStream panicked: %v\n%s", panicVal, panicStack)
@@ -319,8 +319,22 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 		envelope.DynclientError = openErr.Error()
 		failures = append(failures, fmt.Sprintf("dynclient stream open: %v", openErr))
 	} else {
-		dynPartials, dynFinal, dynKinds, drainErr := drainDynclientStream(stream)
+		var (
+			dynPartials []json.RawMessage
+			dynFinal    json.RawMessage
+			dynKinds    []string
+			drainErr    error
+		)
+		panicked, panicVal, panicStack = callWithRecover(func() {
+			dynPartials, dynFinal, dynKinds, drainErr = drainDynclientStream(stream)
+		})
 		stream.Close()
+		if panicked {
+			envelope.DynclientPanic = fmt.Sprintf("%v", panicVal)
+			envelope.DynclientPanicStack = string(panicStack)
+			failAndDumpStreaming(t, envelope, "drainDynclientStream panicked: %v\n%s", panicVal, panicStack)
+			return
+		}
 		envelope.DynclientPartials = dynPartials
 		envelope.DynclientFinal = dynFinal
 		envelope.DynclientKinds = dynKinds
@@ -340,16 +354,30 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 		sseEvents <-chan testutil.StreamEvent
 		sseErrs   <-chan error
 	)
-	panicVal, panicStack = callWithRecover(func() {
+	panicked, panicVal, panicStack = callWithRecover(func() {
 		sseEvents, sseErrs = BAMLClient.DynamicStreamBody(sseCtx, restBody)
 	})
-	if panicVal != nil {
+	if panicked {
 		envelope.RESTPanicSSE = fmt.Sprintf("%v", panicVal)
 		envelope.RESTPanicStackSSE = string(panicStack)
 		failAndDumpStreaming(t, envelope, "BAMLClient.DynamicStreamBody panicked: %v\n%s", panicVal, panicStack)
 		return
 	}
-	ssePartials, sseFinal, sseKinds, sseErr := drainRESTStream(sseEvents, sseErrs)
+	var (
+		ssePartials []json.RawMessage
+		sseFinal    json.RawMessage
+		sseKinds    []string
+		sseErr      error
+	)
+	panicked, panicVal, panicStack = callWithRecover(func() {
+		ssePartials, sseFinal, sseKinds, sseErr = drainRESTStream(sseEvents, sseErrs)
+	})
+	if panicked {
+		envelope.RESTPanicSSE = fmt.Sprintf("%v", panicVal)
+		envelope.RESTPanicStackSSE = string(panicStack)
+		failAndDumpStreaming(t, envelope, "drainRESTStream (SSE) panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
 	envelope.RESTPartialsSSE = ssePartials
 	envelope.RESTFinalSSE = sseFinal
 	envelope.RESTKindsSSE = sseKinds
@@ -368,16 +396,30 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 		ndjsonEvents <-chan testutil.StreamEvent
 		ndjsonErrs   <-chan error
 	)
-	panicVal, panicStack = callWithRecover(func() {
+	panicked, panicVal, panicStack = callWithRecover(func() {
 		ndjsonEvents, ndjsonErrs = BAMLClient.DynamicStreamNDJSONBody(ndjsonCtx, restBody)
 	})
-	if panicVal != nil {
+	if panicked {
 		envelope.RESTPanicNDJSON = fmt.Sprintf("%v", panicVal)
 		envelope.RESTPanicStackNDJSON = string(panicStack)
 		failAndDumpStreaming(t, envelope, "BAMLClient.DynamicStreamNDJSONBody panicked: %v\n%s", panicVal, panicStack)
 		return
 	}
-	ndjsonPartials, ndjsonFinal, ndjsonKinds, ndjsonErr := drainRESTStream(ndjsonEvents, ndjsonErrs)
+	var (
+		ndjsonPartials []json.RawMessage
+		ndjsonFinal    json.RawMessage
+		ndjsonKinds    []string
+		ndjsonErr      error
+	)
+	panicked, panicVal, panicStack = callWithRecover(func() {
+		ndjsonPartials, ndjsonFinal, ndjsonKinds, ndjsonErr = drainRESTStream(ndjsonEvents, ndjsonErrs)
+	})
+	if panicked {
+		envelope.RESTPanicNDJSON = fmt.Sprintf("%v", panicVal)
+		envelope.RESTPanicStackNDJSON = string(panicStack)
+		failAndDumpStreaming(t, envelope, "drainRESTStream (NDJSON) panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
 	envelope.RESTPartialsNDJSON = ndjsonPartials
 	envelope.RESTFinalNDJSON = ndjsonFinal
 	envelope.RESTKindsNDJSON = ndjsonKinds
@@ -396,10 +438,10 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 		unaryResp *dynclient.CallResult
 		unaryErr  error
 	)
-	panicVal, panicStack = callWithRecover(func() {
+	panicked, panicVal, panicStack = callWithRecover(func() {
 		unaryResp, unaryErr = dyn.DynamicCall(unaryCtx, libReq)
 	})
-	if panicVal != nil {
+	if panicked {
 		envelope.UnaryPanic = fmt.Sprintf("%v", panicVal)
 		envelope.UnaryPanicStack = string(panicStack)
 		failAndDumpStreaming(t, envelope, "dyn.DynamicCall (unary cross-check) panicked: %v\n%s", panicVal, panicStack)

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -1380,6 +1381,11 @@ func (c *BAMLRestClient) dynamicStreamRequestBody(ctx context.Context, url strin
 	go func() {
 		defer close(events)
 		defer close(errs)
+		defer func() {
+			if r := recover(); r != nil {
+				errs <- fmt.Errorf("SSE goroutine panic: %v\n%s", r, debug.Stack())
+			}
+		}()
 
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
 		if err != nil {
@@ -1417,6 +1423,11 @@ func (c *BAMLRestClient) dynamicStreamRequestBodyNDJSON(ctx context.Context, url
 	go func() {
 		defer close(events)
 		defer close(errs)
+		defer func() {
+			if r := recover(); r != nil {
+				errs <- fmt.Errorf("NDJSON goroutine panic: %v\n%s", r, debug.Stack())
+			}
+		}()
 
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
 		if err != nil {

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"runtime/debug"
 	"strings"
 	"syscall"
@@ -1383,7 +1384,12 @@ func (c *BAMLRestClient) dynamicStreamRequestBody(ctx context.Context, url strin
 		defer close(errs)
 		defer func() {
 			if r := recover(); r != nil {
-				errs <- fmt.Errorf("SSE goroutine panic: %v\n%s", r, debug.Stack())
+				msg := fmt.Errorf("SSE goroutine panic: %v\n%s", r, debug.Stack())
+				select {
+				case errs <- msg:
+				default:
+					fmt.Fprintf(os.Stderr, "stream producer panic (errs channel full): %v\n", msg)
+				}
 			}
 		}()
 
@@ -1425,7 +1431,12 @@ func (c *BAMLRestClient) dynamicStreamRequestBodyNDJSON(ctx context.Context, url
 		defer close(errs)
 		defer func() {
 			if r := recover(); r != nil {
-				errs <- fmt.Errorf("NDJSON goroutine panic: %v\n%s", r, debug.Stack())
+				msg := fmt.Errorf("NDJSON goroutine panic: %v\n%s", r, debug.Stack())
+				select {
+				case errs <- msg:
+				default:
+					fmt.Fprintf(os.Stderr, "stream producer panic (errs channel full): %v\n", msg)
+				}
 			}
 		}()
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

- Wrap every `dynclient`/`BAMLClient` invocation in the bamlfuzz harnesses with a `recover()`-based helper (`callWithRecover`) that converts panics into structured test failures — the fuzz engine sees `t.Errorf` (graceful failure with full panic value + stack trace) in place of a subprocess EOF that strips all diagnostic context and blocks minimization.
- Add panic-capture fields (`DynclientPanic`, `DynclientPanicStack`, `RESTPanic`, `RESTPanicStack`, plus streaming-specific variants) to all three failure envelope structs so the artifact JSON preserves the full panic context for post-mortem analysis.
- 11 call sites wrapped across `bamlfuzz_dynamic_test.go` (2), `bamlfuzz_invalid_test.go` (2), `bamlfuzz_streaming_test.go` (7: stream open, drain guards for SSE/NDJSON open + drain, unary cross-check), and `bamlfuzz_static_test.go` (1: `bamlClient.Call`).
- Stream-producer goroutines in `testutil/client.go` recover panics via a non-blocking channel send — prevents deadlock when the `errs` channel buffer is already occupied by a prior transport/parse error.
- `callWithRecover(fn) (panicked bool, recovered any, stack []byte)` — the `panicked` sentinel handles `panic(nil)` correctly.

## Motivation

The bamlfuzz nightly recently hit a Go SDK panic (`reflect: call of reflect.Value.Set on zero Value`) deep inside BAML's response decoder. The panic propagated through `dyn.DynamicCall` and killed the fuzz subprocess. Go's fuzz engine reports this as `"fuzzing process hung or terminated unexpectedly while minimizing: EOF"` — an opaque message that strips the panic + stack trace and makes input minimization impossible.

Upstream bug filed: BoundaryML/baml#3620. This PR makes the harness resilient to future panics regardless of the upstream fix status.

## Design

`callWithRecover(fn func()) (panicked bool, recovered any, stack []byte)` wraps each dynclient/BAMLClient call. On panic it captures the value and `debug.Stack()`. `runtime.Goexit` (from `t.FailNow`/`t.Fatalf`) is *not* recovered, so legitimate test failures propagate normally. The `panicked bool` sentinel is set before `fn()` and cleared on normal return, so `panic(nil)` is correctly distinguished from a clean return.

At each call site, when a panic is recovered:
1. The panic value + stack trace are written to the envelope's new fields
2. The envelope is flushed to the artifact directory via the existing `failAndDump*` / `failStaticAndDump` path
3. `t.Errorf` reports the failure cleanly — fuzz engine minimization works

Stream-producer goroutines (SSE + NDJSON in `testutil/client.go`) use a non-blocking `select` send to avoid deadlocking when the 1-buffered `errs` channel already holds a prior error. If the channel is full, the panic is logged to stderr so it is not silently lost.

## Test plan

- [ ] `go vet -tags=integration,subprocess ./integration` — clean
- [ ] `go test -tags=integration,subprocess -run='^$' -count=1 ./integration` — compiles, no test runs
- [ ] Reproduce known-failing input `7af197900c1cf4d1` on BAML 0.222.0 — should now report the panic message + stack trace in the failure output and envelope artifact, not EOF
- [ ] Fuzz engine minimization should work (test process stays alive)

Part of #349. Upstream: BoundaryML/baml#3620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced panic diagnostics in failure reporting: test harnesses now capture and record panic messages and full stack traces across dynamic, invalid-case, streaming, and unary flows, surfacing them in failure envelopes for faster diagnosis.
  * Streaming test clients and goroutines now recover from panics and report panic details to the test harness to prevent silent crashes and improve reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->