### PR TITLE
ci: pin base-image digests + shared free-disk reclaim (#458, #459)

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,24 @@
+name: Free disk space
+description: Reclaim unused runner disk before warm Docker image loads
+
+# Shared wrapper around jlumbroso/free-disk-space so every disk-heavy CI job
+# reclaims the same set of preinstalled toolchains/images (#459). GitHub-hosted
+# runners start with ~14 GiB free, which the disk-heavy integration/fuzz jobs
+# exhaust ("no space left on device"). docker-images:true is only safe BEFORE
+# the repo's warm base-image tarballs are loaded — every consumer must place
+# this step ahead of its `docker load`, or the warmed images get deleted and
+# the Docker Hub pulls (#447) come back. tool-cache:false keeps setup-go's tool
+# cache intact.
+runs:
+  using: composite
+  steps:
+    - name: Free runner disk before Docker image load
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -134,21 +134,36 @@ jobs:
 
       - name: Resolve base-image digests
         id: resolve
-        # Resolve each floating tag to its current registry index digest so the
-        # cache key tracks image CONTENT, not the mutable tag, and so the pull
-        # below is by immutable digest (no tag float between resolve and pull).
+        # Single-source each warm base image's digest from its pinned Dockerfile
+        # `FROM` line instead of querying the registry at runtime (#458). The
+        # cache key then tracks image CONTENT via the in-repo pin (bumped by
+        # Renovate's docker custom manager), and the warm pull below is by that
+        # immutable digest — zero Docker Hub calls on the resolve path. Assert
+        # exactly one pinned `FROM` per image and fail loudly otherwise, so a
+        # botched pin can't silently fall through to an empty digest. No rust
+        # here: the fuzz job never builds cffi. node/debian live in
+        # cmd/build/Dockerfile.tmpl; golang/alpine in integration/mockllm.
         run: |
           set -euo pipefail
+          # key|file|image  (image is the repo:tag prefix of the FROM ref)
           for entry in \
-            "node:node:22-bookworm" \
-            "debian:debian:bookworm-slim" \
-            "golang:golang:1.26.3-alpine" \
-            "alpine:alpine:3.19"; do
-            key="${entry%%:*}"
-            ref="${entry#*:}"
-            digest=$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}')
+            "node|cmd/build/Dockerfile.tmpl|node:22-bookworm" \
+            "debian|cmd/build/Dockerfile.tmpl|debian:bookworm-slim" \
+            "golang|integration/mockllm/Dockerfile|golang:1.26.3-alpine" \
+            "alpine|integration/mockllm/Dockerfile|alpine:3.19"; do
+            key="${entry%%|*}"
+            rest="${entry#*|}"
+            file="${rest%%|*}"
+            image="${rest#*|}"
+            matches=$(grep -cE "^FROM ${image}@sha256:[0-9a-f]{64}" "$file")
+            if [ "$matches" -ne 1 ]; then
+              echo "::error file=${file}::expected exactly one pinned 'FROM ${image}@sha256:' line, found $matches"
+              exit 1
+            fi
+            # Full sha256:<64hex>: warm_tag does `docker pull "${repo}@${digest}"`.
+            digest=$(grep -oE "${image}@sha256:[0-9a-f]{64}" "$file" | head -n1 | sed -E 's/.*@//')
             echo "$key=$digest" >> "$GITHUB_OUTPUT"
-            echo "resolved $ref -> $digest"
+            echo "resolved $image -> $digest"
           done
 
       # Per-image cross-run caches keyed on the resolved digest: a bump to one

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -155,13 +155,16 @@ jobs:
             rest="${entry#*|}"
             file="${rest%%|*}"
             image="${rest#*|}"
-            matches=$(grep -cE "^FROM ${image}@sha256:[0-9a-f]{64}" "$file")
+            # Escape regex metacharacters (the tags contain literal dots) so the
+            # grep -E patterns match the image string literally, not as a regex.
+            image_re=$(printf '%s' "$image" | sed -E 's/[][(){}.^$*+?|\\]/\\&/g')
+            matches=$(grep -cE "^FROM ${image_re}@sha256:[0-9a-f]{64}" "$file")
             if [ "$matches" -ne 1 ]; then
               echo "::error file=${file}::expected exactly one pinned 'FROM ${image}@sha256:' line, found $matches"
               exit 1
             fi
             # Full sha256:<64hex>: warm_tag does `docker pull "${repo}@${digest}"`.
-            digest=$(grep -oE "${image}@sha256:[0-9a-f]{64}" "$file" | head -n1 | sed -E 's/.*@//')
+            digest=$(grep -oE "${image_re}@sha256:[0-9a-f]{64}" "$file" | head -n1 | sed -E 's/.*@//')
             echo "$key=$digest" >> "$GITHUB_OUTPUT"
             echo "resolved $image -> $digest"
           done

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -293,21 +293,10 @@ jobs:
           persist-credentials: false
 
       - name: Free runner disk before Docker image load
-        # GitHub-hosted runners start with ~14 GiB free, which the static
-        # oracle's per-batch baml-rest image builds exhaust ("no space left
-        # on device"). Reclaim the preinstalled toolchains/images we never
-        # use BEFORE the warm tarballs are loaded — docker-images:true is
-        # only safe here because our warm base images aren't loaded yet, and
-        # tool-cache:false keeps setup-go's tool cache intact.
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
+        # Shared composite (docker-images:true) placed BEFORE the warm-image
+        # load so it doesn't delete the warmed bases. See the action for why
+        # the static oracle's per-batch image builds need this (#459).
+        uses: ./.github/actions/free-disk-space
 
       - name: Download warm base images
         # Base images are pulled once by the warm-images job and handed over as

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -132,13 +132,16 @@ jobs:
             rest="${entry#*|}"
             file="${rest%%|*}"
             image="${rest#*|}"
-            matches=$(grep -cE "^FROM ${image}@sha256:[0-9a-f]{64}" "$file")
+            # Escape regex metacharacters (the tags contain literal dots) so the
+            # grep -E patterns match the image string literally, not as a regex.
+            image_re=$(printf '%s' "$image" | sed -E 's/[][(){}.^$*+?|\\]/\\&/g')
+            matches=$(grep -cE "^FROM ${image_re}@sha256:[0-9a-f]{64}" "$file")
             if [ "$matches" -ne 1 ]; then
               echo "::error file=${file}::expected exactly one pinned 'FROM ${image}@sha256:' line, found $matches"
               exit 1
             fi
             # Full sha256:<64hex>: warm_tag does `docker pull "${repo}@${digest}"`.
-            digest=$(grep -oE "${image}@sha256:[0-9a-f]{64}" "$file" | head -n1 | sed -E 's/.*@//')
+            digest=$(grep -oE "${image_re}@sha256:[0-9a-f]{64}" "$file" | head -n1 | sed -E 's/.*@//')
             echo "$key=$digest" >> "$GITHUB_OUTPUT"
             echo "resolved $image -> $digest"
           done

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -440,6 +440,12 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
 
+      - name: Free runner disk before Docker image load
+        # This job loads warm images AND may run a cold full cargo release build
+        # inside rust — the other disk-heavy integration job (#459). Placed
+        # before the warm-image load (docker-images:true must not delete them).
+        uses: ./.github/actions/free-disk-space
+
       - name: Download warm base images
         # The cffi build below `docker run`s the rust base. The warm-images job
         # pulled the pinned digest and saved it under a local alias; this cell
@@ -613,6 +619,12 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
+
+      - name: Free runner disk before Docker image load
+        # The observed ENOSPC job: builds BAML from source per cell (#459).
+        # Placed before the warm-image load (docker-images:true must not
+        # delete them).
+        uses: ./.github/actions/free-disk-space
 
       - name: Download warm base images
         # Base images are pulled once by the warm-images job and handed over as

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -111,22 +111,36 @@ jobs:
 
       - name: Resolve base-image digests
         id: resolve
-        # Resolve each floating tag to its current registry index digest so the
-        # cache key tracks image CONTENT, not the mutable tag, and so the pull
-        # below is by immutable digest (no tag float between resolve and pull).
-        # imagetools inspect queries the registry using the login above.
+        # Single-source each warm base image's digest from its pinned Dockerfile
+        # `FROM` line instead of querying the registry at runtime (#458). The
+        # cache key then tracks image CONTENT via the in-repo pin (bumped by
+        # Renovate's docker custom manager), and the warm pull below is by that
+        # immutable digest — zero Docker Hub calls on the resolve path. Same
+        # guard shape as the rust step below: assert exactly one pinned `FROM`
+        # per image and fail loudly otherwise, so a botched pin can't silently
+        # fall through to an empty digest. node/debian live in
+        # cmd/build/Dockerfile.tmpl; golang/alpine in integration/mockllm.
         run: |
           set -euo pipefail
+          # key|file|image  (image is the repo:tag prefix of the FROM ref)
           for entry in \
-            "node:node:22-bookworm" \
-            "debian:debian:bookworm-slim" \
-            "golang:golang:1.26.3-alpine" \
-            "alpine:alpine:3.19"; do
-            key="${entry%%:*}"
-            ref="${entry#*:}"
-            digest=$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}')
+            "node|cmd/build/Dockerfile.tmpl|node:22-bookworm" \
+            "debian|cmd/build/Dockerfile.tmpl|debian:bookworm-slim" \
+            "golang|integration/mockllm/Dockerfile|golang:1.26.3-alpine" \
+            "alpine|integration/mockllm/Dockerfile|alpine:3.19"; do
+            key="${entry%%|*}"
+            rest="${entry#*|}"
+            file="${rest%%|*}"
+            image="${rest#*|}"
+            matches=$(grep -cE "^FROM ${image}@sha256:[0-9a-f]{64}" "$file")
+            if [ "$matches" -ne 1 ]; then
+              echo "::error file=${file}::expected exactly one pinned 'FROM ${image}@sha256:' line, found $matches"
+              exit 1
+            fi
+            # Full sha256:<64hex>: warm_tag does `docker pull "${repo}@${digest}"`.
+            digest=$(grep -oE "${image}@sha256:[0-9a-f]{64}" "$file" | head -n1 | sed -E 's/.*@//')
             echo "$key=$digest" >> "$GITHUB_OUTPUT"
-            echo "resolved $ref -> $digest"
+            echo "resolved $image -> $digest"
           done
 
       - name: Resolve pinned rust image

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -323,6 +323,14 @@ jobs:
           # are ephemeral and torn down after the job, so leaked containers
           # are cleaned up regardless. Never set this for local runs.
           TESTCONTAINERS_RYUK_DISABLED: true
+          # This suite includes TestBamlfuzzStaticOracle, whose per-batch
+          # full baml-rest image builds otherwise accumulate and exhaust the
+          # runner disk ("no space left on device"). This gate activates the
+          # harness's happy-path `docker image prune -f` between static envs,
+          # bounding per-batch image growth at ~zero runtime cost while
+          # leaving the BuildKit cache warm. Cheaper than the free-disk step
+          # across every matrix cell (#459).
+          BAMLFUZZ_STATIC_DOCKER_PRUNE: "1"
         # -p 1 ensures tests run sequentially (no parallelism) since integration tests
         # share state (server config, worker pool) that could cause flakiness if parallel.
         # `subprocess` matches the normal server deployment path (server +
@@ -420,6 +428,14 @@ jobs:
           # are ephemeral and torn down after the job, so leaked containers
           # are cleaned up regardless. Never set this for local runs.
           TESTCONTAINERS_RYUK_DISABLED: true
+          # This suite includes TestBamlfuzzStaticOracle, whose per-batch
+          # full baml-rest image builds otherwise accumulate and exhaust the
+          # runner disk ("no space left on device"). This gate activates the
+          # harness's happy-path `docker image prune -f` between static envs,
+          # bounding per-batch image growth at ~zero runtime cost while
+          # leaving the BuildKit cache warm. Cheaper than the free-disk step
+          # across every matrix cell (#459).
+          BAMLFUZZ_STATIC_DOCKER_PRUNE: "1"
         # No `subprocess` tag — the default no-tag build compiles the
         # direct in-process worker path.
         run: go test -tags=integration -v -count=1 -p 1 -timeout 40m ./integration/...

--- a/cmd/build/Dockerfile.tmpl
+++ b/cmd/build/Dockerfile.tmpl
@@ -5,6 +5,7 @@ ARG GO_VERSION=1.26.3
 # Rust builder stage: Build BAML CFFI library and CLI from source.
 # Pinned to a digest so a silent base-image bump cannot change the
 # toolchain (and thus the produced .so) underneath a fixed cache key.
+# renovate: datasource=docker
 FROM rust:bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 AS cffi-builder
 
 # Install Go (needed for protoc-gen-go during CFFI build)
@@ -33,7 +34,8 @@ RUN cargo build --release -p baml-cli -p baml_cffi
 {{- end }}
 
 # Builder stage: Node.js + Go combined environment
-FROM node:22-bookworm AS builder
+# renovate: datasource=docker
+FROM node:22-bookworm@sha256:2d178f2785b96dfbf62a416ca2e40f50e30150b4ff3320d706f0d96e90600eb3 AS builder
 
 # Install Go (multi-architecture support)
 ARG TARGETARCH{{ if .defaultTargetArch }}={{ .defaultTargetArch }}{{ end }}
@@ -147,7 +149,8 @@ RUN --mount=type=cache,target=/cache \
 {{- end }}
 
 # Final stage: Minimal Debian image
-FROM debian:bookworm-slim
+# renovate: datasource=docker
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716
 
 RUN apt-get update && \
     apt-get install -y ca-certificates tzdata bash \

--- a/integration/mockllm/Dockerfile
+++ b/integration/mockllm/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26.3-alpine AS builder
+# renovate: datasource=docker
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 
 WORKDIR /app
 
@@ -11,7 +12,8 @@ COPY integration/mockllm/ ./integration/mockllm/
 # Build the mock server
 RUN CGO_ENABLED=0 GOOS=linux go build -tags=integration -o /mockllm ./integration/mockllm/cmd
 
-FROM alpine:3.19
+# renovate: datasource=docker
+FROM alpine:3.19@sha256:6baf43584bcb78f2e5847d1de515f23499913ac9f12bdf834811a3145eb11ca1
 
 # Add ca-certificates for HTTPS (not strictly needed but good practice)
 RUN apk --no-cache add ca-certificates

--- a/renovate.json
+++ b/renovate.json
@@ -54,9 +54,47 @@
       "depNameTemplate": "go",
       "datasourceTemplate": "golang-version",
       "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "description": "Update pinned CI base-image digests in Dockerfiles",
+      "managerFilePatterns": [
+        "/^cmd/build/Dockerfile\\.tmpl$/",
+        "/^integration/mockllm/Dockerfile$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=docker\\s+FROM(?:\\s+--platform=[^\\s]+)?\\s+(?<depName>[^:@\\s]+):(?<currentValue>[^@\\s]+)@sha256:(?<currentDigest>[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ],
+  "docker": {
+    "enabled": true
+  },
   "packageRules": [
+    {
+      "description": "Batch CI base image tag/digest updates. The inherited preset disables Docker handling, so these come from the custom regex manager above (datasource=docker) rather than the native Dockerfile manager.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchFileNames": [
+        "cmd/build/Dockerfile.tmpl",
+        "integration/mockllm/Dockerfile"
+      ],
+      "matchPackageNames": [
+        "rust",
+        "node",
+        "debian",
+        "golang",
+        "alpine"
+      ],
+      "groupName": "base docker images",
+      "groupSlug": "base-docker-images"
+    },
     {
       "matchDatasources": [
         "golang-version"


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

CI base-image hygiene: pin the five Docker base images to digests and reclaim runner disk on the disk-heavy jobs. One PR, two separable commits. Follow-up to the #457 warm-image throughput work and the #459 ENOSPC observation.

## Commit 1 — #458: pin digests + resolve warm digests from repo pins
- Pin all five base images in-repo as `image:tag@sha256:<64hex>` with a `# renovate: datasource=docker` annotation above each `FROM`:
  - `cmd/build/Dockerfile.tmpl`: `rust:bookworm` (refreshed to the freshly-resolved digest — same value), `node:22-bookworm`, `debian:bookworm-slim`.
  - `integration/mockllm/Dockerfile`: `golang:1.26.3-alpine`, `alpine:3.19`.
- Rewrite both `warm-images` resolvers (`integration-tests.yml`, `bamlfuzz-nightly.yml`) to grep the pinned digest out of the Dockerfiles instead of a live `docker buildx imagetools inspect` loop — generalizing the existing pinned-rust guard. Each image must match exactly one pinned `FROM` line or the step fails loudly; node/debian/golang/alpine emit the full `sha256:<64hex>` the `warm_tag` helper feeds to `docker pull "${repo}@${digest}"`. Cache-key semantics are preserved (keys still include the content digest, now sourced from the repo pin). bamlfuzz stays rust-free; integration keeps rust's full-image + 12-char-fragment output for the local alias / cffi cache key.
- Renovate wiring: the inherited preset `local>invakid404/renovate-config` ships `"docker": { "enabled": false }`, so the native Dockerfile manager won't pick these up. Added a **custom regex manager** (`datasource=docker` over both Dockerfiles), a `base docker images` grouping package rule, and a top-level `"docker": { "enabled": true }` override so the custom docker datasource isn't suppressed. The existing `golang-version` custom manager and its package rule are untouched.

## Commit 2 — #459: shared free-disk composite action
- Extract the inline `jlumbroso/free-disk-space@54081f1…` step into `.github/actions/free-disk-space` (same pinned ref + inputs). `docker-images: true` is only safe before warm tarballs are loaded, so every consumer places it after checkout and before its `docker load`.
- `bamlfuzz-nightly.yml`: inline step replaced by the composite (same placement).
- `integration-tests.yml`: added to `integration-tests-baml-source` (the observed ENOSPC job) and `build-baml-cffi` (loads warm images + may run a cold full cargo release build). Not added to the lighter versioned/in-process matrix cells, and not to `build-and-publish.yml` (out of scope).

## Verification
Static/local only. `npx renovate-config-validator renovate.json` passes; the custom-manager regex was checked by inspection to extract all five docker deps (rust/node/debian/golang/alpine) with correct `depName`/`currentValue`/`currentDigest`. No full Renovate dry-run was attempted — the repo's Renovate **Dependency Dashboard** sticky issue will confirm post-merge whether the five docker deps were discovered, and the config is patchable later if not. YAML parses for all touched workflows + the composite action; `Dockerfile.tmpl` still renders through the Go template parser; each pinned `FROM` matches exactly one line and the grep resolvers extract the right digests.

Closes #458
Closes #459


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI consistency by pinning Docker base images to immutable digests across build and test environments.
  * Updated CI to derive warm base-image digests directly from pinned Dockerfile references, avoiding runtime lookups.
  * Strengthened runner disk management by reclaiming disk space before warming/using Docker images, plus enabling additional prune behavior between static test phases.
* **Documentation**
  * Expanded automated dependency management to detect and batch digest-pinned Docker base images for safe, controlled updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->