### PR TITLE
fix(bamlfuzz): run Static target via -run oracle, not -fuzz (10s watchdog)

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -346,7 +346,7 @@ jobs:
               echo "This cell ran the Static oracle via \`-run\` (FuzzBamlfuzzStatic overruns Go's 10s/input fuzz watchdog). Repro:"
               echo
               echo '```'
-              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} go test -tags=integration,subprocess -run='TestBamlfuzzStaticOracle' ./integration -count=1 -p 1"
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} BAMLFUZZ_SEED=${BAMLFUZZ_SEED} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} go test -tags=integration,subprocess -run='TestBamlfuzzStaticOracle' ./integration -count=1 -p 1"
               echo '```'
             elif [ "${MODE}" = "fuzz" ]; then
               echo "Corpus artifact: bamlfuzz-corpus-${BAML}-${UNARY}-${TARGET}"

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -13,7 +13,7 @@ on:
         options: [fuzz, rapid]
         default: fuzz
       seed:
-        description: BAMLFUZZ_SEED override (defaults to github.run_id; rapid mode only)
+        description: BAMLFUZZ_SEED override (defaults to github.run_id; rapid mode + the fuzz-mode Static oracle cell)
         type: string
         required: false
       dynamic_cases:
@@ -22,7 +22,7 @@ on:
         required: false
         default: "50"
       static_batches:
-        description: Rapid-mode static batches (default 10)
+        description: Static rapid batches; used by both rapid mode and the fuzz-mode Static oracle cell (default 10)
         type: string
         required: false
         default: "10"

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -119,8 +119,11 @@ jobs:
       BAMLFUZZ_KEEP_ARTIFACTS: "1"
       MODE: ${{ github.event.inputs.mode || 'fuzz' }}
       FUZZTIME: ${{ github.event.inputs.fuzztime || '15m' }}
-      # Rapid-mode knobs: ignored by the fuzz-mode step. Kept addressable
-      # via dispatch inputs so a manual run can mix-and-match.
+      # Oracle knobs. BAMLFUZZ_STATIC_BATCHES is respected in fuzz mode
+      # too — the Static step routes through TestBamlfuzzStaticOracle
+      # under -run. The rest apply in rapid mode only (the -fuzz step
+      # ignores them). Kept addressable via dispatch inputs so a manual
+      # run can mix-and-match.
       BAMLFUZZ_DYNAMIC_CASES: ${{ github.event.inputs.dynamic_cases || '50' }}
       BAMLFUZZ_STATIC_BATCHES: ${{ github.event.inputs.static_batches || '10' }}
       BAMLFUZZ_INVALID_CASES: ${{ github.event.inputs.invalid_cases || '50' }}

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -138,7 +138,10 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Restore corpus from prior nightly (target-scoped)
-        if: ${{ env.MODE == 'fuzz' }}
+        # FuzzBamlfuzzStatic runs through TestBamlfuzzStaticOracle under
+        # -run (see the Static step below), which does not use the fuzz
+        # corpus, so skip corpus restore/upload for that target.
+        if: ${{ env.MODE == 'fuzz' && matrix.target != 'FuzzBamlfuzzStatic' }}
         id: restore-target
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -181,7 +184,7 @@ jobs:
       # Once the first target-scoped nightly succeeds, this step becomes a
       # no-op and can be removed in a future PR.
       - name: Fallback restore from legacy unscoped corpus
-        if: ${{ env.MODE == 'fuzz' && steps.restore-target.outputs.restored == '' }}
+        if: ${{ env.MODE == 'fuzz' && matrix.target != 'FuzzBamlfuzzStatic' && steps.restore-target.outputs.restored == '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACT_NAME: bamlfuzz-corpus-${{ matrix.baml-version }}-${{ matrix.unary-server }}
@@ -218,7 +221,9 @@ jobs:
           fi
 
       - name: Fuzz ${{ matrix.target }} (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
-        if: ${{ env.MODE == 'fuzz' }}
+        # FuzzBamlfuzzStatic is handled by the Static oracle step below,
+        # not the native fuzz engine — see that step for why.
+        if: ${{ env.MODE == 'fuzz' && matrix.target != 'FuzzBamlfuzzStatic' }}
         # Each matrix cell runs exactly one fuzz target via the `target`
         # axis. BAMLFUZZ_KEEP_ARTIFACTS is forced off; the success-path
         # envelope dump writes to _artifacts/fuzz.json which races under
@@ -233,6 +238,27 @@ jobs:
             -fuzztime="${FUZZTIME}" \
             ./integration \
             -test.fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache"
+
+      - name: Static oracle (-run, no fuzz watchdog) (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
+        if: ${{ env.MODE == 'fuzz' && matrix.target == 'FuzzBamlfuzzStatic' }}
+        # FuzzBamlfuzzStatic builds a full Docker env per iteration
+        # (~30-60s: npx baml generate + go build + container start), but
+        # Go's fuzz engine hard-caps every input at a 10s watchdog
+        # (internal/fuzz/worker.go → panic("deadlocked!")), so -fuzz
+        # always overruns and crashes this target on its first exec with
+        # exit status 2 (the worker's stderr is wired to /dev/null, so the
+        # panic never surfaces). Run the identical schema-gen + build +
+        # REST + oracle path through TestBamlfuzzStaticOracle under -run
+        # instead, which has no per-input watchdog.
+        #
+        # BAMLFUZZ_STATIC_BATCHES (job env, default 10) scales the rapid
+        # batches; 10 × staticCasesPerBatch (5) = 50 cases, matching the
+        # ~50-case budget the other targets explore per nightly cell.
+        # No corpus restore/upload: -run does not use the fuzz corpus.
+        run: |
+          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
+            -run='TestBamlfuzzStaticOracle' \
+            ./integration
 
       - name: Run bamlfuzz oracles — rapid mode (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'rapid' && matrix.target == 'FuzzBamlfuzzStatic' }}
@@ -254,7 +280,8 @@ jobs:
             -run='^TestBamlfuzz(Static|Dynamic|Streaming)Oracle$|^TestBamlfuzzInvalid(Dynamic|JSONCoercion)$' ./integration/...
 
       - name: Upload corpus for next nightly
-        if: ${{ always() && env.MODE == 'fuzz' }}
+        # Static runs via -run (no fuzz corpus), so nothing to persist.
+        if: ${{ always() && env.MODE == 'fuzz' && matrix.target != 'FuzzBamlfuzzStatic' }}
         # Uploaded on every run (including failures) so a fuzz failure
         # the engine already wrote to the cache survives into the next
         # restore pass — the corpus is the only mechanism that lets the
@@ -310,7 +337,18 @@ jobs:
             echo "Matrix: baml-version=${BAML}, unary-server=${UNARY}, target=${TARGET}"
             echo "Workflow: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
             echo "Envelope artifact: bamlfuzz-envelopes-${BAML}-${UNARY}-${TARGET}-${RUN_ID}"
-            if [ "${MODE}" = "fuzz" ]; then
+            if [ "${MODE}" = "fuzz" ] && [ "${TARGET}" = "FuzzBamlfuzzStatic" ]; then
+              # Static runs through TestBamlfuzzStaticOracle under -run
+              # (FuzzBamlfuzzStatic is incompatible with go test -fuzz's
+              # hardcoded 10s/input watchdog), so there is no fuzz corpus
+              # and the repro is the oracle command.
+              echo
+              echo "This cell ran the Static oracle via \`-run\` (FuzzBamlfuzzStatic overruns Go's 10s/input fuzz watchdog). Repro:"
+              echo
+              echo '```'
+              echo "BAML_VERSION=${BAML} UNARY_SERVER=${UNARY} BAMLFUZZ_STATIC_BATCHES=${BAMLFUZZ_STATIC_BATCHES} go test -tags=integration,subprocess -run='TestBamlfuzzStaticOracle' ./integration -count=1 -p 1"
+              echo '```'
+            elif [ "${MODE}" = "fuzz" ]; then
               echo "Corpus artifact: bamlfuzz-corpus-${BAML}-${UNARY}-${TARGET}"
               echo
               echo "This cell ran fuzz target \`${TARGET}\`. Repro (from repo root, after downloading the corpus artifact and extracting under adapters/common/codegen/testdata/bamlfuzz/.fuzzcache/):"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -198,17 +198,6 @@ func TestMain(m *testing.M) {
 	}
 	UseBuildRequest = parseBoolEnv(os.Getenv("BAML_REST_USE_BUILD_REQUEST"))
 
-	// FuzzBamlfuzzStatic worker subprocesses re-run TestMain but don't need
-	// the shared Docker environment — that target builds its own per-iteration
-	// env via setupStaticEnv and never touches TestEnv. Skip the expensive
-	// Setup for those workers to avoid resource conflicts and unrecovered
-	// goroutine panics from testcontainers health-check goroutines. The other
-	// fuzz targets (Dynamic, Streaming, InvalidJSONCoercion) use the shared
-	// TestEnv/MockClient/BAMLClient, so their workers must still build it.
-	if isStaticFuzzWorker() {
-		os.Exit(m.Run())
-	}
-
 	TestEnv, err = testutil.Setup(ctx, matrixSetupOptions())
 	if err != nil {
 		println("Failed to setup test environment:", err.Error())
@@ -247,40 +236,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(code)
-}
-
-// isStaticFuzzWorker reports whether this process is a Go fuzzing worker
-// subprocess (-test.fuzzworker) that is fuzzing the FuzzBamlfuzzStatic
-// target. Only that target builds its own per-iteration environment via
-// setupStaticEnv; the others (Dynamic, Streaming, InvalidJSONCoercion) rely
-// on the shared TestEnv, so their workers must still run the Docker setup.
-//
-// The fuzz framework launches workers with -test.fuzzworker prepended to a
-// copy of the coordinator's args (internal/fuzz.startWorkers), so the worker
-// inherits the same -test.fuzz=<pattern> regexp the coordinator was invoked
-// with — the nightly uses -fuzz='^FuzzBamlfuzzStatic$'.
-func isStaticFuzzWorker() bool {
-	var fuzzWorker bool
-	var fuzzPattern string
-	args := os.Args[1:]
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		switch {
-		case arg == "-test.fuzzworker" || arg == "--test.fuzzworker",
-			strings.HasPrefix(arg, "-test.fuzzworker="), strings.HasPrefix(arg, "--test.fuzzworker="):
-			fuzzWorker = true
-		case strings.HasPrefix(arg, "-test.fuzz="):
-			fuzzPattern = strings.TrimPrefix(arg, "-test.fuzz=")
-		case strings.HasPrefix(arg, "--test.fuzz="):
-			fuzzPattern = strings.TrimPrefix(arg, "--test.fuzz=")
-		case arg == "-test.fuzz" || arg == "--test.fuzz":
-			if i+1 < len(args) {
-				fuzzPattern = args[i+1]
-				i++
-			}
-		}
-	}
-	return fuzzWorker && strings.Contains(fuzzPattern, "FuzzBamlfuzzStatic")
 }
 
 // dumpContainerLogs fetches and prints logs from a Docker container.


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Problem

`FuzzBamlfuzzStatic` crashes the nightly with `exit status 2` on its first exec (seen on BAML 0.219.0 / 0.222.0). Root cause: Go's fuzz engine hard-codes a **10s-per-input watchdog** (`internal/fuzz/worker.go` → `panic("deadlocked!")`), but `FuzzBamlfuzzStatic`'s body does a **full Docker build per iteration** (`npx baml generate` + `go build` + container start, ~30–60s). Every iteration overruns 10s and panics. The worker's stderr is wired to `/dev/null` by the fuzz framework, so the panic never appeared in CI logs.

This is a structural incompatibility — the per-iteration work cannot be brought under 10s — so no codegen/runtime change fixes it. (The separate `(int)?`-in-union codegen bug, PR #399, is real but orthogonal.)

## Fix

Route the Static target through the existing `TestBamlfuzzStaticOracle` under **`-run`** instead of `-fuzz`. The oracle runs the *identical* schema generation → Docker build → `/call` REST request → expected-vs-actual oracle comparison (incl. the `preserve_schema_order` check), but as a normal test with **no per-input watchdog**.

In `.github/workflows/bamlfuzz-nightly.yml`, for `matrix.target == 'FuzzBamlfuzzStatic'` in fuzz mode:

```
go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
  -run='TestBamlfuzzStaticOracle' \
  ./integration
```

- **Batches:** inherits `BAMLFUZZ_STATIC_BATCHES` from job env (default `10`). `10 × staticCasesPerBatch (5) = 50` cases — matching the ~50-case budget the other targets explore per cell (`BAMLFUZZ_DYNAMIC_CASES`/`_STREAMING_CASES`/`_INVALID_CASES` = 50), and the same value rapid mode already uses.
- **Corpus restore/upload** steps are skipped for Static (`-run` doesn't use the fuzz corpus).
- **Sticky-issue repro** is made Static-aware: emits the `-run='TestBamlfuzzStaticOracle'` command (with `BAMLFUZZ_STATIC_BATCHES`) instead of a `-fuzz` corpus repro, and omits the corpus-artifact line.
- **All other targets** (Dynamic, Streaming, InvalidDynamic, InvalidJSONCoercion) keep the native `-fuzz` path **unchanged**.

## Also: revert #397

#397 added `isStaticFuzzWorker()` to skip the shared Docker setup specifically in `FuzzBamlfuzzStatic` *fuzz-worker* subprocesses. With Static no longer run under `-fuzz` in CI, there is no such worker left to guard, so the special-case is dead code. Reverted in the **same** commit so the switch-over is atomic.

## Verification

- `go vet -tags=integration,subprocess ./integration/` — clean.
- Integration test binary compiles (`go test -c`).
- Workflow YAML parses (`yaml.safe_load`).
- (`TestBamlfuzzStaticOracle` is already exercised today by the nightly's rapid-mode step, so the `-run` path is known-good; this PR just makes fuzz-mode use it for Static.)

Refs #349


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Nightly workflow now treats static validation targets separately, refines corpus restore/upload behavior, splits execution into native fuzz and dedicated static-oracle steps, and improves artifact persistence and failure diagnostics.
* **Tests**
  * Integration test harness updated so static fuzz worker processes use the shared test environment setup instead of being short-circuited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->