### PR TITLE
fix(bamlfuzz): omit absent optionals reached through union arm from oracle expected

### DIFF
--- a/adapters/common/codegen/bamlfuzz/normalize.go
+++ b/adapters/common/codegen/bamlfuzz/normalize.go
@@ -19,10 +19,14 @@ type WalkResult struct {
 	MockLLMContent json.RawMessage
 	// Expected is the schema-normalized parsed value that matches
 	// what the BAML parser produces: present optionals carry their
-	// inner value, explicit-null optionals appear as JSON null.
-	// Absent optionals always appear as JSON null, matching the
-	// static path and the dynamic path's InjectAbsentOptionals
-	// post-processing.
+	// inner value, explicit-null optionals appear as JSON null. An
+	// absent optional reached through a deterministic (non-union)
+	// path appears as JSON null, matching the static path and the
+	// dynamic path's InjectAbsentOptionals post-processing. An absent
+	// optional reached through a union arm is omitted entirely: the
+	// runtime re-derives the active arm structurally and can land on a
+	// different arm than the recorded one, so it never injects the
+	// null and the key stays off the wire.
 	Expected json.RawMessage
 	// Metadata is per-case provenance the failure envelope embeds.
 	Metadata CaseMetadata
@@ -71,7 +75,7 @@ func Walk(schema FuzzSchema, value FuzzValue, opts ...WalkOption) (WalkResult, e
 	if err := state.renderValueMock(&mockBuf, root, value, ""); err != nil {
 		return WalkResult{}, err
 	}
-	if err := state.renderValueExpected(&expectBuf, root, value); err != nil {
+	if err := state.renderValueExpected(&expectBuf, root, value, false); err != nil {
 		return WalkResult{}, err
 	}
 	return WalkResult{
@@ -134,7 +138,12 @@ func (s *walkState) renderClassMock(buf *bytes.Buffer, val FuzzValue, path strin
 	return nil
 }
 
-func (s *walkState) renderClassExpected(buf *bytes.Buffer, val FuzzValue) error {
+// renderClassExpected renders a class instance into the expected
+// (schema-normalized) JSON. `inUnion` is true when this class was
+// reached through one or more union arms: see renderValueExpected's
+// KindOptional/KindUnion handling for why absent optionals are
+// omitted rather than nulled in that case.
+func (s *walkState) renderClassExpected(buf *bytes.Buffer, val FuzzValue, inUnion bool) error {
 	cls, ok := s.schema.FindClass(val.ClassName)
 	if !ok {
 		return fmt.Errorf("walk: unknown class %q in expected", val.ClassName)
@@ -151,6 +160,17 @@ func (s *walkState) renderClassExpected(buf *bytes.Buffer, val FuzzValue) error 
 		if !ok {
 			return fmt.Errorf("walk: missing field %q on class %q in expected", prop.Name, cls.Name)
 		}
+		// Inside a union arm an absent optional produces no key at all.
+		// The runtime's InjectAbsentOptionals re-derives the active
+		// union arm structurally from the wire value, and that
+		// derivation can land on a different arm than the one that
+		// actually generated the value (or one without this optional),
+		// so the null is never injected and the key stays off the wire.
+		// Outside a union the deterministic inject-null contract still
+		// holds, so absent optionals there render as JSON null below.
+		if inUnion && prop.Type.Kind == KindOptional && fv.OptionalShape == OptionalAbsent {
+			continue
+		}
 		if !first {
 			buf.WriteByte(',')
 		}
@@ -161,7 +181,7 @@ func (s *walkState) renderClassExpected(buf *bytes.Buffer, val FuzzValue) error 
 		}
 		buf.Write(keyBytes)
 		buf.WriteByte(':')
-		if err := s.renderValueExpected(buf, prop.Type, fv); err != nil {
+		if err := s.renderValueExpected(buf, prop.Type, fv, inUnion); err != nil {
 			return err
 		}
 	}
@@ -271,7 +291,13 @@ func (s *walkState) renderValueMock(buf *bytes.Buffer, t FuzzType, val FuzzValue
 	}
 }
 
-func (s *walkState) renderValueExpected(buf *bytes.Buffer, t FuzzType, val FuzzValue) error {
+// renderValueExpected renders one value into the expected JSON.
+// `inUnion` propagates whether the value sits beneath a union arm so
+// renderClassExpected can omit (rather than null) absent optionals
+// there. Descending into a union variant sets it for the subtree; it
+// never resets, since once the runtime's arm derivation can diverge
+// every absent optional below is unreliable.
+func (s *walkState) renderValueExpected(buf *bytes.Buffer, t FuzzType, val FuzzValue, inUnion bool) error {
 	switch t.Kind {
 	case KindString:
 		return writeJSON(buf, val.String)
@@ -299,9 +325,12 @@ func (s *walkState) renderValueExpected(buf *bytes.Buffer, t FuzzType, val FuzzV
 			if val.Inner == nil || t.Inner == nil {
 				return fmt.Errorf("expected: present optional missing inner")
 			}
-			return s.renderValueExpected(buf, *t.Inner, *val.Inner)
+			return s.renderValueExpected(buf, *t.Inner, *val.Inner, inUnion)
 		}
-		// Absent and null collapse to JSON null.
+		// Absent and null collapse to JSON null. (An absent optional
+		// inside a union arm is omitted by renderClassExpected before it
+		// ever reaches here, so this null is only ever the explicit-null
+		// shape or a non-union absent optional.)
 		buf.WriteString("null")
 		return nil
 	case KindList:
@@ -313,7 +342,7 @@ func (s *walkState) renderValueExpected(buf *bytes.Buffer, t FuzzType, val FuzzV
 			if i > 0 {
 				buf.WriteByte(',')
 			}
-			if err := s.renderValueExpected(buf, *t.Inner, item); err != nil {
+			if err := s.renderValueExpected(buf, *t.Inner, item, inUnion); err != nil {
 				return err
 			}
 		}
@@ -334,14 +363,14 @@ func (s *walkState) renderValueExpected(buf *bytes.Buffer, t FuzzType, val FuzzV
 			}
 			buf.Write(keyBytes)
 			buf.WriteByte(':')
-			if err := s.renderValueExpected(buf, *t.Inner, entry.Value); err != nil {
+			if err := s.renderValueExpected(buf, *t.Inner, entry.Value, inUnion); err != nil {
 				return err
 			}
 		}
 		buf.WriteByte('}')
 		return nil
 	case KindClassRef:
-		return s.renderClassExpected(buf, val)
+		return s.renderClassExpected(buf, val, inUnion)
 	case KindUnion:
 		if val.Kind != KindUnion || val.Variant == nil {
 			return fmt.Errorf("expected: union value missing selected variant")
@@ -349,7 +378,7 @@ func (s *walkState) renderValueExpected(buf *bytes.Buffer, t FuzzType, val FuzzV
 		if val.VariantIndex < 0 || val.VariantIndex >= len(t.Variants) {
 			return fmt.Errorf("expected: union variant index %d out of range [0,%d)", val.VariantIndex, len(t.Variants))
 		}
-		return s.renderValueExpected(buf, t.Variants[val.VariantIndex], *val.Variant)
+		return s.renderValueExpected(buf, t.Variants[val.VariantIndex], *val.Variant, true)
 	default:
 		return fmt.Errorf("expected: unknown kind %q", t.Kind)
 	}
@@ -402,8 +431,9 @@ func writeLiteral(buf *bytes.Buffer, lit *FuzzLiteral) error {
 // NormalizeMockToExpected re-parses `mock` and walks the schema's
 // class graph to produce the canonical-equivalent of the walker's
 // Expected output: class instance keys follow schema declaration
-// order, and map keys retain the mock's wire order. Absent optional
-// fields are always emitted as JSON null.
+// order, and map keys retain the mock's wire order. An absent optional
+// field is emitted as JSON null outside a union arm and omitted within
+// one — see WalkResult.Expected and renderClassExpected.
 //
 // Union schemas require union-choice metadata to disambiguate which
 // arm produced the mock; call NormalizeMockToExpectedWithChoices
@@ -416,8 +446,9 @@ func NormalizeMockToExpected(schema FuzzSchema, mock json.RawMessage, rootClass 
 // NormalizeMockToExpectedWithChoices is the union-aware variant. The
 // `choices` map mirrors CaseMetadata.UnionChoices: each entry tells
 // the normalizer which arm produced the JSON at that path. The
-// `preserve` parameter is accepted for API compatibility but absent
-// optional fields are always emitted as JSON null.
+// `preserve` parameter is accepted for API compatibility; absent
+// optional fields are emitted as JSON null outside a union arm and
+// omitted within one (see NormalizeMockToExpected).
 //
 // Normalization is driven by the schema's effective root type
 // (FuzzSchema.EffectiveRoot): when the schema sets RootType the
@@ -433,7 +464,7 @@ func NormalizeMockToExpectedWithChoices(schema FuzzSchema, mock json.RawMessage,
 		return nil, fmt.Errorf("normalize: parse mock: %w", err)
 	}
 	root := effectiveNormalizeRoot(schema, rootClass)
-	out, err := normalizeValue(schema, root, raw, "", choices, preserve)
+	out, err := normalizeValue(schema, root, raw, "", choices, preserve, false)
 	if err != nil {
 		return nil, err
 	}
@@ -516,7 +547,14 @@ func effectiveNormalizeRoot(schema FuzzSchema, rootClass string) FuzzType {
 	return schema.EffectiveRoot()
 }
 
-func normalizeClass(schema FuzzSchema, className string, raw any, basePath string, choices map[string]UnionChoice, preserve bool) (*bamlutils.OrderedMap[any], error) {
+// normalizeClass builds the order-preserving carrier for a class
+// instance. `inUnion` reports whether this class was reached through a
+// union arm: an absent optional is then left out of the carrier
+// entirely (so the re-emitter omits it), mirroring renderClassExpected
+// and the runtime's union-arm-derived InjectAbsentOptionals behaviour.
+// Outside a union the missing optional is recorded as nil so it
+// re-emits as JSON null.
+func normalizeClass(schema FuzzSchema, className string, raw any, basePath string, choices map[string]UnionChoice, preserve, inUnion bool) (*bamlutils.OrderedMap[any], error) {
 	cls, ok := schema.FindClass(className)
 	if !ok {
 		return nil, fmt.Errorf("normalize: unknown class %q", className)
@@ -532,12 +570,15 @@ func normalizeClass(schema FuzzSchema, className string, raw any, basePath strin
 			if prop.Type.Kind != KindOptional {
 				return nil, fmt.Errorf("normalize: required field %q on %q missing from mock", prop.Name, className)
 			}
+			if inUnion {
+				continue
+			}
 			if err := out.Set(prop.Name, nil); err != nil {
 				return nil, err
 			}
 			continue
 		}
-		nv, err := normalizeValue(schema, prop.Type, fv, basePath+"."+prop.Name, choices, preserve)
+		nv, err := normalizeValue(schema, prop.Type, fv, basePath+"."+prop.Name, choices, preserve, inUnion)
 		if err != nil {
 			return nil, fmt.Errorf("normalize: field %q on %q: %w", prop.Name, className, err)
 		}
@@ -548,7 +589,7 @@ func normalizeClass(schema FuzzSchema, className string, raw any, basePath strin
 	return out, nil
 }
 
-func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices map[string]UnionChoice, preserve bool) (any, error) {
+func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices map[string]UnionChoice, preserve, inUnion bool) (any, error) {
 	switch t.Kind {
 	case KindString, KindInt, KindFloat, KindBool, KindLiteral, KindEnumRef:
 		return raw, nil
@@ -561,7 +602,7 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices
 		if t.Inner == nil {
 			return nil, fmt.Errorf("optional missing inner")
 		}
-		return normalizeValue(schema, *t.Inner, raw, path, choices, preserve)
+		return normalizeValue(schema, *t.Inner, raw, path, choices, preserve, inUnion)
 	case KindList:
 		if raw == nil {
 			return nil, nil
@@ -572,7 +613,7 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices
 		}
 		out := make([]any, len(arr))
 		for i, item := range arr {
-			nv, err := normalizeValue(schema, *t.Inner, item, fmt.Sprintf("%s[%d]", path, i), choices, preserve)
+			nv, err := normalizeValue(schema, *t.Inner, item, fmt.Sprintf("%s[%d]", path, i), choices, preserve, inUnion)
 			if err != nil {
 				return nil, fmt.Errorf("list[%d]: %w", i, err)
 			}
@@ -590,7 +631,7 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices
 		out := &bamlutils.OrderedMap[any]{}
 		var firstErr error
 		obj.Range(func(k string, v any) bool {
-			nv, err := normalizeValue(schema, *t.Inner, v, fmt.Sprintf("%s[%q]", path, k), choices, preserve)
+			nv, err := normalizeValue(schema, *t.Inner, v, fmt.Sprintf("%s[%q]", path, k), choices, preserve, inUnion)
 			if err != nil {
 				firstErr = fmt.Errorf("map[%q]: %w", k, err)
 				return false
@@ -606,7 +647,7 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices
 		}
 		return out, nil
 	case KindClassRef:
-		return normalizeClass(schema, t.Ref, raw, path, choices, preserve)
+		return normalizeClass(schema, t.Ref, raw, path, choices, preserve, inUnion)
 	case KindUnion:
 		choice, ok := choices[path]
 		if !ok {
@@ -615,7 +656,7 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices
 		if choice.Index < 0 || choice.Index >= len(t.Variants) {
 			return nil, fmt.Errorf("normalize: union choice index %d out of range at %q", choice.Index, path)
 		}
-		return normalizeValue(schema, t.Variants[choice.Index], raw, path+":v", choices, preserve)
+		return normalizeValue(schema, t.Variants[choice.Index], raw, path+":v", choices, preserve, true)
 	default:
 		return nil, fmt.Errorf("normalize: unknown kind %q", t.Kind)
 	}
@@ -633,13 +674,19 @@ func normalizeValue(schema FuzzSchema, t FuzzType, raw any, path string, choices
 // through the class helper.
 func marshalSchemaOrdered(schema FuzzSchema, root FuzzType, normalized any, choices map[string]UnionChoice, preserve bool) (json.RawMessage, error) {
 	var buf bytes.Buffer
-	if err := writeOrderedValue(&buf, schema, root, normalized, "", choices, preserve); err != nil {
+	if err := writeOrderedValue(&buf, schema, root, normalized, "", choices, preserve, false); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
 }
 
-func writeOrderedClass(buf *bytes.Buffer, schema FuzzSchema, className string, v any, path string, choices map[string]UnionChoice, preserve bool) error {
+// writeOrderedClass re-emits a class instance in schema declaration
+// order. `inUnion` reports whether this class sits beneath a union arm.
+// A declared optional missing from the carrier re-emits as JSON null
+// outside a union (the inject-null contract); inside a union it is
+// omitted, matching normalizeClass / renderClassExpected and the
+// runtime's union-arm-derived InjectAbsentOptionals behaviour.
+func writeOrderedClass(buf *bytes.Buffer, schema FuzzSchema, className string, v any, path string, choices map[string]UnionChoice, preserve, inUnion bool) error {
 	cls, ok := schema.FindClass(className)
 	if !ok {
 		return fmt.Errorf("ordered: unknown class %q", className)
@@ -653,6 +700,9 @@ func writeOrderedClass(buf *bytes.Buffer, schema FuzzSchema, className string, v
 	for _, prop := range cls.Properties {
 		fv, present := obj.Get(prop.Name)
 		if !present && prop.Type.Kind == KindOptional {
+			if inUnion {
+				continue
+			}
 			if !first {
 				buf.WriteByte(',')
 			}
@@ -675,7 +725,7 @@ func writeOrderedClass(buf *bytes.Buffer, schema FuzzSchema, className string, v
 		}
 		buf.Write(keyBytes)
 		buf.WriteByte(':')
-		if err := writeOrderedValue(buf, schema, prop.Type, fv, path+"."+prop.Name, choices, preserve); err != nil {
+		if err := writeOrderedValue(buf, schema, prop.Type, fv, path+"."+prop.Name, choices, preserve, inUnion); err != nil {
 			return err
 		}
 	}
@@ -683,14 +733,14 @@ func writeOrderedClass(buf *bytes.Buffer, schema FuzzSchema, className string, v
 	return nil
 }
 
-func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any, path string, choices map[string]UnionChoice, preserve bool) error {
+func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any, path string, choices map[string]UnionChoice, preserve, inUnion bool) error {
 	switch t.Kind {
 	case KindOptional:
 		if v == nil {
 			buf.WriteString("null")
 			return nil
 		}
-		return writeOrderedValue(buf, schema, *t.Inner, v, path, choices, preserve)
+		return writeOrderedValue(buf, schema, *t.Inner, v, path, choices, preserve, inUnion)
 	case KindList:
 		if v == nil {
 			buf.WriteString("null")
@@ -705,7 +755,7 @@ func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any, 
 			if i > 0 {
 				buf.WriteByte(',')
 			}
-			if err := writeOrderedValue(buf, schema, *t.Inner, item, fmt.Sprintf("%s[%d]", path, i), choices, preserve); err != nil {
+			if err := writeOrderedValue(buf, schema, *t.Inner, item, fmt.Sprintf("%s[%d]", path, i), choices, preserve, inUnion); err != nil {
 				return err
 			}
 		}
@@ -735,7 +785,7 @@ func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any, 
 			}
 			buf.Write(kb)
 			buf.WriteByte(':')
-			if err := writeOrderedValue(buf, schema, *t.Inner, mv, fmt.Sprintf("%s[%q]", path, k), choices, preserve); err != nil {
+			if err := writeOrderedValue(buf, schema, *t.Inner, mv, fmt.Sprintf("%s[%q]", path, k), choices, preserve, inUnion); err != nil {
 				firstErr = err
 				return false
 			}
@@ -747,7 +797,7 @@ func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any, 
 		buf.WriteByte('}')
 		return nil
 	case KindClassRef:
-		return writeOrderedClass(buf, schema, t.Ref, v, path, choices, preserve)
+		return writeOrderedClass(buf, schema, t.Ref, v, path, choices, preserve, inUnion)
 	case KindUnion:
 		choice, ok := choices[path]
 		if !ok {
@@ -756,7 +806,7 @@ func writeOrderedValue(buf *bytes.Buffer, schema FuzzSchema, t FuzzType, v any, 
 		if choice.Index < 0 || choice.Index >= len(t.Variants) {
 			return fmt.Errorf("ordered: union choice index %d out of range at %q", choice.Index, path)
 		}
-		return writeOrderedValue(buf, schema, t.Variants[choice.Index], v, path+":v", choices, preserve)
+		return writeOrderedValue(buf, schema, t.Variants[choice.Index], v, path+":v", choices, preserve, true)
 	default:
 		b, err := json.Marshal(v)
 		if err != nil {

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -240,6 +240,96 @@ func TestWalkUnionRendersPickedArm(t *testing.T) {
 	}
 }
 
+// TestWalkUnionArmOmitsAbsentOptional pins the asymmetric absent-optional
+// contract that boundaryml/baml#3690 forces on the oracle: an absent
+// optional in a class reached through a union arm is OMITTED from the
+// expected output, while the same shape reached through a deterministic
+// (non-union) field still renders as JSON null.
+//
+// The runtime's InjectAbsentOptionals re-derives the active union arm
+// structurally from the wire value, and that derivation can land on a
+// different (or narrower) arm than the one that actually produced the
+// value, so it never injects the null and the key stays off the wire —
+// exactly what both dynclient and REST emit. The deterministic field has
+// no such ambiguity, so the inject-null contract still holds there.
+//
+// Mirrors the nightly repro: FuzzClass0.Fuzz_field_0 is a union whose
+// picked arm is a class with an absent optional<int>, and both actual
+// outputs dropped the key while the oracle wrongly carried it as null.
+func TestWalkUnionArmOmitsAbsentOptional(t *testing.T) {
+	inner := FuzzClass{
+		Name: "Inner",
+		Properties: []FuzzProperty{
+			{Name: "req", Type: FuzzType{Kind: KindString}},
+			{Name: "opt", Type: FuzzType{Kind: KindOptional, Inner: &FuzzType{Kind: KindInt}}},
+		},
+	}
+	schema := FuzzSchema{
+		Classes: []FuzzClass{
+			{
+				Name: "Root",
+				Properties: []FuzzProperty{
+					{Name: "viaUnion", Type: FuzzType{
+						Kind: KindUnion,
+						Variants: []FuzzType{
+							{Kind: KindString},
+							{Kind: KindClassRef, Ref: "Inner"},
+						},
+					}},
+					{Name: "viaField", Type: FuzzType{Kind: KindClassRef, Ref: "Inner"}},
+				},
+			},
+			inner,
+		},
+		RootClass: "Root",
+	}
+	// In both Inner instances req is present and opt is absent. Only the
+	// arm reached through the union should drop the opt key.
+	mkInner := func(req string) FuzzValue {
+		return FuzzValue{
+			Kind: KindClassRef, ClassName: "Inner",
+			Fields: []FuzzFieldValue{
+				{Name: "req", Value: FuzzValue{Kind: KindString, String: req}},
+				{Name: "opt", Value: FuzzValue{Kind: KindOptional, OptionalShape: OptionalAbsent}},
+			},
+		}
+	}
+	unionArm := mkInner("a")
+	value := FuzzValue{
+		Kind: KindClassRef, ClassName: "Root",
+		Fields: []FuzzFieldValue{
+			{Name: "viaUnion", Value: FuzzValue{
+				Kind: KindUnion, VariantIndex: 1, Variant: &unionArm,
+			}},
+			{Name: "viaField", Value: mkInner("b")},
+		},
+	}
+	res, err := Walk(schema, value)
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	// The LLM never emits an absent optional, in either position.
+	wantMock := `{"viaUnion":{"req":"a"},"viaField":{"req":"b"}}`
+	if string(res.MockLLMContent) != wantMock {
+		t.Errorf("mock mismatch\nwant: %s\ngot:  %s", wantMock, string(res.MockLLMContent))
+	}
+	// Expected: union-arm opt omitted, deterministic-field opt is null.
+	wantExpected := `{"viaUnion":{"req":"a"},"viaField":{"req":"b","opt":null}}`
+	if string(res.Expected) != wantExpected {
+		t.Errorf("expected mismatch\nwant: %s\ngot:  %s", wantExpected, string(res.Expected))
+	}
+	// The normalize-from-mock path must agree with the walker's Expected
+	// byte-for-byte (the invariant TestWalkRoundTripNormalizesAbsent
+	// asserts at scale), including the union-arm omission.
+	normalized, err := NormalizeMockToExpectedWithChoices(schema, res.MockLLMContent, "Root", res.Metadata.UnionChoices, false)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if string(normalized) != string(res.Expected) {
+		t.Errorf("normalize round-trip\nwant: %s\ngot:  %s", string(res.Expected), string(normalized))
+	}
+}
+
 // TestWalkTNullUnionEmitsExplicitNull asserts T|null implemented as a
 // union with a KindNull variant emits JSON null when the null arm is
 // picked, separately from KindOptional's absent-key semantics.


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Problem

The bamlfuzz oracle's expected-value walker rendered absent optionals nested inside a union arm as JSON `null`, but at runtime `bamlutils.InjectAbsentOptionals` may not inject the null when the field is inside a union arm (the runtime re-derives the active arm structurally, and a different arm may match first). Both dynclient and REST omit the key, so the oracle should too.

## Fix

Threaded an `inUnion` flag through both expected-output paths in `normalize.go`:
- `renderValueExpected` / `renderClassExpected` (the Walk path)
- `normalizeValue` / `normalizeClass` / `writeOrderedValue` / `writeOrderedClass` (the normalize-from-mock path)

When `inUnion` is true, absent optionals are omitted from the expected JSON instead of being serialized as null. Outside union arms, the deterministic inject-null contract from #395 is unchanged. Exported signatures are untouched.

### Files changed

- `normalize.go`: `inUnion` flag threaded through Walk and normalize paths
- `union_test.go`: `TestWalkUnionArmOmitsAbsentOptional` — union-arm omit + deterministic-field null + normalize round-trip

## Test plan

- [x] `GOWORK=off go test ./codegen/bamlfuzz/... -count=1` passes (incl. 100-case property-based `TestWalkRoundTripNormalizesAbsent`)
- [x] New test confirmed to fail on pre-fix code with the exact leaked `"opt":null`
- [x] `go vet` clean, integration package builds with `-tags=integration`

Umbrella: #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed JSON serialization behavior for optional fields within union types—they are now properly omitted rather than included as null values in union-selected branches.

* **Tests**
  * Added regression test to verify correct handling of absent optional fields in union type serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->