### PR TITLE
perf(buildrequest+sseclient): synchronous callback SSE parser (#475, Stage 4)

### DIFF
--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
 	"github.com/invakid404/baml-rest/bamlutils/retry"
 	"github.com/invakid404/baml-rest/bamlutils/sse"
+	"github.com/invakid404/baml-rest/bamlutils/sseclient"
 )
 
 // parseBuildRequestEnv reads BAML_REST_USE_BUILD_REQUEST and returns its
@@ -789,11 +790,21 @@ func RunStreamOrchestration(
 			return nil, "", "", fmt.Errorf("buildrequest: failed to build request: %w", err)
 		}
 
-		resp, err := httpClient.ExecuteStream(ctx, req)
+		// Synchronous, per-event byte path (Stage 4 of #475 follow-up).
+		// Unlike the channel-based ExecuteStream/StreamResponse used by other
+		// consumers, ExecuteStreamCallback drives the SSE parser inline via
+		// ForEach: each event's data bytes are parsed in place
+		// (sse.ExtractDeltaPartsFromBytes -> gjson.GetBytes) before the next
+		// scanner read, so the parser never materializes a durable
+		// Event.Data string per frame. Everything the callback retains —
+		// the accumulated parseable/raw/reasoning deltas — is copied out of
+		// the byte view (gjson copies Str/Raw; WriteString copies into the
+		// builders), so no view into the scanner buffer escapes the call.
+		handle, err := httpClient.ExecuteStreamCallback(ctx, req)
 		if err != nil {
 			return nil, "", "", err
 		}
-		defer resp.Close()
+		defer handle.Close()
 
 		// Send heartbeat on connection success
 		sendHeartbeat()
@@ -808,12 +819,21 @@ func RunStreamOrchestration(
 		// ctx-cancellation / sawStreamFrame contract.
 		trySendPartial := trySendPartialShared
 
-		for ev := range resp.Events {
+		// callbackErr captures an error raised from inside the per-event
+		// callback (extraction failure or a trySendPartial ctx cancellation)
+		// so it can be propagated verbatim after ForEach returns. The
+		// callback returns sseclient.ErrStopScan to halt parsing cleanly
+		// (ForEach -> nil) whenever callbackErr is set, keeping that error
+		// distinct from a genuine transport/stream error.
+		var callbackErr error
+
+		streamErr := handle.ForEach(ctx, func(ev sseclient.EventBytes) error {
 			// Extract parseable/raw/reasoning delta content from the SSE
-			// event using this attempt's provider. Reasoning text never
-			// enters Parseable or Raw; under IncludeReasoning=true it
-			// populates DeltaParts.Reasoning instead.
-			delta, extractErr := sse.ExtractDeltaPartsFromText(provider, ev.Data, config.IncludeReasoning)
+			// event's data bytes using this attempt's provider. Reasoning
+			// text never enters Parseable or Raw; under IncludeReasoning=true
+			// it populates DeltaParts.Reasoning instead. ExtractDeltaPartsFromBytes
+			// parses ev.Data in place and copies out everything it returns.
+			delta, extractErr := sse.ExtractDeltaPartsFromBytes(provider, ev.Data, config.IncludeReasoning)
 			if extractErr != nil {
 				// Extraction error — fail the attempt so retry logic can handle it
 				// rather than silently accumulating incomplete text.
@@ -822,10 +842,11 @@ func RunStreamOrchestration(
 				// including) the failing frame so the outer error
 				// emission can forward whatever raw arrived before
 				// the break (per #256).
-				return nil, "", "", newRawError(
+				callbackErr = newRawError(
 					fmt.Errorf("buildrequest: delta extraction failed: %w", extractErr),
 					rawAccumulated.String(),
 				)
+				return sseclient.ErrStopScan
 			}
 			// Skip when nothing meaningful arrived on any channel. Under
 			// IncludeReasoning=true a reasoning-only event has empty Raw
@@ -833,7 +854,7 @@ func RunStreamOrchestration(
 			// Reasoning too, otherwise reasoning-only frames would be
 			// dropped without ever reaching the wire.
 			if delta.Raw == "" && delta.Parseable == "" && delta.Reasoning == "" {
-				continue
+				return nil
 			}
 
 			rawAccumulated.WriteString(delta.Raw)
@@ -847,10 +868,11 @@ func RunStreamOrchestration(
 			if config.NeedsPartials && delta.Parseable == "" {
 				if config.NeedsRaw {
 					if err := trySendPartial(nil, delta.Raw, delta.Reasoning); err != nil {
-						return nil, "", "", err
+						callbackErr = err
+						return sseclient.ErrStopScan
 					}
 				}
-				continue
+				return nil
 			}
 
 			// Emit partial if needed.
@@ -877,7 +899,8 @@ func RunStreamOrchestration(
 							reasoningForResult = delta.Reasoning
 						}
 						if err := trySendPartial(parsed, rawForResult, reasoningForResult); err != nil {
-							return nil, "", "", err
+							callbackErr = err
+							return sseclient.ErrStopScan
 						}
 					}
 				}
@@ -886,10 +909,18 @@ func RunStreamOrchestration(
 				// text is included in the final result via rawForFinal /
 				// reasoningForFinal.
 			}
+			return nil
+		})
+
+		// A callback-raised error (extraction failure / ctx cancellation) is
+		// propagated verbatim and takes precedence: ForEach returns nil in
+		// that case because the callback halts via ErrStopScan.
+		if callbackErr != nil {
+			return nil, "", "", callbackErr
 		}
 
 		// Check for stream errors
-		if streamErr := <-resp.Errc; streamErr != nil {
+		if streamErr != nil {
 			// Per #256: forward accumulated raw alongside the
 			// transport error so the outer emission attaches it to
 			// details.raw.

--- a/bamlutils/buildrequest/stream_callback_parity_test.go
+++ b/bamlutils/buildrequest/stream_callback_parity_test.go
@@ -1,0 +1,197 @@
+package buildrequest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
+	"github.com/invakid404/baml-rest/bamlutils/sse"
+	"github.com/invakid404/baml-rest/bamlutils/sseclient"
+)
+
+// accumulated mirrors tryOneStreamChild's per-channel accumulation so the two
+// transport+extraction paths can be compared field-by-field.
+type accumulated struct {
+	parseable string
+	raw       string
+	reasoning string
+}
+
+// accumulateViaChannel consumes the server's SSE stream the OLD way: the
+// channel-based ExecuteStream + sse.ExtractDeltaPartsFromText on the
+// (string) Event.Data.
+func accumulateViaChannel(t *testing.T, client *llmhttp.Client, url, provider string, includeReasoning bool) (accumulated, error) {
+	t.Helper()
+	resp, err := client.ExecuteStream(context.Background(), &llmhttp.Request{URL: url, Method: "POST", Body: `{}`})
+	if err != nil {
+		return accumulated{}, err
+	}
+	defer resp.Close()
+
+	var acc accumulated
+	for ev := range resp.Events {
+		delta, err := sse.ExtractDeltaPartsFromText(provider, ev.Data, includeReasoning)
+		if err != nil {
+			return acc, err
+		}
+		acc.raw += delta.Raw
+		acc.parseable += delta.Parseable
+		acc.reasoning += delta.Reasoning
+	}
+	if err := <-resp.Errc; err != nil {
+		return acc, err
+	}
+	return acc, nil
+}
+
+// accumulateViaCallback consumes the server's SSE stream the NEW way: the
+// synchronous ExecuteStreamCallback + sse.ExtractDeltaPartsFromBytes on the
+// (byte) EventBytes.Data — never materializing a durable Event.Data string.
+func accumulateViaCallback(t *testing.T, client *llmhttp.Client, url, provider string, includeReasoning bool) (accumulated, error) {
+	t.Helper()
+	handle, err := client.ExecuteStreamCallback(context.Background(), &llmhttp.Request{URL: url, Method: "POST", Body: `{}`})
+	if err != nil {
+		return accumulated{}, err
+	}
+	defer handle.Close()
+
+	var acc accumulated
+	var cbErr error
+	streamErr := handle.ForEach(context.Background(), func(ev sseclient.EventBytes) error {
+		delta, err := sse.ExtractDeltaPartsFromBytes(provider, ev.Data, includeReasoning)
+		if err != nil {
+			cbErr = err
+			return sseclient.ErrStopScan
+		}
+		acc.raw += delta.Raw
+		acc.parseable += delta.Parseable
+		acc.reasoning += delta.Reasoning
+		return nil
+	})
+	if cbErr != nil {
+		return acc, cbErr
+	}
+	return acc, streamErr
+}
+
+// makeAnthropicThinkingServer emits interleaved thinking_delta and text_delta
+// events plus a [DONE]-style terminal, to exercise reasoning parity.
+func makeAnthropicThinkingServer(thinking, text []string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, _ := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		fmt.Fprint(w, "event: message_start\ndata: {\"type\":\"message_start\"}\n\n")
+		for _, th := range thinking {
+			fmt.Fprintf(w, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"%s\"}}\n\n", th)
+		}
+		for _, tx := range text {
+			fmt.Fprintf(w, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"%s\"}}\n\n", tx)
+		}
+		fmt.Fprint(w, "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+}
+
+// makeGoogleMultiPartServer emits a single event whose parts[] mixes a
+// thought-tagged part and answer parts, exercising multi-part parity.
+func makeGoogleMultiPartServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		fmt.Fprint(w, "data: {\"candidates\":[{\"content\":{\"parts\":["+
+			"{\"text\":\"reasoning here\",\"thought\":true},"+
+			"{\"text\":\"answer one\"},"+
+			"{\"text\":\" answer two\"}]}}]}\n\n")
+		fmt.Fprint(w, "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" tail\"}]}}]}\n\n")
+	}))
+}
+
+func TestStreamCallbackParity_AllProviders(t *testing.T) {
+	type scenario struct {
+		name             string
+		provider         string
+		server           *httptest.Server
+		includeReasoning bool
+	}
+
+	scenarios := []scenario{
+		{"openai", "openai", makeOpenAIServer([]string{"Hello", " world", "!"}), false},
+		{"azure", "azure-openai", makeOpenAIServer([]string{"Az", "ure"}), false},
+		{"ollama", "ollama", makeOpenAIServer([]string{"oll", "ama"}), false},
+		{"openrouter", "openrouter", makeOpenAIServer([]string{"open", "router"}), false},
+		{"anthropic_text", "anthropic", makeAnthropicServer([]string{"Hello", " from", " Claude"}), false},
+		{"anthropic_thinking_off", "anthropic", makeAnthropicThinkingServer([]string{"plan ", "more"}, []string{"final ", "answer"}), false},
+		{"anthropic_thinking_on", "anthropic", makeAnthropicThinkingServer([]string{"plan ", "more"}, []string{"final ", "answer"}), true},
+		{"openai_responses", "openai-responses", makeOpenAIResponsesServer([]string{"Hello", " responses"}), false},
+		{"google_simple", "google-ai", makeGoogleAIServer([]string{"Hello", " Gemini"}), false},
+		{"vertex_simple", "vertex-ai", makeGoogleAIServer([]string{"Vertex", " resp"}), false},
+		{"google_multipart_off", "google-ai", makeGoogleMultiPartServer(), false},
+		{"google_multipart_on", "google-ai", makeGoogleMultiPartServer(), true},
+	}
+
+	for _, sc := range scenarios {
+		sc := sc
+		t.Run(sc.name, func(t *testing.T) {
+			defer sc.server.Close()
+			client := llmhttp.NewClient(nil)
+
+			chanAcc, chanErr := accumulateViaChannel(t, client, sc.server.URL, sc.provider, sc.includeReasoning)
+			cbAcc, cbErr := accumulateViaCallback(t, client, sc.server.URL, sc.provider, sc.includeReasoning)
+
+			if (chanErr == nil) != (cbErr == nil) {
+				t.Fatalf("terminal error mismatch: channel=%v callback=%v", chanErr, cbErr)
+			}
+			if chanAcc != cbAcc {
+				t.Errorf("accumulation mismatch (includeReasoning=%v):\n channel=%#v\ncallback=%#v",
+					sc.includeReasoning, chanAcc, cbAcc)
+			}
+			// Sanity: the callback path actually accumulated something.
+			if cbAcc.parseable == "" && cbAcc.reasoning == "" {
+				t.Errorf("callback path accumulated nothing for %s", sc.name)
+			}
+		})
+	}
+}
+
+// TestStreamCallbackParity_MidStreamTruncation verifies both paths surface a
+// terminal error on an aborted chunked stream (io.ErrUnexpectedEOF), so the
+// orchestrator's retry gating behaves identically.
+func TestStreamCallbackParity_MidStreamTruncation(t *testing.T) {
+	makeServer := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			flusher, _ := w.(http.Flusher)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(200)
+			fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			// Abort mid-stream: panic with ErrAbortHandler drops the chunked
+			// framing without a terminating zero chunk.
+			panic(http.ErrAbortHandler)
+		}))
+	}
+
+	server := makeServer()
+	defer server.Close()
+	client := llmhttp.NewClient(nil)
+
+	_, chanErr := accumulateViaChannel(t, client, server.URL, "openai", false)
+	_, cbErr := accumulateViaCallback(t, client, server.URL, "openai", false)
+
+	if chanErr == nil || cbErr == nil {
+		t.Fatalf("expected truncation errors, got channel=%v callback=%v", chanErr, cbErr)
+	}
+	// Both should mention the same body-read failure shape.
+	if !strings.Contains(chanErr.Error(), "failed to read response body") ||
+		!strings.Contains(cbErr.Error(), "failed to read response body") {
+		t.Errorf("expected both to be body-read errors:\n channel=%v\ncallback=%v", chanErr, cbErr)
+	}
+}

--- a/bamlutils/llmhttp/errors.go
+++ b/bamlutils/llmhttp/errors.go
@@ -184,16 +184,23 @@ func classifyStreamErrc(src <-chan error) <-chan error {
 	out := make(chan error, 1)
 	go func() {
 		defer close(out)
-		err := <-src
-		if err == nil {
-			out <- nil
-			return
-		}
-		if te := classifyTransportErr(err, "llmhttp: failed to read response body", false); te != nil {
-			out <- te
-			return
-		}
-		out <- fmt.Errorf("llmhttp: failed to read response body: %w", err)
+		out <- classifyStreamErr(<-src)
 	}()
 	return out
+}
+
+// classifyStreamErr is the synchronous core of classifyStreamErrc, shared with
+// the callback streaming path (StreamCallback.ForEach). It runs a non-nil
+// terminal stream error through classifyTransportErr with body-read semantics
+// (staleConnTeardownAcceptable=false, since any delivered bytes rule out the
+// gated stale-conn-teardown family) and wraps anything else generically so
+// io.ErrUnexpectedEOF keeps its content-integrity meaning. nil passes through.
+func classifyStreamErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if te := classifyTransportErr(err, "llmhttp: failed to read response body", false); te != nil {
+		return te
+	}
+	return fmt.Errorf("llmhttp: failed to read response body: %w", err)
 }

--- a/bamlutils/llmhttp/llmhttp.go
+++ b/bamlutils/llmhttp/llmhttp.go
@@ -449,11 +449,40 @@ var DefaultClient = NewClient(&http.Client{Transport: defaultLLMTransport})
 // On error (non-2xx status, connection failure), an error is returned and
 // no cleanup is needed.
 func (c *Client) ExecuteStream(ctx context.Context, req *Request) (*StreamResponse, error) {
+	body, status, headers, err := c.openStream(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Start SSE parsing on the response body. The terminal value sseclient
+	// emits on errc is run through classifyStreamErrc so a mid-stream typed
+	// transport drop (ECONNRESET / EPIPE / ECONNREFUSED / net.ErrClosed) or
+	// an idle timeout (ErrIdleTimeout) carries ErrTransportFlake out of the
+	// streaming path — matching the non-streaming body-read site at Execute
+	// below.
+	events, errc := sseclient.Stream(ctx, body)
+
+	return &StreamResponse{
+		StatusCode: status,
+		Headers:    headers,
+		Events:     events,
+		Errc:       classifyStreamErrc(errc),
+		body:       body,
+	}, nil
+}
+
+// openStream performs the shared streaming connect used by both the
+// channel-based ExecuteStream and the synchronous ExecuteStreamCallback: URL
+// rewrite, SigV4 signing, net/http request build + Do, status-code check,
+// Content-Type validation, and the inter-token idle-read-timeout body wrap.
+// It returns the wrapped body (caller owns Close), status code, and response
+// headers. On error nothing needs cleanup.
+func (c *Client) openStream(ctx context.Context, req *Request) (io.ReadCloser, int, http.Header, error) {
 	if c == nil || c.httpClient == nil {
-		return nil, fmt.Errorf("llmhttp: nil client")
+		return nil, 0, nil, fmt.Errorf("llmhttp: nil client")
 	}
 	if req == nil {
-		return nil, fmt.Errorf("llmhttp: nil request")
+		return nil, 0, nil, fmt.Errorf("llmhttp: nil request")
 	}
 
 	rewritten := c.resolveRequestURL(req)
@@ -463,7 +492,7 @@ func (c *Client) ExecuteStream(ctx context.Context, req *Request) (*StreamRespon
 	// backend dispatch (so net/http and fasthttp see the same signed
 	// headers).
 	if err := signRequest(ctx, req, rewritten); err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
 
 	// Streaming always routes through net/http, even when BAML_REST_HTTP_CLIENT
@@ -477,22 +506,22 @@ func (c *Client) ExecuteStream(ctx context.Context, req *Request) (*StreamRespon
 
 	httpReq, err := buildHTTPRequest(ctx, req, rewritten)
 	if err != nil {
-		return nil, fmt.Errorf("llmhttp: failed to build request: %w", err)
+		return nil, 0, nil, fmt.Errorf("llmhttp: failed to build request: %w", err)
 	}
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		if te := classifyTransportErr(err, "llmhttp: request failed", true); te != nil {
-			return nil, te
+			return nil, 0, nil, te
 		}
-		return nil, fmt.Errorf("llmhttp: request failed: %w", err)
+		return nil, 0, nil, fmt.Errorf("llmhttp: request failed: %w", err)
 	}
 
 	// Check for non-success status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, MaxErrorBodyBytes))
 		resp.Body.Close()
-		return nil, &HTTPError{
+		return nil, 0, nil, &HTTPError{
 			StatusCode: resp.StatusCode,
 			Body:       string(body),
 		}
@@ -507,9 +536,9 @@ func (c *Client) ExecuteStream(ctx context.Context, req *Request) (*StreamRespon
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, MaxErrorBodyBytes))
 		resp.Body.Close()
 		if ct == "" {
-			return nil, fmt.Errorf("llmhttp: missing Content-Type header (expected text/event-stream): %s", string(body))
+			return nil, 0, nil, fmt.Errorf("llmhttp: missing Content-Type header (expected text/event-stream): %s", string(body))
 		}
-		return nil, fmt.Errorf("llmhttp: unexpected Content-Type %q (expected text/event-stream): %s", ct, string(body))
+		return nil, 0, nil, fmt.Errorf("llmhttp: unexpected Content-Type %q (expected text/event-stream): %s", ct, string(body))
 	}
 
 	// Wrap the body with an inter-token idle read timeout before handing it
@@ -521,21 +550,70 @@ func (c *Client) ExecuteStream(ctx context.Context, req *Request) (*StreamRespon
 	// concurrently with a parked Read.
 	body := newIdleTimeoutReader(ctx, resp.Body, nil, c.GetStreamIdleTimeout())
 
-	// Start SSE parsing on the response body. The terminal value sseclient
-	// emits on errc is run through classifyStreamErrc so a mid-stream typed
-	// transport drop (ECONNRESET / EPIPE / ECONNREFUSED / net.ErrClosed) or
-	// an idle timeout (ErrIdleTimeout) carries ErrTransportFlake out of the
-	// streaming path — matching the non-streaming body-read site at Execute
-	// below.
-	events, errc := sseclient.Stream(ctx, body)
+	return body, resp.StatusCode, resp.Header, nil
+}
 
-	return &StreamResponse{
-		StatusCode: resp.StatusCode,
-		Headers:    resp.Header,
-		Events:     events,
-		Errc:       classifyStreamErrc(errc),
+// StreamCallback represents an active streaming HTTP connection consumed via a
+// synchronous per-event callback rather than the StreamResponse channel. It is
+// used by the BuildRequest stream orchestrator to parse each SSE event's data
+// bytes in place (gjson.GetBytes via sse.ExtractDeltaPartsFromBytes) WITHOUT
+// materializing a durable Event.Data string per frame — the saving that the
+// buffered channel path cannot make because there the parser runs ahead of the
+// consumer.
+//
+// The channel-based ExecuteStream / StreamResponse path is unchanged and
+// remains for all other consumers. The caller must call Close() when done.
+type StreamCallback struct {
+	// StatusCode is the HTTP response status code.
+	StatusCode int
+
+	// Headers are the HTTP response headers.
+	Headers http.Header
+
+	// body holds the (idle-timeout-wrapped) response body.
+	body io.ReadCloser
+}
+
+// ExecuteStreamCallback connects exactly like ExecuteStream (same URL rewrite,
+// signing, net/http transport, status/Content-Type checks, and idle-timeout
+// body wrap) but returns a StreamCallback for synchronous, per-event byte
+// consumption instead of a channel. The caller drives the stream with
+// ForEach and must Close() when done.
+func (c *Client) ExecuteStreamCallback(ctx context.Context, req *Request) (*StreamCallback, error) {
+	body, status, headers, err := c.openStream(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &StreamCallback{
+		StatusCode: status,
+		Headers:    headers,
 		body:       body,
 	}, nil
+}
+
+// ForEach parses the SSE stream synchronously, invoking fn for each event in
+// stream order on the calling goroutine. fn receives byte views valid only for
+// the duration of the call (see sseclient.ScanEvents / EventBytes); it must
+// fully consume them before returning. fn may return sseclient.ErrStopScan to
+// halt parsing cleanly (ForEach returns nil).
+//
+// The terminal stream error is returned (nil on clean EOF), classified the
+// same way StreamResponse.Errc is: a mid-stream typed transport drop or idle
+// timeout carries the ErrTransportFlake umbrella, while io.ErrUnexpectedEOF
+// (chunked truncation) falls through to the generic wrap so its
+// content-integrity meaning is preserved.
+func (s *StreamCallback) ForEach(ctx context.Context, fn sseclient.EventFunc) error {
+	return classifyStreamErr(sseclient.ScanEvents(ctx, s.body, fn))
+}
+
+// Close releases the HTTP connection and interrupts a parked read. It is safe
+// to call multiple times.
+func (s *StreamCallback) Close() {
+	if s == nil || s.body == nil {
+		return
+	}
+	s.body.Close()
+	s.body = nil
 }
 
 // DefaultCallTimeout is the maximum time Execute() will wait for a

--- a/bamlutils/sse/extract.go
+++ b/bamlutils/sse/extract.go
@@ -102,6 +102,44 @@ func ExtractDeltaContent(provider string, chunk SSEChunk, includeReasoning bool)
 // construction so neither the BAML parser nor the wire's raw channel can
 // be influenced by reasoning text.
 func ExtractDeltaPartsFromText(provider string, rawText string, includeReasoning bool) (DeltaParts, error) {
+	// gjson.Get aliases rawText for unescaped result substrings; the
+	// per-provider logic copies what it keeps into string builders / the
+	// returned DeltaParts strings, so no aliasing outlives this call.
+	return extractDeltaParts(provider, func(path string) gjson.Result {
+		return gjson.Get(rawText, path)
+	}, includeReasoning)
+}
+
+// ExtractDeltaPartsFromBytes is the byte-oriented twin of
+// ExtractDeltaPartsFromText for the synchronous BuildRequest stream path,
+// where each SSE event's data is available as caller-owned bytes that live
+// only for the duration of the call (sseclient.ScanEvents hands the parser's
+// reused scratch buffer to its callback). It extracts via gjson.GetBytes
+// instead of converting the event data to a string first, eliminating the
+// per-frame Event.Data string the channel path must materialize.
+//
+// Safety: gjson.GetBytes views data as a string only for the duration of each
+// path lookup and copies the matched Raw/Str out before returning, so every
+// gjson.Result handed back owns its data; the per-provider extractors further
+// copy retained text into the returned DeltaParts strings. data must stay
+// valid through the call (it does — the callback runs before the next Scan);
+// it need not survive afterward. Returns results identical to
+// ExtractDeltaPartsFromText for the same JSON — see the callback-vs-channel
+// parity tests.
+func ExtractDeltaPartsFromBytes(provider string, data []byte, includeReasoning bool) (DeltaParts, error) {
+	return extractDeltaParts(provider, func(path string) gjson.Result {
+		return gjson.GetBytes(data, path)
+	}, includeReasoning)
+}
+
+// extractDeltaParts holds the provider-specific delta extraction logic shared
+// by ExtractDeltaPartsFromText (string input, gjson.Get) and
+// ExtractDeltaPartsFromBytes (byte input, gjson.GetBytes). The get closure
+// performs each top-level path lookup against the underlying JSON; nested
+// navigation happens on the returned gjson.Result values, which are
+// source-agnostic. This keeps the string and byte entry points sharing one
+// implementation so they cannot drift.
+func extractDeltaParts(provider string, get func(path string) gjson.Result, includeReasoning bool) (DeltaParts, error) {
 	switch provider {
 	// OpenAI-compatible providers (Chat Completions API format)
 	// Path: choices[0].delta.content (parseable+raw); choices[0].delta.reasoning_content
@@ -109,10 +147,10 @@ func ExtractDeltaPartsFromText(provider string, rawText string, includeReasoning
 	// for DeepSeek-R1 and several OAI-compat gateways; non-string values are
 	// silently skipped, matching the forgiving streaming semantics.
 	case "openai", "openai-generic", "azure-openai", "ollama", "openrouter":
-		delta := gjson.Get(rawText, "choices.0.delta.content").String()
+		delta := get("choices.0.delta.content").String()
 		parts := DeltaParts{Parseable: delta, Raw: delta}
 		if includeReasoning {
-			reasoning := gjson.Get(rawText, "choices.0.delta.reasoning_content")
+			reasoning := get("choices.0.delta.reasoning_content")
 			if reasoning.Type == gjson.String {
 				parts.Reasoning = reasoning.String()
 			}
@@ -126,9 +164,9 @@ func ExtractDeltaPartsFromText(provider string, rawText string, includeReasoning
 	// OpenAI exposes for o1/o3-style models; the underlying chain-of-thought
 	// is server-encrypted and intentionally not surfaced.
 	case "openai-responses":
-		switch gjson.Get(rawText, "type").String() {
+		switch get("type").String() {
 		case "response.output_text.delta":
-			delta := gjson.Get(rawText, "delta")
+			delta := get("delta")
 			if delta.Type != gjson.String {
 				return DeltaParts{}, nil
 			}
@@ -139,7 +177,7 @@ func ExtractDeltaPartsFromText(provider string, rawText string, includeReasoning
 			if !includeReasoning {
 				return DeltaParts{}, nil
 			}
-			delta := gjson.Get(rawText, "delta")
+			delta := get("delta")
 			if delta.Type != gjson.String {
 				return DeltaParts{}, nil
 			}
@@ -154,16 +192,16 @@ func ExtractDeltaPartsFromText(provider string, rawText string, includeReasoning
 	// always exclude thinking so neither the parser nor /with-raw's raw
 	// channel sees reasoning text.
 	case "anthropic":
-		if gjson.Get(rawText, "type").String() == "content_block_delta" {
-			switch gjson.Get(rawText, "delta.type").String() {
+		if get("type").String() == "content_block_delta" {
+			switch get("delta.type").String() {
 			case "text_delta":
-				delta := gjson.Get(rawText, "delta.text").String()
+				delta := get("delta.text").String()
 				return DeltaParts{Parseable: delta, Raw: delta}, nil
 			case "thinking_delta":
 				if !includeReasoning {
 					return DeltaParts{}, nil
 				}
-				return DeltaParts{Reasoning: gjson.Get(rawText, "delta.thinking").String()}, nil
+				return DeltaParts{Reasoning: get("delta.thinking").String()}, nil
 			}
 		}
 		return DeltaParts{}, nil
@@ -179,7 +217,7 @@ func ExtractDeltaPartsFromText(provider string, rawText string, includeReasoning
 	// on any part is silently skipped — preserving the forgiving streaming
 	// semantics.
 	case "google-ai", "vertex-ai":
-		parts := gjson.Get(rawText, "candidates.0.content.parts")
+		parts := get("candidates.0.content.parts")
 		var parseableSB strings.Builder
 		var rawSB strings.Builder
 		var reasoningSB strings.Builder
@@ -209,7 +247,7 @@ func ExtractDeltaPartsFromText(provider string, rawText string, includeReasoning
 	// AWS Bedrock (Debug string format)
 	// Path: debug (then parsed via regex)
 	case "aws-bedrock":
-		delta, err := extractBedrockFromDebug(gjson.Get(rawText, "debug").String())
+		delta, err := extractBedrockFromDebug(get("debug").String())
 		if err != nil {
 			return DeltaParts{}, err
 		}

--- a/bamlutils/sse/extract_bytes_parity_test.go
+++ b/bamlutils/sse/extract_bytes_parity_test.go
@@ -1,0 +1,80 @@
+package sse
+
+import "testing"
+
+// extractParityCase is one provider + event-JSON fixture run through both the
+// string entry point (ExtractDeltaPartsFromText / gjson.Get) and the byte
+// entry point (ExtractDeltaPartsFromBytes / gjson.GetBytes). Both must produce
+// identical DeltaParts and identical error behaviour.
+type extractParityCase struct {
+	name     string
+	provider string
+	json     string
+}
+
+var extractParityCases = []extractParityCase{
+	// OpenAI / openai-compat (Chat Completions)
+	{"openai_text", "openai", `{"choices":[{"delta":{"content":"hello"}}]}`},
+	{"openai_empty", "openai", `{"choices":[{"delta":{}}]}`},
+	{"openai_reasoning", "openai", `{"choices":[{"delta":{"content":"hi","reasoning_content":"because"}}]}`},
+	{"openai_escaped", "openai", `{"choices":[{"delta":{"content":"line1\nline2 \"q\" é"}}]}`},
+	{"azure_text", "azure-openai", `{"choices":[{"delta":{"content":"az"}}]}`},
+	{"ollama_text", "ollama", `{"choices":[{"delta":{"content":"ol"}}]}`},
+	{"openrouter_text", "openrouter", `{"choices":[{"delta":{"content":"or"}}]}`},
+
+	// OpenAI Responses
+	{"responses_text", "openai-responses", `{"type":"response.output_text.delta","delta":"chunk"}`},
+	{"responses_reasoning", "openai-responses", `{"type":"response.reasoning_summary_text.delta","delta":"think"}`},
+	{"responses_other", "openai-responses", `{"type":"response.completed"}`},
+	{"responses_nonstring_delta", "openai-responses", `{"type":"response.output_text.delta","delta":123}`},
+
+	// Anthropic
+	{"anthropic_text", "anthropic", `{"type":"content_block_delta","delta":{"type":"text_delta","text":"ab"}}`},
+	{"anthropic_thinking", "anthropic", `{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"hmm"}}`},
+	{"anthropic_other", "anthropic", `{"type":"message_start"}`},
+	{"anthropic_escaped", "anthropic", `{"type":"content_block_delta","delta":{"type":"text_delta","text":"a\tb☃"}}`},
+
+	// Google / Vertex
+	{"google_text", "google-ai", `{"candidates":[{"content":{"parts":[{"text":"g1"},{"text":"g2"}]}}]}`},
+	{"google_thought", "google-ai", `{"candidates":[{"content":{"parts":[{"text":"think","thought":true},{"text":"answer"}]}}]}`},
+	{"google_empty", "google-ai", `{"candidates":[{"content":{"parts":[]}}]}`},
+	{"google_missing", "google-ai", `{"candidates":[]}`},
+	{"vertex_text", "vertex-ai", `{"candidates":[{"content":{"parts":[{"text":"v"}]}}]}`},
+
+	// AWS Bedrock (debug-string format)
+	{"bedrock_text", "aws-bedrock", `{"debug":"ContentBlockDelta { delta: Some(Text(\"hi\")) }"}`},
+	{"bedrock_nondelta", "aws-bedrock", `{"debug":"MessageStart { role: Assistant }"}`},
+}
+
+func TestExtractDeltaPartsFromBytesMatchesString(t *testing.T) {
+	for _, includeReasoning := range []bool{false, true} {
+		for _, tc := range extractParityCases {
+			name := tc.name
+			if includeReasoning {
+				name += "_reasoning_on"
+			}
+			t.Run(name, func(t *testing.T) {
+				strParts, strErr := ExtractDeltaPartsFromText(tc.provider, tc.json, includeReasoning)
+				bytParts, bytErr := ExtractDeltaPartsFromBytes(tc.provider, []byte(tc.json), includeReasoning)
+
+				if (strErr == nil) != (bytErr == nil) {
+					t.Fatalf("error mismatch: string=%v bytes=%v", strErr, bytErr)
+				}
+				if strParts != bytParts {
+					t.Errorf("DeltaParts mismatch (includeReasoning=%v):\n string=%#v\n  bytes=%#v",
+						includeReasoning, strParts, bytParts)
+				}
+			})
+		}
+	}
+}
+
+// TestExtractDeltaPartsFromBytesUnsupportedProvider confirms the byte path
+// errors identically to the string path for an unknown provider.
+func TestExtractDeltaPartsFromBytesUnsupportedProvider(t *testing.T) {
+	_, strErr := ExtractDeltaPartsFromText("made-up", `{}`, false)
+	_, bytErr := ExtractDeltaPartsFromBytes("made-up", []byte(`{}`), false)
+	if strErr == nil || bytErr == nil {
+		t.Fatalf("expected errors for unsupported provider, got string=%v bytes=%v", strErr, bytErr)
+	}
+}

--- a/bamlutils/sseclient/sseclient.go
+++ b/bamlutils/sseclient/sseclient.go
@@ -314,6 +314,18 @@ func ScanEvents(ctx context.Context, r io.Reader, fn EventFunc) error {
 	)
 
 	emit := func() error {
+		// Re-check ctx at dispatch time, mirroring the channel-based Stream's
+		// `select { case out <- ev: case <-ctx.Done(): return ctx.Err() }`.
+		// The top-of-loop check alone leaves two gaps: a concurrent cancel in
+		// the window between that check and this dispatch, and the trailing
+		// (post-loop) event below — which the loop-body check never guards
+		// because the loop exits via a false Scan(). Checking here stops a
+		// cancelled stream promptly without ever entering fn for a further
+		// event. ctx.Err() is allocation-free. Returned ctx.Err() is not
+		// ErrStopScan, so callers surface it as the terminal error.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		return fn(EventBytes{Type: typeBuf, Data: dataBuf, ID: idBuf})
 	}
 

--- a/bamlutils/sseclient/sseclient.go
+++ b/bamlutils/sseclient/sseclient.go
@@ -11,6 +11,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"sync"
@@ -224,6 +225,169 @@ func scan(ctx context.Context, r io.Reader, out chan<- Event) error {
 		case out <- ev:
 		case <-ctx.Done():
 			return ctx.Err()
+		}
+	}
+
+	return nil
+}
+
+// EventBytes is the byte-oriented view of a parsed SSE event handed to an
+// EventFunc by ScanEvents. Every slice aliases parser-owned scratch buffers
+// that are RESET and reused on the next event — the views are valid ONLY for
+// the duration of the EventFunc invocation that received them.
+//
+// The callback MUST fully consume these bytes (e.g. parse Data via
+// gjson.GetBytes) before returning, and MUST NOT let any slice — nor any
+// gjson.Result / string that aliases one — escape the call. gjson.GetBytes
+// copies the matched Raw/Str out before returning, so DeltaParts strings
+// built from it are owned and safe to retain; the raw Data/Type/ID slices
+// themselves are not.
+//
+// This is the whole point of the synchronous path: because the parser never
+// runs ahead of the consumer (no channel, no goroutine), Data need not be
+// materialized into a durable string per frame the way Stream's Event.Data
+// must be.
+type EventBytes struct {
+	// Type is the SSE event type (from "event:" lines), empty for the
+	// default "message" type. Aliases a parser-owned buffer.
+	Type []byte
+
+	// Data is the concatenated content of all "data:" lines for this event,
+	// joined with "\n". Aliases a parser-owned buffer.
+	Data []byte
+
+	// ID is the event ID from "id:" lines, if present. Aliases a
+	// parser-owned buffer.
+	ID []byte
+}
+
+// EventFunc is invoked synchronously by ScanEvents for each parsed SSE event,
+// in stream order. Returning a non-nil error stops scanning: ScanEvents
+// returns that error verbatim, EXCEPT ErrStopScan, which stops scanning
+// cleanly (ScanEvents returns nil) so a caller can halt for its own reason
+// while tracking its own error separately.
+type EventFunc func(ev EventBytes) error
+
+// ErrStopScan, when returned by an EventFunc, stops ScanEvents cleanly:
+// ScanEvents returns nil rather than surfacing this sentinel as a stream
+// error. Use it when the caller wants to abort parsing for a caller-side
+// reason (e.g. a downstream context cancellation or a tracked extraction
+// error) without it being misclassified as a transport failure.
+var ErrStopScan = errors.New("sseclient: stop scan")
+
+// ScanEvents reads SSE events from r until EOF, an error, or ctx
+// cancellation, invoking fn synchronously for each event. Unlike Stream, it
+// uses NO channel and NO goroutine — fn runs inline on the parsing goroutine,
+// so the event bytes handed to fn never cross a buffering boundary and need
+// not be copied into a durable string. This lets a caller parse Data in place
+// (gjson.GetBytes) without the per-frame Event.Data allocation Stream
+// requires.
+//
+// fn receives EventBytes whose slices alias parser-owned scratch buffers that
+// are reused on the next event; fn must fully consume them before returning
+// (see EventBytes). The terminal error is returned directly (nil on clean
+// EOF), with the same semantics as the value Stream delivers on its error
+// channel before classification.
+//
+// The public Stream channel API is unchanged and remains the path for all
+// concurrent/buffered consumers; ScanEvents is the additional synchronous
+// path for callers that can consume each event in place.
+func ScanEvents(ctx context.Context, r io.Reader, fn EventFunc) error {
+	bufp := getSSEScannerBuffer()
+	defer putSSEScannerBuffer(bufp)
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer((*bufp)[:0], sseScannerMaxTokenSize)
+
+	// Reused per-event scratch buffers. Field values are append-copied out of
+	// the scanner buffer into these (so they survive across the several Scan
+	// iterations that make up one event), and reset to [:0] at each event
+	// boundary so steady-state parsing allocates nothing per token. The
+	// buffers — and therefore the EventBytes views built from them — are
+	// reused on the next event, which is safe precisely because fn consumes
+	// them synchronously before the next Scan.
+	var (
+		typeBuf []byte
+		dataBuf []byte
+		idBuf   []byte
+		hasData bool
+	)
+
+	emit := func() error {
+		return fn(EventBytes{Type: typeBuf, Data: dataBuf, ID: idBuf})
+	}
+
+	for scanner.Scan() {
+		// Check for context cancellation between lines.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// line aliases the scanner's pooled buffer; valid only until the next
+		// Scan(). Field values are copied out of it via append below.
+		line := bytes.TrimRight(scanner.Bytes(), "\r")
+
+		// Blank line = event boundary (dispatch if we have data).
+		if len(line) == 0 {
+			if hasData {
+				if err := emit(); err != nil {
+					if errors.Is(err, ErrStopScan) {
+						return nil
+					}
+					return err
+				}
+			}
+			// Reset for next event. Truncate (not reallocate) so the backing
+			// arrays are reused.
+			typeBuf = typeBuf[:0]
+			dataBuf = dataBuf[:0]
+			idBuf = idBuf[:0]
+			hasData = false
+			continue
+		}
+
+		// SSE comment lines start with ':' — skip them (keepalives).
+		if line[0] == ':' {
+			continue
+		}
+
+		field, value := parseSSELine(line)
+
+		switch string(field) {
+		case "data":
+			if hasData {
+				// Multiple data lines are joined with newlines per SSE spec.
+				dataBuf = append(dataBuf, '\n')
+			}
+			// append copies value out of the scanner buffer into dataBuf.
+			dataBuf = append(dataBuf, value...)
+			hasData = true
+		case "event":
+			// Last event: line wins per spec; overwrite by truncating first.
+			typeBuf = append(typeBuf[:0], value...)
+		case "id":
+			// Per SSE spec, ignore IDs containing null.
+			if bytes.IndexByte(value, '\x00') < 0 {
+				idBuf = append(idBuf[:0], value...)
+			}
+		case "retry":
+			// Not relevant for one-shot LLM streams; ignore.
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	// Trailing event without a final blank line.
+	if hasData {
+		if err := emit(); err != nil {
+			if errors.Is(err, ErrStopScan) {
+				return nil
+			}
+			return err
 		}
 	}
 

--- a/bamlutils/sseclient/sseclient_callback_test.go
+++ b/bamlutils/sseclient/sseclient_callback_test.go
@@ -1,0 +1,226 @@
+package sseclient
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// collectViaStream drains the channel API into a slice of owned Events.
+func collectViaStream(t *testing.T, body string) ([]Event, error) {
+	t.Helper()
+	events, errc := Stream(context.Background(), strings.NewReader(body))
+	var got []Event
+	for ev := range events {
+		got = append(got, ev)
+	}
+	return got, <-errc
+}
+
+// collectViaScanEvents drains the synchronous callback API into a slice of
+// owned Events. Because EventBytes views are only valid during the callback,
+// each field is copied out with string(...) — exactly what a real consumer
+// that needs to retain data must do.
+func collectViaScanEvents(t *testing.T, body string) ([]Event, error) {
+	t.Helper()
+	var got []Event
+	err := ScanEvents(context.Background(), strings.NewReader(body), func(ev EventBytes) error {
+		got = append(got, Event{
+			Type: string(ev.Type),
+			Data: string(ev.Data),
+			ID:   string(ev.ID),
+		})
+		return nil
+	})
+	return got, err
+}
+
+// sseParityFixtures exercises the SSE features both parsers must handle
+// identically: default/typed events, ids, multi-line data joined with \n,
+// comment/keepalive lines, CRLF line endings, a trailing event with no final
+// blank line, and the [DONE] sentinel.
+var sseParityFixtures = map[string]string{
+	"single_event":        "data: hello\n\n",
+	"multi_event":         "data: a\n\ndata: b\n\ndata: c\n\n",
+	"typed_event":         "event: content_block_delta\ndata: {\"x\":1}\n\n",
+	"with_id":             "id: 42\ndata: payload\n\n",
+	"multiline_data":      "data: line1\ndata: line2\ndata: line3\n\n",
+	"comment_keepalive":   ": keepalive\ndata: real\n\n",
+	"crlf_endings":        "event: e\r\ndata: v\r\n\r\n",
+	"trailing_no_blank":   "data: last",
+	"done_sentinel":       "data: {\"a\":1}\n\ndata: [DONE]\n\n",
+	"empty_data":          "data:\n\n",
+	"id_with_null_skip":   "id: a\x00b\ndata: x\n\n",
+	"event_last_wins":     "event: first\nevent: second\ndata: x\n\n",
+	"interleaved_fields":  "event: t\nid: 7\ndata: d1\ndata: d2\n\n",
+	"blank_lines_between": "\n\ndata: x\n\n\n\ndata: y\n\n",
+}
+
+func TestScanEventsMatchesStream(t *testing.T) {
+	for name, body := range sseParityFixtures {
+		t.Run(name, func(t *testing.T) {
+			streamEvents, streamErr := collectViaStream(t, body)
+			scanEvents, scanErr := collectViaScanEvents(t, body)
+
+			if (streamErr == nil) != (scanErr == nil) {
+				t.Fatalf("terminal error mismatch: stream=%v scan=%v", streamErr, scanErr)
+			}
+			if len(streamEvents) != len(scanEvents) {
+				t.Fatalf("event count mismatch: stream=%d scan=%d\nstream=%#v\nscan=%#v",
+					len(streamEvents), len(scanEvents), streamEvents, scanEvents)
+			}
+			for i := range streamEvents {
+				if streamEvents[i] != scanEvents[i] {
+					t.Errorf("event %d mismatch:\n stream=%#v\n   scan=%#v", i, streamEvents[i], scanEvents[i])
+				}
+			}
+		})
+	}
+}
+
+// TestScanEventsErrStopScan verifies that returning ErrStopScan halts parsing
+// cleanly: ScanEvents returns nil and no further events are delivered.
+func TestScanEventsErrStopScan(t *testing.T) {
+	body := "data: a\n\ndata: b\n\ndata: c\n\n"
+	var seen []string
+	err := ScanEvents(context.Background(), strings.NewReader(body), func(ev EventBytes) error {
+		seen = append(seen, string(ev.Data))
+		if string(ev.Data) == "b" {
+			return ErrStopScan
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ErrStopScan should yield nil, got %v", err)
+	}
+	if len(seen) != 2 || seen[0] != "a" || seen[1] != "b" {
+		t.Fatalf("expected to stop after [a b], got %v", seen)
+	}
+}
+
+// TestScanEventsCallbackErrorPropagates verifies a non-ErrStopScan error from
+// the callback is returned verbatim.
+func TestScanEventsCallbackErrorPropagates(t *testing.T) {
+	sentinel := errors.New("boom")
+	err := ScanEvents(context.Background(), strings.NewReader("data: a\n\ndata: b\n\n"), func(ev EventBytes) error {
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}
+
+// TestScanEventsContextCancellation verifies ctx cancellation surfaces
+// ctx.Err() — matching the channel path's between-line cancellation check.
+func TestScanEventsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// A multi-line body so the loop has a chance to observe Done between lines.
+	err := ScanEvents(ctx, strings.NewReader("data: a\n\ndata: b\n\n"), func(ev EventBytes) error {
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestScanEventsBufferReuse proves the parser reuses one backing array for
+// Data across events (no per-event allocation) and that the bytes handed to a
+// PRIOR callback are overwritten by a LATER event — the exact reason the
+// callback must consume them synchronously and copy out anything it retains.
+func TestScanEventsBufferReuse(t *testing.T) {
+	body := "data: AAAA\n\ndata: BBBB\n\n"
+
+	var (
+		firstCap      int
+		secondCap     int
+		retainedView  []byte // deliberately retained (unsafe in real code)
+		copiedOut     string
+		afterRetained string
+	)
+	idx := 0
+	err := ScanEvents(context.Background(), strings.NewReader(body), func(ev EventBytes) error {
+		switch idx {
+		case 0:
+			firstCap = cap(ev.Data)
+			retainedView = ev.Data // capture the slice header (aliases scratch buf)
+			copiedOut = string(ev.Data)
+		case 1:
+			secondCap = cap(ev.Data)
+			// The retained view now observes the second event's bytes,
+			// because the scratch buffer was reused. This is the hazard the
+			// design avoids by consuming synchronously.
+			afterRetained = string(retainedView)
+		}
+		idx++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	if firstCap == 0 || secondCap == 0 {
+		t.Fatalf("expected non-zero caps, got %d %d", firstCap, secondCap)
+	}
+	// Same backing array reused → identical capacity, no growth for equal-size payloads.
+	if firstCap != secondCap {
+		t.Errorf("expected reused backing array (equal cap), got %d then %d", firstCap, secondCap)
+	}
+	if copiedOut != "AAAA" {
+		t.Errorf("copied-out first event = %q, want AAAA", copiedOut)
+	}
+	// The retained []byte view was overwritten by event 2 — demonstrating why
+	// copying out (copiedOut) is mandatory and a retained view is not safe.
+	if afterRetained != "BBBB" {
+		t.Errorf("retained view after second event = %q, want BBBB (proves reuse)", afterRetained)
+	}
+}
+
+// TestScanEventsReaderError surfaces a mid-stream reader error verbatim
+// (parity with the channel path's scanner.Err()).
+func TestScanEventsReaderError(t *testing.T) {
+	boom := errors.New("read failure")
+	r := io.MultiReader(strings.NewReader("data: a\n\n"), &errReader{err: boom})
+	var seen int
+	err := ScanEvents(context.Background(), r, func(ev EventBytes) error {
+		seen++
+		return nil
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected reader error, got %v", err)
+	}
+	if seen != 1 {
+		t.Fatalf("expected one delivered event before error, got %d", seen)
+	}
+}
+
+type errReader struct{ err error }
+
+func (e *errReader) Read(p []byte) (int, error) { return 0, e.err }
+
+// BenchmarkScanEventsParallel mirrors BenchmarkStreamParallel for the
+// synchronous callback path. The callback parses nothing durable — it only
+// touches the bytes — so the steady-state per-event allocation that Stream
+// pays for Event.Data should not appear here.
+func BenchmarkScanEventsParallel(b *testing.B) {
+	smallPayload := strings.Repeat("x", 128)
+	body := buildSSEStream(1000, smallPayload)
+	b.SetParallelism(16)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		var sink int
+		for pb.Next() {
+			err := ScanEvents(context.Background(), bytes.NewReader(body), func(ev EventBytes) error {
+				sink += len(ev.Data) // touch the bytes without retaining them
+				return nil
+			})
+			if err != nil {
+				b.Fatalf("scan error: %v", err)
+			}
+		}
+		_ = sink
+	})
+}

--- a/bamlutils/sseclient/sseclient_callback_test.go
+++ b/bamlutils/sseclient/sseclient_callback_test.go
@@ -200,6 +200,82 @@ type errReader struct{ err error }
 
 func (e *errReader) Read(p []byte) (int, error) { return 0, e.err }
 
+// cancelOnEOFReader delivers data once, then cancels the context on the
+// follow-up Read that the scanner makes to detect EOF, before returning EOF.
+// This deterministically reproduces the dispatch-time cancellation gap: the
+// cancel lands during the Scan() that returns false (so the loop exits via the
+// for-condition and the loop-body's top-of-iteration ctx check never runs),
+// leaving the post-loop trailing-event dispatch as the only thing that could
+// observe the cancellation.
+type cancelOnEOFReader struct {
+	data   []byte
+	off    int
+	cancel context.CancelFunc
+	done   bool
+}
+
+func (r *cancelOnEOFReader) Read(p []byte) (int, error) {
+	if r.off < len(r.data) {
+		n := copy(p, r.data[r.off:])
+		r.off += n
+		return n, nil
+	}
+	if !r.done {
+		r.done = true
+		r.cancel()
+	}
+	return 0, io.EOF
+}
+
+// TestScanEventsCtxCheckedBeforeTrailingDispatch is the regression test for the
+// cubic P2 on PR #493: a context cancelled at end-of-stream must NOT dispatch
+// the trailing event. The data line "data: b\n" sets hasData, then the EOF
+// Read cancels the context; without the dispatch-time ctx check the trailing
+// emit would still invoke the callback for "b" and ScanEvents would return nil.
+// With the fix it returns context.Canceled and the callback is never entered.
+func TestScanEventsCtxCheckedBeforeTrailingDispatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &cancelOnEOFReader{data: []byte("data: b\n"), cancel: cancel}
+
+	var dispatched []string
+	err := ScanEvents(ctx, r, func(ev EventBytes) error {
+		dispatched = append(dispatched, string(ev.Data))
+		return nil
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if len(dispatched) != 0 {
+		t.Fatalf("trailing event dispatched after cancel: %v", dispatched)
+	}
+}
+
+// TestScanEventsNoDispatchAfterCallbackCancel verifies that when the callback
+// cancels the context mid-stream, no further event is dispatched and
+// ScanEvents returns the ctx error. Deterministic: all bytes are available up
+// front, so the parser would otherwise run straight through every event.
+func TestScanEventsNoDispatchAfterCallbackCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	body := "data: a\n\ndata: b\n\ndata: c\n\n"
+
+	var dispatched []string
+	err := ScanEvents(ctx, strings.NewReader(body), func(ev EventBytes) error {
+		dispatched = append(dispatched, string(ev.Data))
+		if string(ev.Data) == "a" {
+			cancel() // cancel mid-stream after the first event
+		}
+		return nil
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if len(dispatched) != 1 || dispatched[0] != "a" {
+		t.Fatalf("expected only [a] dispatched before cancel, got %v", dispatched)
+	}
+}
+
 // BenchmarkScanEventsParallel mirrors BenchmarkStreamParallel for the
 // synchronous callback path. The callback parses nothing durable — it only
 // touches the bytes — so the steady-state per-event allocation that Stream


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
Stage 4 (final) of the **#475** streaming-memory follow-up. Adds a BuildRequest-only **synchronous callback SSE parser** that avoids materializing a durable `Event.Data` string per frame.

Stages 1–3 made streaming net/http-only, the sseclient parser byte-level, and the unary response byte-oriented. This stage closes the loop: on the BuildRequest stream path the per-frame `Event.Data` allocation is eliminated entirely.

## What changed

**sseclient** — new `ScanEvents(ctx, r, EventFunc)` synchronous parser:
- Invokes a callback per event with `EventBytes` (byte views into reused, parser-owned scratch buffers). **No channel, no goroutine** — the callback runs inline before the next `scanner.Scan()`, so it may parse the data bytes in place without copying them into a durable string.
- Reused `type`/`data`/`id` buffers (truncated to `[:0]` at each event boundary) → steady-state **zero per-token allocation**.
- `ErrStopScan` halts parsing cleanly so a caller can abort for its own reason while tracking its own error.
- The public `Stream` channel API is **unchanged** and remains for all other consumers.

**sse** — `ExtractDeltaPartsFromBytes` (byte twin of `ExtractDeltaPartsFromText`):
- Both delegate to one `extractDeltaParts(provider, get, …)` via a `get(path) gjson.Result` closure (`gjson.GetBytes` vs `gjson.Get`), mirroring Stage 3's `ExtractResponseContentBytes`. `gjson.GetBytes` copies `Str`/`Raw` out, so nothing aliases the byte input past the call.

**llmhttp** — factored `ExecuteStream`'s connect logic into `openStream`; added `ExecuteStreamCallback` returning a `StreamCallback` whose `ForEach` drives `ScanEvents` synchronously and classifies the terminal error via a shared `classifyStreamErr` core (same semantics as `StreamResponse.Errc`).

**orchestrator** — `tryOneStreamChild`'s SSE consumption now uses the callback path (`ExecuteStreamCallback` + `ExtractDeltaPartsFromBytes`). Identical accumulation, partial-emission (drop-on-full / ctx-cancel / `sawStreamFrame`), error classification (#256 raw-carrying), and heartbeat timing to the channel path. The `aws-bedrock` and channel paths are untouched.

## Safety

The callback fully consumes the byte view before returning; nothing escapes the call. Everything retained — accumulated parseable/raw/reasoning — is copied out (gjson copies `Str`/`Raw`; `WriteString` copies into the builders). A `-race` test (`TestScanEventsBufferReuse`) demonstrates the scratch buffer is reused across events (proving why synchronous consumption + copy-out is mandatory).

## Golden parity

- `sseclient.TestScanEventsMatchesStream` — 14 SSE fixtures (multi-line data, typed events, ids, CRLF, comments, trailing-no-blank, [DONE]) produce identical events on both APIs.
- `sse.TestExtractDeltaPartsFromBytesMatchesString` — 22 provider fixtures × reasoning on/off, byte path == string path.
- `buildrequest.TestStreamCallbackParity_AllProviders` — same httptest SSE server consumed via channel+string and callback+bytes yields identical parseable/raw/reasoning across OpenAI, openai-compat (azure/ollama/openrouter), Anthropic (text + thinking on/off), OpenAI-Responses, Google/Vertex (incl. multi-part thought), reasoning on/off.
- `TestStreamCallbackParity_MidStreamTruncation` — both paths surface the same body-read error on chunked abort (`io.ErrUnexpectedEOF`).
- All pre-existing orchestrator streaming integration tests pass unchanged (they now exercise the callback path).

## Per-token alloc improvement

`BenchmarkScanEventsParallel` vs `BenchmarkStreamParallel/small_128B`, 1000 events:

| Path | allocs/op | B/op |
|---|---:|---:|
| channel `Stream` | 1006 | 130324 |
| synchronous `ScanEvents` | **2** | **183** |

The per-frame `Event.Data` allocation (~1 alloc/token) and its byte copy (~128 B/token here) are **fully eliminated** on the BuildRequest path — better than the design's "remove one of two per-token allocations" projection, because the data buffer is reused across events rather than re-allocated per frame.

## Validation

- `go build ./...`, `go vet` (clean on touched pkgs), `gofmt -l` clean.
- `go test -race ./bamlutils/llmhttp ./bamlutils/buildrequest ./bamlutils/sseclient ./bamlutils/sse` — all pass.
- `go build -o /tmp/wk ./cmd/worker/` — OK; `dynclient` module builds.
- No new non-test `.go` under embedded dirs (only edits to already-embedded files + new test files), so `embed.go` is unchanged and dynclient regen is not triggered. The generated `adapter.go` calls `RunStreamOrchestration` with its unchanged signature (references the API, not source text), so regen output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a synchronous callback-based SSE scanning API and improved byte-oriented delta extraction to support streaming more efficiently.

* **Performance**
  * Refined SSE streaming to reduce per-event overhead by processing events via callbacks and bytes-based parsing.

* **Bug Fixes**
  * Preserved reasoning-only frames when reasoning is enabled.
  * Improved streaming error handling so transport/parse failures report consistently.

* **Tests**
  * Added parity and truncation regression tests to confirm consistent behavior across streaming implementations and providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->