### PR TITLE
fix(hacks): normalize pointer-wrapped slice carriers in static-map helpers (#456)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/static/11_static_optional_list_of_string_map.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/static/11_static_optional_list_of_string_map.json
@@ -1,0 +1,100 @@
+{
+  "name": "static_optional_list_of_string_map",
+  "seed": 456,
+  "case_index": 11,
+  "mode": "static_prompt",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "items",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {
+                  "kind": "list",
+                  "inner": {
+                    "kind": "map",
+                    "inner": {
+                      "kind": "string"
+                    },
+                    "key": {
+                      "kind": "string"
+                    }
+                  }
+                },
+                {
+                  "kind": "null"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_self_ref": false,
+    "has_mutual_cycle": false,
+    "has_union": true,
+    "requires_dynamic_skip": false
+  },
+  "value": {
+    "kind": "class_ref",
+    "class_name": "Root",
+    "fields": [
+      {
+        "name": "items",
+        "value": {
+          "kind": "union",
+          "variant": {
+            "kind": "list",
+            "items": [
+              {
+                "kind": "map",
+                "map_entries": [
+                  {
+                    "key": "k3",
+                    "value": {
+                      "kind": "string",
+                      "string": "ߥ/%"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "mock_llm_content": {
+    "items": [
+      {
+        "k3": "ߥ/%"
+      }
+    ]
+  },
+  "expected": {
+    "items": [
+      {
+        "k3": "ߥ/%"
+      }
+    ]
+  },
+  "metadata": {
+    "recursion_depths": {
+      "Root": 1
+    },
+    "union_choices": {
+      ".items": {
+        "index": 0,
+        "kind": "list",
+        "variant_count": 2
+      }
+    }
+  }
+}

--- a/cmd/hacks/hacks/dynamic_order_client.go
+++ b/cmd/hacks/hacks/dynamic_order_client.go
@@ -2219,7 +2219,16 @@ func emitSliceWrappedStaticMapHelper(name, typeExpr string, pkgIdx *pkgTypeIndex
 	}
 	b.WriteString("\tlistVal, ok := value.([]any)\n")
 	b.WriteString("\tif !ok {\n")
-	b.WriteString("\t\treturn nil\n")
+	// The 0.219+ optional/list decode path can hand this helper a
+	// non-nil pointer-wrapped (or otherwise non-[]any) slice carrier
+	// whose elements are ordered/native map carriers. The static
+	// assertions above all miss it, so without reflection
+	// normalization the helper falls through to `return nil` and a
+	// real list is silently serialized as JSON null (issue #456).
+	// Peel a non-nil pointer, then iterate any slice carrier by
+	// reflection and convert each element through the same per-
+	// element conversion the `[]any` fast path uses.
+	emitStaticMapSliceReflectFallback(&b, "\t\t", sliceType, elem, pkgIdx, isPtr)
 	b.WriteString("\t}\n")
 	fmt.Fprintf(&b, "\tout := make(%s, len(listVal))\n", sliceType)
 	b.WriteString("\tfor i, ev := range listVal {\n")
@@ -2237,6 +2246,48 @@ func emitSliceWrappedStaticMapHelper(name, typeExpr string, pkgIdx *pkgTypeIndex
 	}
 	b.WriteString("}")
 	return b.String()
+}
+
+// emitStaticMapSliceReflectFallback writes the reflection-based slice
+// normalization shared by emitSliceWrappedStaticMapHelper and
+// emitConvertListHelper. Both helpers accept only a small set of static
+// carrier shapes (`*[]T`, `[]T`, `[]any`) and otherwise drop the value
+// to nil; the BAML 0.219+ optional/list decode path can hand them a
+// non-nil pointer-wrapped (or otherwise non-`[]any`) slice carrier whose
+// elements are ordered/native map carriers, which matches none of those
+// shapes (issue #456). This emits: peel a non-nil pointer; if the
+// underlying value is a slice, rebuild a typed `[]T` by converting each
+// element through the same per-element conversion the `[]any` fast path
+// uses (with the nilable-element nil guard); a non-pointer, non-slice
+// carrier still returns nil.
+//
+// `indent` is the leading tabs for the emitted block (the caller places
+// the block at its own scope depth). `retPtr` controls whether the
+// rebuilt slice is returned by address (`*[]T` helpers) or by value.
+// `reflect` is always imported into the helper file (see
+// ensureStaticMapHelperFile), so no extra import bookkeeping is needed.
+func emitStaticMapSliceReflectFallback(b *strings.Builder, indent, sliceType, elem string, pkgIdx *pkgTypeIndex, retPtr bool) {
+	fmt.Fprintf(b, "%srv := reflect.ValueOf(value)\n", indent)
+	fmt.Fprintf(b, "%sif rv.Kind() == reflect.Pointer {\n", indent)
+	fmt.Fprintf(b, "%s\tif rv.IsNil() {\n", indent)
+	fmt.Fprintf(b, "%s\t\treturn nil\n", indent)
+	fmt.Fprintf(b, "%s\t}\n", indent)
+	fmt.Fprintf(b, "%s\trv = rv.Elem()\n", indent)
+	fmt.Fprintf(b, "%s}\n", indent)
+	fmt.Fprintf(b, "%sif rv.Kind() != reflect.Slice {\n", indent)
+	fmt.Fprintf(b, "%s\treturn nil\n", indent)
+	fmt.Fprintf(b, "%s}\n", indent)
+	fmt.Fprintf(b, "%sout := make(%s, rv.Len())\n", indent, sliceType)
+	fmt.Fprintf(b, "%sfor i := 0; i < rv.Len(); i++ {\n", indent)
+	fmt.Fprintf(b, "%s\tev := rv.Index(i).Interface()\n", indent)
+	emitStaticMapElementGuard(b, indent+"\t", "ev", elem, pkgIdx, "out[i] = nil\n"+indent+"\t\tcontinue\n")
+	fmt.Fprintf(b, "%s\tout[i] = %s\n", indent, convertStaticMapValueExpr("ev", elem))
+	fmt.Fprintf(b, "%s}\n", indent)
+	if retPtr {
+		fmt.Fprintf(b, "%sreturn &out\n", indent)
+	} else {
+		fmt.Fprintf(b, "%sreturn out\n", indent)
+	}
 }
 
 // emitConvertListHelper renders the per-element-type list conversion
@@ -2273,7 +2324,11 @@ func emitConvertListHelper(name, listType string, pkgIdx *pkgTypeIndex) string {
 	b.WriteString("\t}\n")
 	b.WriteString("\tlistVal, ok := value.([]any)\n")
 	b.WriteString("\tif !ok {\n")
-	b.WriteString("\t\treturn nil\n")
+	// Same class as issue #456 nested under a map/list: a composite
+	// list carrier can reach this helper pointer-wrapped or as a
+	// non-`[]any` slice, matching none of the static shapes above.
+	// Normalize by reflection instead of dropping the list to nil.
+	emitStaticMapSliceReflectFallback(&b, "\t\t", listType, elem, pkgIdx, false)
 	b.WriteString("\t}\n")
 	fmt.Fprintf(&b, "\tout := make(%s, len(listVal))\n", listType)
 	b.WriteString("\tfor i, ev := range listVal {\n")

--- a/cmd/hacks/hacks/dynamic_order_fix_test.go
+++ b/cmd/hacks/hacks/dynamic_order_fix_test.go
@@ -37,6 +37,21 @@ var perVersionTestRan atomic.Int32
 // while the first preserves full coverage.
 var staticMapNilCarrierProbeRan atomic.Int32
 
+// staticMapSliceCarrierProbeRan gates the issue #456 slice-carrier
+// preservation probe the same way staticMapNilCarrierProbeRan gates the
+// #448 probe: each invocation shells out to `go run` twice (as-generated
+// + reflection-stripped pre-fix shape), so under the unit-tests
+// workflow's `go test -race -count=100 ./...` loop it would balloon into
+// hundreds of nested go-run calls. The fail-before / pass-after
+// assertions are deterministic and gain no extra signal from re-running,
+// so the second and subsequent invocations skip while the first
+// preserves full coverage. The slice-wrapped and convert-list halves
+// each get their own counter so both run on the first iteration.
+var (
+	staticMapSliceCarrierProbeRan atomic.Int32
+	convertListCarrierProbeRan    atomic.Int32
+)
+
 // TestApplyDynamicOrderFixToDir_PerVersion exercises the hack against
 // each pinned upstream BAML version. The fixture is the read-only
 // module cache copy of github.com/boundaryml/baml@<v>; the test copies
@@ -3428,6 +3443,278 @@ func (m OrderedMap[V]) RangeAny(fn func(string, any) bool) {
 	// "no modules were found in the current workspace". `off` (not "")
 	// is the repo's temp-module isolation pattern — empty falls back to
 	// workspace auto-discovery.
+	cmd.Env = append(os.Environ(), "GOFLAGS=-mod=mod", "GOWORK=off")
+	out, _ := cmd.CombinedOutput()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("go run timed out:\n%s", out)
+	}
+	return string(out)
+}
+
+// TestStaticMapSliceCarrierPreservation is the issue #456 regression
+// probe. The 0.219+ static-map rewrite turns a `*[]map[string]string`
+// field (`((map<string,string>)[] | null)`) into `*[]baml.OrderedMap[string]`
+// and routes its decode through bamlOrderedAs_Ptr_Slice_OM_string. The
+// pre-fix helper accepted only the exact typed slice / pointer-to-slice
+// / `[]any` carrier shapes and dropped everything else to nil, so the
+// non-nil pointer-wrapped list carrier the optional/list decode path
+// hands it (a `*[]` of ordered or native map carriers whose generic
+// type parameter differs from the helper's) fell through to `return nil`
+// and a real list was serialized as JSON null.
+//
+// The probe drives the as-generated helper with two such carriers — a
+// non-nil `*[]baml.OrderedMap[any]` ordered carrier and a non-nil
+// `*[]map[string]string` native carrier — and asserts the list and its
+// value survive. It then strips the reflection normalization back to the
+// pre-fix `return nil` fall-through and asserts the same carriers are
+// dropped to nil, so the harness reproduces #456 before the fix and
+// confirms it after.
+func TestStaticMapSliceCarrierPreservation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("compiles + runs a temp module; skip under -short")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	if staticMapSliceCarrierProbeRan.Add(1) > 1 {
+		t.Skip("static-map slice-carrier probe shells out to go run twice; only run on the first -count iteration to keep -count=100 bounded")
+	}
+
+	idx, err := newPkgTypeIndex(t.TempDir())
+	if err != nil {
+		t.Fatalf("newPkgTypeIndex: %v", err)
+	}
+	// The exact helper pair the #456 rewrite emits for
+	// `*[]baml.OrderedMap[string]`: the slice-wrapped helper plus the
+	// per-element ordered-map helper it recurses through.
+	sliceName := staticMapHelperName("*[]baml.OrderedMap[string]")
+	if sliceName != "bamlOrderedAs_Ptr_Slice_OM_string" {
+		t.Fatalf("unexpected slice helper name %q; the #456 repro tracks bamlOrderedAs_Ptr_Slice_OM_string", sliceName)
+	}
+	sliceSrc := emitStaticMapHelper(sliceName, "*[]baml.OrderedMap[string]", idx)
+	elemSrc := emitStaticMapHelper(staticMapHelperName("baml.OrderedMap[string]"), "baml.OrderedMap[string]", idx)
+	if !strings.Contains(sliceSrc, "reflect.ValueOf(value)") || !strings.Contains(sliceSrc, "reflect.Slice") {
+		t.Fatalf("slice helper is missing the #456 reflection normalization:\n%s", sliceSrc)
+	}
+	coreSrc := staticMapHelperCore()
+
+	mainBody := fmt.Sprintf(`func main() {
+	var om baml.OrderedMap[any]
+	_ = om.Set("k", "v")
+	ordered := []baml.OrderedMap[any]{om}
+	gotOrdered := %[1]s(any(&ordered))
+	if gotOrdered == nil {
+		fmt.Println("ORDERED_NIL")
+		return
+	}
+	if len(*gotOrdered) != 1 {
+		fmt.Println("ORDERED_LEN")
+		return
+	}
+	if v, ok := (*gotOrdered)[0].Get("k"); !ok || v != "v" {
+		fmt.Println("ORDERED_VALUE")
+		return
+	}
+
+	native := []map[string]string{{"k": "v"}}
+	gotNative := %[1]s(any(&native))
+	if gotNative == nil {
+		fmt.Println("NATIVE_NIL")
+		return
+	}
+	if len(*gotNative) != 1 {
+		fmt.Println("NATIVE_LEN")
+		return
+	}
+	if v, ok := (*gotNative)[0].Get("k"); !ok || v != "v" {
+		fmt.Println("NATIVE_VALUE")
+		return
+	}
+	fmt.Println("OK_PRESERVED")
+}`, sliceName)
+
+	// As-generated → both carriers preserved.
+	out := runStaticMapSliceCarrierProbe(t, []string{sliceSrc, elemSrc}, coreSrc, mainBody)
+	if !strings.Contains(out, "OK_PRESERVED") {
+		t.Fatalf("as-generated slice helper dropped a non-nil pointer-wrapped list carrier (issue #456 regression):\n%s", out)
+	}
+
+	// Pre-fix shape: strip the reflection fall-through back to `return
+	// nil` so the unsupported carrier is dropped, reproducing #456.
+	strippedSliceSrc := stripSliceReflectFallback(t, sliceSrc)
+	if strippedSliceSrc == sliceSrc {
+		t.Fatalf("failed to strip the reflection normalization from the slice helper:\n%s", sliceSrc)
+	}
+	stripped := runStaticMapSliceCarrierProbe(t, []string{strippedSliceSrc, elemSrc}, coreSrc, mainBody)
+	if !strings.Contains(stripped, "ORDERED_NIL") {
+		t.Fatalf("pre-fix slice helper unexpectedly did not drop the carrier — the harness no longer reproduces issue #456:\n%s", stripped)
+	}
+}
+
+// TestConvertListHelperPointerWrappedCarrierPreserved pins the same
+// #456 class for the convert-list helper, which carries the identical
+// `[]any`-only assumption for composite list carriers and is reached
+// when a `(map<string,string>)[]` list is nested under a map or list.
+// The non-nil pointer-wrapped carrier must round-trip through the
+// reflection normalization rather than dropping to nil.
+func TestConvertListHelperPointerWrappedCarrierPreserved(t *testing.T) {
+	if testing.Short() {
+		t.Skip("compiles + runs a temp module; skip under -short")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	if convertListCarrierProbeRan.Add(1) > 1 {
+		t.Skip("convert-list slice-carrier probe shells out to go run; only run on the first -count iteration to keep -count=100 bounded")
+	}
+
+	idx, err := newPkgTypeIndex(t.TempDir())
+	if err != nil {
+		t.Fatalf("newPkgTypeIndex: %v", err)
+	}
+	listName := convertListHelperName("[]baml.OrderedMap[string]")
+	listSrc := emitConvertListHelper(listName, "[]baml.OrderedMap[string]", idx)
+	elemSrc := emitStaticMapHelper(staticMapHelperName("baml.OrderedMap[string]"), "baml.OrderedMap[string]", idx)
+	if !strings.Contains(listSrc, "reflect.ValueOf(value)") || !strings.Contains(listSrc, "reflect.Slice") {
+		t.Fatalf("convert-list helper is missing the #456 reflection normalization:\n%s", listSrc)
+	}
+	coreSrc := staticMapHelperCore()
+
+	mainBody := fmt.Sprintf(`func main() {
+	var om baml.OrderedMap[any]
+	_ = om.Set("k", "v")
+	ordered := []baml.OrderedMap[any]{om}
+	got := %[1]s(any(&ordered))
+	if got == nil {
+		fmt.Println("LIST_NIL")
+		return
+	}
+	if len(got) != 1 {
+		fmt.Println("LIST_LEN")
+		return
+	}
+	if v, ok := got[0].Get("k"); !ok || v != "v" {
+		fmt.Println("LIST_VALUE")
+		return
+	}
+	fmt.Println("OK_PRESERVED")
+}`, listName)
+
+	out := runStaticMapSliceCarrierProbe(t, []string{listSrc, elemSrc}, coreSrc, mainBody)
+	if !strings.Contains(out, "OK_PRESERVED") {
+		t.Fatalf("as-generated convert-list helper dropped a non-nil pointer-wrapped list carrier (issue #456 regression):\n%s", out)
+	}
+
+	strippedListSrc := stripSliceReflectFallback(t, listSrc)
+	if strippedListSrc == listSrc {
+		t.Fatalf("failed to strip the reflection normalization from the convert-list helper:\n%s", listSrc)
+	}
+	stripped := runStaticMapSliceCarrierProbe(t, []string{strippedListSrc, elemSrc}, coreSrc, mainBody)
+	if !strings.Contains(stripped, "LIST_NIL") {
+		t.Fatalf("pre-fix convert-list helper unexpectedly did not drop the carrier — the harness no longer reproduces issue #456:\n%s", stripped)
+	}
+}
+
+// stripSliceReflectFallback rewrites the reflection-normalization block
+// the #456 fix emits inside a slice / convert-list helper's
+// `if !ok { ... }` fall-through back to the pre-fix `return nil` body,
+// so a probe can assert the bug reproduces before the fix. It anchors on
+// the `if !ok {` line (the `value.([]any)` fall-through) and replaces its
+// body up to the matching single-tab `}` close. The fallback's own inner
+// closes are two-tab (`\t\t}`), so the first `\n\t}\n` after the opener
+// is the block close.
+func stripSliceReflectFallback(t *testing.T, src string) string {
+	t.Helper()
+	const open = "\tif !ok {\n"
+	oi := strings.Index(src, open)
+	if oi < 0 {
+		t.Fatalf("helper has no `if !ok {` fall-through block to strip:\n%s", src)
+	}
+	bodyStart := oi + len(open)
+	ci := strings.Index(src[bodyStart:], "\n\t}\n")
+	if ci < 0 {
+		t.Fatalf("could not find the close of the `if !ok {` block:\n%s", src)
+	}
+	end := bodyStart + ci + len("\n\t}\n")
+	return src[:oi] + "\tif !ok {\n\t\treturn nil\n\t}\n" + src[end:]
+}
+
+// runStaticMapSliceCarrierProbe writes a self-contained temp module that
+// pairs the supplied generated helper sources + core with a faithful
+// stub OrderedMap (value-receiver RangeAny/Len/Get, pointer-receiver Set,
+// matching the patched serde carrier's receiver shapes), drives the
+// supplied main body, and returns the combined `go run` output. The
+// caller inspects the printed sentinel rather than the exit code.
+func runStaticMapSliceCarrierProbe(t *testing.T, helperSrcs []string, coreSrc, mainBody string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	mustWrite := func(rel, content string) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	mustWrite("go.mod", "module ordmaptest\n\ngo 1.23\n")
+	mustWrite("baml/baml.go", `package baml
+
+type entry[V any] struct {
+	key   string
+	value V
+}
+
+type OrderedMap[V any] struct {
+	entries []entry[V]
+	index   map[string]int
+}
+
+func (m *OrderedMap[V]) Set(key string, value V) error {
+	if m.index == nil {
+		m.index = map[string]int{}
+	}
+	if i, ok := m.index[key]; ok {
+		m.entries[i].value = value
+		return nil
+	}
+	m.index[key] = len(m.entries)
+	m.entries = append(m.entries, entry[V]{key: key, value: value})
+	return nil
+}
+
+func (m OrderedMap[V]) Len() int { return len(m.entries) }
+
+func (m OrderedMap[V]) RangeAny(fn func(string, any) bool) {
+	for _, e := range m.entries {
+		if !fn(e.key, e.value) {
+			return
+		}
+	}
+}
+
+func (m OrderedMap[V]) Get(key string) (V, bool) {
+	if m.index != nil {
+		if i, ok := m.index[key]; ok {
+			return m.entries[i].value, true
+		}
+	}
+	var zero V
+	return zero, false
+}
+`)
+	main := "package main\n\nimport (\n\t\"fmt\"\n\t\"reflect\"\n\n\tbaml \"ordmaptest/baml\"\n)\n\nvar _ = reflect.ValueOf\n\n" +
+		strings.Join(helperSrcs, "\n\n") + "\n\n" + coreSrc + "\n\n" + mainBody + "\n"
+	mustWrite("main.go", main)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "run", ".")
+	cmd.Dir = dir
+	// GOWORK=off isolates the temp module from any caller-configured Go
+	// workspace; mirrors runStaticMapNilCarrierProbe.
 	cmd.Env = append(os.Environ(), "GOFLAGS=-mod=mod", "GOWORK=off")
 	out, _ := cmd.CombinedOutput()
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Root cause

On BAML 0.219+ (adapter family `adapter_v0_219_0`), the static-map generated-client hack rewrites a `*[]map[string]string` field (from `((map<string,string>)[] | null)`) to `*[]baml.OrderedMap[string]` and routes its decode through the emitted slice helper `bamlOrderedAs_Ptr_Slice_OM_string`. The emitted helper accepted only the exact carrier shapes `*[]baml.OrderedMap[string]`, `[]baml.OrderedMap[string]`, and `[]any`, and otherwise returned `nil`.

The 0.219+ optional/list decode path hands the helper a **non-nil pointer-wrapped list carrier** whose elements are ordered/native map carriers. That carrier matches none of the accepted shapes, so the helper fell through to `return nil` → a real list (e.g. `[{"k3":"…"}]`) was silently serialized as JSON `null`. Direct upstream BAML 0.219 preserves the value across Parse/Call/Call+OnTick/Stream.Final; the data loss was purely in our emitter's helper fall-through. This is a new, non-crashing data-loss sibling of the #448/#451 typed-nil carrier work.

## The fix

In `cmd/hacks/hacks/dynamic_order_client.go`, before the `[]any` fall-through in **both** `emitSliceWrappedStaticMapHelper` and `emitConvertListHelper`, add shared reflection-based normalization (`emitStaticMapSliceReflectFallback`):

- peel a non-nil pointer (`reflect.Pointer` → `Elem()`),
- if the underlying value is a slice, rebuild a properly-typed `[]T` by converting each element through the **existing** per-element static-map conversion (`convertStaticMapValueExpr`, with the nilable-element nil guard), returning pointer-wrapped where the helper expects a pointer,
- a non-pointer, non-slice carrier still returns `nil`.

`emitConvertListHelper` gets the same treatment because it carries the identical `[]any`-only assumption and is reached when this list is nested under a map/list. The fix reuses the `reflect` import already emitted into every helper file (used by `bamlStaticMapCarrierIsNil`), mirroring the #448/#451 reflect idiom. Change is confined to the emitter helpers.

## Tests

- **Runtime regression probes** in `cmd/hacks/hacks/dynamic_order_fix_test.go` (`TestStaticMapSliceCarrierPreservation`, `TestConvertListHelperPointerWrappedCarrierPreserved`): route a non-nil `*[]baml.OrderedMap[any]` ordered carrier **and** a `*[]map[string]string` native carrier through the as-generated `bamlOrderedAs_Ptr_Slice_OM_string` / convert-list helpers and assert the value is preserved (not nil). Stripping the reflection normalization back to `return nil` reproduces the drop, giving a fail-before / pass-after assertion. Gated with the run-once `testing.Short()` / `exec.LookPath` / atomic-counter pattern (per #451) so the `-race -count=100` envelope stays bounded.
- **Static bamlfuzz corpus case** `adapters/common/codegen/testdata/bamlfuzz/static/11_static_optional_list_of_string_map.json` for `((map<string,string>)[] | null)` choosing the non-null list arm, generated via `bamlfuzz.Walk` so the schema/value/mock/expected/metadata are mutually consistent. Pins the 0.219+ behavior in the integration oracle.

**No `SemanticDiffWithSchema` tolerance was added** — the REST value was semantically wrong, not an oracle over-strictness issue.

## Fresh-tree / embed / worker-plugin validation

- `go run ./cmd/regenerate-dynclient` (canonical regen, defaults to `.latest` = 0.222.0) then `go run ./cmd/embed`, then `git diff` → the committed dynclient tree is **byte-clean** (no changes). The regen log shows the `dynamic-order-client-fix` hack ran but emitted **no `Modified (static-map)` lines**, confirming `cmd/build/dynamic.baml` exposes no static-map slice surfaces, so the emitter change is unreachable for the committed dynclient — i.e. no unintended drift. (`go work sync` added 3 spurious transitive `/go.mod`-only checksums to `go.work.sum`; reverted to keep the PR scoped.)
- Worker path compiles: `dynclient` and `workerplugin` modules `go build ./...` clean (the `dynclient` module holds the regenerated embedded adapter the worker loads).
- Local checks: `go build ./...` (root), `go vet ./cmd/hacks/...`, `adapters/common` build + `bamlfuzz` vet, and `go test -race ./cmd/hacks/...` all pass. `gofmt` clean on touched files (the only `gofmt -l` flag on `dynamic_order_client.go` is a pre-existing backtick-comment quirk at L1308, present on `master` too).

Repro pinned in the verdict: `BAMLFUZZ_STATIC_BATCHES=10 BAMLFUZZ_SEED=27605271243 BAML_VERSION=0.219.0 go test -tags=integration,subprocess -run='^TestBamlfuzzStaticOracle$/^rapid_batch_0$/^rapid_b0_c3$' ./integration` (nightly run 27605271243).

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where list data could be incorrectly dropped during decoding operations, ensuring data is properly preserved.

* **Tests**
  * Added regression tests to verify list carriers are preserved correctly during decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->