### PR TITLE
ci: authenticate to Docker Hub in integration jobs to avoid pull rate-limit flakes (#447)

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -95,6 +95,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      # Job-level so the Docker Hub login step's own `if:` can read it — a
+      # step-level env is not reliably in scope for that step's own `if:`,
+      # which would skip the login and leave the cold pulls unauthenticated.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     # Single prebuild that resolves the base-image digests, pulls each one
     # ONCE (authenticated), saves it to a tarball, and hands the set to the
     # fuzz matrix as a per-run artifact. This replaces the per-cell anonymous
@@ -117,17 +122,15 @@ jobs:
         # `docker load` the warmed tarballs — so it runs here, before digest
         # resolution and the cold pulls below.
         #
-        # secrets.* can't be referenced directly in a step `if:`, so route the
-        # username through step env and gate on that — the step skips cleanly on
-        # forks / when the secret is absent instead of running login-action with
-        # empty credentials.
+        # secrets.* can't be referenced directly in a step `if:`, so gate on
+        # the job-level DOCKERHUB_USERNAME env (set above) — the step skips
+        # cleanly on forks / when the secret is absent instead of running
+        # login-action with empty credentials.
         if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
       - name: Resolve base-image digests
         id: resolve

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -135,6 +135,26 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Log in to Docker Hub
+        # The fuzz/oracle steps run the integration targets via testcontainers,
+        # which pulls the mock-LLM base off Docker Hub. Authenticated pulls get
+        # a much higher rate limit than anonymous pulls off the shared
+        # GitHub-runner IP pool, which were throttling container setup and
+        # surfacing as "registry-1.docker.io ... context deadline exceeded"
+        # flakes (#447). Runs before the go-test steps that trigger the pull.
+        #
+        # secrets.* can't be referenced directly in a step `if:`, so route the
+        # username through step env and gate on that — the step skips cleanly on
+        # forks / when the secret is absent instead of running login-action with
+        # empty credentials.
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
         with:

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -91,8 +91,140 @@ jobs:
           }' integration/baml_versions.json)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
+  warm-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Single prebuild that resolves the base-image digests, pulls each one
+    # ONCE (authenticated), saves it to a tarball, and hands the set to the
+    # fuzz matrix as a per-run artifact. This replaces the per-cell anonymous
+    # Docker Hub pulls that bursted the shared GitHub-runner IP pool against
+    # Docker Hub's rate limit and surfaced as "registry-1.docker.io ...
+    # context deadline exceeded" container-setup flakes (#447). The fuzz cells
+    # `docker load` the tarballs and never touch Docker Hub — so the Docker
+    # Hub login now lives here, not per cell. Same base set as
+    # integration-tests.yml; no rust (the fuzz job never builds cffi).
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Log in to Docker Hub
+        # Authenticated Docker Hub pulls get a much higher rate limit than
+        # anonymous pulls off the shared GitHub-runner IP pool (#447). This is
+        # the ONLY Docker Hub login in this workflow — the fuzz cells just
+        # `docker load` the warmed tarballs — so it runs here, before digest
+        # resolution and the cold pulls below.
+        #
+        # secrets.* can't be referenced directly in a step `if:`, so route the
+        # username through step env and gate on that — the step skips cleanly on
+        # forks / when the secret is absent instead of running login-action with
+        # empty credentials.
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
+      - name: Resolve base-image digests
+        id: resolve
+        # Resolve each floating tag to its current registry index digest so the
+        # cache key tracks image CONTENT, not the mutable tag, and so the pull
+        # below is by immutable digest (no tag float between resolve and pull).
+        run: |
+          set -euo pipefail
+          for entry in \
+            "node:node:22-bookworm" \
+            "debian:debian:bookworm-slim" \
+            "golang:golang:1.26.3-alpine" \
+            "alpine:alpine:3.19"; do
+            key="${entry%%:*}"
+            ref="${entry#*:}"
+            digest=$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}')
+            echo "$key=$digest" >> "$GITHUB_OUTPUT"
+            echo "resolved $ref -> $digest"
+          done
+
+      # Per-image cross-run caches keyed on the resolved digest: a bump to one
+      # tag re-pulls only that image. On a hit the tarball is restored to disk
+      # and the pull step skips it.
+      - name: Cache node:22-bookworm tarball
+        id: cache-node
+        uses: actions/cache@v5.0.5
+        with:
+          path: warm-images/node.tar
+          key: warm-image-${{ runner.os }}-node-${{ steps.resolve.outputs.node }}
+      - name: Cache debian:bookworm-slim tarball
+        id: cache-debian
+        uses: actions/cache@v5.0.5
+        with:
+          path: warm-images/debian.tar
+          key: warm-image-${{ runner.os }}-debian-${{ steps.resolve.outputs.debian }}
+      - name: Cache golang:1.26.3-alpine tarball
+        id: cache-golang
+        uses: actions/cache@v5.0.5
+        with:
+          path: warm-images/golang.tar
+          key: warm-image-${{ runner.os }}-golang-${{ steps.resolve.outputs.golang }}
+      - name: Cache alpine:3.19 tarball
+        id: cache-alpine
+        uses: actions/cache@v5.0.5
+        with:
+          path: warm-images/alpine.tar
+          key: warm-image-${{ runner.os }}-alpine-${{ steps.resolve.outputs.alpine }}
+
+      - name: Pull and save base images
+        # For each cache miss, pull by immutable digest and tag to the exact
+        # tag the Dockerfiles reference, so testcontainers' tag-based `FROM`
+        # reuses the loaded image with no registry lookup, then `docker save` a
+        # raw tar (Actions compresses the artifact/cache). Cache hits already
+        # have the tar on disk from the restore above.
+        env:
+          NODE_DIGEST: ${{ steps.resolve.outputs.node }}
+          DEBIAN_DIGEST: ${{ steps.resolve.outputs.debian }}
+          GOLANG_DIGEST: ${{ steps.resolve.outputs.golang }}
+          ALPINE_DIGEST: ${{ steps.resolve.outputs.alpine }}
+          NODE_HIT: ${{ steps.cache-node.outputs.cache-hit }}
+          DEBIAN_HIT: ${{ steps.cache-debian.outputs.cache-hit }}
+          GOLANG_HIT: ${{ steps.cache-golang.outputs.cache-hit }}
+          ALPINE_HIT: ${{ steps.cache-alpine.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          mkdir -p warm-images
+
+          warm_tag() {
+            local tag="$1" digest="$2" tarfile="$3" hit="$4"
+            if [ "$hit" = "true" ] && [ -f "warm-images/$tarfile" ]; then
+              echo "cache hit: $tag ($tarfile)"
+              return
+            fi
+            local repo="${tag%%:*}"
+            echo "pulling ${repo}@${digest} -> ${tag}"
+            docker pull "${repo}@${digest}"
+            docker tag "${repo}@${digest}" "$tag"
+            docker save "$tag" -o "warm-images/$tarfile"
+          }
+
+          warm_tag "node:22-bookworm"     "$NODE_DIGEST"   "node.tar"   "$NODE_HIT"
+          warm_tag "debian:bookworm-slim" "$DEBIAN_DIGEST" "debian.tar" "$DEBIAN_HIT"
+          warm_tag "golang:1.26.3-alpine" "$GOLANG_DIGEST" "golang.tar" "$GOLANG_HIT"
+          warm_tag "alpine:3.19"          "$ALPINE_DIGEST" "alpine.tar" "$ALPINE_HIT"
+
+          ls -lh warm-images/
+
+      - name: Upload warm images
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: warm-images-${{ github.run_id }}
+          path: warm-images/*.tar
+          if-no-files-found: error
+          retention-days: 1
+
   fuzz:
-    needs: get-versions
+    needs: [get-versions, warm-images]
     runs-on: ubuntu-latest
     # Each matrix cell runs ONE fuzz target via the `target` axis.
     # Budget per cell:
@@ -116,6 +248,13 @@ jobs:
       BAML_VERSION: ${{ matrix.baml-version }}
       UNARY_SERVER: ${{ matrix.unary-server }}
       BAML_REST_HTTP_CLIENT: nethttp
+      # CI-only: skip the testcontainers Ryuk reaper so setup doesn't
+      # pull/create it from Docker Hub — matching the integration jobs. With
+      # the warm-images set scoped to the integration bases (no ryuk), this
+      # keeps Ryuk from being a stray Docker Hub pull source here (#447). Safe
+      # because GH runners are ephemeral and torn down after the job, so leaked
+      # containers are cleaned up regardless. Never set this for local runs.
+      TESTCONTAINERS_RYUK_DISABLED: true
       BAMLFUZZ_KEEP_ARTIFACTS: "1"
       MODE: ${{ github.event.inputs.mode || 'fuzz' }}
       FUZZTIME: ${{ github.event.inputs.fuzztime || '15m' }}
@@ -135,25 +274,26 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Log in to Docker Hub
-        # The fuzz/oracle steps run the integration targets via testcontainers,
-        # which pulls the mock-LLM base off Docker Hub. Authenticated pulls get
-        # a much higher rate limit than anonymous pulls off the shared
-        # GitHub-runner IP pool, which were throttling container setup and
-        # surfacing as "registry-1.docker.io ... context deadline exceeded"
-        # flakes (#447). Runs before the go-test steps that trigger the pull.
-        #
-        # secrets.* can't be referenced directly in a step `if:`, so route the
-        # username through step env and gate on that — the step skips cleanly on
-        # forks / when the secret is absent instead of running login-action with
-        # empty credentials.
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v4.2.0
+      - name: Download warm base images
+        # Base images are pulled once by the warm-images job and handed over as
+        # a per-run artifact; this cell only loads them — no Docker Hub login,
+        # no pull (#447).
+        uses: actions/download-artifact@v8.0.1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          name: warm-images-${{ github.run_id }}
+          path: warm-images
+
+      - name: Load warm base images
+        # `docker load` the warmed tarballs before the go-test steps so
+        # testcontainers' tag-based `FROM` builds reuse them locally instead of
+        # pulling from Docker Hub.
+        run: |
+          set -euo pipefail
+          for tar in warm-images/*.tar; do
+            echo "loading $tar"
+            docker load -i "$tar"
+          done
+          docker image ls
 
       - name: Set up Go
         uses: actions/setup-go@v6.4.0

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -150,6 +150,11 @@ jobs:
   # Build Docker images (multi-arch)
   build-docker:
     runs-on: ubuntu-latest
+    env:
+      # Job-level so the Docker Hub login step's own `if:` can read it — a
+      # step-level env is not reliably in scope for that step's own `if:`,
+      # which would skip the login and leave the base-image pull unauthenticated.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -165,17 +170,15 @@ jobs:
         # (#447). This is separate from — and in addition to — the ghcr.io login
         # below (ghcr.io is the push target, not the base-image source).
         #
-        # secrets.* can't be referenced directly in a step `if:`, so route the
-        # username through step env and gate on that — the step skips cleanly on
-        # forks / when the secret is absent instead of running login-action with
-        # empty credentials.
+        # secrets.* can't be referenced directly in a step `if:`, so gate on
+        # the job-level DOCKERHUB_USERNAME env (set above) — the step skips
+        # cleanly on forks / when the secret is absent instead of running
+        # login-action with empty credentials.
         if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -202,6 +202,16 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/invakid404/baml-rest-builder,push-by-digest=true,name-canonical=true,push=true
+          # setup-buildx-action's default docker-container driver keeps a build
+          # cache separate from the daemon image store, so a daemon `docker
+          # load` would not warm it — wire up the GitHub Actions BuildKit cache
+          # instead. After one warm run, base layers (FROM node:22-bookworm)
+          # and build steps restore from the gha cache instead of pulling from
+          # Docker Hub (#447); the Docker Hub login above still covers cold
+          # misses. Scoped per arch so the amd64 and arm64 matrix cells don't
+          # clobber each other's cache.
+          cache-from: type=gha,scope=baml-rest-builder-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=baml-rest-builder-${{ matrix.arch }}
 
       - name: Export digest
         run: |

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -158,6 +158,25 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
 
+      - name: Log in to Docker Hub
+        # Dockerfile.builder's `FROM node:22-bookworm` resolves to Docker Hub,
+        # so the build-push-action below does an anonymous base-image pull that
+        # hits the same shared-runner-IP rate limit as the integration jobs
+        # (#447). This is separate from — and in addition to — the ghcr.io login
+        # below (ghcr.io is the push target, not the base-image source).
+        #
+        # secrets.* can't be referenced directly in a step `if:`, so route the
+        # username through step env and gate on that — the step skips cleanly on
+        # forks / when the secret is absent instead of running login-action with
+        # empty credentials.
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -68,6 +68,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      # Job-level so the Docker Hub login step's own `if:` can read it — a
+      # step-level env is not reliably in scope for that step's own `if:`,
+      # which would skip the login and leave the cold pulls unauthenticated.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     # Single prebuild that resolves the base-image digests, pulls each one
     # ONCE (authenticated), saves it to a tarball, and hands the set to every
     # Docker-consuming matrix cell as a per-run artifact. This replaces the
@@ -94,17 +99,15 @@ jobs:
         # `docker load` the warmed tarballs — so it runs here, before digest
         # resolution and the cold pulls below.
         #
-        # secrets.* can't be referenced directly in a step `if:`, so route the
-        # username through step env and gate on that — the step skips cleanly on
-        # forks / when the secret is absent instead of running login-action with
-        # empty credentials.
+        # secrets.* can't be referenced directly in a step `if:`, so gate on
+        # the job-level DOCKERHUB_USERNAME env (set above) — the step skips
+        # cleanly on forks / when the secret is absent instead of running
+        # login-action with empty credentials.
         if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
       - name: Resolve base-image digests
         id: resolve

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -81,6 +81,25 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
 
+      - name: Log in to Docker Hub
+        # Authenticated Docker Hub pulls get a much higher rate limit than
+        # anonymous pulls off the shared GitHub-runner IP pool, which were
+        # throttling testcontainers' mock-LLM base-image pull and surfacing as
+        # "registry-1.docker.io ... context deadline exceeded" container-setup
+        # flakes (#447). Runs before the go-test step that triggers the pull.
+        #
+        # secrets.* can't be referenced directly in a step `if:`, so route the
+        # username through step env and gate on that — the step skips cleanly on
+        # forks / when the secret is absent instead of running login-action with
+        # empty credentials.
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
         with:
@@ -160,6 +179,25 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
 
+      - name: Log in to Docker Hub
+        # Authenticated Docker Hub pulls get a much higher rate limit than
+        # anonymous pulls off the shared GitHub-runner IP pool, which were
+        # throttling testcontainers' mock-LLM base-image pull and surfacing as
+        # "registry-1.docker.io ... context deadline exceeded" container-setup
+        # flakes (#447). Runs before the go-test step that triggers the pull.
+        #
+        # secrets.* can't be referenced directly in a step `if:`, so route the
+        # username through step env and gate on that — the step skips cleanly on
+        # forks / when the secret is absent instead of running login-action with
+        # empty credentials.
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
         with:
@@ -203,6 +241,24 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
+
+      - name: Log in to Docker Hub
+        # The cffi build below `docker run`s the pinned rust:bookworm image,
+        # an anonymous Docker Hub pull that hits the same shared-runner-IP rate
+        # limit as the integration jobs (#447). docker/login-action writes
+        # ~/.docker/config.json, which `docker run` reads for the pull.
+        #
+        # secrets.* can't be referenced directly in a step `if:`, so route the
+        # username through step env and gate on that — the step skips cleanly on
+        # forks / when the secret is absent instead of running login-action with
+        # empty credentials.
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
       - name: Read BAML source commit
         id: baml-source
@@ -355,6 +411,25 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
+
+      - name: Log in to Docker Hub
+        # Authenticated Docker Hub pulls get a much higher rate limit than
+        # anonymous pulls off the shared GitHub-runner IP pool, which were
+        # throttling testcontainers' mock-LLM base-image pull and surfacing as
+        # "registry-1.docker.io ... context deadline exceeded" container-setup
+        # flakes (#447). Runs before the go-test step that triggers the pull.
+        #
+        # secrets.* can't be referenced directly in a step `if:`, so route the
+        # username through step env and gate on that — the step skips cleanly on
+        # forks / when the secret is absent instead of running login-action with
+        # empty credentials.
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
       - name: Checkout BAML Source
         uses: actions/checkout@v6.0.3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -64,8 +64,184 @@ jobs:
           ' integration/baml_versions.json)
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
+  warm-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Single prebuild that resolves the base-image digests, pulls each one
+    # ONCE (authenticated), saves it to a tarball, and hands the set to every
+    # Docker-consuming matrix cell as a per-run artifact. This replaces the
+    # per-cell anonymous Docker Hub pulls that bursted the shared
+    # GitHub-runner IP pool against Docker Hub's rate limit and surfaced as
+    # "registry-1.docker.io ... context deadline exceeded" container-setup
+    # flakes (#447). Consuming cells `docker load` the tarballs and never
+    # touch Docker Hub — so the Docker Hub login now lives here, not per cell.
+    outputs:
+      # build-baml-cffi `docker run`s the pinned rust base. `docker save`/`load`
+      # does NOT restore repo-digest mappings, so a digest-qualified
+      # `rust:bookworm@sha256:...` ref would still hit Docker Hub after a load.
+      # The warm job pulls the pinned digest and tags it to this deterministic
+      # local alias; build-baml-cffi runs the alias instead of the digest ref.
+      rust-alias: ${{ steps.rust.outputs.alias }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6.0.3
+
+      - name: Log in to Docker Hub
+        # Authenticated Docker Hub pulls get a much higher rate limit than
+        # anonymous pulls off the shared GitHub-runner IP pool (#447). This is
+        # the ONLY Docker Hub login in this workflow — consuming cells just
+        # `docker load` the warmed tarballs — so it runs here, before digest
+        # resolution and the cold pulls below.
+        #
+        # secrets.* can't be referenced directly in a step `if:`, so route the
+        # username through step env and gate on that — the step skips cleanly on
+        # forks / when the secret is absent instead of running login-action with
+        # empty credentials.
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
+      - name: Resolve base-image digests
+        id: resolve
+        # Resolve each floating tag to its current registry index digest so the
+        # cache key tracks image CONTENT, not the mutable tag, and so the pull
+        # below is by immutable digest (no tag float between resolve and pull).
+        # imagetools inspect queries the registry using the login above.
+        run: |
+          set -euo pipefail
+          for entry in \
+            "node:node:22-bookworm" \
+            "debian:debian:bookworm-slim" \
+            "golang:golang:1.26.3-alpine" \
+            "alpine:alpine:3.19"; do
+            key="${entry%%:*}"
+            ref="${entry#*:}"
+            digest=$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}')
+            echo "$key=$digest" >> "$GITHUB_OUTPUT"
+            echo "resolved $ref -> $digest"
+          done
+
+      - name: Resolve pinned rust image
+        id: rust
+        # Single-source the rust base from the Dockerfile FROM pin (same guard
+        # as build-baml-cffi) so the warm alias and that job's cache key derive
+        # from the same digest. A future digest bump in Dockerfile.tmpl then
+        # invalidates the warm cache automatically.
+        run: |
+          set -euo pipefail
+          matches=$(grep -cE '^FROM rust:bookworm@sha256:[0-9a-f]+' cmd/build/Dockerfile.tmpl)
+          if [ "$matches" -ne 1 ]; then
+            echo "::error file=cmd/build/Dockerfile.tmpl::expected exactly one pinned 'FROM rust:bookworm@sha256:' line, found $matches"
+            exit 1
+          fi
+          image=$(grep -oE 'rust:bookworm@sha256:[0-9a-f]+' cmd/build/Dockerfile.tmpl | head -n1)
+          digest=$(printf '%s' "$image" | sed -E 's/.*@sha256://' | cut -c1-12)
+          alias="baml-rest-warm/rust-bookworm:${digest}"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "alias=$alias" >> "$GITHUB_OUTPUT"
+
+      # Per-image cross-run caches keyed on the resolved digest: a bump to one
+      # tag re-pulls only that image, not the whole set. On a hit the tarball
+      # is restored to disk and the pull step skips it.
+      - name: Cache node:22-bookworm tarball
+        id: cache-node
+        uses: actions/cache@v5.0.5
+        with:
+          path: warm-images/node.tar
+          key: warm-image-${{ runner.os }}-node-${{ steps.resolve.outputs.node }}
+      - name: Cache debian:bookworm-slim tarball
+        id: cache-debian
+        uses: actions/cache@v5.0.5
+        with:
+          path: warm-images/debian.tar
+          key: warm-image-${{ runner.os }}-debian-${{ steps.resolve.outputs.debian }}
+      - name: Cache golang:1.26.3-alpine tarball
+        id: cache-golang
+        uses: actions/cache@v5.0.5
+        with:
+          path: warm-images/golang.tar
+          key: warm-image-${{ runner.os }}-golang-${{ steps.resolve.outputs.golang }}
+      - name: Cache alpine:3.19 tarball
+        id: cache-alpine
+        uses: actions/cache@v5.0.5
+        with:
+          path: warm-images/alpine.tar
+          key: warm-image-${{ runner.os }}-alpine-${{ steps.resolve.outputs.alpine }}
+      - name: Cache rust alias tarball
+        id: cache-rust
+        uses: actions/cache@v5.0.5
+        with:
+          path: warm-images/rust-bookworm.tar
+          key: warm-image-${{ runner.os }}-rust-bookworm-${{ steps.rust.outputs.digest }}
+
+      - name: Pull and save base images
+        # For each cache miss, pull by immutable digest and tag to the exact
+        # tag the Dockerfiles reference, so testcontainers' tag-based `FROM`
+        # reuses the loaded image with no registry lookup, then `docker save` a
+        # raw tar (Actions compresses the artifact/cache). Cache hits already
+        # have the tar on disk from the restore above. Rust is pulled by its
+        # pinned digest and tagged ONLY to the local alias.
+        env:
+          NODE_DIGEST: ${{ steps.resolve.outputs.node }}
+          DEBIAN_DIGEST: ${{ steps.resolve.outputs.debian }}
+          GOLANG_DIGEST: ${{ steps.resolve.outputs.golang }}
+          ALPINE_DIGEST: ${{ steps.resolve.outputs.alpine }}
+          RUST_IMAGE: ${{ steps.rust.outputs.image }}
+          RUST_ALIAS: ${{ steps.rust.outputs.alias }}
+          NODE_HIT: ${{ steps.cache-node.outputs.cache-hit }}
+          DEBIAN_HIT: ${{ steps.cache-debian.outputs.cache-hit }}
+          GOLANG_HIT: ${{ steps.cache-golang.outputs.cache-hit }}
+          ALPINE_HIT: ${{ steps.cache-alpine.outputs.cache-hit }}
+          RUST_HIT: ${{ steps.cache-rust.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          mkdir -p warm-images
+
+          warm_tag() {
+            local tag="$1" digest="$2" tarfile="$3" hit="$4"
+            if [ "$hit" = "true" ] && [ -f "warm-images/$tarfile" ]; then
+              echo "cache hit: $tag ($tarfile)"
+              return
+            fi
+            local repo="${tag%%:*}"
+            echo "pulling ${repo}@${digest} -> ${tag}"
+            docker pull "${repo}@${digest}"
+            docker tag "${repo}@${digest}" "$tag"
+            docker save "$tag" -o "warm-images/$tarfile"
+          }
+
+          warm_tag "node:22-bookworm"     "$NODE_DIGEST"   "node.tar"   "$NODE_HIT"
+          warm_tag "debian:bookworm-slim" "$DEBIAN_DIGEST" "debian.tar" "$DEBIAN_HIT"
+          warm_tag "golang:1.26.3-alpine" "$GOLANG_DIGEST" "golang.tar" "$GOLANG_HIT"
+          warm_tag "alpine:3.19"          "$ALPINE_DIGEST" "alpine.tar" "$ALPINE_HIT"
+
+          if [ "$RUST_HIT" = "true" ] && [ -f "warm-images/rust-bookworm.tar" ]; then
+            echo "cache hit: $RUST_ALIAS (rust-bookworm.tar)"
+          else
+            echo "pulling ${RUST_IMAGE} -> ${RUST_ALIAS}"
+            docker pull "$RUST_IMAGE"
+            docker tag "$RUST_IMAGE" "$RUST_ALIAS"
+            docker save "$RUST_ALIAS" -o "warm-images/rust-bookworm.tar"
+          fi
+
+          ls -lh warm-images/
+
+      - name: Upload warm images
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: warm-images-${{ github.run_id }}
+          path: warm-images/*.tar
+          if-no-files-found: error
+          retention-days: 1
+
   integration-tests:
-    needs: get-versions
+    needs: [get-versions, warm-images]
     runs-on: ubuntu-latest
     # Outer backstop only: step timeout-minutes (45m, below) bounds the
     # go-test step from go-test start — the same origin as the watchdog —
@@ -81,24 +257,26 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
 
-      - name: Log in to Docker Hub
-        # Authenticated Docker Hub pulls get a much higher rate limit than
-        # anonymous pulls off the shared GitHub-runner IP pool, which were
-        # throttling testcontainers' mock-LLM base-image pull and surfacing as
-        # "registry-1.docker.io ... context deadline exceeded" container-setup
-        # flakes (#447). Runs before the go-test step that triggers the pull.
-        #
-        # secrets.* can't be referenced directly in a step `if:`, so route the
-        # username through step env and gate on that — the step skips cleanly on
-        # forks / when the secret is absent instead of running login-action with
-        # empty credentials.
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v4.2.0
+      - name: Download warm base images
+        # Base images are pulled once by the warm-images job and handed over as
+        # a per-run artifact; this cell only loads them — no Docker Hub login,
+        # no pull (#447).
+        uses: actions/download-artifact@v8.0.1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          name: warm-images-${{ github.run_id }}
+          path: warm-images
+
+      - name: Load warm base images
+        # `docker load` the warmed tarballs before the go-test step so
+        # testcontainers' tag-based `FROM` builds reuse them locally instead of
+        # pulling from Docker Hub.
+        run: |
+          set -euo pipefail
+          for tar in warm-images/*.tar; do
+            echo "loading $tar"
+            docker load -i "$tar"
+          done
+          docker image ls
 
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
@@ -160,7 +338,7 @@ jobs:
           echo "latest=$latest" >> "$GITHUB_OUTPUT"
 
   integration-tests-inprocess:
-    needs: get-latest-version
+    needs: [get-latest-version, warm-images]
     runs-on: ubuntu-latest
     # Outer backstop only: step timeout-minutes (45m) + pre-test budget
     # (~10m). The step timeout and watchdog share the go-test origin. #420
@@ -179,24 +357,26 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
 
-      - name: Log in to Docker Hub
-        # Authenticated Docker Hub pulls get a much higher rate limit than
-        # anonymous pulls off the shared GitHub-runner IP pool, which were
-        # throttling testcontainers' mock-LLM base-image pull and surfacing as
-        # "registry-1.docker.io ... context deadline exceeded" container-setup
-        # flakes (#447). Runs before the go-test step that triggers the pull.
-        #
-        # secrets.* can't be referenced directly in a step `if:`, so route the
-        # username through step env and gate on that — the step skips cleanly on
-        # forks / when the secret is absent instead of running login-action with
-        # empty credentials.
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v4.2.0
+      - name: Download warm base images
+        # Base images are pulled once by the warm-images job and handed over as
+        # a per-run artifact; this cell only loads them — no Docker Hub login,
+        # no pull (#447).
+        uses: actions/download-artifact@v8.0.1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          name: warm-images-${{ github.run_id }}
+          path: warm-images
+
+      - name: Load warm base images
+        # `docker load` the warmed tarballs before the go-test step so
+        # testcontainers' tag-based `FROM` builds reuse them locally instead of
+        # pulling from Docker Hub.
+        run: |
+          set -euo pipefail
+          for tar in warm-images/*.tar; do
+            echo "loading $tar"
+            docker load -i "$tar"
+          done
+          docker image ls
 
       - name: Set up Go
         uses: actions/setup-go@v6.4.0
@@ -225,6 +405,7 @@ jobs:
         run: go test -tags=integration -v -count=1 -p 1 -timeout 40m ./integration/...
 
   build-baml-cffi:
+    needs: warm-images
     runs-on: ubuntu-latest
     # Build the BAML cffi artifact (libbaml_cffi.so + baml-cli) exactly once,
     # OUTSIDE the integration-tests-baml-source watchdog window, and hand it to
@@ -242,23 +423,26 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
 
-      - name: Log in to Docker Hub
-        # The cffi build below `docker run`s the pinned rust:bookworm image,
-        # an anonymous Docker Hub pull that hits the same shared-runner-IP rate
-        # limit as the integration jobs (#447). docker/login-action writes
-        # ~/.docker/config.json, which `docker run` reads for the pull.
-        #
-        # secrets.* can't be referenced directly in a step `if:`, so route the
-        # username through step env and gate on that — the step skips cleanly on
-        # forks / when the secret is absent instead of running login-action with
-        # empty credentials.
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v4.2.0
+      - name: Download warm base images
+        # The cffi build below `docker run`s the rust base. The warm-images job
+        # pulled the pinned digest and saved it under a local alias; this cell
+        # loads that tarball and runs the alias — no Docker Hub login, no pull
+        # (#447).
+        uses: actions/download-artifact@v8.0.1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          name: warm-images-${{ github.run_id }}
+          path: warm-images
+
+      - name: Load warm base images
+        # `docker load` the warmed tarballs before the cffi `docker run` so the
+        # rust alias resolves locally instead of pulling from Docker Hub.
+        run: |
+          set -euo pipefail
+          for tar in warm-images/*.tar; do
+            echo "loading $tar"
+            docker load -i "$tar"
+          done
+          docker image ls
 
       - name: Read BAML source commit
         id: baml-source
@@ -340,9 +524,10 @@ jobs:
         # glibc parity is load-bearing: the .so MUST be compiled inside
         # rust:bookworm (Debian, glibc 2.36), NOT on the bare ubuntu-latest
         # runner (glibc 2.39), or it fails to load in the bookworm-slim runtime
-        # with GLIBC_2.3x-not-found. The image is the Dockerfile FROM pin
-        # (resolved above) so this reproduces the in-Docker cffi-builder
-        # environment exactly.
+        # with GLIBC_2.3x-not-found. The run uses the warm-images rust alias,
+        # which is the Dockerfile FROM pin pulled-and-tagged by the warm job
+        # (steps.rust-image above resolves the same digest for the cache key),
+        # so this reproduces the in-Docker cffi-builder environment exactly.
         if: steps.cache.outputs.cache-hit != 'true'
         env:
           PROTOC_GEN_GO_VERSION: ${{ steps.protoc.outputs.version }}
@@ -353,7 +538,7 @@ jobs:
             -e PROTOC_GEN_GO_VERSION \
             -v "${{ github.workspace }}/baml-source:/baml-source" \
             -v "${{ github.workspace }}/prebuilt-cffi:/out" \
-            "${{ steps.rust-image.outputs.image }}" \
+            "${{ needs.warm-images.outputs.rust-alias }}" \
             bash -euo pipefail -c '
               apt-get update >/dev/null && apt-get install -y wget >/dev/null
               arch=$(dpkg --print-architecture)
@@ -381,7 +566,7 @@ jobs:
           if-no-files-found: error
 
   integration-tests-baml-source:
-    needs: build-baml-cffi
+    needs: [build-baml-cffi, warm-images]
     runs-on: ubuntu-latest
     # The baml-source matrix builds BAML from source, which dominates the
     # per-cell wall time and pushes consistent runs into the 38-45m
@@ -412,24 +597,26 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
 
-      - name: Log in to Docker Hub
-        # Authenticated Docker Hub pulls get a much higher rate limit than
-        # anonymous pulls off the shared GitHub-runner IP pool, which were
-        # throttling testcontainers' mock-LLM base-image pull and surfacing as
-        # "registry-1.docker.io ... context deadline exceeded" container-setup
-        # flakes (#447). Runs before the go-test step that triggers the pull.
-        #
-        # secrets.* can't be referenced directly in a step `if:`, so route the
-        # username through step env and gate on that — the step skips cleanly on
-        # forks / when the secret is absent instead of running login-action with
-        # empty credentials.
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v4.2.0
+      - name: Download warm base images
+        # Base images are pulled once by the warm-images job and handed over as
+        # a per-run artifact; this cell only loads them — no Docker Hub login,
+        # no pull (#447).
+        uses: actions/download-artifact@v8.0.1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          name: warm-images-${{ github.run_id }}
+          path: warm-images
+
+      - name: Load warm base images
+        # `docker load` the warmed tarballs before the go-test step so
+        # testcontainers' tag-based `FROM` builds reuse them locally instead of
+        # pulling from Docker Hub.
+        run: |
+          set -euo pipefail
+          for tar in warm-images/*.tar; do
+            echo "loading $tar"
+            docker load -i "$tar"
+          done
+          docker image ls
 
       - name: Checkout BAML Source
         uses: actions/checkout@v6.0.3


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Problem

Integration-test CI jobs intermittently fail during container setup with:

```
Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

Docker Hub **pull rate-limiting** on the shared GitHub-runner IP pool: testcontainers builds the mock-LLM / baml-rest images from bases pulled off Docker Hub, and with up to ~40 concurrent matrix cells (GitHub Pro) all pulling the same tags at once, the shared account gets throttled. See #447.

## Why auth-only wasn't enough

The first cut on this branch added a per-cell `docker/login-action`. Authenticated pulls have a higher limit, but ~40 cells still pull the *same* base images concurrently against one shared account — any stray throttle reintroduces the same flake, and per-cell login can mask a pull that should have been eliminated.

## Fix: warm the base images once per run

Add a `warm-images` prebuild job that pulls each base image **once**, then hands the set to every Docker-consuming cell as a per-run artifact. Cells `docker load` the tarballs and never touch Docker Hub.

### `warm-images` job (integration-tests.yml + bamlfuzz-nightly.yml)
1. Log into Docker Hub (the fork-safe `env.DOCKERHUB_USERNAME != ''` conditional) — now the **only** Docker Hub login in these workflows.
2. Resolve each floating tag to its current registry **index digest** via `docker buildx imagetools inspect` (`node:22-bookworm`, `debian:bookworm-slim`, `golang:1.26.3-alpine`, `alpine:3.19`).
3. Restore a per-image `actions/cache` keyed on the resolved digest (a bump to one tag re-pulls only that image).
4. On a miss: pull **by immutable digest** (no tag float), tag to the exact Dockerfile tag, `docker save` a raw tarball (Actions compresses the artifact/cache).
5. Upload the `warm-images/*.tar` set as a per-run artifact (`retention-days: 1`).

### Rust alias (integration-tests.yml)

`docker save`/`load` does **not** restore repo-digest mappings, so a digest-qualified `docker run rust:bookworm@sha256:...` would still hit Docker Hub after a load. The warm job pulls the pinned digest (single-sourced from `cmd/build/Dockerfile.tmpl`), tags it to a deterministic local alias `baml-rest-warm/rust-bookworm:<digest12>`, saves the alias, and exposes it as a **job output**. `build-baml-cffi` runs the alias instead of the digest ref.

### Consuming jobs

| Job | Workflow | warmed/loaded? | rust alias? | gha cache? |
| --- | --- | --- | --- | --- |
| `integration-tests` | integration-tests.yml | ✅ needs+load | — | — |
| `integration-tests-inprocess` | integration-tests.yml | ✅ needs+load | — | — |
| `build-baml-cffi` | integration-tests.yml | ✅ needs+load | ✅ runs alias | — |
| `integration-tests-baml-source` | integration-tests.yml | ✅ needs+load | — | — |
| `fuzz` | bamlfuzz-nightly.yml | ✅ needs+load | — | — |
| `build-docker` | build-and-publish.yml | n/a (BuildKit) | — | ✅ type=gha per-arch |

Each consuming cell gains `needs: warm-images`, a `download-artifact` + `docker load -i` loop **before** its test/docker step, and no longer logs into or pulls from Docker Hub.

### Fuzz Ryuk

`bamlfuzz-nightly.yml` `fuzz` now sets `TESTCONTAINERS_RYUK_DISABLED: true` (matching the integration jobs), so the testcontainers Ryuk reaper is not a stray Docker Hub pull source — the warm set is scoped to the integration bases (no ryuk).

### build-docker (build-and-publish.yml)

`setup-buildx-action`'s default `docker-container` driver keeps its build cache separate from the daemon image store, so a daemon `docker load` cannot warm it. Instead wire BuildKit `cache-from`/`cache-to: type=gha` (scoped per arch) onto the `build-push-action` step. After one warm run, base layers and build steps restore from the gha cache instead of pulling from Docker Hub; the Docker Hub login stays for cold misses.

## Auth fold-in

The per-cell `docker/login-action` steps from the earlier commits on this branch are **removed**. Docker Hub auth now lives in the `warm-images` jobs and in `build-docker` only. The unrelated GHCR logins in `build-and-publish.yml` are untouched.

## Validation (local)
- All three changed workflow YAMLs parse (`ruby YAML.load_file`).
- `go run ./cmd/embed && git status` — only the three workflow YAMLs changed; no `.go`/embed change.
- Traced every consuming job: `needs: warm-images` present, download+load is before the test/docker step, and `build-baml-cffi` runs the rust alias.
- Confirmed `docker pull` exists only in the warm-images jobs and the sole `docker run` uses the rust alias — no consuming cell pulls from Docker Hub.
- Integration suite intentionally **not** run locally.

Closes #447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Optimized CI/CD build pipelines with Docker image caching and pre-warming to reduce build times and enhance Docker Hub rate limit resilience
* Improved Docker authentication handling and image artifact management to increase build reliability and consistency across workflow configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->