### PR TITLE
fix(integration): grow + centralize per-attempt setup budget (#424)

### DIFF
--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -73,12 +73,6 @@ const integrationBamlSrcDir = "testdata/baml_src"
 // blast radius per Docker build.
 const staticCasesPerBatch = 5
 
-// staticEnvSetupTimeout caps how long any one batch is allowed to
-// spend bringing up its dedicated integration environment. Scope D9
-// sets 10 minutes inside the 12-minute job timeout; tests get the
-// full slice so cold-cache builds can complete on slower runners.
-const staticEnvSetupTimeout = 10 * time.Minute
-
 // staticCallTimeout bounds one /call/<FunctionName> request inside a
 // batch. Generous so a slow worker doesn't trip a per-case timeout
 // before the integration server reports a real failure.
@@ -539,10 +533,15 @@ func copyFile(src, dst string) error {
 // matrixSetupOptions so the static oracle runs under the same
 // runtime shape as the rest of the integration suite.
 func setupStaticEnv(bamlSrcDir string) (*testutil.TestEnvironment, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), staticEnvSetupTimeout)
-	defer cancel()
 	opts := matrixSetupOptions()
 	opts.BAMLSrcPath = bamlSrcDir
+
+	// Centralized, mode-aware setup budget (#424). A batch's dedicated env is
+	// the same container the rest of the suite builds, so it rides the same
+	// budget; cold-cache builds still complete well within the nightly job's
+	// `go test -timeout`.
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.SetupBudget(opts))
+	defer cancel()
 	return testutil.Setup(ctx, opts)
 }
 

--- a/integration/bridge_test.go
+++ b/integration/bridge_test.go
@@ -36,9 +36,6 @@ func TestCallBridge_ForcesStreamRequest(t *testing.T) {
 		t.Skip("bridge requires BuildRequest path; skipping on legacy or pre-0.219 runtimes")
 	}
 
-	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
-	defer setupCancel()
-
 	opts := matrixSetupOptions()
 	opts.UseBuildRequest = true
 	opts.RuntimeEnv = map[string]string{
@@ -47,6 +44,11 @@ func TestCallBridge_ForcesStreamRequest(t *testing.T) {
 		// accumulation bridge.
 		"BAML_REST_DISABLE_CALL_BUILD_REQUEST": "true",
 	}
+
+	// Centralized, mode-aware setup budget (#424).
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), testutil.SetupBudget(opts))
+	defer setupCancel()
+
 	env, err := testutil.Setup(setupCtx, opts)
 	if err != nil {
 		t.Fatalf("Failed to setup dedicated env: %v", err)
@@ -263,9 +265,6 @@ func TestCallBridge_MixedChainFallsThrough(t *testing.T) {
 		t.Skip("bridge requires BuildRequest path; skipping on legacy or pre-0.219 runtimes")
 	}
 
-	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
-	defer setupCancel()
-
 	opts := matrixSetupOptions()
 	opts.UseBuildRequest = true
 	opts.RuntimeEnv = map[string]string{
@@ -273,6 +272,11 @@ func TestCallBridge_MixedChainFallsThrough(t *testing.T) {
 		// supported). Debug-tag only — no effect on release builds.
 		"BAML_REST_CALL_UNSUPPORTED_PROVIDERS": "openai-generic",
 	}
+
+	// Centralized, mode-aware setup budget (#424).
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), testutil.SetupBudget(opts))
+	defer setupCancel()
+
 	env, err := testutil.Setup(setupCtx, opts)
 	if err != nil {
 		t.Fatalf("Failed to setup dedicated env: %v", err)

--- a/integration/client_defaults_test.go
+++ b/integration/client_defaults_test.go
@@ -43,13 +43,15 @@ func TestClientDefaults_AllowedRoleMetadata(t *testing.T) {
 		// blanket form would mask the openai-generic BuildRequest path
 		// the user originally reported on.
 
-		setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
-		defer setupCancel()
-
 		opts := matrixSetupOptions()
 		opts.RuntimeEnv = map[string]string{
 			"BAML_REST_CLIENT_DEFAULTS": `{"client_defaults":{"options":{"allowed_role_metadata":["cache_control"]}}}`,
 		}
+
+		// Centralized, mode-aware setup budget (#424).
+		setupCtx, setupCancel := context.WithTimeout(context.Background(), testutil.SetupBudget(opts))
+		defer setupCancel()
+
 		env, err := testutil.Setup(setupCtx, opts)
 		if err != nil {
 			t.Fatalf("Failed to setup dedicated env: %v", err)

--- a/integration/dynamic_output_format_preserve_order_test.go
+++ b/integration/dynamic_output_format_preserve_order_test.go
@@ -192,13 +192,15 @@ func TestDynamicOutputFormatPreserveSchemaOrder_ServerDefault(t *testing.T) {
 		t.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
 	}
 
-	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
-	defer setupCancel()
-
 	opts := matrixSetupOptions()
 	opts.RuntimeEnv = map[string]string{
 		"BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT": "true",
 	}
+
+	// Centralized, mode-aware setup budget (#424).
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), testutil.SetupBudget(opts))
+	defer setupCancel()
+
 	env, err := testutil.Setup(setupCtx, opts)
 	if err != nil {
 		t.Fatalf("Failed to setup dedicated env: %v", err)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -430,13 +430,6 @@ func TestMain(m *testing.M) {
 	// still be live during teardown (#420).
 	startSuiteWatchdog(suiteWatchdogTimeout())
 
-	timeout := 10 * time.Minute
-	if BAMLSourcePath != "" {
-		timeout = 30 * time.Minute // Rust compilation is slow
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
 	// Find the testdata directory
 	var err error
 	bamlSrcPath, err = findTestdataPath()
@@ -470,7 +463,16 @@ func TestMain(m *testing.M) {
 	}
 	UseBuildRequest = parseBoolEnv(os.Getenv("BAML_REST_USE_BUILD_REQUEST"))
 
-	TestEnv, err = testutil.Setup(ctx, matrixSetupOptions())
+	// The overall setup budget is mode-aware and centralized in testutil
+	// (#424): baml-source builds the Rust cffi stage and need the larger
+	// budget, the light jobs a smaller one. This ctx is NOT covered by
+	// `go test -timeout` (it runs before m.Run); the suite watchdog and step
+	// timeout are its outer guards.
+	opts := matrixSetupOptions()
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.SetupBudget(opts))
+	defer cancel()
+
+	TestEnv, err = testutil.Setup(ctx, opts)
 	if err != nil {
 		println("Failed to setup test environment:", err.Error())
 		os.Exit(1)

--- a/integration/shutdown_test.go
+++ b/integration/shutdown_test.go
@@ -33,10 +33,13 @@ import (
 // UnaryClient is configured (UNARY_SERVER=true leg), we enable chi in the
 // dedicated container too and assert the drain property on both stacks.
 func TestGracefulShutdownDrainsInFlightCall(t *testing.T) {
-	setupCtx, setupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	setupOpts := matrixSetupOptions()
+
+	// Centralized, mode-aware setup budget (#424).
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), testutil.SetupBudget(setupOpts))
 	defer setupCancel()
 
-	env, err := testutil.Setup(setupCtx, matrixSetupOptions())
+	env, err := testutil.Setup(setupCtx, setupOpts)
 	if err != nil {
 		t.Fatalf("Failed to setup dedicated shutdown env: %v", err)
 	}

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -133,6 +133,95 @@ var setupRetryBackoff = []time.Duration{
 	30 * time.Second,
 }
 
+// Setup-budget constants — the single source of truth for every setup-ctx
+// construction across the integration suite (#424). Every callsite that does
+// context.WithTimeout(..., testutil.Setup) routes its budget through
+// SetupBudget so the per-attempt/overall relationship is enforced in one
+// place rather than scattered as magic numbers.
+//
+// The #424 failure was a slow-but-healthy Docker image build (mockllm +
+// baml-rest, sequential, on a contended GitHub runner) exceeding the old 10m
+// main-setup ctx (integration_test.go) and tripping the
+// "context done before retrying" bail before the retry path could engage. The
+// load-bearing fix is growing the OVERALL (parent) budget so one generous
+// single attempt can ride out that transient slowness; the per-attempt budget
+// (below) is the structural cleanup that stops a slow attempt from silently
+// consuming the whole parent.
+//
+// Budgets are sized against MEASURED green-CI timings and the #422 suite
+// watchdog, which bounds the window Go's `go test -timeout` does not cover
+// (setup + m.Run + teardown). The governing inequality, per job class, is:
+//
+//	overall_setup + healthy_m.Run + teardown(<= defaultTeardownTimeout=5m) <= watchdog
+//
+// Measured on a green master run (build = "Setting up..." -> "ready",
+// m.Run = "ready" -> "Tearing down"):
+//
+//	light (versioned/in-process, watchdog 42m): build ~4.5m, m.Run ~12m worst,
+//	    teardown <1s. Ceiling check: 20 + 12 + 5 = 37m < 42m (>=2m margin) and
+//	    < the 45m step timeout.
+//	baml-source (watchdog 57m): build ~18.5m cold (Rust cargo build --release
+//	    cffi stage dominates), m.Run ~26m worst, teardown ~1s. Real:
+//	    18.5 + 26 + ~0 = ~44.5m < 57m. The 30m ceiling intentionally exceeds the
+//	    strict ceiling-sum (30 + 26 + 5 > 57) because real cold setup is ~18.5m,
+//	    not 30m; 30m is a pathology ceiling the watchdog still backstops, and it
+//	    is left unchanged so baml-source's single-attempt budget never shrinks.
+const (
+	// OverallSetupBudgetLight is the overall (parent) ctx budget for a full
+	// Setup call in the light job classes (versioned + in-process matrices,
+	// BAML_SOURCE unset). Grown from the historical 10m to ride out a
+	// slow-but-healthy build while staying under the 42m watchdog (#424).
+	OverallSetupBudgetLight = 20 * time.Minute
+
+	// OverallSetupBudgetBAMLSource is the overall budget for baml-source
+	// builds (BAML_SOURCE set), whose Rust cargo build --release cffi stage
+	// dominates setup. Unchanged from the historical 30m so the single-attempt
+	// budget never shrinks (scope G1); the 57m watchdog backstops it.
+	OverallSetupBudgetBAMLSource = 30 * time.Minute
+
+	// setupRetryReserve is the slice of the overall budget held back from a
+	// single attempt so a FAST-failing attempt (build.sh non-zero exit, BAML
+	// library 404, init panic, registry blip — the transient classes #415's
+	// retry targets) leaves real headroom for the retry to actually run. A
+	// slow-success build that exhausts its per-attempt budget deliberately
+	// does NOT get a meaningful retry: retrying a build that is slow due to
+	// runner/daemon contention just hits the same wall (scope G4/G5), so the
+	// design favors one big single attempt over guaranteeing a second.
+	setupRetryReserve = 2 * time.Minute
+)
+
+// SetupBudget returns the overall (parent) context budget a Setup call should
+// be given for the supplied options. baml-source builds compile the Rust cffi
+// stage and need the larger budget; every other build uses the light budget.
+// This is the one knob every setup-ctx callsite reads (#424).
+func SetupBudget(opts SetupOptions) time.Duration {
+	if opts.BAMLSource != "" {
+		return OverallSetupBudgetBAMLSource
+	}
+	return OverallSetupBudgetLight
+}
+
+// perAttemptBudget derives the per-attempt deadline from the parent ctx at
+// loop entry: the whole remaining parent budget minus setupRetryReserve, so
+// the first attempt gets a generous single build window while leaving room for
+// a fast-fail retry. This is mode-aware for free — a 20m parent yields ~18m,
+// a 30m parent ~28m (scope G1). Returns 0 ("no per-attempt bound; use the
+// parent ctx as-is") when the parent has no deadline, or when too little
+// budget remains to both run an attempt and reserve retry headroom — in the
+// latter case a sub-context would only shrink the attempt further, and the
+// parent deadline still caps it.
+func perAttemptBudget(ctx context.Context) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return 0
+	}
+	budget := time.Until(deadline) - setupRetryReserve
+	if budget <= 0 {
+		return 0
+	}
+	return budget
+}
+
 // Setup creates the test environment with mock LLM server and baml-rest
 // container, retrying the whole build+start sequence on transient failures.
 //
@@ -148,46 +237,90 @@ var setupRetryBackoff = []time.Duration{
 // and any started containers) via setupOnce before the next attempt, so retries
 // always start from a clean slate.
 func Setup(ctx context.Context, opts SetupOptions) (*TestEnvironment, error) {
-	totalAttempts := len(setupRetryBackoff) + 1
+	return setupWithRetry(ctx, perAttemptBudget(ctx), setupRetryBackoff,
+		func(attemptCtx context.Context) (*TestEnvironment, error) {
+			return runSetupAttempt(attemptCtx, opts)
+		})
+}
+
+// setupWithRetry is the retry loop extracted from Setup so it can be
+// unit-tested without real Docker (#424). It runs attempt under its own
+// per-attempt deadline (perAttempt, capped by the parent ctx) so a slow
+// attempt cannot silently consume the whole parent budget, then decides
+// retry-vs-bail on the PARENT ctx:
+//
+//   - attempt timed out on its per-attempt budget but the parent still has
+//     budget left -> ctx.Err() == nil -> fall through and retry (the
+//     fast-fail transient path #415 targets); and
+//   - parent exhausted -> ctx.Err() != nil -> bail, since every further
+//     attempt would fail the same way.
+//
+// perAttempt <= 0 means "no per-attempt bound": the attempt runs on the
+// parent ctx directly. attempt receives the per-attempt context and MUST
+// honor it (runSetupAttempt -> setupOnce threads it through both the mockllm
+// and baml-rest builds plus their startup waits, so one attempt's deadline
+// covers the whole sequence — scope G9).
+func setupWithRetry(
+	ctx context.Context,
+	perAttempt time.Duration,
+	backoff []time.Duration,
+	attempt func(context.Context) (*TestEnvironment, error),
+) (*TestEnvironment, error) {
+	totalAttempts := len(backoff) + 1
 
 	var lastErr error
-	for attempt := 1; attempt <= totalAttempts; attempt++ {
-		if attempt > 1 {
-			backoff := setupRetryBackoff[attempt-2]
+	for n := 1; n <= totalAttempts; n++ {
+		if n > 1 {
+			wait := backoff[n-2]
 			log.Printf("[testutil] container setup attempt %d/%d failed: %v; "+
-				"cleaning up and retrying in %s", attempt-1, totalAttempts, lastErr, backoff)
+				"cleaning up and retrying in %s", n-1, totalAttempts, lastErr, wait)
 
 			// Respect cancellation/deadline while backing off so we don't
 			// burn the remaining context budget sleeping.
-			timer := time.NewTimer(backoff)
+			timer := time.NewTimer(wait)
 			select {
 			case <-ctx.Done():
 				timer.Stop()
 				return nil, fmt.Errorf("container setup aborted after %d attempt(s) while "+
-					"waiting to retry: %w (last error: %v)", attempt-1, ctx.Err(), lastErr)
+					"waiting to retry: %w (last error: %v)", n-1, ctx.Err(), lastErr)
 			case <-timer.C:
 			}
 		}
 
-		env, err := runSetupAttempt(ctx, opts)
+		attemptCtx, cancel := attemptContext(ctx, perAttempt)
+		env, err := attempt(attemptCtx)
+		cancel()
 		if err == nil {
-			if attempt > 1 {
-				log.Printf("[testutil] container setup succeeded on attempt %d/%d", attempt, totalAttempts)
+			if n > 1 {
+				log.Printf("[testutil] container setup succeeded on attempt %d/%d", n, totalAttempts)
 			}
 			return env, nil
 		}
 		lastErr = err
 
-		// If the context is already done there's no point retrying: every
-		// further attempt would fail the same way. Surface the error now,
-		// reporting the number of attempts actually made (not the cap).
+		// If the PARENT context is already done there's no point retrying:
+		// every further attempt would fail the same way. A per-attempt
+		// timeout that leaves parent budget intact does NOT take this branch,
+		// so it proceeds to the next attempt. Report the number of attempts
+		// actually made (not the cap).
 		if ctx.Err() != nil {
 			return nil, fmt.Errorf("container setup failed after %d attempt(s); "+
-				"context done before retrying: %w (last error: %v)", attempt, ctx.Err(), lastErr)
+				"context done before retrying: %w (last error: %v)", n, ctx.Err(), lastErr)
 		}
 	}
 
 	return nil, fmt.Errorf("container setup failed after %d attempt(s): %w", totalAttempts, lastErr)
+}
+
+// attemptContext derives the per-attempt context from the parent. A
+// non-positive perAttempt means "no per-attempt bound" (the attempt runs on
+// the parent ctx directly); otherwise the attempt deadline is
+// min(perAttempt, parent-remaining) since the child is derived from ctx.
+func attemptContext(ctx context.Context, perAttempt time.Duration) (context.Context, context.CancelFunc) {
+	if perAttempt <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, perAttempt)
 }
 
 // runSetupAttempt performs a single setupOnce and converts a panic into an

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -188,19 +188,20 @@ const (
 	// runner/daemon contention just hits the same wall (scope G4/G5), so the
 	// design favors one big single attempt over guaranteeing a second.
 	setupRetryReserve = 2 * time.Minute
-
-	// setupCleanupTimeout bounds the partial-teardown of a failed attempt
-	// (terminating whatever network/containers it had already created before
-	// the next attempt or before the error propagates). This budget is
-	// deliberately INDEPENDENT of the per-attempt work context: testcontainers
-	// Terminate needs a LIVE context to issue Docker stop/remove, but the most
-	// common cleanup trigger is the per-attempt deadline firing — so cleanup is
-	// run on a fresh context.Background()-derived ctx (see runSetupCleanup), not
-	// the expired work ctx. Sized smaller than the 5m defaultTeardownTimeout
-	// because a partially-started attempt has at most a half-built container and
-	// a network to remove, not a full running environment.
-	setupCleanupTimeout = 2 * time.Minute
 )
+
+// setupCleanupTimeout bounds the partial-teardown of a failed attempt
+// (terminating whatever network/containers it had already created before the
+// next attempt or before the error propagates). This budget is deliberately
+// INDEPENDENT of the per-attempt work context: testcontainers Terminate needs
+// a LIVE context to issue Docker stop/remove, but the most common cleanup
+// trigger is the per-attempt deadline firing — so cleanup is run on a fresh
+// context.Background()-derived ctx (see runSetupCleanup), not the expired work
+// ctx. Sized smaller than the 5m defaultTeardownTimeout because a
+// partially-started attempt has at most a half-built container and a network to
+// remove, not a full running environment. A var (not const) so tests can shrink
+// it to assert the budget is actually ENFORCED.
+var setupCleanupTimeout = 2 * time.Minute
 
 // SetupBudget returns the overall (parent) context budget a Setup call should
 // be given for the supplied options. baml-source builds compile the Rust cffi
@@ -342,13 +343,26 @@ func attemptContext(ctx context.Context, perAttempt time.Duration) (context.Cont
 // stop/remove; the dominant cleanup trigger is the per-attempt deadline
 // firing, and the overall budget may also be exhausted, so reusing either
 // would leave half-started containers and networks leaked before the retry.
-// Errors are ignored (best-effort teardown), matching the existing setup-path
-// cleanup contract. The cancel is always invoked so the cleanup ctx itself
-// never leaks.
+//
+// The budget is ENFORCED preemptively (same goroutine+select shape as
+// integration.boundedTerminate, the #422 teardown bound): a Docker stop/remove
+// that ignores context cancellation must not block the retry/bail loop past the
+// budget. teardown runs in a goroutine reporting on a buffered channel so it
+// never blocks on send even after we've returned via the deadline; a leaked
+// goroutine on a truly-wedged Terminate is acceptable for best-effort
+// inter-attempt cleanup. Errors are ignored (best-effort), matching the
+// existing setup-path cleanup contract; cancel is always invoked so the cleanup
+// ctx itself never leaks.
 func runSetupCleanup(teardown func(context.Context) error) {
 	ctx, cancel := context.WithTimeout(context.Background(), setupCleanupTimeout)
 	defer cancel()
-	_ = teardown(ctx)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- teardown(ctx) }()
+	select {
+	case <-errCh:
+	case <-ctx.Done():
+	}
 }
 
 // runSetupAttempt performs a single setupOnce and converts a panic into an

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -188,6 +188,18 @@ const (
 	// runner/daemon contention just hits the same wall (scope G4/G5), so the
 	// design favors one big single attempt over guaranteeing a second.
 	setupRetryReserve = 2 * time.Minute
+
+	// setupCleanupTimeout bounds the partial-teardown of a failed attempt
+	// (terminating whatever network/containers it had already created before
+	// the next attempt or before the error propagates). This budget is
+	// deliberately INDEPENDENT of the per-attempt work context: testcontainers
+	// Terminate needs a LIVE context to issue Docker stop/remove, but the most
+	// common cleanup trigger is the per-attempt deadline firing — so cleanup is
+	// run on a fresh context.Background()-derived ctx (see runSetupCleanup), not
+	// the expired work ctx. Sized smaller than the 5m defaultTeardownTimeout
+	// because a partially-started attempt has at most a half-built container and
+	// a network to remove, not a full running environment.
+	setupCleanupTimeout = 2 * time.Minute
 )
 
 // SetupBudget returns the overall (parent) context budget a Setup call should
@@ -323,6 +335,22 @@ func attemptContext(ctx context.Context, perAttempt time.Duration) (context.Cont
 	return context.WithTimeout(ctx, perAttempt)
 }
 
+// runSetupCleanup runs a partial-teardown function under a fresh, bounded
+// context derived from context.Background() — independent of BOTH the
+// (possibly expired) per-attempt work ctx AND a (possibly cancelled) parent
+// ctx. testcontainers Terminate needs a LIVE context to issue Docker
+// stop/remove; the dominant cleanup trigger is the per-attempt deadline
+// firing, and the overall budget may also be exhausted, so reusing either
+// would leave half-started containers and networks leaked before the retry.
+// Errors are ignored (best-effort teardown), matching the existing setup-path
+// cleanup contract. The cancel is always invoked so the cleanup ctx itself
+// never leaks.
+func runSetupCleanup(teardown func(context.Context) error) {
+	ctx, cancel := context.WithTimeout(context.Background(), setupCleanupTimeout)
+	defer cancel()
+	_ = teardown(ctx)
+}
+
 // runSetupAttempt performs a single setupOnce and converts a panic into an
 // error so a true Go panic from deep inside testcontainers still triggers a
 // retry instead of tearing down the whole test binary. setupOnce tears down
@@ -350,7 +378,7 @@ func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error)
 	// wrapper, so a retry doesn't leak a network or half-started container.
 	defer func() {
 		if r := recover(); r != nil {
-			_ = env.Terminate(ctx)
+			runSetupCleanup(env.Terminate)
 			panic(r)
 		}
 	}()
@@ -365,7 +393,7 @@ func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error)
 	// Start mock LLM server
 	mockLLM, err := startMockLLMContainer(ctx, net.Name)
 	if err != nil {
-		_ = env.Terminate(ctx)
+		runSetupCleanup(env.Terminate)
 		return nil, fmt.Errorf("failed to start mock LLM container: %w", err)
 	}
 	env.MockLLM = mockLLM
@@ -373,12 +401,12 @@ func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error)
 	// Get mock LLM mapped port
 	mockPort, err := mockLLM.MappedPort(ctx, MockLLMInternalPort)
 	if err != nil {
-		_ = env.Terminate(ctx)
+		runSetupCleanup(env.Terminate)
 		return nil, fmt.Errorf("failed to get mock LLM port: %w", err)
 	}
 	mockHost, err := mockLLM.Host(ctx)
 	if err != nil {
-		_ = env.Terminate(ctx)
+		runSetupCleanup(env.Terminate)
 		return nil, fmt.Errorf("failed to get mock LLM host: %w", err)
 	}
 	env.MockLLMURL = fmt.Sprintf("http://%s:%s", mockHost, mockPort.Port())
@@ -387,7 +415,7 @@ func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error)
 	// Build and start baml-rest container
 	bamlRest, err := startBAMLRestContainer(ctx, net.Name, opts)
 	if err != nil {
-		_ = env.Terminate(ctx)
+		runSetupCleanup(env.Terminate)
 		return nil, fmt.Errorf("failed to start baml-rest container: %w", err)
 	}
 	env.BAMLRest = bamlRest
@@ -395,12 +423,12 @@ func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error)
 	// Get baml-rest mapped ports
 	restPort, err := bamlRest.MappedPort(ctx, BAMLRestInternalPort)
 	if err != nil {
-		_ = env.Terminate(ctx)
+		runSetupCleanup(env.Terminate)
 		return nil, fmt.Errorf("failed to get baml-rest port: %w", err)
 	}
 	restHost, err := bamlRest.Host(ctx)
 	if err != nil {
-		_ = env.Terminate(ctx)
+		runSetupCleanup(env.Terminate)
 		return nil, fmt.Errorf("failed to get baml-rest host: %w", err)
 	}
 	env.BAMLRestURL = fmt.Sprintf("http://%s:%s", restHost, restPort.Port())
@@ -408,7 +436,7 @@ func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error)
 	if opts.UnaryServer {
 		unaryPort, err := bamlRest.MappedPort(ctx, BAMLRestUnaryPort)
 		if err != nil {
-			_ = env.Terminate(ctx)
+			runSetupCleanup(env.Terminate)
 			return nil, fmt.Errorf("failed to get baml-rest unary port: %w", err)
 		}
 		env.BAMLRestUnaryURL = fmt.Sprintf("http://%s:%s", restHost, unaryPort.Port())
@@ -447,7 +475,7 @@ func startMockLLMContainer(ctx context.Context, networkName string) (testcontain
 		// testcontainers may still return a built container. Tear it down so a
 		// retry doesn't leak it.
 		if c != nil {
-			_ = c.Terminate(ctx)
+			runSetupCleanup(func(cleanupCtx context.Context) error { return c.Terminate(cleanupCtx) })
 		}
 		return nil, err
 	}
@@ -541,7 +569,7 @@ func startBAMLRestContainer(ctx context.Context, networkName string, opts SetupO
 		// still hand back a built container; terminate it so a retry starts
 		// clean instead of leaking a half-started container.
 		if c != nil {
-			_ = c.Terminate(ctx)
+			runSetupCleanup(func(cleanupCtx context.Context) error { return c.Terminate(cleanupCtx) })
 		}
 		return nil, err
 	}

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -358,7 +358,20 @@ func runSetupCleanup(teardown func(context.Context) error) {
 	defer cancel()
 
 	errCh := make(chan error, 1)
-	go func() { errCh <- teardown(ctx) }()
+	go func() {
+		// teardown runs on its own goroutine, outside runSetupAttempt's recover
+		// wrapper, so contain a panic from Terminate/network removal here — a
+		// panicking best-effort cleanup must not crash the test binary. teardown
+		// either returns OR panics (never both), so at most one send happens;
+		// errCh is buffered (cap 1) so neither send blocks.
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("[testutil] recovered panic during setup cleanup: %v", r)
+				errCh <- fmt.Errorf("setup cleanup panicked: %v\n%s", r, debug.Stack())
+			}
+		}()
+		errCh <- teardown(ctx)
+	}()
 	select {
 	case <-errCh:
 	case <-ctx.Done():

--- a/integration/testutil/container_retry_test.go
+++ b/integration/testutil/container_retry_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fastBackoff is a backoff slice the length of the production setupRetryBackoff
+// (3 retries -> 4 total attempts) but with negligible delays, so the
+// inter-attempt sleep can never dominate or flake these timing tests. The
+// retry-vs-bail behavior under test is event-driven (it keys off context
+// cancellation, not wall-clock sleeps), so 1ms is plenty.
+var fastBackoff = []time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}
+
+// TestSetupWithRetry_PerAttemptTimeoutDoesNotPoisonParent is the #424
+// regression: an attempt that exhausts its per-attempt budget must NOT poison
+// the parent into the "context done before retrying" bail — a subsequent
+// attempt must still run while the parent has budget left.
+//
+// Non-flaky by construction: attempt 1 consumes EXACTLY its per-attempt budget
+// by blocking on the attempt ctx (no fixed sleep), and the parent (1s) is far
+// larger than perAttempt (20ms) + backoff so the parent is never the limiter.
+func TestSetupWithRetry_PerAttemptTimeoutDoesNotPoisonParent(t *testing.T) {
+	parent, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	const perAttempt = 20 * time.Millisecond
+
+	var calls int
+	want := &TestEnvironment{}
+	attempt := func(ctx context.Context) (*TestEnvironment, error) {
+		calls++
+		if calls == 1 {
+			// Consume exactly the per-attempt budget, event-driven: block
+			// until this attempt's ctx fires, then surface its deadline error.
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return want, nil
+	}
+
+	got, err := setupWithRetry(parent, perAttempt, fastBackoff, attempt)
+	if err != nil {
+		t.Fatalf("setupWithRetry returned error, want success after retry: %v", err)
+	}
+	if got != want {
+		t.Fatalf("setupWithRetry returned %p, want the attempt-2 env %p", got, want)
+	}
+	if calls != 2 {
+		t.Fatalf("attempt ran %d time(s), want exactly 2 (attempt 2 must run after attempt 1's per-attempt timeout)", calls)
+	}
+	if parent.Err() != nil {
+		t.Fatalf("parent ctx was consumed (%v); a per-attempt timeout must not poison the parent", parent.Err())
+	}
+}
+
+// TestSetupWithRetry_ParentExhaustionBails is the negative counterpart: when
+// every attempt exhausts its per-attempt budget and the parent is too small to
+// fund another, the loop must bail via the parent ctx.Err() path (authoritative
+// parent cap) rather than looping forever.
+//
+// Non-flaky by construction: parent (25ms) is just over one perAttempt (20ms),
+// so attempt 1 gets its own 20ms timer (parent alive afterwards -> retry) and
+// attempt 2's requested deadline lands AFTER the parent deadline, so Go ties it
+// directly to the parent (no independent timer) — its cancellation therefore
+// guarantees parent.Err() is set when we check. Under scheduler jitter the only
+// drift is bailing one attempt earlier, which the assertions still accept.
+func TestSetupWithRetry_ParentExhaustionBails(t *testing.T) {
+	parent, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	const perAttempt = 20 * time.Millisecond
+
+	var calls int
+	attempt := func(ctx context.Context) (*TestEnvironment, error) {
+		calls++
+		<-ctx.Done() // every attempt exhausts its (parent-capped) budget
+		return nil, ctx.Err()
+	}
+
+	env, err := setupWithRetry(parent, perAttempt, fastBackoff, attempt)
+	if env != nil {
+		t.Fatalf("setupWithRetry returned env %p, want nil on parent exhaustion", env)
+	}
+	if err == nil {
+		t.Fatal("setupWithRetry returned nil error, want a parent-exhaustion failure")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error %v does not wrap context.DeadlineExceeded", err)
+	}
+	if !strings.Contains(err.Error(), "context done before retrying") {
+		t.Fatalf("error %q is not the parent-exhaustion bail", err)
+	}
+	if maxAttempts := len(fastBackoff) + 1; calls > maxAttempts {
+		t.Fatalf("attempt ran %d time(s), want <= %d (must not loop past the cap)", calls, maxAttempts)
+	}
+}
+
+// TestSetupWithRetry_NoPerAttemptBound proves perAttempt <= 0 runs the attempt
+// on the parent ctx directly (no sub-context), so an attempt that ignores any
+// per-attempt deadline still sees the parent's.
+func TestSetupWithRetry_NoPerAttemptBound(t *testing.T) {
+	parent, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var gotDeadline time.Time
+	attempt := func(ctx context.Context) (*TestEnvironment, error) {
+		d, _ := ctx.Deadline()
+		gotDeadline = d
+		return &TestEnvironment{}, nil
+	}
+
+	if _, err := setupWithRetry(parent, 0, fastBackoff, attempt); err != nil {
+		t.Fatalf("setupWithRetry returned error: %v", err)
+	}
+	parentDeadline, _ := parent.Deadline()
+	if !gotDeadline.Equal(parentDeadline) {
+		t.Fatalf("attempt ctx deadline = %v, want the parent deadline %v (no per-attempt sub-context)", gotDeadline, parentDeadline)
+	}
+}
+
+func TestSetupBudget(t *testing.T) {
+	if got := SetupBudget(SetupOptions{}); got != OverallSetupBudgetLight {
+		t.Fatalf("SetupBudget(light) = %s, want %s", got, OverallSetupBudgetLight)
+	}
+	if got := SetupBudget(SetupOptions{BAMLSource: "/some/baml"}); got != OverallSetupBudgetBAMLSource {
+		t.Fatalf("SetupBudget(baml-source) = %s, want %s", got, OverallSetupBudgetBAMLSource)
+	}
+}
+
+func TestPerAttemptBudget(t *testing.T) {
+	// No deadline -> 0 ("no per-attempt bound").
+	if got := perAttemptBudget(context.Background()); got != 0 {
+		t.Fatalf("perAttemptBudget(no deadline) = %s, want 0", got)
+	}
+
+	// Healthy parent -> remaining minus the retry reserve.
+	parent, cancel := context.WithTimeout(context.Background(), OverallSetupBudgetLight)
+	defer cancel()
+	got := perAttemptBudget(parent)
+	want := OverallSetupBudgetLight - setupRetryReserve
+	// Allow a small delta for the time elapsed between construction and read.
+	if delta := want - got; delta < 0 || delta > time.Second {
+		t.Fatalf("perAttemptBudget(%s parent) = %s, want ~%s (reserve %s)", OverallSetupBudgetLight, got, want, setupRetryReserve)
+	}
+
+	// Parent smaller than the reserve -> 0 (don't shrink the attempt with a
+	// non-positive sub-deadline; the parent still caps it).
+	tight, cancelTight := context.WithTimeout(context.Background(), setupRetryReserve/2)
+	defer cancelTight()
+	if got := perAttemptBudget(tight); got != 0 {
+		t.Fatalf("perAttemptBudget(sub-reserve parent) = %s, want 0", got)
+	}
+}

--- a/integration/testutil/container_retry_test.go
+++ b/integration/testutil/container_retry_test.go
@@ -90,11 +90,19 @@ func TestSetupWithRetry_ParentExhaustionBails(t *testing.T) {
 	if err == nil {
 		t.Fatal("setupWithRetry returned nil error, want a parent-exhaustion failure")
 	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("error %v does not wrap context.DeadlineExceeded", err)
+	// setupWithRetry has TWO parent-deadline bail branches — post-attempt
+	// ("context done before retrying") and during the backoff wait ("while
+	// waiting to retry") — and under the tiny budgets here scheduler timing
+	// decides which wins. Both wrap the parent ctx.Err(), so assert the
+	// parent-deadline SHAPE (the robust invariant) rather than a single
+	// message; that IS the test's contract: parent exhaustion bails with a
+	// parent-deadline error.
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("error %v does not wrap a parent-deadline error (DeadlineExceeded/Canceled)", err)
 	}
-	if !strings.Contains(err.Error(), "context done before retrying") {
-		t.Fatalf("error %q is not the parent-exhaustion bail", err)
+	if !strings.Contains(err.Error(), "context done before retrying") &&
+		!strings.Contains(err.Error(), "while waiting to retry") {
+		t.Fatalf("error %q is not a parent-exhaustion bail", err)
 	}
 	if maxAttempts := len(fastBackoff) + 1; calls > maxAttempts {
 		t.Fatalf("attempt ran %d time(s), want <= %d (must not loop past the cap)", calls, maxAttempts)
@@ -173,6 +181,43 @@ func TestRunSetupCleanup_UsesLiveContext(t *testing.T) {
 	}
 	if remaining := time.Until(dlAtCall); remaining <= 0 {
 		t.Fatalf("cleanup ctx deadline already passed (remaining %s)", remaining)
+	}
+}
+
+// TestRunSetupCleanup_EnforcesBudget proves the cleanup budget is actually
+// enforced: a teardown that IGNORES its context and blocks must NOT stall the
+// retry/bail loop — runSetupCleanup must return when the budget expires. This
+// is the #422 failure mode (Docker stop/remove that doesn't honor ctx). Under
+// the previous synchronous implementation this test would hang and time out.
+// Event-driven and non-flaky: a tiny budget bounds the return, and the blocked
+// teardown goroutine is released only after the assertion.
+func TestRunSetupCleanup_EnforcesBudget(t *testing.T) {
+	saved := setupCleanupTimeout
+	setupCleanupTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { setupCleanupTimeout = saved })
+
+	// release unblocks the (intentionally leaked) teardown goroutine after the
+	// assertion, so it can drain to the buffered channel and exit cleanly.
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	started := make(chan struct{})
+	returned := make(chan struct{})
+	go func() {
+		runSetupCleanup(func(ctx context.Context) error {
+			close(started)
+			<-release // ignore ctx entirely: a sync impl would hang here forever
+			return nil
+		})
+		close(returned)
+	}()
+
+	<-started // teardown is running and blocked
+	select {
+	case <-returned:
+		// returned despite teardown ignoring its ctx — budget enforced
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSetupCleanup did not return within its budget when teardown ignored its context")
 	}
 }
 

--- a/integration/testutil/container_retry_test.go
+++ b/integration/testutil/container_retry_test.go
@@ -221,6 +221,27 @@ func TestRunSetupCleanup_EnforcesBudget(t *testing.T) {
 	}
 }
 
+// TestRunSetupCleanup_ContainsPanic proves a panicking teardown does NOT crash
+// the test binary. teardown runs on its own goroutine (outside
+// runSetupAttempt's recover), so without containment a panic from
+// Terminate/network removal would be unhandled and abort the process. The
+// helper must recover it and return normally. Deterministic: the panic fires
+// synchronously inside teardown, and runSetupCleanup blocks until it observes
+// the result, so reaching the line after the call proves containment.
+func TestRunSetupCleanup_ContainsPanic(t *testing.T) {
+	var called bool
+	runSetupCleanup(func(ctx context.Context) error {
+		called = true
+		panic("boom from Terminate")
+	})
+
+	if !called {
+		t.Fatal("runSetupCleanup did not invoke the teardown func")
+	}
+	// Reaching here at all is the assertion: the panic was contained on the
+	// cleanup goroutine instead of crashing the process.
+}
+
 func TestSetupBudget(t *testing.T) {
 	if got := SetupBudget(SetupOptions{}); got != OverallSetupBudgetLight {
 		t.Fatalf("SetupBudget(light) = %s, want %s", got, OverallSetupBudgetLight)

--- a/integration/testutil/container_retry_test.go
+++ b/integration/testutil/container_retry_test.go
@@ -124,6 +124,58 @@ func TestSetupWithRetry_NoPerAttemptBound(t *testing.T) {
 	}
 }
 
+// TestRunSetupCleanup_UsesLiveContext is the partial-cleanup-leak regression:
+// when an attempt times out, setupOnce / the start helpers must tear down
+// whatever they partially created on a LIVE context (testcontainers Terminate
+// needs one to issue Docker stop/remove). runSetupCleanup is the single path
+// all those teardowns now route through; this proves the context it hands the
+// teardown func is not already-done — even though the per-attempt work ctx (and
+// potentially the parent) has expired — and is bounded so it can't itself hang.
+func TestRunSetupCleanup_UsesLiveContext(t *testing.T) {
+	// Stand in for the failure scenario: the per-attempt work ctx has already
+	// expired by the time cleanup runs.
+	attemptCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	<-attemptCtx.Done() // event-driven: wait for the deadline, no fixed sleep
+	if attemptCtx.Err() == nil {
+		t.Fatal("precondition: attempt ctx should be expired before cleanup")
+	}
+
+	// Capture the cleanup ctx's state INSIDE the callback, while it is still
+	// live — runSetupCleanup defers cancel(), so inspecting it after the call
+	// returns would always show "canceled".
+	var (
+		called    bool
+		isSame    bool
+		errAtCall error
+		dlAtCall  time.Time
+		dlOK      bool
+	)
+	runSetupCleanup(func(ctx context.Context) error {
+		called = true
+		isSame = ctx == attemptCtx
+		errAtCall = ctx.Err()
+		dlAtCall, dlOK = ctx.Deadline()
+		return nil
+	})
+
+	if !called {
+		t.Fatal("runSetupCleanup did not invoke the teardown func")
+	}
+	if errAtCall != nil {
+		t.Fatalf("cleanup ctx was already done at teardown time (%v); teardown needs a LIVE context", errAtCall)
+	}
+	if isSame {
+		t.Fatal("cleanup ctx is the expired attempt ctx; it must be independent")
+	}
+	if !dlOK {
+		t.Fatal("cleanup ctx has no deadline; it must be bounded")
+	}
+	if remaining := time.Until(dlAtCall); remaining <= 0 {
+		t.Fatalf("cleanup ctx deadline already passed (remaining %s)", remaining)
+	}
+}
+
 func TestSetupBudget(t *testing.T) {
 	if got := SetupBudget(SetupOptions{}); got != OverallSetupBudgetLight {
 		t.Fatalf("SetupBudget(light) = %s, want %s", got, OverallSetupBudgetLight)

--- a/integration/testutil/container_retry_test.go
+++ b/integration/testutil/container_retry_test.go
@@ -5,7 +5,6 @@ package testutil
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 )
@@ -93,16 +92,12 @@ func TestSetupWithRetry_ParentExhaustionBails(t *testing.T) {
 	// setupWithRetry has TWO parent-deadline bail branches — post-attempt
 	// ("context done before retrying") and during the backoff wait ("while
 	// waiting to retry") — and under the tiny budgets here scheduler timing
-	// decides which wins. Both wrap the parent ctx.Err(), so assert the
-	// parent-deadline SHAPE (the robust invariant) rather than a single
-	// message; that IS the test's contract: parent exhaustion bails with a
-	// parent-deadline error.
-	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
-		t.Fatalf("error %v does not wrap a parent-deadline error (DeadlineExceeded/Canceled)", err)
-	}
-	if !strings.Contains(err.Error(), "context done before retrying") &&
-		!strings.Contains(err.Error(), "while waiting to retry") {
-		t.Fatalf("error %q is not a parent-exhaustion bail", err)
+	// decides which wins. Both wrap the parent ctx.Err(), which for this
+	// WithTimeout parent (only cancel()'d after the assertion) is always
+	// DeadlineExceeded — so that single check is the robust invariant both
+	// branches satisfy and IS the test's contract.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error %v does not wrap context.DeadlineExceeded", err)
 	}
 	if maxAttempts := len(fastBackoff) + 1; calls > maxAttempts {
 		t.Fatalf("attempt ran %d time(s), want <= %d (must not loop past the cap)", calls, maxAttempts)
@@ -212,7 +207,11 @@ func TestRunSetupCleanup_EnforcesBudget(t *testing.T) {
 		close(returned)
 	}()
 
-	<-started // teardown is running and blocked
+	select {
+	case <-started: // teardown is running and blocked
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSetupCleanup did not invoke teardown")
+	}
 	select {
 	case <-returned:
 		// returned despite teardown ignoring its ctx — budget enforced


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Summary

Fixes #424 — integration setup intermittently failing at ~600s with `create container: build image: context deadline exceeded`.

**Root cause.** The 600s was the **10m main-`TestMain` setup ctx** (`integration_test.go`), exhausted by a *slow-but-healthy* Docker image build on a contended GitHub runner (the same build completed fine on rerun). Because the whole parent ctx was shared across retry attempts with **no per-attempt budget**, the slow first attempt consumed the entire 10m and `Setup` bailed via `container setup failed after 1 attempt(s); context done before retrying` before any retry could engage.

**The load-bearing fix is growing the OVERALL (parent) budget**, not the per-attempt split. Per-attempt budgets alone are a no-op for a slow-success build because the parent caps every child — the #420-style wrong-layer trap. Both changes ship together.

## Changes

- **Per-attempt budget inside the retry loop.** Each attempt now runs under its own deadline derived from the parent at loop entry (`remaining − 2m retryReserve`), so a slow attempt can't silently eat the whole parent. Retry-vs-bail stays keyed on the **parent** ctx: a per-attempt timeout that leaves parent budget retries; parent exhaustion bails (the existing `:184` branch, kept authoritative). The per-attempt deadline covers **both** the mockllm and baml-rest builds + startup waits within one attempt (scope G9).
- **Grown, mode-aware, centralized budgets.** Light jobs `10m → 20m`; baml-source **unchanged at 30m** (its Rust `cargo build --release` cffi stage must not be chopped — scope G1). All **7** setup-ctx call sites (`TestMain`, `bridge` ×2, `client_defaults`, `dynamic_output_format_preserve_order`, `shutdown`, `bamlfuzz` static — the scope listed 6; `shutdown_test.go` was the 7th) now route through `testutil.SetupBudget(opts)`, replacing scattered `10m/15m/30m` magic numbers with one source of truth.
- **Testable seam.** The retry loop is extracted into `setupWithRetry(ctx, perAttempt, backoff, attemptFn)`; `Setup` derives `perAttempt` via `perAttemptBudget(ctx)` and delegates.
- **Deterministic regression tests** (event-driven, no fixed sleeps): a per-attempt timeout does **not** poison the parent into the bail (attempt 2 runs); parent exhaustion bails without looping past the cap; `perAttempt ≤ 0` runs on the parent ctx directly; plus `SetupBudget`/`perAttemptBudget` math. Ran green under `-race -count=50`.

## Measured timings (green master run `27171277621`)

Markers: build = `Setting up…` → `Test environment ready:`; m.Run = `ready` → `Tearing down…`.

| Job class | build (setup) | m.Run (worst observed) | teardown |
|---|---|---|---|
| versioned `0.222.0` | ~4m28s (heaviest ~4m31s) | ~11m09s (heaviest ~11m52s) | <1s |
| in-process | ~4m23s (heaviest ~4m26s) | ~10m16s (heaviest ~10m40s) | <1s |
| baml-source | ~18m27s (heaviest ~18m30s) | ~21m07s (heaviest ~26m13s) | ~1s |

## Chosen budgets & watchdog headroom

Governing inequality (the watchdog covers the window `go test -timeout` does not — setup runs *before* `m.Run`):
`overall_setup + healthy_m.Run + teardown(≤ defaultTeardownTimeout = 5m) ≤ watchdog`

| Job class | per-attempt | overall (parent) | watchdog | headroom math |
|---|---|---|---|---|
| light (versioned / in-process) | ~18m (`20m − 2m`) | **20m** (was 10m) | 42m (step 45m) | ceiling: `20 + 12 + 5 = 37m < 42m` (5m margin); real: `4.5 + 12 = ~16.5m` |
| baml-source | ~28m (`30m − 2m`) | **30m** (unchanged) | 57m (step 60m) | real: `18.5 + 26 + ~0 = ~44.5m < 57m` (12m margin). The 30m ceiling intentionally exceeds the strict ceiling-sum because real cold setup is ~18.5m, not 30m; the watchdog backstops it, and the single-attempt budget is left unshrunk |

## Validation

- `go vet -tags=integration ./integration/...` — clean
- `go vet -tags=integration,subprocess ./integration/...` — clean
- New unit tests: `go test -tags=integration -race -count=50 -run 'TestSetupWithRetry|TestSetupBudget|TestPerAttemptBudget' ./integration/testutil/` — pass (also pass under `integration,subprocess`)
- Full integration test binary compiles under both tag sets

No full Docker integration run locally (out of scope). The retry/budget logic is covered by the deterministic unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests covering setup budgeting, per-attempt timeouts, retry behavior, cleanup semantics, panic containment, and deterministic timing to improve reliability of environment startup and recovery.

* **Chores**
  * Centralized mode-aware setup time budgeting and refactored setup/retry/teardown flows for more deterministic, robust environment setup and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->