### PR TITLE
fix(bamlfuzz): flatten optional union members to (T | null) in static lowering

### DIFF
--- a/adapters/common/codegen/bamlfuzz/emit_static.go
+++ b/adapters/common/codegen/bamlfuzz/emit_static.go
@@ -314,6 +314,11 @@ func typeSpelling(t FuzzType, classNames, enumNames map[string]string) (string, 
 // outer union's arm count unchanged (the flattened optional stays a
 // single sub-union arm), so the oracle's recorded UnionChoice indices
 // still line up with the emitted source.
+//
+// The inner spelling is taken recursively through unionMemberSpelling so
+// a nested optional (`optional<optional<int>>`) flattens at every level:
+// `((int | null) | null)`, not `((int)? | null)` which would re-introduce
+// the rejected `(T)?` inside the sub-union.
 func unionMemberSpelling(v FuzzType, classNames, enumNames map[string]string) (string, error) {
 	if v.Kind != KindOptional {
 		return typeSpelling(v, classNames, enumNames)
@@ -321,7 +326,7 @@ func unionMemberSpelling(v FuzzType, classNames, enumNames map[string]string) (s
 	if v.Inner == nil {
 		return "", fmt.Errorf("optional missing inner")
 	}
-	inner, err := typeSpelling(*v.Inner, classNames, enumNames)
+	inner, err := unionMemberSpelling(*v.Inner, classNames, enumNames)
 	if err != nil {
 		return "", err
 	}

--- a/adapters/common/codegen/bamlfuzz/emit_static.go
+++ b/adapters/common/codegen/bamlfuzz/emit_static.go
@@ -280,7 +280,7 @@ func typeSpelling(t FuzzType, classNames, enumNames map[string]string) (string, 
 		}
 		parts := make([]string, len(t.Variants))
 		for i, v := range t.Variants {
-			s, err := typeSpelling(v, classNames, enumNames)
+			s, err := unionMemberSpelling(v, classNames, enumNames)
 			if err != nil {
 				return "", fmt.Errorf("union variant %d: %w", i, err)
 			}
@@ -295,6 +295,37 @@ func typeSpelling(t FuzzType, classNames, enumNames map[string]string) (string, 
 	default:
 		return "", fmt.Errorf("unsupported kind %q", t.Kind)
 	}
+}
+
+// unionMemberSpelling spells one variant of a union. It differs from
+// typeSpelling only for an optional variant: BAML's parser rejects a
+// parenthesized-optional (`(T)?`) sitting as a union member — it reads
+// the leading `(` as a grouped union, then chokes on the trailing `?`
+// and reports "No type specified for field" / "not a valid field or
+// attribute definition" (BoundaryML/baml; surfaced via the static fuzz
+// oracle). Standalone optional fields keep the `(T)?` spelling, which
+// the parser accepts; only the union-member position is affected.
+//
+// An optional that lives inside a union can only ever render as its
+// inner value or an explicit null — an omitted key is impossible
+// mid-union, so renderValueMock degrades OptionalAbsent to null. The
+// equivalent, parseable spelling is therefore the flattened
+// `(inner | null)` union. Wrapping it in its own parens keeps the
+// outer union's arm count unchanged (the flattened optional stays a
+// single sub-union arm), so the oracle's recorded UnionChoice indices
+// still line up with the emitted source.
+func unionMemberSpelling(v FuzzType, classNames, enumNames map[string]string) (string, error) {
+	if v.Kind != KindOptional {
+		return typeSpelling(v, classNames, enumNames)
+	}
+	if v.Inner == nil {
+		return "", fmt.Errorf("optional missing inner")
+	}
+	inner, err := typeSpelling(*v.Inner, classNames, enumNames)
+	if err != nil {
+		return "", err
+	}
+	return "(" + inner + " | null)", nil
 }
 
 // typeSpellingNoUnionParens spells `t` but, when t is a KindUnion,

--- a/adapters/common/codegen/bamlfuzz/emit_static.go
+++ b/adapters/common/codegen/bamlfuzz/emit_static.go
@@ -319,7 +319,17 @@ func typeSpelling(t FuzzType, classNames, enumNames map[string]string) (string, 
 // a nested optional (`optional<optional<int>>`) flattens at every level:
 // `((int | null) | null)`, not `((int)? | null)` which would re-introduce
 // the rejected `(T)?` inside the sub-union.
+//
+// A single-arm union variant is unwrapped and re-spelled through
+// unionMemberSpelling rather than typeSpelling: typeSpelling collapses a
+// one-arm union to its bare variant, which would drop us back into the
+// `(T)?` spelling for `union[union[optional<int>]]`. Unwrapping here keeps
+// the union-member context across the collapse, so the optional still
+// flattens to `(int | null)`.
 func unionMemberSpelling(v FuzzType, classNames, enumNames map[string]string) (string, error) {
+	if v.Kind == KindUnion && len(v.Variants) == 1 {
+		return unionMemberSpelling(v.Variants[0], classNames, enumNames)
+	}
 	if v.Kind != KindOptional {
 		return typeSpelling(v, classNames, enumNames)
 	}

--- a/adapters/common/codegen/bamlfuzz/emit_static.go
+++ b/adapters/common/codegen/bamlfuzz/emit_static.go
@@ -345,7 +345,7 @@ func typeSpellingNoUnionParens(t FuzzType, classNames, enumNames map[string]stri
 	}
 	parts := make([]string, len(t.Variants))
 	for i, v := range t.Variants {
-		s, err := typeSpelling(v, classNames, enumNames)
+		s, err := unionMemberSpelling(v, classNames, enumNames)
 		if err != nil {
 			return "", fmt.Errorf("union variant %d: %w", i, err)
 		}

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -558,6 +558,84 @@ func TestEmitStaticUnionPipeSyntax(t *testing.T) {
 	}
 }
 
+// TestEmitStaticOptionalUnionMemberFlattensToNull pins the fix for the
+// FuzzBamlfuzzStatic crash class: an optional sitting as a union member
+// must be spelled as the flattened `(inner | null)` sub-union, never as
+// `(inner)?`. BAML's parser rejects a parenthesized-optional in union
+// position ("No type specified for field"), which crashed the static
+// fuzz worker on its first exec. The standalone optional field in the
+// same schema keeps its `(string)?` spelling — only the union-member
+// position changes.
+func TestEmitStaticOptionalUnionMemberFlattensToNull(t *testing.T) {
+	// Union with an optional-int arm alongside a plain string arm,
+	// mirroring the crasher shape `(... | ((int)? | ...))`.
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindOptional, Inner: &FuzzType{Kind: KindInt}},
+			{Kind: KindString},
+		},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "u", Type: uni},
+				// Standalone optional field must stay `(string)?`.
+				{Name: "opt", Type: FuzzType{Kind: KindOptional, Inner: &FuzzType{Kind: KindString}}},
+			},
+		}},
+		RootClass: "Root",
+	}
+	src, err := LowerToBamlSource(schema, "TestC")
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	// Optional union member flattens to `(int | null)`.
+	if !strings.Contains(src.Source, "u ((int | null) | string)") {
+		t.Errorf("optional union member should flatten to (int | null), got source:\n%s", src.Source)
+	}
+	// The `(T)?` form must not appear anywhere — it is exactly the
+	// construct BAML rejects inside a union.
+	if strings.Contains(src.Source, "(int)?") {
+		t.Errorf("emitted forbidden parenthesized-optional `(int)?` inside union:\n%s", src.Source)
+	}
+	// Standalone optional field is untouched.
+	if !strings.Contains(src.Source, "opt (string)?") {
+		t.Errorf("standalone optional field should keep `(string)?` spelling, got source:\n%s", src.Source)
+	}
+}
+
+// TestEmitStaticOptionalUnionMemberPreservesArmCount asserts the
+// flattened optional arm stays a single parenthesised sub-union so the
+// outer union's arm count (and therefore the oracle's UnionChoice
+// indices) is unchanged.
+func TestEmitStaticOptionalUnionMemberPreservesArmCount(t *testing.T) {
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindBool},
+			{Kind: KindOptional, Inner: &FuzzType{Kind: KindClassRef, Ref: "Leaf"}},
+			{Kind: KindInt},
+		},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{
+			{Name: "Root", Properties: []FuzzProperty{{Name: "u", Type: uni}}},
+			{Name: "Leaf", Properties: []FuzzProperty{{Name: "n", Type: FuzzType{Kind: KindInt}}}},
+		},
+		RootClass: "Root",
+	}
+	src, err := LowerToBamlSource(schema, "TestC")
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	// Three outer arms preserved: bool, (Leaf_TestC | null), int.
+	if !strings.Contains(src.Source, "u (bool | (Leaf_TestC | null) | int)") {
+		t.Errorf("optional class-ref union member should flatten in place keeping 3 arms, got source:\n%s", src.Source)
+	}
+}
+
 // TestEmitStaticSingleArmUnionEmitsBareVariant asserts the static
 // emitter renders a single-arm union (only reachable through the
 // shrink-collapse pass) as the bare variant. Emitting a one-operand

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -606,6 +606,39 @@ func TestEmitStaticOptionalUnionMemberFlattensToNull(t *testing.T) {
 	}
 }
 
+// TestEmitStaticNestedOptionalUnionMemberFlattensRecursively asserts
+// that a nested optional union member (optional<optional<int>>) flattens
+// at every level to `((int | null) | null)`. A non-recursive flatten
+// would emit `((int)? | null)`, re-introducing the parser-rejected
+// `(T)?` inside the sub-union.
+func TestEmitStaticNestedOptionalUnionMemberFlattensRecursively(t *testing.T) {
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindOptional, Inner: &FuzzType{Kind: KindOptional, Inner: &FuzzType{Kind: KindInt}}},
+			{Kind: KindString},
+		},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name:       "Root",
+			Properties: []FuzzProperty{{Name: "u", Type: uni}},
+		}},
+		RootClass: "Root",
+	}
+	src, err := LowerToBamlSource(schema, "TestC")
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	if !strings.Contains(src.Source, "u (((int | null) | null) | string)") {
+		t.Errorf("nested optional union member should flatten recursively, got source:\n%s", src.Source)
+	}
+	// No `(T)?` form may survive at any nesting level.
+	if strings.Contains(src.Source, ")?") {
+		t.Errorf("emitted a parenthesized-optional `)?` inside union:\n%s", src.Source)
+	}
+}
+
 // TestEmitStaticOptionalUnionMemberPreservesArmCount asserts the
 // flattened optional arm stays a single parenthesised sub-union so the
 // outer union's arm count (and therefore the oracle's UnionChoice

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -639,6 +639,41 @@ func TestEmitStaticNestedOptionalUnionMemberFlattensRecursively(t *testing.T) {
 	}
 }
 
+// TestEmitStaticSingleArmUnionOptionalMemberFlattens asserts that an
+// optional buried under a single-arm union variant still flattens.
+// typeSpelling collapses a one-arm union to its bare variant, so
+// union[union[optional<int>], string] would emit ((int)? | string)
+// unless unionMemberSpelling unwraps the single-arm union while keeping
+// the union-member context.
+func TestEmitStaticSingleArmUnionOptionalMemberFlattens(t *testing.T) {
+	uni := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindUnion, Variants: []FuzzType{
+				{Kind: KindOptional, Inner: &FuzzType{Kind: KindInt}},
+			}},
+			{Kind: KindString},
+		},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name:       "Root",
+			Properties: []FuzzProperty{{Name: "u", Type: uni}},
+		}},
+		RootClass: "Root",
+	}
+	src, err := LowerToBamlSource(schema, "TestC")
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	if !strings.Contains(src.Source, "u ((int | null) | string)") {
+		t.Errorf("single-arm union wrapping an optional should flatten to (int | null), got source:\n%s", src.Source)
+	}
+	if strings.Contains(src.Source, ")?") {
+		t.Errorf("emitted a parenthesized-optional `)?` inside union:\n%s", src.Source)
+	}
+}
+
 // TestEmitStaticOptionalUnionMemberPreservesArmCount asserts the
 // flattened optional arm stays a single parenthesised sub-union so the
 // outer union's arm count (and therefore the oracle's UnionChoice

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -691,6 +691,39 @@ func TestEmitStaticRawTopLevelUnion(t *testing.T) {
 	}
 }
 
+// TestEmitStaticRawTopLevelUnionOptionalMemberFlattens asserts that an
+// optional variant in a raw top-level union (rendered via the
+// no-outer-parens return-type path) also flattens to `(inner | null)`
+// rather than `(inner)?`. Without routing the return-type union loop
+// through unionMemberSpelling, the function signature would carry the
+// parser-rejected `(int)?` form.
+func TestEmitStaticRawTopLevelUnionOptionalMemberFlattens(t *testing.T) {
+	root := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindOptional, Inner: &FuzzType{Kind: KindInt}},
+			{Kind: KindString},
+		},
+	}
+	schema := FuzzSchema{
+		Classes:  []FuzzClass{},
+		Enums:    []FuzzEnum{},
+		RootType: &root,
+	}
+	src, err := LowerToBamlSource(schema, "TestC")
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	// Top-level union: no outer parens, but the optional arm still
+	// flattens to a parenthesised `(int | null)` sub-union.
+	if !strings.Contains(src.Source, "-> (int | null) | string {") {
+		t.Errorf("expected '-> (int | null) | string {' in source, got:\n%s", src.Source)
+	}
+	if strings.Contains(src.Source, "(int)?") {
+		t.Errorf("emitted forbidden parenthesized-optional `(int)?` in return type:\n%s", src.Source)
+	}
+}
+
 // TestValueGenTerminatesThroughUnionRecursion is a rapid-driven
 // safety test: union variants can contain class refs that, when
 // chosen, would recurse into the same class. The value generator


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## What

The static BAML lowering (`adapters/common/codegen/bamlfuzz/emit_static.go`) spelled an **optional union member** as `(T)?` — e.g. `Fuzz_field_1 (... | ((int)? | (string | null)))`. BAML's parser rejects a parenthesized-optional sitting as a union member (it reads the leading `(` as a grouped union, then chokes on the trailing `?`):

```
error: Error validating: This line is not a valid field or attribute definition.
error: Error validating: No type specified for field `Fuzz_field_1`
```

Any generated schema with an optional union variant therefore fails `baml generate`.

## Fix

In the union-variant loop, an optional variant is now spelled as the flattened **`(inner | null)`** sub-union instead of `(inner)?`. This is semantically exact: an optional inside a union can only ever render as its inner value or an explicit `null` (an omitted key is impossible mid-union — `renderValueMock` degrades `OptionalAbsent` → `null`). Wrapping it in its own parens keeps the **outer union's arm count unchanged**, so the oracle's recorded `UnionChoice` indices still line up.

Standalone optional fields are deliberately **untouched** — `(T)?` is valid in field position and must stay optional to preserve absent-key semantics. Only the union-member position changes.

## Tests

- `TestEmitStaticOptionalUnionMemberFlattensToNull` — optional union member → `(int | null)`, never `(int)?`; standalone optional field still `(string)?`.
- `TestEmitStaticOptionalUnionMemberPreservesArmCount` — flattened optional class-ref arm keeps the outer union at 3 arms.
- `go test ./codegen/bamlfuzz/` passes (from `adapters/common`, `GOWORK=off`).
- End-to-end: the original crasher input replays to **PASS** under `BAML_VERSION=0.222.0 go test -tags=integration,subprocess -run='FuzzBamlfuzzStatic/<hash>' ./integration` — valid BAML, oracle (incl. `preserve_schema_order`) passes.

## ⚠️ This does NOT fix the CI `exit status 2` crash

Investigating the nightly crash surfaced a **second, independent root cause** that this PR does not (and cannot) address in codegen:

`go test -fuzz` enforces a **hard-coded 10s-per-input watchdog** in the Go runtime (`internal/fuzz/worker.go:492`):

```go
timer := time.AfterFunc(10*time.Second, func() {
    panic("deadlocked!") // this error message won't be printed
})
```

`FuzzBamlfuzzStatic`'s body runs `setupStaticEnv` — a **full Docker image build (`npx baml generate` + `go build`) + container start per exec** (~30–60s). Every fresh build overruns the 10s budget → unrecovered `panic("deadlocked!")` → `exit status 2`. The worker's stderr is wired to `/dev/null` by the fuzz framework, so the message is discarded — which is why CI never showed a stack. The 10s is not configurable by any flag/env.

Captured worker trace (via temporary local instrumentation, reverted) shows the panic firing mid-build:
```
Running BAML client generation (npx @boundaryml/baml@0.222.0 generate)...
panic: deadlocked!
goroutine ... [running]:
internal/fuzz.RunFuzzWorker.func1.1()
    .../internal/fuzz/worker.go:493
created by time.goFunc
```

This reproduces with **1 worker as well as 10** (it's per-input, not parallelism), and every individual input **passes** under `-run` (no watchdog) and via cached seed replay (<10s). So it is orthogonal to the codegen bug fixed here.

### Recommended follow-up (separate change)

The per-exec work cannot be brought under 10s while it builds a Docker image, so `FuzzBamlfuzzStatic` is fundamentally incompatible with the native `-fuzz` engine. Options for a separate PR:

- Drive static-schema coverage through the rapid-based `TestBamlfuzzStaticOracle` under `-run` (no watchdog) instead of the native fuzz engine in the nightly; and/or
- Restrict `FuzzBamlfuzzStatic` to corpus-replay under `-run` rather than `-fuzz`.

Refs #349


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Union type emission now consistently renders optional members as flattened "(Type | null)" arms inside unions (including top-level return types), preventing parenthesized-optional syntax and ensuring stable, predictable emitted spelling.

* **Tests**
  * Added regression tests covering optional-in-union flattening, recursive handling of nested optionals, single-arm-union unwrapping, exact union spelling, and preservation of union arm counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->