### PR TITLE
ci: populate workspace checksums in renovate-sync + harden dynclient go.work.sum gate (#442)

### DIFF
--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -60,31 +60,33 @@ jobs:
       - name: Run scripts/sync.sh
         run: ./scripts/sync.sh
 
-      - name: Populate workspace module checksums
-        # scripts/sync.sh reconciles go.mod/go.sum and some go.work.sum
-        # entries, but `go work sync` + `GOWORK=off go mod tidy` do not
-        # force a download/verify of every module zip the workspace tests
-        # later load. That left module-content `h1:` lines (e.g.
-        # golang.org/x/crypto vX.Y.Z) missing from go.work.sum after a
-        # dep-bump sync, so the first workspace-mode package load in
-        # unit-tests appended them and dirtied the tree before
-        # cmd/regenerate-dynclient (#442 / unblocks #438).
-        #
-        # Mirror the unit-tests.yml workspace-mode module traversal but use
-        # `go list -deps -test` instead of running tests: it forces module
-        # zip verification so Go appends the required workspace checksums
-        # before the allowlist/commit step below.
-        run: |
-          find . -name go.mod -not -path '*/adapters/adapter_*' -not -path '*/dynclient/baml-patched/*' -exec dirname {} \; | while read -r dir; do
-            if [ "$dir" = "./adapters/common" ]; then
-              (cd "$dir" && GOWORK=off go list -deps -test ./... >/dev/null)
-            else
-              (cd "$dir" && go list -deps -test ./... >/dev/null)
-            fi
-          done
-
       - name: Validate, commit, and push sync result
         run: |
+          # scripts/sync.sh reconciles go.mod/go.sum and some go.work.sum
+          # entries, but `go work sync` + `GOWORK=off go mod tidy` do not
+          # force a download/verify of every module zip the workspace tests
+          # later load. That left module-content `h1:` lines (e.g.
+          # golang.org/x/crypto vX.Y.Z) missing from go.work.sum after a
+          # dep-bump sync, so the first workspace-mode package load in
+          # unit-tests appended them and dirtied the tree before
+          # cmd/regenerate-dynclient (#442 / unblocks #438).
+          #
+          # Mirror the unit-tests.yml workspace-mode module traversal but use
+          # `go list -deps -test` instead of running tests: it forces module
+          # zip verification so Go appends the required workspace checksums.
+          # Defined once and called after EVERY ./scripts/sync.sh run (the
+          # initial step above and the non-fast-forward retry below), so the
+          # populate-then-validate sequence is identical on both passes.
+          populate_workspace_checksums() {
+            find . -name go.mod -not -path '*/adapters/adapter_*' -not -path '*/dynclient/baml-patched/*' -exec dirname {} \; | while read -r dir; do
+              if [ "$dir" = "./adapters/common" ]; then
+                (cd "$dir" && GOWORK=off go list -deps -test ./... >/dev/null)
+              else
+                (cd "$dir" && go list -deps -test ./... >/dev/null)
+              fi
+            done
+          }
+
           # Allowlist: only Go module metadata may change.
           #   go.mod, go.sum, go.work.sum at the root, and go.mod / go.sum
           #   under any nested module directory. Anything else (tracked or
@@ -149,6 +151,9 @@ jobs:
           }
 
           # ---- first pass: validate, commit, push ----
+          # Initial ./scripts/sync.sh already ran in the step above; force
+          # workspace module-content checksums before validating.
+          populate_workspace_checksums
           validate_diff_allowlist
 
           if [ -z "$(git status --porcelain --untracked-files=all)" ]; then
@@ -175,6 +180,7 @@ jobs:
           git fetch origin "${GITHUB_REF_NAME}"
           git reset --hard "origin/${GITHUB_REF_NAME}"
           ./scripts/sync.sh
+          populate_workspace_checksums
           validate_diff_allowlist
           if [ -z "$(git status --porcelain --untracked-files=all)" ]; then
             echo "Sync is a no-op on top of remote; nothing to push."

--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -7,7 +7,11 @@ on:
 
 concurrency:
   group: renovate-sync-${{ github.ref }}
-  cancel-in-progress: true
+  # A github-actions[bot] sync commit pushed by this workflow must not
+  # cancel the dep-bump run that just produced it (that older run is
+  # finishing post-job cleanup). Real Renovate dep-bump/rebase pushes
+  # (authored by renovate[bot]) still cancel older in-flight sync runs.
+  cancel-in-progress: ${{ github.event.head_commit.author.name != 'github-actions[bot]' }}
 
 env:
   GO_VERSION: "1.26.3"
@@ -55,6 +59,29 @@ jobs:
 
       - name: Run scripts/sync.sh
         run: ./scripts/sync.sh
+
+      - name: Populate workspace module checksums
+        # scripts/sync.sh reconciles go.mod/go.sum and some go.work.sum
+        # entries, but `go work sync` + `GOWORK=off go mod tidy` do not
+        # force a download/verify of every module zip the workspace tests
+        # later load. That left module-content `h1:` lines (e.g.
+        # golang.org/x/crypto vX.Y.Z) missing from go.work.sum after a
+        # dep-bump sync, so the first workspace-mode package load in
+        # unit-tests appended them and dirtied the tree before
+        # cmd/regenerate-dynclient (#442 / unblocks #438).
+        #
+        # Mirror the unit-tests.yml workspace-mode module traversal but use
+        # `go list -deps -test` instead of running tests: it forces module
+        # zip verification so Go appends the required workspace checksums
+        # before the allowlist/commit step below.
+        run: |
+          find . -name go.mod -not -path '*/adapters/adapter_*' -not -path '*/dynclient/baml-patched/*' -exec dirname {} \; | while read -r dir; do
+            if [ "$dir" = "./adapters/common" ]; then
+              (cd "$dir" && GOWORK=off go list -deps -test ./... >/dev/null)
+            else
+              (cd "$dir" && go list -deps -test ./... >/dev/null)
+            fi
+          done
 
       - name: Validate, commit, and push sync result
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -124,6 +124,16 @@ jobs:
         # accumulates silently across PRs (the latent-drift class of bug
         # that produced #299).
         run: |
+          # go.work.sum may be dirtied by earlier workspace-mode Go commands
+          # (the per-module test loop above appends additive module-content
+          # checksums). Restore the committed version before checking
+          # dynclient-owned drift. This only discards uncommitted go.work.sum
+          # mutations — `git checkout -- go.work.sum` restores it to HEAD,
+          # which already includes any committed PR change, and the full-tree
+          # status check immediately below still fails on every other dirty
+          # file (#442).
+          git checkout -- go.work.sum 2>/dev/null || true
+
           if [ -n "$(git status --porcelain)" ]; then
             echo "ERROR: tree is dirty before cmd/regenerate-dynclient."
             git status --short


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Workflow/CI-only change fixing #442. Two pieces.

## Piece 1 — `renovate-sync.yml`: close the content-hash gap

`scripts/sync.sh` (`go work sync` + `GOWORK=off go mod tidy`) reconciles `go.mod`/`go.sum` and some `go.work.sum` entries, but it does **not** force a download/verify of every module zip the workspace tests later load. For #438 the sync commit added only `.../go.mod` checksum lines (e.g. `golang.org/x/crypto v0.53.0/go.mod`), leaving the module-content `h1:` line missing from `go.work.sum`. The first workspace-mode package load in `unit-tests` then appended that line and dirtied the tree before `cmd/regenerate-dynclient`, failing CI.

- **New step `Populate workspace module checksums`** sits between `Run scripts/sync.sh` and `Validate, commit, and push sync result`. It mirrors the `unit-tests.yml` workspace-mode module traversal (same `find` exclusions, same `adapters/common` `GOWORK=off` special-case) but runs `go list -deps -test ./...` instead of tests. That forces module-zip verification so Go appends the required workspace checksums **before** the allowlist/commit step — the sync commit now carries the content hash.
- **Conditional `cancel-in-progress`** (`${{ github.event.head_commit.author.name != 'github-actions[bot]' }}`): a `github-actions[bot]` sync commit no longer self-cancels the dep-bump run that just pushed it (status noise during post-job cleanup). Real `renovate[bot]` dep-bump/rebase pushes still cancel older in-flight sync runs.
- The job-level loop-guard `if:` is **unchanged** — it correctly skips the sync commit's own re-trigger while still running `renovate[bot]`-authored dep bumps.

## Piece 2 — `unit-tests.yml`: harden the dynclient fresh-tree gate

Inside `cmd/regenerate-dynclient fresh-tree gate`, restore the committed `go.work.sum` immediately **before** the before-regen dirty check:

```yaml
git checkout -- go.work.sum 2>/dev/null || true
```

This discards only **uncommitted** `go.work.sum` drift left by earlier workspace-mode Go commands. It restores to `HEAD`, so a committed PR change to `go.work.sum` is preserved, and the full-tree `git status --porcelain` immediately after still fails on every other dirty file. The existing post-regen `go.work.sum` checkout and both dirty checks are left intact.

## Validation
- Both workflow YAMLs parse.
- `go run ./cmd/embed && git diff` → only the two YAMLs changed, no `.go` drift.

Fixes #442. Unblocks #438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD reliability for dependency and module automation by refining sync workflow concurrency so bot-triggered syncs don’t cancel the runs that generated their commits.
  * Added consistent checksum population across nested Go modules before validation/commit and during retry handling.
  * Updated unit-test regeneration gating to reset `go.work.sum` to the committed state to avoid false “tree dirty” failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->