### PR TITLE
ci: cache baml-source cffi build in a dedicated prebuild job (#433)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -186,7 +186,115 @@ jobs:
         # direct in-process worker path.
         run: go test -tags=integration -v -count=1 -p 1 -timeout 40m ./integration/...
 
+  build-baml-cffi:
+    runs-on: ubuntu-latest
+    # Build the BAML cffi artifact (libbaml_cffi.so + baml-cli) exactly once,
+    # OUTSIDE the integration-tests-baml-source watchdog window, and hand it to
+    # the 8 matrix cells so they skip the ~18m cargo build entirely. On a warm
+    # cache (the common case — .source is a pinned SHA) this restores in ~1-2m;
+    # on a cold cache (a Renovate .source bump) it runs the full release build
+    # here, where a generous cap absorbs it and the matrix cells never see the
+    # ~18m under their 67m watchdog. See #433.
+    timeout-minutes: 35
+    outputs:
+      commit: ${{ steps.baml-source.outputs.commit }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6.0.3
+
+      - name: Read BAML source commit
+        id: baml-source
+        run: echo "commit=$(jq -r '.source' integration/baml_versions.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout BAML Source
+        uses: actions/checkout@v6.0.3
+        with:
+          repository: BoundaryML/baml
+          ref: ${{ steps.baml-source.outputs.commit }}
+          path: baml-source
+
+      - name: Detect protoc-gen-go version
+        id: protoc
+        # Mirror cmd/build/main.go detectProtocGenGoVersion: read the
+        # `// protoc-gen-go vX.Y.Z` marker from a generated .pb.go file so the
+        # prebuild's protobuf toolchain matches what the in-Docker cffi-builder
+        # stage would have used (currently v1.34.1).
+        run: |
+          ver=$(grep -rhoE 'protoc-gen-go v[0-9]+\.[0-9]+\.[0-9]+' \
+            baml-source/engine/language_client_go/pkg/cffi/*.pb.go \
+            | head -n1 | sed 's/protoc-gen-go v/v/')
+          if [ -z "$ver" ]; then
+            echo "::error::could not detect protoc-gen-go version from baml-source"
+            exit 1
+          fi
+          echo "Detected protoc-gen-go $ver"
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: Restore prebuilt cffi cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: prebuilt-cffi
+          # Final-artifact cache. The key fully pins the artifact: the BAML
+          # source commit fixes the source AND Cargo.lock; the rust:bookworm
+          # digest fragment fixes the toolchain so a silent base bump (which
+          # also flips the Dockerfile FROM digest) invalidates the cache rather
+          # than serving a stale .so. Cargo.lock hash is a cheap belt-and-braces
+          # guard against a dirty tree.
+          key: baml-cffi-${{ runner.os }}-rust-bookworm-19817ead3289-${{ steps.baml-source.outputs.commit }}-${{ hashFiles('baml-source/engine/Cargo.lock') }}
+          # Partial restores warm the slot for inspection only — a different
+          # commit's .so is the WRONG artifact, so the cargo build below gates
+          # on an EXACT-key hit (cache-hit == 'true'), not these fallbacks.
+          restore-keys: |
+            baml-cffi-${{ runner.os }}-rust-bookworm-19817ead3289-${{ steps.baml-source.outputs.commit }}-
+            baml-cffi-${{ runner.os }}-rust-bookworm-19817ead3289-
+
+      - name: Build cffi artifact in rust:bookworm
+        # Gate on an EXACT-key cache hit only (see restore-keys note above).
+        # glibc parity is load-bearing: the .so MUST be compiled inside
+        # rust:bookworm (Debian, glibc 2.36), NOT on the bare ubuntu-latest
+        # runner (glibc 2.39), or it fails to load in the bookworm-slim runtime
+        # with GLIBC_2.3x-not-found. The digest matches the Dockerfile FROM pin
+        # so this reproduces the in-Docker cffi-builder environment exactly.
+        if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          PROTOC_GEN_GO_VERSION: ${{ steps.protoc.outputs.version }}
+        run: |
+          mkdir -p prebuilt-cffi
+          docker run --rm \
+            -e GO_VERSION="${GO_VERSION}" \
+            -e PROTOC_GEN_GO_VERSION \
+            -v "${{ github.workspace }}/baml-source:/baml-source" \
+            -v "${{ github.workspace }}/prebuilt-cffi:/out" \
+            rust:bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 \
+            bash -euo pipefail -c '
+              apt-get update >/dev/null && apt-get install -y wget >/dev/null
+              arch=$(dpkg --print-architecture)
+              wget -q "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz"
+              tar -C /usr/local -xzf "go${GO_VERSION}.linux-${arch}.tar.gz"
+              export GOPATH=/go
+              export PATH="/usr/local/go/bin:/go/bin:${PATH}"
+              go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}
+              cd /baml-source/engine
+              cargo build --release -p baml-cli -p baml_cffi
+              cp target/release/libbaml_cffi.so /out/libbaml_cffi.so
+              cp target/release/baml-cli /out/baml-cli
+            '
+
+      - name: Upload prebuilt cffi artifact
+        uses: actions/upload-artifact@v4
+        with:
+          # Name keyed on the source commit so overlapping retention windows
+          # across runs can never hand a cell the wrong commit's artifact.
+          name: baml-cffi-${{ steps.baml-source.outputs.commit }}
+          path: |
+            prebuilt-cffi/libbaml_cffi.so
+            prebuilt-cffi/baml-cli
+          retention-days: 1
+          if-no-files-found: error
+
   integration-tests-baml-source:
+    needs: build-baml-cffi
     runs-on: ubuntu-latest
     # The baml-source matrix builds BAML from source, which dominates the
     # per-cell wall time and pushes consistent runs into the 38-45m
@@ -228,6 +336,16 @@ jobs:
           ref: ${{ steps.baml-source.outputs.commit }}
           path: baml-source
 
+      - name: Download prebuilt cffi artifact
+        # Built once by build-baml-cffi (same source commit -> same artifact
+        # name). Injecting it lets the Docker build COPY the .so + baml-cli and
+        # skip the cffi-builder cargo stage, removing ~18m from each cell's
+        # pre-go-test wall time. See #433.
+        uses: actions/download-artifact@v4
+        with:
+          name: baml-cffi-${{ steps.baml-source.outputs.commit }}
+          path: prebuilt-cffi
+
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
         with:
@@ -242,6 +360,10 @@ jobs:
         timeout-minutes: 70
         env:
           BAML_SOURCE: ${{ github.workspace }}/baml-source
+          # Directory of the prebuilt cffi artifact downloaded above. Its
+          # presence flips the Docker build to inject the prebuilt .so + baml-cli
+          # instead of running the in-image cargo build (testutil/container.go).
+          BAML_PREBUILT_CFFI_DIR: ${{ github.workspace }}/prebuilt-cffi
           UNARY_SERVER: ${{ matrix.unary-server }}
           BAML_REST_USE_BUILD_REQUEST: ${{ matrix.use-build-request }}
           BAML_REST_HTTP_CLIENT: ${{ matrix.http-client }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -196,6 +196,8 @@ jobs:
     # here, where a generous cap absorbs it and the matrix cells never see the
     # ~18m under their 67m watchdog. See #433.
     timeout-minutes: 35
+    permissions:
+      contents: read
     outputs:
       commit: ${{ steps.baml-source.outputs.commit }}
     steps:
@@ -204,7 +206,17 @@ jobs:
 
       - name: Read BAML source commit
         id: baml-source
-        run: echo "commit=$(jq -r '.source' integration/baml_versions.json)" >> "$GITHUB_OUTPUT"
+        # Guard against a missing/null .source: jq -r writes the literal
+        # "null" on a missing key, which would propagate as a bogus git ref
+        # and cache input. Fail fast instead. This is the single source of
+        # the commit — the consumer job reads it via needs.*.outputs.commit.
+        run: |
+          commit=$(jq -r '.source // empty' integration/baml_versions.json)
+          if [ -z "$commit" ] || [ "$commit" = "null" ]; then
+            echo "::error file=integration/baml_versions.json::missing non-empty .source BAML source commit"
+            exit 1
+          fi
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
 
       - name: Checkout BAML Source
         uses: actions/checkout@v6.0.3
@@ -230,6 +242,24 @@ jobs:
           echo "Detected protoc-gen-go $ver"
           echo "version=$ver" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve pinned rust image
+        id: rust-image
+        # Single-source the rust base from the Dockerfile FROM pin so the cache
+        # key and the build's docker run both derive from the same digest. A
+        # future digest bump in cmd/build/Dockerfile.tmpl then invalidates this
+        # cache automatically, instead of risking a cache-hit that serves a .so
+        # built under the old toolchain.
+        run: |
+          matches=$(grep -cE '^FROM rust:bookworm@sha256:[0-9a-f]+' cmd/build/Dockerfile.tmpl)
+          if [ "$matches" -ne 1 ]; then
+            echo "::error file=cmd/build/Dockerfile.tmpl::expected exactly one pinned 'FROM rust:bookworm@sha256:' line, found $matches"
+            exit 1
+          fi
+          image=$(grep -oE 'rust:bookworm@sha256:[0-9a-f]+' cmd/build/Dockerfile.tmpl | head -n1)
+          digest=$(printf '%s' "$image" | sed -E 's/.*@sha256://' | cut -c1-12)
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
       - name: Restore prebuilt cffi cache
         id: cache
         uses: actions/cache@v4
@@ -237,25 +267,26 @@ jobs:
           path: prebuilt-cffi
           # Final-artifact cache. The key fully pins the artifact: the BAML
           # source commit fixes the source AND Cargo.lock; the rust:bookworm
-          # digest fragment fixes the toolchain so a silent base bump (which
-          # also flips the Dockerfile FROM digest) invalidates the cache rather
-          # than serving a stale .so. Cargo.lock hash is a cheap belt-and-braces
-          # guard against a dirty tree.
-          key: baml-cffi-${{ runner.os }}-rust-bookworm-19817ead3289-${{ steps.baml-source.outputs.commit }}-${{ hashFiles('baml-source/engine/Cargo.lock') }}
+          # digest fragment (derived from the Dockerfile FROM pin) fixes the
+          # toolchain so a base bump invalidates the cache rather than serving a
+          # stale .so. Cargo.lock hash is a cheap belt-and-braces guard against
+          # a dirty tree.
+          key: baml-cffi-${{ runner.os }}-rust-bookworm-${{ steps.rust-image.outputs.digest }}-${{ steps.baml-source.outputs.commit }}-${{ hashFiles('baml-source/engine/Cargo.lock') }}
           # Partial restores warm the slot for inspection only — a different
           # commit's .so is the WRONG artifact, so the cargo build below gates
           # on an EXACT-key hit (cache-hit == 'true'), not these fallbacks.
           restore-keys: |
-            baml-cffi-${{ runner.os }}-rust-bookworm-19817ead3289-${{ steps.baml-source.outputs.commit }}-
-            baml-cffi-${{ runner.os }}-rust-bookworm-19817ead3289-
+            baml-cffi-${{ runner.os }}-rust-bookworm-${{ steps.rust-image.outputs.digest }}-${{ steps.baml-source.outputs.commit }}-
+            baml-cffi-${{ runner.os }}-rust-bookworm-${{ steps.rust-image.outputs.digest }}-
 
       - name: Build cffi artifact in rust:bookworm
         # Gate on an EXACT-key cache hit only (see restore-keys note above).
         # glibc parity is load-bearing: the .so MUST be compiled inside
         # rust:bookworm (Debian, glibc 2.36), NOT on the bare ubuntu-latest
         # runner (glibc 2.39), or it fails to load in the bookworm-slim runtime
-        # with GLIBC_2.3x-not-found. The digest matches the Dockerfile FROM pin
-        # so this reproduces the in-Docker cffi-builder environment exactly.
+        # with GLIBC_2.3x-not-found. The image is the Dockerfile FROM pin
+        # (resolved above) so this reproduces the in-Docker cffi-builder
+        # environment exactly.
         if: steps.cache.outputs.cache-hit != 'true'
         env:
           PROTOC_GEN_GO_VERSION: ${{ steps.protoc.outputs.version }}
@@ -266,7 +297,7 @@ jobs:
             -e PROTOC_GEN_GO_VERSION \
             -v "${{ github.workspace }}/baml-source:/baml-source" \
             -v "${{ github.workspace }}/prebuilt-cffi:/out" \
-            rust:bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 \
+            "${{ steps.rust-image.outputs.image }}" \
             bash -euo pipefail -c '
               apt-get update >/dev/null && apt-get install -y wget >/dev/null
               arch=$(dpkg --print-architecture)
@@ -325,15 +356,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
 
-      - name: Read BAML source commit
-        id: baml-source
-        run: echo "commit=$(jq -r '.source' integration/baml_versions.json)" >> "$GITHUB_OUTPUT"
-
       - name: Checkout BAML Source
         uses: actions/checkout@v6.0.3
         with:
           repository: BoundaryML/baml
-          ref: ${{ steps.baml-source.outputs.commit }}
+          ref: ${{ needs.build-baml-cffi.outputs.commit }}
           path: baml-source
 
       - name: Download prebuilt cffi artifact
@@ -343,7 +370,7 @@ jobs:
         # pre-go-test wall time. See #433.
         uses: actions/download-artifact@v4
         with:
-          name: baml-cffi-${{ steps.baml-source.outputs.commit }}
+          name: baml-cffi-${{ needs.build-baml-cffi.outputs.commit }}
           path: prebuilt-cffi
 
       - name: Set up Go

--- a/cmd/build/Dockerfile.tmpl
+++ b/cmd/build/Dockerfile.tmpl
@@ -1,9 +1,11 @@
 # Go version (defined once, re-declared in each stage that needs it)
 ARG GO_VERSION=1.26.3
 
-{{- if .bamlSource }}
-# Rust builder stage: Build BAML CFFI library and CLI from source
-FROM rust:bookworm AS cffi-builder
+{{- if and .bamlSource (not .prebuiltCffi) }}
+# Rust builder stage: Build BAML CFFI library and CLI from source.
+# Pinned to a digest so a silent base-image bump cannot change the
+# toolchain (and thus the produced .so) underneath a fixed cache key.
+FROM rust:bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 AS cffi-builder
 
 # Install Go (needed for protoc-gen-go during CFFI build)
 ARG TARGETARCH{{ if .defaultTargetArch }}={{ .defaultTargetArch }}{{ end }}
@@ -71,14 +73,30 @@ COPY baml_src /workspace/baml_src
 COPY baml_rest /workspace/baml_rest
 
 {{- if .bamlSource }}
+{{- if .prebuiltCffi }}
+# Copy prebuilt CFFI library and CLI from the build context (the cffi-builder
+# cargo stage is skipped — the artifacts were built once in a dedicated CI job
+# inside the same rust:bookworm base for glibc parity, then injected here).
+COPY prebuilt/libbaml_cffi.so /workspace/custom_baml_lib.so
+COPY prebuilt/baml-cli /usr/local/bin/baml-cli
+# upload/download-artifact does not preserve the executable bit, so restore it.
+RUN chmod +x /usr/local/bin/baml-cli
+{{- else }}
 # Copy built CFFI library and CLI from Rust stage
 COPY --from=cffi-builder /baml_engine/target/release/libbaml_cffi.so /workspace/custom_baml_lib.so
 COPY --from=cffi-builder /baml_engine/target/release/baml-cli /usr/local/bin/baml-cli
+{{- end }}
 
 # Assemble Go module for replace directive (go.mod is at repo root, Go source under engine/)
 COPY baml_go.mod /workspace/custom_baml_go_lib/go.mod
 COPY baml_go.sum* /workspace/custom_baml_go_lib/
+{{- if .prebuiltCffi }}
+# language_client_go is plain Go source (not a cargo output), copied from the
+# build context rather than the skipped cffi-builder stage.
+COPY baml_engine/language_client_go /workspace/custom_baml_go_lib/engine/language_client_go
+{{- else }}
 COPY --from=cffi-builder /baml_engine/language_client_go /workspace/custom_baml_go_lib/engine/language_client_go
+{{- end }}
 RUN touch /workspace/custom_baml_go_lib/.provided
 {{- else }}
 {{- if not .noCustomBamlLib }}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -40,6 +40,12 @@ var BAMLVersion string
 // BAMLSourcePath is the path to a local BAML source repo (set via BAML_SOURCE env var)
 var BAMLSourcePath string
 
+// PrebuiltCffiDir is the path to a directory holding a prebuilt libbaml_cffi.so
+// + baml-cli (set via BAML_PREBUILT_CFFI_DIR). When set (CI only), the Docker
+// build injects these artifacts and skips the in-image cargo build. Unset for
+// local runs, which keep building the cffi lib from source.
+var PrebuiltCffiDir string
+
 // UseBuildRequest is true when the test container runs the BuildRequest path.
 // Set in TestMain from the BAML_REST_USE_BUILD_REQUEST env var.
 var UseBuildRequest bool
@@ -62,6 +68,7 @@ func matrixSetupOptions() testutil.SetupOptions {
 		BAMLVersion:     BAMLVersion,
 		AdapterVersion:  adapterVersion,
 		BAMLSource:      BAMLSourcePath,
+		PrebuiltCffiDir: PrebuiltCffiDir,
 		UnaryServer:     unaryServer,
 		UseBuildRequest: UseBuildRequest,
 		InProcess:       inProcessBuild,
@@ -103,6 +110,7 @@ func parseBoolEnv(value string) bool {
 
 func init() {
 	BAMLSourcePath = os.Getenv("BAML_SOURCE")
+	PrebuiltCffiDir = os.Getenv("BAML_PREBUILT_CFFI_DIR")
 	BAMLVersion = getBAMLVersion()
 }
 

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -100,6 +100,15 @@ type SetupOptions struct {
 	// BAMLSource is the path to a local BAML source repository for building from unreleased versions
 	BAMLSource string
 
+	// PrebuiltCffiDir, when set, points at a directory holding a prebuilt
+	// libbaml_cffi.so + baml-cli (built once in CI inside rust:bookworm for
+	// glibc parity). When set, the in-Docker cargo build (cffi-builder stage)
+	// is skipped and these artifacts are injected into the build context
+	// instead. Requires BAMLSource to be set (for language_client_go source).
+	// When unset, behavior is unchanged: the cffi lib is built from source
+	// inside the Docker image (the local-dev default).
+	PrebuiltCffiDir string
+
 	// UnaryServer enables the opt-in chi/net-http unary server on port 8081.
 	UnaryServer bool
 
@@ -630,6 +639,7 @@ type dockerfileTemplateData struct {
 	noCacheMount       bool   // Disable BuildKit cache mount (not supported in testcontainers)
 	noCustomBamlLib    bool   // Don't copy custom_baml_lib.so (not used in tests)
 	bamlSource         bool   // Build from BAML source (enables cffi-builder stage)
+	prebuiltCffi       bool   // Inject prebuilt cffi artifacts instead of running the cffi-builder cargo stage
 	protocGenGoVersion string // protoc-gen-go version for BAML source builds
 	unaryServer        bool   // Build with unaryserver tag for chi unary server
 	inProcess          bool   // Build single-process server+worker (drops subprocess tag)
@@ -646,6 +656,7 @@ func (d dockerfileTemplateData) toMap() map[string]any {
 		"noCacheMount":       d.noCacheMount,
 		"noCustomBamlLib":    d.noCustomBamlLib,
 		"bamlSource":         d.bamlSource,
+		"prebuiltCffi":       d.prebuiltCffi,
 		"protocGenGoVersion": d.protocGenGoVersion,
 		"unaryServer":        d.unaryServer,
 		"inProcess":          d.inProcess,
@@ -683,6 +694,7 @@ func createBAMLRestBuildContext(opts SetupOptions) (io.ReadSeeker, error) {
 
 	if opts.BAMLSource != "" {
 		tmplData.bamlSource = true
+		tmplData.prebuiltCffi = opts.PrebuiltCffiDir != ""
 		protocGenGoVersion, err := detectProtocGenGoVersion(opts.BAMLSource)
 		if err != nil {
 			return nil, fmt.Errorf("failed to detect protoc-gen-go version: %w", err)
@@ -747,12 +759,34 @@ func createBAMLRestBuildContext(opts SetupOptions) (io.ReadSeeker, error) {
 
 	// Add BAML source to build context for --baml-source builds
 	if opts.BAMLSource != "" {
-		// Copy engine directory (for Rust CFFI/CLI build), excluding large/irrelevant dirs
-		engineDir := filepath.Join(opts.BAMLSource, "engine")
-		if err := addDirToTarExclude(tw, engineDir, "baml_engine", map[string]bool{
-			"target": true, ".git": true, "node_modules": true,
-		}); err != nil {
-			return nil, fmt.Errorf("failed to copy BAML engine source: %w", err)
+		if opts.PrebuiltCffiDir != "" {
+			// Prebuilt path: inject the cffi artifacts built once in CI and
+			// skip taring the full engine/ tree (the cffi-builder cargo stage
+			// is gone). language_client_go is plain Go source still required
+			// for the module replace directive, so tar just that subtree.
+			soSrc := filepath.Join(opts.PrebuiltCffiDir, "libbaml_cffi.so")
+			if err := addFileToTar(tw, soSrc, "prebuilt/libbaml_cffi.so"); err != nil {
+				return nil, fmt.Errorf("failed to add prebuilt libbaml_cffi.so: %w", err)
+			}
+			cliSrc := filepath.Join(opts.PrebuiltCffiDir, "baml-cli")
+			if err := addFileToTar(tw, cliSrc, "prebuilt/baml-cli"); err != nil {
+				return nil, fmt.Errorf("failed to add prebuilt baml-cli: %w", err)
+			}
+
+			lcgDir := filepath.Join(opts.BAMLSource, "engine", "language_client_go")
+			if err := addDirToTarExclude(tw, lcgDir, "baml_engine/language_client_go", map[string]bool{
+				"target": true, ".git": true, "node_modules": true,
+			}); err != nil {
+				return nil, fmt.Errorf("failed to copy language_client_go source: %w", err)
+			}
+		} else {
+			// Copy engine directory (for Rust CFFI/CLI build), excluding large/irrelevant dirs
+			engineDir := filepath.Join(opts.BAMLSource, "engine")
+			if err := addDirToTarExclude(tw, engineDir, "baml_engine", map[string]bool{
+				"target": true, ".git": true, "node_modules": true,
+			}); err != nil {
+				return nil, fmt.Errorf("failed to copy BAML engine source: %w", err)
+			}
 		}
 
 		// Copy go.mod and go.sum from repo root (needed for Go module replace directive)


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## What & why

The `integration-tests-baml-source` matrix (8 cells) trips the 67m suite watchdog because **each** cell rebuilds the BAML cffi lib from Rust source (`cargo build --release`, ~18.5m, zero caching) *inside* the testcontainers Docker build before `go test` even starts, leaving too little room for the growing bamlfuzz suite. This is CI/test-infra only — **no product behavior change**.

## Design

Build the cffi artifact **once** in a dedicated prebuild job, cache it, and inject it into the 8 cells so they skip cargo entirely.

- **New `build-baml-cffi` job**: checkout repo → read `.source` → checkout `BoundaryML/baml@<commit>` → `actions/cache` (final-artifact strategy) → on an **exact-key cache miss**, `docker run` the pinned `rust:bookworm` to `cargo build --release -p baml-cli -p baml_cffi` and copy `libbaml_cffi.so` + `baml-cli` into a cached dir → `upload-artifact`. `timeout-minutes: 35`.
- **`integration-tests-baml-source`**: `needs: build-baml-cffi`; adds a `download-artifact` step; sets `BAML_PREBUILT_CFFI_DIR` to the download path. **Budget (67m/70m/65m/75m) left exactly as-is** — the freed ~18m becomes pure headroom.
- **`cmd/build/Dockerfile.tmpl`**: new `{{ if .prebuiltCffi }}` branch — skips the `cffi-builder` cargo stage, `COPY`s the prebuilt `.so` (→ `custom_baml_lib.so`) and `baml-cli` (→ `/usr/local/bin/baml-cli`) from the build context, and still copies `language_client_go` (plain Go source) from source. A `chmod +x` restores the CLI's exec bit (upload/download-artifact strips it).
- **`integration/testutil/container.go`** + **`integration/integration_test.go`**: `PrebuiltCffiDir` (`SetupOptions`) fed from the new `BAML_PREBUILT_CFFI_DIR` env; when set, the build context injects the two prebuilt files and skips taring the full `baml_engine/` tree. **When unset, behavior is byte-for-byte unchanged** — local devs keep the in-Docker source build.

## rust:bookworm digest pin

Pinned `rust:bookworm` to the multi-arch index digest **`sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9`** (resolved via `docker buildx imagetools inspect`) in both the Dockerfile `FROM` and the prebuild's `docker run`, and embedded its `19817ead3289` fragment in the cache key. A silent base-image bump now flips the digest → invalidates the cache rather than serving a stale `.so` under the fixed source-commit key. This also pins the local-dev source-build base (deliberate, per the locked decision).

## Critical correctness constraints

- **glibc parity (load-bearing):** the prebuild compiles the `.so` **inside `rust:bookworm`** (Debian, glibc 2.36) via `docker run`, **not** on the bare `ubuntu-latest` runner (glibc 2.39). A host-built `.so` would link newer glibc symbols and fail to load in the `debian:bookworm-slim` runtime.
- **Cold-miss stays green:** the ~18m cargo build lives in the prebuild job, **outside** the 67m watchdog. Even on a cold cache (a Renovate `.source` bump) the 8 cells only download + do the ~4–5m Go build before `go test`.
- **Exact-key gate:** the cargo build is gated on `cache-hit == 'true'`, not a partial `restore-keys` match — a different commit's `.so` is the wrong artifact.
- **`protoc-gen-go` version** is detected from the generated `.pb.go` marker (mirroring `detectProtocGenGoVersion`, currently `v1.34.1`) and passed into the docker run, matching the in-Docker build.

## Validation

Done locally (cheap):
- Rendered `Dockerfile.tmpl` with `prebuiltCffi=true/false`: `cffi-builder` stage gone on `true`, two `COPY`s point at the build context, `language_client_go` still copied; `false` is unchanged (plus the new FROM digest).
- `go build ./...`, `go vet -tags=integration,subprocess ./integration/...`, `go build -tags=integration,subprocess ./integration/...` — all pass.
- `go run ./cmd/embed && git diff --exit-code` — **clean** (no embedded `.go` file changed).
- Workflow YAML parses; jobs + `needs` wiring verified.

**Full validation happens in CI** — the prebuild-job cold/warm cache behavior (cache-miss build → upload, warm restore → skip cargo, forced-miss-stays-green) can't be exercised locally and isn't run here (it would build BAML from source ~18m).

Fixes #433


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI caching and a dedicated build job to produce and reuse prebuilt native artifacts, reducing redundant compilation.
  * Integration tests can now inject prebuilt artifacts into their build context for faster, more reliable test runs.
  * Docker build paths updated to support optional prebuilt artifacts and use a pinned base image for reproducible builds.
  * Improved artifact reuse across test runs for more efficient CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->