### PR TITLE
fix(llmhttp): cut fasthttp unary wrapper overhead on Execute (#475)

### DIFF
--- a/bamlutils/llmhttp/cache.go
+++ b/bamlutils/llmhttp/cache.go
@@ -18,6 +18,17 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
+// maxBufferedResponseBackstop bounds the body the buffered unary HostClient
+// will read, purely as an out-of-memory backstop — NOT for semantic limit
+// enforcement. It sits well above both MaxResponseBodyBytes (the success cap)
+// and MaxErrorBodyBytes (the diagnostic cap) so executeFastBuffered can branch
+// on status first and then enforce the real limits in code: a non-2xx body
+// larger than MaxResponseBodyBytes still becomes an *HTTPError capped to
+// MaxErrorBodyBytes (matching the net/http and streamed paths) rather than a
+// premature "body too large" error. Only a pathological body beyond this
+// backstop trips fasthttp's ErrBodyTooLarge before status is known.
+const maxBufferedResponseBackstop = 2 * MaxResponseBodyBytes
+
 // defaultFastHTTPMaxConns is the per-origin connection cap used when
 // FastHTTPClientOptions.MaxConns is zero or negative. fasthttp falls back
 // to DefaultMaxConnsPerHost = 512 on its own zero value, which throttles
@@ -121,11 +132,13 @@ const (
 //   - host: StreamResponseBody=true. Used by ExecuteStream (SSE) and by the
 //     unary header-streaming lane in Execute where onSuccess must fire after
 //     2xx headers but before the body is read.
-//   - unaryHost: StreamResponseBody=false, MaxResponseBodySize=MaxResponseBodyBytes.
-//     Used only by Execute's buffered fast lane (onSuccess==nil, deadline-only
-//     ctx), where fasthttp reads the full body before DoDeadline returns and
-//     the wrapper can read fResp.Body() with a single copy — no intermediate
-//     io.ReadAll buffer and no body-read goroutine.
+//   - unaryHost: StreamResponseBody=false, MaxResponseBodySize set to an
+//     OOM backstop (maxBufferedResponseBackstop). Used only by Execute's
+//     buffered fast lane (onSuccess==nil, deadline-only ctx), where fasthttp
+//     reads the full body before DoDeadline returns and the wrapper can read
+//     fResp.Body() with a single copy — no intermediate io.ReadAll buffer and
+//     no body-read goroutine. The real success/error size limits are enforced
+//     in executeFastBuffered after the status is known (see B2).
 //
 // The split exists because StreamResponseBody is a per-HostClient setting and
 // must not be mutated per request (the client is shared and toggling it would
@@ -436,7 +449,7 @@ func (c *protocolCache) buildEntry(origin originURL, d decision) *hostEntry {
 		IsTLS:                         origin.scheme == "https",
 		DisableHeaderNamesNormalizing: tmpl.DisableHeaderNamesNormalizing,
 		StreamResponseBody:            false,
-		MaxResponseBodySize:           MaxResponseBodyBytes,
+		MaxResponseBodySize:           maxBufferedResponseBackstop,
 		MaxIdleConnDuration:           tmpl.MaxIdleConnDuration,
 		MaxConnWaitTimeout:            tmpl.MaxConnWaitTimeout,
 		MaxConns:                      tmpl.MaxConns,

--- a/bamlutils/llmhttp/cache.go
+++ b/bamlutils/llmhttp/cache.go
@@ -111,13 +111,29 @@ const (
 	decisionFast
 )
 
-// hostEntry is the cache payload for a single origin. host is populated only
-// when decision == decisionFast; entries created for decisionNet never
-// allocate a fasthttp.HostClient. Entries are treated as immutable after
-// install so readers never take a lock.
+// hostEntry is the cache payload for a single origin. host/unaryHost are
+// populated only when decision == decisionFast; entries created for
+// decisionNet never allocate a fasthttp.HostClient. Entries are treated as
+// immutable after install so readers never take a lock.
+//
+// Two HostClients are kept per fasthttp origin, differing only in body
+// handling:
+//   - host: StreamResponseBody=true. Used by ExecuteStream (SSE) and by the
+//     unary header-streaming lane in Execute where onSuccess must fire after
+//     2xx headers but before the body is read.
+//   - unaryHost: StreamResponseBody=false, MaxResponseBodySize=MaxResponseBodyBytes.
+//     Used only by Execute's buffered fast lane (onSuccess==nil, deadline-only
+//     ctx), where fasthttp reads the full body before DoDeadline returns and
+//     the wrapper can read fResp.Body() with a single copy — no intermediate
+//     io.ReadAll buffer and no body-read goroutine.
+//
+// The split exists because StreamResponseBody is a per-HostClient setting and
+// must not be mutated per request (the client is shared and toggling it would
+// race and corrupt concurrent streaming reads).
 type hostEntry struct {
-	decision decision
-	host     *fasthttp.HostClient
+	decision  decision
+	host      *fasthttp.HostClient
+	unaryHost *fasthttp.HostClient
 }
 
 // protocolCache stores the routing decision (net/http vs fasthttp) per
@@ -408,5 +424,23 @@ func (c *protocolCache) buildEntry(origin originURL, d decision) *hostEntry {
 		MaxConns:                      tmpl.MaxConns,
 		TLSConfig:                     tmpl.TLSConfig,
 	}
-	return &hostEntry{decision: d, host: hc}
+	// Buffered sibling for Execute's fast lane. Identical wire/pooling config
+	// as host, but StreamResponseBody is OFF so fasthttp reads the full body
+	// into its pooled response buffer before DoDeadline returns, and
+	// MaxResponseBodySize enforces the same MaxResponseBodyBytes ceiling the
+	// streamed path checks manually (fasthttp rejects strictly-greater, so the
+	// exact-at-limit body still succeeds — matching the net/http path).
+	unaryHC := &fasthttp.HostClient{
+		Name:                          tmpl.Name,
+		Addr:                          origin.addr(),
+		IsTLS:                         origin.scheme == "https",
+		DisableHeaderNamesNormalizing: tmpl.DisableHeaderNamesNormalizing,
+		StreamResponseBody:            false,
+		MaxResponseBodySize:           MaxResponseBodyBytes,
+		MaxIdleConnDuration:           tmpl.MaxIdleConnDuration,
+		MaxConnWaitTimeout:            tmpl.MaxConnWaitTimeout,
+		MaxConns:                      tmpl.MaxConns,
+		TLSConfig:                     tmpl.TLSConfig,
+	}
+	return &hostEntry{decision: d, host: hc, unaryHost: unaryHC}
 }

--- a/bamlutils/llmhttp/errors.go
+++ b/bamlutils/llmhttp/errors.go
@@ -173,7 +173,7 @@ func classifyTransportErr(err error, prefix string, staleConnTeardownAcceptable 
 // classifyStreamErrc consumes the single terminal value sseclient.Stream
 // (and the fast-path stream reader) emits and re-emits it on a buffered(1)
 // channel after running non-nil values through classifyTransportErr with
-// body-read semantics — same as Execute and readFastBodyLimitedCtx, where
+// body-read semantics — same as Execute and drainFastBodyLimited, where
 // any bytes already delivered upstream rule out the gated stale-conn-
 // teardown family. A typed mid-stream transport drop (ECONNRESET / EPIPE /
 // ECONNREFUSED / net.ErrClosed) therefore carries the ErrTransportFlake

--- a/bamlutils/llmhttp/fast_backend.go
+++ b/bamlutils/llmhttp/fast_backend.go
@@ -707,15 +707,19 @@ func readFastErrorBodyCapped(resp *fasthttp.Response, limit int) []byte {
 		return body
 	}
 
-	raw, _ := io.ReadAll(io.LimitReader(stream, int64(limit)+1))
-	if len(raw) > limit {
-		// Body exceeded the diagnostic cap: we stopped before EOF, so the conn
-		// is dirty — discard it.
-		raw = raw[:limit]
+	raw, err := io.ReadAll(io.LimitReader(stream, int64(limit)+1))
+	if err != nil || len(raw) > limit {
+		// We stopped before EOF — either the body exceeded the diagnostic cap
+		// (len > limit) or the read errored/timed out/reset mid-body. Either
+		// way unread bytes may remain on the wire, so the conn is dirty and
+		// MUST be discarded, not pooled (B1).
+		if len(raw) > limit {
+			raw = raw[:limit]
+		}
 		closeFastConnDiscard(resp)
 		return raw
 	}
-	// Full error body read to EOF: the conn is clean and can return to the pool.
+	// Clean EOF read within the cap: the conn can return to the pool.
 	_ = resp.CloseBodyStream()
 	return raw
 }

--- a/bamlutils/llmhttp/fast_backend.go
+++ b/bamlutils/llmhttp/fast_backend.go
@@ -211,6 +211,15 @@ func (c *Client) executeFastStreamed(ctx context.Context, req *Request, rewritte
 
 	// For non-2xx responses, read a bounded diagnostic body and surface it as
 	// *HTTPError. Matches the net/http path's error-body policy exactly.
+	//
+	// Accepted trade-off: this diagnostic read is synchronous and NOT ctx-aware,
+	// so a mid-flight ctx cancel during it can block until the request deadline
+	// (DoDeadline / DefaultCallTimeout) on a rare stalled/trickled error body.
+	// This is deliberate — restoring ctx-awareness here would require a
+	// per-request body-read goroutine + force-close, reintroducing exactly the
+	// race / double-close hazards this PR removed (fasthttp exposes no per-read
+	// deadline to do it cleanly). The block is bounded by the already-set
+	// request deadline.
 	if status < 200 || status >= 300 {
 		body := readFastErrorBodyCapped(fResp, MaxErrorBodyBytes)
 		return nil, &HTTPError{StatusCode: status, Body: string(body)}
@@ -694,6 +703,11 @@ func readFastBodyCappedSlot(ctx context.Context, resp *fasthttp.Response, slot *
 // unread bytes remain on the wire, so the connection MUST be discarded rather
 // than pooled (B1) — otherwise the next request would read leftover garbage. A
 // fully-read (<= limit) error body leaves the conn clean and poolable.
+//
+// Synchronous and NOT ctx-aware by design: a mid-flight ctx cancel can block
+// here until the request deadline on a rare stalled error body (see the call
+// site in executeFastStreamed for the full rationale — adding ctx-awareness
+// would reintroduce the per-request goroutine + force-close race removed here).
 //
 // Used by the unary streamed lane. Streaming paths use readFastBodyCappedSlot,
 // which closes the captured conn directly.

--- a/bamlutils/llmhttp/fast_backend.go
+++ b/bamlutils/llmhttp/fast_backend.go
@@ -92,6 +92,9 @@ func (c *Client) executeFastBuffered(ctx context.Context, req *Request, rewritte
 
 	if err := hc.DoDeadline(fReq, fResp, fastDeadline(ctx)); err != nil {
 		if errors.Is(err, fasthttp.ErrBodyTooLarge) {
+			// Body exceeded the OOM backstop (maxBufferedResponseBackstop),
+			// well above MaxResponseBodyBytes. We can't read status, so report
+			// the size error; this only triggers for pathological bodies.
 			return nil, fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", MaxResponseBodyBytes)
 		}
 		if ctxErr := awaitCtxIfPastDeadline(ctx); ctxErr != nil {
@@ -104,9 +107,13 @@ func (c *Client) executeFastBuffered(ctx context.Context, req *Request, rewritte
 	}
 
 	status := fResp.StatusCode()
+
+	// Non-2xx: surface *HTTPError with the body capped to MaxErrorBodyBytes,
+	// matching the net/http and streamed error-body policy. The buffered host's
+	// MaxResponseBodySize is only an OOM backstop, so a non-2xx body larger
+	// than MaxResponseBodyBytes still reaches here and is capped (preserving
+	// the error contract — see B2 / maxBufferedResponseBackstop).
 	if status < 200 || status >= 300 {
-		// Body is already buffered; cap the diagnostic to MaxErrorBodyBytes to
-		// match the net/http and streamed error-body policy.
 		body := fResp.Body()
 		if len(body) > MaxErrorBodyBytes {
 			body = body[:MaxErrorBodyBytes]
@@ -114,11 +121,21 @@ func (c *Client) executeFastBuffered(ctx context.Context, req *Request, rewritte
 		return nil, &HTTPError{StatusCode: status, Body: string(body)}
 	}
 
+	// Success: enforce the real MaxResponseBodyBytes limit in code (strictly
+	// greater is rejected, exact-at-limit succeeds), matching the net/http and
+	// streamed paths. The backstop on the host is higher, so a body between the
+	// limit and the backstop is read here and rejected rather than silently
+	// truncated.
+	body := fResp.Body()
+	if len(body) > MaxResponseBodyBytes {
+		return nil, fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", MaxResponseBodyBytes)
+	}
+
 	// onSuccess is nil in this lane by construction (executeFast gates on it).
 	return &Response{
 		StatusCode: status,
 		Headers:    fastHeadersToHTTP(&fResp.Header),
-		Body:       string(fResp.Body()),
+		Body:       string(body),
 	}, nil
 }
 
@@ -149,8 +166,13 @@ func (c *Client) executeFastStreamed(ctx context.Context, req *Request, rewritte
 		select {
 		case <-ctx.Done():
 			// Hand off cleanup so the pool isn't starved by the orphaned Do.
+			// When the orphan Do eventually returns having received headers,
+			// fResp holds an unread body stream; discard the connection rather
+			// than letting ReleaseResponse pool a conn with unread bytes still
+			// on the wire (B1). discard is a no-op when Do failed (no stream).
 			go func() {
 				<-doneCh
+				closeFastConnDiscard(fResp)
 				fasthttp.ReleaseRequest(fReq)
 				fasthttp.ReleaseResponse(fResp)
 			}()
@@ -190,7 +212,7 @@ func (c *Client) executeFastStreamed(ctx context.Context, req *Request, rewritte
 	// For non-2xx responses, read a bounded diagnostic body and surface it as
 	// *HTTPError. Matches the net/http path's error-body policy exactly.
 	if status < 200 || status >= 300 {
-		body := readFastBodyCappedCtx(ctx, fResp, MaxErrorBodyBytes)
+		body := readFastErrorBodyCapped(fResp, MaxErrorBodyBytes)
 		return nil, &HTTPError{StatusCode: status, Body: string(body)}
 	}
 
@@ -666,27 +688,16 @@ func readFastBodyCappedSlot(ctx context.Context, resp *fasthttp.Response, slot *
 	}
 }
 
-// forceCloseWaitWindow bounds how long a ctx-cancelled Execute waits for
-// the Read goroutine to exit naturally via the conn's SetReadDeadline
-// (installed by DoDeadline) before falling back to fasthttp's
-// CloseWithError. At 500 ms the vast majority of cancel-timeouts hit the
-// natural path — ctx.Done and SetReadDeadline fire within a scheduling
-// tick of each other — while an explicit cancel fired before any deadline
-// remains responsive enough for interactive callers. Letting the Read
-// exit naturally is strictly preferable because CloseWithError mutates
-// fasthttp's requestStream state concurrently with an in-flight Read,
-// which the race detector flags as a real pool-corruption hazard.
-const forceCloseWaitWindow = 500 * time.Millisecond
-
-// readFastBodyCappedCtx reads up to limit bytes from the response body,
-// respecting ctx cancellation. On ctx fire it waits briefly for the Read
-// goroutine to exit naturally via the conn's SetReadDeadline (installed by
-// DoDeadline) before falling back to force-close — this avoids racing
-// with the in-flight Read on fasthttp's requestStream internal state.
+// readFastErrorBodyCapped reads up to limit bytes of a non-2xx diagnostic body
+// synchronously (bounded by the conn read deadline DoDeadline installed). It
+// reads limit+1 bytes to detect truncation: if the error body exceeded the cap,
+// unread bytes remain on the wire, so the connection MUST be discarded rather
+// than pooled (B1) — otherwise the next request would read leftover garbage. A
+// fully-read (<= limit) error body leaves the conn clean and poolable.
 //
-// Used by Execute. Streaming paths should use readFastBodyCappedSlot,
-// which closes the captured conn directly and has no race window.
-func readFastBodyCappedCtx(ctx context.Context, resp *fasthttp.Response, limit int) []byte {
+// Used by the unary streamed lane. Streaming paths use readFastBodyCappedSlot,
+// which closes the captured conn directly.
+func readFastErrorBodyCapped(resp *fasthttp.Response, limit int) []byte {
 	stream := resp.BodyStream()
 	if stream == nil {
 		body := resp.Body()
@@ -696,25 +707,17 @@ func readFastBodyCappedCtx(ctx context.Context, resp *fasthttp.Response, limit i
 		return body
 	}
 
-	resCh := make(chan []byte, 1)
-	go func() {
-		buf, _ := io.ReadAll(io.LimitReader(stream, int64(limit)))
-		resCh <- buf
-	}()
-
-	select {
-	case <-ctx.Done():
-		select {
-		case buf := <-resCh:
-			return buf
-		case <-time.After(forceCloseWaitWindow):
-			forceCloseFastBodyStream(resp, ctx.Err())
-			return <-resCh
-		}
-	case buf := <-resCh:
-		_ = resp.CloseBodyStream()
-		return buf
+	raw, _ := io.ReadAll(io.LimitReader(stream, int64(limit)+1))
+	if len(raw) > limit {
+		// Body exceeded the diagnostic cap: we stopped before EOF, so the conn
+		// is dirty — discard it.
+		raw = raw[:limit]
+		closeFastConnDiscard(resp)
+		return raw
 	}
+	// Full error body read to EOF: the conn is clean and can return to the pool.
+	_ = resp.CloseBodyStream()
+	return raw
 }
 
 // fastBodyBufPool reuses scratch buffers for draining streamed unary response
@@ -761,9 +764,14 @@ func drainFastBodyLimited(ctx context.Context, resp *fasthttp.Response, maxBytes
 		}
 	}()
 
+	// LimitReader caps at maxBytes+1. If the body is <= maxBytes the underlying
+	// stream reaches EOF and the connection is clean → poolable. If we stop at
+	// maxBytes+1 (oversize) or hit a read error, unread body bytes remain on the
+	// wire, so the connection MUST be discarded — otherwise the next request on
+	// that pooled conn would read leftover garbage (B1).
 	_, err := buf.ReadFrom(io.LimitReader(stream, int64(maxBytes)+1))
-	_ = resp.CloseBodyStream()
 	if err != nil {
+		closeFastConnDiscard(resp)
 		// fasthttp's per-conn SetDeadline (installed by DoDeadline) can fire a
 		// tick ahead of the Go ctx timer. If we're past the deadline, wait
 		// briefly for the ctx timer to land and surface ctx.Err() so the
@@ -777,32 +785,30 @@ func drainFastBodyLimited(ctx context.Context, resp *fasthttp.Response, maxBytes
 		return "", fmt.Errorf("llmhttp: failed to read response body: %w", err)
 	}
 	if buf.Len() > maxBytes {
+		// Oversize: we stopped before EOF, so the conn is dirty — discard it.
+		closeFastConnDiscard(resp)
 		return "", fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", maxBytes)
 	}
+	// Full body read to EOF: the connection is clean and can return to the pool.
+	_ = resp.CloseBodyStream()
 	return buf.String(), nil
 }
 
-// forceCloseFastBodyStream triggers a true connection close on a fasthttp
-// response body stream via CloseWithError — which internally routes
-// through HostClient.CloseConn to sever the TCP socket. This is what
-// unblocks a reader parked in a blocking syscall Read.
+// closeFastConnDiscard closes a streamed fasthttp response body in a way that
+// DISCARDS the underlying pooled connection rather than returning it for reuse.
 //
-// Safe to call only when the in-flight Read goroutine (if any) has
-// already exited requestStream.Read. Execute satisfies that invariant
-// because its conn carries a SetReadDeadline from DoDeadline; streaming
-// callers do not, so they use captureSlot.shutdown instead.
-func forceCloseFastBodyStream(resp *fasthttp.Response, reason error) {
-	stream := resp.BodyStream()
-	if stream == nil {
-		return
-	}
-	if rcw, ok := stream.(fasthttp.ReadCloserWithError); ok {
-		_ = rcw.CloseWithError(reason)
-		return
-	}
-	if cl, ok := stream.(io.Closer); ok {
-		_ = cl.Close()
-	}
+// fasthttp's streamed-body close closure (client.go doNonNilReqResp) pools the
+// connection unless Connection: close is set on the response or the close
+// carries an error. On any path that stops before the body EOF — oversized
+// success, a read error/deadline, the capped non-2xx diagnostic, the ctx-cancel
+// orphan — unread bytes remain on the wire, so reusing the conn would corrupt
+// the next request. Setting Connection: close before CloseBodyStream forces
+// that closure down the CloseConn path. CloseBodyStream (not a raw
+// CloseWithError) is used so resp.bodyStream is nil'd and a later
+// ReleaseResponse → Reset does not double-run the close closure.
+func closeFastConnDiscard(resp *fasthttp.Response) {
+	resp.SetConnectionClose()
+	_ = resp.CloseBodyStream()
 }
 
 // awaitCtxIfPastDeadline returns ctx.Err() when ctx is already done or when

--- a/bamlutils/llmhttp/fast_backend.go
+++ b/bamlutils/llmhttp/fast_backend.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -18,97 +19,195 @@ import (
 	"github.com/invakid404/baml-rest/bamlutils/sseclient"
 )
 
+// fastUnaryMode selects how executeFast drives a unary request, derived in
+// Client.Execute from whether the ORIGINAL caller context could be cancelled
+// before DefaultCallTimeout was injected.
+type fastUnaryMode int
+
+const (
+	// fastUnaryDeadlineOnly: the caller context had no Done channel
+	// (context.Background / context.TODO), so the only cancellation source is
+	// the deadline Execute injects. DoDeadline can run synchronously — no
+	// per-request goroutine — and, when no onSuccess callback is needed, the
+	// buffered HostClient reads the whole body before returning so the wrapper
+	// just copies fResp.Body() once.
+	fastUnaryDeadlineOnly fastUnaryMode = iota
+	// fastUnaryCancellable: the caller context was already cancellable
+	// (server request contexts, retry/orchestration contexts). DoDeadline runs
+	// in a goroutine so a mid-flight cancel returns the caller promptly while
+	// the orphaned Do winds down to its deadline and releases the pooled
+	// objects (fasthttp exposes no way to abort an in-flight Do).
+	fastUnaryCancellable
+)
+
 // executeFast runs a non-streaming request through fasthttp. The caller has
-// already applied URL rewrite and resolved the per-origin HostClient via the
+// already applied URL rewrite and resolved the per-origin host entry via the
 // protocol cache.
-func (c *Client) executeFast(ctx context.Context, req *Request, rewrittenURL string, hc *fasthttp.HostClient, onSuccess func()) (*Response, error) {
+//
+// Two body-handling lanes:
+//   - Buffered fast lane (deadline-only ctx AND no onSuccess): uses the
+//     entry's buffered unaryHost (StreamResponseBody=false), so DoDeadline
+//     reads the full body into fasthttp's pooled buffer and the wrapper does a
+//     single string copy — no intermediate buffer, no body-read goroutine.
+//   - Streamed-header lane (onSuccess != nil, or externally cancellable): uses
+//     the streaming host so DoDeadline returns after 2xx headers and onSuccess
+//     can fire before the body is read. The body is then drained synchronously
+//     (no io.ReadAll goroutine) into a pooled buffer with a MaxResponseBodyBytes+1
+//     limit.
+func (c *Client) executeFast(ctx context.Context, req *Request, rewrittenURL string, entry *hostEntry, onSuccess func(), mode fastUnaryMode) (*Response, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	deadline, hasDeadline := ctx.Deadline()
-	if !hasDeadline {
-		deadline = time.Now().Add(DefaultCallTimeout)
+
+	// Buffered fast lane: nothing to cancel beyond the deadline and no
+	// header-time callback to honour, so we can let fasthttp buffer the whole
+	// body and read it in one copy.
+	if mode == fastUnaryDeadlineOnly && onSuccess == nil && entry.unaryHost != nil {
+		return c.executeFastBuffered(ctx, req, rewrittenURL, entry.unaryHost)
 	}
+	return c.executeFastStreamed(ctx, req, rewrittenURL, entry.host, onSuccess, mode == fastUnaryCancellable)
+}
+
+// fastDeadline returns the deadline to pass to DoDeadline: the caller's if set,
+// otherwise DefaultCallTimeout from now (Execute always injects one, so the
+// fallback only guards direct executeFast callers).
+func fastDeadline(ctx context.Context) time.Time {
+	if d, ok := ctx.Deadline(); ok {
+		return d
+	}
+	return time.Now().Add(DefaultCallTimeout)
+}
+
+// executeFastBuffered runs the buffered fast lane: synchronous DoDeadline
+// against the buffered unaryHost, then a single copy of fResp.Body(). The
+// host's MaxResponseBodySize enforces the body cap, so an oversized 2xx body
+// surfaces as fasthttp.ErrBodyTooLarge, mapped to the same size-limit error
+// the net/http and streamed paths return.
+func (c *Client) executeFastBuffered(ctx context.Context, req *Request, rewrittenURL string, hc *fasthttp.HostClient) (*Response, error) {
+	fReq := fasthttp.AcquireRequest()
+	fResp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(fReq)
+	defer fasthttp.ReleaseResponse(fResp)
+	buildFastRequest(fReq, req, rewrittenURL)
+
+	if err := hc.DoDeadline(fReq, fResp, fastDeadline(ctx)); err != nil {
+		if errors.Is(err, fasthttp.ErrBodyTooLarge) {
+			return nil, fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", MaxResponseBodyBytes)
+		}
+		if ctxErr := awaitCtxIfPastDeadline(ctx); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if te := classifyTransportErr(err, "llmhttp: request failed", true); te != nil {
+			return nil, te
+		}
+		return nil, fmt.Errorf("llmhttp: request failed: %w", err)
+	}
+
+	status := fResp.StatusCode()
+	if status < 200 || status >= 300 {
+		// Body is already buffered; cap the diagnostic to MaxErrorBodyBytes to
+		// match the net/http and streamed error-body policy.
+		body := fResp.Body()
+		if len(body) > MaxErrorBodyBytes {
+			body = body[:MaxErrorBodyBytes]
+		}
+		return nil, &HTTPError{StatusCode: status, Body: string(body)}
+	}
+
+	// onSuccess is nil in this lane by construction (executeFast gates on it).
+	return &Response{
+		StatusCode: status,
+		Headers:    fastHeadersToHTTP(&fResp.Header),
+		Body:       string(fResp.Body()),
+	}, nil
+}
+
+// executeFastStreamed runs the streamed-header lane against the streaming host
+// (StreamResponseBody=true). DoDeadline returns after the 2xx headers so
+// onSuccess can fire before the body is read; the body is then drained
+// synchronously by drainFastBodyLimited. When cancellable, DoDeadline runs in a
+// goroutine so a mid-flight ctx cancel returns the caller promptly.
+func (c *Client) executeFastStreamed(ctx context.Context, req *Request, rewrittenURL string, hc *fasthttp.HostClient, onSuccess func(), cancellable bool) (*Response, error) {
+	deadline := fastDeadline(ctx)
 
 	fReq := fasthttp.AcquireRequest()
 	fResp := fasthttp.AcquireResponse()
 	buildFastRequest(fReq, req, rewrittenURL)
 
-	// Run Do in a goroutine so ctx cancellation returns promptly even though
-	// fasthttp.HostClient.DoDeadline is blocking and not ctx-aware. If ctx
-	// fires before Do returns, the goroutine keeps running until the
-	// deadline and then releases the pooled request/response — there is no
-	// mechanism to abort Do mid-flight short of closing the underlying
-	// connection (HostClient does not expose one).
-	doneCh := make(chan error, 1)
-	go func() {
-		doneCh <- hc.DoDeadline(fReq, fResp, deadline)
-	}()
-
-	select {
-	case <-ctx.Done():
-		// Hand off cleanup so the pool isn't starved by the orphaned Do.
+	var doErr error
+	if cancellable {
+		// Run DoDeadline in a goroutine so ctx cancellation returns promptly
+		// even though DoDeadline is blocking and not ctx-aware. If ctx fires
+		// first, the goroutine keeps running until the deadline and then
+		// releases the pooled request/response — there is no mechanism to abort
+		// Do mid-flight short of closing the underlying connection (HostClient
+		// does not expose one for the shared pool).
+		doneCh := make(chan error, 1)
 		go func() {
-			<-doneCh
-			fasthttp.ReleaseRequest(fReq)
-			fasthttp.ReleaseResponse(fResp)
+			doneCh <- hc.DoDeadline(fReq, fResp, deadline)
 		}()
-		return nil, ctx.Err()
-	case err := <-doneCh:
-		// Must not release until body read completes — with
-		// StreamResponseBody=true, fResp owns the body stream until it is
-		// fully drained or force-closed. Releasing early would return the
-		// response object (and its live body stream reference) to the pool
-		// while the reader is still using it, corrupting the next borrower.
-		// The deferred release below runs AFTER the body path runs.
-		defer fasthttp.ReleaseRequest(fReq)
-		defer fasthttp.ReleaseResponse(fResp)
-		if err != nil {
-			// See awaitCtxIfPastDeadline comment in readFastBodyLimitedCtx:
-			// normalise fasthttp's deadline-exceeded error to ctx.Err()
-			// when the ctx timer is about to fire, so the caller's
-			// ctx-gated cleanup sees a consistent state.
-			if ctxErr := awaitCtxIfPastDeadline(ctx); ctxErr != nil {
-				return nil, ctxErr
-			}
-			if te := classifyTransportErr(err, "llmhttp: request failed", true); te != nil {
-				return nil, te
-			}
-			return nil, fmt.Errorf("llmhttp: request failed: %w", err)
+		select {
+		case <-ctx.Done():
+			// Hand off cleanup so the pool isn't starved by the orphaned Do.
+			go func() {
+				<-doneCh
+				fasthttp.ReleaseRequest(fReq)
+				fasthttp.ReleaseResponse(fResp)
+			}()
+			return nil, ctx.Err()
+		case doErr = <-doneCh:
 		}
-
-		status := fResp.StatusCode()
-
-		// For non-2xx responses, read a bounded diagnostic body (regardless
-		// of StreamResponseBody mode) and surface it as *HTTPError. Matches
-		// the net/http path's error-body policy exactly.
-		if status < 200 || status >= 300 {
-			body := readFastBodyCappedCtx(ctx, fResp, MaxErrorBodyBytes)
-			return nil, &HTTPError{StatusCode: status, Body: string(body)}
-		}
-
-		if onSuccess != nil {
-			onSuccess()
-		}
-
-		// StreamResponseBody is on at the client level; for non-streaming
-		// responses we still need the full body. Read through BodyStream
-		// with the same +1 / truncation check as the net/http path so a
-		// provider sending > MaxResponseBodyBytes is reported, not silently
-		// truncated. Reading is ctx-aware because Do returned after headers
-		// (StreamResponseBody=true) — the caller's deadline therefore must
-		// be enforced during the body read, not just the headers read.
-		body, err := readFastBodyLimitedCtx(ctx, fResp, MaxResponseBodyBytes)
-		if err != nil {
-			return nil, err
-		}
-
-		return &Response{
-			StatusCode: status,
-			Headers:    fastHeadersToHTTP(&fResp.Header),
-			Body:       string(body),
-		}, nil
+	} else {
+		// Deadline-only ctx with an onSuccess callback: nothing to cancel
+		// beyond the deadline, so DoDeadline can run synchronously with no
+		// per-request goroutine. The deadline still bounds a stalled upstream.
+		doErr = hc.DoDeadline(fReq, fResp, deadline)
 	}
+
+	// Must not release until the body read completes — with
+	// StreamResponseBody=true, fResp owns the body stream until it is fully
+	// drained or force-closed. Releasing early would return the response (and
+	// its live body stream reference) to the pool while the reader is still
+	// using it. These defers run AFTER the body path below.
+	defer fasthttp.ReleaseRequest(fReq)
+	defer fasthttp.ReleaseResponse(fResp)
+
+	if doErr != nil {
+		// Normalise fasthttp's deadline-exceeded error to ctx.Err() when the
+		// ctx timer is about to fire, so the caller's ctx-gated cleanup sees a
+		// consistent state.
+		if ctxErr := awaitCtxIfPastDeadline(ctx); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if te := classifyTransportErr(doErr, "llmhttp: request failed", true); te != nil {
+			return nil, te
+		}
+		return nil, fmt.Errorf("llmhttp: request failed: %w", doErr)
+	}
+
+	status := fResp.StatusCode()
+
+	// For non-2xx responses, read a bounded diagnostic body and surface it as
+	// *HTTPError. Matches the net/http path's error-body policy exactly.
+	if status < 200 || status >= 300 {
+		body := readFastBodyCappedCtx(ctx, fResp, MaxErrorBodyBytes)
+		return nil, &HTTPError{StatusCode: status, Body: string(body)}
+	}
+
+	if onSuccess != nil {
+		onSuccess()
+	}
+
+	body, err := drainFastBodyLimited(ctx, fResp, MaxResponseBodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Response{
+		StatusCode: status,
+		Headers:    fastHeadersToHTTP(&fResp.Header),
+		Body:       body,
+	}, nil
 }
 
 // executeStreamFast runs a streaming request through fasthttp. The returned
@@ -618,73 +717,69 @@ func readFastBodyCappedCtx(ctx context.Context, resp *fasthttp.Response, limit i
 	}
 }
 
-// readFastBodyLimitedCtx reads the full response body up to maxBytes,
-// respecting ctx cancellation. Returns an error when the body exceeds the
-// cap — matching Execute's contract that oversized responses are reportable
-// rather than silently truncated. On ctx fire the underlying connection is
-// force-closed and ctx.Err() is returned, mirroring the net/http path where
-// a cancelled body read surfaces the context error.
+// fastBodyBufPool reuses scratch buffers for draining streamed unary response
+// bodies, so the per-request growing intermediate that io.ReadAll allocated is
+// replaced by a pooled buffer. Buffers larger than maxPooledFastBody are not
+// returned to the pool so an occasional oversized body cannot pin large memory.
+var fastBodyBufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
+
+// maxPooledFastBody caps the capacity of a buffer kept in fastBodyBufPool.
+// 1 MiB comfortably holds typical LLM completions while keeping the pool's
+// retained footprint bounded.
+const maxPooledFastBody = 1 << 20
+
+// drainFastBodyLimited reads a streamed unary response body up to maxBytes,
+// synchronously (no per-request goroutine). It drains BodyStream into a pooled
+// scratch buffer with a maxBytes+1 limit so a body exceeding the cap is
+// reported — matching Execute's contract that oversized responses are an error,
+// not a silent truncation — and matching the net/http path's +1/strictly-greater
+// check exactly.
 //
-// Used exclusively by Execute: see readFastBodyCappedCtx's doc comment for
-// why the CloseWithError race is benign on that code path.
-func readFastBodyLimitedCtx(ctx context.Context, resp *fasthttp.Response, maxBytes int) ([]byte, error) {
+// Unlike the previous goroutine-based reader, a mid-body ctx cancel is not
+// force-closed here: the read is bounded by the conn deadline DoDeadline
+// installed (the same deadline Execute injected), consistent with fasthttp
+// having no real mid-flight abort. awaitCtxIfPastDeadline still normalises a
+// deadline-race error to ctx.Err() so downstream cancellation suppression stays
+// consistent.
+func drainFastBodyLimited(ctx context.Context, resp *fasthttp.Response, maxBytes int) (string, error) {
 	stream := resp.BodyStream()
 	if stream == nil {
-		// Non-streaming path (shouldn't happen with StreamResponseBody on,
-		// but keep a correct fallback).
+		// Body already buffered (defensive — the streaming host should always
+		// yield a stream). One copy, with the same strictly-greater cap check.
 		body := resp.Body()
 		if len(body) > maxBytes {
-			return nil, fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", maxBytes)
+			return "", fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", maxBytes)
 		}
-		return append([]byte(nil), body...), nil
+		return string(body), nil
 	}
 
-	type result struct {
-		buf []byte
-		err error
-	}
-	resCh := make(chan result, 1)
-	go func() {
-		buf, err := io.ReadAll(io.LimitReader(stream, int64(maxBytes)+1))
-		resCh <- result{buf: buf, err: err}
+	buf := fastBodyBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer func() {
+		if buf.Cap() <= maxPooledFastBody {
+			fastBodyBufPool.Put(buf)
+		}
 	}()
 
-	select {
-	case <-ctx.Done():
-		// Wait for the Read goroutine to exit naturally via the conn's
-		// SetReadDeadline (see forceCloseWaitWindow doc) before falling
-		// back to force-close. Read result is discarded — we're
-		// returning ctx.Err() either way.
-		select {
-		case <-resCh:
-		case <-time.After(forceCloseWaitWindow):
-			forceCloseFastBodyStream(resp, ctx.Err())
-			<-resCh
+	_, err := buf.ReadFrom(io.LimitReader(stream, int64(maxBytes)+1))
+	_ = resp.CloseBodyStream()
+	if err != nil {
+		// fasthttp's per-conn SetDeadline (installed by DoDeadline) can fire a
+		// tick ahead of the Go ctx timer. If we're past the deadline, wait
+		// briefly for the ctx timer to land and surface ctx.Err() so the
+		// orchestrator's trySend cancellation suppression stays consistent.
+		if ctxErr := awaitCtxIfPastDeadline(ctx); ctxErr != nil {
+			return "", ctxErr
 		}
-		return nil, ctx.Err()
-	case r := <-resCh:
-		_ = resp.CloseBodyStream()
-		if r.err != nil {
-			// fasthttp's per-conn SetDeadline (installed by DoDeadline)
-			// can fire a tick ahead of the Go ctx timer. Returning a
-			// non-ctx error here would make the orchestrator's trySend
-			// race with ctx.Done() — occasionally emitting an error
-			// result even though the cancellation path should suppress
-			// it. If we're past the deadline, wait briefly for the ctx
-			// timer to land and surface ctx.Err() instead.
-			if err := awaitCtxIfPastDeadline(ctx); err != nil {
-				return nil, err
-			}
-			if te := classifyTransportErr(r.err, "llmhttp: failed to read response body", false); te != nil {
-				return nil, te
-			}
-			return nil, fmt.Errorf("llmhttp: failed to read response body: %w", r.err)
+		if te := classifyTransportErr(err, "llmhttp: failed to read response body", false); te != nil {
+			return "", te
 		}
-		if int64(len(r.buf)) > int64(maxBytes) {
-			return nil, fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", maxBytes)
-		}
-		return r.buf, nil
+		return "", fmt.Errorf("llmhttp: failed to read response body: %w", err)
 	}
+	if buf.Len() > maxBytes {
+		return "", fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", maxBytes)
+	}
+	return buf.String(), nil
 }
 
 // forceCloseFastBodyStream triggers a true connection close on a fasthttp

--- a/bamlutils/llmhttp/llmhttp.go
+++ b/bamlutils/llmhttp/llmhttp.go
@@ -559,6 +559,17 @@ func (c *Client) Execute(ctx context.Context, req *Request, onSuccess func()) (*
 		ctx = context.Background()
 	}
 
+	// Capture whether the ORIGINAL caller context can be cancelled before we
+	// inject DefaultCallTimeout below. A context with no Done channel
+	// (context.Background / context.TODO) can only ever be bounded by the
+	// deadline we are about to add, so the fasthttp backend can call
+	// DoDeadline synchronously and read a fully buffered body — no per-request
+	// goroutine, no body intermediate. A context that was already cancellable
+	// (server request contexts, retry/orchestration contexts) keeps the
+	// goroutine race so a mid-flight cancel still returns the caller promptly.
+	// This must be read before WithTimeout, which always adds a Done channel.
+	cancellable := ctx.Done() != nil
+
 	// Enforce a deadline on the outbound call if the caller didn't set one.
 	// The HTTP client is shared with ExecuteStream (which must not have a
 	// fixed timeout), so the timeout is applied per-request via context
@@ -569,6 +580,11 @@ func (c *Client) Execute(ctx context.Context, req *Request, onSuccess func()) (*
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, DefaultCallTimeout)
 		defer cancel()
+	}
+
+	fastMode := fastUnaryDeadlineOnly
+	if cancellable {
+		fastMode = fastUnaryCancellable
 	}
 
 	rewritten := c.resolveRequestURL(req)
@@ -584,7 +600,7 @@ func (c *Client) Execute(ctx context.Context, req *Request, onSuccess func()) (*
 	if c.cache != nil {
 		if origin, err := parseOrigin(rewritten); err == nil {
 			if entry := c.cache.resolve(ctx, origin); entry != nil && entry.decision == decisionFast && entry.host != nil {
-				return c.executeFast(ctx, req, rewritten, entry.host, onSuccess)
+				return c.executeFast(ctx, req, rewritten, entry, onSuccess, fastMode)
 			}
 		}
 	}

--- a/bamlutils/llmhttp/llmhttp_after_bench_test.go
+++ b/bamlutils/llmhttp/llmhttp_after_bench_test.go
@@ -136,8 +136,11 @@ func BenchmarkExecuteAfter(b *testing.B) {
 // TestExecuteAfterLoadDist: latency distribution for both lanes on small/c256
 // and medium/c256 (where the tail blew up before the fix).
 func TestExecuteAfterLoadDist(t *testing.T) {
-	if testing.Short() {
-		t.Skip("after load distribution test skipped in -short mode")
+	// Heavy: fires 30k/8k-request load loops and would blow CI's unit-test
+	// timeout. Gated to explicit measurement runs — skipped unless the output
+	// env is present, or in -short mode.
+	if testing.Short() || os.Getenv("BENCH_AFTER_OUT") == "" {
+		t.Skip("load measurement; set BENCH_AFTER_OUT to run")
 	}
 
 	gomaxprocs := runtime.GOMAXPROCS(0)

--- a/bamlutils/llmhttp/llmhttp_after_bench_test.go
+++ b/bamlutils/llmhttp/llmhttp_after_bench_test.go
@@ -1,0 +1,189 @@
+package llmhttp
+
+// Re-measurement harness for the #475 wrapper fix. Measures BOTH unary lanes so
+// we don't flatter ourselves:
+//
+//   - wf-buffered: wrapped-fasthttp on the buffered fast lane (context.Background
+//     + onSuccess==nil) — the easy lane; should approach raw-fasthttp.
+//   - wf-streamed: wrapped-fasthttp on the production-shaped streamed lane
+//     (cancellable ctx + onSuccess!=nil) — keeps the DoDeadline goroutine race,
+//     but the body intermediate + io.ReadAll goroutine are gone, so it should
+//     still show a big alloc/throughput/tail win vs before.
+//   - raw-fasthttp: the synchronous-library floor (reference).
+//
+// Reuses helpers from llmhttp_bench_test.go / llmhttp_control_bench_test.go
+// (mockServer, controlDoFunc, warmupDriver, runControlLoad, percentile, us).
+//
+// Run:
+//   GOMAXPROCS=8 go test ./bamlutils/llmhttp -run '^$' -bench '^BenchmarkExecuteAfter$' -benchmem -benchtime=5s -count=6
+//   GOMAXPROCS=8 BENCH_AFTER_OUT=/tmp/shared/475-after-load-table.md go test ./bamlutils/llmhttp -run '^TestExecuteAfterLoadDist$' -v
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// afterBackend factories take a testing.TB so the cancellable lane can register
+// its context cancel via Cleanup (vet-clean, no leaked cancel).
+type afterBackend struct {
+	name string
+	make func(tb testing.TB, m *mockServer) controlDoFunc
+}
+
+// wrappedFastBufferedDriver: background ctx + nil onSuccess → buffered fast lane.
+func wrappedFastBufferedDriver(_ testing.TB, m *mockServer) controlDoFunc {
+	client := newBenchClient(ClientModeFastHTTP)
+	req := m.request()
+	ctx := context.Background()
+	return func() error {
+		resp, err := client.Execute(ctx, req, nil)
+		if err != nil {
+			return err
+		}
+		if resp.Body != m.body {
+			return fmt.Errorf("wf-buffered: body mismatch (%d vs %d bytes)", len(resp.Body), len(m.body))
+		}
+		return nil
+	}
+}
+
+// wrappedFastStreamedDriver: cancellable ctx (never cancelled) + non-nil
+// onSuccess → streamed-header lane with the DoDeadline goroutine race. This is
+// the production-shaped lane (server request context + pool heartbeat).
+func wrappedFastStreamedDriver(tb testing.TB, m *mockServer) controlDoFunc {
+	client := newBenchClient(ClientModeFastHTTP)
+	req := m.request()
+	ctx, cancel := context.WithCancel(context.Background())
+	tb.Cleanup(cancel)
+	var beats int64
+	onSuccess := func() { atomic.AddInt64(&beats, 1) }
+	return func() error {
+		resp, err := client.Execute(ctx, req, onSuccess)
+		if err != nil {
+			return err
+		}
+		if resp.Body != m.body {
+			return fmt.Errorf("wf-streamed: body mismatch (%d vs %d bytes)", len(resp.Body), len(m.body))
+		}
+		return nil
+	}
+}
+
+func rawFastAfterDriver(_ testing.TB, m *mockServer) controlDoFunc {
+	return rawFastHTTPDriver(m)
+}
+
+var afterBackends = []afterBackend{
+	{"raw-fasthttp", rawFastAfterDriver},
+	{"wf-buffered", wrappedFastBufferedDriver},
+	{"wf-streamed", wrappedFastStreamedDriver},
+}
+
+// BenchmarkExecuteAfter: ns/op + B/op + allocs/op for both lanes on the key
+// cases where the regression lived.
+func BenchmarkExecuteAfter(b *testing.B) {
+	servers := map[string]*mockServer{
+		respSmall:  newMockServer(respSmall),
+		respMedium: newMockServer(respMedium),
+	}
+	for _, m := range servers {
+		b.Cleanup(m.close)
+	}
+
+	for _, bk := range afterBackends {
+		for _, cs := range controlCases {
+			m := servers[cs.size]
+			name := fmt.Sprintf("%s/%s/c%d", bk.name, cs.size, cs.conc)
+			b.Run(name, func(b *testing.B) {
+				do := bk.make(b, m)
+				warmupDriver(b, do, cs.conc)
+
+				var errCount atomic.Int64
+				remaining := int64(b.N)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				var wg sync.WaitGroup
+				for w := 0; w < cs.conc; w++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						for atomic.AddInt64(&remaining, -1) >= 0 {
+							if err := do(); err != nil {
+								errCount.Add(1)
+							}
+						}
+					}()
+				}
+				wg.Wait()
+
+				b.StopTimer()
+				if n := errCount.Load(); n > 0 {
+					b.Fatalf("%d errors/body-mismatches — fast-but-broken path must not score as a win", n)
+				}
+			})
+		}
+	}
+}
+
+// TestExecuteAfterLoadDist: latency distribution for both lanes on small/c256
+// and medium/c256 (where the tail blew up before the fix).
+func TestExecuteAfterLoadDist(t *testing.T) {
+	if testing.Short() {
+		t.Skip("after load distribution test skipped in -short mode")
+	}
+
+	gomaxprocs := runtime.GOMAXPROCS(0)
+	t.Logf("environment: GOMAXPROCS=%d NumCPU=%d go=%s os=%s/%s",
+		gomaxprocs, runtime.NumCPU(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
+
+	loadCases := []controlCase{
+		{respSmall, 256},
+		{respMedium, 256},
+	}
+
+	var results []loadResult
+	for _, cs := range loadCases {
+		m := newMockServer(cs.size)
+		for _, bk := range afterBackends {
+			do := bk.make(t, m)
+			res := runControlLoad(t, do, m, bk.name, cs.conc, loadCount(cs.size))
+			res.respSize = cs.size
+			if res.errors > 0 {
+				t.Errorf("%s/%s/c%d: %d errors", bk.name, cs.size, cs.conc, res.errors)
+			}
+			if res.serverReq != int64(res.requests) {
+				t.Errorf("%s/%s/c%d: server saw %d, expected %d", bk.name, cs.size, cs.conc, res.serverReq, res.requests)
+			}
+			results = append(results, res)
+		}
+		m.close()
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "\nafter-fix latency distribution — GOMAXPROCS=%d NumCPU=%d go=%s %s/%s\n\n",
+		gomaxprocs, runtime.NumCPU(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(&b, "| backend | resp | conc | req/s | p50(us) | p95(us) | p99(us) | max(us) | errors | srv-reqs |\n")
+	fmt.Fprintf(&b, "|---------|------|-----:|------:|--------:|--------:|--------:|--------:|-------:|---------:|\n")
+	for _, r := range results {
+		fmt.Fprintf(&b, "| %s | %s | %d | %.0f | %.1f | %.1f | %.1f | %.1f | %d | %d |\n",
+			r.backend, r.respSize, r.conc, r.reqPerSec,
+			us(r.p50), us(r.p95), us(r.p99), us(r.max), r.errors, r.serverReq)
+	}
+	t.Log(b.String())
+
+	if out := os.Getenv("BENCH_AFTER_OUT"); out != "" {
+		if err := os.WriteFile(out, []byte(b.String()), 0o644); err != nil {
+			t.Logf("failed to write BENCH_AFTER_OUT=%s: %v", out, err)
+		} else {
+			t.Logf("wrote after load table to %s", out)
+		}
+	}
+}

--- a/bamlutils/llmhttp/llmhttp_after_bench_test.go
+++ b/bamlutils/llmhttp/llmhttp_after_bench_test.go
@@ -61,8 +61,9 @@ func wrappedFastStreamedDriver(tb testing.TB, m *mockServer) controlDoFunc {
 	req := m.request()
 	ctx, cancel := context.WithCancel(context.Background())
 	tb.Cleanup(cancel)
-	var beats int64
-	onSuccess := func() { atomic.AddInt64(&beats, 1) }
+	// Empty non-nil callback: selects the streamed-header lane without adding
+	// per-request atomic overhead to the measured lane.
+	onSuccess := func() {}
 	return func() error {
 		resp, err := client.Execute(ctx, req, onSuccess)
 		if err != nil {

--- a/bamlutils/llmhttp/llmhttp_bench_test.go
+++ b/bamlutils/llmhttp/llmhttp_bench_test.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"runtime"
 	"sort"
@@ -37,21 +38,14 @@ import (
 	"time"
 )
 
-// proxy env that would otherwise pin auto-mode http:// origins to net/http
-// (the cache proxy check runs before the plaintext short-circuit, see
-// protocolCache.probe). Cleared once at package init so auto resolves to
-// fasthttp for our plaintext server, as the issue expects. net/http caches
-// the proxy config on first use, so this must run before any HTTP.
-func init() {
-	for _, k := range []string{
-		"HTTP_PROXY", "http_proxy",
-		"HTTPS_PROXY", "https_proxy",
-		"NO_PROXY", "no_proxy",
-		"ALL_PROXY", "all_proxy",
-	} {
-		os.Unsetenv(k)
-	}
-}
+// noProxy is an explicit "no proxy for any request" resolver. Bench clients
+// install it on their transports so the auto-mode probe never pins our
+// plaintext http:// origin to net/http via a proxy, and the net/http backend
+// dials the local server directly — WITHOUT mutating process-global proxy env
+// (which would leak into every other test in the package). A nil Transport.Proxy
+// is NOT sufficient: proxyFuncFromHTTPClient falls back to
+// http.ProxyFromEnvironment when Proxy is nil, so we must set an explicit func.
+func noProxy(*http.Request) (*url.URL, error) { return nil, nil }
 
 // --- payloads -------------------------------------------------------------
 
@@ -150,12 +144,19 @@ var backendCases = []backendCase{
 }
 
 // newBenchClient builds a Client for the given mode via the explicit options
-// constructor — NOT env. NewDefaultClientWithOptions installs the tuned
-// defaultLLMTransport on the net/http side; the fasthttp side uses the
+// constructor — NOT env. It clones the tuned defaultLLMTransport and installs an
+// explicit no-proxy resolver so the auto-mode probe resolves our plaintext
+// origin to fasthttp and the net/http backend dials directly, with no
+// process-global proxy-env mutation. The fasthttp side uses the
 // effectively-unbounded MaxConns default (math.MaxInt32) so high concurrency
 // never trips ErrNoFreeConns.
 func newBenchClient(mode ClientMode) *Client {
-	return NewDefaultClientWithOptions(ClientOptions{Mode: mode})
+	tr := defaultLLMTransport.Clone()
+	tr.Proxy = noProxy
+	return NewClientWithOptions(ClientOptions{
+		Mode:          mode,
+		NetHTTPClient: &http.Client{Transport: tr},
+	})
 }
 
 // warmup fires `conc` concurrent requests (a few rounds) before measuring so
@@ -381,8 +382,11 @@ func percentile(sorted []time.Duration, p float64) time.Duration {
 //
 //	GOMAXPROCS=8 go test ./bamlutils/llmhttp -run '^TestExecuteLoadDist$' -v
 func TestExecuteLoadDist(t *testing.T) {
-	if testing.Short() {
-		t.Skip("load distribution test skipped in -short mode")
+	// Heavy: fires 30k/8k-request load loops and would blow CI's unit-test
+	// timeout. Gated to explicit measurement runs — skipped unless the output
+	// env (which a measurement run sets anyway) is present, or in -short mode.
+	if testing.Short() || os.Getenv("BENCH_LOAD_OUT") == "" {
+		t.Skip("load measurement; set BENCH_LOAD_OUT to run")
 	}
 
 	gomaxprocs := runtime.GOMAXPROCS(0)

--- a/bamlutils/llmhttp/llmhttp_bench_test.go
+++ b/bamlutils/llmhttp/llmhttp_bench_test.go
@@ -1,0 +1,437 @@
+package llmhttp
+
+// Focused benchmark for issue #475: does fasthttp actually beat net/http for
+// our high-volume HTTP/1.1 plaintext BuildRequest path, or are we carrying its
+// complexity for no payoff?
+//
+// This measures the REAL shared (*llmhttp.Client).Execute path — header
+// conversion, the cancellation goroutine, body handling, response
+// normalization — NOT raw fasthttp/net/http. Backends are selected by explicit
+// ClientMode (no env), against a local in-process plaintext HTTP/1.1 server.
+//
+// Two measurement vehicles:
+//   (1) BenchmarkExecute    — testing.B sub-benchmarks → ns/op, B/op, allocs/op
+//   (2) TestExecuteLoadDist — fixed-worker load loop → req/s, p50/p95/p99/max,
+//                             errors, server-observed request count
+//
+// Run (record GOMAXPROCS + machine):
+//   go build ./bamlutils/llmhttp/
+//   GOMAXPROCS=8 go test ./bamlutils/llmhttp -run '^$' -bench '^BenchmarkExecute$' -benchmem -benchtime=5s -count=6
+//   GOMAXPROCS=8 go test ./bamlutils/llmhttp -run '^TestExecuteLoadDist$' -v
+//
+// This file is benchmark-only; it changes no production code.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// proxy env that would otherwise pin auto-mode http:// origins to net/http
+// (the cache proxy check runs before the plaintext short-circuit, see
+// protocolCache.probe). Cleared once at package init so auto resolves to
+// fasthttp for our plaintext server, as the issue expects. net/http caches
+// the proxy config on first use, so this must run before any HTTP.
+func init() {
+	for _, k := range []string{
+		"HTTP_PROXY", "http_proxy",
+		"HTTPS_PROXY", "https_proxy",
+		"NO_PROXY", "no_proxy",
+		"ALL_PROXY", "all_proxy",
+	} {
+		os.Unsetenv(k)
+	}
+}
+
+// --- payloads -------------------------------------------------------------
+
+// benchRequestBody is a small OpenAI-style chat-completion request (~1.5 KB),
+// resembling generated BuildRequest traffic. Request stays small in every
+// case; only the response size varies as a sub-case.
+var benchRequestBody = buildRequestBody()
+
+func buildRequestBody() string {
+	// pad the user message so the whole JSON lands around 1.5 KB.
+	userContent := strings.Repeat(
+		"Summarize the following passage in two sentences, preserving key facts. ", 18)
+	return fmt.Sprintf(
+		`{"model":"gpt-4o","messages":[`+
+			`{"role":"system","content":"You are a helpful assistant that answers concisely."},`+
+			`{"role":"user","content":%q}],`+
+			`"temperature":0.7,"max_tokens":256,"top_p":1,"stream":false}`,
+		userContent)
+}
+
+const (
+	respSmall  = "small"  // ~256 B JSON completion
+	respMedium = "medium" // ~64 KB JSON completion
+)
+
+// mockBody returns a fixed JSON response body of approximately the requested
+// size. Small mimics a terse completion; medium (~64 KB) exposes
+// allocation/body-handling differences between the backends.
+func mockBody(size string) string {
+	switch size {
+	case respMedium:
+		// ~64 KB of content inside an OpenAI-style envelope.
+		content := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 1456) // ~64 KB
+		return fmt.Sprintf(
+			`{"id":"chatcmpl-bench","object":"chat.completion","model":"gpt-4o",`+
+				`"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":%q}}],`+
+				`"usage":{"prompt_tokens":42,"completion_tokens":4096,"total_tokens":4138}}`,
+			content)
+	default:
+		return `{"id":"chatcmpl-bench","object":"chat.completion","model":"gpt-4o",` +
+			`"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Hello! How can I help you today?"}}],` +
+			`"usage":{"prompt_tokens":42,"completion_tokens":9,"total_tokens":51}}`
+	}
+}
+
+// mockServer is a local in-process plaintext HTTP/1.1 server. It accepts POST,
+// drains the request body (so keep-alive connections are reused), and returns a
+// fixed JSON body with Content-Type: application/json. No logging, no sleeps.
+type mockServer struct {
+	srv      *httptest.Server
+	url      string // server.URL + "/v1/chat/completions"
+	body     string // exact expected response body
+	reqCount atomic.Int64
+}
+
+func newMockServer(size string) *mockServer {
+	m := &mockServer{body: mockBody(size)}
+	m.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Drain + discard the request body so the connection is reusable.
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		m.reqCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, m.body)
+	}))
+	m.url = m.srv.URL + "/v1/chat/completions"
+	return m
+}
+
+func (m *mockServer) close() { m.srv.Close() }
+
+func (m *mockServer) request() *Request {
+	return &Request{
+		Method: "POST",
+		URL:    m.url,
+		Headers: map[string]string{
+			"Content-Type":  "application/json",
+			"Authorization": "Bearer sk-bench-0000000000000000000000000000",
+		},
+		Body: benchRequestBody,
+	}
+}
+
+// --- client construction --------------------------------------------------
+
+type backendCase struct {
+	name string
+	mode ClientMode
+}
+
+var backendCases = []backendCase{
+	{"nethttp", ClientModeNetHTTP},
+	{"fasthttp", ClientModeFastHTTP},
+	{"auto", ClientModeAuto},
+}
+
+// newBenchClient builds a Client for the given mode via the explicit options
+// constructor — NOT env. NewDefaultClientWithOptions installs the tuned
+// defaultLLMTransport on the net/http side; the fasthttp side uses the
+// effectively-unbounded MaxConns default (math.MaxInt32) so high concurrency
+// never trips ErrNoFreeConns.
+func newBenchClient(mode ClientMode) *Client {
+	return NewDefaultClientWithOptions(ClientOptions{Mode: mode})
+}
+
+// warmup fires `conc` concurrent requests (a few rounds) before measuring so
+// the connection pool is populated and, for auto mode, the per-origin protocol
+// cache (ALPN probe) is resolved. Returns the resolved decision string for
+// auto-mode reporting. It also fails the test if any warmup request errors or
+// the body doesn't match — a broken-but-fast path must not look like a win.
+func warmup(tb testing.TB, client *Client, m *mockServer, conc int) {
+	tb.Helper()
+	ctx := context.Background()
+	rounds := 3
+	for r := 0; r < rounds; r++ {
+		var wg sync.WaitGroup
+		var failed atomic.Bool
+		for i := 0; i < conc; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				resp, err := client.Execute(ctx, m.request(), nil)
+				if err != nil {
+					tb.Errorf("warmup request failed: %v", err)
+					failed.Store(true)
+					return
+				}
+				if resp.Body != m.body {
+					tb.Errorf("warmup body mismatch: got %d bytes, want %d", len(resp.Body), len(m.body))
+					failed.Store(true)
+				}
+			}()
+		}
+		wg.Wait()
+		if failed.Load() {
+			tb.FailNow()
+		}
+	}
+}
+
+// resolvedDecision reports whether the client's protocol cache routed the mock
+// origin to fasthttp or net/http (after warmup). Used to confirm what "auto"
+// actually resolved to.
+func resolvedDecision(client *Client, m *mockServer) string {
+	if client.cache == nil {
+		return "no-cache"
+	}
+	origin, err := parseOrigin(m.url)
+	if err != nil {
+		return "parse-error"
+	}
+	entry := client.cache.lookup(origin.key)
+	if entry == nil {
+		return "unresolved"
+	}
+	switch entry.decision {
+	case decisionFast:
+		return "fasthttp"
+	case decisionNet:
+		return "nethttp"
+	default:
+		return "unknown"
+	}
+}
+
+// --- vehicle 1: testing.B sub-benchmarks ----------------------------------
+
+var benchConcurrency = []int{1, 16, 64, 256}
+
+// BenchmarkExecute measures (*Client).Execute across backend × response-size ×
+// concurrency. Each leaf warms up the client, resets the timer, then runs b.N
+// requests spread across a fixed number of worker goroutines. -benchmem yields
+// B/op and allocs/op for the timed region.
+func BenchmarkExecute(b *testing.B) {
+	for _, size := range []string{respSmall, respMedium} {
+		m := newMockServer(size)
+		b.Cleanup(m.close)
+		for _, bc := range backendCases {
+			for _, conc := range benchConcurrency {
+				name := fmt.Sprintf("%s/%s/c%d", bc.name, size, conc)
+				b.Run(name, func(b *testing.B) {
+					client := newBenchClient(bc.mode)
+					warmup(b, client, m, conc)
+
+					var errCount atomic.Int64
+					remaining := int64(b.N)
+					ctx := context.Background()
+
+					b.ReportAllocs()
+					b.ResetTimer()
+
+					var wg sync.WaitGroup
+					for w := 0; w < conc; w++ {
+						wg.Add(1)
+						go func() {
+							defer wg.Done()
+							req := m.request()
+							for atomic.AddInt64(&remaining, -1) >= 0 {
+								resp, err := client.Execute(ctx, req, nil)
+								if err != nil {
+									errCount.Add(1)
+									continue
+								}
+								if resp.Body != m.body {
+									errCount.Add(1)
+								}
+							}
+						}()
+					}
+					wg.Wait()
+
+					b.StopTimer()
+					if n := errCount.Load(); n > 0 {
+						b.Fatalf("%d errors/body-mismatches during benchmark — fast-but-broken path must not score as a win", n)
+					}
+				})
+			}
+		}
+	}
+}
+
+// --- vehicle 2: fixed-worker latency-distribution load test ---------------
+
+type loadResult struct {
+	backend   string
+	respSize  string
+	conc      int
+	requests  int
+	errors    int64
+	serverReq int64
+	resolved  string
+	elapsed   time.Duration
+	reqPerSec float64
+	p50, p95  time.Duration
+	p99, max  time.Duration
+}
+
+// loadCount returns how many requests to fire for the given response size.
+// Medium fires fewer because each request moves ~64 KB through the body path.
+func loadCount(size string) int {
+	if size == respMedium {
+		return 8000
+	}
+	return 30000
+}
+
+// runLoad fires exactly `requests` requests at fixed `conc` concurrency,
+// recording per-request latency. It verifies zero errors and that every
+// response body matched the expected fixed body.
+func runLoad(tb testing.TB, client *Client, m *mockServer, bc backendCase, size string, conc, requests int) loadResult {
+	tb.Helper()
+	warmup(tb, client, m, conc)
+	resolved := resolvedDecision(client, m)
+
+	// Reset the server-observed counter so it reflects only the measured run.
+	m.reqCount.Store(0)
+
+	latencies := make([]time.Duration, requests)
+	var errCount atomic.Int64
+	var idx int64 = -1
+	ctx := context.Background()
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	for w := 0; w < conc; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := m.request()
+			for {
+				i := atomic.AddInt64(&idx, 1)
+				if i >= int64(requests) {
+					return
+				}
+				t0 := time.Now()
+				resp, err := client.Execute(ctx, req, nil)
+				lat := time.Since(t0)
+				latencies[i] = lat
+				if err != nil {
+					errCount.Add(1)
+					continue
+				}
+				if resp.Body != m.body {
+					errCount.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+	res := loadResult{
+		backend:   bc.name,
+		respSize:  size,
+		conc:      conc,
+		requests:  requests,
+		errors:    errCount.Load(),
+		serverReq: m.reqCount.Load(),
+		resolved:  resolved,
+		elapsed:   elapsed,
+		reqPerSec: float64(requests) / elapsed.Seconds(),
+		p50:       percentile(latencies, 0.50),
+		p95:       percentile(latencies, 0.95),
+		p99:       percentile(latencies, 0.99),
+		max:       latencies[len(latencies)-1],
+	}
+	return res
+}
+
+func percentile(sorted []time.Duration, p float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	rank := int(p * float64(len(sorted)))
+	if rank >= len(sorted) {
+		rank = len(sorted) - 1
+	}
+	return sorted[rank]
+}
+
+// TestExecuteLoadDist is the latency-distribution vehicle. testing.B alone
+// can't produce percentiles, so this fires a fixed number of requests at each
+// concurrency level and reports req/s + p50/p95/p99/max + errors +
+// server-observed request count. Run with -v to see the table:
+//
+//	GOMAXPROCS=8 go test ./bamlutils/llmhttp -run '^TestExecuteLoadDist$' -v
+func TestExecuteLoadDist(t *testing.T) {
+	if testing.Short() {
+		t.Skip("load distribution test skipped in -short mode")
+	}
+
+	gomaxprocs := runtime.GOMAXPROCS(0)
+	t.Logf("environment: GOMAXPROCS=%d NumCPU=%d go=%s os=%s/%s",
+		gomaxprocs, runtime.NumCPU(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
+
+	var results []loadResult
+	for _, size := range []string{respSmall, respMedium} {
+		m := newMockServer(size)
+		for _, bc := range backendCases {
+			for _, conc := range benchConcurrency {
+				client := newBenchClient(bc.mode)
+				res := runLoad(t, client, m, bc, size, conc, loadCount(size))
+				if res.errors > 0 {
+					t.Errorf("%s/%s/c%d: %d errors — broken path must not be reported as fast",
+						bc.name, size, conc, res.errors)
+				}
+				if res.serverReq != int64(res.requests) {
+					t.Errorf("%s/%s/c%d: server saw %d requests, expected %d",
+						bc.name, size, conc, res.serverReq, res.requests)
+				}
+				results = append(results, res)
+			}
+		}
+		m.close()
+	}
+
+	// Emit a markdown table to the test log (captured into the results file).
+	var b strings.Builder
+	fmt.Fprintf(&b, "\nGOMAXPROCS=%d NumCPU=%d go=%s %s/%s\n\n",
+		gomaxprocs, runtime.NumCPU(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(&b, "| backend | resp | conc | resolved | req/s | p50(us) | p95(us) | p99(us) | max(us) | errors | srv-reqs |\n")
+	fmt.Fprintf(&b, "|---------|------|-----:|----------|------:|--------:|--------:|--------:|--------:|-------:|---------:|\n")
+	for _, r := range results {
+		fmt.Fprintf(&b, "| %s | %s | %d | %s | %.0f | %.1f | %.1f | %.1f | %.1f | %d | %d |\n",
+			r.backend, r.respSize, r.conc, r.resolved, r.reqPerSec,
+			us(r.p50), us(r.p95), us(r.p99), us(r.max), r.errors, r.serverReq)
+	}
+	t.Log(b.String())
+
+	// Also write the table to a file when BENCH_LOAD_OUT is set, so the load
+	// table can be captured independently of -v log formatting.
+	if out := os.Getenv("BENCH_LOAD_OUT"); out != "" {
+		if err := os.WriteFile(out, []byte(b.String()), 0o644); err != nil {
+			t.Logf("failed to write BENCH_LOAD_OUT=%s: %v", out, err)
+		} else {
+			t.Logf("wrote load table to %s", out)
+		}
+	}
+}
+
+func us(d time.Duration) float64 { return float64(d.Microseconds()) }

--- a/bamlutils/llmhttp/llmhttp_control_bench_test.go
+++ b/bamlutils/llmhttp/llmhttp_control_bench_test.go
@@ -1,0 +1,372 @@
+package llmhttp
+
+// Control benchmark for issue #475 follow-up: separate "fasthttp the library"
+// from "our llmhttp fasthttp wrapper".
+//
+// The original bench (llmhttp_bench_test.go) showed wrapped-fasthttp ns/op
+// WORSE than wrapped-nethttp at c64+ and a medium/c256 tail blow-up, despite
+// fasthttp's lower allocs. Prime suspect: OUR wrapper — executeFast spawns one
+// goroutine per request for ctx-cancellable DoDeadline, and converts fasthttp
+// headers->http.Header and body->string. fasthttp itself is synchronous (no
+// per-request goroutine) and []byte-based.
+//
+// This file adds RAW variants that hit the SAME mock server with NO llmhttp
+// wrapper:
+//   - raw-nethttp:  http.Client.Do(POST) + io.ReadAll + Close, tuned transport.
+//   - raw-fasthttp: AcquireRequest/Response + HostClient.Do (SYNCHRONOUS, no
+//                   per-request goroutine, no ctx wrapping) + Body() + Release.
+//                   No http.Header conversion, no []byte->string conversion.
+//
+// Run:
+//   GOMAXPROCS=8 go test ./bamlutils/llmhttp -run '^$' -bench '^BenchmarkExecuteControl$' -benchmem -benchtime=5s -count=6
+//   GOMAXPROCS=8 BENCH_CONTROL_OUT=/tmp/shared/475-control-load-table.md go test ./bamlutils/llmhttp -run '^TestExecuteControlLoadDist$' -v
+//
+// Benchmark-only; changes no production code. Reuses helpers from
+// llmhttp_bench_test.go (newMockServer, benchRequestBody, percentile, us, ...).
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+const benchAuthHeader = "Bearer sk-bench-0000000000000000000000000000"
+
+// controlDoFunc performs exactly one request and returns a non-nil error on
+// transport failure, non-2xx status, or a response body that doesn't match the
+// expected fixed body. Verifying the body keeps a fast-but-broken path from
+// scoring as a win.
+type controlDoFunc func() error
+
+// newRawNetHTTPTransport mirrors the tuning of defaultLLMTransport (keep-alive,
+// effectively unbounded idle conns per host) on a fresh instance so the raw
+// net/http control isn't sharing a pool with the wrapped client under test.
+func newRawNetHTTPTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:   true,
+		MaxIdleConns:        0,
+		MaxIdleConnsPerHost: math.MaxInt32,
+		MaxConnsPerHost:     0,
+		IdleConnTimeout:     90 * time.Second,
+	}
+}
+
+// rawNetHTTPDriver: plain http.Client.Do + io.ReadAll, no llmhttp wrapper.
+func rawNetHTTPDriver(m *mockServer) controlDoFunc {
+	client := &http.Client{Transport: newRawNetHTTPTransport()}
+	want := []byte(m.body)
+	ctx := context.Background()
+	return func() error {
+		req, err := http.NewRequestWithContext(ctx, "POST", m.url, strings.NewReader(benchRequestBody))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", benchAuthHeader)
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("raw-nethttp: status %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(body, want) {
+			return fmt.Errorf("raw-nethttp: body mismatch (%d vs %d bytes)", len(body), len(want))
+		}
+		return nil
+	}
+}
+
+// rawFastHTTPDriver: synchronous fasthttp HostClient.Do, []byte body, no
+// http.Header conversion, no per-request goroutine, no ctx wrapping. This is
+// the raw-library baseline the wrapper's executeFast is compared against.
+//
+// MaxConns is set to the same effectively-unbounded value the wrapper's
+// protocol cache uses (math.MaxInt32) so neither side trips ErrNoFreeConns.
+// StreamResponseBody is left off (default) so Body() returns the fully
+// buffered body — the standard synchronous fasthttp usage.
+func rawFastHTTPDriver(m *mockServer) controlDoFunc {
+	origin, err := parseOrigin(m.url)
+	if err != nil {
+		panic(fmt.Sprintf("rawFastHTTPDriver: bad mock url %q: %v", m.url, err))
+	}
+	hc := &fasthttp.HostClient{
+		Name:                          "bench-raw-fasthttp",
+		Addr:                          origin.addr(),
+		IsTLS:                         origin.scheme == "https",
+		DisableHeaderNamesNormalizing: true,
+		MaxConns:                      math.MaxInt32,
+	}
+	want := []byte(m.body)
+	return func() error {
+		fReq := fasthttp.AcquireRequest()
+		fResp := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseRequest(fReq)
+		defer fasthttp.ReleaseResponse(fResp)
+
+		fReq.Header.DisableNormalizing()
+		fReq.SetRequestURI(m.url)
+		fReq.Header.SetMethod("POST")
+		fReq.Header.Set("Content-Type", "application/json")
+		fReq.Header.Set("Authorization", benchAuthHeader)
+		fReq.SetBodyString(benchRequestBody)
+
+		if err := hc.Do(fReq, fResp); err != nil {
+			return err
+		}
+		if fResp.StatusCode() != http.StatusOK {
+			return fmt.Errorf("raw-fasthttp: status %d", fResp.StatusCode())
+		}
+		if !bytes.Equal(fResp.Body(), want) {
+			return fmt.Errorf("raw-fasthttp: body mismatch (%d vs %d bytes)", len(fResp.Body()), len(want))
+		}
+		return nil
+	}
+}
+
+// wrappedDriver drives the real (*llmhttp.Client).Execute path for the given
+// mode. The llmhttp.Request is shared read-only across worker goroutines
+// (Execute does not mutate it for a nil-AWSAuth request).
+func wrappedDriver(mode ClientMode, m *mockServer) controlDoFunc {
+	client := newBenchClient(mode)
+	req := m.request()
+	ctx := context.Background()
+	return func() error {
+		resp, err := client.Execute(ctx, req, nil)
+		if err != nil {
+			return err
+		}
+		if resp.Body != m.body {
+			return fmt.Errorf("wrapped: body mismatch (%d vs %d bytes)", len(resp.Body), len(m.body))
+		}
+		return nil
+	}
+}
+
+type controlBackend struct {
+	name string
+	make func(*mockServer) controlDoFunc
+}
+
+var controlBackends = []controlBackend{
+	{"raw-nethttp", rawNetHTTPDriver},
+	{"raw-fasthttp", rawFastHTTPDriver},
+	{"wrapped-nethttp", func(m *mockServer) controlDoFunc { return wrappedDriver(ClientModeNetHTTP, m) }},
+	{"wrapped-fasthttp", func(m *mockServer) controlDoFunc { return wrappedDriver(ClientModeFastHTTP, m) }},
+}
+
+type controlCase struct {
+	size string
+	conc int
+}
+
+// The key cases where surprises appeared in the original grid.
+var controlCases = []controlCase{
+	{respSmall, 1},
+	{respSmall, 256},
+	{respMedium, 256},
+}
+
+// warmupDriver fires `conc` concurrent requests for a few rounds so connection
+// pools are populated before measuring, and fails the test on any error or
+// body mismatch.
+func warmupDriver(tb testing.TB, do controlDoFunc, conc int) {
+	tb.Helper()
+	for r := 0; r < 3; r++ {
+		var wg sync.WaitGroup
+		var failed atomic.Bool
+		for i := 0; i < conc; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := do(); err != nil {
+					tb.Errorf("warmup request failed: %v", err)
+					failed.Store(true)
+				}
+			}()
+		}
+		wg.Wait()
+		if failed.Load() {
+			tb.FailNow()
+		}
+	}
+}
+
+// BenchmarkExecuteControl measures raw-vs-wrapped for both backends on the key
+// cases (small/c1, small/c256, medium/c256). ns/op + B/op + allocs/op via
+// -benchmem. Same fixed-worker scheme as BenchmarkExecute.
+func BenchmarkExecuteControl(b *testing.B) {
+	servers := map[string]*mockServer{
+		respSmall:  newMockServer(respSmall),
+		respMedium: newMockServer(respMedium),
+	}
+	for _, m := range servers {
+		b.Cleanup(m.close)
+	}
+
+	for _, bk := range controlBackends {
+		for _, cs := range controlCases {
+			m := servers[cs.size]
+			name := fmt.Sprintf("%s/%s/c%d", bk.name, cs.size, cs.conc)
+			b.Run(name, func(b *testing.B) {
+				do := bk.make(m)
+				warmupDriver(b, do, cs.conc)
+
+				var errCount atomic.Int64
+				remaining := int64(b.N)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				var wg sync.WaitGroup
+				for w := 0; w < cs.conc; w++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						for atomic.AddInt64(&remaining, -1) >= 0 {
+							if err := do(); err != nil {
+								errCount.Add(1)
+							}
+						}
+					}()
+				}
+				wg.Wait()
+
+				b.StopTimer()
+				if n := errCount.Load(); n > 0 {
+					b.Fatalf("%d errors/body-mismatches — fast-but-broken path must not score as a win", n)
+				}
+			})
+		}
+	}
+}
+
+// runControlLoad fires `requests` requests at fixed `conc`, recording
+// per-request latency for percentile reporting. Verifies zero errors and the
+// server-observed request count.
+func runControlLoad(tb testing.TB, do controlDoFunc, m *mockServer, name string, conc, requests int) loadResult {
+	tb.Helper()
+	warmupDriver(tb, do, conc)
+	m.reqCount.Store(0)
+
+	latencies := make([]time.Duration, requests)
+	var errCount atomic.Int64
+	var idx int64 = -1
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	for w := 0; w < conc; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				i := atomic.AddInt64(&idx, 1)
+				if i >= int64(requests) {
+					return
+				}
+				t0 := time.Now()
+				err := do()
+				latencies[i] = time.Since(t0)
+				if err != nil {
+					errCount.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+	return loadResult{
+		backend:   name,
+		respSize:  respMedium,
+		conc:      conc,
+		requests:  requests,
+		errors:    errCount.Load(),
+		serverReq: m.reqCount.Load(),
+		resolved:  "n/a",
+		elapsed:   elapsed,
+		reqPerSec: float64(requests) / elapsed.Seconds(),
+		p50:       percentile(latencies, 0.50),
+		p95:       percentile(latencies, 0.95),
+		p99:       percentile(latencies, 0.99),
+		max:       latencies[len(latencies)-1],
+	}
+}
+
+// TestExecuteControlLoadDist runs the latency-distribution loop on medium/c256
+// for all four backends — the case where wrapped-fasthttp's tail blew up. This
+// isolates whether the tail blow-up is fasthttp-inherent (raw-fasthttp tail
+// also bad) or wrapper-induced (raw-fasthttp tail fine, wrapped-fasthttp bad).
+func TestExecuteControlLoadDist(t *testing.T) {
+	if testing.Short() {
+		t.Skip("control load distribution test skipped in -short mode")
+	}
+
+	gomaxprocs := runtime.GOMAXPROCS(0)
+	t.Logf("environment: GOMAXPROCS=%d NumCPU=%d go=%s os=%s/%s",
+		gomaxprocs, runtime.NumCPU(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
+
+	const conc = 256
+	requests := loadCount(respMedium) // 8000
+
+	m := newMockServer(respMedium)
+	defer m.close()
+
+	var results []loadResult
+	for _, bk := range controlBackends {
+		do := bk.make(m)
+		res := runControlLoad(t, do, m, bk.name, conc, requests)
+		if res.errors > 0 {
+			t.Errorf("%s: %d errors — broken path must not be reported as fast", bk.name, res.errors)
+		}
+		if res.serverReq != int64(res.requests) {
+			t.Errorf("%s: server saw %d requests, expected %d", bk.name, res.serverReq, res.requests)
+		}
+		results = append(results, res)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "\nmedium/c256 latency distribution — GOMAXPROCS=%d NumCPU=%d go=%s %s/%s\n\n",
+		gomaxprocs, runtime.NumCPU(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(&b, "| backend | conc | req/s | p50(us) | p95(us) | p99(us) | max(us) | errors | srv-reqs |\n")
+	fmt.Fprintf(&b, "|---------|-----:|------:|--------:|--------:|--------:|--------:|-------:|---------:|\n")
+	for _, r := range results {
+		fmt.Fprintf(&b, "| %s | %d | %.0f | %.1f | %.1f | %.1f | %.1f | %d | %d |\n",
+			r.backend, r.conc, r.reqPerSec,
+			us(r.p50), us(r.p95), us(r.p99), us(r.max), r.errors, r.serverReq)
+	}
+	t.Log(b.String())
+
+	if out := os.Getenv("BENCH_CONTROL_OUT"); out != "" {
+		if err := os.WriteFile(out, []byte(b.String()), 0o644); err != nil {
+			t.Logf("failed to write BENCH_CONTROL_OUT=%s: %v", out, err)
+		} else {
+			t.Logf("wrote control load table to %s", out)
+		}
+	}
+}

--- a/bamlutils/llmhttp/llmhttp_control_bench_test.go
+++ b/bamlutils/llmhttp/llmhttp_control_bench_test.go
@@ -57,7 +57,10 @@ type controlDoFunc func() error
 // net/http control isn't sharing a pool with the wrapped client under test.
 func newRawNetHTTPTransport() *http.Transport {
 	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		// Explicit no-proxy (not ProxyFromEnvironment) so the raw control dials
+		// the local server directly regardless of ambient proxy env — matching
+		// the no-proxy bench clients without mutating process-global env.
+		Proxy: noProxy,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
@@ -323,8 +326,11 @@ func runControlLoad(tb testing.TB, do controlDoFunc, m *mockServer, name string,
 // isolates whether the tail blow-up is fasthttp-inherent (raw-fasthttp tail
 // also bad) or wrapper-induced (raw-fasthttp tail fine, wrapped-fasthttp bad).
 func TestExecuteControlLoadDist(t *testing.T) {
-	if testing.Short() {
-		t.Skip("control load distribution test skipped in -short mode")
+	// Heavy: fires 30k/8k-request load loops and would blow CI's unit-test
+	// timeout. Gated to explicit measurement runs — skipped unless the output
+	// env is present, or in -short mode.
+	if testing.Short() || os.Getenv("BENCH_CONTROL_OUT") == "" {
+		t.Skip("load measurement; set BENCH_CONTROL_OUT to run")
 	}
 
 	gomaxprocs := runtime.GOMAXPROCS(0)

--- a/bamlutils/llmhttp/wrapper_fix_test.go
+++ b/bamlutils/llmhttp/wrapper_fix_test.go
@@ -1,0 +1,264 @@
+package llmhttp
+
+// Targeted tests for the fasthttp unary wrapper fix (#475): the buffered fast
+// lane, the synchronous streamed-header drain, the externally-cancellable lane,
+// and isolation of the streaming path. These complement the existing contract
+// tests (TestExecuteOnSuccessFiresBeforeBodyRead, TestExecuteExactlyAtLimit,
+// TestFastExecute_OversizedResponse, etc.).
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/bamlutils/sseclient"
+)
+
+// TestFastBufferedLaneSizeLimit pins exact MaxResponseBodyBytes semantics on
+// the buffered fast lane (background ctx + nil onSuccess): a body exactly at
+// the limit succeeds, one byte over is rejected with the size-limit error
+// (fasthttp's MaxResponseBodySize maps to the same message as the net/http and
+// streamed paths).
+func TestFastBufferedLaneSizeLimit(t *testing.T) {
+	cases := []struct {
+		name    string
+		size    int
+		wantErr bool
+	}{
+		{"exactly at limit", MaxResponseBodyBytes, false},
+		{"one over limit", MaxResponseBodyBytes + 1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := strings.Repeat("x", tc.size)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(200)
+				fmt.Fprint(w, body)
+			}))
+			defer server.Close()
+
+			c := withFastClient(t, server.Client())
+			// Background ctx (no Done) + nil onSuccess selects the buffered lane.
+			resp, err := c.Execute(context.Background(), &Request{URL: server.URL, Method: "POST", Body: `{}`}, nil)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected size-limit error")
+				}
+				if !strings.Contains(err.Error(), "exceeds maximum size") {
+					t.Errorf("expected size-limit error, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for body at limit: %v", err)
+			}
+			if len(resp.Body) != tc.size {
+				t.Errorf("expected body length %d, got %d", tc.size, len(resp.Body))
+			}
+		})
+	}
+}
+
+// TestFastBufferedLaneNoPerRequestGoroutine asserts the buffered fast lane is
+// fully synchronous: a batch of sequential Execute calls leaves no residual
+// goroutines (the io.ReadAll body-read goroutine and the DoDeadline goroutine
+// are both gone for this lane).
+func TestFastBufferedLaneNoPerRequestGoroutine(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	c := withFastClient(t, server.Client())
+	req := &Request{URL: server.URL, Method: "POST", Body: `{}`}
+
+	// Warm up the pool + protocol cache so steady-state goroutines are settled.
+	for i := 0; i < 20; i++ {
+		if _, err := c.Execute(context.Background(), req, nil); err != nil {
+			t.Fatalf("warmup failed: %v", err)
+		}
+	}
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 200; i++ {
+		resp, err := c.Execute(context.Background(), req, nil)
+		if err != nil {
+			t.Fatalf("request %d failed: %v", i, err)
+		}
+		if resp.Body != `{"ok":true}` {
+			t.Fatalf("request %d body mismatch: %q", i, resp.Body)
+		}
+	}
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	// A synchronous lane must not grow the goroutine count across 200 requests.
+	// Allow a tiny slack for unrelated runtime/test goroutines.
+	if after > before+2 {
+		t.Errorf("buffered lane appears to spawn per-request goroutines: before=%d after=%d", before, after)
+	}
+}
+
+// TestFastStreamedLaneOnSuccessBeforeBody verifies the streamed-header lane
+// (onSuccess != nil) still fires onSuccess after 2xx headers but before the
+// body is read, on the fasthttp backend.
+func TestFastStreamedLaneOnSuccessBeforeBody(t *testing.T) {
+	callbackFired := make(chan struct{})
+	seenBeforeBody := make(chan bool, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		select {
+		case <-callbackFired:
+			seenBeforeBody <- true
+		case <-time.After(2 * time.Second):
+			seenBeforeBody <- false
+		}
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	c := withFastClient(t, server.Client())
+	resp, err := c.Execute(context.Background(), &Request{URL: server.URL, Method: "POST", Body: `{}`},
+		func() { close(callbackFired) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Body != `{"ok":true}` {
+		t.Errorf("unexpected body: %q", resp.Body)
+	}
+	if seen := <-seenBeforeBody; !seen {
+		t.Fatal("onSuccess did not fire before the body on the streamed fasthttp lane")
+	}
+}
+
+// TestFastCancellableLaneReturnsPromptlyOnCancel pins that a no-deadline
+// context.WithCancel unary request on the fasthttp backend returns promptly
+// when the caller cancels mid-flight — well before DefaultCallTimeout — even
+// though fasthttp's DoDeadline cannot itself be aborted. This is the
+// externally-cancellable lane's whole reason for keeping the goroutine race.
+func TestFastCancellableLaneReturnsPromptlyOnCancel(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hang until the test releases, so the only way Execute returns is the
+		// caller's cancellation.
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer server.Close()
+	defer close(release)
+
+	c := withFastClient(t, server.Client())
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := c.Execute(ctx, &Request{URL: server.URL, Method: "POST", Body: `{}`}, nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("Execute did not return promptly on cancel: took %v", elapsed)
+	}
+}
+
+// TestExecuteStreamStillStreamsAfterUnaryHost confirms ExecuteStream keeps
+// using the streaming host (StreamResponseBody=true) and parses SSE events
+// after the unary buffered host was added to the cache entry.
+func TestExecuteStreamStillStreamsAfterUnaryHost(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		fmt.Fprint(w, "data: {\"delta\":\"a\"}\n\n")
+		fmt.Fprint(w, "data: {\"delta\":\"b\"}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	c := withFastClient(t, server.Client())
+	resp, err := c.ExecuteStream(context.Background(), &Request{
+		URL:     server.URL,
+		Method:  "POST",
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Body:    `{"stream":true}`,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Close()
+
+	var events []sseclient.Event
+	for ev := range resp.Events {
+		events = append(events, ev)
+	}
+	if streamErr := <-resp.Errc; streamErr != nil {
+		t.Fatalf("unexpected stream error: %v", streamErr)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+	if events[2].Data != "[DONE]" {
+		t.Errorf("expected [DONE], got %q", events[2].Data)
+	}
+}
+
+// TestFastBufferedLaneConcurrent stresses the buffered lane under concurrency
+// to surface any pooled-buffer reuse race (the fastBodyBufPool path is only hit
+// by the streamed lane, but the buffered lane shares fasthttp's response pool).
+func TestFastBufferedLaneConcurrent(t *testing.T) {
+	want := `{"id":"x","choices":[{"message":{"content":"hello world"}}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, want)
+	}))
+	defer server.Close()
+
+	c := withFastClient(t, server.Client())
+	var wg sync.WaitGroup
+	errs := make(chan error, 64)
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				resp, err := c.Execute(context.Background(), &Request{URL: server.URL, Method: "POST", Body: `{}`}, nil)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if resp.Body != want {
+					errs <- fmt.Errorf("body mismatch: %q", resp.Body)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent buffered Execute failed: %v", err)
+	}
+}

--- a/bamlutils/llmhttp/wrapper_fix_test.go
+++ b/bamlutils/llmhttp/wrapper_fix_test.go
@@ -341,6 +341,43 @@ func TestFastStreamedConnReuseAfterCappedError(t *testing.T) {
 	assertCleanConnReuse(t, c, server.URL, normal, onSuccess, 5)
 }
 
+// TestFastStreamedConnReuseAfterErrorBodyReadError pins B1 for the non-2xx
+// diagnostic path when the body read ERRORS before EOF (not just exceeds the
+// cap): the first response declares a Content-Length larger than the bytes it
+// writes and then closes the connection, so reading the error body fails
+// mid-stream. The connection must be discarded, not pooled, so a subsequent
+// request on the same client is not corrupted.
+func TestFastStreamedConnReuseAfterErrorBodyReadError(t *testing.T) {
+	normal := `{"ok":true}`
+	var n atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if n.Add(1) == 1 {
+			// Declare more body bytes than we write: net/http then closes the
+			// connection when the handler returns short, so the client's body
+			// read hits EOF before the declared length — a partial read via the
+			// error branch (not the cap branch).
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Length", "1024")
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":"boom"`)) // < 1024 bytes
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, normal)
+	}))
+	defer server.Close()
+
+	c := withFastClient(t, server.Client())
+	onSuccess := func() {} // non-nil → streamed lane
+
+	// The first request errors (5xx with a short-then-closed body). Whatever the
+	// exact surfaced error, the contract under test is that it must not poison
+	// the pool for the next request.
+	_, _ = c.Execute(context.Background(), &Request{URL: server.URL, Method: "POST", Body: `{}`}, onSuccess)
+	assertCleanConnReuse(t, c, server.URL, normal, onSuccess, 5)
+}
+
 // TestFastBufferedLaneConcurrent stresses the buffered lane under concurrency
 // to surface any pooled-buffer reuse race (the fastBodyBufPool path is only hit
 // by the streamed lane, but the buffered lane shares fasthttp's response pool).

--- a/bamlutils/llmhttp/wrapper_fix_test.go
+++ b/bamlutils/llmhttp/wrapper_fix_test.go
@@ -352,15 +352,20 @@ func TestFastStreamedConnReuseAfterErrorBodyReadError(t *testing.T) {
 	var n atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if n.Add(1) == 1 {
-			// Declare more body bytes than we write: net/http then closes the
-			// connection when the handler returns short, so the client's body
-			// read hits EOF before the declared length — a partial read via the
-			// error branch (not the cap branch).
+			// 500 with a chunked body that is flushed (so headers + one chunk
+			// reach the client and DoDeadline returns a body stream) then
+			// aborted mid-stream WITHOUT the terminating 0-chunk. The client's
+			// diagnostic body read in readFastErrorBodyCapped therefore errors
+			// before EOF — the read-error branch we want to cover. (A
+			// Content-Length body would be pre-read inside DoDeadline instead,
+			// never reaching readFastErrorBodyCapped.)
 			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("Content-Length", "1024")
 			w.WriteHeader(500)
-			_, _ = w.Write([]byte(`{"error":"boom"`)) // < 1024 bytes
-			return
+			_, _ = w.Write([]byte(`{"error":"boom"`))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			panic(http.ErrAbortHandler) // abort the conn with no chunk terminator
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
@@ -371,11 +376,46 @@ func TestFastStreamedConnReuseAfterErrorBodyReadError(t *testing.T) {
 	c := withFastClient(t, server.Client())
 	onSuccess := func() {} // non-nil → streamed lane
 
-	// The first request errors (5xx with a short-then-closed body). Whatever the
-	// exact surfaced error, the contract under test is that it must not poison
-	// the pool for the next request.
-	_, _ = c.Execute(context.Background(), &Request{URL: server.URL, Method: "POST", Body: `{}`}, onSuccess)
-	assertCleanConnReuse(t, c, server.URL, normal, onSuccess, 5)
+	// First request: 500 headers arrive, DoDeadline returns the chunked body
+	// stream, then the diagnostic read in readFastErrorBodyCapped errors before
+	// EOF (truncated chunk). Assert the error path was ACTUALLY exercised: it
+	// must surface as an *HTTPError carrying status 500 and the body prefix that
+	// did arrive ("boom"). This fails loudly if this stops hitting that branch
+	// (e.g. if the partial response started erroring inside DoDeadline instead).
+	_, err := c.Execute(context.Background(), &Request{URL: server.URL, Method: "POST", Body: `{}`}, onSuccess)
+	httpErr, ok := err.(*HTTPError)
+	if !ok {
+		t.Fatalf("expected *HTTPError from the 500 partial-body response, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != 500 {
+		t.Errorf("expected status 500, got %d", httpErr.StatusCode)
+	}
+	if !strings.Contains(httpErr.Body, "boom") {
+		t.Errorf("expected diagnostic body to contain the written prefix %q, got %q", "boom", httpErr.Body)
+	}
+
+	// Conn-reuse: the connection carrying the partial read must not be pooled
+	// with unread bytes — that is the B1 corruption, which would surface as a
+	// GARBAGE / unparseable response on a later request. Because the server
+	// also closed the conn on abort, fasthttp may return one benign
+	// ErrConnectionClosed for a stale keep-alive conn before dialing fresh;
+	// that's tolerated. What must hold is: at least one follow-up succeeds, and
+	// EVERY successful follow-up returns the exact normal body (never garbage).
+	// (Deterministic dirty-byte reuse is covered by the oversize/capped tests.)
+	gotClean := false
+	for i := 0; i < 6; i++ {
+		resp, ferr := c.Execute(context.Background(), &Request{URL: server.URL, Method: "POST", Body: `{}`}, onSuccess)
+		if ferr != nil {
+			continue // tolerate a transient stale-keepalive close
+		}
+		if resp.Body != normal {
+			t.Fatalf("follow-up %d returned corrupted body (dirty pooled conn?): %q", i, resp.Body)
+		}
+		gotClean = true
+	}
+	if !gotClean {
+		t.Fatal("no follow-up request succeeded after the partial-read error; pool may be wedged")
+	}
 }
 
 // TestFastBufferedLaneConcurrent stresses the buffered lane under concurrency

--- a/bamlutils/llmhttp/wrapper_fix_test.go
+++ b/bamlutils/llmhttp/wrapper_fix_test.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -222,6 +223,122 @@ func TestExecuteStreamStillStreamsAfterUnaryHost(t *testing.T) {
 	if events[2].Data != "[DONE]" {
 		t.Errorf("expected [DONE], got %q", events[2].Data)
 	}
+}
+
+// TestFastBufferedNon2xxHugeBody pins B2: on the buffered fast lane, a non-2xx
+// response whose body exceeds MaxResponseBodyBytes must still surface as an
+// *HTTPError with the body capped to MaxErrorBodyBytes — NOT a
+// "response body exceeds maximum size" error. (The buffered host's
+// MaxResponseBodySize is only an OOM backstop; the real limits are enforced in
+// code after the status is known.)
+func TestFastBufferedNon2xxHugeBody(t *testing.T) {
+	hugeError := strings.Repeat("e", MaxResponseBodyBytes+4096) // > MaxResponseBodyBytes
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Fprint(w, hugeError)
+	}))
+	defer server.Close()
+
+	c := withFastClient(t, server.Client())
+	// Background ctx + nil onSuccess → buffered lane.
+	_, err := c.Execute(context.Background(), &Request{URL: server.URL, Method: "POST", Body: `{}`}, nil)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Fatalf("non-2xx huge body must not become a size-limit error: %v", err)
+	}
+	httpErr, ok := err.(*HTTPError)
+	if !ok {
+		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != 500 {
+		t.Errorf("expected status 500, got %d", httpErr.StatusCode)
+	}
+	if len(httpErr.Body) != MaxErrorBodyBytes {
+		t.Errorf("expected error body capped to %d, got %d", MaxErrorBodyBytes, len(httpErr.Body))
+	}
+}
+
+// firstThenNormalServer returns a server whose FIRST response is `first`
+// (status firstStatus) and every subsequent response is the normal small JSON
+// body with 200. Used to verify a partial/oversized first read doesn't corrupt
+// the next request reusing the same pooled connection.
+func firstThenNormalServer(t *testing.T, firstStatus int, first, normal string) *httptest.Server {
+	t.Helper()
+	var n atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if n.Add(1) == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(firstStatus)
+			fmt.Fprint(w, first)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, normal)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// assertCleanConnReuse fires `reps` sequential requests on the same client and
+// asserts each returns the normal body — i.e. the connection pool was not
+// poisoned by a prior partial read. Sequential single requests reuse the same
+// pooled conn, so a dirty-pooled conn would surface here as a parse error or a
+// garbage body (B1).
+func assertCleanConnReuse(t *testing.T, c *Client, url, normal string, onSuccess func(), reps int) {
+	t.Helper()
+	for i := 0; i < reps; i++ {
+		resp, err := c.Execute(context.Background(), &Request{URL: url, Method: "POST", Body: `{}`}, onSuccess)
+		if err != nil {
+			t.Fatalf("follow-up request %d failed (dirty pooled conn?): %v", i, err)
+		}
+		if resp.Body != normal {
+			t.Fatalf("follow-up request %d got corrupted body (dirty pooled conn?): %q", i, resp.Body)
+		}
+	}
+}
+
+// TestFastStreamedConnReuseAfterOversize pins B1 for the streamed lane's
+// oversized-body path: after an oversized 2xx response trips the size limit
+// (LimitReader stops before EOF), the connection must be DISCARDED, not pooled,
+// so the next request doesn't read leftover body bytes.
+func TestFastStreamedConnReuseAfterOversize(t *testing.T) {
+	normal := `{"ok":true}`
+	oversized := strings.Repeat("x", MaxResponseBodyBytes+1024)
+	server := firstThenNormalServer(t, 200, oversized, normal)
+
+	c := withFastClient(t, server.Client())
+	onSuccess := func() {} // non-nil → streamed lane
+
+	_, err := c.Execute(context.Background(), &Request{URL: server.URL, Method: "POST", Body: `{}`}, onSuccess)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Fatalf("expected size-limit error on oversized response, got: %v", err)
+	}
+	assertCleanConnReuse(t, c, server.URL, normal, onSuccess, 5)
+}
+
+// TestFastStreamedConnReuseAfterCappedError pins B1 for the streamed lane's
+// non-2xx diagnostic path: an error body larger than MaxErrorBodyBytes is read
+// only up to the cap (partial), so the connection must be DISCARDED, not pooled.
+func TestFastStreamedConnReuseAfterCappedError(t *testing.T) {
+	normal := `{"ok":true}`
+	largeError := strings.Repeat("e", MaxErrorBodyBytes*4) // > the 4KB diagnostic cap
+	server := firstThenNormalServer(t, 500, largeError, normal)
+
+	c := withFastClient(t, server.Client())
+	onSuccess := func() {} // non-nil → streamed lane
+
+	_, err := c.Execute(context.Background(), &Request{URL: server.URL, Method: "POST", Body: `{}`}, onSuccess)
+	httpErr, ok := err.(*HTTPError)
+	if !ok {
+		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
+	}
+	if len(httpErr.Body) != MaxErrorBodyBytes {
+		t.Errorf("expected error body capped to %d, got %d", MaxErrorBodyBytes, len(httpErr.Body))
+	}
+	assertCleanConnReuse(t, c, server.URL, normal, onSuccess, 5)
 }
 
 // TestFastBufferedLaneConcurrent stresses the buffered lane under concurrency


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Summary

Fixes the `llmhttp` fasthttp **unary `Execute`** wrapper, which a benchmark in this branch proved was neutralizing fasthttp's wins — dragging it down to net/http parity. Refs #475.

This PR contains the **benchmark** (the re-measurement vehicle), the **fix**, and **before/after proof**.

## The problem

A focused benchmark of the real shared `(*llmhttp.Client).Execute` path (plaintext HTTP/1.1, in-process mock) showed that while **raw** fasthttp clearly beats raw net/http (≈3.4× fewer allocs, ~1.76× faster at medium/c256, tighter tail), our **wrapper** erased that advantage on the unary path. At medium (~64 KB response) / c256:

| metric | raw-fasthttp | wrapped-fasthttp (before) |
|---|--:|--:|
| ns/op | 28,478 | 50,519 (**+77%**) |
| B/op | 2,761 | 224,638 (**+81×**) |
| allocs/op | 58 | 104 |
| p99 | 21.7 ms | 61 ms (**2.8×**) |
| max | 33.9 ms | 141 ms (**4.2×**) |

A raw-vs-wrapped control run isolated the cause: the wrapper imposed overhead **disproportionately on fasthttp** (+77% ns/op at medium) while adding almost nothing to net/http (+2%).

## The insight

**fasthttp has no real mid-flight cancellation** — `DoDeadline` honors a deadline only. The wrapper's per-request goroutine never aborted the request; it just let the *caller* return early on ctx-cancel while the orphaned `Do` ran to its deadline. So the goroutine wasn't the main cost — the **body handling** was: `StreamResponseBody=true` forced the unary path through `io.ReadAll` in a *second* goroutine, allocating a response-sized intermediate (224 KB/op at 64 KB) that also drove the GC tail.

## The fix (`fix(llmhttp): cut fasthttp unary wrapper overhead on Execute`)

Body handling is the primary, correctness-neutral win; cancellation semantics are unchanged.

- **cache.go** — add a buffered per-origin `unaryHost` beside the streaming `host` (`StreamResponseBody=false`, `MaxResponseBodySize=MaxResponseBodyBytes`). The streaming `host` and `ExecuteStream` are untouched; `StreamResponseBody` is never mutated per-request.
- **Execute** — capture whether the *original* caller ctx was cancellable (`ctx.Done() != nil`) **before** `DefaultCallTimeout` is injected, and pass a fast-unary mode into `executeFast`.
- **executeFast** splits into two lanes:
  - **Buffered fast lane** (deadline-only ctx **and** `onSuccess==nil`): synchronous `DoDeadline` on `unaryHost`, then one `string(fResp.Body())` copy — no per-request goroutine, no intermediate buffer. fasthttp's `MaxResponseBodySize` enforces the cap (strictly-greater, so exact-at-limit still succeeds); `ErrBodyTooLarge` maps to the existing size-limit error.
  - **Streamed-header lane** (`onSuccess!=nil`, or externally cancellable): keeps header streaming so `onSuccess` still fires after 2xx headers / before body. `DoDeadline` runs synchronously for deadline-only ctx, or in the **existing goroutine race** for cancellable ctx (prompt caller early-return preserved). The body is drained **synchronously** into a pooled buffer with a `MaxResponseBodyBytes+1` limit — replacing the `io.ReadAll` goroutine and its response-sized allocation.

### Preserved contracts (all pinned by existing tests)

`onSuccess` fires after 2xx headers before body • `MaxResponseBodyBytes` exact/+1/oversized semantics • `MaxErrorBodyBytes` diagnostics • caller early-return for cancellable ctx • SigV4 before dispatch • `Response.Headers` via `fastHeadersToHTTP` • streaming path (`ExecuteStream`/`executeStreamFast`/`newStreamHostClient`/`fastStreamReader`) untouched. New targeted tests added in `wrapper_fix_test.go` (buffered-lane size limit + no per-request goroutine, streamed-lane `onSuccess`-before-body, prompt cancel, `ExecuteStream` still streams, concurrency).

**Tradeoff:** a mid-*body* ctx cancel is now bounded by the request deadline rather than force-closing the conn (the streamed body drain is synchronous), consistent with fasthttp having no real mid-flight abort. Prompt early-return during the request/header phase is preserved.

## Before / after (both lanes, paired back-to-back, median of 6, GOMAXPROCS=8)

`wf-buffered` = background ctx + `onSuccess==nil`; `wf-streamed` = cancellable ctx + `onSuccess!=nil` (production-shaped); `raw-fasthttp` = library floor (unchanged by the fix, confirming the runs are comparable).

| backend | resp | conc | ns/op before→after | B/op before→after | allocs before→after |
|---|---|--:|--:|--:|--:|
| raw-fasthttp | small | 1 | 22,011 → 22,288 | 2,536 → 2,534 | 26 → 26 |
| wf-buffered | small | 1 | 28,080 → 23,092 (**-18%**) | 5,106 → 3,887 (**-24%**) | 57 → 45 |
| wf-streamed | small | 1 | 28,282 → 27,453 (-3%) | 5,094 → 4,367 (-14%) | 57 → 53 |
| wf-buffered | small | 256 | 6,130 → 6,055 | 4,978 → 3,795 (**-24%**) | 57 → 45 |
| wf-streamed | small | 256 | 6,114 → 6,628 | 4,980 → 4,264 (-14%) | 57 → 53 |
| raw-fasthttp | medium | 256 | 28,843 → 28,404 | 2,802 → 2,812 | 58 → 58 |
| wf-buffered | medium | 256 | 42,589 → 33,876 (**-20%**) | 224,708 → 84,357 (**-62%**) | 104 → 77 |
| wf-streamed | medium | 256 | 42,402 → 35,522 (**-16%**) | 224,716 → 80,784 (**-64%**) | 104 → 85 |

**Headline:** at medium/c256, **B/op drops ~63%** (225 KB → 80–84 KB) and **ns/op drops 16–20%** on both lanes, landing near the raw-fasthttp floor (28.4 µs) instead of net/http parity (~50 µs). The residual ~80 KB is the unavoidable `string(body)` copy for the public `Response.Body string` field (raw stays in `[]byte`). In the paired load run, wf-streamed medium/c256 tail improved p99 60 → 46 ms and max 94 → 73 ms; small high-concurrency ns/op is flat (the body intermediate was already tiny there).

*Caveat:* this session's machine was noisier than the original control run (even raw-fasthttp's medium tail ≈2× higher), so trust the stable, paired `testing.B` alloc/ns deltas over absolute load-loop tail numbers. Full data + raw output: `475-bench-control.md` (before/analysis) and `475-bench-after.md` (before/after).

## Validation

- `go build ./...`, `go vet`, `gofmt -l` clean, `go build ./cmd/worker/` (worker plugin) ✅
- `go test ./bamlutils/llmhttp ./bamlutils/buildrequest ./pool ./worker` ✅ (incl. `-race` on `llmhttp`)
- New targeted tests for both lanes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked fast unary execution into separate buffered and streamed lanes with clearer deadline/cancellation handling.
  * Extended fast-path host caching to support both streaming and buffered unary behavior.
* **Bug Fixes**
  * Improved response-size enforcement and capped error-body reading to reduce oversized-body and error-path issues.
  * Strengthened connection-pool hygiene to avoid dirty connection reuse after limits or read failures.
* **Tests**
  * Added regression tests for size-limit boundaries, callback ordering, prompt cancellation, SSE parsing, and concurrency safety.
  * Added benchmarks and optional load-distribution tests across execution modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->