### PR TITLE
fix(bamlfuzz): tolerate string-literal source-escape mismatch in static oracle diff

### DIFF
--- a/adapters/common/codegen/bamlfuzz/envelope.go
+++ b/adapters/common/codegen/bamlfuzz/envelope.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/invakid404/baml-rest/adapters/common/codegen/internal/testharness"
@@ -248,6 +249,49 @@ func SemanticDiffParity(side string, a, b json.RawMessage) ([]SemanticDiffEntry,
 	return semanticDiff(side, a, b, nullParity)
 }
 
+// SemanticDiffWithSchema is the schema-aware variant of SemanticDiff
+// used by the static prompt oracle. On top of SemanticDiff's
+// expected-vs-actual semantics (including the boundaryml/baml#3690
+// null-key tolerance) it forgives a string-literal escape-level
+// mismatch: BAML's static codegen is inconsistent about literal string
+// values containing special characters — for some positions (e.g. a
+// top-level class-field literal) it echoes the source-escaped token
+// (`\"quoted\"`), while for others (e.g. a deeply nested union arm) it
+// returns the decoded value (`"quoted"`). The oracle's expected output
+// always carries the decoded value (see normalize.go's writeLiteral).
+// When the schema types a field as a string literal, the two forms are
+// treated as equal so the position-dependent escaping does not flag a
+// false disagreement.
+//
+// `choices` mirrors CaseMetadata.UnionChoices and lets the literal-path
+// collector descend through union arms; a missing entry simply stops the
+// descent (the unresolved union arm contributes no literal paths), which
+// is safe because an unresolved-arm literal would not be tolerated.
+//
+// The tolerance is narrow: it applies ONLY at JSON paths the schema
+// types as a string literal. A plain `string` field that happens to
+// contain quotes is unaffected and still diffs normally.
+func SemanticDiffWithSchema(side string, schema FuzzSchema, choices map[string]UnionChoice, a, b json.RawMessage) ([]SemanticDiffEntry, error) {
+	av, err := decodeAny(a)
+	if err != nil {
+		return nil, fmt.Errorf("decode a: %w", err)
+	}
+	bv, err := decodeAny(b)
+	if err != nil {
+		return nil, fmt.Errorf("decode b: %w", err)
+	}
+	lit := make(map[string]bool)
+	root := schema.EffectiveRoot()
+	// Walk both sides: class-field literal positions are schema-fixed, but
+	// list indices / map keys come from the value, so collecting from both
+	// payloads ensures a literal path present on either side is recognized.
+	collectLiteralStringPaths(lit, schema, choices, "$", "", root, av)
+	collectLiteralStringPaths(lit, schema, choices, "$", "", root, bv)
+	var out []SemanticDiffEntry
+	diffAny(&out, side, "$", av, bv, nullExpectedVsActual, lit)
+	return out, nil
+}
+
 func semanticDiff(side string, a, b json.RawMessage, mode nullMode) ([]SemanticDiffEntry, error) {
 	av, err := decodeAny(a)
 	if err != nil {
@@ -258,8 +302,102 @@ func semanticDiff(side string, a, b json.RawMessage, mode nullMode) ([]SemanticD
 		return nil, fmt.Errorf("decode b: %w", err)
 	}
 	var out []SemanticDiffEntry
-	diffAny(&out, side, "$", av, bv, mode)
+	diffAny(&out, side, "$", av, bv, mode, nil)
 	return out, nil
+}
+
+// collectLiteralStringPaths records, into `out`, every JSON path (in
+// diffAny's path convention) whose schema type resolves to a
+// KindLiteral / LiteralString. It walks the schema type guided by the
+// decoded value `v` so list indices and map keys come from the actual
+// data. Two path strings are tracked in parallel: `jsonPath` (rooted at
+// "$", `.key` for every object member — diffAny treats class and map
+// nodes identically) and `choicePath` (rooted at "", `[%q]` for map
+// keys plus a `:v` step into each union arm — the CaseMetadata.UnionChoices
+// key convention shared with normalize.go and order.go). Only the
+// jsonPath form is emitted; the choicePath form exists solely to look up
+// union choices.
+func collectLiteralStringPaths(out map[string]bool, schema FuzzSchema, choices map[string]UnionChoice, jsonPath, choicePath string, t FuzzType, v any) {
+	switch t.Kind {
+	case KindLiteral:
+		if t.Literal != nil && t.Literal.Kind == LiteralString {
+			out[jsonPath] = true
+		}
+	case KindOptional:
+		if t.Inner == nil || v == nil {
+			return
+		}
+		collectLiteralStringPaths(out, schema, choices, jsonPath, choicePath, *t.Inner, v)
+	case KindClassRef:
+		cls, ok := schema.FindClass(t.Ref)
+		if !ok {
+			return
+		}
+		m, ok := v.(map[string]any)
+		if !ok {
+			return
+		}
+		for _, prop := range cls.Properties {
+			cv, ok := m[prop.Name]
+			if !ok {
+				continue
+			}
+			collectLiteralStringPaths(out, schema, choices, jsonPath+"."+prop.Name, choicePath+"."+prop.Name, prop.Type, cv)
+		}
+	case KindList:
+		if t.Inner == nil {
+			return
+		}
+		arr, ok := v.([]any)
+		if !ok {
+			return
+		}
+		for i, e := range arr {
+			collectLiteralStringPaths(out, schema, choices, fmt.Sprintf("%s[%d]", jsonPath, i), fmt.Sprintf("%s[%d]", choicePath, i), *t.Inner, e)
+		}
+	case KindMap:
+		if t.Inner == nil {
+			return
+		}
+		m, ok := v.(map[string]any)
+		if !ok {
+			return
+		}
+		for k, mv := range m {
+			collectLiteralStringPaths(out, schema, choices, jsonPath+"."+k, fmt.Sprintf("%s[%q]", choicePath, k), *t.Inner, mv)
+		}
+	case KindUnion:
+		choice, ok := choices[choicePath]
+		if !ok {
+			return
+		}
+		if choice.Index < 0 || choice.Index >= len(t.Variants) {
+			return
+		}
+		collectLiteralStringPaths(out, schema, choices, jsonPath, choicePath+":v", t.Variants[choice.Index], v)
+	}
+}
+
+// literalEscapeEquivalent reports whether two string values are equal
+// modulo source-escaping of a string literal: one side is the
+// strconv.Quote body (the quoted form without its surrounding double
+// quotes) of the other. This forgives BAML's position-dependent literal
+// echo, where one oracle leg carries the decoded value (`"quoted"`) and
+// the other the source-escaped token (`\"quoted\"`). It is symmetric, so
+// it covers both expected=decoded/actual=escaped and the reverse. The
+// match is exact in both directions, so it only suppresses a genuine
+// escape relationship — never two unrelated strings.
+func literalEscapeEquivalent(a, b string) bool {
+	return escapeBody(a) == b || escapeBody(b) == a
+}
+
+// escapeBody returns strconv.Quote(s) with its surrounding double quotes
+// stripped — i.e. the Go source-escaped rendering of s without the outer
+// delimiters. strconv.Quote never returns a string shorter than two
+// characters (the two delimiters), so the slice bounds are always valid.
+func escapeBody(s string) string {
+	quoted := strconv.Quote(s)
+	return quoted[1 : len(quoted)-1]
 }
 
 // DetectOrderWarning compares the top-level key order of two JSON
@@ -418,7 +556,11 @@ func deepEqualSemantic(a, b any, mode nullMode) bool {
 	}
 }
 
-func diffAny(out *[]SemanticDiffEntry, side, path string, a, b any, mode nullMode) {
+// diffAny appends path-level disagreements between `a` and `b` to `out`.
+// `lit` (nil for non-schema-aware callers) is the set of JSON paths the
+// schema types as a string literal; at those paths a source-escape-level
+// string mismatch is tolerated (see literalEscapeEquivalent).
+func diffAny(out *[]SemanticDiffEntry, side, path string, a, b any, mode nullMode, lit map[string]bool) {
 	if deepEqualSemantic(a, b, mode) {
 		return
 	}
@@ -461,7 +603,7 @@ func diffAny(out *[]SemanticDiffEntry, side, path string, a, b any, mode nullMod
 				*out = append(*out, SemanticDiffEntry{Side: side, Path: path + "." + k, Got: av1, Want: bv1})
 				continue
 			}
-			diffAny(out, side, path+"."+k, av1, bv1, mode)
+			diffAny(out, side, path+"."+k, av1, bv1, mode, lit)
 		}
 	case []any:
 		bv, ok := b.([]any)
@@ -470,8 +612,17 @@ func diffAny(out *[]SemanticDiffEntry, side, path string, a, b any, mode nullMod
 			return
 		}
 		for i := range av {
-			diffAny(out, side, fmt.Sprintf("%s[%d]", path, i), av[i], bv[i], mode)
+			diffAny(out, side, fmt.Sprintf("%s[%d]", path, i), av[i], bv[i], mode, lit)
 		}
+	case string:
+		// At a schema string-literal path, a source-escape-level mismatch
+		// between the two legs is BAML's position-dependent literal echo,
+		// not a real disagreement. Reached only when the strings already
+		// differ (deepEqualSemantic short-circuited equal values above).
+		if bv, ok := b.(string); ok && lit[path] && literalEscapeEquivalent(av, bv) {
+			return
+		}
+		*out = append(*out, SemanticDiffEntry{Side: side, Path: path, Got: a, Want: b})
 	default:
 		*out = append(*out, SemanticDiffEntry{Side: side, Path: path, Got: a, Want: b})
 	}

--- a/adapters/common/codegen/bamlfuzz/envelope_test.go
+++ b/adapters/common/codegen/bamlfuzz/envelope_test.go
@@ -186,6 +186,146 @@ func TestSemanticDiffParity_RealDifferencesStillDiff(t *testing.T) {
 	}
 }
 
+// literalClassSchema is a single-class schema whose Fuzz_field_0 is a
+// string literal (value `"quoted"`, i.e. the two-quote token) and whose
+// Fuzz_field_1 is a plain string — used to pin that the literal-escape
+// tolerance fires only at the literal-typed path.
+func literalClassSchema() FuzzSchema {
+	return FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "FuzzClass0",
+			Properties: []FuzzProperty{
+				{Name: "Fuzz_field_0", Type: FuzzType{Kind: KindLiteral, Literal: &FuzzLiteral{Kind: LiteralString, String: `"quoted"`}}},
+				{Name: "Fuzz_field_1", Type: FuzzType{Kind: KindString}},
+			},
+		}},
+		RootClass: "FuzzClass0",
+	}
+}
+
+// decoded / escaped are the two wire forms BAML's static codegen emits
+// for the same `"quoted"` literal depending on the literal's position in
+// the type tree: the decoded value (`"quoted"`) vs the source-escaped
+// token (`\"quoted\"`). Both are valid JSON strings; they decode to
+// different Go strings, which is why the comparison layer must reconcile
+// them when the schema says the field is a literal.
+const (
+	decodedLiteralObj = `{"Fuzz_field_0":"\"quoted\"","Fuzz_field_1":"plain"}`
+	escapedLiteralObj = `{"Fuzz_field_0":"\\\"quoted\\\"","Fuzz_field_1":"plain"}`
+)
+
+// TestSemanticDiffWithSchema_ToleratesLiteralEscape pins the
+// position-dependent literal-escape tolerance: when the schema types a
+// field as a string literal, the decoded form (`"quoted"`) and the
+// source-escaped form (`\"quoted\"`) are treated as equal in BOTH
+// directions. This reproduces nightly #9 (BAML returns escaped, oracle
+// expects decoded) and the symmetric case.
+func TestSemanticDiffWithSchema_ToleratesLiteralEscape(t *testing.T) {
+	schema := literalClassSchema()
+	cases := []struct {
+		name string
+		a, b string
+	}{
+		{"expected decoded, actual escaped", decodedLiteralObj, escapedLiteralObj},
+		{"expected escaped, actual decoded", escapedLiteralObj, decodedLiteralObj},
+		{"both decoded", decodedLiteralObj, decodedLiteralObj},
+		{"both escaped", escapedLiteralObj, escapedLiteralObj},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			diff, err := SemanticDiffWithSchema("expected_vs_rest", schema, nil, []byte(c.a), []byte(c.b))
+			if err != nil {
+				t.Fatalf("SemanticDiffWithSchema: %v", err)
+			}
+			if len(diff) != 0 {
+				t.Errorf("expected no diff entries, got %v", diff)
+			}
+		})
+	}
+}
+
+// TestSemanticDiffWithSchema_LiteralEscapeIsNarrow asserts the tolerance
+// is confined to literal-typed string fields: an escape-level mismatch on
+// a plain string field still diffs, and a genuinely different literal
+// value still diffs.
+func TestSemanticDiffWithSchema_LiteralEscapeIsNarrow(t *testing.T) {
+	schema := literalClassSchema()
+	cases := []struct {
+		name string
+		a, b string
+	}{
+		// Fuzz_field_1 is a plain string; an escape-level difference there
+		// is a real disagreement, not the literal echo.
+		{
+			"plain string escape diff still diffs",
+			`{"Fuzz_field_0":"\"quoted\"","Fuzz_field_1":"\"q\""}`,
+			`{"Fuzz_field_0":"\"quoted\"","Fuzz_field_1":"\\\"q\\\""}`,
+		},
+		// A literal value that genuinely differs (not an escape relation)
+		// must still diff.
+		{
+			"different literal value still diffs",
+			`{"Fuzz_field_0":"\"quoted\"","Fuzz_field_1":"plain"}`,
+			`{"Fuzz_field_0":"different","Fuzz_field_1":"plain"}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			diff, err := SemanticDiffWithSchema("expected_vs_rest", schema, nil, []byte(c.a), []byte(c.b))
+			if err != nil {
+				t.Fatalf("SemanticDiffWithSchema: %v", err)
+			}
+			if len(diff) == 0 {
+				t.Errorf("expected a diff entry, got none")
+			}
+		})
+	}
+}
+
+// TestSemanticDiffWithSchema_LiteralUnderUnion exercises the choices-driven
+// descent: a literal that sits in a union arm is reconciled only when the
+// recorded UnionChoice resolves the arm. Without the choice the union is
+// unresolved, no literal path is collected, and the escape mismatch diffs.
+func TestSemanticDiffWithSchema_LiteralUnderUnion(t *testing.T) {
+	schema := FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "FuzzClass0",
+			Properties: []FuzzProperty{{
+				Name: "Fuzz_field_0",
+				Type: FuzzType{Kind: KindUnion, Variants: []FuzzType{
+					{Kind: KindLiteral, Literal: &FuzzLiteral{Kind: LiteralString, String: `"quoted"`}},
+					{Kind: KindInt},
+				}},
+			}},
+		}},
+		RootClass: "FuzzClass0",
+		HasUnion:  true,
+	}
+	decoded := `{"Fuzz_field_0":"\"quoted\""}`
+	escaped := `{"Fuzz_field_0":"\\\"quoted\\\""}`
+	choices := map[string]UnionChoice{
+		".Fuzz_field_0": {Index: 0, Kind: KindLiteral, VariantCount: 2},
+	}
+
+	diff, err := SemanticDiffWithSchema("expected_vs_rest", schema, choices, []byte(decoded), []byte(escaped))
+	if err != nil {
+		t.Fatalf("SemanticDiffWithSchema: %v", err)
+	}
+	if len(diff) != 0 {
+		t.Errorf("with union choice resolving the literal arm, expected no diff, got %v", diff)
+	}
+
+	// Without the choice the union arm is unresolved, so the literal path is
+	// not collected and the escape mismatch is reported as a real diff.
+	diff, err = SemanticDiffWithSchema("expected_vs_rest", schema, nil, []byte(decoded), []byte(escaped))
+	if err != nil {
+		t.Fatalf("SemanticDiffWithSchema: %v", err)
+	}
+	if len(diff) == 0 {
+		t.Error("without a union choice the unresolved-arm literal must still diff, got none")
+	}
+}
+
 func TestDetectOrderWarning(t *testing.T) {
 	warns := DetectOrderWarning("top",
 		[]byte(`{"a":1,"b":2,"c":3}`),

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -364,7 +364,7 @@ func runOneStaticCase(t *testing.T, env *testutil.TestEnvironment, mockClient *m
 	}
 	envelope.RESTBody = resp.Body
 
-	if diff, err := bamlfuzz.SemanticDiff("expected_vs_rest", lc.Case.Expected, resp.Body); err != nil {
+	if diff, err := bamlfuzz.SemanticDiffWithSchema("expected_vs_rest", lc.Case.Schema, lc.Case.Metadata.UnionChoices, lc.Case.Expected, resp.Body); err != nil {
 		envelope.RESTError = err.Error()
 		failStaticAndDump(t, envelope, "expected_vs_rest diff: %v", err)
 		return


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Problem

BAML's static codegen echoes string literal values inconsistently — source-escaped (`\"quoted\"`) at some type-tree positions, decoded (`"quoted"`) at others. PR #411 tried to fix this by escaping the oracle expected, but that was position-dependent and wrong (nightly #10 regressed). This PR reverts that approach and adds comparison-layer tolerance instead.

## Fix

Added `SemanticDiffWithSchema` to `envelope.go` that precomputes literal-string JSON paths via `collectLiteralStringPaths` (walks classes/optionals/lists/maps, resolves union arms through `UnionChoices`). At literal paths, `literalEscapeEquivalent` forgives the mismatch when one value is the `strconv.Quote` body of the other — symmetric in both directions, handling both "BAML returns escaped" and "BAML returns decoded" cases.

### Files changed

- `envelope.go`: `SemanticDiffWithSchema`, `collectLiteralStringPaths`, `literalEscapeEquivalent`
- `bamlfuzz_static_test.go`: Static oracle gate calls `SemanticDiffWithSchema`
- `envelope_test.go`: Tests for both mismatch directions, plain-string boundary, and union-choice-driven paths
- `normalize.go` and `order.go` untouched

## Test plan

- [x] `GOWORK=off go test ./codegen/bamlfuzz/... -count=1` passes
- [x] Nightly #9 repro (seed 27017748168, `rapid_b7_c1`) — BAML returns escaped, oracle expects decoded → passes
- [x] Nightly #10 repro (seed 27065033228, `rapid_b2_c1`) — both sides decoded → passes

Umbrella: #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added schema-aware semantic diffing for JSON comparison to intelligently handle string literal escaping differences
  * Improved comparison accuracy when schema context is provided for JSON payload validation

* **Tests**
  * Added comprehensive test coverage for schema-aware JSON comparison, including string literal escape tolerance and union type scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->