### PR TITLE
fix(nightly): keep BuildKit cache warm on static-fuzz happy path (#454 follow-up)

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -441,12 +441,20 @@ jobs:
         # ~50-case budget the other targets explore per nightly cell.
         # No corpus restore/upload: -run does not use the fuzz corpus.
         #
-        # BAMLFUZZ_STATIC_DOCKER_PRUNE prunes dangling images + BuildKit
-        # cache between static envs so this target's many full baml-rest
-        # builds don't accumulate and exhaust the runner disk. Scoped to
-        # this step only — the harness no-ops without it.
+        # BAMLFUZZ_STATIC_DOCKER_PRUNE prunes dangling images between
+        # successful envs; failed setup additionally prunes the BuildKit
+        # cache. Keeping builder prune off the happy path preserves warm
+        # layer reuse so later batches rebuild fast, while still keeping
+        # this target's many full baml-rest builds from accumulating and
+        # exhausting the runner disk. Scoped to this step only — the
+        # harness no-ops without it.
+        #
+        # BAML_REST_SUITE_WATCHDOG is a margin for runner variance, not
+        # the throughput fix: warm-cache runtime is ~20-25m, well under
+        # 50m. Go's -timeout 80m and the job timeout-minutes are unchanged.
         env:
           BAMLFUZZ_STATIC_DOCKER_PRUNE: "1"
+          BAML_REST_SUITE_WATCHDOG: 50m
         run: |
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
             -run='TestBamlfuzzStaticOracle' \

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -258,8 +258,9 @@ func runStaticBatch(t *testing.T, cases []bamlfuzz.OracleCase, batchLabel string
 	env, err := setupStaticEnv(batchDir)
 	if err != nil {
 		// Failed builds are the largest source of unreferenced Docker
-		// residue; reclaim it before the isolation rebuilds run.
-		pruneStaticDockerArtifacts(t)
+		// residue; reclaim it (including the BuildKit cache) before the
+		// isolation rebuilds run.
+		pruneStaticDockerArtifactsAfterFailedSetup(t)
 		t.Logf("batch build failed for %s: %v; isolating cases singly", batchLabel, err)
 		if !isolateStaticBatch(t, lowered, batchLabel, source) {
 			// All isolated rebuilds passed, but the batch build failed.
@@ -442,8 +443,9 @@ func runIsolatedStaticCase(t *testing.T, lc loweredStaticCase, caseIdx int, batc
 	env, err := setupStaticEnv(singleDir)
 	if err != nil {
 		// Failed isolated builds leave build residue too; reclaim it
-		// before the next isolated case rebuilds.
-		pruneStaticDockerArtifacts(t)
+		// (including the BuildKit cache) before the next isolated case
+		// rebuilds.
+		pruneStaticDockerArtifactsAfterFailedSetup(t)
 		envelope.BuildError = err.Error()
 		failStaticAndDump(t, envelope, "isolated build failed: %v", err)
 		return
@@ -565,41 +567,68 @@ func terminateStaticEnv(t *testing.T, env *testutil.TestEnvironment) {
 }
 
 // terminateStaticEnvAndPrune terminates a static env and then reclaims
-// Docker build residue. Used wherever runStaticBatch / the isolation
+// dangling Docker images. Used wherever runStaticBatch / the isolation
 // path finishes with a live env so the static oracle's per-batch
-// baml-rest image builds don't accumulate on the runner disk.
+// baml-rest image builds don't accumulate on the runner disk. The happy
+// path prunes dangling images only; it deliberately does NOT prune the
+// BuildKit cache, so warm layer reuse survives across batches.
 func terminateStaticEnvAndPrune(t *testing.T, env *testutil.TestEnvironment) {
 	t.Helper()
 	terminateStaticEnv(t, env)
 	pruneStaticDockerArtifacts(t)
 }
 
-// pruneStaticDockerArtifacts reclaims Docker build residue between
+// pruneStaticDockerArtifacts reclaims dangling Docker images between
 // static envs so the static oracle's many full baml-rest image builds
 // don't exhaust the runner disk ("no space left on device"). It is a
 // no-op unless BAMLFUZZ_STATIC_DOCKER_PRUNE is set, so local runs and
 // other integration tests are unaffected.
 //
-// It prunes only dangling images and the BuildKit cache — never `-a`
-// / `docker system prune -a`, which would delete the warm base images
-// the nightly job loads and force Docker Hub pulls. The static oracle
-// runs serially (-p 1), so pruning between env lifecycles never races
-// a live container. Prune failures are logged as warnings, never
-// failing the test.
+// This is the happy-path prune: it removes only dangling images and
+// deliberately leaves the BuildKit cache intact, because `docker builder
+// prune` is throughput-destructive — it forces every later batch to
+// rebuild cold instead of reusing warm layers. Failed setup uses
+// pruneStaticDockerArtifactsAfterFailedSetup, which additionally prunes
+// the BuildKit cache.
+//
+// It never uses `-a` / `docker system prune -a`, which would delete the
+// warm base images the nightly job loads and force Docker Hub pulls. The
+// static oracle runs serially (-p 1), so pruning between env lifecycles
+// never races a live container. Prune failures are logged as warnings,
+// never failing the test.
 func pruneStaticDockerArtifacts(t *testing.T) {
 	t.Helper()
 	if os.Getenv("BAMLFUZZ_STATIC_DOCKER_PRUNE") == "" {
 		return
 	}
+	runStaticDockerPrune(t, []string{"image", "prune", "-f"})
+}
+
+// pruneStaticDockerArtifactsAfterFailedSetup reclaims Docker build
+// residue after a failed static setup. In addition to dangling images,
+// it prunes the BuildKit cache, because failed/partial builds are the
+// largest source of unreferenced residue. Builder prune is confined to
+// this failure path because it is throughput-destructive on the happy
+// path (it discards warm layers and forces cold rebuilds). Same gating
+// and best-effort semantics as pruneStaticDockerArtifacts.
+func pruneStaticDockerArtifactsAfterFailedSetup(t *testing.T) {
+	t.Helper()
+	if os.Getenv("BAMLFUZZ_STATIC_DOCKER_PRUNE") == "" {
+		return
+	}
+	runStaticDockerPrune(t, []string{"image", "prune", "-f"})
+	runStaticDockerPrune(t, []string{"builder", "prune", "-f"})
+}
+
+// runStaticDockerPrune runs a single best-effort `docker <args>` prune
+// with a bounded timeout. Failures are logged as warnings and never fail
+// the test.
+func runStaticDockerPrune(t *testing.T, args []string) {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	for _, args := range [][]string{
-		{"image", "prune", "-f"},
-		{"builder", "prune", "-f"},
-	} {
-		if out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput(); err != nil {
-			t.Logf("WARNING: docker %s: %v\n%s", strings.Join(args, " "), err, out)
-		}
+	if out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput(); err != nil {
+		t.Logf("WARNING: docker %s: %v\n%s", strings.Join(args, " "), err, out)
 	}
 }
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## What

Follow-up to #454. Split the static-fuzz Docker prune helper so the **happy path prunes dangling images only** (`docker image prune -f`) and the **failed-setup paths additionally prune the BuildKit cache** (`docker builder prune -f`).

- `integration/bamlfuzz_static_test.go`:
  - `pruneStaticDockerArtifacts` (happy path, via `terminateStaticEnvAndPrune`) now runs only `docker image prune -f`.
  - New `pruneStaticDockerArtifactsAfterFailedSetup` runs `docker image prune -f` **+** `docker builder prune -f`, wired into the two `setupStaticEnv` error paths (`runStaticBatch`, `runIsolatedStaticCase`).
  - Shared `runStaticDockerPrune` helper preserves the existing env gate (`BAMLFUZZ_STATIC_DOCKER_PRUNE`), 60s timeout, and best-effort `t.Logf` warning semantics. No `-a`.
- `.github/workflows/bamlfuzz-nightly.yml`: add `BAML_REST_SUITE_WATCHDOG: 50m` to the static oracle step `env:` as a safety margin.

## Why

#454's harness pruned Docker after **every** static batch with `docker image prune -f` **+ `docker builder prune -f`**. The `builder prune` wipes the BuildKit layer cache, so every subsequent batch rebuilt **cold** (~3.5 min) instead of **warm** (~1–1.5 min). Across 13 builds per static cell that overran the ~42-min suite watchdog — see failed manual dispatch run `27605271243` and the watchdog mechanism added in #377.

Disk pressure is already addressed by #454's free-disk step; we only need to stop destroying the build cache on the happy path. Builder prune stays on the failed-setup paths, where failed/partial builds are the largest residue source.

The `BAML_REST_SUITE_WATCHDOG: 50m` is a **margin for runner variance, not the fix** — warm-cache runtime is ~20–25m. Go's `-timeout 80m` and the job `timeout-minutes: 105` are unchanged.

## Validation / re-validation

`gofmt`, `go vet`, `go build` (`-tags=integration,subprocess`) and YAML parse all clean. PR CI does **not** run the fuzz job, so re-validation is a post-merge nightly `workflow_dispatch` (`mode=fuzz`, default `static_batches=10`, `fuzztime=15m`): confirm no suite-watchdog failures, static cells complete materially below 42m (~20–25m envelope), and no `no space left on device`.

The separate `rapid_b0_c3` oracle mismatch is unrelated to throughput and tracked in #456.

Does not close an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced fuzz testing infrastructure with more aggressive Docker cleanup procedures following setup failures and added watchdog timeout management to improve test reliability and consistency across runner environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->