### PR TITLE
fix(nightly): stop bamlfuzz fuzz-job disk exhaustion (free disk + prune static builds)

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -251,13 +251,6 @@ jobs:
       BAML_VERSION: ${{ matrix.baml-version }}
       UNARY_SERVER: ${{ matrix.unary-server }}
       BAML_REST_HTTP_CLIENT: nethttp
-      # CI-only: skip the testcontainers Ryuk reaper so setup doesn't
-      # pull/create it from Docker Hub — matching the integration jobs. With
-      # the warm-images set scoped to the integration bases (no ryuk), this
-      # keeps Ryuk from being a stray Docker Hub pull source here (#447). Safe
-      # because GH runners are ephemeral and torn down after the job, so leaked
-      # containers are cleaned up regardless. Never set this for local runs.
-      TESTCONTAINERS_RYUK_DISABLED: true
       BAMLFUZZ_KEEP_ARTIFACTS: "1"
       MODE: ${{ github.event.inputs.mode || 'fuzz' }}
       FUZZTIME: ${{ github.event.inputs.fuzztime || '15m' }}
@@ -276,6 +269,23 @@ jobs:
         uses: actions/checkout@v6.0.3
         with:
           persist-credentials: false
+
+      - name: Free runner disk before Docker image load
+        # GitHub-hosted runners start with ~14 GiB free, which the static
+        # oracle's per-batch baml-rest image builds exhaust ("no space left
+        # on device"). Reclaim the preinstalled toolchains/images we never
+        # use BEFORE the warm tarballs are loaded — docker-images:true is
+        # only safe here because our warm base images aren't loaded yet, and
+        # tool-cache:false keeps setup-go's tool cache intact.
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Download warm base images
         # Base images are pulled once by the warm-images job and handed over as
@@ -423,6 +433,13 @@ jobs:
         # batches; 10 × staticCasesPerBatch (5) = 50 cases, matching the
         # ~50-case budget the other targets explore per nightly cell.
         # No corpus restore/upload: -run does not use the fuzz corpus.
+        #
+        # BAMLFUZZ_STATIC_DOCKER_PRUNE prunes dangling images + BuildKit
+        # cache between static envs so this target's many full baml-rest
+        # builds don't accumulate and exhaust the runner disk. Scoped to
+        # this step only — the harness no-ops without it.
+        env:
+          BAMLFUZZ_STATIC_DOCKER_PRUNE: "1"
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
             -run='TestBamlfuzzStaticOracle' \

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -251,6 +251,13 @@ jobs:
       BAML_VERSION: ${{ matrix.baml-version }}
       UNARY_SERVER: ${{ matrix.unary-server }}
       BAML_REST_HTTP_CLIENT: nethttp
+      # CI-only: skip the testcontainers Ryuk reaper so setup doesn't
+      # pull/create it from Docker Hub — matching the integration jobs. With
+      # the warm-images set scoped to the integration bases (no ryuk), this
+      # keeps Ryuk from being a stray Docker Hub pull source here (#447). Safe
+      # because GH runners are ephemeral and torn down after the job, so leaked
+      # containers are cleaned up regardless. Never set this for local runs.
+      TESTCONTAINERS_RYUK_DISABLED: true
       BAMLFUZZ_KEEP_ARTIFACTS: "1"
       MODE: ${{ github.event.inputs.mode || 'fuzz' }}
       FUZZTIME: ${{ github.event.inputs.fuzztime || '15m' }}

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -33,6 +33,7 @@ import (
 	"hash/fnv"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -256,6 +257,9 @@ func runStaticBatch(t *testing.T, cases []bamlfuzz.OracleCase, batchLabel string
 
 	env, err := setupStaticEnv(batchDir)
 	if err != nil {
+		// Failed builds are the largest source of unreferenced Docker
+		// residue; reclaim it before the isolation rebuilds run.
+		pruneStaticDockerArtifacts(t)
 		t.Logf("batch build failed for %s: %v; isolating cases singly", batchLabel, err)
 		if !isolateStaticBatch(t, lowered, batchLabel, source) {
 			// All isolated rebuilds passed, but the batch build failed.
@@ -268,7 +272,7 @@ func runStaticBatch(t *testing.T, cases []bamlfuzz.OracleCase, batchLabel string
 		}
 		return
 	}
-	defer terminateStaticEnv(t, env)
+	defer terminateStaticEnvAndPrune(t, env)
 
 	mockClient := mockllm.NewClient(env.MockLLMURL)
 	bamlClient := testutil.NewBAMLRestClient(env.BAMLRestURL)
@@ -437,11 +441,14 @@ func runIsolatedStaticCase(t *testing.T, lc loweredStaticCase, caseIdx int, batc
 	}
 	env, err := setupStaticEnv(singleDir)
 	if err != nil {
+		// Failed isolated builds leave build residue too; reclaim it
+		// before the next isolated case rebuilds.
+		pruneStaticDockerArtifacts(t)
 		envelope.BuildError = err.Error()
 		failStaticAndDump(t, envelope, "isolated build failed: %v", err)
 		return
 	}
-	terminateStaticEnv(t, env)
+	terminateStaticEnvAndPrune(t, env)
 }
 
 // caseSourcePath returns the absolute path to the generated .baml
@@ -554,6 +561,45 @@ func terminateStaticEnv(t *testing.T, env *testutil.TestEnvironment) {
 	defer termCancel()
 	if err := env.Terminate(termCtx); err != nil {
 		t.Logf("static env Terminate: %v", err)
+	}
+}
+
+// terminateStaticEnvAndPrune terminates a static env and then reclaims
+// Docker build residue. Used wherever runStaticBatch / the isolation
+// path finishes with a live env so the static oracle's per-batch
+// baml-rest image builds don't accumulate on the runner disk.
+func terminateStaticEnvAndPrune(t *testing.T, env *testutil.TestEnvironment) {
+	t.Helper()
+	terminateStaticEnv(t, env)
+	pruneStaticDockerArtifacts(t)
+}
+
+// pruneStaticDockerArtifacts reclaims Docker build residue between
+// static envs so the static oracle's many full baml-rest image builds
+// don't exhaust the runner disk ("no space left on device"). It is a
+// no-op unless BAMLFUZZ_STATIC_DOCKER_PRUNE is set, so local runs and
+// other integration tests are unaffected.
+//
+// It prunes only dangling images and the BuildKit cache — never `-a`
+// / `docker system prune -a`, which would delete the warm base images
+// the nightly job loads and force Docker Hub pulls. The static oracle
+// runs serially (-p 1), so pruning between env lifecycles never races
+// a live container. Prune failures are logged as warnings, never
+// failing the test.
+func pruneStaticDockerArtifacts(t *testing.T) {
+	t.Helper()
+	if os.Getenv("BAMLFUZZ_STATIC_DOCKER_PRUNE") == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	for _, args := range [][]string{
+		{"image", "prune", "-f"},
+		{"builder", "prune", "-f"},
+	} {
+		if out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput(); err != nil {
+			t.Logf("WARNING: docker %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## What this does

Fixes the nightly `fuzz` job's `FuzzBamlfuzzStatic` cell failing with `write /output/baml-rest: no space left on device`.

**Root cause:** `FuzzBamlfuzzStatic` builds a fresh full baml-rest Docker image per static batch (testcontainers `FromDockerfile`, random tags). Failed builds + BuildKit cache leave residue that nothing prunes between batches, so the ~14 GiB runner fills and setup dies. No oracle/worker bug.

### A — reclaim runner disk
Adds `jlumbroso/free-disk-space` (pinned to the v1.3.1 SHA) as the **first** step of the `fuzz` job, **before** the warm-image download/load. `tool-cache: false` keeps `setup-go`'s tool cache intact; `docker-images: true` is safe only because the step runs before our warm base images are `docker load`ed.

### B — stop the per-batch image/cache leak (env-gated, static-fuzz-only)
- Sets `BAMLFUZZ_STATIC_DOCKER_PRUNE: "1"` on **only** the static oracle step (`TestBamlfuzzStaticOracle`), not globally.
- Adds a harness helper (`integration/bamlfuzz_static_test.go`) that **no-ops unless that env is set**. When set it runs `docker image prune -f` + `docker builder prune -f` under a 60s context, logging failures as warnings (never failing the test).
- Called after each static env teardown, after isolated-case teardown, and on `setupStaticEnv` error (failed builds are the biggest residue source).
- Deliberately **no `-a` / `docker system prune -a`** — that would delete the warm base images and trigger Docker Hub pulls. Serial `-p 1` keeps the prune race-free.

### Ryuk stays disabled (intentional)
`TESTCONTAINERS_RYUK_DISABLED: true` is kept on the `fuzz` job. An earlier revision of this PR tried removing it as hygiene, but re-enabling the reaper makes testcontainers pull `testcontainers/ryuk:0.13.0` (pinned by testcontainers-go v0.42.0) from Docker Hub **un-warmed** on every matrix cell, reintroducing the 429/registry-flake class that #449 removed. On ephemeral GH runners the reaper buys little — the harness already terminates each env explicitly, and fix B reclaims the disk — so it stays disabled to preserve the warm-image-only design.

## Scope
Fuzz-job-local: `integration-tests.yml` and other jobs are not touched. No `-s -w` ldflags here (tracked separately in #453).

## Validation
- `gofmt -l`, `go vet -tags=integration,subprocess ./integration/`, and `go build -tags=integration,subprocess ./integration/...` all clean.
- Workflow YAML parses.
- Note: PR CI does not run the nightly `fuzz` job, so it validates the harness change compiles + doesn't regress `integration-tests`; the fix itself is confirmed by a nightly dispatch after merge.

References the nightly failure tracked on the "bamlfuzz nightly status" sticky issue (#377). The cited failing run is `27537455074` (job `fuzz (0.219.0, false, FuzzBamlfuzzStatic)`). Does not close an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved disk space management in CI fuzzing workflows by implementing automatic cleanup of Docker build artifacts and images during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
