### PR TITLE
fix(bamlutils): don't treat map<string,ClassRef> container as a class in absent-optional injection

### DIFF
--- a/bamlutils/dynamic_absent.go
+++ b/bamlutils/dynamic_absent.go
@@ -111,7 +111,16 @@ func (w *absentOptionalWalker) injectClass(className string, node orderedNode) (
 // injectType recurses into composite types to reach nested class
 // instances that may have their own absent optionals.
 func (w *absentOptionalWalker) injectType(spec DynamicTypeSpec, node orderedNode) (orderedNode, error) {
-	if spec.Ref != "" {
+	// A class/enum reference is spelled as a spec with Ref set and no
+	// structural Type. When Type IS set the spec is a composite (map,
+	// list, optional, union, …) and must take its structural path even
+	// if a stray Ref rode along — hand-written / replay / corpus
+	// envelopes can carry a `map<string, ClassRef>` whose property spec
+	// also stamps the value class's name into Ref. Honouring Ref first
+	// there would treat the map CONTAINER as a class instance and inject
+	// the class's absent optionals into the map's key namespace instead
+	// of recursing into each map value.
+	if spec.Ref != "" && spec.Type == "" {
 		if w.isClassRef(spec.Ref) {
 			return w.injectClass(spec.Ref, node)
 		}

--- a/bamlutils/dynamic_absent_test.go
+++ b/bamlutils/dynamic_absent_test.go
@@ -132,6 +132,67 @@ func TestInjectAbsentOptionals_UnionTwoClassArmsDisambiguation(t *testing.T) {
 	}
 }
 
+func TestInjectAbsentOptionals_MapClassRefInjectsInsideValues(t *testing.T) {
+	t.Parallel()
+
+	// map<string, FuzzClass2> where FuzzClass2 has one optional property.
+	// Injection must recurse into each map VALUE — a value missing the
+	// optional gets it injected INSIDE that value — and must NOT inject
+	// the class's properties at the map container level.
+	f2 := MustOrderedMap(
+		OrderedKV("id", &DynamicProperty{Type: "int"}),
+		OrderedKV("note", &DynamicProperty{Type: "optional", Inner: &DynamicTypeSpec{Type: "string"}}),
+	)
+	classes := MustOrderedMap(
+		OrderedKV("FuzzClass2", &DynamicClass{Properties: f2}),
+	)
+	props := MustOrderedMap(
+		OrderedKV("m", &DynamicProperty{
+			Type:   "map",
+			Keys:   &DynamicTypeSpec{Type: "string"},
+			Values: &DynamicTypeSpec{Ref: "FuzzClass2"},
+		}),
+	)
+	s := &DynamicOutputSchema{Properties: props, Classes: classes}
+	// k0 already has note; kA is missing it.
+	got := inject(t, `{"m":{"k0":{"id":1,"note":"x"},"kA":{"id":2}}}`, s)
+	want := `{"m":{"k0":{"id":1,"note":"x"},"kA":{"id":2,"note":null}}}`
+	if got != want {
+		t.Fatalf("map class-ref injects inside values:\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestInjectAbsentOptionals_MapPropertyWithStrayRefNotTreatedAsClass(t *testing.T) {
+	t.Parallel()
+
+	// Regression for the nightly-envelope shape: a map<string, ClassRef>
+	// property whose spec ALSO carries the value class's name in Ref.
+	// injectType must take the map path (recurse into values), not the
+	// Ref/class path — otherwise FuzzClass2's optional gets injected at
+	// the map container level as a spurious sibling of the map keys.
+	f2 := MustOrderedMap(
+		OrderedKV("Fuzz_field_0", &DynamicProperty{Type: "optional", Inner: &DynamicTypeSpec{Type: "int"}}),
+	)
+	classes := MustOrderedMap(
+		OrderedKV("FuzzClass2", &DynamicClass{Properties: f2}),
+	)
+	props := MustOrderedMap(
+		OrderedKV("Fuzz_field_0", &DynamicProperty{
+			Type:   "map",
+			Ref:    "FuzzClass2", // stray ref carried alongside the map type
+			Keys:   &DynamicTypeSpec{Type: "string"},
+			Values: &DynamicTypeSpec{Ref: "FuzzClass2"},
+		}),
+	)
+	s := &DynamicOutputSchema{Properties: props, Classes: classes}
+	// Every map value already has the optional present → nothing to inject.
+	in := `{"Fuzz_field_0":{"k0":{"Fuzz_field_0":0},"kA":{"Fuzz_field_0":-42}}}`
+	got := inject(t, in, s)
+	if got != in {
+		t.Fatalf("map property with stray ref must not inject at container level:\n got %s\nwant %s", got, in)
+	}
+}
+
 func TestInjectAbsentOptionals_TopLevelAbsentOptional(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Summary

Follow-up to #395. `InjectAbsentOptionals` (`bamlutils/dynamic_absent.go`) mis-handled `map<string, ClassRef>` properties: it could inject the referenced class's absent-optional properties into the **map container's** key namespace instead of recursing into each map value.

## Root cause

`injectType` checked `spec.Ref != ""` **before** dispatching on `spec.Type`. A composite spec (`map`/`list`/`optional`/`union`) that *also* carried a stray `Ref` was therefore misrouted to `injectClass`, treating the map container as a class instance.

The standard generator (`LowerToDynamicSchema`) emits maps as `{"type":"map","values":{"ref":"FuzzClass2"}}` with **no** property-level `ref`, so the random fuzzer never tripped this. But hand-written / replay / corpus envelopes (which `emit_dynamic.go` notes reach the dynamic emitter) can stamp the value class's name into the map property's `Ref`, producing the nightly failure.

### Concrete example from the nightly envelope
- Schema: `Fuzz_field_0` is `map<string, FuzzClass2>`; `FuzzClass2` has one optional property `Fuzz_field_0`.
- Actual map: `{"k0": {"Fuzz_field_0": 0}, "kA": {"Fuzz_field_0": -42}}`

```
before: {"Fuzz_field_0": null, "k0": {"Fuzz_field_0": 0}, "kA": {"Fuzz_field_0": -42}}   # spurious null at map level
after:  {"k0": {"Fuzz_field_0": 0}, "kA": {"Fuzz_field_0": -42}}                          # unchanged — values already complete
```

## Fix

Only follow the bare-`Ref` class path when the spec has **no** structural `Type`. A class/enum reference is spelled as `{ref: ...}` with empty `Type`; any composite with a stray `Ref` now takes its structural path and recurses into map values / list items as intended.

## Tests

- `TestInjectAbsentOptionals_MapClassRefInjectsInsideValues` — `map<string,ClassRef>` recursion injects the absent optional **inside** the map value that is missing it, not at the container.
- `TestInjectAbsentOptionals_MapPropertyWithStrayRefNotTreatedAsClass` — reproduces the nightly envelope shape (map property with a stray value-class `ref`); fails on the old code with the spurious container-level `null`, passes with the fix.

Refs #394, #349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed optional field injection for map properties containing class references to inject inside map values rather than at the container level.
  * Corrected reference field handling to prevent misinterpretation in map specifications.

* **Tests**
  * Added test coverage for optional field injection in map properties with class references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->