### PR TITLE
fix(bamlfuzz): fold degenerate unions so BAML 0.219+ codegen stops panicking

### DIFF
--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -1224,8 +1224,8 @@ func rewriteTypeAtPath(t FuzzType, path string, plan collapsePlan) FuzzType {
 		deduped, _ := rewriteUnionVariants(t, path, plan)
 		if allVariantsNull(deduped) {
 			// Every surviving arm is null: the union carries no real
-			// alternative, so emit a bare null instead of a union that
-			// `baml generate` would panic on.
+			// alternative, so emit a bare null. A union with no non-null
+			// arm makes `baml generate` panic on BAML 0.219+.
 			return FuzzType{Kind: KindNull}
 		}
 		if len(deduped) == 1 {
@@ -1281,7 +1281,16 @@ func rewriteTypeAtPath(t FuzzType, path string, plan collapsePlan) FuzzType {
 func rewriteUnionVariants(t FuzzType, path string, plan collapsePlan) (deduped []FuzzType, mapping []int) {
 	rewritten := make([]FuzzType, len(t.Variants))
 	for i, v := range t.Variants {
-		rewritten[i] = rewriteTypeAtPath(v, fmt.Sprintf("%s:v%d", path, i), plan)
+		rv := rewriteTypeAtPath(v, fmt.Sprintf("%s:v%d", path, i), plan)
+		// A nested-union collapse can turn an optional<union[...]> arm
+		// into optional<null>, which unionMemberSpelling flattens to
+		// `(null | null)` — the panic shape. Reduce any arm that spells
+		// to a null-only union member down to a bare null so the dedup
+		// below merges it with the union's other null arms.
+		if nullEquivalentUnionArm(rv) {
+			rv = FuzzType{Kind: KindNull}
+		}
+		rewritten[i] = rv
 	}
 	mapping = make([]int, len(rewritten))
 	for i, rv := range rewritten {
@@ -1338,6 +1347,15 @@ func normalizeUnionType(t FuzzType) FuzzType {
 		deduped := make([]FuzzType, 0, len(t.Variants))
 		for _, v := range t.Variants {
 			nv := normalizeUnionType(v)
+			// optional<null> (and deeper optional<...<null>>) spells via
+			// unionMemberSpelling as a null-only `(null | null)` arm, so
+			// reduce it to a bare null before dedup. This keeps it from
+			// surviving the structural dedup as a distinct arm and lets
+			// the all-null fold below catch unions like
+			// union[optional<null>, null].
+			if nullEquivalentUnionArm(nv) {
+				nv = FuzzType{Kind: KindNull}
+			}
 			dup := false
 			for _, d := range deduped {
 				if reflect.DeepEqual(nv, d) {
@@ -1360,6 +1378,24 @@ func normalizeUnionType(t FuzzType) FuzzType {
 		return out
 	}
 	return t
+}
+
+// nullEquivalentUnionArm reports whether `t`, sitting as a union arm,
+// spells to a null-only union member. A bare null qualifies, as does an
+// optional wrapping a null-equivalent type: unionMemberSpelling renders
+// optional<X> as `(spelling(X) | null)`, so optional<null> becomes
+// `(null | null)` and optional<optional<null>> becomes
+// `((null | null) | null)` — both carry no non-null alternative and trip
+// the BAML 0.219+ union validation. Such arms are folded to a bare null
+// before union dedup so the all-null check can collapse them away.
+func nullEquivalentUnionArm(t FuzzType) bool {
+	switch t.Kind {
+	case KindNull:
+		return true
+	case KindOptional:
+		return t.Inner != nil && nullEquivalentUnionArm(*t.Inner)
+	}
+	return false
 }
 
 // allVariantsNull reports whether `variants` is non-empty and every
@@ -1413,19 +1449,29 @@ func rewriteValueByPlans(schema FuzzSchema, t FuzzType, v FuzzValue, plans map[f
 			// selects the surviving subtree.
 			return rewriteValueByPlans(schema, t.Variants[idx], *v.Variant, plans, currentPlan, fmt.Sprintf("%s:v%d", path, idx))
 		}
-		// Union stays in the schema. Rewrite the picked arm's value,
-		// then mirror rewriteTypeAtPath's arm dedup so the value tracks
-		// the post-dedup schema: if the union folded to a single arm the
-		// wrapper is dropped (value becomes the bare arm); otherwise the
-		// picked index is remapped onto the deduped arm list.
-		newInner := rewriteValueByPlans(schema, t.Variants[v.VariantIndex], *v.Variant, plans, currentPlan, fmt.Sprintf("%s:v%d", path, v.VariantIndex))
+		// Union stays in the schema. Mirror rewriteTypeAtPath's arm dedup
+		// so the value tracks the post-dedup schema: the picked arm's
+		// index is remapped onto the deduped arm list, and when the union
+		// folds to a single arm the wrapper is dropped (value becomes the
+		// bare arm).
 		deduped, mapping := rewriteUnionVariants(t, path, currentPlan)
-		if allVariantsNull(deduped) || len(deduped) == 1 {
-			return newInner
+		mapped := mapping[v.VariantIndex]
+		var aligned FuzzValue
+		if deduped[mapped].Kind == KindNull {
+			// The picked arm reduced to a bare null — it was a direct null
+			// or an optional<null...> arm that spells null-only. The
+			// aligned value at a null slot is an explicit null, matching
+			// how a mid-union optional renders (absent degrades to null).
+			aligned = FuzzValue{Kind: KindNull}
+		} else {
+			aligned = rewriteValueByPlans(schema, t.Variants[v.VariantIndex], *v.Variant, plans, currentPlan, fmt.Sprintf("%s:v%d", path, v.VariantIndex))
+		}
+		if len(deduped) == 1 {
+			return aligned
 		}
 		out := v
-		out.VariantIndex = mapping[v.VariantIndex]
-		out.Variant = &newInner
+		out.VariantIndex = mapped
+		out.Variant = &aligned
 		return out
 	case KindClassRef:
 		if v.Kind != KindClassRef {

--- a/adapters/common/codegen/bamlfuzz/generator.go
+++ b/adapters/common/codegen/bamlfuzz/generator.go
@@ -2,6 +2,7 @@ package bamlfuzz
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"pgregory.net/rapid"
@@ -167,6 +168,19 @@ func drawSchema(t *rapid.T, opts SchemaGenOptions) FuzzSchema {
 	}
 	if selfRefRoot {
 		injectSelfRef(&classes[0])
+	}
+
+	// Fold degenerate unions (duplicate arms, all-null) out of every
+	// drawn property type before the schema escapes the generator. The
+	// self-ref / cycle injections above only ever write optional<class>
+	// edges, so normalizing after them is safe and keeps the cleanup in
+	// one place. Done here (not in drawType) so the whole subtree —
+	// including arms that themselves contain unions — is normalized
+	// bottom-up in a single pass.
+	for i := range classes {
+		for j := range classes[i].Properties {
+			classes[i].Properties[j].Type = normalizeUnionType(classes[i].Properties[j].Type)
+		}
 	}
 
 	schema := FuzzSchema{
@@ -1177,9 +1191,13 @@ func planRoot(rootType FuzzType, value FuzzValue) collapsePlan {
 }
 
 func rewriteTypeWithPlan(t FuzzType, plan collapsePlan) FuzzType {
-	if len(plan.choices) == 0 {
-		return t
-	}
+	// No early-return on an empty plan: rewriteTypeAtPath also performs
+	// the unconditional union-arm dedup (folding duplicate / all-null
+	// arms that the raw generator or a nested collapse can produce), and
+	// that cleanup must run even when no position in this field
+	// collapses. Skipping it here would leave the schema with a
+	// duplicate-arm union while rewriteValueByPlans — which has no such
+	// guard — still dedups the value, drifting the two out of alignment.
 	return rewriteTypeAtPath(t, "", plan)
 }
 
@@ -1194,11 +1212,29 @@ func rewriteTypeAtPath(t FuzzType, path string, plan collapsePlan) FuzzType {
 			// silently leave nested unions uncollapsed.
 			return rewriteTypeAtPath(t.Variants[idx], fmt.Sprintf("%s:v%d", path, idx), plan)
 		}
-		out := t
-		out.Variants = make([]FuzzType, len(t.Variants))
-		for i, v := range t.Variants {
-			out.Variants[i] = rewriteTypeAtPath(v, fmt.Sprintf("%s:v%d", path, i), plan)
+		// The union itself stays (its arm choice disagreed across
+		// visits, or it sits at an uncollapsed path). Rewrite each arm,
+		// then deduplicate: collapsing a nested union to its picked arm
+		// can make sibling arms structurally identical — e.g. a parent
+		// union[null, union[null, string]] whose inner union picked its
+		// null arm rewrites to union[null, null]. BAML 0.219+ rejects a
+		// union with no non-null arm (and even pre-0.219 a duplicate-arm
+		// union is degenerate), so fold the duplicates away before the
+		// type reaches the emitter.
+		deduped, _ := rewriteUnionVariants(t, path, plan)
+		if allVariantsNull(deduped) {
+			// Every surviving arm is null: the union carries no real
+			// alternative, so emit a bare null instead of a union that
+			// `baml generate` would panic on.
+			return FuzzType{Kind: KindNull}
 		}
+		if len(deduped) == 1 {
+			// Dedup collapsed the union to a single arm; unwrap it so
+			// the emitter never has to render a one-operand pipe.
+			return deduped[0]
+		}
+		out := t
+		out.Variants = deduped
 		return out
 	case KindOptional:
 		if t.Inner == nil {
@@ -1226,6 +1262,119 @@ func rewriteTypeAtPath(t FuzzType, path string, plan collapsePlan) FuzzType {
 		return out
 	}
 	return t
+}
+
+// rewriteUnionVariants rewrites every arm of the union `t` at `path`
+// under `plan` (mirroring rewriteTypeAtPath's per-arm descent exactly,
+// ":v<idx>" step and all) and then deduplicates the results by
+// structural identity, preserving first-seen arm order. It returns the
+// deduplicated arm list together with a mapping from each original arm
+// index to its index in the deduped list.
+//
+// Both the schema rewrite (rewriteTypeAtPath) and the value rewrite
+// (rewriteValueByPlans) call this so they agree on the post-dedup arm
+// set and indices: the schema stores `deduped`, and the value remaps
+// its picked VariantIndex through `mapping` (or drops the wrapper
+// entirely when the union folded to a single arm). Drifting the two
+// apart would leave a union-shaped value sitting in a non-union schema
+// slot, the misalignment assertValueAlignsWithSchema guards against.
+func rewriteUnionVariants(t FuzzType, path string, plan collapsePlan) (deduped []FuzzType, mapping []int) {
+	rewritten := make([]FuzzType, len(t.Variants))
+	for i, v := range t.Variants {
+		rewritten[i] = rewriteTypeAtPath(v, fmt.Sprintf("%s:v%d", path, i), plan)
+	}
+	mapping = make([]int, len(rewritten))
+	for i, rv := range rewritten {
+		at := -1
+		for j, d := range deduped {
+			if reflect.DeepEqual(rv, d) {
+				at = j
+				break
+			}
+		}
+		if at < 0 {
+			at = len(deduped)
+			deduped = append(deduped, rv)
+		}
+		mapping[i] = at
+	}
+	return deduped, mapping
+}
+
+// normalizeUnionType folds degenerate unions out of a freshly drawn
+// type tree. It recursively deduplicates structurally-identical union
+// arms, unwraps a union that dedups down to a single arm, and replaces
+// an all-null union with a bare null. The raw schema generator draws
+// each union arm independently, so it readily produces duplicate arms
+// (string|string) or an all-null union (null|null); BAML 0.219+ panics
+// on a union with no non-null arm ("Union type must have at least one
+// non-null type"). Applying this at draw time — before the schema is
+// handed to ValueGen — keeps the value generator, walker, and static
+// emitter all observing the same cleaned shape, so the panic is avoided
+// even for "preserve" cases that never run the Move B collapse pass.
+//
+// This complements the dedup baked into rewriteTypeAtPath: the draw-time
+// pass cleans raw generator output, while the rewrite-time pass cleans
+// duplicates that a nested-union collapse introduces later.
+func normalizeUnionType(t FuzzType) FuzzType {
+	switch t.Kind {
+	case KindOptional, KindList:
+		if t.Inner == nil {
+			return t
+		}
+		inner := normalizeUnionType(*t.Inner)
+		out := t
+		out.Inner = &inner
+		return out
+	case KindMap:
+		if t.Inner == nil {
+			return t
+		}
+		inner := normalizeUnionType(*t.Inner)
+		out := t
+		out.Inner = &inner
+		return out
+	case KindUnion:
+		deduped := make([]FuzzType, 0, len(t.Variants))
+		for _, v := range t.Variants {
+			nv := normalizeUnionType(v)
+			dup := false
+			for _, d := range deduped {
+				if reflect.DeepEqual(nv, d) {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				deduped = append(deduped, nv)
+			}
+		}
+		if allVariantsNull(deduped) {
+			return FuzzType{Kind: KindNull}
+		}
+		if len(deduped) == 1 {
+			return deduped[0]
+		}
+		out := t
+		out.Variants = deduped
+		return out
+	}
+	return t
+}
+
+// allVariantsNull reports whether `variants` is non-empty and every
+// entry is a bare KindNull. Used to fold an all-null union — the shape
+// BAML 0.219+ panics on — down to a single null.
+func allVariantsNull(variants []FuzzType) bool {
+	if len(variants) == 0 {
+		return false
+	}
+	for _, v := range variants {
+		if v.Kind != KindNull {
+			return false
+		}
+	}
+	return true
 }
 
 // rewriteValueByPlans rewrites the value to match a schema rewritten
@@ -1264,8 +1413,18 @@ func rewriteValueByPlans(schema FuzzSchema, t FuzzType, v FuzzValue, plans map[f
 			// selects the surviving subtree.
 			return rewriteValueByPlans(schema, t.Variants[idx], *v.Variant, plans, currentPlan, fmt.Sprintf("%s:v%d", path, idx))
 		}
+		// Union stays in the schema. Rewrite the picked arm's value,
+		// then mirror rewriteTypeAtPath's arm dedup so the value tracks
+		// the post-dedup schema: if the union folded to a single arm the
+		// wrapper is dropped (value becomes the bare arm); otherwise the
+		// picked index is remapped onto the deduped arm list.
 		newInner := rewriteValueByPlans(schema, t.Variants[v.VariantIndex], *v.Variant, plans, currentPlan, fmt.Sprintf("%s:v%d", path, v.VariantIndex))
+		deduped, mapping := rewriteUnionVariants(t, path, currentPlan)
+		if allVariantsNull(deduped) || len(deduped) == 1 {
+			return newInner
+		}
 		out := v
+		out.VariantIndex = mapping[v.VariantIndex]
 		out.Variant = &newInner
 		return out
 	case KindClassRef:

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -861,6 +861,51 @@ func TestSchemaGenDoesNotProduceLiteralInt(t *testing.T) {
 	})
 }
 
+// TestSchemaGenDoesNotProduceAllNullUnion is a rapid-driven invariant:
+// no union with an all-null arm set (and no duplicate-arm union) may
+// survive in a drawn schema. The raw generator draws each union arm
+// independently and so readily produces null|null or string|string;
+// BAML 0.219+ panics on a union with no non-null arm during
+// `baml generate`. normalizeUnionType folds these at draw time, so this
+// pins that the cleanup stays wired into the generator and the
+// preserve-mode (non-collapsed) corpus never ships the panic shape.
+func TestSchemaGenDoesNotProduceAllNullUnion(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		schema := StaticSchemaGen().Draw(rt, "schema")
+		for _, cls := range schema.Classes {
+			for _, prop := range cls.Properties {
+				checkNoDegenerateUnion(rt, prop.Type)
+			}
+		}
+		if schema.RootType != nil {
+			checkNoDegenerateUnion(rt, *schema.RootType)
+		}
+	})
+}
+
+func checkNoDegenerateUnion(rt *rapid.T, t FuzzType) {
+	switch t.Kind {
+	case KindUnion:
+		if allVariantsNull(t.Variants) {
+			rt.Fatalf("drawn schema contains an all-null union: %#v", t)
+		}
+		for i := range t.Variants {
+			for j := i + 1; j < len(t.Variants); j++ {
+				if reflect.DeepEqual(t.Variants[i], t.Variants[j]) {
+					rt.Fatalf("drawn schema contains a duplicate-arm union (arms %d and %d): %#v", i, j, t)
+				}
+			}
+		}
+		for _, v := range t.Variants {
+			checkNoDegenerateUnion(rt, v)
+		}
+	case KindOptional, KindList, KindMap:
+		if t.Inner != nil {
+			checkNoDegenerateUnion(rt, *t.Inner)
+		}
+	}
+}
+
 func checkNoLiteralInt(rt *rapid.T, t FuzzType) {
 	switch t.Kind {
 	case KindLiteral:
@@ -1157,6 +1202,205 @@ func TestCollapseUnionsToPickedNestedUnionInsideMixedOuter(t *testing.T) {
 	}
 	if outerType.Variants[1].Kind != KindInt {
 		t.Errorf("outer variant 1 should still be int, got %#v", outerType.Variants[1])
+	}
+}
+
+// TestRewriteTypeAtPathDedupesAllNullToSingleNull pins the BAML 0.219+
+// panic fix: when a parent union does not collapse on its own but a
+// nested union arm collapses to null, the rewritten arms become
+// [null, null]. BAML 0.219+ rejects a union with no non-null arm
+// ("Union type must have at least one non-null type"), so the rewrite
+// must fold the duplicate nulls and return a bare KindNull rather than
+// a degenerate two-null union.
+func TestRewriteTypeAtPathDedupesAllNullToSingleNull(t *testing.T) {
+	inner := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindNull},
+			{Kind: KindString},
+		},
+	}
+	parent := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindNull},
+			inner,
+		},
+	}
+	// Plan: the parent (path "") does not collapse, but the inner union
+	// at ":v1" collapses to its null arm (index 0). Rewriting arm 1 then
+	// yields null, so the parent's arms are [null, null].
+	plan := collapsePlan{choices: map[string]int{":v1": 0}}
+	got := rewriteTypeAtPath(parent, "", plan)
+	if got.Kind != KindNull {
+		t.Fatalf("all-null union should fold to a bare null, got %#v", got)
+	}
+	if len(got.Variants) != 0 {
+		t.Errorf("folded null should carry no variants, got %d", len(got.Variants))
+	}
+}
+
+// TestRewriteTypeAtPathDedupesNestedDuplicates pins that a nested-union
+// collapse which makes two surviving arms structurally identical is
+// deduplicated. Here the inner union collapses to int, colliding with
+// the parent's existing int arm; the result keeps the distinct arms
+// (string, int) once each rather than emitting int twice.
+func TestRewriteTypeAtPathDedupesNestedDuplicates(t *testing.T) {
+	inner := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindInt},
+			{Kind: KindBool},
+		},
+	}
+	parent := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindInt},
+			inner,
+		},
+	}
+	// Inner union at ":v2" collapses to its int arm (index 0), making
+	// the parent's arms [string, int, int].
+	plan := collapsePlan{choices: map[string]int{":v2": 0}}
+	got := rewriteTypeAtPath(parent, "", plan)
+	if got.Kind != KindUnion {
+		t.Fatalf("mixed union should stay a union after dedup, got kind %q", got.Kind)
+	}
+	if len(got.Variants) != 2 {
+		t.Fatalf("expected 2 deduped arms, got %d: %#v", len(got.Variants), got.Variants)
+	}
+	if got.Variants[0].Kind != KindString || got.Variants[1].Kind != KindInt {
+		t.Errorf("expected deduped arms [string, int], got [%q, %q]",
+			got.Variants[0].Kind, got.Variants[1].Kind)
+	}
+}
+
+// TestRewriteTypeAtPathLeavesMixedUnionUnchanged pins that a union
+// whose arms stay structurally distinct after the per-arm rewrite is
+// returned unchanged — the dedup pass must not perturb a well-formed
+// multi-arm union.
+func TestRewriteTypeAtPathLeavesMixedUnionUnchanged(t *testing.T) {
+	parent := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindString},
+			{Kind: KindInt},
+		},
+	}
+	got := rewriteTypeAtPath(parent, "", newCollapsePlan())
+	if !reflect.DeepEqual(got, parent) {
+		t.Errorf("distinct-arm union should be unchanged\nwant: %#v\ngot:  %#v", parent, got)
+	}
+}
+
+// TestCollapseUnionsToPickedFoldsAllNullUnionEndToEnd is the
+// end-to-end regression for the reported `baml generate` panic: a
+// parent union[null, union[null, string]] sitting inside a list, where
+// observations disagree at the parent (so it does not collapse) but the
+// reached inner union consistently picks its null arm (so it collapses
+// to null). Before the fix the parent rewrote to union[null, null],
+// which BAML 0.219+ panics on. After the fix the position folds to a
+// bare null and the rewritten value stays aligned with the rewritten
+// schema (no stale union wrapper left over a non-union slot).
+func TestCollapseUnionsToPickedFoldsAllNullUnionEndToEnd(t *testing.T) {
+	inner := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindNull},
+			{Kind: KindString},
+		},
+	}
+	parent := FuzzType{
+		Kind: KindUnion,
+		Variants: []FuzzType{
+			{Kind: KindNull},
+			inner,
+		},
+	}
+	listOfParent := FuzzType{Kind: KindList, Inner: &parent}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "items", Type: listOfParent},
+			},
+		}},
+		RootClass: "Root",
+	}
+	// Two list elements with disagreeing parent picks: element 0 picks
+	// the parent's direct null arm; element 1 picks the inner union,
+	// which in turn picks its null arm. The parent choice disagrees
+	// (0 vs 1) so the parent stays; the inner choice is consistent
+	// across the single visit that reaches it, so it collapses to null.
+	elemDirectNull := FuzzValue{
+		Kind: KindUnion, VariantIndex: 0,
+		Variant: &FuzzValue{Kind: KindNull},
+	}
+	elemInnerNull := FuzzValue{
+		Kind: KindUnion, VariantIndex: 1,
+		Variant: &FuzzValue{
+			Kind: KindUnion, VariantIndex: 0,
+			Variant: &FuzzValue{Kind: KindNull},
+		},
+	}
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{{
+			Name:  "items",
+			Value: FuzzValue{Kind: KindList, Items: []FuzzValue{elemDirectNull, elemInnerNull}},
+		}},
+	}
+
+	newSchema, newValue, err := collapseUnionsToPicked(schema, value)
+	if err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+
+	cls, _ := newSchema.FindClass("Root")
+	listType := cls.Properties[0].Type
+	if listType.Kind != KindList || listType.Inner == nil {
+		t.Fatalf("expected list type, got %#v", listType)
+	}
+	if listType.Inner.Kind != KindNull {
+		t.Fatalf("all-null union under the list should fold to bare null, got %#v", *listType.Inner)
+	}
+	// No union with all-null arms may survive anywhere in the schema —
+	// that is the exact shape that panics `baml generate`.
+	assertNoAllNullUnion(t, newSchema.EffectiveRoot())
+	for _, c := range newSchema.Classes {
+		for _, p := range c.Properties {
+			assertNoAllNullUnion(t, p.Type)
+		}
+	}
+	// The rewritten value must align with the rewritten schema: the
+	// list elements drop their union wrappers and become bare nulls.
+	if err := assertValueAlignsWithSchema(newSchema, newSchema.EffectiveRoot(), newValue); err != nil {
+		t.Fatalf("rewritten value not aligned with schema: %v\nschema: %s\nvalue: %s",
+			err, schemaDumpJSON(newSchema), valueDumpJSON(newValue))
+	}
+	if _, err := Walk(newSchema, newValue); err != nil {
+		t.Fatalf("walk of collapsed pair failed: %v", err)
+	}
+}
+
+// assertNoAllNullUnion fails the test if `ft` contains a KindUnion
+// whose every arm is KindNull — the BAML 0.219+ panic shape.
+func assertNoAllNullUnion(t *testing.T, ft FuzzType) {
+	t.Helper()
+	switch ft.Kind {
+	case KindUnion:
+		if allVariantsNull(ft.Variants) {
+			t.Errorf("found all-null union: %#v", ft)
+		}
+		for _, v := range ft.Variants {
+			assertNoAllNullUnion(t, v)
+		}
+	case KindOptional, KindList, KindMap:
+		if ft.Inner != nil {
+			assertNoAllNullUnion(t, *ft.Inner)
+		}
 	}
 }
 

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -890,6 +890,14 @@ func checkNoDegenerateUnion(rt *rapid.T, t FuzzType) {
 			rt.Fatalf("drawn schema contains an all-null union: %#v", t)
 		}
 		for i := range t.Variants {
+			// A null-equivalent arm that is not a bare null (e.g.
+			// optional<null>) spells via unionMemberSpelling as a
+			// null-only `(null | null)` member and trips the BAML 0.219+
+			// validation. normalizeUnionType folds these to bare null, so
+			// none may remain in a drawn schema.
+			if t.Variants[i].Kind != KindNull && nullEquivalentUnionArm(t.Variants[i]) {
+				rt.Fatalf("drawn schema contains a null-equivalent union arm (e.g. optional<null>): %#v", t.Variants[i])
+			}
 			for j := i + 1; j < len(t.Variants); j++ {
 				if reflect.DeepEqual(t.Variants[i], t.Variants[j]) {
 					rt.Fatalf("drawn schema contains a duplicate-arm union (arms %d and %d): %#v", i, j, t)
@@ -1210,8 +1218,8 @@ func TestCollapseUnionsToPickedNestedUnionInsideMixedOuter(t *testing.T) {
 // nested union arm collapses to null, the rewritten arms become
 // [null, null]. BAML 0.219+ rejects a union with no non-null arm
 // ("Union type must have at least one non-null type"), so the rewrite
-// must fold the duplicate nulls and return a bare KindNull rather than
-// a degenerate two-null union.
+// must fold the duplicate nulls down to a single bare KindNull; a
+// two-null union is the degenerate shape this guards against.
 func TestRewriteTypeAtPathDedupesAllNullToSingleNull(t *testing.T) {
 	inner := FuzzType{
 		Kind: KindUnion,
@@ -1243,8 +1251,8 @@ func TestRewriteTypeAtPathDedupesAllNullToSingleNull(t *testing.T) {
 // TestRewriteTypeAtPathDedupesNestedDuplicates pins that a nested-union
 // collapse which makes two surviving arms structurally identical is
 // deduplicated. Here the inner union collapses to int, colliding with
-// the parent's existing int arm; the result keeps the distinct arms
-// (string, int) once each rather than emitting int twice.
+// the parent's existing int arm; the result keeps each distinct arm
+// (string, int) exactly once, with the duplicate int dropped.
 func TestRewriteTypeAtPathDedupesNestedDuplicates(t *testing.T) {
 	inner := FuzzType{
 		Kind: KindUnion,
@@ -1292,6 +1300,97 @@ func TestRewriteTypeAtPathLeavesMixedUnionUnchanged(t *testing.T) {
 	got := rewriteTypeAtPath(parent, "", newCollapsePlan())
 	if !reflect.DeepEqual(got, parent) {
 		t.Errorf("distinct-arm union should be unchanged\nwant: %#v\ngot:  %#v", parent, got)
+	}
+}
+
+// TestNormalizeUnionTypeReducesOptionalNull pins that an optional<null>
+// union arm is folded to a bare null at draw time. unionMemberSpelling
+// flattens optional<null> to `(null | null)`, so without this reduction
+// union[optional<null>, null] would survive structural dedup (the two
+// arms differ in kind) and emit a panic-inducing all-null union, and
+// union[optional<null>, string] would emit `((null | null) | string)`.
+func TestNormalizeUnionTypeReducesOptionalNull(t *testing.T) {
+	null := FuzzType{Kind: KindNull}
+	optNull := FuzzType{Kind: KindOptional, Inner: &null}
+
+	// union[optional<null>, null] → both arms null-equivalent → bare null.
+	allNull := FuzzType{Kind: KindUnion, Variants: []FuzzType{optNull, {Kind: KindNull}}}
+	if got := normalizeUnionType(allNull); got.Kind != KindNull {
+		t.Errorf("union[optional<null>, null] should fold to bare null, got %#v", got)
+	}
+
+	// union[optional<null>, string] → optional<null> becomes null, leaving
+	// union[null, string].
+	mixed := FuzzType{Kind: KindUnion, Variants: []FuzzType{optNull, {Kind: KindString}}}
+	got := normalizeUnionType(mixed)
+	if got.Kind != KindUnion || len(got.Variants) != 2 {
+		t.Fatalf("expected a 2-arm union, got %#v", got)
+	}
+	if got.Variants[0].Kind != KindNull || got.Variants[1].Kind != KindString {
+		t.Errorf("expected union[null, string], got [%q, %q]", got.Variants[0].Kind, got.Variants[1].Kind)
+	}
+}
+
+// TestCollapseUnionsToPickedFoldsOptionalNullArm pins that the collapse
+// pass also avoids the optional<null> panic shape: an outer union arm
+// optional<union[null, string]> whose inner union consistently picks
+// null collapses to optional<null>, which must be reduced to a bare null
+// so the surrounding union does not emit `((null | null) | null)`. The
+// rewritten value must stay aligned with the rewritten schema.
+func TestCollapseUnionsToPickedFoldsOptionalNullArm(t *testing.T) {
+	innerUni := FuzzType{Kind: KindUnion, Variants: []FuzzType{{Kind: KindNull}, {Kind: KindString}}}
+	optArm := FuzzType{Kind: KindOptional, Inner: &innerUni}
+	outer := FuzzType{Kind: KindUnion, Variants: []FuzzType{{Kind: KindNull}, optArm}}
+	listOfOuter := FuzzType{Kind: KindList, Inner: &outer}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name:       "Root",
+			Properties: []FuzzProperty{{Name: "items", Type: listOfOuter}},
+		}},
+		RootClass: "Root",
+	}
+	// Element 0 picks the outer's direct null arm; element 1 picks the
+	// optional arm, present, whose inner union picks null. The outer pick
+	// disagrees (0 vs 1) so the outer union stays; the inner union is
+	// visited once and consistently picks null, so it collapses to null,
+	// turning the optional arm into optional<null>.
+	elemDirectNull := FuzzValue{Kind: KindUnion, VariantIndex: 0, Variant: &FuzzValue{Kind: KindNull}}
+	elemOptInnerNull := FuzzValue{
+		Kind: KindUnion, VariantIndex: 1,
+		Variant: &FuzzValue{
+			Kind: KindOptional, OptionalShape: OptionalPresent,
+			Inner: &FuzzValue{
+				Kind: KindUnion, VariantIndex: 0,
+				Variant: &FuzzValue{Kind: KindNull},
+			},
+		},
+	}
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{{
+			Name:  "items",
+			Value: FuzzValue{Kind: KindList, Items: []FuzzValue{elemDirectNull, elemOptInnerNull}},
+		}},
+	}
+
+	newSchema, newValue, err := collapseUnionsToPicked(schema, value)
+	if err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+	// After reducing optional<null> to null, the outer union's arms are
+	// [null, null] → folded to a bare null under the list.
+	cls, _ := newSchema.FindClass("Root")
+	listType := cls.Properties[0].Type
+	if listType.Kind != KindList || listType.Inner == nil || listType.Inner.Kind != KindNull {
+		t.Fatalf("expected list<null> after optional<null> reduction, got %#v", listType)
+	}
+	assertNoAllNullUnion(t, newSchema.EffectiveRoot())
+	if err := assertValueAlignsWithSchema(newSchema, newSchema.EffectiveRoot(), newValue); err != nil {
+		t.Fatalf("rewritten value not aligned with schema: %v\nschema: %s\nvalue: %s",
+			err, schemaDumpJSON(newSchema), valueDumpJSON(newValue))
+	}
+	if _, err := Walk(newSchema, newValue); err != nil {
+		t.Fatalf("walk of collapsed pair failed: %v", err)
 	}
 }
 
@@ -1594,6 +1693,17 @@ func TestCoupledCaseGenValueShapeMatchesSchema(t *testing.T) {
 		if err := assertValueAlignsWithSchema(cc.Schema, cc.Schema.EffectiveRoot(), cc.Value); err != nil {
 			rt.Fatalf("value/schema misalignment: %v\nschema: %s\nvalue: %s",
 				err, schemaDumpJSON(cc.Schema), valueDumpJSON(cc.Value))
+		}
+		// The collapse pass must not reintroduce a degenerate union (all
+		// arms null, duplicate arms, or an optional<null> arm) into the
+		// post-collapse schema — those panic `baml generate` on 0.219+.
+		for _, cls := range cc.Schema.Classes {
+			for _, prop := range cls.Properties {
+				checkNoDegenerateUnion(rt, prop.Type)
+			}
+		}
+		if cc.Schema.RootType != nil {
+			checkNoDegenerateUnion(rt, *cc.Schema.RootType)
 		}
 	})
 }


### PR DESCRIPTION
<!-- webtty-bridge: s-yqyd29e14n -->

Part of #349.

## Problem

BAML 0.219+ added a validation requiring every union to carry at least one non-null arm. An all-null union now panics during `baml generate`:

```
thread panicked at baml-lib/baml-types/src/ir_type/union_type.rs:15:13:
FATAL: Union type must have at least one non-null type. Got [Primitive(Null, ...), Primitive(Null, ...)]
```

The static fuzz codegen reaches this shape through two independent paths, both fixed here.

### 1. Collapse pass (Move B)

`rewriteTypeAtPath` collapses a nested union to its picked arm, which can leave a parent union's arms structurally identical — e.g. `union[null, union[null, string]]` where the inner union picked its null arm rewrites to `union[null, null]`.

- After rewriting arms, `rewriteTypeAtPath` now **deduplicates** them, **unwraps** a union that folds to a single arm, and returns a **bare `null`** when every arm is null.
- `rewriteValueByPlans` mirrors the same dedup (remapping the picked `VariantIndex`, or dropping the wrapper entirely) so the rewritten value stays aligned with the rewritten schema.
- `rewriteTypeWithPlan` no longer short-circuits on an empty plan: the dedup has to run even when no position collapses, otherwise the schema keeps a duplicate-arm union while the value side dedups and the two drift out of alignment (caught by `assertValueAlignsWithSchema` under heavy fuzzing).

### 2. Raw generation (preserve cases)

The generator draws each union arm independently, so it readily produces `null | null` or `string | string` even without the collapse pass — confirmed reachable within ~15 random draws. `normalizeUnionType` folds these at draw time, before the schema reaches `ValueGen`, so the value generator, walker, and static emitter all observe the same cleaned shape.

## Tests

- `TestRewriteTypeAtPathDedupesAllNullToSingleNull` — all-null fold → bare null
- `TestRewriteTypeAtPathDedupesNestedDuplicates` — nested collapse creating duplicates → deduped
- `TestRewriteTypeAtPathLeavesMixedUnionUnchanged` — still-mixed union → unchanged
- `TestCollapseUnionsToPickedFoldsAllNullUnionEndToEnd` — end-to-end regression pinning value/schema alignment
- `TestSchemaGenDoesNotProduceAllNullUnion` — rapid invariant that raw schemas never ship a degenerate union

`GOWORK=off go test ./codegen/bamlfuzz/...` passes (run from `adapters/common`, which is intentionally outside the workspace), including 30k-iteration rapid runs of the property tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated duplicate union variants and collapsed degenerate all-null unions so generated schemas no longer produce invalid/ambiguous union shapes
  * Ensured schema rewrites keep values aligned with the cleaned-up schemas

* **Tests**
  * Added comprehensive tests and invariants to prevent regressions around union deduplication, optional-null collapsing, and nested union edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->