### PR TITLE
ci: add explicit 20m timeout to unit-tests -race -count=100 stress runs

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -65,9 +65,9 @@ jobs:
           find . -name go.mod -not -path '*/adapters/adapter_*' -not -path '*/dynclient/baml-patched/*' -exec dirname {} \; | while read dir; do
             echo "=== Testing $dir ==="
             if [ "$dir" = "./adapters/common" ]; then
-              (cd "$dir" && GOWORK=off go test -race -count=100 ./...)
+              (cd "$dir" && GOWORK=off go test -race -count=100 -timeout 20m ./...)
             else
-              (cd "$dir" && go test -race -count=100 ./...)
+              (cd "$dir" && go test -race -count=100 -timeout 20m ./...)
             fi
           done
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Add explicit 20m package timeout to `-race -count=100` stress runs

`.github/workflows/unit-tests.yml` runs `go test -race -count=100 ./...` per
module in its main loop, relying on Go's implicit 600s (10m) package timeout.
The `adapters/common/codegen` package runs at ~529s under that CI-shaped
command (and ~535s in a passing x/net v0.56.0 run), leaving only ~65–70s of
headroom. That is a latent timeout cliff: ordinary runner/cache/race-detector
variance or moderate test growth can push it over 600s and produce
`panic: test timed out after 10m0s`.

### Change
Add `-timeout 20m` to **both** `-race -count=100` invocations in the main loop:
- the `./adapters/common` `GOWORK=off` branch (line 68)
- the sibling normal-workspace branch (line 70)

20m gives ~2.25× headroom over the 529s baseline — enough for variance and
near-term growth. This does **not** disable hang detection: a genuinely stuck
package still fails with Go's own timeout (now at 20m, with a useful test stack
dump) well before the job-level `timeout-minutes: 35` kill switch. Both
invocations get the flag so the high-count race-test pattern has a consistent
package-timeout policy across all modules rather than leaving the same latent
failure mode on the sibling branch.

### Why de-count is deferred
`TestPoolLifecycle_RegressionSeeds` is the dominant cost driver (four
regression-seed subtests, each shelling out to `go test` via the test harness,
repeated by `-count=100`). Pulling it out of the loop would change coverage
semantics — the seeds would lose the same `-race -count=100` stress envelope as
the rest of the package. That is a runtime-reduction change driven by a
wall-clock goal, not part of this minimal timeout-hardening fix, so it is left
for a follow-up.

### Validation
- `go run ./cmd/embed && git diff` shows no embedded `.go` drift — only the
  workflow YAML differs.
- Workflow YAML parses cleanly.
- `rg` confirms only the two main-loop stress commands carry `-race -count=100`,
  and both now include `-timeout 20m`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to run unit tests with enhanced race condition detection, increased iteration count, and extended timeouts for improved test coverage across all modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->