### PR TITLE
build: strip production binaries with -ldflags "-s -w" (#453)

### DIFF
--- a/cmd/build/build.sh
+++ b/cmd/build/build.sh
@@ -550,14 +550,14 @@ go run "${ADAPTER_VERSION}/cmd/main.go"
 # BAML call path. Subprocess builds bake it into cmd/worker;
 # in-process builds bake it into cmd/serve because cmd/worker is not
 # built at all.
-WORKER_LDFLAGS=""
-SERVE_LDFLAGS=""
+WORKER_LDFLAGS="-s -w"
+SERVE_LDFLAGS="-s -w"
 if [ -n "${BAML_REST_BASE_URL_REWRITES:-}" ]; then
     echo "Baking in base URL rewrites: ${BAML_REST_BASE_URL_REWRITES}"
     if [ "${SUBPROCESS:-true}" = "true" ]; then
-        WORKER_LDFLAGS="-X 'github.com/invakid404/baml-rest/bamlutils/urlrewrite.builtinRules=${BAML_REST_BASE_URL_REWRITES}'"
+        WORKER_LDFLAGS="${WORKER_LDFLAGS} -X 'github.com/invakid404/baml-rest/bamlutils/urlrewrite.builtinRules=${BAML_REST_BASE_URL_REWRITES}'"
     else
-        SERVE_LDFLAGS="-X 'github.com/invakid404/baml-rest/bamlutils/urlrewrite.builtinRules=${BAML_REST_BASE_URL_REWRITES}'"
+        SERVE_LDFLAGS="${SERVE_LDFLAGS} -X 'github.com/invakid404/baml-rest/bamlutils/urlrewrite.builtinRules=${BAML_REST_BASE_URL_REWRITES}'"
     fi
 fi
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## What changed

`cmd/build/build.sh` now builds the two shipped production binaries (worker via `./cmd/worker/`, serve via `./cmd/serve/`) with `-ldflags "-s -w"` as the always-present base. The existing conditional `-X` URL-rewrite injection (`BAML_REST_BASE_URL_REWRITES`) is now **appended** to that base rather than overwriting it.

Resulting ldflags:
- No rewrites: `-ldflags "-s -w"`
- With rewrites: `-ldflags "-s -w -X '...urlrewrite.builtinRules=...'"`

## Why

`-s` drops the symbol table and `-w` drops DWARF, producing meaningfully smaller shipped binaries — locally `./cmd/serve/` went from ~36.3 MB to ~25.3 MB (~30% smaller). Smaller binaries mean smaller fuzz-job container images, which is part of keeping the nightly fuzz jobs from exhausting disk.

## Tradeoff

`-w` drops DWARF, so source-level debugging with `dlv` against these binaries is no longer possible. Panic stack traces stay readable (Go's runtime stack unwinding does not depend on DWARF), so production crash diagnostics are unaffected.

## Scope

Only the two shipped production binaries are touched. The `Dockerfile.builder` goimports build and the `cmd/build/main.go` builder-tool builds are intentionally left alone — #453 lists those as optional and they are build-time tooling, not shipped artifacts.

## Validation

- `bash -n cmd/build/build.sh` passes.
- Verified argv expansion of `${SERVE_LDFLAGS:+-ldflags "${SERVE_LDFLAGS}"}` under both conditions — the whole ldflags value stays one double-quoted arg with the `-X` value single-quoted inside, identical quoting shape to before.
- `go build -ldflags "-s -w" -o /tmp/... ./cmd/serve/` links cleanly; `nm` confirms the Go symbol table is gone.

Closes #453


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build process to produce smaller binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->