### PR TITLE
fix(bamlfuzz): skip shared Docker setup in fuzz worker subprocesses

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -197,6 +197,17 @@ func TestMain(m *testing.M) {
 		}
 	}
 	UseBuildRequest = parseBoolEnv(os.Getenv("BAML_REST_USE_BUILD_REQUEST"))
+
+	// Fuzz worker subprocesses re-run TestMain but don't need the shared
+	// Docker environment — FuzzBamlfuzzStatic builds its own via
+	// setupStaticEnv, and FuzzBamlfuzzDynamic uses the coordinator's
+	// TestEnv (not the worker's). Skip the expensive Setup to avoid
+	// resource conflicts and unrecovered goroutine panics from
+	// testcontainers health-check goroutines in the worker process.
+	if isFuzzWorker() {
+		os.Exit(m.Run())
+	}
+
 	TestEnv, err = testutil.Setup(ctx, matrixSetupOptions())
 	if err != nil {
 		println("Failed to setup test environment:", err.Error())
@@ -235,6 +246,19 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(code)
+}
+
+// isFuzzWorker reports whether this process is a Go fuzzing worker
+// subprocess, which the fuzz framework launches with the internal
+// -test.fuzzworker flag. Workers re-run TestMain but must not build the
+// shared Docker environment.
+func isFuzzWorker() bool {
+	for _, arg := range os.Args[1:] {
+		if arg == "-test.fuzzworker" || strings.HasPrefix(arg, "-test.fuzzworker=") {
+			return true
+		}
+	}
+	return false
 }
 
 // dumpContainerLogs fetches and prints logs from a Docker container.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -198,13 +198,14 @@ func TestMain(m *testing.M) {
 	}
 	UseBuildRequest = parseBoolEnv(os.Getenv("BAML_REST_USE_BUILD_REQUEST"))
 
-	// Fuzz worker subprocesses re-run TestMain but don't need the shared
-	// Docker environment — FuzzBamlfuzzStatic builds its own via
-	// setupStaticEnv, and FuzzBamlfuzzDynamic uses the coordinator's
-	// TestEnv (not the worker's). Skip the expensive Setup to avoid
-	// resource conflicts and unrecovered goroutine panics from
-	// testcontainers health-check goroutines in the worker process.
-	if isFuzzWorker() {
+	// FuzzBamlfuzzStatic worker subprocesses re-run TestMain but don't need
+	// the shared Docker environment — that target builds its own per-iteration
+	// env via setupStaticEnv and never touches TestEnv. Skip the expensive
+	// Setup for those workers to avoid resource conflicts and unrecovered
+	// goroutine panics from testcontainers health-check goroutines. The other
+	// fuzz targets (Dynamic, Streaming, InvalidJSONCoercion) use the shared
+	// TestEnv/MockClient/BAMLClient, so their workers must still build it.
+	if isStaticFuzzWorker() {
 		os.Exit(m.Run())
 	}
 
@@ -248,17 +249,38 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// isFuzzWorker reports whether this process is a Go fuzzing worker
-// subprocess, which the fuzz framework launches with the internal
-// -test.fuzzworker flag. Workers re-run TestMain but must not build the
-// shared Docker environment.
-func isFuzzWorker() bool {
-	for _, arg := range os.Args[1:] {
-		if arg == "-test.fuzzworker" || strings.HasPrefix(arg, "-test.fuzzworker=") {
-			return true
+// isStaticFuzzWorker reports whether this process is a Go fuzzing worker
+// subprocess (-test.fuzzworker) that is fuzzing the FuzzBamlfuzzStatic
+// target. Only that target builds its own per-iteration environment via
+// setupStaticEnv; the others (Dynamic, Streaming, InvalidJSONCoercion) rely
+// on the shared TestEnv, so their workers must still run the Docker setup.
+//
+// The fuzz framework launches workers with -test.fuzzworker prepended to a
+// copy of the coordinator's args (internal/fuzz.startWorkers), so the worker
+// inherits the same -test.fuzz=<pattern> regexp the coordinator was invoked
+// with — the nightly uses -fuzz='^FuzzBamlfuzzStatic$'.
+func isStaticFuzzWorker() bool {
+	var fuzzWorker bool
+	var fuzzPattern string
+	args := os.Args[1:]
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-test.fuzzworker" || arg == "--test.fuzzworker",
+			strings.HasPrefix(arg, "-test.fuzzworker="), strings.HasPrefix(arg, "--test.fuzzworker="):
+			fuzzWorker = true
+		case strings.HasPrefix(arg, "-test.fuzz="):
+			fuzzPattern = strings.TrimPrefix(arg, "-test.fuzz=")
+		case strings.HasPrefix(arg, "--test.fuzz="):
+			fuzzPattern = strings.TrimPrefix(arg, "--test.fuzz=")
+		case arg == "-test.fuzz" || arg == "--test.fuzz":
+			if i+1 < len(args) {
+				fuzzPattern = args[i+1]
+				i++
+			}
 		}
 	}
-	return false
+	return fuzzWorker && strings.Contains(fuzzPattern, "FuzzBamlfuzzStatic")
 }
 
 // dumpContainerLogs fetches and prints logs from a Docker container.


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Problem

`FuzzBamlfuzzStatic` crashes on its first fuzz iteration with `fuzzing process hung or terminated unexpectedly: exit status 2`. This affects all static fuzz cells on BAML 0.219+. Dynamic, Streaming, and InvalidJSONCoercion targets are unaffected.

## Root cause

Go's fuzz framework spawns worker subprocesses that re-run `TestMain`. In `integration/integration_test.go`, `TestMain` calls `testutil.Setup`, which builds a full Docker environment (baml-rest + mock-llm + Ryuk via testcontainers) — including health-check / log-reader goroutines.

`FuzzBamlfuzzStatic` doesn't need that shared environment: it builds its own per-iteration env via `setupStaticEnv` and never touches `TestEnv`. Under CI resource contention (the coordinator's containers are already running, plus limited GitHub Actions resources), one of the testcontainers goroutines panics unrecovered, exiting the worker process with status 2 — not the normal fuzz worker exit code 70.

## Fix

Skip `testutil.Setup` (and the subsequent client creation) **only** for `FuzzBamlfuzzStatic` worker subprocesses. `isStaticFuzzWorker()` requires both:

1. `-test.fuzzworker` — this is a fuzz worker subprocess, and
2. a `-test.fuzz` pattern matching `FuzzBamlfuzzStatic` — we're fuzzing the static target.

The fuzz framework launches workers with `-test.fuzzworker` prepended to a copy of the coordinator's args (`internal/fuzz.startWorkers`), so the worker inherits the same `-test.fuzz=<pattern>` regexp the coordinator was invoked with (the nightly uses `-fuzz='^FuzzBamlfuzzStatic$'`).

The lightweight initialization (`BAMLVersion`, `bamlSrcPath`, `adapterVersion`, `unaryServer`, `UseBuildRequest`) still runs, so the static fuzz callback has everything it needs. The coordinator process and all other fuzz workers are unchanged and still build the shared environment.

> Scoping note (addressing review feedback): an earlier revision skipped Docker setup for *every* fuzz worker, which would break `FuzzBamlfuzzDynamic`, `FuzzBamlfuzzStreaming`, and the invalid-JSON targets — they use the shared `TestEnv`/`MockClient`/`BAMLClient` in their callbacks. The skip is now scoped to the static target only.

## Verification

- `go test -tags integration -run '^$' ./integration/` — compiles and vets clean
- `TestBamlfuzzStaticOracle` (non-fuzz) is unaffected — it uses its own `setupStaticEnv`
- `FuzzBamlfuzzDynamic` / `FuzzBamlfuzzStreaming` / invalid-JSON workers are unaffected — they don't match `isStaticFuzzWorker`, so the coordinator and their workers still build `TestEnv`

Refs #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Integration test startup now detects fuzz-worker subprocesses and exits early to skip shared environment setup, improving test run speed and avoiding unnecessary resource initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->