### PR TITLE
test(integration): retry testcontainer creation on transient infra failures

### DIFF
--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"text/template"
@@ -168,7 +169,7 @@ func Setup(ctx context.Context, opts SetupOptions) (*TestEnvironment, error) {
 			}
 		}
 
-		env, err := setupOnce(ctx, opts)
+		env, err := runSetupAttempt(ctx, opts)
 		if err == nil {
 			if attempt > 1 {
 				log.Printf("[testutil] container setup succeeded on attempt %d/%d", attempt, totalAttempts)
@@ -178,13 +179,31 @@ func Setup(ctx context.Context, opts SetupOptions) (*TestEnvironment, error) {
 		lastErr = err
 
 		// If the context is already done there's no point retrying: every
-		// further attempt would fail the same way. Surface the error now.
+		// further attempt would fail the same way. Surface the error now,
+		// reporting the number of attempts actually made (not the cap).
 		if ctx.Err() != nil {
-			break
+			return nil, fmt.Errorf("container setup failed after %d attempt(s); "+
+				"context done before retrying: %w (last error: %v)", attempt, ctx.Err(), lastErr)
 		}
 	}
 
 	return nil, fmt.Errorf("container setup failed after %d attempt(s): %w", totalAttempts, lastErr)
+}
+
+// runSetupAttempt performs a single setupOnce and converts a panic into an
+// error so a true Go panic from deep inside testcontainers still triggers a
+// retry instead of tearing down the whole test binary. setupOnce tears down
+// its own partial resources (including on panic, see its deferred recover)
+// before the panic propagates here, so no network or container is leaked.
+func runSetupAttempt(ctx context.Context, opts SetupOptions) (env *TestEnvironment, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("container setup panicked: %v\n%s", r, debug.Stack())
+			log.Printf("[testutil] recovered panic during container setup: %v", r)
+		}
+	}()
+
+	return setupOnce(ctx, opts)
 }
 
 // setupOnce performs a single build+start of the mock LLM server and baml-rest
@@ -192,6 +211,16 @@ func Setup(ctx context.Context, opts SetupOptions) (*TestEnvironment, error) {
 // (network and/or containers) before returning, so callers can safely retry.
 func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error) {
 	env := &TestEnvironment{}
+
+	// If anything below panics (e.g. deep inside testcontainers), tear down
+	// whatever was already created before the panic propagates to the retry
+	// wrapper, so a retry doesn't leak a network or half-started container.
+	defer func() {
+		if r := recover(); r != nil {
+			_ = env.Terminate(ctx)
+			panic(r)
+		}
+	}()
 
 	// Create Docker network
 	net, err := network.New(ctx)

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -120,8 +121,76 @@ type SetupOptions struct {
 	RuntimeEnv map[string]string
 }
 
-// Setup creates the test environment with mock LLM server and baml-rest container.
+// setupRetryBackoff is the delay applied before each retry of the container
+// build+start sequence. Its length determines how many retries Setup performs:
+// the first entry is the wait before the 2nd attempt, the second before the
+// 3rd, and so on. Three retries (plus the initial attempt) gives four total
+// tries with escalating backoff.
+var setupRetryBackoff = []time.Duration{
+	5 * time.Second,
+	15 * time.Second,
+	30 * time.Second,
+}
+
+// Setup creates the test environment with mock LLM server and baml-rest
+// container, retrying the whole build+start sequence on transient failures.
+//
+// Container creation is the flaky part of the integration suite: Docker image
+// builds (build.sh) occasionally exit non-zero, the BAML library download can
+// fail ("could not find BAML library v0.XXX.0 for linux/amd64"), the BAML
+// runtime can panic on init inside the container, the registry can time out,
+// and runners hit disk pressure. These are transient infra failures, not test
+// logic bugs, so we retry the entire setup with exponential backoff. Only the
+// build/start sequence is retried here; actual test execution is untouched.
+//
+// Each failed attempt fully tears down whatever was partially created (network
+// and any started containers) via setupOnce before the next attempt, so retries
+// always start from a clean slate.
 func Setup(ctx context.Context, opts SetupOptions) (*TestEnvironment, error) {
+	totalAttempts := len(setupRetryBackoff) + 1
+
+	var lastErr error
+	for attempt := 1; attempt <= totalAttempts; attempt++ {
+		if attempt > 1 {
+			backoff := setupRetryBackoff[attempt-2]
+			log.Printf("[testutil] container setup attempt %d/%d failed: %v; "+
+				"cleaning up and retrying in %s", attempt-1, totalAttempts, lastErr, backoff)
+
+			// Respect cancellation/deadline while backing off so we don't
+			// burn the remaining context budget sleeping.
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, fmt.Errorf("container setup aborted after %d attempt(s) while "+
+					"waiting to retry: %w (last error: %v)", attempt-1, ctx.Err(), lastErr)
+			case <-timer.C:
+			}
+		}
+
+		env, err := setupOnce(ctx, opts)
+		if err == nil {
+			if attempt > 1 {
+				log.Printf("[testutil] container setup succeeded on attempt %d/%d", attempt, totalAttempts)
+			}
+			return env, nil
+		}
+		lastErr = err
+
+		// If the context is already done there's no point retrying: every
+		// further attempt would fail the same way. Surface the error now.
+		if ctx.Err() != nil {
+			break
+		}
+	}
+
+	return nil, fmt.Errorf("container setup failed after %d attempt(s): %w", totalAttempts, lastErr)
+}
+
+// setupOnce performs a single build+start of the mock LLM server and baml-rest
+// container. On any failure it terminates whatever it had already created
+// (network and/or containers) before returning, so callers can safely retry.
+func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error) {
 	env := &TestEnvironment{}
 
 	// Create Docker network
@@ -207,10 +276,20 @@ func startMockLLMContainer(ctx context.Context, networkName string) (testcontain
 		WaitingFor: wait.ForHTTP("/_admin/health").WithPort(MockLLMInternalPort).WithStartupTimeout(30 * time.Second),
 	}
 
-	return testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
+	if err != nil {
+		// On a start/wait failure (e.g. the health check never passes)
+		// testcontainers may still return a built container. Tear it down so a
+		// retry doesn't leak it.
+		if c != nil {
+			_ = c.Terminate(ctx)
+		}
+		return nil, err
+	}
+	return c, nil
 }
 
 func createMockLLMBuildContext() (io.ReadSeeker, error) {
@@ -290,10 +369,21 @@ func startBAMLRestContainer(ctx context.Context, networkName string, opts SetupO
 		WaitingFor: waitFor,
 	}
 
-	return testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
+	if err != nil {
+		// A build.sh non-zero exit, a BAML library init panic, or a startup
+		// timeout all surface here. In the start/wait cases testcontainers may
+		// still hand back a built container; terminate it so a retry starts
+		// clean instead of leaking a half-started container.
+		if c != nil {
+			_ = c.Terminate(ctx)
+		}
+		return nil, err
+	}
+	return c, nil
 }
 
 // buildContainerEnv returns the env map passed to the baml-rest container.


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Problem

Integration tests frequently fail in CI due to transient Docker infra issues: `build.sh` non-zero exit during image build, BAML library download failures, Docker registry timeouts. These account for the majority of nightly failures (6/6 failures in nightly #12 were infra).

## Fix

Added retry logic around testcontainer creation in `testutil.Setup()` — the single central entry point for all integration test container setup.

- **3 retries / 4 total attempts** with escalating backoff (5s, 15s, 30s)
- Each attempt is logged with timestamp (visible in CI)
- Partial containers cleaned up between retries (deferred cleanup in `setupOnce` + `runSetupAttempt` panic recovery)
- Backoff respects context cancellation (TestMain timeout)
- Error messages report actual attempt count, distinguishing exhaustion from cancellation
- Panics from testcontainers are caught via `recover()` + `debug.Stack()` and retried

### Only container creation is retried — not test execution.

## Files changed

- `integration/testutil/container.go`: `Setup()` → retry wrapper around `setupOnce()`, plus `runSetupAttempt()` panic recovery

## Test plan

- [x] `go vet -tags=integration ./integration/...` passes
- [x] `go build -tags=integration ./integration/...` passes
- [x] `go test -tags=integration ./integration/testutil` passes
- [ ] Nightly validation (CI-only, needs Docker + BAML versions)

Umbrella: #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Improved robustness of integration test container setup with enhanced error handling and automatic retry mechanisms for more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->