### PR TITLE
fix(bamlfuzz): tolerate extra null keys from upstream BAML union serialization bug

### DIFF
--- a/adapters/common/codegen/bamlfuzz/envelope.go
+++ b/adapters/common/codegen/bamlfuzz/envelope.go
@@ -290,21 +290,24 @@ func decodeAny(b json.RawMessage) (any, error) {
 // null-valued optional fields from a class union arm even when the
 // active arm is a map or a different class, so a payload like
 // {"k0": -26} comes back as {"Fuzz_field_0": null, "k0": -26}. The
-// comparators below treat a missing key as equivalent to a key whose
-// value is null, suppressing the spurious diff. This is a
-// comparison-only relaxation — it never touches the serialized output.
-// Remove when the upstream fix lands and the leaked null keys stop
-// appearing on the wire.
+// comparators below tolerate this, but asymmetrically: `a` is the
+// expected/reference side and `b` is the actual side, and the upstream
+// bug only ever ADDS keys to the actual output. So an extra null-valued
+// key present in `b` but absent from `a` is suppressed; the reverse — a
+// null key the expected side carries that the actual side dropped — is a
+// genuine missing field and still fails. This is a comparison-only
+// relaxation — it never touches the serialized output. Remove when the
+// upstream fix lands and the leaked null keys stop appearing on the wire.
 
-// withoutExtraNullKeys returns a view of m excluding keys that are
-// null-valued in m and absent from ref. Keeping null keys that ref also
-// carries preserves genuine null-vs-null agreement while dropping the
-// leaked extras described above.
-func withoutExtraNullKeys(m, ref map[string]any) map[string]any {
-	out := make(map[string]any, len(m))
-	for k, v := range m {
+// withoutExtraNullKeys returns a view of the actual-side map `actual`
+// excluding keys that are null-valued there and absent from the
+// expected-side reference `expected`. Null keys the expected side also
+// carries are kept so genuine null-vs-null agreement still participates.
+func withoutExtraNullKeys(actual, expected map[string]any) map[string]any {
+	out := make(map[string]any, len(actual))
+	for k, v := range actual {
 		if v == nil {
-			if _, ok := ref[k]; !ok {
+			if _, ok := expected[k]; !ok {
 				continue
 			}
 		}
@@ -320,12 +323,13 @@ func deepEqualSemantic(a, b any) bool {
 		if !ok {
 			return false
 		}
-		af := withoutExtraNullKeys(av, bv)
+		// Only the actual side (b) is stripped of leaked null keys; the
+		// expected side (a) is compared as-is so a missing field fails.
 		bf := withoutExtraNullKeys(bv, av)
-		if len(af) != len(bf) {
+		if len(av) != len(bf) {
 			return false
 		}
-		for k, v := range af {
+		for k, v := range av {
 			rv, present := bf[k]
 			if !present {
 				return false
@@ -401,14 +405,13 @@ func diffAny(out *[]SemanticDiffEntry, side, path string, a, b any) {
 			av1, ok1 := av[k]
 			bv1, ok2 := bv[k]
 			if !ok1 || !ok2 {
-				// boundaryml/baml#3690 workaround: a key present on
-				// only one side whose value is null is the leaked
-				// optional field, not a real disagreement. Skip it.
-				present := av1
-				if !ok1 {
-					present = bv1
-				}
-				if present == nil {
+				// boundaryml/baml#3690 workaround: an extra null-valued
+				// key on the actual side (b) that the expected side (a)
+				// lacks is the leaked optional field, not a real
+				// disagreement. The reverse — a null key in expected
+				// that actual dropped — is a genuine missing field and
+				// is still reported.
+				if !ok1 && bv1 == nil {
 					continue
 				}
 				*out = append(*out, SemanticDiffEntry{Side: side, Path: path + "." + k, Got: av1, Want: bv1})

--- a/adapters/common/codegen/bamlfuzz/envelope.go
+++ b/adapters/common/codegen/bamlfuzz/envelope.go
@@ -215,7 +215,7 @@ func SemanticEqual(a, b json.RawMessage) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("decode b: %w", err)
 	}
-	return deepEqualSemantic(av, bv), nil
+	return deepEqualSemantic(av, bv, nullExpectedVsActual), nil
 }
 
 // SemanticDiff returns the list of path-level disagreements between two
@@ -225,10 +225,30 @@ func SemanticEqual(a, b json.RawMessage) (bool, error) {
 // emitted SemanticDiffEntry so callers can label which oracle leg pair
 // they're comparing.
 //
+// SemanticDiff is for expected-vs-actual comparisons: `a` is the
+// expected/reference side and the boundaryml/baml#3690 null-key
+// tolerance is applied only to extra null keys on the actual side `b`
+// (see the null-tolerance block lower in this file). For actual-vs-actual
+// parity comparisons where either leg may independently carry the leak,
+// use SemanticDiffParity.
+//
 // Either input being empty (len == 0) is a decode error — same contract
 // as SemanticEqual. Callers wrap with `decode a: %w` / `decode b: %w`
 // so the failure log identifies which side was empty.
 func SemanticDiff(side string, a, b json.RawMessage) ([]SemanticDiffEntry, error) {
+	return semanticDiff(side, a, b, nullExpectedVsActual)
+}
+
+// SemanticDiffParity is the symmetric variant of SemanticDiff for
+// actual-vs-actual parity comparisons (e.g. dynclient_vs_rest), where
+// both legs are BAML-generated and either side may independently carry a
+// boundaryml/baml#3690 leaked null key. An extra null-valued key on
+// either side is tolerated; every other disagreement is still reported.
+func SemanticDiffParity(side string, a, b json.RawMessage) ([]SemanticDiffEntry, error) {
+	return semanticDiff(side, a, b, nullParity)
+}
+
+func semanticDiff(side string, a, b json.RawMessage, mode nullMode) ([]SemanticDiffEntry, error) {
 	av, err := decodeAny(a)
 	if err != nil {
 		return nil, fmt.Errorf("decode a: %w", err)
@@ -238,7 +258,7 @@ func SemanticDiff(side string, a, b json.RawMessage) ([]SemanticDiffEntry, error
 		return nil, fmt.Errorf("decode b: %w", err)
 	}
 	var out []SemanticDiffEntry
-	diffAny(&out, side, "$", av, bv)
+	diffAny(&out, side, "$", av, bv, mode)
 	return out, nil
 }
 
@@ -290,24 +310,39 @@ func decodeAny(b json.RawMessage) (any, error) {
 // null-valued optional fields from a class union arm even when the
 // active arm is a map or a different class, so a payload like
 // {"k0": -26} comes back as {"Fuzz_field_0": null, "k0": -26}. The
-// comparators below tolerate this, but asymmetrically: `a` is the
-// expected/reference side and `b` is the actual side, and the upstream
-// bug only ever ADDS keys to the actual output. So an extra null-valued
-// key present in `b` but absent from `a` is suppressed; the reverse — a
-// null key the expected side carries that the actual side dropped — is a
-// genuine missing field and still fails. This is a comparison-only
-// relaxation — it never touches the serialized output. Remove when the
-// upstream fix lands and the leaked null keys stop appearing on the wire.
+// comparators below tolerate this leaked null key. The bug only ever
+// ADDS keys to a BAML-generated output, so the tolerance direction
+// depends on what is being compared (selected via nullMode):
+//
+//   - nullExpectedVsActual: `a` is the expected/reference side and `b`
+//     is the actual output. Only an extra null key present in `b` but
+//     absent from `a` is suppressed; a null key the expected side
+//     carries that the actual side dropped is a genuine missing field
+//     and still fails.
+//   - nullParity: both sides are BAML-generated (actual-vs-actual), so
+//     either may independently carry the leak. An extra null key on
+//     either side is suppressed.
+//
+// This is a comparison-only relaxation — it never touches the serialized
+// output. Remove when the upstream fix lands and the leaked null keys
+// stop appearing on the wire.
+type nullMode int
 
-// withoutExtraNullKeys returns a view of the actual-side map `actual`
-// excluding keys that are null-valued there and absent from the
-// expected-side reference `expected`. Null keys the expected side also
-// carries are kept so genuine null-vs-null agreement still participates.
-func withoutExtraNullKeys(actual, expected map[string]any) map[string]any {
-	out := make(map[string]any, len(actual))
-	for k, v := range actual {
+const (
+	nullExpectedVsActual nullMode = iota
+	nullParity
+)
+
+// withoutExtraNullKeys returns a view of `src` excluding keys that are
+// null-valued there and absent from the reference `ref`. Null keys that
+// `ref` also carries are kept so genuine null-vs-null agreement still
+// participates. The caller chooses which side(s) to strip, encoding the
+// asymmetric / parity tolerance described above.
+func withoutExtraNullKeys(src, ref map[string]any) map[string]any {
+	out := make(map[string]any, len(src))
+	for k, v := range src {
 		if v == nil {
-			if _, ok := expected[k]; !ok {
+			if _, ok := ref[k]; !ok {
 				continue
 			}
 		}
@@ -316,25 +351,30 @@ func withoutExtraNullKeys(actual, expected map[string]any) map[string]any {
 	return out
 }
 
-func deepEqualSemantic(a, b any) bool {
+func deepEqualSemantic(a, b any, mode nullMode) bool {
 	switch av := a.(type) {
 	case map[string]any:
 		bv, ok := b.(map[string]any)
 		if !ok {
 			return false
 		}
-		// Only the actual side (b) is stripped of leaked null keys; the
-		// expected side (a) is compared as-is so a missing field fails.
+		// The actual side (b) is always stripped of leaked null keys. In
+		// parity mode the expected side (a) is stripped too; otherwise a
+		// is authoritative so a missing field still fails.
 		bf := withoutExtraNullKeys(bv, av)
-		if len(av) != len(bf) {
+		af := av
+		if mode == nullParity {
+			af = withoutExtraNullKeys(av, bv)
+		}
+		if len(af) != len(bf) {
 			return false
 		}
-		for k, v := range av {
+		for k, v := range af {
 			rv, present := bf[k]
 			if !present {
 				return false
 			}
-			if !deepEqualSemantic(v, rv) {
+			if !deepEqualSemantic(v, rv, mode) {
 				return false
 			}
 		}
@@ -348,7 +388,7 @@ func deepEqualSemantic(a, b any) bool {
 			return false
 		}
 		for i := range av {
-			if !deepEqualSemantic(av[i], bv[i]) {
+			if !deepEqualSemantic(av[i], bv[i], mode) {
 				return false
 			}
 		}
@@ -378,8 +418,8 @@ func deepEqualSemantic(a, b any) bool {
 	}
 }
 
-func diffAny(out *[]SemanticDiffEntry, side, path string, a, b any) {
-	if deepEqualSemantic(a, b) {
+func diffAny(out *[]SemanticDiffEntry, side, path string, a, b any, mode nullMode) {
+	if deepEqualSemantic(a, b, mode) {
 		return
 	}
 	switch av := a.(type) {
@@ -405,19 +445,23 @@ func diffAny(out *[]SemanticDiffEntry, side, path string, a, b any) {
 			av1, ok1 := av[k]
 			bv1, ok2 := bv[k]
 			if !ok1 || !ok2 {
-				// boundaryml/baml#3690 workaround: an extra null-valued
-				// key on the actual side (b) that the expected side (a)
-				// lacks is the leaked optional field, not a real
-				// disagreement. The reverse — a null key in expected
-				// that actual dropped — is a genuine missing field and
-				// is still reported.
+				// boundaryml/baml#3690 workaround: a leaked null-valued
+				// key present on only one side is not a real
+				// disagreement. An extra null on the actual side (b) is
+				// always tolerated; in parity mode an extra null on the
+				// a side is too. A non-null one-sided key, or (outside
+				// parity) a null key the expected side carries that
+				// actual dropped, is still reported.
 				if !ok1 && bv1 == nil {
+					continue
+				}
+				if mode == nullParity && !ok2 && av1 == nil {
 					continue
 				}
 				*out = append(*out, SemanticDiffEntry{Side: side, Path: path + "." + k, Got: av1, Want: bv1})
 				continue
 			}
-			diffAny(out, side, path+"."+k, av1, bv1)
+			diffAny(out, side, path+"."+k, av1, bv1, mode)
 		}
 	case []any:
 		bv, ok := b.([]any)
@@ -426,7 +470,7 @@ func diffAny(out *[]SemanticDiffEntry, side, path string, a, b any) {
 			return
 		}
 		for i := range av {
-			diffAny(out, side, fmt.Sprintf("%s[%d]", path, i), av[i], bv[i])
+			diffAny(out, side, fmt.Sprintf("%s[%d]", path, i), av[i], bv[i], mode)
 		}
 	default:
 		*out = append(*out, SemanticDiffEntry{Side: side, Path: path, Got: a, Want: b})

--- a/adapters/common/codegen/bamlfuzz/envelope.go
+++ b/adapters/common/codegen/bamlfuzz/envelope.go
@@ -286,6 +286,33 @@ func decodeAny(b json.RawMessage) (any, error) {
 	return v, nil
 }
 
+// Workaround for boundaryml/baml#3690: BAML's Go codegen serializes
+// null-valued optional fields from a class union arm even when the
+// active arm is a map or a different class, so a payload like
+// {"k0": -26} comes back as {"Fuzz_field_0": null, "k0": -26}. The
+// comparators below treat a missing key as equivalent to a key whose
+// value is null, suppressing the spurious diff. This is a
+// comparison-only relaxation — it never touches the serialized output.
+// Remove when the upstream fix lands and the leaked null keys stop
+// appearing on the wire.
+
+// withoutExtraNullKeys returns a view of m excluding keys that are
+// null-valued in m and absent from ref. Keeping null keys that ref also
+// carries preserves genuine null-vs-null agreement while dropping the
+// leaked extras described above.
+func withoutExtraNullKeys(m, ref map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if v == nil {
+			if _, ok := ref[k]; !ok {
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
+}
+
 func deepEqualSemantic(a, b any) bool {
 	switch av := a.(type) {
 	case map[string]any:
@@ -293,11 +320,13 @@ func deepEqualSemantic(a, b any) bool {
 		if !ok {
 			return false
 		}
-		if len(av) != len(bv) {
+		af := withoutExtraNullKeys(av, bv)
+		bf := withoutExtraNullKeys(bv, av)
+		if len(af) != len(bf) {
 			return false
 		}
-		for k, v := range av {
-			rv, present := bv[k]
+		for k, v := range af {
+			rv, present := bf[k]
 			if !present {
 				return false
 			}
@@ -372,6 +401,16 @@ func diffAny(out *[]SemanticDiffEntry, side, path string, a, b any) {
 			av1, ok1 := av[k]
 			bv1, ok2 := bv[k]
 			if !ok1 || !ok2 {
+				// boundaryml/baml#3690 workaround: a key present on
+				// only one side whose value is null is the leaked
+				// optional field, not a real disagreement. Skip it.
+				present := av1
+				if !ok1 {
+					present = bv1
+				}
+				if present == nil {
+					continue
+				}
 				*out = append(*out, SemanticDiffEntry{Side: side, Path: path + "." + k, Got: av1, Want: bv1})
 				continue
 			}

--- a/adapters/common/codegen/bamlfuzz/envelope_test.go
+++ b/adapters/common/codegen/bamlfuzz/envelope_test.go
@@ -19,10 +19,12 @@ func TestSemanticEqual(t *testing.T) {
 		{"missing key", `{"a":1,"b":2}`, `{"a":1}`, false},
 		{"nested order", `{"x":{"a":1,"b":2}}`, `{"x":{"b":2,"a":1}}`, true},
 		{"array order matters", `[1,2,3]`, `[3,2,1]`, false},
-		// boundaryml/baml#3690 workaround: a key present and null on one
-		// side but absent on the other is treated as equivalent, so the
-		// leaked optional field does not break equality.
-		{"null vs missing", `{"a":null}`, `{}`, true},
+		// boundaryml/baml#3690 workaround is asymmetric: an extra null
+		// key on the actual side (b) is tolerated, but a null key the
+		// expected side (a) carries that actual dropped is a genuine
+		// missing field and still fails.
+		{"null missing from actual", `{"a":null}`, `{}`, false},
+		{"extra null on actual", `{}`, `{"a":null}`, true},
 		{"both null", `null`, `null`, true},
 	}
 	for _, c := range cases {
@@ -80,18 +82,17 @@ func TestSemanticDiff_FindsDifferences(t *testing.T) {
 }
 
 // TestSemanticDiff_ToleratesExtraNullKeys pins the boundaryml/baml#3690
-// workaround: when the only difference between two payloads is a key
-// that is present (and null-valued) on one side but absent on the other,
-// SemanticDiff reports no disagreement.
+// workaround: when the only difference is a null-valued key present on
+// the actual side (b) but absent from the expected side (a), SemanticDiff
+// reports no disagreement. The tolerance is asymmetric — a is expected.
 func TestSemanticDiff_ToleratesExtraNullKeys(t *testing.T) {
 	cases := []struct {
 		name string
 		a, b string
 	}{
-		{"extra null on b", `{"k0":-26}`, `{"Fuzz_field_0":null,"k0":-26}`},
-		{"extra null on a", `{"Fuzz_field_0":null,"k0":-26}`, `{"k0":-26}`},
+		{"extra null on actual", `{"k0":-26}`, `{"Fuzz_field_0":null,"k0":-26}`},
 		{"null on both", `{"f":null,"k0":-26}`, `{"f":null,"k0":-26}`},
-		{"nested extra null", `{"o":{"k":1}}`, `{"o":{"leak":null,"k":1}}`},
+		{"nested extra null on actual", `{"o":{"k":1}}`, `{"o":{"leak":null,"k":1}}`},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -107,16 +108,18 @@ func TestSemanticDiff_ToleratesExtraNullKeys(t *testing.T) {
 }
 
 // TestSemanticDiff_RealDifferencesSurviveNullTolerance asserts the
-// #3690 workaround only suppresses extra null keys: a missing non-null
-// key or an extra non-null key still produces a diff entry.
+// #3690 workaround only suppresses extra null keys on the actual side:
+// an extra non-null key, a missing non-null key, or a null key the
+// expected side carries that actual dropped still produces a diff entry.
 func TestSemanticDiff_RealDifferencesSurviveNullTolerance(t *testing.T) {
 	cases := []struct {
 		name string
 		a, b string
 	}{
-		{"extra non-null key on b", `{"k0":-26}`, `{"extra":1,"k0":-26}`},
-		{"missing non-null key on b", `{"a":1,"b":2}`, `{"a":1}`},
+		{"extra non-null key on actual", `{"k0":-26}`, `{"extra":1,"k0":-26}`},
+		{"missing non-null key on actual", `{"a":1,"b":2}`, `{"a":1}`},
 		{"null vs non-null value", `{"a":null}`, `{"a":1}`},
+		{"null key missing from actual", `{"a":null,"k":1}`, `{"k":1}`},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/adapters/common/codegen/bamlfuzz/envelope_test.go
+++ b/adapters/common/codegen/bamlfuzz/envelope_test.go
@@ -134,6 +134,58 @@ func TestSemanticDiff_RealDifferencesSurviveNullTolerance(t *testing.T) {
 	}
 }
 
+// TestSemanticDiffParity_ToleratesExtraNullEitherSide pins the symmetric
+// #3690 tolerance used for actual-vs-actual parity comparisons: a leaked
+// null key on either side is forgiven, since both legs are BAML-generated
+// and may independently carry the leak.
+func TestSemanticDiffParity_ToleratesExtraNullEitherSide(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+	}{
+		{"same extra null both sides", `{"f":null,"k0":-26}`, `{"f":null,"k0":-26}`},
+		{"extra null on a only", `{"f":null,"k0":-26}`, `{"k0":-26}`},
+		{"extra null on b only", `{"k0":-26}`, `{"f":null,"k0":-26}`},
+		{"different leaked null each side", `{"fa":null,"k0":-26}`, `{"fb":null,"k0":-26}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			diff, err := SemanticDiffParity("side", []byte(c.a), []byte(c.b))
+			if err != nil {
+				t.Fatalf("SemanticDiffParity: %v", err)
+			}
+			if len(diff) != 0 {
+				t.Errorf("expected no diff entries, got %v", diff)
+			}
+		})
+	}
+}
+
+// TestSemanticDiffParity_RealDifferencesStillDiff asserts the parity
+// variant only forgives extra null keys: an extra non-null key on either
+// side, or a differing value, still produces a diff entry.
+func TestSemanticDiffParity_RealDifferencesStillDiff(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+	}{
+		{"extra non-null key on a", `{"extra":1,"k0":-26}`, `{"k0":-26}`},
+		{"extra non-null key on b", `{"k0":-26}`, `{"extra":1,"k0":-26}`},
+		{"differing value", `{"k0":-26}`, `{"k0":-27}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			diff, err := SemanticDiffParity("side", []byte(c.a), []byte(c.b))
+			if err != nil {
+				t.Fatalf("SemanticDiffParity: %v", err)
+			}
+			if len(diff) == 0 {
+				t.Errorf("expected a diff entry, got none")
+			}
+		})
+	}
+}
+
 func TestDetectOrderWarning(t *testing.T) {
 	warns := DetectOrderWarning("top",
 		[]byte(`{"a":1,"b":2,"c":3}`),

--- a/adapters/common/codegen/bamlfuzz/envelope_test.go
+++ b/adapters/common/codegen/bamlfuzz/envelope_test.go
@@ -19,7 +19,10 @@ func TestSemanticEqual(t *testing.T) {
 		{"missing key", `{"a":1,"b":2}`, `{"a":1}`, false},
 		{"nested order", `{"x":{"a":1,"b":2}}`, `{"x":{"b":2,"a":1}}`, true},
 		{"array order matters", `[1,2,3]`, `[3,2,1]`, false},
-		{"null vs missing", `{"a":null}`, `{}`, false},
+		// boundaryml/baml#3690 workaround: a key present and null on one
+		// side but absent on the other is treated as equivalent, so the
+		// leaked optional field does not break equality.
+		{"null vs missing", `{"a":null}`, `{}`, true},
 		{"both null", `null`, `null`, true},
 	}
 	for _, c := range cases {
@@ -73,6 +76,58 @@ func TestSemanticDiff_FindsDifferences(t *testing.T) {
 		if d.Side != "a_vs_b" {
 			t.Errorf("entry side=%q want %q", d.Side, "a_vs_b")
 		}
+	}
+}
+
+// TestSemanticDiff_ToleratesExtraNullKeys pins the boundaryml/baml#3690
+// workaround: when the only difference between two payloads is a key
+// that is present (and null-valued) on one side but absent on the other,
+// SemanticDiff reports no disagreement.
+func TestSemanticDiff_ToleratesExtraNullKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+	}{
+		{"extra null on b", `{"k0":-26}`, `{"Fuzz_field_0":null,"k0":-26}`},
+		{"extra null on a", `{"Fuzz_field_0":null,"k0":-26}`, `{"k0":-26}`},
+		{"null on both", `{"f":null,"k0":-26}`, `{"f":null,"k0":-26}`},
+		{"nested extra null", `{"o":{"k":1}}`, `{"o":{"leak":null,"k":1}}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			diff, err := SemanticDiff("side", []byte(c.a), []byte(c.b))
+			if err != nil {
+				t.Fatalf("SemanticDiff: %v", err)
+			}
+			if len(diff) != 0 {
+				t.Errorf("expected no diff entries, got %v", diff)
+			}
+		})
+	}
+}
+
+// TestSemanticDiff_RealDifferencesSurviveNullTolerance asserts the
+// #3690 workaround only suppresses extra null keys: a missing non-null
+// key or an extra non-null key still produces a diff entry.
+func TestSemanticDiff_RealDifferencesSurviveNullTolerance(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+	}{
+		{"extra non-null key on b", `{"k0":-26}`, `{"extra":1,"k0":-26}`},
+		{"missing non-null key on b", `{"a":1,"b":2}`, `{"a":1}`},
+		{"null vs non-null value", `{"a":null}`, `{"a":1}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			diff, err := SemanticDiff("side", []byte(c.a), []byte(c.b))
+			if err != nil {
+				t.Fatalf("SemanticDiff: %v", err)
+			}
+			if len(diff) == 0 {
+				t.Errorf("expected a diff entry, got none")
+			}
+		})
 	}
 }
 

--- a/adapters/common/codegen/bamlfuzz/order.go
+++ b/adapters/common/codegen/bamlfuzz/order.go
@@ -253,10 +253,13 @@ func (w *orderWalker) setErr(err error) {
 //     is stripped; `exp` is compared as-is, so a null key the expected
 //     side carries that `got` dropped still registers as a mismatch.
 //   - actual-vs-actual (parity == true): both sides are BAML-generated,
-//     so leaked null keys on either side are stripped. In a map arm,
-//     where a null is never a real entry, parity mode drops every null
-//     key from both sides — even one both carry — so two leaks landing
-//     in different positions do not produce a spurious order diff.
+//     so leaked null keys on either side are stripped. In a map arm
+//     whose value type cannot be null, a null is never a real entry, so
+//     parity mode drops every null key from both sides — even one both
+//     carry — so two leaks landing in different positions do not produce
+//     a spurious order diff. When the map's value type CAN be null (e.g.
+//     map<string, null> or map<string, optional<T>>) the nulls are real
+//     entries and only the reference-aware strip applies.
 //
 // This is a comparison-only relaxation. Remove when the upstream fix lands.
 
@@ -291,6 +294,28 @@ func stripNullKeys(keys []string, src map[string]orderedJSON) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// canBeNull reports whether a value of `typ` can legitimately serialize
+// as JSON null. It gates the parity map-arm null stripping: only when a
+// map's value type CANNOT be null is a null entry necessarily a
+// boundaryml/baml#3690 leak. For a map whose value type can be null
+// (e.g. map<string, null> or map<string, optional<T>>) the null entries
+// are real and their order must still be compared.
+func canBeNull(typ FuzzType) bool {
+	switch typ.Kind {
+	case KindNull, KindOptional:
+		return true
+	case KindUnion:
+		for _, v := range typ.Variants {
+			if canBeNull(v) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
 }
 
 func (w *orderWalker) walkClass(path, className string, exp, got orderedJSON) {
@@ -354,7 +379,12 @@ func (w *orderWalker) walkType(path string, typ FuzzType, exp, got orderedJSON) 
 		if exp.kind != orderedObject || got.kind != orderedObject {
 			return
 		}
-		expKeys, gotKeys := w.orderKeys(exp, got, true)
+		// A null map entry is necessarily a #3690 leak only when the
+		// value type cannot itself be null; for map<string, null> or
+		// map<string, optional<T>> the nulls are real entries whose order
+		// still matters, so fall back to the reference-aware strip.
+		stripLeakedNulls := !canBeNull(*typ.Inner)
+		expKeys, gotKeys := w.orderKeys(exp, got, stripLeakedNulls)
 		if !slices.Equal(expKeys, gotKeys) {
 			w.diffs = append(w.diffs, SchemaOrderDiffEntry{
 				Side:     w.side,
@@ -364,11 +394,12 @@ func (w *orderWalker) walkType(path string, typ FuzzType, exp, got orderedJSON) 
 			})
 		}
 		for _, key := range sortedIntersection(exp.byKey, got.byKey) {
-			// In parity mode a null-valued map key is a leaked field, not
-			// a real entry. Its value carries no order signal, and a
-			// nested union beneath it has no recorded choice — recursing
-			// would surface a spurious ErrSchemaOrderUnsupported. Skip it.
-			if w.parity && (exp.byKey[key].kind == orderedNull || got.byKey[key].kind == orderedNull) {
+			// In parity mode a null-valued map key whose value type
+			// cannot be null is a leaked field, not a real entry. Its
+			// value carries no order signal, and a nested union beneath
+			// it has no recorded choice — recursing would surface a
+			// spurious ErrSchemaOrderUnsupported. Skip it.
+			if w.parity && stripLeakedNulls && (exp.byKey[key].kind == orderedNull || got.byKey[key].kind == orderedNull) {
 				continue
 			}
 			w.walkType(fmt.Sprintf("%s[%q]", path, key), *typ.Inner, exp.byKey[key], got.byKey[key])

--- a/adapters/common/codegen/bamlfuzz/order.go
+++ b/adapters/common/codegen/bamlfuzz/order.go
@@ -200,19 +200,22 @@ func (w *orderWalker) setErr(err error) {
 // null-valued optional fields from a class union arm even when the
 // active arm is a map or a different class, leaking extra null-valued
 // keys into the wire object. The order comparisons below drop those
-// leaked keys before checking key-order equality so the spurious key
-// does not register as an order mismatch. This is a comparison-only
+// leaked keys before checking key-order equality, but asymmetrically:
+// the upstream bug only ever ADDS keys to the actual output, so only
+// `got` (the actual side) is stripped. `exp` (the expected side) is
+// compared as-is, so a null key the expected side carries that `got`
+// dropped still registers as a mismatch. This is a comparison-only
 // relaxation. Remove when the upstream fix lands.
 
-// stripExtraNullKeys returns a filtered copy of keys removing entries
-// that are null-valued in src and absent from the reference set ref.
-// Null keys that ref also carries are preserved so genuine null-valued
-// fields still participate in the order check.
-func stripExtraNullKeys(keys []string, src, ref map[string]orderedJSON) []string {
+// stripExtraNullKeys returns a filtered copy of the actual side's keys,
+// removing entries that are null-valued in `got` and absent from the
+// expected-side reference `exp`. Null keys that `exp` also carries are
+// preserved so genuine null-valued fields still participate.
+func stripExtraNullKeys(keys []string, got, exp map[string]orderedJSON) []string {
 	out := make([]string, 0, len(keys))
 	for _, k := range keys {
-		if src[k].kind == orderedNull {
-			if _, ok := ref[k]; !ok {
+		if got[k].kind == orderedNull {
+			if _, ok := exp[k]; !ok {
 				continue
 			}
 		}
@@ -233,13 +236,12 @@ func (w *orderWalker) walkClass(path, className string, exp, got orderedJSON) {
 	if exp.kind != orderedObject || got.kind != orderedObject {
 		return
 	}
-	expKeys := stripExtraNullKeys(exp.keys, exp.byKey, got.byKey)
 	gotKeys := stripExtraNullKeys(got.keys, got.byKey, exp.byKey)
-	if !slices.Equal(expKeys, gotKeys) {
+	if !slices.Equal(exp.keys, gotKeys) {
 		w.diffs = append(w.diffs, SchemaOrderDiffEntry{
 			Side:     w.side,
 			Path:     path,
-			Expected: expKeys,
+			Expected: append([]string{}, exp.keys...),
 			Actual:   gotKeys,
 		})
 	}
@@ -283,13 +285,12 @@ func (w *orderWalker) walkType(path string, typ FuzzType, exp, got orderedJSON) 
 		if exp.kind != orderedObject || got.kind != orderedObject {
 			return
 		}
-		expKeys := stripExtraNullKeys(exp.keys, exp.byKey, got.byKey)
 		gotKeys := stripExtraNullKeys(got.keys, got.byKey, exp.byKey)
-		if !slices.Equal(expKeys, gotKeys) {
+		if !slices.Equal(exp.keys, gotKeys) {
 			w.diffs = append(w.diffs, SchemaOrderDiffEntry{
 				Side:     w.side,
 				Path:     path,
-				Expected: expKeys,
+				Expected: append([]string{}, exp.keys...),
 				Actual:   gotKeys,
 			})
 		}

--- a/adapters/common/codegen/bamlfuzz/order.go
+++ b/adapters/common/codegen/bamlfuzz/order.go
@@ -214,7 +214,18 @@ type orderWalker struct {
 // class/map node and returns the (expectedKeys, actualKeys) to compare.
 // The actual side is always stripped of leaked nulls; in parity mode the
 // expected side is stripped too.
-func (w *orderWalker) orderKeys(exp, got orderedJSON) (expKeys, gotKeys []string) {
+//
+// stripAllNulls is set by map-arm callers. A null value is never a
+// legitimate map entry, so in parity mode (two actual outputs that may
+// each leak) every null key is dropped from both sides — including a
+// null key both sides carry, whose position would otherwise produce a
+// spurious order diff when the two leaks land in different spots. Class
+// nodes pass false: a null there can be a real optional field whose
+// declared position still matters.
+func (w *orderWalker) orderKeys(exp, got orderedJSON, stripAllNulls bool) (expKeys, gotKeys []string) {
+	if w.parity && stripAllNulls {
+		return stripNullKeys(exp.keys, exp.byKey), stripNullKeys(got.keys, got.byKey)
+	}
 	gotKeys = stripExtraNullKeys(got.keys, got.byKey, exp.byKey)
 	if w.parity {
 		expKeys = stripExtraNullKeys(exp.keys, exp.byKey, got.byKey)
@@ -242,7 +253,10 @@ func (w *orderWalker) setErr(err error) {
 //     is stripped; `exp` is compared as-is, so a null key the expected
 //     side carries that `got` dropped still registers as a mismatch.
 //   - actual-vs-actual (parity == true): both sides are BAML-generated,
-//     so leaked null keys on either side are stripped.
+//     so leaked null keys on either side are stripped. In a map arm,
+//     where a null is never a real entry, parity mode drops every null
+//     key from both sides — even one both carry — so two leaks landing
+//     in different positions do not produce a spurious order diff.
 //
 // This is a comparison-only relaxation. Remove when the upstream fix lands.
 
@@ -264,6 +278,21 @@ func stripExtraNullKeys(keys []string, src, ref map[string]orderedJSON) []string
 	return out
 }
 
+// stripNullKeys returns a copy of `keys` with every null-valued entry
+// removed, unconditional of any reference set. Used for parity map-arm
+// contexts where a null is never a real entry, so its position carries
+// no order signal even when both actual sides carry it.
+func stripNullKeys(keys []string, src map[string]orderedJSON) []string {
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if src[k].kind == orderedNull {
+			continue
+		}
+		out = append(out, k)
+	}
+	return out
+}
+
 func (w *orderWalker) walkClass(path, className string, exp, got orderedJSON) {
 	cls, ok := w.schema.FindClass(className)
 	if !ok {
@@ -276,7 +305,7 @@ func (w *orderWalker) walkClass(path, className string, exp, got orderedJSON) {
 	if exp.kind != orderedObject || got.kind != orderedObject {
 		return
 	}
-	expKeys, gotKeys := w.orderKeys(exp, got)
+	expKeys, gotKeys := w.orderKeys(exp, got, false)
 	if !slices.Equal(expKeys, gotKeys) {
 		w.diffs = append(w.diffs, SchemaOrderDiffEntry{
 			Side:     w.side,
@@ -325,7 +354,7 @@ func (w *orderWalker) walkType(path string, typ FuzzType, exp, got orderedJSON) 
 		if exp.kind != orderedObject || got.kind != orderedObject {
 			return
 		}
-		expKeys, gotKeys := w.orderKeys(exp, got)
+		expKeys, gotKeys := w.orderKeys(exp, got, true)
 		if !slices.Equal(expKeys, gotKeys) {
 			w.diffs = append(w.diffs, SchemaOrderDiffEntry{
 				Side:     w.side,
@@ -335,6 +364,13 @@ func (w *orderWalker) walkType(path string, typ FuzzType, exp, got orderedJSON) 
 			})
 		}
 		for _, key := range sortedIntersection(exp.byKey, got.byKey) {
+			// In parity mode a null-valued map key is a leaked field, not
+			// a real entry. Its value carries no order signal, and a
+			// nested union beneath it has no recorded choice — recursing
+			// would surface a spurious ErrSchemaOrderUnsupported. Skip it.
+			if w.parity && (exp.byKey[key].kind == orderedNull || got.byKey[key].kind == orderedNull) {
+				continue
+			}
 			w.walkType(fmt.Sprintf("%s[%q]", path, key), *typ.Inner, exp.byKey[key], got.byKey[key])
 		}
 	case KindUnion:

--- a/adapters/common/codegen/bamlfuzz/order.go
+++ b/adapters/common/codegen/bamlfuzz/order.go
@@ -296,19 +296,20 @@ func stripNullKeys(keys []string, src map[string]orderedJSON) []string {
 	return out
 }
 
-// canBeNull reports whether a value of `typ` can legitimately serialize
-// as JSON null. It gates the parity map-arm null stripping: only when a
-// map's value type CANNOT be null is a null entry necessarily a
-// boundaryml/baml#3690 leak. For a map whose value type can be null
-// (e.g. map<string, null> or map<string, optional<T>>) the null entries
-// are real and their order must still be compared.
-func canBeNull(typ FuzzType) bool {
+// CanBeNull reports whether a value of `typ` can legitimately serialize
+// as JSON null. It gates the boundaryml/baml#3690 null-leak tolerance:
+// only when a type CANNOT be null is an observed null necessarily a leak.
+// For the parity map-arm strip here, and for union-arm derivation in the
+// integration oracle, a map whose value type can be null (e.g.
+// map<string, null> or map<string, optional<T>>) has real null entries
+// that must still be compared / matched.
+func CanBeNull(typ FuzzType) bool {
 	switch typ.Kind {
 	case KindNull, KindOptional:
 		return true
 	case KindUnion:
 		for _, v := range typ.Variants {
-			if canBeNull(v) {
+			if CanBeNull(v) {
 				return true
 			}
 		}
@@ -383,7 +384,7 @@ func (w *orderWalker) walkType(path string, typ FuzzType, exp, got orderedJSON) 
 		// value type cannot itself be null; for map<string, null> or
 		// map<string, optional<T>> the nulls are real entries whose order
 		// still matters, so fall back to the reference-aware strip.
-		stripLeakedNulls := !canBeNull(*typ.Inner)
+		stripLeakedNulls := !CanBeNull(*typ.Inner)
 		expKeys, gotKeys := w.orderKeys(exp, got, stripLeakedNulls)
 		if !slices.Equal(expKeys, gotKeys) {
 			w.diffs = append(w.diffs, SchemaOrderDiffEntry{

--- a/adapters/common/codegen/bamlfuzz/order.go
+++ b/adapters/common/codegen/bamlfuzz/order.go
@@ -59,8 +59,24 @@ func SchemaOrderDiff(label string, schema FuzzSchema, expected, actual json.RawM
 }
 
 // SchemaOrderDiffWithChoices is the union-aware variant of
-// SchemaOrderDiff. `choices` mirrors CaseMetadata.UnionChoices.
+// SchemaOrderDiff. `choices` mirrors CaseMetadata.UnionChoices. It is for
+// expected-vs-actual comparisons: the boundaryml/baml#3690 null-key
+// tolerance is applied only to the actual side. For actual-vs-actual
+// parity order checks use SchemaOrderDiffParityWithChoices.
 func SchemaOrderDiffWithChoices(label string, schema FuzzSchema, expected, actual json.RawMessage, choices map[string]UnionChoice) ([]SchemaOrderDiffEntry, error) {
+	return schemaOrderDiff(label, schema, expected, actual, choices, false)
+}
+
+// SchemaOrderDiffParityWithChoices is the symmetric variant for
+// actual-vs-actual parity order checks (e.g. dynclient_vs_rest), where
+// both legs are BAML-generated and either may carry a boundaryml/baml#3690
+// leaked null key. Leaked null keys on either side are tolerated before
+// the key-order comparison.
+func SchemaOrderDiffParityWithChoices(label string, schema FuzzSchema, a, b json.RawMessage, choices map[string]UnionChoice) ([]SchemaOrderDiffEntry, error) {
+	return schemaOrderDiff(label, schema, a, b, choices, true)
+}
+
+func schemaOrderDiff(label string, schema FuzzSchema, expected, actual json.RawMessage, choices map[string]UnionChoice, parity bool) ([]SchemaOrderDiffEntry, error) {
 	if schema.RootClass == "" && schema.RootType == nil {
 		return nil, fmt.Errorf("bamlfuzz: schema missing both RootClass and RootType")
 	}
@@ -77,7 +93,7 @@ func SchemaOrderDiffWithChoices(label string, schema FuzzSchema, expected, actua
 	if err != nil {
 		return nil, fmt.Errorf("decode actual: %w", err)
 	}
-	w := &orderWalker{schema: schema, side: label, choices: choices}
+	w := &orderWalker{schema: schema, side: label, choices: choices, parity: parity}
 	w.walkType("$", schema.EffectiveRoot(), exp, got)
 	return w.diffs, w.err
 }
@@ -188,6 +204,24 @@ type orderWalker struct {
 	diffs   []SchemaOrderDiffEntry
 	err     error
 	choices map[string]UnionChoice
+	// parity tolerates boundaryml/baml#3690 leaked null keys on either
+	// side (actual-vs-actual). When false, only the actual side (got) is
+	// stripped (expected-vs-actual).
+	parity bool
+}
+
+// orderKeys applies the boundaryml/baml#3690 null-key tolerance to a
+// class/map node and returns the (expectedKeys, actualKeys) to compare.
+// The actual side is always stripped of leaked nulls; in parity mode the
+// expected side is stripped too.
+func (w *orderWalker) orderKeys(exp, got orderedJSON) (expKeys, gotKeys []string) {
+	gotKeys = stripExtraNullKeys(got.keys, got.byKey, exp.byKey)
+	if w.parity {
+		expKeys = stripExtraNullKeys(exp.keys, exp.byKey, got.byKey)
+	} else {
+		expKeys = append([]string{}, exp.keys...)
+	}
+	return expKeys, gotKeys
 }
 
 func (w *orderWalker) setErr(err error) {
@@ -200,22 +234,28 @@ func (w *orderWalker) setErr(err error) {
 // null-valued optional fields from a class union arm even when the
 // active arm is a map or a different class, leaking extra null-valued
 // keys into the wire object. The order comparisons below drop those
-// leaked keys before checking key-order equality, but asymmetrically:
-// the upstream bug only ever ADDS keys to the actual output, so only
-// `got` (the actual side) is stripped. `exp` (the expected side) is
-// compared as-is, so a null key the expected side carries that `got`
-// dropped still registers as a mismatch. This is a comparison-only
-// relaxation. Remove when the upstream fix lands.
+// leaked keys before checking key-order equality. The bug only ever
+// ADDS keys to a BAML-generated output, so the direction depends on what
+// is being compared (orderWalker.parity):
+//
+//   - expected-vs-actual (parity == false): only `got` (the actual side)
+//     is stripped; `exp` is compared as-is, so a null key the expected
+//     side carries that `got` dropped still registers as a mismatch.
+//   - actual-vs-actual (parity == true): both sides are BAML-generated,
+//     so leaked null keys on either side are stripped.
+//
+// This is a comparison-only relaxation. Remove when the upstream fix lands.
 
-// stripExtraNullKeys returns a filtered copy of the actual side's keys,
-// removing entries that are null-valued in `got` and absent from the
-// expected-side reference `exp`. Null keys that `exp` also carries are
-// preserved so genuine null-valued fields still participate.
-func stripExtraNullKeys(keys []string, got, exp map[string]orderedJSON) []string {
+// stripExtraNullKeys returns a filtered copy of `keys`, removing entries
+// that are null-valued in `src` and absent from the reference set `ref`.
+// Null keys that `ref` also carries are preserved so genuine null-valued
+// fields still participate. The caller chooses which side(s) to strip,
+// encoding the asymmetric / parity tolerance described above.
+func stripExtraNullKeys(keys []string, src, ref map[string]orderedJSON) []string {
 	out := make([]string, 0, len(keys))
 	for _, k := range keys {
-		if got[k].kind == orderedNull {
-			if _, ok := exp[k]; !ok {
+		if src[k].kind == orderedNull {
+			if _, ok := ref[k]; !ok {
 				continue
 			}
 		}
@@ -236,12 +276,12 @@ func (w *orderWalker) walkClass(path, className string, exp, got orderedJSON) {
 	if exp.kind != orderedObject || got.kind != orderedObject {
 		return
 	}
-	gotKeys := stripExtraNullKeys(got.keys, got.byKey, exp.byKey)
-	if !slices.Equal(exp.keys, gotKeys) {
+	expKeys, gotKeys := w.orderKeys(exp, got)
+	if !slices.Equal(expKeys, gotKeys) {
 		w.diffs = append(w.diffs, SchemaOrderDiffEntry{
 			Side:     w.side,
 			Path:     path,
-			Expected: append([]string{}, exp.keys...),
+			Expected: expKeys,
 			Actual:   gotKeys,
 		})
 	}
@@ -285,12 +325,12 @@ func (w *orderWalker) walkType(path string, typ FuzzType, exp, got orderedJSON) 
 		if exp.kind != orderedObject || got.kind != orderedObject {
 			return
 		}
-		gotKeys := stripExtraNullKeys(got.keys, got.byKey, exp.byKey)
-		if !slices.Equal(exp.keys, gotKeys) {
+		expKeys, gotKeys := w.orderKeys(exp, got)
+		if !slices.Equal(expKeys, gotKeys) {
 			w.diffs = append(w.diffs, SchemaOrderDiffEntry{
 				Side:     w.side,
 				Path:     path,
-				Expected: append([]string{}, exp.keys...),
+				Expected: expKeys,
 				Actual:   gotKeys,
 			})
 		}

--- a/adapters/common/codegen/bamlfuzz/order.go
+++ b/adapters/common/codegen/bamlfuzz/order.go
@@ -196,6 +196,31 @@ func (w *orderWalker) setErr(err error) {
 	}
 }
 
+// Workaround for boundaryml/baml#3690: BAML's Go codegen serializes
+// null-valued optional fields from a class union arm even when the
+// active arm is a map or a different class, leaking extra null-valued
+// keys into the wire object. The order comparisons below drop those
+// leaked keys before checking key-order equality so the spurious key
+// does not register as an order mismatch. This is a comparison-only
+// relaxation. Remove when the upstream fix lands.
+
+// stripExtraNullKeys returns a filtered copy of keys removing entries
+// that are null-valued in src and absent from the reference set ref.
+// Null keys that ref also carries are preserved so genuine null-valued
+// fields still participate in the order check.
+func stripExtraNullKeys(keys []string, src, ref map[string]orderedJSON) []string {
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if src[k].kind == orderedNull {
+			if _, ok := ref[k]; !ok {
+				continue
+			}
+		}
+		out = append(out, k)
+	}
+	return out
+}
+
 func (w *orderWalker) walkClass(path, className string, exp, got orderedJSON) {
 	cls, ok := w.schema.FindClass(className)
 	if !ok {
@@ -208,12 +233,14 @@ func (w *orderWalker) walkClass(path, className string, exp, got orderedJSON) {
 	if exp.kind != orderedObject || got.kind != orderedObject {
 		return
 	}
-	if !slices.Equal(exp.keys, got.keys) {
+	expKeys := stripExtraNullKeys(exp.keys, exp.byKey, got.byKey)
+	gotKeys := stripExtraNullKeys(got.keys, got.byKey, exp.byKey)
+	if !slices.Equal(expKeys, gotKeys) {
 		w.diffs = append(w.diffs, SchemaOrderDiffEntry{
 			Side:     w.side,
 			Path:     path,
-			Expected: append([]string{}, exp.keys...),
-			Actual:   append([]string{}, got.keys...),
+			Expected: expKeys,
+			Actual:   gotKeys,
 		})
 	}
 	for _, prop := range cls.Properties {
@@ -256,12 +283,14 @@ func (w *orderWalker) walkType(path string, typ FuzzType, exp, got orderedJSON) 
 		if exp.kind != orderedObject || got.kind != orderedObject {
 			return
 		}
-		if !slices.Equal(exp.keys, got.keys) {
+		expKeys := stripExtraNullKeys(exp.keys, exp.byKey, got.byKey)
+		gotKeys := stripExtraNullKeys(got.keys, got.byKey, exp.byKey)
+		if !slices.Equal(expKeys, gotKeys) {
 			w.diffs = append(w.diffs, SchemaOrderDiffEntry{
 				Side:     w.side,
 				Path:     path,
-				Expected: append([]string{}, exp.keys...),
-				Actual:   append([]string{}, got.keys...),
+				Expected: expKeys,
+				Actual:   gotKeys,
 			})
 		}
 		for _, key := range sortedIntersection(exp.byKey, got.byKey) {

--- a/adapters/common/codegen/bamlfuzz/order_test.go
+++ b/adapters/common/codegen/bamlfuzz/order_test.go
@@ -691,6 +691,23 @@ func TestSchemaOrderDiff_ToleratesExtraNullKeysInClass(t *testing.T) {
 	}
 }
 
+// TestSchemaOrderDiff_NullKeyMissingFromActualStillDiffs pins the
+// asymmetry: the workaround only forgives extra null keys ON the actual
+// side. A null-valued key the expected side carries that the actual side
+// dropped is a genuine missing field and still surfaces a diff.
+func TestSchemaOrderDiff_NullKeyMissingFromActualStillDiffs(t *testing.T) {
+	schema := schemaRootOnly("a", "b")
+	exp := json.RawMessage(`{"a":"1","b":"2","leak":null}`)
+	got := json.RawMessage(`{"a":"1","b":"2"}`)
+	diffs, err := SchemaOrderDiffWithChoices("side", schema, exp, got, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for null key missing from actual, got %d (%v)", len(diffs), diffs)
+	}
+}
+
 // TestSchemaOrderDiff_ExtraNonNullKeyInClassStillDiffs asserts the
 // workaround is scoped to null keys: an extra non-null key remains an
 // order mismatch.
@@ -738,6 +755,18 @@ func TestSchemaOrderDiff_ToleratesExtraNullKeysInMap(t *testing.T) {
 	}
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff for extra non-null map key, got %d (%v)", len(diffs), diffs)
+	}
+
+	// Asymmetry: a null map key the expected side carries that the
+	// actual side dropped is a genuine missing entry and still diffs.
+	expMissing := json.RawMessage(`{"m":{"leak":null,"k0":-26}}`)
+	gotMissing := json.RawMessage(`{"m":{"k0":-26}}`)
+	diffs, err = SchemaOrderDiffWithChoices("side", schema, expMissing, gotMissing, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for null map key missing from actual, got %d (%v)", len(diffs), diffs)
 	}
 }
 

--- a/adapters/common/codegen/bamlfuzz/order_test.go
+++ b/adapters/common/codegen/bamlfuzz/order_test.go
@@ -805,6 +805,62 @@ func TestSchemaOrderDiffWithChoices_UnionMapArmToleratesLeakedNull(t *testing.T)
 	}
 }
 
+// TestSchemaOrderDiffParity_ToleratesExtraNullEitherSide pins the
+// symmetric #3690 order tolerance for actual-vs-actual parity checks: a
+// leaked null key on either side is dropped before the key-order
+// comparison, so it does not register as a mismatch. The asymmetric
+// variant flags an a-side-only null (see
+// TestSchemaOrderDiff_NullKeyMissingFromActualStillDiffs); parity does
+// not.
+func TestSchemaOrderDiffParity_ToleratesExtraNullEitherSide(t *testing.T) {
+	schema := schemaRootOnly("a", "b")
+	cases := []struct {
+		name   string
+		a, b   string
+		parity bool
+		want   int
+	}{
+		{"null on a only, parity tolerates", `{"a":"1","b":"2","leak":null}`, `{"a":"1","b":"2"}`, true, 0},
+		{"null on b only, parity tolerates", `{"a":"1","b":"2"}`, `{"a":"1","b":"2","leak":null}`, true, 0},
+		{"null on a only, asymmetric flags", `{"a":"1","b":"2","leak":null}`, `{"a":"1","b":"2"}`, false, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var (
+				diffs []SchemaOrderDiffEntry
+				err   error
+			)
+			if c.parity {
+				diffs, err = SchemaOrderDiffParityWithChoices("side", schema, json.RawMessage(c.a), json.RawMessage(c.b), nil)
+			} else {
+				diffs, err = SchemaOrderDiffWithChoices("side", schema, json.RawMessage(c.a), json.RawMessage(c.b), nil)
+			}
+			if err != nil {
+				t.Fatalf("SchemaOrderDiff: %v", err)
+			}
+			if len(diffs) != c.want {
+				t.Errorf("expected %d diffs, got %d (%v)", c.want, len(diffs), diffs)
+			}
+		})
+	}
+}
+
+// TestSchemaOrderDiffParity_ExtraNonNullKeyStillDiffs asserts the parity
+// order tolerance is scoped to null keys: an extra non-null key on either
+// side remains a mismatch.
+func TestSchemaOrderDiffParity_ExtraNonNullKeyStillDiffs(t *testing.T) {
+	schema := schemaRootOnly("a", "b")
+	exp := json.RawMessage(`{"a":"1","b":"2","extra":"3"}`)
+	got := json.RawMessage(`{"a":"1","b":"2"}`)
+	diffs, err := SchemaOrderDiffParityWithChoices("side", schema, exp, got, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for extra non-null key, got %d (%v)", len(diffs), diffs)
+	}
+}
+
 func keysEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/adapters/common/codegen/bamlfuzz/order_test.go
+++ b/adapters/common/codegen/bamlfuzz/order_test.go
@@ -940,7 +940,7 @@ func TestSchemaOrderDiffParity_MapSameLeakedNullUnionValueNoUnsupported(t *testi
 }
 
 // TestSchemaOrderDiffParity_MapNullValueTypeKeepsOrderCheck pins the
-// boundaryml/baml#3690 canBeNull gate: when a map's value type can itself
+// boundaryml/baml#3690 CanBeNull gate: when a map's value type can itself
 // be null (map<string, null>), every entry is legitimately null, so the
 // parity all-null strip must NOT apply — a real key-order difference is
 // still flagged.

--- a/adapters/common/codegen/bamlfuzz/order_test.go
+++ b/adapters/common/codegen/bamlfuzz/order_test.go
@@ -861,6 +861,84 @@ func TestSchemaOrderDiffParity_ExtraNonNullKeyStillDiffs(t *testing.T) {
 	}
 }
 
+// TestSchemaOrderDiffParity_MapSameLeakedNullDifferentPosition pins the
+// boundaryml/baml#3690 map-arm parity fix: when both actual outputs carry
+// the same leaked null key but in different positions, the order check
+// must not flag it. A null is never a real map entry, so parity mode
+// drops it from both sides before the key-order comparison.
+func TestSchemaOrderDiffParity_MapSameLeakedNullDifferentPosition(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "m", Type: mapOf(FuzzType{Kind: KindInt})},
+			},
+		}},
+		RootClass: "Root",
+	}
+	// Both legs leaked "Fuzz_field_0":null, but the leak landed in a
+	// different spot relative to the real "k0" entry on each side.
+	a := json.RawMessage(`{"m":{"Fuzz_field_0":null,"k0":1}}`)
+	b := json.RawMessage(`{"m":{"k0":1,"Fuzz_field_0":null}}`)
+	diffs, err := SchemaOrderDiffParityWithChoices("side", schema, a, b, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs for same leaked null in different positions, got %v", diffs)
+	}
+
+	// A real ordering swap of non-null entries still diffs, even with the
+	// leaked null present.
+	a = json.RawMessage(`{"m":{"Fuzz_field_0":null,"k0":1,"k1":2}}`)
+	b = json.RawMessage(`{"m":{"k1":2,"k0":1,"Fuzz_field_0":null}}`)
+	diffs, err = SchemaOrderDiffParityWithChoices("side", schema, a, b, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for real key-order swap, got %d (%v)", len(diffs), diffs)
+	}
+}
+
+// TestSchemaOrderDiffParity_MapSameLeakedNullUnionValueNoUnsupported
+// guards point 3 of the fix: a leaked null map key whose declared value
+// type is a union must be skipped in the recursion, not walked into —
+// otherwise the missing union choice surfaces a spurious
+// ErrSchemaOrderUnsupported.
+func TestSchemaOrderDiffParity_MapSameLeakedNullUnionValueNoUnsupported(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "m", Type: mapOf(FuzzType{
+					Kind: KindUnion,
+					Variants: []FuzzType{
+						{Kind: KindString},
+						{Kind: KindInt},
+					},
+				})},
+			},
+		}},
+		RootClass: "Root",
+	}
+	// "leak":null is a leaked null entry; its value type is the union,
+	// but the walker must not consult choices for it. "k0":"x" walks the
+	// string arm, which needs no choice.
+	choices := map[string]UnionChoice{
+		`.m["k0"]`: {Index: 0, Kind: KindString, VariantCount: 2},
+	}
+	a := json.RawMessage(`{"m":{"leak":null,"k0":"x"}}`)
+	b := json.RawMessage(`{"m":{"k0":"x","leak":null}}`)
+	diffs, err := SchemaOrderDiffParityWithChoices("side", schema, a, b, choices)
+	if err != nil {
+		t.Fatalf("unexpected err (leaked null union value should be skipped): %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
 func keysEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/adapters/common/codegen/bamlfuzz/order_test.go
+++ b/adapters/common/codegen/bamlfuzz/order_test.go
@@ -674,6 +674,108 @@ func TestSchemaOrderDiffUnionMissingChoiceReturnsUnsupported(t *testing.T) {
 	}
 }
 
+// TestSchemaOrderDiff_ToleratesExtraNullKeysInClass pins the
+// boundaryml/baml#3690 workaround at a class node: an extra null-valued
+// key on the actual side that expected does not carry must not register
+// as a key-order mismatch.
+func TestSchemaOrderDiff_ToleratesExtraNullKeysInClass(t *testing.T) {
+	schema := schemaRootOnly("a", "b")
+	exp := json.RawMessage(`{"a":"1","b":"2"}`)
+	got := json.RawMessage(`{"a":"1","b":"2","Fuzz_field_0":null}`)
+	diffs, err := SchemaOrderDiffWithChoices("side", schema, exp, got, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs for leaked null key, got %v", diffs)
+	}
+}
+
+// TestSchemaOrderDiff_ExtraNonNullKeyInClassStillDiffs asserts the
+// workaround is scoped to null keys: an extra non-null key remains an
+// order mismatch.
+func TestSchemaOrderDiff_ExtraNonNullKeyInClassStillDiffs(t *testing.T) {
+	schema := schemaRootOnly("a", "b")
+	exp := json.RawMessage(`{"a":"1","b":"2"}`)
+	got := json.RawMessage(`{"a":"1","b":"2","extra":"3"}`)
+	diffs, err := SchemaOrderDiffWithChoices("side", schema, exp, got, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for extra non-null key, got %d (%v)", len(diffs), diffs)
+	}
+}
+
+// TestSchemaOrderDiff_ToleratesExtraNullKeysInMap pins the workaround at
+// a map node: the leaked null key on the actual side is dropped before
+// the insertion-order comparison.
+func TestSchemaOrderDiff_ToleratesExtraNullKeysInMap(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "m", Type: mapOf(FuzzType{Kind: KindInt})},
+			},
+		}},
+		RootClass: "Root",
+	}
+	exp := json.RawMessage(`{"m":{"k0":-26}}`)
+	got := json.RawMessage(`{"m":{"Fuzz_field_0":null,"k0":-26}}`)
+	diffs, err := SchemaOrderDiffWithChoices("side", schema, exp, got, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs for leaked null map key, got %v", diffs)
+	}
+
+	// An extra non-null map key remains a mismatch.
+	got = json.RawMessage(`{"m":{"extra":1,"k0":-26}}`)
+	diffs, err = SchemaOrderDiffWithChoices("side", schema, exp, got, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for extra non-null map key, got %d (%v)", len(diffs), diffs)
+	}
+}
+
+// TestSchemaOrderDiffWithChoices_UnionMapArmToleratesLeakedNull mirrors
+// the exact boundaryml/baml#3690 shape: a `class | map<string,int>`
+// union whose active map arm comes back with a leaked null field from
+// the class arm. The order walker descends into the map arm and the
+// leaked key is tolerated.
+func TestSchemaOrderDiffWithChoices_UnionMapArmToleratesLeakedNull(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "FuzzClass1",
+			Properties: []FuzzProperty{
+				{Name: "Fuzz_field_0", Type: optionalOf(FuzzType{Kind: KindFloat})},
+			},
+		}},
+		RootType: &FuzzType{
+			Kind: KindUnion,
+			Variants: []FuzzType{
+				classRef("FuzzClass1"),
+				mapOf(FuzzType{Kind: KindInt}),
+			},
+		},
+	}
+	choices := map[string]UnionChoice{
+		"": {Index: 1, Kind: KindMap, VariantCount: 2},
+	}
+	exp := json.RawMessage(`{"k0":-26}`)
+	got := json.RawMessage(`{"Fuzz_field_0":null,"k0":-26}`)
+	diffs, err := SchemaOrderDiffWithChoices("side", schema, exp, got, choices)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs for leaked null key in map arm, got %v", diffs)
+	}
+}
+
 func keysEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/adapters/common/codegen/bamlfuzz/order_test.go
+++ b/adapters/common/codegen/bamlfuzz/order_test.go
@@ -939,6 +939,106 @@ func TestSchemaOrderDiffParity_MapSameLeakedNullUnionValueNoUnsupported(t *testi
 	}
 }
 
+// TestSchemaOrderDiffParity_MapNullValueTypeKeepsOrderCheck pins the
+// boundaryml/baml#3690 canBeNull gate: when a map's value type can itself
+// be null (map<string, null>), every entry is legitimately null, so the
+// parity all-null strip must NOT apply — a real key-order difference is
+// still flagged.
+func TestSchemaOrderDiffParity_MapNullValueTypeKeepsOrderCheck(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "m", Type: mapOf(FuzzType{Kind: KindNull})},
+			},
+		}},
+		RootClass: "Root",
+	}
+	// Both entries are real null-valued map entries; the order differs.
+	a := json.RawMessage(`{"m":{"x":null,"y":null}}`)
+	b := json.RawMessage(`{"m":{"y":null,"x":null}}`)
+	diffs, err := SchemaOrderDiffParityWithChoices("side", schema, a, b, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for reordered null entries, got %d (%v)", len(diffs), diffs)
+	}
+
+	// Identical order on both sides → no diff.
+	a = json.RawMessage(`{"m":{"x":null,"y":null}}`)
+	b = json.RawMessage(`{"m":{"x":null,"y":null}}`)
+	diffs, err = SchemaOrderDiffParityWithChoices("side", schema, a, b, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs for identical null-entry order, got %v", diffs)
+	}
+}
+
+// TestSchemaOrderDiffParity_MapOptionalValueTypeKeepsOrderCheck pins that
+// the gate also fires through optional<T>: map<string, optional<int>>
+// entries can be null legitimately, so the all-null strip is suppressed
+// and a real reorder of null entries still diffs.
+func TestSchemaOrderDiffParity_MapOptionalValueTypeKeepsOrderCheck(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "m", Type: mapOf(optionalOf(FuzzType{Kind: KindInt}))},
+			},
+		}},
+		RootClass: "Root",
+	}
+	a := json.RawMessage(`{"m":{"x":null,"y":null}}`)
+	b := json.RawMessage(`{"m":{"y":null,"x":null}}`)
+	diffs, err := SchemaOrderDiffParityWithChoices("side", schema, a, b, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for reordered optional entries, got %d (%v)", len(diffs), diffs)
+	}
+}
+
+// TestSchemaOrderDiffParity_MapIntValueTypeStripsLeakedNulls reaffirms the
+// non-nullable case: for map<string, int> a null entry can only be a leak,
+// so parity strips it (different leak positions agree) while a real reorder
+// of the int entries still diffs.
+func TestSchemaOrderDiffParity_MapIntValueTypeStripsLeakedNulls(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "m", Type: mapOf(FuzzType{Kind: KindInt})},
+			},
+		}},
+		RootClass: "Root",
+	}
+	// Same leaked null, different position → no diff.
+	a := json.RawMessage(`{"m":{"leak":null,"k0":1}}`)
+	b := json.RawMessage(`{"m":{"k0":1,"leak":null}}`)
+	diffs, err := SchemaOrderDiffParityWithChoices("side", schema, a, b, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs for leaked null in different positions, got %v", diffs)
+	}
+
+	// Real reorder of int entries (leak present) → diff.
+	a = json.RawMessage(`{"m":{"leak":null,"k0":1,"k1":2}}`)
+	b = json.RawMessage(`{"m":{"k1":2,"k0":1}}`)
+	diffs, err = SchemaOrderDiffParityWithChoices("side", schema, a, b, nil)
+	if err != nil {
+		t.Fatalf("SchemaOrderDiff: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for reordered int entries, got %d (%v)", len(diffs), diffs)
+	}
+}
+
 func keysEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -438,7 +438,7 @@ func runDynamicOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Oracle
 		checkSchemaOrder(t, c, envelope, &failures, "expected_vs_rest", c.Expected, envelope.RESTBody)
 	}
 	if libErr == nil && envelope.RESTError == "" && envelope.DynclientOutput != nil && envelope.RESTBody != nil {
-		if diff, err := bamlfuzz.SemanticDiff("dynclient_vs_rest", envelope.DynclientOutput, envelope.RESTBody); err != nil {
+		if diff, err := bamlfuzz.SemanticDiffParity("dynclient_vs_rest", envelope.DynclientOutput, envelope.RESTBody); err != nil {
 			failures = append(failures, fmt.Sprintf("dynclient_vs_rest diff: %v", err))
 		} else if len(diff) > 0 {
 			envelope.SemanticDiff = append(envelope.SemanticDiff, diff...)

--- a/integration/bamlfuzz_invalid_test.go
+++ b/integration/bamlfuzz_invalid_test.go
@@ -715,10 +715,12 @@ func variantNarrowness(t bamlfuzz.FuzzType) int {
 // stack.
 //
 // boundaryml/baml#3690 tolerance: a leaked null-valued key is ignored
-// when matching both maps (it is not a real entry) and classes (it is
-// not a real extra key). The order walker that consumes the derived
-// choice is itself null-tolerant, so the arm picked here must agree
-// with the null-stripped view the walker compares.
+// when matching maps whose value type cannot be null (the null is not a
+// real entry) and classes (it is not a real extra key). For a map whose
+// value type can be null the null is a legitimate entry and is matched
+// normally. The order walker that consumes the derived choice is itself
+// null-tolerant, so the arm picked here must agree with the null-stripped
+// view the walker compares.
 func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any, depth int) bool {
 	if depth <= 0 {
 		// Out of depth budget: accept on top-level shape only. The
@@ -792,18 +794,31 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any,
 		if t.Inner == nil {
 			return true
 		}
+		innerNullable := bamlfuzz.CanBeNull(*t.Inner)
+		matched := 0
 		for _, val := range obj {
 			// boundaryml/baml#3690: a leaked null-valued key from a
 			// sibling class union arm is not a real map entry, so it
 			// must not disqualify the map arm. The null-tolerant order
 			// walker strips it from the comparison anyway; ignore it
 			// here so arm derivation agrees with what the walker sees.
-			if val == nil {
+			// Only skip when the value type cannot itself be null — for
+			// map<string, null> / map<string, optional<T>> a null is a
+			// legitimate entry and must be checked normally.
+			if val == nil && !innerNullable {
 				continue
 			}
 			if !variantMatchesValue(schema, *t.Inner, val, depth-1) {
 				return false
 			}
+			matched++
+		}
+		// A non-empty object whose every entry was a skipped leaked null
+		// is not a real instance of a non-nullable-value map: e.g.
+		// {"k0": null} must not match map<string, int>. An empty object
+		// ({}) is still a valid empty map.
+		if len(obj) > 0 && matched == 0 && !innerNullable {
+			return false
 		}
 		return true
 	case bamlfuzz.KindClassRef:

--- a/integration/bamlfuzz_invalid_test.go
+++ b/integration/bamlfuzz_invalid_test.go
@@ -434,7 +434,7 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 	case bamlfuzz.OutcomeConditional:
 		switch {
 		case dynSuccess && restSuccess:
-			diffs, derr := bamlfuzz.SemanticDiff("dynclient_vs_rest", envelope.DynclientOutput, envelope.RESTBody)
+			diffs, derr := bamlfuzz.SemanticDiffParity("dynclient_vs_rest", envelope.DynclientOutput, envelope.RESTBody)
 			if derr != nil {
 				failAndDumpInvalid(t, artifactDir, envelope, "axis C diff decode (mutation=%s): %v", c.Mutation, derr)
 				return
@@ -529,7 +529,7 @@ func checkInvalidOrderC(c bamlfuzz.InvalidOracleCase, dyn, rest json.RawMessage)
 	if err != nil {
 		return fmt.Sprintf("axis C order check: derive union choices: %v", err), true
 	}
-	diffs, err := bamlfuzz.SchemaOrderDiffWithChoices("dynclient_vs_rest_order", c.Schema, dyn, rest, choices)
+	diffs, err := bamlfuzz.SchemaOrderDiffParityWithChoices("dynclient_vs_rest_order", c.Schema, dyn, rest, choices)
 	switch {
 	case errors.Is(err, bamlfuzz.ErrSchemaOrderUnsupported):
 		return fmt.Sprintf("axis C order check: %v (derivation did not cover every union path; treat as hard fail per F1 contract)", err), true

--- a/integration/bamlfuzz_invalid_test.go
+++ b/integration/bamlfuzz_invalid_test.go
@@ -713,6 +713,12 @@ func variantNarrowness(t bamlfuzz.FuzzType) int {
 // ClassRef<T> recurse into elements so nested narrowness is checked
 // too, depth-limited to keep a degenerate cycle from blowing the
 // stack.
+//
+// boundaryml/baml#3690 tolerance: a leaked null-valued key is ignored
+// when matching both maps (it is not a real entry) and classes (it is
+// not a real extra key). The order walker that consumes the derived
+// choice is itself null-tolerant, so the arm picked here must agree
+// with the null-stripped view the walker compares.
 func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any, depth int) bool {
 	if depth <= 0 {
 		// Out of depth budget: accept on top-level shape only. The
@@ -787,6 +793,14 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any,
 			return true
 		}
 		for _, val := range obj {
+			// boundaryml/baml#3690: a leaked null-valued key from a
+			// sibling class union arm is not a real map entry, so it
+			// must not disqualify the map arm. The null-tolerant order
+			// walker strips it from the comparison anyway; ignore it
+			// here so arm derivation agrees with what the walker sees.
+			if val == nil {
+				continue
+			}
 			if !variantMatchesValue(schema, *t.Inner, val, depth-1) {
 				return false
 			}
@@ -805,8 +819,14 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any,
 		for _, p := range cls.Properties {
 			propByName[p.Name] = p.Type
 		}
-		for k := range obj {
+		for k, val := range obj {
 			if _, ok := propByName[k]; !ok {
+				// boundaryml/baml#3690: tolerate a leaked null-valued
+				// key that is not a declared property; a non-null
+				// unknown key still disqualifies the class arm.
+				if val == nil {
+					continue
+				}
 				return false
 			}
 		}

--- a/integration/bamlfuzz_invalid_test.go
+++ b/integration/bamlfuzz_invalid_test.go
@@ -661,9 +661,15 @@ func pickUnionArm(schema bamlfuzz.FuzzSchema, variants []bamlfuzz.FuzzType, v an
 	sort.SliceStable(indices, func(a, b int) bool {
 		return variantNarrowness(variants[indices[a]]) < variantNarrowness(variants[indices[b]])
 	})
-	for _, idx := range indices {
-		if variantMatchesValue(schema, variants[idx], v, defaultMatchDepth) {
-			return idx
+	// Two passes: a strict pass first so an arm that matches every entry
+	// exactly is preferred over one that only matches by tolerating
+	// boundaryml/baml#3690 leaked nulls. Only if no arm matches strictly
+	// do we fall back to the tolerant pass, which is the prior behavior.
+	for _, tolerant := range []bool{false, true} {
+		for _, idx := range indices {
+			if variantMatchesValue(schema, variants[idx], v, defaultMatchDepth, tolerant) {
+				return idx
+			}
 		}
 	}
 	return -1
@@ -714,14 +720,20 @@ func variantNarrowness(t bamlfuzz.FuzzType) int {
 // too, depth-limited to keep a degenerate cycle from blowing the
 // stack.
 //
-// boundaryml/baml#3690 tolerance: a leaked null-valued key is ignored
-// when matching maps whose value type cannot be null (the null is not a
-// real entry) and classes (it is not a real extra key). For a map whose
-// value type can be null the null is a legitimate entry and is matched
-// normally. The order walker that consumes the derived choice is itself
-// null-tolerant, so the arm picked here must agree with the null-stripped
-// view the walker compares.
-func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any, depth int) bool {
+// boundaryml/baml#3690 tolerance: when `tolerant` is set, a leaked
+// null-valued key is ignored when matching maps whose value type cannot
+// be null (the null is not a real entry) and classes (it is not a real
+// extra key). For a map whose value type can be null the null is a
+// legitimate entry and is matched normally regardless of `tolerant`. The
+// order walker that consumes the derived choice is itself null-tolerant,
+// so the arm picked here must agree with the null-stripped view the
+// walker compares.
+//
+// pickUnionArm runs a strict pass (tolerant=false) before a tolerant one
+// so an arm that matches every entry EXACTLY wins over one that only
+// matches by skipping leaked nulls — e.g. map<string, optional<int>>
+// beats map<string, int> for {"x": null, "y": 1}.
+func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any, depth int, tolerant bool) bool {
 	if depth <= 0 {
 		// Out of depth budget: accept on top-level shape only. The
 		// v1 grammar bounds nesting at bamlfuzz.MaxTypeDepth=4, so
@@ -781,7 +793,7 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any,
 			return true
 		}
 		for _, item := range arr {
-			if !variantMatchesValue(schema, *t.Inner, item, depth-1) {
+			if !variantMatchesValue(schema, *t.Inner, item, depth-1, tolerant) {
 				return false
 			}
 		}
@@ -804,11 +816,14 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any,
 			// here so arm derivation agrees with what the walker sees.
 			// Only skip when the value type cannot itself be null — for
 			// map<string, null> / map<string, optional<T>> a null is a
-			// legitimate entry and must be checked normally.
-			if val == nil && !innerNullable {
+			// legitimate entry and must be checked normally. The skip is
+			// also gated on tolerant: the strict pass rejects a null
+			// against a non-nullable value so an exactly-matching arm is
+			// preferred.
+			if val == nil && !innerNullable && tolerant {
 				continue
 			}
-			if !variantMatchesValue(schema, *t.Inner, val, depth-1) {
+			if !variantMatchesValue(schema, *t.Inner, val, depth-1, tolerant) {
 				return false
 			}
 			matched++
@@ -838,8 +853,10 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any,
 			if _, ok := propByName[k]; !ok {
 				// boundaryml/baml#3690: tolerate a leaked null-valued
 				// key that is not a declared property; a non-null
-				// unknown key still disqualifies the class arm.
-				if val == nil {
+				// unknown key still disqualifies the class arm. Gated on
+				// tolerant so the strict pass rejects an unknown null key
+				// and an exactly-matching arm is preferred.
+				if val == nil && tolerant {
 					continue
 				}
 				return false
@@ -858,7 +875,7 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any,
 			if !present {
 				continue
 			}
-			if !variantMatchesValue(schema, fieldType, fv, depth-1) {
+			if !variantMatchesValue(schema, fieldType, fv, depth-1, tolerant) {
 				return false
 			}
 		}
@@ -868,12 +885,12 @@ func variantMatchesValue(schema bamlfuzz.FuzzSchema, t bamlfuzz.FuzzType, v any,
 			return true
 		}
 		if t.Inner != nil {
-			return variantMatchesValue(schema, *t.Inner, v, depth-1)
+			return variantMatchesValue(schema, *t.Inner, v, depth-1, tolerant)
 		}
 		return false
 	case bamlfuzz.KindUnion:
 		for _, variant := range t.Variants {
-			if variantMatchesValue(schema, variant, v, depth-1) {
+			if variantMatchesValue(schema, variant, v, depth-1, tolerant) {
 				return true
 			}
 		}

--- a/integration/bamlfuzz_invalid_union_test.go
+++ b/integration/bamlfuzz_invalid_union_test.go
@@ -105,3 +105,55 @@ func TestCheckInvalidOrderC_RealOrderMismatchStillFails(t *testing.T) {
 		t.Errorf("expected a hard fail for the key-order swap, got fail=false msg=%q", msg)
 	}
 }
+
+// unionMapOrStringSchema builds `map<string, V> | string` for the given
+// map value type, exercising the variantMatchesValue map-arm null gate.
+func unionMapOrStringSchema(mapValue bamlfuzz.FuzzType) bamlfuzz.FuzzSchema {
+	strT := bamlfuzz.FuzzType{Kind: bamlfuzz.KindString}
+	return bamlfuzz.FuzzSchema{
+		RootType: &bamlfuzz.FuzzType{
+			Kind: bamlfuzz.KindUnion,
+			Variants: []bamlfuzz.FuzzType{
+				{Kind: bamlfuzz.KindMap, Key: &strT, Inner: &mapValue},
+				{Kind: bamlfuzz.KindString},
+			},
+		},
+	}
+}
+
+// TestDeriveUnionChoices_MapNullableInnerRejectsPayload pins the
+// boundaryml/baml#3690 CanBeNull gate on arm derivation: for
+// `map<string,int> | string`, a payload whose only entry is null
+// ({"k0": null}) must NOT match the map arm. int cannot be null, so the
+// sole null entry is not a real map entry and the map arm has nothing
+// real to match — neither arm resolves.
+func TestDeriveUnionChoices_MapNullableInnerRejectsPayload(t *testing.T) {
+	schema := unionMapOrStringSchema(bamlfuzz.FuzzType{Kind: bamlfuzz.KindInt})
+	payload := json.RawMessage(`{"k0":null}`)
+	choices, err := deriveUnionChoicesFromParsed(schema, payload)
+	if err != nil {
+		t.Fatalf("deriveUnionChoicesFromParsed: %v", err)
+	}
+	if choice, ok := choices[""]; ok && choice.Kind == bamlfuzz.KindMap {
+		t.Errorf("expected the map arm to be rejected for an all-null payload, got %+v", choice)
+	}
+}
+
+// TestDeriveUnionChoices_MapNullValueTypeAcceptsNullEntry is the positive
+// counterpart: when the map value type CAN be null (map<string,null>), a
+// null entry is legitimate, so {"k0": null} resolves to the map arm.
+func TestDeriveUnionChoices_MapNullValueTypeAcceptsNullEntry(t *testing.T) {
+	schema := unionMapOrStringSchema(bamlfuzz.FuzzType{Kind: bamlfuzz.KindNull})
+	payload := json.RawMessage(`{"k0":null}`)
+	choices, err := deriveUnionChoicesFromParsed(schema, payload)
+	if err != nil {
+		t.Fatalf("deriveUnionChoicesFromParsed: %v", err)
+	}
+	choice, ok := choices[""]
+	if !ok {
+		t.Fatalf("expected a union choice at root path, got none (%v)", choices)
+	}
+	if choice.Kind != bamlfuzz.KindMap || choice.Index != 0 {
+		t.Errorf("expected map arm (index 0) for nullable value type, got %+v", choice)
+	}
+}

--- a/integration/bamlfuzz_invalid_union_test.go
+++ b/integration/bamlfuzz_invalid_union_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/bamlfuzz"
+)
+
+// unionClassOrMapSchema builds the boundaryml/baml#3690 shape: a
+// top-level union of `FuzzClass1 | map<string,int>`, where FuzzClass1
+// carries an optional float field BAML's codegen can leak as a null key
+// into the map arm's serialization.
+func unionClassOrMapSchema() bamlfuzz.FuzzSchema {
+	floatT := bamlfuzz.FuzzType{Kind: bamlfuzz.KindFloat}
+	intT := bamlfuzz.FuzzType{Kind: bamlfuzz.KindInt}
+	strT := bamlfuzz.FuzzType{Kind: bamlfuzz.KindString}
+	return bamlfuzz.FuzzSchema{
+		Classes: []bamlfuzz.FuzzClass{{
+			Name: "FuzzClass1",
+			Properties: []bamlfuzz.FuzzProperty{
+				{Name: "Fuzz_field_0", Type: bamlfuzz.FuzzType{Kind: bamlfuzz.KindOptional, Inner: &floatT}},
+			},
+		}},
+		RootType: &bamlfuzz.FuzzType{
+			Kind: bamlfuzz.KindUnion,
+			Variants: []bamlfuzz.FuzzType{
+				{Kind: bamlfuzz.KindClassRef, Ref: "FuzzClass1"},
+				{Kind: bamlfuzz.KindMap, Key: &strT, Inner: &intT},
+			},
+		},
+	}
+}
+
+// TestDeriveUnionChoices_LeakedNullPicksMapArm pins the boundaryml/baml#3690
+// arm-derivation fix: a map-arm payload carrying a leaked null key from
+// the sibling class arm still resolves to the map arm. Before the fix the
+// class arm rejected the unknown `k0` and the map arm rejected the null
+// `Fuzz_field_0`, so pickUnionArm returned no choice and the order walker
+// hard-failed with ErrSchemaOrderUnsupported.
+func TestDeriveUnionChoices_LeakedNullPicksMapArm(t *testing.T) {
+	schema := unionClassOrMapSchema()
+	dyn := json.RawMessage(`{"Fuzz_field_0":null,"k0":-26}`)
+	choices, err := deriveUnionChoicesFromParsed(schema, dyn)
+	if err != nil {
+		t.Fatalf("deriveUnionChoicesFromParsed: %v", err)
+	}
+	choice, ok := choices[""]
+	if !ok {
+		t.Fatalf("expected a union choice at root path, got none (%v)", choices)
+	}
+	if choice.Kind != bamlfuzz.KindMap || choice.Index != 1 {
+		t.Errorf("expected map arm (index 1), got %+v", choice)
+	}
+}
+
+// TestDeriveUnionChoices_RealClassStillPicksClassArm guards the fix's
+// scope: a genuine class-instance payload still resolves to the (narrower)
+// class arm, so the null tolerance does not slacken arm selection for
+// real values.
+func TestDeriveUnionChoices_RealClassStillPicksClassArm(t *testing.T) {
+	schema := unionClassOrMapSchema()
+	dyn := json.RawMessage(`{"Fuzz_field_0":1.5}`)
+	choices, err := deriveUnionChoicesFromParsed(schema, dyn)
+	if err != nil {
+		t.Fatalf("deriveUnionChoicesFromParsed: %v", err)
+	}
+	choice, ok := choices[""]
+	if !ok {
+		t.Fatalf("expected a union choice at root path, got none (%v)", choices)
+	}
+	if choice.Kind != bamlfuzz.KindClassRef || choice.Index != 0 {
+		t.Errorf("expected class arm (index 0), got %+v", choice)
+	}
+}
+
+// TestCheckInvalidOrderC_LeakedNullDoesNotHardFail exercises the full axis-C
+// order-parity path end to end: dynclient leaked the null key, REST returned
+// the clean map. Derivation resolves the map arm and the null-tolerant parity
+// walker strips the leak from both sides, so the key order agrees and the
+// check neither reports a diagnostic nor hard-fails.
+func TestCheckInvalidOrderC_LeakedNullDoesNotHardFail(t *testing.T) {
+	c := bamlfuzz.InvalidOracleCase{Schema: unionClassOrMapSchema(), PreserveSchemaOrder: true}
+	dyn := json.RawMessage(`{"Fuzz_field_0":null,"k0":-26}`)
+	rest := json.RawMessage(`{"k0":-26}`)
+	msg, fail := checkInvalidOrderC(c, dyn, rest)
+	if fail {
+		t.Errorf("expected no hard fail, got fail=true msg=%q", msg)
+	}
+	if msg != "" {
+		t.Errorf("expected no diagnostic, got %q", msg)
+	}
+}
+
+// TestCheckInvalidOrderC_RealOrderMismatchStillFails confirms the path still
+// catches a genuine map insertion-order swap once the leaked null is stripped.
+func TestCheckInvalidOrderC_RealOrderMismatchStillFails(t *testing.T) {
+	c := bamlfuzz.InvalidOracleCase{Schema: unionClassOrMapSchema(), PreserveSchemaOrder: true}
+	dyn := json.RawMessage(`{"Fuzz_field_0":null,"k0":1,"k1":2}`)
+	rest := json.RawMessage(`{"k1":2,"k0":1}`)
+	msg, fail := checkInvalidOrderC(c, dyn, rest)
+	if !fail {
+		t.Errorf("expected a hard fail for the key-order swap, got fail=false msg=%q", msg)
+	}
+}

--- a/integration/bamlfuzz_invalid_union_test.go
+++ b/integration/bamlfuzz_invalid_union_test.go
@@ -157,3 +157,64 @@ func TestDeriveUnionChoices_MapNullValueTypeAcceptsNullEntry(t *testing.T) {
 		t.Errorf("expected map arm (index 0) for nullable value type, got %+v", choice)
 	}
 }
+
+// unionDualMapSchema builds `map<string,int> | map<string,optional<int>>`
+// with the non-nullable arm FIRST, so without the strict-first arm
+// selection it would win by stable order even when the payload has a real
+// null entry the nullable arm matches exactly.
+func unionDualMapSchema() bamlfuzz.FuzzSchema {
+	strT := bamlfuzz.FuzzType{Kind: bamlfuzz.KindString}
+	intT := bamlfuzz.FuzzType{Kind: bamlfuzz.KindInt}
+	optIntT := bamlfuzz.FuzzType{Kind: bamlfuzz.KindOptional, Inner: &intT}
+	return bamlfuzz.FuzzSchema{
+		RootType: &bamlfuzz.FuzzType{
+			Kind: bamlfuzz.KindUnion,
+			Variants: []bamlfuzz.FuzzType{
+				{Kind: bamlfuzz.KindMap, Key: &strT, Inner: &intT},
+				{Kind: bamlfuzz.KindMap, Key: &strT, Inner: &optIntT},
+			},
+		},
+	}
+}
+
+// TestDeriveUnionChoices_PrefersNullableMapArm pins the two-pass arm
+// selection: a payload with a real null entry ({"x": null, "y": 1}) must
+// resolve to map<string, optional<int>> (index 1), which matches every
+// entry exactly, over map<string, int> (index 0), which only matches by
+// tolerating the null as a leaked key. Picking the non-nullable arm would
+// let the order walker strip "x" as leaked and hide real order mismatches.
+func TestDeriveUnionChoices_PrefersNullableMapArm(t *testing.T) {
+	schema := unionDualMapSchema()
+	payload := json.RawMessage(`{"x":null,"y":1}`)
+	choices, err := deriveUnionChoicesFromParsed(schema, payload)
+	if err != nil {
+		t.Fatalf("deriveUnionChoicesFromParsed: %v", err)
+	}
+	choice, ok := choices[""]
+	if !ok {
+		t.Fatalf("expected a union choice at root path, got none (%v)", choices)
+	}
+	if choice.Index != 1 {
+		t.Errorf("expected the nullable map arm (index 1), got %+v", choice)
+	}
+}
+
+// TestDeriveUnionChoices_NonNullPayloadStillPicksFirstMap guards the
+// strict-pass tie-break: with no nulls ({"x": 1, "y": 2}) both map arms
+// match strictly, so stable declaration order keeps the first arm
+// (index 0).
+func TestDeriveUnionChoices_NonNullPayloadStillPicksFirstMap(t *testing.T) {
+	schema := unionDualMapSchema()
+	payload := json.RawMessage(`{"x":1,"y":2}`)
+	choices, err := deriveUnionChoicesFromParsed(schema, payload)
+	if err != nil {
+		t.Fatalf("deriveUnionChoicesFromParsed: %v", err)
+	}
+	choice, ok := choices[""]
+	if !ok {
+		t.Fatalf("expected a union choice at root path, got none (%v)", choices)
+	}
+	if choice.Index != 0 {
+		t.Errorf("expected the first map arm (index 0) by stable order, got %+v", choice)
+	}
+}

--- a/integration/bamlfuzz_streaming_test.go
+++ b/integration/bamlfuzz_streaming_test.go
@@ -472,17 +472,18 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 	envelope.SawReset = dynReset || sseReset || ndjsonReset
 
 	// Assertion 1 — three-way final equivalence: dynclient final ≡ REST
-	// SSE final ≡ Expected.
-	diffAndRecord(envelope, &failures, "expected_vs_dynclient_final", c.Expected, envelope.DynclientFinal)
-	diffAndRecord(envelope, &failures, "expected_vs_rest_sse_final", c.Expected, envelope.RESTFinalSSE)
-	diffAndRecord(envelope, &failures, "dynclient_vs_rest_sse_final", envelope.DynclientFinal, envelope.RESTFinalSSE)
+	// SSE final ≡ Expected. The first two are expected-vs-actual; the
+	// dynclient-vs-REST leg is actual-vs-actual parity.
+	diffAndRecord(envelope, &failures, "expected_vs_dynclient_final", c.Expected, envelope.DynclientFinal, false)
+	diffAndRecord(envelope, &failures, "expected_vs_rest_sse_final", c.Expected, envelope.RESTFinalSSE, false)
+	diffAndRecord(envelope, &failures, "dynclient_vs_rest_sse_final", envelope.DynclientFinal, envelope.RESTFinalSSE, true)
 
 	// Assertion 3 — streaming final ≡ unary parse. Directly probes a
-	// streaming-vs-unary parser divergence.
-	diffAndRecord(envelope, &failures, "dynclient_final_vs_unary", envelope.DynclientFinal, envelope.UnaryParse)
+	// streaming-vs-unary parser divergence (both BAML-generated: parity).
+	diffAndRecord(envelope, &failures, "dynclient_final_vs_unary", envelope.DynclientFinal, envelope.UnaryParse, true)
 
 	// Assertion 4 — transport parity: SSE final ≡ NDJSON final.
-	diffAndRecord(envelope, &failures, "rest_sse_vs_ndjson_final", envelope.RESTFinalSSE, envelope.RESTFinalNDJSON)
+	diffAndRecord(envelope, &failures, "rest_sse_vs_ndjson_final", envelope.RESTFinalSSE, envelope.RESTFinalNDJSON, true)
 
 	// Assertion 2 — final-frame key order on each leg (preserve only).
 	checkStreamFinalOrder(t, c, envelope, &failures, "dynclient_final_order", envelope.DynclientFinal)
@@ -505,11 +506,20 @@ func runStreamingOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 // (empty payload) is skipped here — the absent final is reported by the
 // single-clean-final check, so re-flagging it as a decode error would
 // just duplicate the signal.
-func diffAndRecord(envelope *bamlfuzz.StreamingFailureEnvelope, failures *[]string, side string, a, b json.RawMessage) {
+//
+// `parity` selects the boundaryml/baml#3690 null-key tolerance: false for
+// expected-vs-actual pairings (only the actual side's leaked nulls are
+// forgiven), true for actual-vs-actual parity pairings where either
+// BAML-generated leg may independently carry the leak.
+func diffAndRecord(envelope *bamlfuzz.StreamingFailureEnvelope, failures *[]string, side string, a, b json.RawMessage, parity bool) {
 	if len(a) == 0 || len(b) == 0 {
 		return
 	}
-	diff, err := bamlfuzz.SemanticDiff(side, a, b)
+	diffFn := bamlfuzz.SemanticDiff
+	if parity {
+		diffFn = bamlfuzz.SemanticDiffParity
+	}
+	diff, err := diffFn(side, a, b)
 	if err != nil {
 		*failures = append(*failures, fmt.Sprintf("%s diff: %v", side, err))
 		return


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Problem

BAML's Go codegen ([boundaryml/baml#3690](https://github.com/boundaryml/baml/issues/3690)) serializes null-valued optional fields from a class union arm even when the active union arm is a map or a different class.

Example:
- Schema: `FuzzClass1 | map[string]int`, where `FuzzClass1` has `Fuzz_field_0: optional<float>`
- LLM returns: `{"k0": -26}`
- Expected (oracle): `{"k0": -26}`
- BAML produces: `{"Fuzz_field_0": null, "k0": -26}`

The bamlfuzz dynamic oracle flags the extra `Fuzz_field_0: null` as either a "schema key order mismatch" or a "semantic diff", accounting for 9/42 nightly #8 failures.

## Fix

Relax the **comparison-only** paths so a missing key is treated as equivalent to a null-valued key:

- **`envelope.go`** — `deepEqualSemantic` / `diffAny`: drop keys that are null-valued on one side and absent from the other before comparing lengths / emitting diff entries (helper `withoutExtraNullKeys`).
- **`order.go`** — `walkClass` and the `KindMap` case: strip leaked null keys (helper `stripExtraNullKeys`) before the wire-order equality check.

Both helpers are documented as a workaround for the upstream bug and marked for removal once it lands.

### What this does NOT touch

- No change to serialization or generated code (no `omitempty`).
- Non-null mismatches (extra/missing non-null keys, null-vs-value) still produce diffs.
- Only the presence of a leaked null key is suppressed.

## Tests

- `envelope_test.go`: `SemanticDiff` returns zero entries when the only difference is an extra null key; real differences still surface. Updated the `null vs missing` case in `TestSemanticEqual` to reflect the new contract.
- `order_test.go`: `SchemaOrderDiffWithChoices` returns zero diffs for leaked null keys at class and map nodes (including a test mirroring the exact `class | map<string,int>` shape from #3690); extra non-null keys still diff.

`GOWORK=off go test ./codegen/bamlfuzz/... -count=1` passes.

Umbrella: #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ignore extra null-valued keys present only on the actual side for value comparisons and key-order checks, preventing spurious diffs while preserving genuine mismatches.

* **New Features**
  * Add a symmetric "parity" mode that tolerates extra nulls on either side for parity comparisons and order checks.

* **Tests**
  * Add extensive unit and integration tests validating asymmetric and parity null-key tolerance across diffs, semantic equality, schema-order, nested structures, and unions.

* **Integration**
  * Switch relevant integration checks to parity comparisons and make union-arm selection tolerant of leaked nulls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->