### PR TITLE
fix(nightly): stop pruning classic-builder cache between successful static batches (#467)

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -448,24 +448,42 @@ jobs:
         # ~50-case budget the other targets explore per nightly cell.
         # No corpus restore/upload: -run does not use the fuzz corpus.
         #
-        # BAMLFUZZ_STATIC_DOCKER_PRUNE prunes dangling images between
-        # successful envs; failed setup additionally prunes the BuildKit
-        # cache. Keeping builder prune off the happy path preserves warm
-        # layer reuse so later batches rebuild fast, while still keeping
-        # this target's many full baml-rest builds from accumulating and
-        # exhausting the runner disk. Scoped to this step only — the
-        # harness no-ops without it.
+        # Successful static env teardown does NOT prune: testcontainers
+        # already removes each tagged final per-batch image, and the
+        # classic-builder intermediate layer cache must survive on disk so
+        # later batches reuse the warm Go toolchain / apt / goimports
+        # layers instead of rebuilding them cold. The cold-rebuild churn
+        # the success-path prune used to cause is what overran the 50m
+        # watchdog (#467). Disk between batches is bounded by the
+        # free-disk-space step above (#454/#460), not by pruning.
         #
-        # BAML_REST_SUITE_WATCHDOG is a margin for runner variance, not
-        # the throughput fix: warm-cache runtime is ~20-25m, well under
-        # 50m. Go's -timeout 80m and the job timeout-minutes are unchanged.
+        # BAMLFUZZ_STATIC_DOCKER_PRUNE_ON_FAILURE gates ONLY the
+        # failed-setup prune (dangling images + BuildKit cache), since
+        # failed/partial builds are the real residue source. Scoped to
+        # this step only — the harness no-ops without it.
+        #
+        # BAML_REST_SUITE_WATCHDOG is a margin for runner variance. This
+        # fix clears the watchdog by keeping the layer cache warm; the
+        # per-batch `RUN build.sh` work still reruns, so full warmth
+        # (~20-25m) is the separate #470 follow-up. Go's -timeout 80m and
+        # the job timeout-minutes are unchanged.
         env:
-          BAMLFUZZ_STATIC_DOCKER_PRUNE: "1"
+          BAMLFUZZ_STATIC_DOCKER_PRUNE_ON_FAILURE: "1"
           BAML_REST_SUITE_WATCHDOG: 50m
         run: |
+          echo "=== disk before static oracle ==="
+          df -h /
+          docker system df || true
+          # Capture go test's exit without tripping the default `set -e`,
+          # so the after-snapshot always runs even on a test failure.
+          status=0
           go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
             -run='TestBamlfuzzStaticOracle' \
-            ./integration
+            ./integration || status=$?
+          echo "=== disk after static oracle ==="
+          df -h /
+          docker system df || true
+          exit $status
 
       - name: Streaming oracle (-run, no fuzz watchdog) (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'fuzz' && matrix.target == 'FuzzBamlfuzzStreaming' }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -323,14 +323,14 @@ jobs:
           # are ephemeral and torn down after the job, so leaked containers
           # are cleaned up regardless. Never set this for local runs.
           TESTCONTAINERS_RYUK_DISABLED: true
-          # This suite includes TestBamlfuzzStaticOracle, whose per-batch
-          # full baml-rest image builds otherwise accumulate and exhaust the
-          # runner disk ("no space left on device"). This gate activates the
-          # harness's happy-path `docker image prune -f` between static envs,
-          # bounding per-batch image growth at ~zero runtime cost while
-          # leaving the BuildKit cache warm. Cheaper than the free-disk step
-          # across every matrix cell (#459).
-          BAMLFUZZ_STATIC_DOCKER_PRUNE: "1"
+          # This suite includes TestBamlfuzzStaticOracle. Successful static
+          # env teardown does NOT prune: testcontainers already removes each
+          # tagged final per-batch image, and the classic-builder layer cache
+          # must survive so later batches reuse warm Go toolchain / apt /
+          # goimports layers instead of rebuilding cold (#467). This gate
+          # activates ONLY the failed-setup prune (dangling images + BuildKit
+          # cache), since failed/partial builds are the real residue source.
+          BAMLFUZZ_STATIC_DOCKER_PRUNE_ON_FAILURE: "1"
         # -p 1 ensures tests run sequentially (no parallelism) since integration tests
         # share state (server config, worker pool) that could cause flakiness if parallel.
         # `subprocess` matches the normal server deployment path (server +
@@ -428,14 +428,14 @@ jobs:
           # are ephemeral and torn down after the job, so leaked containers
           # are cleaned up regardless. Never set this for local runs.
           TESTCONTAINERS_RYUK_DISABLED: true
-          # This suite includes TestBamlfuzzStaticOracle, whose per-batch
-          # full baml-rest image builds otherwise accumulate and exhaust the
-          # runner disk ("no space left on device"). This gate activates the
-          # harness's happy-path `docker image prune -f` between static envs,
-          # bounding per-batch image growth at ~zero runtime cost while
-          # leaving the BuildKit cache warm. Cheaper than the free-disk step
-          # across every matrix cell (#459).
-          BAMLFUZZ_STATIC_DOCKER_PRUNE: "1"
+          # This suite includes TestBamlfuzzStaticOracle. Successful static
+          # env teardown does NOT prune: testcontainers already removes each
+          # tagged final per-batch image, and the classic-builder layer cache
+          # must survive so later batches reuse warm Go toolchain / apt /
+          # goimports layers instead of rebuilding cold (#467). This gate
+          # activates ONLY the failed-setup prune (dangling images + BuildKit
+          # cache), since failed/partial builds are the real residue source.
+          BAMLFUZZ_STATIC_DOCKER_PRUNE_ON_FAILURE: "1"
         # No `subprocess` tag — the default no-tag build compiles the
         # direct in-process worker path.
         run: go test -tags=integration -v -count=1 -p 1 -timeout 40m ./integration/...

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -273,7 +273,7 @@ func runStaticBatch(t *testing.T, cases []bamlfuzz.OracleCase, batchLabel string
 		}
 		return
 	}
-	defer terminateStaticEnvAndPrune(t, env)
+	defer terminateStaticEnv(t, env)
 
 	mockClient := mockllm.NewClient(env.MockLLMURL)
 	bamlClient := testutil.NewBAMLRestClient(env.BAMLRestURL)
@@ -450,7 +450,7 @@ func runIsolatedStaticCase(t *testing.T, lc loweredStaticCase, caseIdx int, batc
 		failStaticAndDump(t, envelope, "isolated build failed: %v", err)
 		return
 	}
-	terminateStaticEnvAndPrune(t, env)
+	terminateStaticEnv(t, env)
 }
 
 // caseSourcePath returns the absolute path to the generated .baml
@@ -566,54 +566,28 @@ func terminateStaticEnv(t *testing.T, env *testutil.TestEnvironment) {
 	}
 }
 
-// terminateStaticEnvAndPrune terminates a static env and then reclaims
-// dangling Docker images. Used wherever runStaticBatch / the isolation
-// path finishes with a live env so the static oracle's per-batch
-// baml-rest image builds don't accumulate on the runner disk. The happy
-// path prunes dangling images only; it deliberately does NOT prune the
-// BuildKit cache, so warm layer reuse survives across batches.
-func terminateStaticEnvAndPrune(t *testing.T, env *testutil.TestEnvironment) {
-	t.Helper()
-	terminateStaticEnv(t, env)
-	pruneStaticDockerArtifacts(t)
-}
-
-// pruneStaticDockerArtifacts reclaims dangling Docker images between
-// static envs so the static oracle's many full baml-rest image builds
-// don't exhaust the runner disk ("no space left on device"). It is a
-// no-op unless BAMLFUZZ_STATIC_DOCKER_PRUNE is set, so local runs and
-// other integration tests are unaffected.
-//
-// This is the happy-path prune: it removes only dangling images and
-// deliberately leaves the BuildKit cache intact, because `docker builder
-// prune` is throughput-destructive — it forces every later batch to
-// rebuild cold instead of reusing warm layers. Failed setup uses
-// pruneStaticDockerArtifactsAfterFailedSetup, which additionally prunes
-// the BuildKit cache.
-//
-// It never uses `-a` / `docker system prune -a`, which would delete the
-// warm base images the nightly job loads and force Docker Hub pulls. The
-// static oracle runs serially (-p 1), so pruning between env lifecycles
-// never races a live container. Prune failures are logged as warnings,
-// never failing the test.
-func pruneStaticDockerArtifacts(t *testing.T) {
-	t.Helper()
-	if os.Getenv("BAMLFUZZ_STATIC_DOCKER_PRUNE") == "" {
-		return
-	}
-	runStaticDockerPrune(t, []string{"image", "prune", "-f"})
-}
-
 // pruneStaticDockerArtifactsAfterFailedSetup reclaims Docker build
-// residue after a failed static setup. In addition to dangling images,
-// it prunes the BuildKit cache, because failed/partial builds are the
-// largest source of unreferenced residue. Builder prune is confined to
-// this failure path because it is throughput-destructive on the happy
-// path (it discards warm layers and forces cold rebuilds). Same gating
-// and best-effort semantics as pruneStaticDockerArtifacts.
+// residue after a failed static setup. It prunes dangling images and the
+// BuildKit cache, because failed/partial builds are the largest source of
+// unreferenced residue.
+//
+// Successful env teardown deliberately does NOT prune: testcontainers
+// already removes the tagged final per-batch image (KeepImage=false), and
+// keeping the classic-builder intermediate layer cache on disk is the
+// whole point — it lets later batches reuse the warm Go toolchain / apt /
+// goimports layers instead of rebuilding them cold (#467). Between-batch
+// runner disk is bounded by the free-disk-space step on the fuzz job
+// (#454/#460), not by pruning here.
+//
+// No-op unless BAMLFUZZ_STATIC_DOCKER_PRUNE_ON_FAILURE is set, so local
+// runs and other integration tests are unaffected. It never uses `-a` /
+// `docker system prune -a`, which would delete the warm base images the
+// nightly job loads and force Docker Hub pulls. The static oracle runs
+// serially (-p 1), so pruning never races a live container. Prune
+// failures are logged as warnings, never failing the test.
 func pruneStaticDockerArtifactsAfterFailedSetup(t *testing.T) {
 	t.Helper()
-	if os.Getenv("BAMLFUZZ_STATIC_DOCKER_PRUNE") == "" {
+	if os.Getenv("BAMLFUZZ_STATIC_DOCKER_PRUNE_ON_FAILURE") == "" {
 		return
 	}
 	runStaticDockerPrune(t, []string{"image", "prune", "-f"})


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Root cause

The static oracle (`TestBamlfuzzStaticOracle`) builds a per-batch baml-rest image with Docker's **classic builder** (testcontainers, not BuildKit — the CI build log is `Step N/36` / `Using cache` format). #457's happy-path `docker image prune -f`, run after each successful static env teardown, deletes the **dangling classic-builder intermediate layers**. So every next batch rebuilds the stable layers (Go toolchain download/extract, gettext/gawk apt, `goimports`) cold. That cold-rebuild churn is what pushed the `0.219.0,false` / `0.222.x` static cells over the 50m suite watchdog (nightly run 27694447738) — no oracle mismatch, no 429, no ENOSPC; build throughput only.

A local legacy-builder prune probe confirmed it: after removing only the tagged final image, a changed-input rebuild reused the earlier stable `RUN` layer; after `docker image prune -f`, Docker deleted the dangling leaves + parents and the stable layer reran. `image prune` alone evicts classic-builder cache for dangling intermediates.

## The fix

- **Success path no longer prunes.** Successful static env teardown now just terminates the env (`terminateStaticEnv`). testcontainers already removes the tagged final per-batch image via `KeepImage=false`; what must survive on disk is the classic intermediate layer cache, so later batches reuse the warm toolchain/apt/goimports layers. Removed `terminateStaticEnvAndPrune` + `pruneStaticDockerArtifacts`.
- **Failure path prune kept.** Failed `setupStaticEnv` still prunes dangling images + the BuildKit cache (failed/partial builds are the real residue source).
- **Env gate renamed** `BAMLFUZZ_STATIC_DOCKER_PRUNE` → `BAMLFUZZ_STATIC_DOCKER_PRUNE_ON_FAILURE` (harness + both workflows), since it now gates only the failure-path prune.
- **Comment corrections.** Both workflows' env comments previously claimed the image-prune preserves the build cache / prunes between envs to bound disk. Corrected: the success path keeps the classic-builder layer cache warm (the point); failed setup additionally prunes; between-batch disk is bounded by the `free-disk-space` step on the fuzz job (#454/#460), not between-batch pruning.
- Applied consistently across `bamlfuzz-nightly.yml` (fuzz static step) and `integration-tests.yml` (versioned + in-process cells).

## Disk instrumentation

Added `df -h /` + `docker system df` snapshots **before and after** the `go test` in the nightly `Static oracle` step (exit status preserved across the default `set -e` shell, so the after-snapshot always runs). This lets the re-validation nightly read disk headroom — the verdict flags disk as the one medium-confidence item (retained classic cache ~6.5–19.5GiB across 13 batches vs ~25–30GB freed by the free-disk step). Does not fail the job on disk; just logs.

## Scope

This clears the watchdog. It does **not** make builds fully warm — the per-batch `RUN /workspace/build.sh` work still reruns after `COPY baml_src`. Full warmth (~20–25m via BuildKit cache mounts / Dockerfile reorder) is the separate **#470** follow-up. Only `integration/bamlfuzz_static_test.go` + the two workflows changed; no correctness/SemanticDiff changes.

## Validation

- `gofmt -l`, `go vet -tags=integration,subprocess ./integration/`, `go build -tags=integration,subprocess ./integration/...` clean.
- Both workflows parse (`yaml.safe_load`).
- Failure-path prune still compiles/works; success path no longer prunes.

Re-validation is a post-merge nightly `workflow_dispatch`. See the verdict (`/tmp/shared/467-verdict.md`) and nightly run 27694447738 for full root-cause evidence. Refs #470.

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test infrastructure resource management to reduce unnecessary cleanup overhead between test runs.
  * Updated automated cleanup behavior to occur only when test failures are detected, improving overall efficiency.
  * Enhanced diagnostic output during testing failures with system state snapshots to aid troubleshooting.
  * Refactored internal test utilities to support the improved cleanup strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->