### PR TITLE
build: enable BuildKit cache mounts for testcontainers baml-rest builds (#470)

### DIFF
--- a/.github/actions/enable-containerd-image-store/action.yml
+++ b/.github/actions/enable-containerd-image-store/action.yml
@@ -1,0 +1,70 @@
+name: Enable containerd image store
+description: >-
+  Switch the runner's Docker daemon to the containerd image store
+  (features.containerd-snapshotter) so docker-loaded images are visible to
+  dockerd-integrated BuildKit, then restart Docker and wait for it to return.
+
+# Why: with #472, the testcontainers baml-rest build runs under BuildKit (so
+# build.sh's `RUN --mount=type=cache` branch is honored). The default
+# dockerd-integrated BuildKit keeps its own content store, separate from the
+# classic image store where the warm-images job `docker load`s the digest-pinned
+# base tarballs. For a pinned-digest `FROM`, BuildKit then tries to resolve the
+# base manifest from the registry and fails with
+# "failed to resolve source metadata ... no active sessions" — there is no
+# registry session over the Docker API, and warm-images deliberately avoids
+# Docker Hub (#447). Enabling the containerd image store unifies the two stores,
+# so BuildKit resolves the warm-loaded bases locally without any registry hit.
+#
+# ORDERING (per job): this step MUST run AFTER any free-disk-space step (which
+# manipulates docker images) and BEFORE the warm-image `docker load` — a docker
+# restart wipes already-loaded images, so loading must happen after the restart.
+runs:
+  using: composite
+  steps:
+    - name: Enable containerd image store and restart Docker
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        daemon_json=/etc/docker/daemon.json
+
+        # Merge {"features":{"containerd-snapshotter":true}} into the existing
+        # daemon.json (if any), PRESERVING every existing key. jq's `*` operator
+        # does a recursive object merge, so existing features.* entries survive
+        # and only this one flag is added/overridden.
+        existing='{}'
+        if sudo test -s "$daemon_json"; then
+          existing="$(sudo cat "$daemon_json")"
+        fi
+        merged="$(jq -n \
+          --argjson existing "$existing" \
+          '$existing * {features: {"containerd-snapshotter": true}}')"
+
+        echo "=== merged /etc/docker/daemon.json ==="
+        echo "$merged"
+        sudo mkdir -p /etc/docker
+        echo "$merged" | sudo tee "$daemon_json" >/dev/null
+
+        echo "=== restarting docker ==="
+        sudo systemctl restart docker
+
+        # Wait for the daemon to come back before any docker load/build runs.
+        for i in $(seq 1 30); do
+          if docker info >/dev/null 2>&1; then
+            echo "docker is back after ${i} attempt(s)"
+            break
+          fi
+          if [ "$i" -eq 30 ]; then
+            echo "::error::docker did not come back after restart"
+            sudo journalctl -u docker --no-pager -n 80 || true
+            exit 1
+          fi
+          sleep 2
+        done
+
+        # Diagnostics: with the containerd snapshotter active the Storage Driver
+        # reports as "overlayfs" (vs the classic "overlay2"); print full info so
+        # a failure to switch is visible in the job log.
+        echo "=== docker info ==="
+        docker info -f 'Storage Driver: {{.Driver}}' || true
+        docker info || true

--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -301,6 +301,14 @@ jobs:
         # the static oracle's per-batch image builds need this (#459).
         uses: ./.github/actions/free-disk-space
 
+      - name: Enable containerd image store for BuildKit
+        # The per-batch baml-rest build runs under BuildKit (#472). The
+        # containerd image store makes the warm-loaded digest-pinned bases
+        # visible to BuildKit so it resolves them locally instead of failing
+        # with "no active sessions". Restarts docker, so it MUST run after
+        # free-disk-space and BEFORE the warm-image load below.
+        uses: ./.github/actions/enable-containerd-image-store
+
       - name: Download warm base images
         # Base images are pulled once by the warm-images job and handed over as
         # a per-run artifact; this cell only loads them — no Docker Hub login,

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -277,6 +277,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
 
+      - name: Enable containerd image store for BuildKit
+        # testcontainers builds baml-rest under BuildKit (#472); the containerd
+        # image store makes the warm-loaded digest-pinned bases visible to
+        # BuildKit (no "no active sessions" registry resolve). Restarts docker,
+        # so it MUST run before the warm-image load below. No free-disk-space
+        # step in this job, so it goes right after checkout.
+        uses: ./.github/actions/enable-containerd-image-store
+
       - name: Download warm base images
         # Base images are pulled once by the warm-images job and handed over as
         # a per-run artifact; this cell only loads them — no Docker Hub login,
@@ -384,6 +392,14 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3
+
+      - name: Enable containerd image store for BuildKit
+        # testcontainers builds baml-rest under BuildKit (#472); the containerd
+        # image store makes the warm-loaded digest-pinned bases visible to
+        # BuildKit (no "no active sessions" registry resolve). Restarts docker,
+        # so it MUST run before the warm-image load below. No free-disk-space
+        # step in this job, so it goes right after checkout.
+        uses: ./.github/actions/enable-containerd-image-store
 
       - name: Download warm base images
         # Base images are pulled once by the warm-images job and handed over as
@@ -644,6 +660,13 @@ jobs:
         # Placed before the warm-image load (docker-images:true must not
         # delete them).
         uses: ./.github/actions/free-disk-space
+
+      - name: Enable containerd image store for BuildKit
+        # testcontainers builds baml-rest under BuildKit (#472); the containerd
+        # image store makes the warm-loaded digest-pinned bases visible to
+        # BuildKit (no "no active sessions" registry resolve). Restarts docker,
+        # so it MUST run after free-disk-space and BEFORE the warm-image load.
+        uses: ./.github/actions/enable-containerd-image-store
 
       - name: Download warm base images
         # Base images are pulled once by the warm-images job and handed over as

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -21,7 +21,9 @@ import (
 
 	bamlrest "github.com/invakid404/baml-rest"
 	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/network"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -574,6 +576,21 @@ func startBAMLRestContainer(ctx context.Context, networkName string, opts SetupO
 			ContextArchive: buildCtx,
 			Dockerfile:     "Dockerfile",
 			PrintBuildLog:  true, // Enable build log output to see compilation errors
+			// Build with BuildKit (not the classic builder) so the Dockerfile's
+			// `RUN --mount=type=cache,target=/cache /workspace/build.sh` branch
+			// is honored and build.sh's /cache/{go,npm,baml-shared-lib} caches
+			// persist across static-oracle batches within a runner. This mirrors
+			// the CLI Docker path (cmd/build/main.go), which already builds with
+			// build.BuilderBuildKit. KeepImage stays false (default) so #467's
+			// success-path no-prune still relies on BuildKit cache, not final
+			// images, for warmth. We deliberately do NOT add a
+			// `# syntax=docker/dockerfile:...` directive to the Dockerfile: a
+			// local probe showed it fails through Docker API sessions with
+			// "no active sessions"; the bundled BuildKit frontend handles the
+			// cache-mount branch on its own.
+			BuildOptionsModifier: func(opts *client.ImageBuildOptions) {
+				opts.Version = build.BuilderBuildKit
+			},
 		},
 		ExposedPorts: exposedPorts,
 		Cmd:          cmd,
@@ -636,7 +653,7 @@ type dockerfileTemplateData struct {
 
 	// Integration test specific flags
 	defaultTargetArch  string // Provide default for TARGETARCH (testcontainers may not set it)
-	noCacheMount       bool   // Disable BuildKit cache mount (not supported in testcontainers)
+	noCacheMount       bool   // Disable the Dockerfile's BuildKit cache-mount branch for build.sh
 	noCustomBamlLib    bool   // Don't copy custom_baml_lib.so (not used in tests)
 	bamlSource         bool   // Build from BAML source (enables cffi-builder stage)
 	prebuiltCffi       bool   // Inject prebuilt cffi artifacts instead of running the cffi-builder cargo stage
@@ -686,10 +703,14 @@ func createBAMLRestBuildContext(opts SetupOptions) (io.ReadSeeker, error) {
 		keepSource:        opts.KeepSource,
 		debugBuild:        true,            // Enable debug endpoints for testing (/_debug/*)
 		defaultTargetArch: getDockerArch(), // Use native architecture
-		noCacheMount:      true,            // testcontainers doesn't reliably support BuildKit
-		noCustomBamlLib:   true,            // Integration tests don't use custom BAML lib
-		unaryServer:       opts.UnaryServer,
-		inProcess:         opts.InProcess,
+		// BuildKit is enabled via BuildOptionsModifier on the FromDockerfile
+		// request (see startBAMLRestContainer), so use the Dockerfile's
+		// `RUN --mount=type=cache,target=/cache` branch: build.sh's Go module,
+		// Go build, npm, and baml-shared-lib caches now persist across batches.
+		noCacheMount:    false,
+		noCustomBamlLib: true, // Integration tests don't use custom BAML lib
+		unaryServer:     opts.UnaryServer,
+		inProcess:       opts.InProcess,
 	}
 
 	if opts.BAMLSource != "" {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## What

Make the **testcontainers** baml-rest build path use **BuildKit** instead of the classic builder, so the per-batch `RUN /workspace/build.sh` step reuses `build.sh`'s persistent caches across static-oracle batches within a runner.

- `integration/testutil/container.go`: set `BuildOptionsModifier` on the baml-rest `FromDockerfile` request → `opts.Version = build.BuilderBuildKit` (this is exactly what the CLI Docker path in `cmd/build/main.go` already does). `KeepImage` stays `false`.
- Flip the rendered Dockerfile template's `.noCacheMount` to `false` for testcontainers, which activates the Dockerfile's already-present branch:
  ```dockerfile
  RUN --mount=type=cache,target=/cache /workspace/build.sh
  ```
  so `build.sh`'s `/cache/go/mod`, `/cache/go/build`, `/cache/npm/${TARGETARCH}`, and `/cache/baml-shared-lib/${BAML_VERSION}/${TARGETARCH}` caches now persist instead of living inside a per-source-invalidated image layer.

No changes to `build.sh`, the Dockerfile build steps, the CLI path (already BuildKit), production `build-and-publish.yml`/`Dockerfile.builder`, or any GHCR base image.

## Why

Per the staged design (Option A / PR1), the remaining ~110s-per-batch hot step is `RUN build.sh` after `COPY baml_src`. Under the classic builder there was no persistent cache, so every static batch re-downloaded Go modules, re-missed the Go build cache for unchanged packages, re-fetched npm/npx packages, and re-downloaded the BAML shared library. Routing through BuildKit + the existing cache-mount branch lets these stable caches survive across batches, expected to save **~50–80s/batch** (design §A) and move the nightly static oracle toward the ~20–25m full-warm target. Per-source work (BAML client generation, hacks, introspection, adapter generation, changed-package compiles, final link) still reruns — no fake cache hits across different `baml_src`.

## Notes / deliberate choices

- **No `# syntax=docker/dockerfile:...` directive.** The design probe showed that directive fails through Docker API sessions (`failed to resolve source metadata ... no active sessions`). The bundled BuildKit frontend handles `--mount=type=cache` on current Docker, so none is added.
- **#467 prune behavior unchanged.** Success path still does **not** prune (warm cache is the point); failure path still prunes dangling images + BuildKit cache when gated. `bamlfuzz_static_test.go` is untouched.

## Validation

- `gofmt -l`, `go vet -tags=integration,subprocess ./integration/...`, `go build -tags=integration,subprocess ./integration/...` — clean.
- **Local BuildKit smoke test** (Docker 29.4.0, the probe environment), one static case (`BAML_VERSION=0.219.0`, seed `27605271243`):
  - **Build runs under BuildKit with the cache mount** — `docker buildx du --verbose` shows `Type: exec.cachemount` records and `mount / from exec /bin/sh -c /workspace/build.sh`, alongside BuildKit stage descriptions (`[stage-1 3/5] COPY --from=builder /output/baml-rest /baml-rest`). `docker system df` reports ~2.5GB of **Build Cache** (a BuildKit-only concept the classic builder never populates).
  - **Test passes** (container builds + serves `/call`): `--- PASS: TestBamlfuzzStaticOracle`.
  - **Second build is much faster (cache warm):** cold package time `123.858s` → warm `8.373s`. (The smoke reran identical inputs, so it got a near-full layer-cache hit on top of the cache mount; the nightly's differing per-batch `baml_src` won't layer-hit but will still reuse the Go/npm/baml-shared-lib cache mount.)

The real speedup proof is a **post-merge nightly `bamlfuzz-nightly` `workflow_dispatch`** capturing per-batch `RUN build.sh` timings, total static-oracle wall time, `df -h /`, and `docker system df` before/after (the #467 instrumentation already covers this).

## Scope

Addresses **#470** (does **not** auto-close it — we close #470 after the nightly confirms the speedup). The broader **GHCR shared buildcache base** (design Option C, PRs 3–4) and the artifact-identity harness (PR 2) are documented follow-ups, not in this PR.

Design reference: the approved staged build-cache design (Option A, PR1). Builds on #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the integration-test and nightly fuzz workflows to enable Docker’s containerd-backed image store for BuildKit.
  * Adjusted the Dockerfile generation used in tests to default to BuildKit cache-mount behavior and explicitly enable BuildKit during builds.
  * Added a reusable automation step to toggle the Docker daemon feature and enhanced diagnostics/logging if startup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->