### PR TITLE
fix(sync): converge scripts/sync.sh to a fixed point so Renovate PRs pass the idempotency gate (#473)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -115,12 +115,30 @@ jobs:
         # from go.work), this step fails with a diff. The verify step
         # double-asserts the pin matrix via cmd/verify-adapter-pins so a
         # diff-free-but-wrong state can't slip through either.
+        #
+        # The diff covers ALL Go module metadata, not just adapter paths
+        # (#473). scripts/sync.sh is a bounded fixed-point loop, so a
+        # converged tree re-run must be byte-clean across every go.mod /
+        # go.sum / go.work / go.work.sum. Diffing the whole set here means
+        # a future non-convergence surfaces as a direct "scripts/sync.sh
+        # is not idempotent" failure at this step, instead of leaking into
+        # the confusing "tree dirty before cmd/regenerate-dynclient" error
+        # downstream — which is exactly how #473 manifested.
+        #
+        # go.work.sum is excluded from --exit-code and restored instead:
+        # it's an additive checksum database (not a lockfile), and an
+        # earlier workspace-mode Go command in this job may have appended
+        # module-content sums the committed file lacks. That additive
+        # growth is tolerated repo-wide (see the cmd/regenerate-dynclient
+        # gate below and #442); restoring it to HEAD keeps that tolerance
+        # while the full set below still fails on any go.mod/go.sum drift.
         run: |
           git status --porcelain
           ./scripts/sync.sh
+          git checkout -- go.work.sum 2>/dev/null || true
           git diff --exit-code -- \
-            adapters/common/go.mod adapters/common/go.sum \
-            'adapters/adapter_v0_*/go.mod' 'adapters/adapter_v0_*/go.sum'
+            go.mod go.sum go.work \
+            '*/go.mod' '*/go.sum'
 
       - name: cmd/regenerate-dynclient fresh-tree gate
         # Fresh-tree gate for committed dynclient regeneration artifacts.

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -118,14 +118,13 @@ verify_pins() {
 # canonical release module set, and silently skipping an entry would
 # hide release/CI drift the moment a module is renamed or moved.
 #
-# A single pass is sufficient given the current graph: `go work sync`
-# above already reconciles workspace members' go.mod files, and the
-# two non-workspace standalone modules — adapters/common and
-# dynclient/baml-patched — depend only on workspace members and on
-# nothing first-party, respectively. If a future standalone module
-# gains a local first-party replace that points outside the
-# workspace, revisit this loop and either order it dependency-first
-# or add a bounded second pass with an idempotency check.
+# This is one step of a single sync pass; it does not need to be a
+# fixed point on its own. The bounded fixed-point loop at the bottom of
+# this script re-runs the whole pass (go work sync + this + adapter
+# tidies) until the module metadata stops changing, so cross-step
+# feedback — a standalone tidy here rewriting a workspace member's
+# go.mod, which then changes the next `go work sync` — converges
+# instead of leaking a non-fixed-point state (see #473).
 tidy_standalone_modules() {
     echo "Tidying standalone-tested module(s) with GOWORK=off..."
     local dir
@@ -166,17 +165,92 @@ tidy_adapter_version_modules() {
     adapter_tidy_count="$count"
 }
 
+# module_metadata_paths emits a NUL-delimited list of every Go module
+# metadata path the repo treats as sync output — the same set the
+# renovate-sync allowlist guards and unit-tests diffs: root go.mod /
+# go.sum / go.work / go.work.sum plus every nested */go.mod and
+# */go.sum (git pathspec wildcards span '/', so this reaches
+# dynclient/baml-patched/go.mod too). Both tracked (--cached) and
+# untracked-but-not-ignored (--others) entries are included so a newly
+# created go.sum is part of the fingerprint, not invisible to it.
+module_metadata_paths() {
+    git ls-files -z --cached --others --exclude-standard \
+        -- 'go.mod' 'go.sum' 'go.work' 'go.work.sum' '*/go.mod' '*/go.sum'
+}
+
+# module_metadata_fingerprint hashes path+content of every module
+# metadata file into a single digest. git hash-object is used (rather
+# than sha256sum/shasum) because it's available wherever git is —
+# macOS and the CI runner alike — and needs no tool-detection. A
+# change to any file's content, or the set of files itself, flips the
+# digest; that's the convergence signal for the fixed-point loop.
+module_metadata_fingerprint() {
+    local p
+    module_metadata_paths | sort -z | while IFS= read -r -d '' p; do
+        printf '%s:' "$p"
+        git hash-object "$p" 2>/dev/null || printf 'MISSING'
+        printf '\n'
+    done | git hash-object --stdin
+}
+
+# run_sync_pass performs exactly one sync pass, honoring the --only-*
+# flags. This is the body that used to run inline; the fixed-point
+# loop below repeats it until the module metadata stops changing.
+#
+# `go work sync` reconciles workspace members against the workspace
+# build list, but the standalone `GOWORK=off go mod tidy` passes that
+# follow can themselves rewrite a workspace member's go.mod, which
+# changes the inputs for the NEXT `go work sync`. A single pass is
+# therefore not guaranteed to be a fixed point (see #473): a Renovate
+# dep bump can make pass 1 produce one indirect set and pass 2 reshuffle
+# it. Running until convergence makes the published state stable.
+run_sync_pass() {
+    if ! $only_adapters; then
+        echo "Running \`go work sync\`..."
+        go work sync
+    fi
+
+    tidy_standalone_modules
+
+    if ! $only_workspace; then
+        tidy_adapter_version_modules
+    fi
+}
+
 if $check_pins_only; then
     verify_pins
     exit 0
 fi
 
-if ! $only_adapters; then
-    echo "Running \`go work sync\`..."
-    go work sync
-fi
-
-tidy_standalone_modules
+# Bounded fixed-point loop. Snapshot the metadata fingerprint, run a
+# pass, re-snapshot: when a pass leaves the fingerprint unchanged the
+# tree is a fixed point and a second full scripts/sync.sh invocation
+# would be a no-op (the property #473 needs). The real Renovate cases
+# converge on pass 2; the cap guards against an oscillating graph —
+# if it hasn't settled by then we fail loudly with the live diff rather
+# than committing a non-convergent state or looping forever.
+max_passes=5
+pass=0
+prev_fingerprint="$(module_metadata_fingerprint)"
+while true; do
+    pass=$((pass + 1))
+    echo
+    echo "=== sync pass $pass ==="
+    run_sync_pass
+    new_fingerprint="$(module_metadata_fingerprint)"
+    if [ "$new_fingerprint" = "$prev_fingerprint" ]; then
+        echo
+        echo "Module metadata converged after $pass pass(es)."
+        break
+    fi
+    prev_fingerprint="$new_fingerprint"
+    if [ "$pass" -ge "$max_passes" ]; then
+        echo "ERROR: scripts/sync.sh did not converge to a fixed point after $max_passes passes." >&2
+        echo "Still-changing module metadata:" >&2
+        git diff -- 'go.mod' 'go.sum' 'go.work' 'go.work.sum' '*/go.mod' '*/go.sum' >&2 || true
+        exit 1
+    fi
+done
 
 if $only_workspace; then
     echo
@@ -184,7 +258,9 @@ if $only_workspace; then
     exit 0
 fi
 
-tidy_adapter_version_modules
+# verify_pins runs ONCE, after convergence — re-running it every pass
+# would be wasted work since the pin matrix can only be valid on the
+# final, stable go.mod set.
 verify_pins
 
 echo


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Root cause

`scripts/sync.sh` was **not a fixed point**. The direct writer is `go work sync` inside it: a single pass (`go work sync` → `GOWORK=off go mod tidy` over the standalone modules → adapter tidies) mutates workspace-member `go.mod` files, so the *next* `go work sync` recomputes the workspace MVS over different inputs and rewrites the indirect set again (observed: otel indirect reshuffle in `dynclient/go.mod` + `pool/go.mod`).

`renovate-sync` runs sync **once**, commits the first-pass state, and is intentionally skipped on its own `github-actions[bot]` commit — so it never re-converges. `unit-tests` then re-runs sync; its old gate only diffed adapter/common paths, so the `dynclient`/`pool` drift slipped through and surfaced downstream as the confusing `cmd/regenerate-dynclient` **"tree is dirty before"** failure. The cases converge on pass 2 (pass 3 stable); it's deterministic and dependency-agnostic. Affected Renovate PRs: #468 (`docker/buildx`), #469 (`moby/buildkit`).

See the full verdict for the reproduction and isolation of `go work sync` as the writer.

## The fix

1. **`scripts/sync.sh` — bounded fixed-point loop.** The sync body is factored into a single `run_sync_pass` (`go work sync` unless `--only-adapters` → `tidy_standalone_modules` → `tidy_adapter_version_modules` unless `--only-workspace`). The pass runs in a loop that snapshots a module-metadata fingerprint (`git hash-object` over `go.mod`, `go.sum`, `go.work`, `go.work.sum`, `*/go.mod`, `*/go.sum` — the same path set the renovate allowlist uses) before/after each pass and repeats until unchanged. Capped at 5 passes; if it hasn't converged it **fails loudly** with the live diff and a non-zero exit rather than looping forever or exiting dirty. `verify_pins` runs **once** after convergence. All existing behavior (the standalone `GOWORK=off go mod tidy` + adapter tidies, the `--only-workspace`/`--only-adapters` semantics) is preserved.

2. **`.github/workflows/unit-tests.yml` — broadened sync gate.** The `scripts/sync.sh fresh-tree gate` now diffs **all** Go module metadata (`go.mod`, `go.sum`, `go.work`, `*/go.mod`, `*/go.sum`) instead of only adapter paths, so a future non-convergence shows up as a direct *"scripts/sync.sh is not idempotent"* failure at this step. `go.work.sum` is restored before the diff (and excluded from `--exit-code`), matching the repo's existing additive-checksum tolerance used by the regenerate-dynclient gate (#442).

**`cmd/regenerate-dynclient` ownership is untouched** — it still owns `dynclient/baml-patched/go.mod`, and **no blanket `git checkout -- '*/go.mod'`** is added anywhere. The root cause is fixed in `sync.sh`; nothing is masked.

## Fixed-point proof (run locally)

- `bash -n scripts/sync.sh` clean; `unit-tests.yml` parses.
- **Clean master:** `./scripts/sync.sh` converges in 1 pass; a 2nd full run is byte-clean.
- **Bug scenario** (PR #468's Renovate commit `801e20250`, fixed `sync.sh` overlaid): the loop **converges after 3 passes** within one invocation — pass 1 → state A, pass 2 → state B, pass 3 stable, exactly matching the verdict. Committing that converged state and re-running `./scripts/sync.sh` reports **"converged after 1 pass"** and leaves the tree byte-clean — i.e. the exact `unit-tests` gate now passes. With the old single-pass script, that second run is what produced the failing `dynclient/go.mod` + `pool/go.mod` diff.

Closes #473


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded Go module metadata validation in continuous integration for more comprehensive dependency verification

* **Chores**
  * Improved build synchronization script stability with enhanced convergence detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->