### PR TITLE
test: cap heavy codegen tests' -count repeats via testharness.CapStress (#444)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,13 @@ env:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    # Cap the handful of subprocess-backed codegen tests that call
+    # testharness.CapStress at 5 inner runs instead of the global
+    # -count=100. Unset means uncapped (local + nightly keep full
+    # -count); only this job carries the knob. See
+    # adapters/common/codegen/internal/testharness/stress.go.
+    env:
+      BAML_HEAVY_TEST_RUNS: "5"
     # -race -count=100 across every module has grown past the 10-minute
     # cap as suites expanded (bamlutils/buildrequest ~4 min,
     # pool ~4 min on their own). 25 leaves headroom for further growth

--- a/adapters/common/codegen/codegen_pool_lifecycle_test.go
+++ b/adapters/common/codegen/codegen_pool_lifecycle_test.go
@@ -34,6 +34,7 @@ import (
 // Inner failures bubble up as the captured `go test` output pinned
 // into the outer fatal message.
 func TestPoolLifecycle(t *testing.T) {
+	testharness.CapStress(t)
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skipf("go binary not on PATH: %v", err)
 	}
@@ -46,6 +47,7 @@ func TestPoolLifecycle(t *testing.T) {
 // (so the harness lost coverage) or this seed has drifted out of sync
 // with the relevant emission path.
 func TestPoolLifecycle_RegressionSeeds(t *testing.T) {
+	testharness.CapStress(t)
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skipf("go binary not on PATH: %v", err)
 	}

--- a/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
+++ b/adapters/common/codegen/codegen_slice_pool_compile_matrix_test.go
@@ -41,6 +41,7 @@ import (
 // the single-non-pooled cell, which `go build` alone wouldn't catch
 // (an unnecessary closure would still compile).
 func TestCompileMatrix(t *testing.T) {
+	testharness.CapStress(t)
 	t.Parallel()
 
 	// Skip when `go` is not on PATH (the subprocess compile step

--- a/adapters/common/codegen/internal/testharness/stress.go
+++ b/adapters/common/codegen/internal/testharness/stress.go
@@ -1,0 +1,97 @@
+package testharness
+
+import (
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// HeavyTestRunsEnv is the environment variable that caps how many
+// times an opted-in heavy test actually executes under `go test
+// -count=N`. It exists because the unit-tests workflow runs the whole
+// suite with `-race -count=100` for race-stress coverage, but a
+// handful of subprocess-backed codegen tests (each shelling out to an
+// inner `go build` / `go test`) would dominate CI wallclock at 100
+// repeats while adding little marginal race coverage.
+//
+// Semantics:
+//   - Unset or empty: UNCAPPED. This preserves the local `go test`
+//     default and the nightly fuzz workflow, neither of which should
+//     silently lose `-count` iterations.
+//   - Positive integer N: opted-in tests run for iterations 1..N and
+//     skip on iteration N+1 and later.
+//   - Invalid or non-positive: the calling test FAILS fast. A typo in
+//     CI (e.g. BAML_HEAVY_TEST_RUNS=abc) must not silently remove the
+//     cap.
+//
+// The .github/workflows/unit-tests.yml `unit-tests` job sets this to
+// "5"; no other workflow sets it.
+const HeavyTestRunsEnv = "BAML_HEAVY_TEST_RUNS"
+
+// heavyTestRunCounts tracks, per logical cap key, how many times
+// CapStressKey has been reached in this test process. `go test
+// -count=N` reruns a package's tests within a single test process, so
+// package-level state accumulates across the N iterations — that is
+// the load-bearing assumption that lets this counter cap repeats.
+// Counters are *atomic.Int64 because parallel tests / parallel
+// subtests may reach the helper concurrently.
+var heavyTestRunCounts sync.Map // map[string]*atomic.Int64
+
+// CapStress is the ergonomic default for a top-level heavy test whose
+// logical cap unit is exactly its name. Call it before expensive setup
+// and before t.Parallel().
+func CapStress(t *testing.T) {
+	t.Helper()
+	CapStressKey(t, t.Name())
+}
+
+// CapStressKey caps a heavy test keyed by an explicit, stable `key`.
+// Use it for subtests / table-driven rows where the logical cap unit
+// is not exactly t.Name() — the key must come from a deterministic
+// case id, not map iteration order or a duplicate generated subtest
+// name.
+//
+// If HeavyTestRunsEnv is unset/empty the call returns immediately
+// (uncapped). If it is a positive integer N, the first N reaches for
+// `key` proceed and every later reach calls t.Skipf. An invalid or
+// non-positive value fails the test via t.Fatalf.
+func CapStressKey(t *testing.T, key string) {
+	t.Helper()
+
+	limit, ok := heavyTestRunCap(t)
+	if !ok {
+		// Unset/empty: uncapped.
+		return
+	}
+
+	counterAny, _ := heavyTestRunCounts.LoadOrStore(key, new(atomic.Int64))
+	counter := counterAny.(*atomic.Int64)
+	run := counter.Add(1)
+	if run > int64(limit) {
+		t.Skipf("%s: skipping run %d (cap %d via %s=%d); unset %s for uncapped runs",
+			key, run, limit, HeavyTestRunsEnv, limit, HeavyTestRunsEnv)
+	}
+}
+
+// heavyTestRunCap parses HeavyTestRunsEnv. It returns (0, false) when
+// the var is unset/empty (uncapped). For a positive integer it returns
+// (N, true). For any invalid or non-positive value it fails the test
+// via t.Fatalf rather than silently uncapping — a CI typo must not
+// quietly drop the cap.
+func heavyTestRunCap(t *testing.T) (int, bool) {
+	t.Helper()
+	raw, set := os.LookupEnv(HeavyTestRunsEnv)
+	if !set || raw == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		t.Fatalf("%s=%q is not a valid integer: %v", HeavyTestRunsEnv, raw, err)
+	}
+	if n <= 0 {
+		t.Fatalf("%s=%q must be a positive integer (got %d); unset it for uncapped runs", HeavyTestRunsEnv, raw, n)
+	}
+	return n, true
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes #444.

## Problem

The `unit-tests` workflow runs `-race -count=100` across every module for race-stress. A handful of subprocess-backed codegen tests each shell out to an inner `go build` / `go test`, so at 100 repeats they dominate CI wallclock (`TestPoolLifecycle_RegressionSeeds` alone is ~6–7 min) while adding little marginal race coverage.

## Solution

A shared cap helper, opted into the three heaviest deterministic codegen tests. The global `-race -count=100` stays intact for the cheap majority.

### Helper — `adapters/common/codegen/internal/testharness/stress.go`

Non-`_test.go` so the `codegen` test package can import it.

- `const HeavyTestRunsEnv = "BAML_HEAVY_TEST_RUNS"`
- `CapStress(t)` — caps a top-level test keyed by `t.Name()`.
- `CapStressKey(t, key)` — caps by an explicit stable key.

`BAML_HEAVY_TEST_RUNS` semantics:

- **Unset/empty → uncapped.** Local `go test` and the nightly fuzz workflow keep full `-count`.
- **Positive integer N → cap.** Opted-in tests run iterations `1..N`, then `t.Skipf` on `N+1`+.
- **Invalid/non-positive → `t.Fatalf` (fail-fast).** A CI typo must not silently drop the cap.

Counters are a package-level `sync.Map[string]*atomic.Int64`. `go test -count=N` reuses one test process per package, so the counter accumulates across the N iterations (verified on Go 1.26.3, including `-race`, `t.Parallel()`, and subtests). Atomic because parallel tests/subtests can reach the helper concurrently.

### Opted-in tests

- `TestPoolLifecycle` — `CapStress(t)` at the top.
- `TestPoolLifecycle_RegressionSeeds` — `CapStress(t)` at the top (caps the 4-seed suite as one unit).
- `TestCompileMatrix` — `CapStress(t)` **before** `t.Parallel()`.

`cmd/hacks` (already self-gated) and the `pool` soak test are intentionally untouched.

### CI

`.github/workflows/unit-tests.yml` `unit-tests` job gains `env: BAML_HEAVY_TEST_RUNS: "5"`. The `-race -count=100 -timeout 20m` commands are unchanged. `bamlfuzz-nightly.yml` is **not** touched (its fuzz/oracle steps already use `-count=1`).

### Embed

The helper is under `codegen/internal`, which `.embedignore` excludes entirely — no `cmd/embed` regeneration needed. `go run ./cmd/embed && git diff` shows zero `embed.go` drift.

## Evidence

| Run | Result |
| --- | --- |
| CAP (`RUNS=2`, `-count=4`) | 2 full runs, then 2 `SKIP` (cap message) |
| UNCAPPED (unset, `-count=3`) | 3 full runs, no skip |
| INVALID (`RUNS=abc`) | `FAIL` fast (not silently uncapped) |
| MIXED (`RUNS=1`, `-count=3`) | cheap test 3×, heavy 1× + 2 skips |
| `go run ./cmd/embed` | zero `embed.go` drift |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test harness infrastructure to limit heavy test execution. Tests can now be controlled via the `BAML_HEAVY_TEST_RUNS` environment variable to reduce test duration while maintaining regression coverage for stress-tested operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->