### PR TITLE
test(bamlfuzz): /call-with-raw raw-channel differential oracle (#349)

### DIFF
--- a/adapters/common/codegen/bamlfuzz/case.go
+++ b/adapters/common/codegen/bamlfuzz/case.go
@@ -25,6 +25,12 @@ const (
 	// the unary parse. Partial frames are not asserted on in v1 — only
 	// the terminal frame, which is chunk-timing invariant.
 	OracleDynamicStreaming OracleMode = "dynamic_streaming"
+	// OracleCallWithRaw: lower the schema through the dynamic emitter and
+	// drive the with-raw legs (dynclient DynamicCallRaw + REST
+	// /call-with-raw/_dynamic). Beyond the dynamic oracle's parsed-data
+	// equivalence it pins the raw echo channel: the extracted output text
+	// must equal the mock's emitted content byte-for-byte on both legs.
+	OracleCallWithRaw OracleMode = "call_with_raw"
 )
 
 // CaseMetadata is per-case provenance that's useful to a developer

--- a/adapters/common/codegen/bamlfuzz/envelope.go
+++ b/adapters/common/codegen/bamlfuzz/envelope.go
@@ -69,19 +69,24 @@ type DynamicFailureEnvelope struct {
 // with byte equality against MockLLMContent (it is pre-parse wire text,
 // not JSON), so DynclientRaw / RESTRaw travel verbatim for forensics.
 type RawFailureEnvelope struct {
-	GeneratorVersion    string                         `json:"generator_version"`
-	GeneratedAt         string                         `json:"generated_at"`
-	RapidSeed           int64                          `json:"rapid_seed"`
-	CaseIndex           int                            `json:"case_index"`
-	CaseName            string                         `json:"case_name"`
-	OracleMode          OracleMode                     `json:"oracle_mode"`
-	PreserveSchemaOrder bool                           `json:"preserve_schema_order"`
-	Schema              FuzzSchema                     `json:"schema"`
-	DynamicSchema       *bamlutils.DynamicOutputSchema `json:"dynamic_schema,omitempty"`
-	DynamicSkipReason   string                         `json:"dynamic_skip_reason,omitempty"`
-	MockLLMScenarioID   string                         `json:"mockllm_scenario_id"`
-	MockLLMContent      json.RawMessage                `json:"mockllm_content"`
-	Expected            json.RawMessage                `json:"expected"`
+	GeneratorVersion    string     `json:"generator_version"`
+	GeneratedAt         string     `json:"generated_at"`
+	RapidSeed           int64      `json:"rapid_seed"`
+	CaseIndex           int        `json:"case_index"`
+	CaseName            string     `json:"case_name"`
+	OracleMode          OracleMode `json:"oracle_mode"`
+	PreserveSchemaOrder bool       `json:"preserve_schema_order"`
+	Schema              FuzzSchema `json:"schema"`
+	// Value is the generated value tree the walker rendered MockLLMContent
+	// and Expected from. Captured alongside Schema + RapidSeed so the
+	// artifact can standalone-reconstruct the failing case even for fuzz
+	// cases, where RapidSeed is 0 and the seed alone is insufficient.
+	Value             FuzzValue                      `json:"value"`
+	DynamicSchema     *bamlutils.DynamicOutputSchema `json:"dynamic_schema,omitempty"`
+	DynamicSkipReason string                         `json:"dynamic_skip_reason,omitempty"`
+	MockLLMScenarioID string                         `json:"mockllm_scenario_id"`
+	MockLLMContent    json.RawMessage                `json:"mockllm_content"`
+	Expected          json.RawMessage                `json:"expected"`
 
 	// Parsed `data` payloads from each with-raw leg.
 	DynclientOutput     json.RawMessage `json:"dynclient_output,omitempty"`

--- a/adapters/common/codegen/bamlfuzz/envelope.go
+++ b/adapters/common/codegen/bamlfuzz/envelope.go
@@ -61,6 +61,88 @@ type DynamicFailureEnvelope struct {
 	Metadata            CaseMetadata                   `json:"metadata"`
 }
 
+// RawFailureEnvelope captures the full context around a disagreement on
+// the /call-with-raw oracle. It mirrors DynamicFailureEnvelope's parsed
+// `data` capture (the with-raw legs still diff their flattened output
+// against the walker's Expected) and adds the raw-channel evidence: the
+// extracted output text each leg returned. The raw channel is asserted
+// with byte equality against MockLLMContent (it is pre-parse wire text,
+// not JSON), so DynclientRaw / RESTRaw travel verbatim for forensics.
+type RawFailureEnvelope struct {
+	GeneratorVersion    string                         `json:"generator_version"`
+	GeneratedAt         string                         `json:"generated_at"`
+	RapidSeed           int64                          `json:"rapid_seed"`
+	CaseIndex           int                            `json:"case_index"`
+	CaseName            string                         `json:"case_name"`
+	OracleMode          OracleMode                     `json:"oracle_mode"`
+	PreserveSchemaOrder bool                           `json:"preserve_schema_order"`
+	Schema              FuzzSchema                     `json:"schema"`
+	DynamicSchema       *bamlutils.DynamicOutputSchema `json:"dynamic_schema,omitempty"`
+	DynamicSkipReason   string                         `json:"dynamic_skip_reason,omitempty"`
+	MockLLMScenarioID   string                         `json:"mockllm_scenario_id"`
+	MockLLMContent      json.RawMessage                `json:"mockllm_content"`
+	Expected            json.RawMessage                `json:"expected"`
+
+	// Parsed `data` payloads from each with-raw leg.
+	DynclientOutput     json.RawMessage `json:"dynclient_output,omitempty"`
+	DynclientError      string          `json:"dynclient_error,omitempty"`
+	DynclientPanic      string          `json:"dynclient_panic,omitempty"`
+	DynclientPanicStack string          `json:"dynclient_panic_stack,omitempty"`
+	RESTStatus          int             `json:"rest_status,omitempty"`
+	RESTBody            json.RawMessage `json:"rest_body,omitempty"`
+	RESTError           string          `json:"rest_error,omitempty"`
+	RESTPanic           string          `json:"rest_panic,omitempty"`
+	RESTPanicStack      string          `json:"rest_panic_stack,omitempty"`
+
+	// Raw-channel capture: the extracted output text each leg returned.
+	// Asserted equal to MockLLMContent (and to each other) via string
+	// equality, not SemanticDiff.
+	DynclientRaw string `json:"dynclient_raw,omitempty"`
+	RESTRaw      string `json:"rest_raw,omitempty"`
+
+	// PlainCallOutput is the parsed `data` from the plain /call dynclient
+	// leg, captured for the with-raw ⊇ plain-call anchor (A4).
+	PlainCallOutput json.RawMessage `json:"plain_call_output,omitempty"`
+	PlainCallError  string          `json:"plain_call_error,omitempty"`
+
+	SemanticDiff []SemanticDiffEntry `json:"semantic_diff,omitempty"`
+	RawMismatch  []string            `json:"raw_mismatch,omitempty"`
+	ReplayPath   string              `json:"replay_path"`
+	Reproduction string              `json:"reproduction"`
+	Metadata     CaseMetadata        `json:"metadata"`
+}
+
+// WriteRawReplayArtifact writes a RawFailureEnvelope to `dir` as a JSON
+// file. Same on-disk format as WriteReplayArtifact (2-space indent,
+// deterministic basename via sanitizeArtifactBasename); envelope.ReplayPath
+// is stamped with the resulting path so the t.Errorf message can point at
+// the artifact.
+func WriteRawReplayArtifact(dir string, envelope *RawFailureEnvelope) (string, error) {
+	if envelope == nil {
+		return "", fmt.Errorf("bamlfuzz: nil envelope")
+	}
+	if envelope.GeneratorVersion == "" {
+		envelope.GeneratorVersion = GeneratorVersion
+	}
+	if envelope.GeneratedAt == "" {
+		envelope.GeneratedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("bamlfuzz: mkdir %s: %w", dir, err)
+	}
+	name := sanitizeArtifactBasename(envelope.CaseName, envelope.CaseIndex)
+	path := filepath.Join(dir, name+".json")
+	envelope.ReplayPath = path
+	buf, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("bamlfuzz: marshal envelope: %w", err)
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		return "", fmt.Errorf("bamlfuzz: write %s: %w", path, err)
+	}
+	return path, nil
+}
+
 // SemanticDiffEntry names one path-level disagreement between two of the
 // oracle legs. `Side` identifies which legs disagree
 // ("expected_vs_dynclient", "expected_vs_rest", "dynclient_vs_rest").

--- a/integration/bamlfuzz_callwithraw_test.go
+++ b/integration/bamlfuzz_callwithraw_test.go
@@ -1,0 +1,573 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/bamlfuzz"
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/dynclient"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// callWithRawOracleArtifactDir is where RawFailureEnvelope artifacts land
+// on failure or with BAMLFUZZ_KEEP_ARTIFACTS=1. Stable relative to the
+// integration test working directory so CI can collect from a predictable
+// path.
+const callWithRawOracleArtifactDir = "../adapters/common/codegen/testdata/bamlfuzz/callwithraw/_artifacts"
+
+// rawCasesPerMode controls how many random call-with-raw cases run per
+// preserve mode. The default of 4 is sized for PR CI wall time; the
+// nightly fuzz workflow cranks it up via BAMLFUZZ_CALLWITHRAW_CASES so
+// each scheduled run explores a broader slice of the schema space.
+func rawCasesPerMode() int {
+	return envIntDefault("BAMLFUZZ_CALLWITHRAW_CASES", 4)
+}
+
+// TestBamlfuzzCallWithRawOracle drives the /call-with-raw oracle: for each
+// fuzz case it lowers the schema through the dynamic emitter and exercises
+// the with-raw legs —
+//
+//  1. dynclient.Client.DynamicCallRaw (in-proc), and
+//  2. the REST /call-with-raw/_dynamic endpoint —
+//
+// then asserts the dynamic oracle's parsed-`data` equivalence still holds
+// (A1/A2) AND pins the raw echo channel (A3): the extracted output text
+// each leg returns must equal the mock's emitted content byte-for-byte and
+// equal each other. Raw is pre-parse wire text, not JSON, so it is
+// compared with Go string equality, never SemanticDiff. A4 anchors the
+// with-raw parsed data against the plain /call dynclient leg, proving
+// with-raw ⊇ plain-call.
+//
+// It reuses the dynamic oracle's case stream verbatim
+// (CoupledCaseGen(DynamicSafeSchemaGen()), LowerToDynamicSchema, the
+// dynamic call-body builder, and unsupportedActionFor) and the dynamic
+// corpus, so no schema/value-generator change is needed for raw coverage —
+// MockLLMContent already *is* the expected raw text.
+func TestBamlfuzzCallWithRawOracle(t *testing.T) {
+	dynclientCallGate(t)
+
+	corpus, err := loadDynamicCorpus(dynamicOracleCorpusDir)
+	if err != nil {
+		t.Fatalf("load corpus from %s: %v", dynamicOracleCorpusDir, err)
+	}
+	if len(corpus) == 0 {
+		t.Fatalf("dynamic corpus at %s is empty — the raw oracle reuses it", dynamicOracleCorpusDir)
+	}
+
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		t.Fatalf("NewDynclient: %v", err)
+	}
+
+	t.Run("corpus", func(t *testing.T) {
+		for i, c := range corpus {
+			caseIdx := i
+			caseCopy := c
+			t.Run(caseCopy.Name, func(t *testing.T) {
+				runCallWithRawOracleCase(t, dyn, caseCopy, caseIdx, caseSourceCorpus)
+			})
+		}
+	})
+
+	t.Run("rapid", func(t *testing.T) {
+		modes := []bool{true, false}
+		for _, preserve := range modes {
+			preserve := preserve
+			label := "preserve_off"
+			if preserve {
+				label = "preserve_on"
+			}
+			t.Run(label, func(t *testing.T) {
+				cases := rawCasesPerMode()
+				for i := 0; i < cases; i++ {
+					i := i
+					seed := rawSeedFor(preserve, i)
+					t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+						caseCopy := buildRawRapidCase(t, seed, preserve, i)
+						runCallWithRawOracleCase(t, dyn, caseCopy, i, caseSourceRapid)
+					})
+				}
+			})
+		}
+	})
+}
+
+// FuzzBamlfuzzCallWithRaw is the testing.F companion to
+// TestBamlfuzzCallWithRawOracle, exposing the raw oracle to Go's native
+// fuzz engine via the bamlfuzz.MakeFuzz bridge. Like FuzzBamlfuzzDynamic
+// it draws PreserveSchemaOrder from the bit stream and ships no f.Add seed
+// corpus (the engine populates its own under -fuzzcachedir). The version
+// gates match the dynamic oracle: dynamic endpoints require BAML
+// >= 0.215.0, and without an external baml source the pre-0.219 streaming
+// API does not propagate dynamic classes to the parser.
+func FuzzBamlfuzzCallWithRaw(f *testing.F) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		f.Skip("Skipping: dynamic endpoints require BAML >= 0.215.0")
+	}
+	if BAMLSourcePath == "" && !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
+		f.Skip("BAML bug: streaming API doesn't propagate dynamic classes to parser")
+	}
+
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		f.Fatalf("NewDynclient: %v", err)
+	}
+
+	bamlfuzz.MakeFuzz(f, func(t *testing.T, rt *rapid.T) {
+		preserve := rapid.Bool().Draw(rt, "preserve_schema_order")
+		cc := bamlfuzz.CoupledCaseGen(bamlfuzz.DynamicSafeSchemaGen()).Draw(rt, "coupled_case")
+		c := bamlfuzz.OracleCase{
+			Name:                "fuzz",
+			Seed:                0,
+			CaseIndex:           0,
+			Mode:                bamlfuzz.OracleCallWithRaw,
+			PreserveSchemaOrder: preserve,
+			Schema:              cc.Schema,
+			Value:               cc.Value,
+			MockLLMContent:      cc.Walk.MockLLMContent,
+			Expected:            cc.Walk.Expected,
+			Metadata:            cc.Walk.Metadata,
+		}
+		runCallWithRawOracleCase(t, dyn, c, 0, caseSourceFuzz)
+	})
+}
+
+// rawSeedFor produces a deterministic rapid seed for a (preserve, i) pair.
+// The "callwithraw" domain prefix keeps the raw oracle's seed stream
+// disjoint from the dynamic oracle's (dynamicSeedFor), so the two oracles
+// explore different schema shapes at the same case index. BAMLFUZZ_SEED,
+// when set, XORs into every per-case seed so a single env var perturbs the
+// whole matrix.
+func rawSeedFor(preserve bool, i int) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte("callwithraw:"))
+	if preserve {
+		h.Write([]byte("preserve_on"))
+	} else {
+		h.Write([]byte("preserve_off"))
+	}
+	fmt.Fprintf(h, ":%d", i)
+	base := h.Sum64()
+	if v := os.Getenv("BAMLFUZZ_SEED"); v != "" {
+		base ^= fnv64aString(v)
+	}
+	return base
+}
+
+// buildRawRapidCase synthesizes one OracleCase by drawing a dynamic-safe
+// schema + value deterministically from seed, using the same
+// CoupledCaseGen the dynamic oracle uses so the raw oracle exercises the
+// identical case stream.
+func buildRawRapidCase(t *testing.T, seed uint64, preserve bool, idx int) bamlfuzz.OracleCase {
+	t.Helper()
+	cc := bamlfuzz.CoupledCaseGen(bamlfuzz.DynamicSafeSchemaGen()).Example(int(seed))
+	return bamlfuzz.OracleCase{
+		Name:                fmt.Sprintf("rawrapid_%t_%d", preserve, idx),
+		Seed:                int64(seed),
+		CaseIndex:           idx,
+		Mode:                bamlfuzz.OracleCallWithRaw,
+		PreserveSchemaOrder: preserve,
+		Schema:              cc.Schema,
+		Value:               cc.Value,
+		MockLLMContent:      cc.Walk.MockLLMContent,
+		Expected:            cc.Walk.Expected,
+		Metadata:            cc.Walk.Metadata,
+	}
+}
+
+// runCallWithRawOracleCase performs the with-raw comparison for one
+// OracleCase, capturing all relevant context into a RawFailureEnvelope
+// when any leg disagrees. `source` selects how
+// ErrDynamicSchemaUnsupported is treated: corpus/fuzz cases skip, rapid
+// cases fail (the dynamic-safe generator must never produce an unsupported
+// schema).
+func runCallWithRawOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.OracleCase, caseIdx int, source caseSource) {
+	t.Helper()
+
+	envelope := &bamlfuzz.RawFailureEnvelope{
+		GeneratorVersion:    bamlfuzz.GeneratorVersion,
+		RapidSeed:           c.Seed,
+		CaseIndex:           caseIdx,
+		CaseName:            c.Name,
+		OracleMode:          bamlfuzz.OracleCallWithRaw,
+		PreserveSchemaOrder: c.PreserveSchemaOrder,
+		Schema:              c.Schema,
+		MockLLMContent:      c.MockLLMContent,
+		Expected:            c.Expected,
+		Metadata:            c.Metadata,
+		Reproduction:        reproductionForRaw(c, caseIdx, source),
+	}
+
+	lowered, err := bamlfuzz.LowerToDynamicSchema(c.Schema)
+	if errors.Is(err, bamlfuzz.ErrDynamicSchemaUnsupported) {
+		switch unsupportedActionFor(source) {
+		case unsupportedSkip:
+			t.Skipf("dynamic emitter skipped schema: %v", err)
+			return
+		case unsupportedFail:
+			envelope.DynamicSkipReason = err.Error()
+			failAndDumpRaw(t, envelope, "rapid generator produced unsupported schema: %v", err)
+			return
+		}
+	}
+	if err != nil {
+		envelope.DynamicSkipReason = err.Error()
+		failAndDumpRaw(t, envelope, "LowerToDynamicSchema failed: %v", err)
+		return
+	}
+	envelope.DynamicSchema = &lowered
+
+	// The raw channel's "expected" is the mock's emitted content. An empty
+	// MockLLMContent would make the A3 string-equality checks vacuous
+	// (raw == "" == ""), so treat it as a harness error: the walker never
+	// renders empty content for a valid case.
+	if len(c.MockLLMContent) == 0 {
+		failAndDumpRaw(t, envelope, "case has empty MockLLMContent; raw oracle cannot assert a vacuous echo")
+		return
+	}
+	expectedRaw := string(c.MockLLMContent)
+
+	scenarioID := fmt.Sprintf("bamlfuzz-raw-%s", scenarioSafe(c.Name))
+	envelope.MockLLMScenarioID = scenarioID
+	registerCtx, registerCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer registerCancel()
+	scenario := &mockllm.Scenario{
+		ID:             scenarioID,
+		Provider:       "openai",
+		Content:        expectedRaw,
+		ChunkSize:      0,
+		InitialDelayMs: 0,
+	}
+	if err := MockClient.RegisterScenario(registerCtx, scenario); err != nil {
+		failAndDumpRaw(t, envelope, "register scenario: %v", err)
+		return
+	}
+
+	clientReg := testutil.CreateTestClient(TestEnv.MockLLMInternal, scenarioID)
+
+	callCtx, callCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer callCancel()
+
+	preserve := c.PreserveSchemaOrder
+	preservePtr := &preserve
+	hello := "Return the dynamic fuzz value."
+	libReq := dynclient.Request{
+		Messages: []dynclient.Message{
+			{Role: "system", PartsContent: []dynclient.ContentPart{
+				{Type: "text", Text: &hello},
+				{Type: "output_format"},
+			}},
+			{Role: "user", TextContent: &hello},
+		},
+		ClientRegistry:      testutil.DynRegistry(clientReg),
+		OutputSchema:        &lowered,
+		PreserveSchemaOrder: preservePtr,
+	}
+
+	// --- dynclient with-raw leg ---
+	var (
+		libResp *dynclient.CallRawResult
+		libErr  error
+	)
+	panicked, panicVal, panicStack := callWithRecover(func() {
+		libResp, libErr = dyn.DynamicCallRaw(callCtx, libReq)
+	})
+	if panicked {
+		envelope.DynclientPanic = fmt.Sprintf("%v", panicVal)
+		envelope.DynclientPanicStack = string(panicStack)
+		failAndDumpRaw(t, envelope, "dyn.DynamicCallRaw panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
+	switch {
+	case libErr != nil:
+		// A context/transport error means the leg never produced a
+		// verdict; letting it satisfy an equality check would mask a real
+		// divergence, so it is a harness failure, not an oracle rejection.
+		if isContextErr(libErr) {
+			t.Fatalf("harness failure: dynclient DynamicCallRaw (case=%s): %v", c.Name, libErr)
+		}
+		envelope.DynclientError = libErr.Error()
+	case libResp == nil:
+		envelope.DynclientError = "nil response from dyn.DynamicCallRaw"
+		failAndDumpRaw(t, envelope, "dynclient returned nil response without an error")
+		return
+	default:
+		envelope.DynclientOutput = libResp.Data
+		envelope.DynclientRaw = libResp.Raw
+	}
+
+	// --- REST /call-with-raw/_dynamic leg ---
+	// Build the body via bamlutils so OrderedMap insertion order travels
+	// intact across the wire (testutil.DynamicOutputSchema is map-backed
+	// and would scramble property order).
+	restBody, err := buildDynamicCallBody(libReq, &lowered)
+	if err != nil {
+		failAndDumpRaw(t, envelope, "build REST body: %v", err)
+		return
+	}
+	var restResp *testutil.DynamicCallWithRawResponse
+	panicked, panicVal, panicStack = callWithRecover(func() {
+		restResp, err = BAMLClient.DynamicCallWithRawJSON(callCtx, restBody)
+	})
+	if panicked {
+		envelope.RESTPanic = fmt.Sprintf("%v", panicVal)
+		envelope.RESTPanicStack = string(panicStack)
+		failAndDumpRaw(t, envelope, "BAMLClient.DynamicCallWithRawJSON panicked: %v\n%s", panicVal, panicStack)
+		return
+	}
+	switch {
+	case err != nil:
+		if isContextErr(err) {
+			t.Fatalf("harness failure: REST DynamicCallWithRawJSON (case=%s): %v", c.Name, err)
+		}
+		envelope.RESTError = err.Error()
+	case restResp == nil:
+		envelope.RESTError = "nil response from BAMLClient.DynamicCallWithRawJSON"
+		failAndDumpRaw(t, envelope, "REST client returned nil response without an error")
+		return
+	default:
+		envelope.RESTStatus = restResp.StatusCode
+		envelope.RESTBody = restResp.Data
+		envelope.RESTRaw = restResp.Raw
+		if restResp.StatusCode >= 400 {
+			envelope.RESTError = restResp.Error
+		}
+	}
+
+	// --- A4 anchor: plain /call dynclient leg (same case) ---
+	// Cheap reuse of the existing DynamicCall path to prove with-raw's
+	// parsed `data` matches the plain call. An error here is recorded but
+	// only fails the A4 assertion below, not the whole case.
+	var (
+		plainResp *dynclient.CallResult
+		plainErr  error
+	)
+	panicked, panicVal, panicStack = callWithRecover(func() {
+		plainResp, plainErr = dyn.DynamicCall(callCtx, libReq)
+	})
+	if panicked {
+		envelope.PlainCallError = fmt.Sprintf("panic: %v", panicVal)
+	} else if plainErr != nil {
+		if isContextErr(plainErr) {
+			t.Fatalf("harness failure: dynclient DynamicCall (A4 anchor, case=%s): %v", c.Name, plainErr)
+		}
+		envelope.PlainCallError = plainErr.Error()
+	} else if plainResp != nil {
+		envelope.PlainCallOutput = plainResp.Data
+	}
+
+	// ---- Assertions ----
+	var failures []string
+	if libErr != nil {
+		failures = append(failures, fmt.Sprintf("dynclient errored: %v", libErr))
+	}
+	if envelope.RESTError != "" {
+		failures = append(failures, fmt.Sprintf("REST errored (status %d): %s", envelope.RESTStatus, envelope.RESTError))
+	}
+
+	// A1 — parsed data still equals Expected on both legs. SemanticDiff
+	// hard-errors on an empty payload (decodeAny), so an empty `data` side
+	// cannot pass by skip.
+	if libErr == nil && envelope.DynclientOutput != nil {
+		if diff, err := bamlfuzz.SemanticDiff("expected_vs_dynclient_raw", c.Expected, envelope.DynclientOutput); err != nil {
+			failures = append(failures, fmt.Sprintf("expected_vs_dynclient_raw diff: %v", err))
+		} else if len(diff) > 0 {
+			envelope.SemanticDiff = append(envelope.SemanticDiff, diff...)
+			failures = append(failures, "expected ≠ dynclient (data)")
+		}
+	}
+	if envelope.RESTError == "" && envelope.RESTBody != nil {
+		if diff, err := bamlfuzz.SemanticDiff("expected_vs_rest_raw", c.Expected, envelope.RESTBody); err != nil {
+			failures = append(failures, fmt.Sprintf("expected_vs_rest_raw diff: %v", err))
+		} else if len(diff) > 0 {
+			envelope.SemanticDiff = append(envelope.SemanticDiff, diff...)
+			failures = append(failures, "expected ≠ REST (data)")
+		}
+	}
+	// A2 — data parity between the two with-raw legs.
+	if libErr == nil && envelope.RESTError == "" && envelope.DynclientOutput != nil && envelope.RESTBody != nil {
+		if diff, err := bamlfuzz.SemanticDiffParity("dynclient_raw_vs_rest_raw", envelope.DynclientOutput, envelope.RESTBody); err != nil {
+			failures = append(failures, fmt.Sprintf("dynclient_raw_vs_rest_raw diff: %v", err))
+		} else if len(diff) > 0 {
+			envelope.SemanticDiff = append(envelope.SemanticDiff, diff...)
+			failures = append(failures, "dynclient ≠ REST (data)")
+		}
+	}
+
+	// A3 — the raw echo channel. raw is plain pre-parse text, NOT JSON, so
+	// it is compared with Go string equality against the known mock input
+	// (MockLLMContent) on both legs, and the two raw strings must equal
+	// each other. Feeding raw into SemanticDiff/decodeAny would error (raw
+	// text isn't JSON) or, worse, falsely pass.
+	if libErr == nil {
+		if envelope.DynclientRaw != expectedRaw {
+			envelope.RawMismatch = append(envelope.RawMismatch,
+				fmt.Sprintf("dynclient raw ≠ MockLLMContent: got %q want %q", envelope.DynclientRaw, expectedRaw))
+			failures = append(failures, "dynclient raw ≠ MockLLMContent")
+		}
+	}
+	if envelope.RESTError == "" {
+		if envelope.RESTRaw != expectedRaw {
+			envelope.RawMismatch = append(envelope.RawMismatch,
+				fmt.Sprintf("REST raw ≠ MockLLMContent: got %q want %q", envelope.RESTRaw, expectedRaw))
+			failures = append(failures, "REST raw ≠ MockLLMContent")
+		}
+	}
+	if libErr == nil && envelope.RESTError == "" {
+		if envelope.DynclientRaw != envelope.RESTRaw {
+			envelope.RawMismatch = append(envelope.RawMismatch,
+				fmt.Sprintf("dynclient raw ≠ REST raw: %q vs %q", envelope.DynclientRaw, envelope.RESTRaw))
+			failures = append(failures, "dynclient raw ≠ REST raw")
+		}
+	}
+
+	// A4 — with-raw parsed data ⊇ plain /call. Parity comparison so a
+	// leaked null key on either BAML-generated side is tolerated like the
+	// dynamic oracle's dynclient_vs_rest check.
+	if envelope.PlainCallError == "" && envelope.PlainCallOutput != nil &&
+		libErr == nil && envelope.DynclientOutput != nil {
+		if diff, err := bamlfuzz.SemanticDiffParity("dynclient_raw_vs_plain_call", envelope.DynclientOutput, envelope.PlainCallOutput); err != nil {
+			failures = append(failures, fmt.Sprintf("dynclient_raw_vs_plain_call diff: %v", err))
+		} else if len(diff) > 0 {
+			envelope.SemanticDiff = append(envelope.SemanticDiff, diff...)
+			failures = append(failures, "with-raw data ≠ plain /call data")
+		}
+	}
+
+	if len(failures) == 0 {
+		if os.Getenv("BAMLFUZZ_KEEP_ARTIFACTS") == "1" {
+			if path, err := bamlfuzz.WriteRawReplayArtifact(callWithRawOracleArtifactDir, envelope); err == nil {
+				t.Logf("kept replay artifact (success): %s", path)
+			}
+		}
+		return
+	}
+	failAndDumpRaw(t, envelope, "%s", strings.Join(failures, "; "))
+}
+
+// failAndDumpRaw writes the RawFailureEnvelope to the artifact dir and
+// fails the test with a message that points at the replay path.
+func failAndDumpRaw(t *testing.T, envelope *bamlfuzz.RawFailureEnvelope, format string, args ...any) {
+	t.Helper()
+	path, err := bamlfuzz.WriteRawReplayArtifact(callWithRawOracleArtifactDir, envelope)
+	if err != nil {
+		t.Errorf("write replay artifact: %v", err)
+		t.Errorf(format, args...)
+		return
+	}
+	msg := fmt.Sprintf(format, args...)
+	t.Errorf("%s\nreplay: %s\nrepro: %s", msg, path, envelope.Reproduction)
+}
+
+// reproductionForRaw returns the canonical command to re-run a failing
+// call-with-raw case in isolation, embedded in the envelope so a developer
+// can copy-paste it. The subtest trees mirror reproductionFor:
+//
+//	TestBamlfuzzCallWithRawOracle / corpus / <case_name>
+//	TestBamlfuzzCallWithRawOracle / rapid  / preserve_{on,off} / case_<index>
+//
+// Fuzz cases bypass the subtest tree: the engine reaches them by replaying
+// a corpus entry under -fuzzcachedir, so the recipe runs the engine.
+func reproductionForRaw(c bamlfuzz.OracleCase, caseIdx int, source caseSource) string {
+	if source == caseSourceFuzz {
+		return "go test -tags=integration,subprocess -run='^$' -fuzz='^FuzzBamlfuzzCallWithRaw$' -fuzztime=10m " +
+			"-fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+	}
+	segments := []string{"^TestBamlfuzzCallWithRawOracle$"}
+	switch source {
+	case caseSourceCorpus:
+		segments = append(segments, "^corpus$", "^"+regexp.QuoteMeta(c.Name)+"$")
+	case caseSourceRapid:
+		preserve := "preserve_off"
+		if c.PreserveSchemaOrder {
+			preserve = "preserve_on"
+		}
+		segments = append(segments,
+			"^rapid$",
+			"^"+regexp.QuoteMeta(preserve)+"$",
+			fmt.Sprintf("^case_%d$", caseIdx),
+		)
+	}
+	cmd := fmt.Sprintf("go test -tags=integration -run='%s' ./integration -count=1",
+		strings.Join(segments, "/"))
+	// Prepend SEED first, then CASES, so CASES lands leftmost — matching
+	// reproductionFor's rendered prefix order.
+	if seed := os.Getenv("BAMLFUZZ_SEED"); seed != "" {
+		cmd = "BAMLFUZZ_SEED=" + seed + " " + cmd
+	}
+	if cases := os.Getenv("BAMLFUZZ_CALLWITHRAW_CASES"); cases != "" {
+		cmd = "BAMLFUZZ_CALLWITHRAW_CASES=" + cases + " " + cmd
+	}
+	return cmd
+}
+
+// TestReproductionForRaw pins the shape of the reproduction command
+// embedded in raw-oracle failure envelopes across the corpus, rapid, and
+// fuzz source trees plus the BAMLFUZZ_SEED / BAMLFUZZ_CALLWITHRAW_CASES env
+// prefixes.
+func TestReproductionForRaw(t *testing.T) {
+	t.Setenv("BAMLFUZZ_SEED", "")
+	t.Setenv("BAMLFUZZ_CALLWITHRAW_CASES", "")
+
+	corpus := reproductionForRaw(bamlfuzz.OracleCase{Name: "scalar_string"}, 0, caseSourceCorpus)
+	wantCorpus := "go test -tags=integration -run='^TestBamlfuzzCallWithRawOracle$/^corpus$/^scalar_string$' ./integration -count=1"
+	if corpus != wantCorpus {
+		t.Errorf("corpus repro:\n got:  %s\n want: %s", corpus, wantCorpus)
+	}
+
+	rapidOn := reproductionForRaw(bamlfuzz.OracleCase{PreserveSchemaOrder: true}, 2, caseSourceRapid)
+	wantRapidOn := "go test -tags=integration -run='^TestBamlfuzzCallWithRawOracle$/^rapid$/^preserve_on$/^case_2$' ./integration -count=1"
+	if rapidOn != wantRapidOn {
+		t.Errorf("rapid preserve-on repro:\n got:  %s\n want: %s", rapidOn, wantRapidOn)
+	}
+
+	rapidOff := reproductionForRaw(bamlfuzz.OracleCase{PreserveSchemaOrder: false}, 3, caseSourceRapid)
+	wantRapidOff := "go test -tags=integration -run='^TestBamlfuzzCallWithRawOracle$/^rapid$/^preserve_off$/^case_3$' ./integration -count=1"
+	if rapidOff != wantRapidOff {
+		t.Errorf("rapid preserve-off repro:\n got:  %s\n want: %s", rapidOff, wantRapidOff)
+	}
+
+	t.Setenv("BAMLFUZZ_SEED", "12345")
+	withSeed := reproductionForRaw(bamlfuzz.OracleCase{PreserveSchemaOrder: true}, 0, caseSourceRapid)
+	wantWithSeed := "BAMLFUZZ_SEED=12345 go test -tags=integration -run='^TestBamlfuzzCallWithRawOracle$/^rapid$/^preserve_on$/^case_0$' ./integration -count=1"
+	if withSeed != wantWithSeed {
+		t.Errorf("rapid+seed repro:\n got:  %s\n want: %s", withSeed, wantWithSeed)
+	}
+
+	t.Setenv("BAMLFUZZ_SEED", "")
+	t.Setenv("BAMLFUZZ_CALLWITHRAW_CASES", "50")
+	withCases := reproductionForRaw(bamlfuzz.OracleCase{PreserveSchemaOrder: false}, 25, caseSourceRapid)
+	wantWithCases := "BAMLFUZZ_CALLWITHRAW_CASES=50 go test -tags=integration -run='^TestBamlfuzzCallWithRawOracle$/^rapid$/^preserve_off$/^case_25$' ./integration -count=1"
+	if withCases != wantWithCases {
+		t.Errorf("rapid+cases repro:\n got:  %s\n want: %s", withCases, wantWithCases)
+	}
+
+	t.Setenv("BAMLFUZZ_SEED", "12345")
+	t.Setenv("BAMLFUZZ_CALLWITHRAW_CASES", "50")
+	withSeedAndCases := reproductionForRaw(bamlfuzz.OracleCase{PreserveSchemaOrder: false}, 25, caseSourceRapid)
+	wantWithSeedAndCases := "BAMLFUZZ_CALLWITHRAW_CASES=50 BAMLFUZZ_SEED=12345 go test -tags=integration -run='^TestBamlfuzzCallWithRawOracle$/^rapid$/^preserve_off$/^case_25$' ./integration -count=1"
+	if withSeedAndCases != wantWithSeedAndCases {
+		t.Errorf("rapid+seed+cases repro:\n got:  %s\n want: %s", withSeedAndCases, wantWithSeedAndCases)
+	}
+
+	t.Setenv("BAMLFUZZ_SEED", "12345")
+	t.Setenv("BAMLFUZZ_CALLWITHRAW_CASES", "50")
+	fuzz := reproductionForRaw(bamlfuzz.OracleCase{PreserveSchemaOrder: true}, 0, caseSourceFuzz)
+	wantFuzz := "go test -tags=integration,subprocess -run='^$' -fuzz='^FuzzBamlfuzzCallWithRaw$' -fuzztime=10m -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
+	if fuzz != wantFuzz {
+		t.Errorf("fuzz repro:\n got:  %s\n want: %s", fuzz, wantFuzz)
+	}
+}

--- a/integration/bamlfuzz_callwithraw_test.go
+++ b/integration/bamlfuzz_callwithraw_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -205,6 +206,7 @@ func runCallWithRawOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Or
 		OracleMode:          bamlfuzz.OracleCallWithRaw,
 		PreserveSchemaOrder: c.PreserveSchemaOrder,
 		Schema:              c.Schema,
+		Value:               c.Value,
 		MockLLMContent:      c.MockLLMContent,
 		Expected:            c.Expected,
 		Metadata:            c.Metadata,
@@ -349,8 +351,12 @@ func runCallWithRawOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Or
 
 	// --- A4 anchor: plain /call dynclient leg (same case) ---
 	// Cheap reuse of the existing DynamicCall path to prove with-raw's
-	// parsed `data` matches the plain call. An error here is recorded but
-	// only fails the A4 assertion below, not the whole case.
+	// parsed `data` matches the plain call. A non-context error / panic /
+	// nil response is recorded as PlainCallError so the A4 assertion below
+	// can fail the case loudly; a context error is a harness failure. Only
+	// a genuinely present payload is recorded as PlainCallOutput — a
+	// "successful" call that returned no Data must not look like clean
+	// output to the anchor.
 	var (
 		plainResp *dynclient.CallResult
 		plainErr  error
@@ -358,14 +364,17 @@ func runCallWithRawOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Or
 	panicked, panicVal, panicStack = callWithRecover(func() {
 		plainResp, plainErr = dyn.DynamicCall(callCtx, libReq)
 	})
-	if panicked {
-		envelope.PlainCallError = fmt.Sprintf("panic: %v", panicVal)
-	} else if plainErr != nil {
+	switch {
+	case panicked:
+		envelope.PlainCallError = fmt.Sprintf("panic: %v\n%s", panicVal, panicStack)
+	case plainErr != nil:
 		if isContextErr(plainErr) {
 			t.Fatalf("harness failure: dynclient DynamicCall (A4 anchor, case=%s): %v", c.Name, plainErr)
 		}
 		envelope.PlainCallError = plainErr.Error()
-	} else if plainResp != nil {
+	case plainResp == nil:
+		envelope.PlainCallError = "nil response from dyn.DynamicCall"
+	default:
 		envelope.PlainCallOutput = plainResp.Data
 	}
 
@@ -378,10 +387,23 @@ func runCallWithRawOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Or
 		failures = append(failures, fmt.Sprintf("REST errored (status %d): %s", envelope.RESTStatus, envelope.RESTError))
 	}
 
-	// A1 — parsed data still equals Expected on both legs. SemanticDiff
-	// hard-errors on an empty payload (decodeAny), so an empty `data` side
-	// cannot pass by skip.
-	if libErr == nil && envelope.DynclientOutput != nil {
+	// A successful leg (no transport/oracle error) MUST carry non-empty
+	// parsed `data`. The walker always renders a non-empty Expected for
+	// these cases, so an empty payload on a clean leg — e.g. a 2xx body
+	// like {"raw": <text>} that unmarshals to Data==nil — is a real
+	// divergence, not something to skip past the A1/A2 diffs. Guarding it
+	// explicitly closes the empty-payload vacuous-pass hole (scope §6): a
+	// leg could otherwise satisfy the raw echo (A3) while the data
+	// comparison was silently skipped on its nil payload.
+	failures = append(failures, rawDataPresenceFailures(
+		libErr == nil, envelope.DynclientOutput,
+		envelope.RESTError == "", envelope.RESTBody)...)
+
+	// A1 — parsed data still equals Expected on both legs. Gated on a
+	// present (non-empty) payload; the emptiness itself is already a
+	// failure recorded above, so an empty side never reaches here to pass
+	// by skip.
+	if libErr == nil && len(envelope.DynclientOutput) > 0 {
 		if diff, err := bamlfuzz.SemanticDiff("expected_vs_dynclient_raw", c.Expected, envelope.DynclientOutput); err != nil {
 			failures = append(failures, fmt.Sprintf("expected_vs_dynclient_raw diff: %v", err))
 		} else if len(diff) > 0 {
@@ -389,7 +411,7 @@ func runCallWithRawOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Or
 			failures = append(failures, "expected ≠ dynclient (data)")
 		}
 	}
-	if envelope.RESTError == "" && envelope.RESTBody != nil {
+	if envelope.RESTError == "" && len(envelope.RESTBody) > 0 {
 		if diff, err := bamlfuzz.SemanticDiff("expected_vs_rest_raw", c.Expected, envelope.RESTBody); err != nil {
 			failures = append(failures, fmt.Sprintf("expected_vs_rest_raw diff: %v", err))
 		} else if len(diff) > 0 {
@@ -398,7 +420,7 @@ func runCallWithRawOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Or
 		}
 	}
 	// A2 — data parity between the two with-raw legs.
-	if libErr == nil && envelope.RESTError == "" && envelope.DynclientOutput != nil && envelope.RESTBody != nil {
+	if libErr == nil && envelope.RESTError == "" && len(envelope.DynclientOutput) > 0 && len(envelope.RESTBody) > 0 {
 		if diff, err := bamlfuzz.SemanticDiffParity("dynclient_raw_vs_rest_raw", envelope.DynclientOutput, envelope.RESTBody); err != nil {
 			failures = append(failures, fmt.Sprintf("dynclient_raw_vs_rest_raw diff: %v", err))
 		} else if len(diff) > 0 {
@@ -434,16 +456,25 @@ func runCallWithRawOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Or
 		}
 	}
 
-	// A4 — with-raw parsed data ⊇ plain /call. Parity comparison so a
-	// leaked null key on either BAML-generated side is tolerated like the
-	// dynamic oracle's dynclient_vs_rest check.
-	if envelope.PlainCallError == "" && envelope.PlainCallOutput != nil &&
-		libErr == nil && envelope.DynclientOutput != nil {
-		if diff, err := bamlfuzz.SemanticDiffParity("dynclient_raw_vs_plain_call", envelope.DynclientOutput, envelope.PlainCallOutput); err != nil {
-			failures = append(failures, fmt.Sprintf("dynclient_raw_vs_plain_call diff: %v", err))
-		} else if len(diff) > 0 {
-			envelope.SemanticDiff = append(envelope.SemanticDiff, diff...)
-			failures = append(failures, "with-raw data ≠ plain /call data")
+	// A4 — with-raw parsed data ⊇ plain /call. Enforced (not skipped)
+	// whenever the with-raw dynclient leg itself produced data: the plain
+	// call hits the same mock with the same case, so a plain-call error or
+	// empty output there is a real problem, not an optional check to no-op.
+	// Parity comparison so a leaked null key on either BAML-generated side
+	// is tolerated like the dynamic oracle's dynclient_vs_rest check.
+	if libErr == nil && len(envelope.DynclientOutput) > 0 {
+		switch {
+		case envelope.PlainCallError != "":
+			failures = append(failures, fmt.Sprintf("plain /call leg failed on a case the with-raw leg handled: %s", envelope.PlainCallError))
+		case len(envelope.PlainCallOutput) == 0:
+			failures = append(failures, "plain /call returned empty data on a successful case")
+		default:
+			if diff, err := bamlfuzz.SemanticDiffParity("dynclient_raw_vs_plain_call", envelope.DynclientOutput, envelope.PlainCallOutput); err != nil {
+				failures = append(failures, fmt.Sprintf("dynclient_raw_vs_plain_call diff: %v", err))
+			} else if len(diff) > 0 {
+				envelope.SemanticDiff = append(envelope.SemanticDiff, diff...)
+				failures = append(failures, "with-raw data ≠ plain /call data")
+			}
 		}
 	}
 
@@ -456,6 +487,29 @@ func runCallWithRawOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Or
 		return
 	}
 	failAndDumpRaw(t, envelope, "%s", strings.Join(failures, "; "))
+}
+
+// rawDataPresenceFailures returns harness-failure messages for any
+// with-raw leg that completed cleanly (no transport/oracle error) yet
+// returned empty parsed `data`. The walker always renders a non-empty
+// Expected for the fuzzed cases, so an empty payload on a successful leg —
+// e.g. a 2xx body like {"raw": <text>} that unmarshals to a nil Data — is
+// a real divergence that must fail explicitly rather than be skipped past
+// the A1/A2 diffs (the empty-payload vacuous-pass hole, scope §6). A leg
+// that DID error is not flagged here: it already contributes its own
+// failure, and its empty data is expected.
+//
+// Extracted as a pure function so the guard's behaviour can be asserted
+// directly (TestRawDataPresenceFailures) without driving the full oracle.
+func rawDataPresenceFailures(dynOK bool, dynData json.RawMessage, restOK bool, restData json.RawMessage) []string {
+	var failures []string
+	if dynOK && len(dynData) == 0 {
+		failures = append(failures, "dynclient returned empty parsed data on a successful call")
+	}
+	if restOK && len(restData) == 0 {
+		failures = append(failures, "REST returned empty parsed data on a successful call")
+	}
+	return failures
 }
 
 // failAndDumpRaw writes the RawFailureEnvelope to the artifact dir and
@@ -569,5 +623,80 @@ func TestReproductionForRaw(t *testing.T) {
 	wantFuzz := "go test -tags=integration,subprocess -run='^$' -fuzz='^FuzzBamlfuzzCallWithRaw$' -fuzztime=10m -fuzzcachedir=adapters/common/codegen/testdata/bamlfuzz/.fuzzcache ./integration"
 	if fuzz != wantFuzz {
 		t.Errorf("fuzz repro:\n got:  %s\n want: %s", fuzz, wantFuzz)
+	}
+}
+
+// TestRawDataPresenceFailures pins the empty-payload guard that closes the
+// vacuous-pass hole: a with-raw leg that did NOT error must carry
+// non-empty parsed data, or the oracle records an explicit failure rather
+// than silently skipping the A1/A2 data comparison on its empty payload.
+// The errored-leg case proves the guard does not double-count a leg that
+// already failed.
+func TestRawDataPresenceFailures(t *testing.T) {
+	nonEmpty := json.RawMessage(`{"k":1}`)
+
+	cases := []struct {
+		name      string
+		dynOK     bool
+		dynData   json.RawMessage
+		restOK    bool
+		restData  json.RawMessage
+		wantCount int
+		wantMatch []string
+	}{
+		{
+			name:  "both_present",
+			dynOK: true, dynData: nonEmpty,
+			restOK: true, restData: nonEmpty,
+			wantCount: 0,
+		},
+		{
+			name:  "dynclient_empty_but_ok_fails",
+			dynOK: true, dynData: nil,
+			restOK: true, restData: nonEmpty,
+			wantCount: 1,
+			wantMatch: []string{"dynclient returned empty parsed data"},
+		},
+		{
+			name:  "rest_empty_but_ok_fails",
+			dynOK: true, dynData: nonEmpty,
+			restOK: true, restData: json.RawMessage(``),
+			wantCount: 1,
+			wantMatch: []string{"REST returned empty parsed data"},
+		},
+		{
+			name:  "both_empty_but_ok_fails_twice",
+			dynOK: true, dynData: nil,
+			restOK: true, restData: nil,
+			wantCount: 2,
+		},
+		{
+			name:  "errored_legs_not_flagged",
+			dynOK: false, dynData: nil,
+			restOK: false, restData: nil,
+			wantCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := rawDataPresenceFailures(tc.dynOK, tc.dynData, tc.restOK, tc.restData)
+			if len(got) != tc.wantCount {
+				t.Fatalf("failure count: got %d %v, want %d", len(got), got, tc.wantCount)
+			}
+			for _, want := range tc.wantMatch {
+				found := false
+				for _, g := range got {
+					if strings.Contains(g, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected a failure containing %q; got %v", want, got)
+				}
+			}
+		})
 	}
 }

--- a/integration/bamlfuzz_callwithraw_test.go
+++ b/integration/bamlfuzz_callwithraw_test.go
@@ -516,13 +516,15 @@ func rawDataPresenceFailures(dynOK bool, dynData json.RawMessage, restOK bool, r
 // fails the test with a message that points at the replay path.
 func failAndDumpRaw(t *testing.T, envelope *bamlfuzz.RawFailureEnvelope, format string, args ...any) {
 	t.Helper()
+	msg := fmt.Sprintf(format, args...)
 	path, err := bamlfuzz.WriteRawReplayArtifact(callWithRawOracleArtifactDir, envelope)
 	if err != nil {
+		// Still emit the repro command: a failed artifact write must not
+		// also cost the developer the one-line command to reproduce.
 		t.Errorf("write replay artifact: %v", err)
-		t.Errorf(format, args...)
+		t.Errorf("%s\nrepro: %s", msg, envelope.Reproduction)
 		return
 	}
-	msg := fmt.Sprintf(format, args...)
 	t.Errorf("%s\nreplay: %s\nrepro: %s", msg, path, envelope.Reproduction)
 }
 

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -487,13 +487,15 @@ func checkSchemaOrder(t *testing.T, c bamlfuzz.OracleCase, envelope *bamlfuzz.Dy
 // with a message that points at the replay path.
 func failAndDump(t *testing.T, envelope *bamlfuzz.DynamicFailureEnvelope, format string, args ...any) {
 	t.Helper()
+	msg := fmt.Sprintf(format, args...)
 	path, err := bamlfuzz.WriteReplayArtifact(dynamicOracleArtifactDir, envelope)
 	if err != nil {
+		// Still emit the repro command: a failed artifact write must not
+		// also cost the developer the one-line command to reproduce.
 		t.Errorf("write replay artifact: %v", err)
-		t.Errorf(format, args...)
+		t.Errorf("%s\nrepro: %s", msg, envelope.Reproduction)
 		return
 	}
-	msg := fmt.Sprintf(format, args...)
 	t.Errorf("%s\nreplay: %s\nrepro: %s", msg, path, envelope.Reproduction)
 }
 

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -585,13 +585,15 @@ func newStaticEnvelope(c bamlfuzz.OracleCase, caseIdx int, batchLabel string, so
 // fails the test with a message that points at the replay path.
 func failStaticAndDump(t *testing.T, envelope *bamlfuzz.StaticFailureEnvelope, format string, args ...any) {
 	t.Helper()
+	msg := fmt.Sprintf(format, args...)
 	path, err := bamlfuzz.WriteStaticReplayArtifact(staticOracleArtifactDir, envelope)
 	if err != nil {
+		// Still emit the repro command: a failed artifact write must not
+		// also cost the developer the one-line command to reproduce.
 		t.Errorf("write static replay artifact: %v", err)
-		t.Errorf(format, args...)
+		t.Errorf("%s\nrepro: %s", msg, envelope.Reproduction)
 		return
 	}
-	msg := fmt.Sprintf(format, args...)
 	t.Errorf("%s\nreplay: %s\nrepro: %s", msg, path, envelope.Reproduction)
 }
 

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -1364,6 +1364,32 @@ func (c *BAMLRestClient) DynamicCall(ctx context.Context, req DynamicRequest) (*
 	return result, nil
 }
 
+// DynamicCallWithRawJSON executes a /call-with-raw/_dynamic request with a
+// caller-provided JSON body. Like DynamicCallJSON, this lets tests build
+// the request via bamlutils-ordered types so insertion order of
+// properties / classes / enums is preserved end-to-end (testutil's
+// map-backed DynamicOutputSchema cannot carry declaration order). On a
+// 2xx the body is decoded into the {data, raw, reasoning} envelope.
+func (c *BAMLRestClient) DynamicCallWithRawJSON(ctx context.Context, body []byte) (*DynamicCallWithRawResponse, error) {
+	url := fmt.Sprintf("%s/call-with-raw/_dynamic", c.baseURL)
+	resp, respBody, err := c.doWithRetry(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &DynamicCallWithRawResponse{
+		StatusCode: resp.StatusCode,
+	}
+	if resp.StatusCode >= 400 {
+		result.Error, result.ErrorCode = extractErrorMessageAndCode(respBody)
+	} else {
+		if err := sonic.Unmarshal(respBody, result); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+		}
+	}
+	return result, nil
+}
+
 // DynamicCallWithRaw executes a /call-with-raw/_dynamic request.
 func (c *BAMLRestClient) DynamicCallWithRaw(ctx context.Context, req DynamicRequest) (*DynamicCallWithRawResponse, error) {
 	body, err := sonic.Marshal(req)


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## /call-with-raw raw-channel bamlfuzz oracle (issue #349, PR A)

Adds a fourth bamlfuzz differential oracle covering the **`/call-with-raw` raw echo channel**. It mirrors the existing dynamic three-way oracle on the with-raw legs, reusing the **identical** case stream (`CoupledCaseGen(DynamicSafeSchemaGen())`, `LowerToDynamicSchema`, the dynamic call-body builder, `unsupportedActionFor`) and the dynamic corpus — no schema/value-generator change, because `MockLLMContent` already *is* the expected raw text.

This is PR A of #349's "/call-with-raw + reasoning oracle coverage" item. The reasoning-channel oracle is a separate follow-up.

### Legs (both already exist — no new product-client code)
- **dynclient in-proc**: `dynclient.Client.DynamicCallRaw` → `CallRawResult{Data, Raw, Reasoning, Metadata}`
- **REST dynamic**: `/call-with-raw/_dynamic` via a new `testutil.DynamicCallWithRawJSON(body []byte)` helper that preserves property declaration order end-to-end (like `DynamicCallJSON`; the map-backed `DynamicOutputSchema` would scramble it)
- **A4 anchor**: the plain `/call` dynclient `DynamicCall` leg for the same case

The with-raw dynclient surface is **dynamic-only** (no static typed `…WithRaw`), so the oracle is **dynclient-dynamic vs REST-dynamic vs Expected** — symmetric with the dynamic oracle.

### Assertions (per fuzz case)
- **A1** — parsed `data` still equals the walker `Expected` on both legs: `SemanticDiff(expected_vs_dynclient_raw, …)` and `SemanticDiff(expected_vs_rest_raw, …)`. Proves with-raw doesn't perturb parsing.
- **A2** — `data` parity: `SemanticDiffParity(dynclient_raw_vs_rest_raw, …)`.
- **A3 (the new invariant)** — the **raw echo channel**. `raw` is plain **pre-parse wire text, not JSON**, so it is compared with Go **string equality**, never `SemanticDiff` (feeding raw into `decodeAny` would error or falsely pass). Asserts `dyn.Raw == MockLLMContent`, `rest.Raw == MockLLMContent`, and `dyn.Raw == rest.Raw` — pinning the raw echo to the known mock input across both client paths.
- **A4** — `dyn.Data` (with-raw) equals the plain `/call` dynclient result (`SemanticDiffParity`), proving with-raw ⊇ plain-call.

### Why `raw == MockLLMContent` (and not the HTTP body)
`raw` is the **extracted output text**, equal to the mock's emitted content — *not* the provider HTTP body (which would be nondeterministic: IDs, usage, ordering). Asserting on the HTTP body would be flaky; pinning `raw == MockLLMContent` is exact (the same byte-equality the endpoint test already checks in `call_test.go`).

### Soundness
- `data` reuses the existing `SemanticDiff`/`SemanticDiffParity` tolerances **unchanged** (null-key #409, union-arm absent-optional #412). Literal-escape #413 is static-only and not needed here.
- Empty `MockLLMContent` is a **harness error** (no vacuous `raw == "" == ""` pass); `SemanticDiff` already hard-errors on an empty `data` side.
- Context/transport errors are **harness failures** (`t.Fatalf` via `isContextErr`), never an equality verdict.
- Options are threaded identically on both legs; no streaming touched.

### Files
- `integration/bamlfuzz_callwithraw_test.go` — `TestBamlfuzzCallWithRawOracle` (corpus + rapid × preserve on/off), `FuzzBamlfuzzCallWithRaw`, run/seed/repro helpers, `TestReproductionForRaw`.
- `adapters/common/codegen/bamlfuzz/case.go` — `OracleCallWithRaw` mode.
- `adapters/common/codegen/bamlfuzz/envelope.go` — `RawFailureEnvelope` (+ `DynclientRaw`/`RESTRaw`) and `WriteRawReplayArtifact`.
- `integration/testutil/client.go` — `DynamicCallWithRawJSON` order-preserving helper.

The bamlfuzz package is **not** embedded (`adapters/common/embed.go` lists no `bamlfuzz` paths) and the test/helper files live under `integration/` (not embedded), so no embed/dynclient regeneration is required.

### Validation
- `gofmt` clean; `go vet` clean (integration + bamlfuzz).
- Compiles under `-tags integration` and `-tags 'integration subprocess'`.
- Real Docker run, `BAML_VERSION=0.219.0`: `TestBamlfuzzCallWithRawOracle` — **all 16 corpus cases pass**, `mutual_recursion` skips (expected, dynamic-emitter-unsupported), **all 8 rapid cases pass** (preserve on/off); `TestReproductionForRaw` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "call-with-raw" oracle mode to validate raw-byte echoes and parsed-data parity across dynamic and REST call paths
  * REST client now supports making raw-call requests and returns structured raw/data responses

* **Tests**
  * New integration and fuzz suites that validate raw echoes, parsed-data parity, and emit deterministic reproduction commands and replay artifacts on failure

* **Bug Fixes**
  * Failure reporting now includes reproduction commands alongside artifact write errors so repro info is preserved on write failure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->