### PR TITLE
perf(sseclient): byte-level SSE parsing to drop ~1 alloc/token (#475)

### DIFF
--- a/bamlutils/sseclient/sseclient.go
+++ b/bamlutils/sseclient/sseclient.go
@@ -141,10 +141,11 @@ func scan(ctx context.Context, r io.Reader, out chan<- Event) error {
 
 		// Strip trailing \r in case the HTTP server uses \r\n line endings
 		// that weren't fully consumed by the scanner's line splitter.
-		// Go's bufio.ScanLines handles \r\n but not bare \r.
-		if n := len(line); n > 0 && line[n-1] == '\r' {
-			line = line[:n-1]
-		}
+		// Go's bufio.ScanLines handles \r\n but not bare \r. This matches
+		// master's strings.TrimRight(line, "\r"): ALL trailing \r are removed,
+		// not just one. bytes.TrimRight reslices in place, so it does not
+		// allocate and the result still aliases the scanner buffer.
+		line = bytes.TrimRight(line, "\r")
 
 		// Blank line = event boundary (dispatch if we have data)
 		if len(line) == 0 {

--- a/bamlutils/sseclient/sseclient.go
+++ b/bamlutils/sseclient/sseclient.go
@@ -9,6 +9,7 @@ package sseclient
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"io"
 	"strings"
@@ -105,10 +106,18 @@ func scan(ctx context.Context, r io.Reader, out chan<- Event) error {
 	scanner := bufio.NewScanner(r)
 	// LLM SSE events are typically small JSON objects, but set a generous
 	// max line size to handle edge cases (e.g., base64-encoded images).
-	// The initial buffer is pooled. Parsing uses scanner.Text() (owned
-	// string) so event fields never alias the pooled buffer; if anything
-	// here ever switches to scanner.Bytes(), it must copy before sending
-	// events or before putSSEScannerBuffer runs.
+	// The initial buffer is pooled.
+	//
+	// Parsing uses scanner.Bytes() (a view over the pooled scanner buffer
+	// that is reused/overwritten on the next Scan) to avoid a per-line string
+	// allocation. This is safe ONLY because no scanner.Bytes() view ever
+	// escapes this loop: data is copied into the owned dataBuf builder via
+	// Write, and the event/id fields are materialized with string(...) which
+	// copies. Event.Data is produced by dataBuf.String(), a view over the
+	// builder's own storage (not reused after Reset). NEVER assign a
+	// scanner.Bytes() slice into an Event or send it on the channel — the
+	// channel is buffered (cap 16) so the parser runs ahead of consumers, and
+	// the underlying bytes would be overwritten before consumers read them.
 	scanner.Buffer((*bufp)[:0], sseScannerMaxTokenSize)
 
 	var (
@@ -126,18 +135,25 @@ func scan(ctx context.Context, r io.Reader, out chan<- Event) error {
 		default:
 		}
 
-		line := scanner.Text()
+		// line aliases the scanner's pooled buffer; valid only until the next
+		// Scan(). It must never be stored in an Event or sent on the channel.
+		line := scanner.Bytes()
 
 		// Strip trailing \r in case the HTTP server uses \r\n line endings
 		// that weren't fully consumed by the scanner's line splitter.
 		// Go's bufio.ScanLines handles \r\n but not bare \r.
-		line = strings.TrimRight(line, "\r")
+		if n := len(line); n > 0 && line[n-1] == '\r' {
+			line = line[:n-1]
+		}
 
 		// Blank line = event boundary (dispatch if we have data)
-		if line == "" {
+		if len(line) == 0 {
 			if hasData {
 				ev := Event{
 					Type: eventType,
+					// dataBuf.String() copies out of the scanner buffer
+					// (data was Write-copied into the builder), so Data is
+					// owned by the event and safe to send on the channel.
 					Data: dataBuf.String(),
 					ID:   eventID,
 				}
@@ -163,23 +179,28 @@ func scan(ctx context.Context, r io.Reader, out chan<- Event) error {
 			continue
 		}
 
-		// Parse "field: value" or "field:value" format.
+		// Parse "field: value" or "field:value" format on the raw bytes.
 		field, value := parseSSELine(line)
 
-		switch field {
+		// switch string(field) is special-cased by the compiler to compare
+		// against the case constants without allocating a string.
+		switch string(field) {
 		case "data":
 			if hasData {
 				// Multiple data lines are joined with newlines per SSE spec.
 				dataBuf.WriteByte('\n')
 			}
-			dataBuf.WriteString(value)
+			// Write copies value out of the scanner buffer into builder
+			// storage, so the eventual dataBuf.String() is owned.
+			dataBuf.Write(value)
 			hasData = true
 		case "event":
-			eventType = value
+			// string(value) copies; eventType escapes via the Event.
+			eventType = string(value)
 		case "id":
 			// Per SSE spec, ignore IDs containing null.
-			if !strings.ContainsRune(value, '\x00') {
-				eventID = value
+			if bytes.IndexByte(value, '\x00') < 0 {
+				eventID = string(value)
 			}
 		case "retry":
 			// Retry field is not relevant for one-shot LLM streams; ignore.
@@ -208,14 +229,18 @@ func scan(ctx context.Context, r io.Reader, out chan<- Event) error {
 	return nil
 }
 
-// parseSSELine splits an SSE line into field name and value.
+// parseSSELine splits an SSE line into field name and value, operating on the
+// raw line bytes to avoid allocating an intermediate string.
 // Format: "field: value" or "field:value" (space after colon is optional but
 // if present the first space is stripped per the SSE spec).
 // If there is no colon, the entire line is the field name with empty value.
-func parseSSELine(line string) (field, value string) {
-	idx := strings.IndexByte(line, ':')
+//
+// The returned slices alias the input (and therefore the scanner buffer);
+// callers must copy before retaining them past the next Scan().
+func parseSSELine(line []byte) (field, value []byte) {
+	idx := bytes.IndexByte(line, ':')
 	if idx < 0 {
-		return line, ""
+		return line, nil
 	}
 
 	field = line[:idx]

--- a/bamlutils/sseclient/sseclient_lifetime_test.go
+++ b/bamlutils/sseclient/sseclient_lifetime_test.go
@@ -1,0 +1,142 @@
+package sseclient
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEventDataByteStableAfterAdvance is the core safety test for the
+// scanner.Bytes() parser: each Event.Data must be an owned copy, not a view
+// into the scanner's pooled buffer (which is reused/overwritten on the next
+// Scan). We emit many events whose payloads are all the same length but with
+// distinct content, so that any aliasing into the reused scanner buffer would
+// corrupt earlier events' Data once the parser advances. We collect every
+// event first, let the parser run to completion, and only then verify the
+// retained Data values are unchanged.
+func TestEventDataByteStableAfterAdvance(t *testing.T) {
+	const n = 500
+	const width = 64 // fixed-width payloads so aliasing would overwrite in place
+
+	var in bytes.Buffer
+	want := make([]string, n)
+	for i := 0; i < n; i++ {
+		// Distinct, fixed-width payload per event.
+		p := fmt.Sprintf("payload-%0*d", width-len("payload-"), i)
+		if len(p) != width {
+			t.Fatalf("payload width mismatch: got %d want %d", len(p), width)
+		}
+		want[i] = p
+		in.WriteString("data: ")
+		in.WriteString(p)
+		in.WriteString("\n\n")
+	}
+
+	events, err := collectEvents(t, context.Background(), bytes.NewReader(in.Bytes()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != n {
+		t.Fatalf("expected %d events, got %d", n, len(events))
+	}
+
+	// All events are now retained; the parser has finished and its scanner
+	// buffer has been recycled. If any Data aliased the scanner buffer, these
+	// comparisons would fail.
+	for i, ev := range events {
+		if ev.Data != want[i] {
+			t.Fatalf("event[%d].Data corrupted: got %q want %q", i, ev.Data, want[i])
+		}
+	}
+}
+
+// TestMultilineDataByteStableAfterAdvance verifies that multi-line data:
+// frames are still joined with newlines AND remain byte-stable after the
+// parser advances well past them.
+func TestMultilineDataByteStableAfterAdvance(t *testing.T) {
+	const n = 200
+	const linesPerEvent = 4
+
+	var in bytes.Buffer
+	want := make([]string, n)
+	for i := 0; i < n; i++ {
+		lines := make([]string, linesPerEvent)
+		for j := 0; j < linesPerEvent; j++ {
+			line := fmt.Sprintf("evt%05d-line%d-%s", i, j, strings.Repeat("z", 32))
+			lines[j] = line
+			in.WriteString("data: ")
+			in.WriteString(line)
+			in.WriteByte('\n')
+		}
+		in.WriteByte('\n')
+		want[i] = strings.Join(lines, "\n")
+	}
+
+	events, err := collectEvents(t, context.Background(), bytes.NewReader(in.Bytes()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != n {
+		t.Fatalf("expected %d events, got %d", n, len(events))
+	}
+	for i, ev := range events {
+		if ev.Data != want[i] {
+			t.Fatalf("event[%d].Data mismatch:\n got %q\nwant %q", i, ev.Data, want[i])
+		}
+	}
+}
+
+// TestSlowConsumerExceedsChannelBuffer drives a deliberately slow consumer so
+// the parser fills the 16-deep channel and runs ahead, then validates every
+// event's Data. Run under -race, this catches both scanner-buffer aliasing and
+// any data race between the producer goroutine and the consumer. Distinct
+// fixed-width payloads ensure aliasing would be observable as corruption.
+func TestSlowConsumerExceedsChannelBuffer(t *testing.T) {
+	const n = 64 // > channel buffer (16) so the producer must run ahead
+	const width = 48
+
+	var in bytes.Buffer
+	want := make([]string, n)
+	for i := 0; i < n; i++ {
+		p := fmt.Sprintf("slow-%0*d", width-len("slow-"), i)
+		want[i] = p
+		in.WriteString("event: tok\n")
+		in.WriteString("id: ")
+		in.WriteString(fmt.Sprintf("id-%05d", i))
+		in.WriteByte('\n')
+		in.WriteString("data: ")
+		in.WriteString(p)
+		in.WriteString("\n\n")
+	}
+
+	events, errc := Stream(context.Background(), bytes.NewReader(in.Bytes()))
+
+	var got []Event
+	for ev := range events {
+		// Slow consumer: let the parser get ahead and fill the channel.
+		time.Sleep(time.Millisecond)
+		got = append(got, ev)
+	}
+	if err := <-errc; err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(got) != n {
+		t.Fatalf("expected %d events, got %d", n, len(got))
+	}
+	for i, ev := range got {
+		if ev.Data != want[i] {
+			t.Fatalf("event[%d].Data corrupted: got %q want %q", i, ev.Data, want[i])
+		}
+		if ev.Type != "tok" {
+			t.Fatalf("event[%d].Type corrupted: got %q want %q", i, ev.Type, "tok")
+		}
+		wantID := fmt.Sprintf("id-%05d", i)
+		if ev.ID != wantID {
+			t.Fatalf("event[%d].ID corrupted: got %q want %q", i, ev.ID, wantID)
+		}
+	}
+}

--- a/bamlutils/sseclient/sseclient_test.go
+++ b/bamlutils/sseclient/sseclient_test.go
@@ -462,6 +462,28 @@ func TestCRLFLineEndings(t *testing.T) {
 	}
 }
 
+func TestMultipleTrailingCR(t *testing.T) {
+	// Parity with master's strings.TrimRight(line, "\r"): ALL trailing
+	// carriage returns are stripped, not just one. This pins the byte-path
+	// trim behavior against regression to a single-\r reslice.
+	input := "data: hello\r\r\r\n\r\r\n"
+
+	events, err := collectEvents(t, context.Background(), strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	// The data line "data: hello\r\r" (after the scanner strips the final
+	// \r\n) must have BOTH trailing \r removed, yielding "hello". The blank
+	// boundary line "\r" (one \r before \n) must trim to empty so it still
+	// acts as an event delimiter.
+	if events[0].Data != "hello" {
+		t.Errorf("expected 'hello' (all trailing \\r trimmed), got %q", events[0].Data)
+	}
+}
+
 func TestCRLFWithEventType(t *testing.T) {
 	input := "event: content_block_delta\r\ndata: {\"text\":\"hi\"}\r\n\r\n"
 

--- a/bamlutils/sseclient/sseclient_test.go
+++ b/bamlutils/sseclient/sseclient_test.go
@@ -414,12 +414,12 @@ func TestParseSSELine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.line, func(t *testing.T) {
-			field, value := parseSSELine(tt.line)
-			if field != tt.field {
-				t.Errorf("field: expected %q, got %q", tt.field, field)
+			field, value := parseSSELine([]byte(tt.line))
+			if string(field) != tt.field {
+				t.Errorf("field: expected %q, got %q", tt.field, string(field))
 			}
-			if value != tt.value {
-				t.Errorf("value: expected %q, got %q", tt.value, value)
+			if string(value) != tt.value {
+				t.Errorf("value: expected %q, got %q", tt.value, string(value))
 			}
 		})
 	}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
**Stage 2 of the llmhttp streaming-memory effort** (follow-up to #475; Stage 1 routed `ExecuteStream` through net/http unconditionally in #490).

## What

Optimize the per-frame allocation in `bamlutils/sseclient`. The parser previously called `scanner.Text()`, which allocates a fresh string for every scanned line. This replaces it with `scanner.Bytes()` + byte-level SSE field/value parsing:

- Split `field:value` with `bytes.IndexByte`.
- Trim a trailing `\r` by reslicing (no copy).
- Compare field names with `switch string(field)` — the Go compiler special-cases this to compare against the case constants **without** allocating.

## Safety (the whole point)

A `scanner.Bytes()` view is valid only until the next `Scan()`; the scanner reuses/overwrites its token buffer. `sseclient.Stream` sends events over a buffered channel (cap 16), so the parser runs **ahead** of consumers. Therefore no `scanner.Bytes()` view may ever escape the parse loop into an `Event` or onto the channel.

This PR preserves exactly **one owned allocation per event**:

- `data:` payloads are copied into the `dataBuf` `strings.Builder` via `Write`. Multi-line `data:` fields are still joined with `\n` exactly as before.
- `Event.Data` is produced by `dataBuf.String()` — a view over the builder's own storage, which is not reused after `Reset()`, so it is owned and safe to send.
- `event:` / `id:` values are materialized with `string(...)`, which copies.

## Results — `BenchmarkStreamParallel` (`-benchmem`, allocs/op)

1000-event streams (100 for `large`):

| case | before | after | per-token |
|---|---:|---:|---|
| small_128B | 2011 | 1010 | **2.0 → 1.0 allocs/token** |
| medium_4KiB | 2011 | 1011 | 2.0 → 1.0 |
| large_80KiB | 211 | 111 | 2.1 → 1.1 (100-event) |
| multiline_4KiB | 9010 | 5011 | drops the 4 line-strings/event |

Bytes/op roughly halve as well (e.g. small_128B 297399 → 143143 B/op). This removes the line-string allocation while keeping the single owned event-data allocation, matching the design target.

## Tests added

- `TestEventDataByteStableAfterAdvance` — distinct fixed-width payloads; collect all events, let the parser finish (recycling its scanner buffer), then verify retained `Event.Data` is unchanged (aliasing would corrupt earlier events).
- `TestMultilineDataByteStableAfterAdvance` — multi-line `data:` frames join correctly and stay byte-stable after the parser advances.
- `TestSlowConsumerExceedsChannelBuffer` — slow consumer (>16-event backlog) forces the parser to run ahead; validates Data/Type/ID integrity (run under `-race`).
- `TestParseSSELine` updated for the `[]byte` signature.

## Validation

- `go build ./...` ✅
- `go vet ./bamlutils/sseclient/` ✅
- `gofmt -l bamlutils/sseclient/` clean ✅
- `go test -race ./bamlutils/sseclient ./bamlutils/llmhttp ./bamlutils/buildrequest` ✅
- `go build -o /tmp/wk ./cmd/worker/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Server-Sent Events parsing stability to ensure event payloads and metadata remain correct even as the stream is consumed, including better handling of carriage returns.

* **Tests**
  * Added regression tests covering byte-stable event data for single-line and multi-line events.
  * Added a slow-consumer scenario to verify payload integrity under backpressure/high-throughput conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->