### PR TITLE
perf(llmhttp): consumer-managed borrowed unary response (#487, Stage 1)

### DIFF
--- a/bamlutils/buildrequest/call_orchestrator.go
+++ b/bamlutils/buildrequest/call_orchestrator.go
@@ -145,7 +145,7 @@ type ExtractResponseFunc func(provider string, responseBody string, includeReaso
 // ExtractResponseBytesFunc is the optional byte-oriented twin of
 // ExtractResponseFunc. When supplied it is used in place of
 // ExtractResponseFunc on transports that hand back caller-owned response
-// bytes (the net/http unary lane, where llmhttp.Response.BodyBytes is
+// bytes (the net/http unary lane, where llmhttp.Response.BodyBytes() is
 // non-nil), letting the extractor parse the body without forcing a
 // whole-body []byte->string copy (e.g. via gjson.GetBytes).
 //
@@ -162,9 +162,9 @@ type ExtractResponseBytesFunc func(provider string, body []byte, includeReasonin
 //  1. buildRequest(ctx, clientOverride) → llmhttp.Request
 //  2. httpClient.Execute(ctx, req, onSuccess) → llmhttp.Response
 //  3. extract(provider, body, includeReasoning) → parseable + raw + reasoning
-//     text — extractResponseBytes over resp.BodyBytes when supplied and the
+//     text — extractResponseBytes over resp.BodyBytes() when supplied and the
 //     transport returned owned bytes (net/http unary), else extractResponse
-//     over resp.Body (fasthttp unary, or no byte extractor injected)
+//     over resp.BodyString() (fasthttp unary, or no byte extractor injected)
 //  4. parseFinal(ctx, parseable) → typed result
 //  5. emit StreamResultKindFinal on channel
 //
@@ -343,13 +343,21 @@ func RunCallOrchestration(
 		if httpErr != nil {
 			return nil, httpErr
 		}
+		// Execute returns an OWNED response (its body is safe to hold for the
+		// life of resp; Release is a no-op here), so the extracted parseable/raw
+		// remain valid through parseFinal below and across the retry boundary.
+		// Release per the llmhttp borrow contract anyway — it is the canonical
+		// pattern and stays correct when Stage 2 switches this call site to
+		// ExecuteBorrowed (which will additionally copy raw/reasoning/error text
+		// before release).
+		defer resp.Release()
 
 		// Extractor routing. The byte path is taken ONLY when the transport
 		// handed back caller-owned bytes (net/http unary success →
-		// resp.BodyBytes != nil) AND the caller supplied a byte extractor;
-		// then we parse resp.BodyBytes directly (e.g. gjson.GetBytes),
+		// resp.BodyBytes() != nil) AND the caller supplied a byte extractor;
+		// then we parse those bytes directly (e.g. gjson.GetBytes),
 		// skipping the whole-body string copy. In every other case — the
-		// fasthttp unary lane (BodyBytes nil, Body an owned copy), or a
+		// fasthttp unary lane (BodyBytes() nil, BodyString() an owned copy), or a
 		// caller that injected only a string extractor — we run the injected
 		// extractResponse over the body. This keeps the injection seam
 		// consistent: a custom extractor is always honored on both lanes; the
@@ -358,10 +366,10 @@ func RunCallOrchestration(
 		// JSON by TestExtractResponseContentBytesMatchesString.
 		var parseable, raw, reasoning string
 		var extractErr error
-		if resp.BodyBytes != nil && extractResponseBytes != nil {
-			parseable, raw, reasoning, extractErr = extractResponseBytes(provider, resp.BodyBytes, config.IncludeReasoning)
+		if rb := resp.BodyBytes(); rb != nil && extractResponseBytes != nil {
+			parseable, raw, reasoning, extractErr = extractResponseBytes(provider, rb, config.IncludeReasoning)
 		} else {
-			parseable, raw, reasoning, extractErr = extractResponse(provider, resp.Body, config.IncludeReasoning)
+			parseable, raw, reasoning, extractErr = extractResponse(provider, resp.BodyString(), config.IncludeReasoning)
 		}
 		if extractErr != nil {
 			// Extraction failed before raw could be split out of the
@@ -374,7 +382,7 @@ func RunCallOrchestration(
 			// details.body via the existing provider_error classifier.
 			return nil, newRawError(
 				fmt.Errorf("buildrequest: failed to extract response content: %w", extractErr),
-				resp.Body,
+				resp.BodyString(),
 			)
 		}
 

--- a/bamlutils/buildrequest/call_orchestrator_test.go
+++ b/bamlutils/buildrequest/call_orchestrator_test.go
@@ -1602,7 +1602,8 @@ func TestRunCallOrchestration_MixedChain_HTTPBackedEndToEnd(t *testing.T) {
 		if err != nil {
 			return nil, "", "", err
 		}
-		raw := resp.Body
+		defer resp.Release()
+		raw := resp.BodyString()
 		if !needsRaw {
 			raw = ""
 		}

--- a/bamlutils/buildrequest/orchestrator_test.go
+++ b/bamlutils/buildrequest/orchestrator_test.go
@@ -1587,7 +1587,8 @@ func TestRunStreamOrchestration_MixedChain_HTTPBackedEndToEnd(t *testing.T) {
 		if err != nil {
 			return nil, "", "", err
 		}
-		raw := resp.Body
+		defer resp.Release()
+		raw := resp.BodyString()
 		if !needsRaw {
 			raw = ""
 		}

--- a/bamlutils/buildrequest/response_extract.go
+++ b/bamlutils/buildrequest/response_extract.go
@@ -56,7 +56,7 @@ func ExtractResponseContent(provider string, responseBody string, includeReasoni
 
 // ExtractResponseContentBytes is the byte-oriented twin of
 // ExtractResponseContent for the net/http unary path, where the response
-// body is available as caller-owned bytes (llmhttp.Response.BodyBytes).
+// body is available as caller-owned bytes (llmhttp.Response.BodyBytes()).
 // It validates and extracts via gjson.ValidBytes / gjson.GetBytes instead
 // of converting the whole body to a string first, eliminating the
 // whole-body []byte->string copy on the hot unary path.

--- a/bamlutils/llmhttp/awssigv4_e2e_test.go
+++ b/bamlutils/llmhttp/awssigv4_e2e_test.go
@@ -85,6 +85,7 @@ func TestEndpointOverride_E2E_NonStreaming(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
+	defer resp.Release()
 	if resp.StatusCode != 200 {
 		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
 	}

--- a/bamlutils/llmhttp/body_bytes_test.go
+++ b/bamlutils/llmhttp/body_bytes_test.go
@@ -129,13 +129,17 @@ func TestExecuteBorrowedContract(t *testing.T) {
 		}
 	})
 
-	// net/http lane: the body is already owned (Release is a no-op), but the
-	// borrow API still applies and BodyBytes is exposed.
+	// net/http lane: the body is already owned even via ExecuteBorrowed
+	// (borrowed()==false), so Release is a true no-op and the accessors stay
+	// valid afterward; BodyBytes is exposed.
 	t.Run("nethttp", func(t *testing.T) {
 		c := NewClientWithOptions(ClientOptions{Mode: ClientModeNetHTTP})
 		resp, err := c.ExecuteBorrowed(context.Background(), req, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.borrowed() {
+			t.Fatal("net/http lane must be owned, not borrowed")
 		}
 		if resp.BodyBytes() == nil {
 			t.Fatal("net/http unary success must populate BodyBytes")
@@ -144,9 +148,89 @@ func TestExecuteBorrowedContract(t *testing.T) {
 			t.Errorf("BodyString = %q, want %q", resp.BodyString(), responseJSON)
 		}
 		resp.Release()
-		if resp.BodyBytes() != nil {
-			t.Error("BodyBytes after Release must be nil")
+		// Owned: Release is a no-op for the accessors.
+		if string(resp.BodyBytes()) != responseJSON {
+			t.Errorf("owned BodyBytes after Release = %q, want %q", resp.BodyBytes(), responseJSON)
 		}
+	})
+}
+
+// TestReleaseOwnedVsBorrowed pins the owned/no-op vs borrowed Release contract:
+// Release must NOT invalidate an owned response's body (so `defer resp.Release()`
+// is safe for Execute / net/http results), but MUST return a borrowed
+// response's pooled storage and clear its now-dangling view.
+func TestReleaseOwnedVsBorrowed(t *testing.T) {
+	const responseJSON = `{"choices":[{"message":{"content":"Hello world"}}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, responseJSON)
+	}))
+	defer server.Close()
+	req := &Request{URL: server.URL, Method: "POST", Body: `{}`}
+
+	// Owned net/http Execute response: accessors stay valid after Release.
+	t.Run("owned-nethttp-survives-release", func(t *testing.T) {
+		c := NewClientWithOptions(ClientOptions{Mode: ClientModeNetHTTP})
+		resp, err := c.Execute(context.Background(), req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.borrowed() {
+			t.Fatal("Execute must return an owned response")
+		}
+		resp.Release()
+		resp.Release() // idempotent
+		if resp.BodyString() != responseJSON {
+			t.Errorf("owned BodyString after Release = %q, want %q", resp.BodyString(), responseJSON)
+		}
+		if string(resp.BodyBytes()) != responseJSON {
+			t.Errorf("owned BodyBytes after Release = %q, want %q", resp.BodyBytes(), responseJSON)
+		}
+	})
+
+	// Owned fasthttp Execute response (own() copied out of the pool): body still
+	// valid after Release, BodyBytes still nil (routing invariant).
+	t.Run("owned-fasthttp-survives-release", func(t *testing.T) {
+		c := withFastClient(t, server.Client())
+		resp, err := c.Execute(context.Background(), req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.borrowed() {
+			t.Fatal("Execute must return an owned response")
+		}
+		resp.Release()
+		if resp.BodyString() != responseJSON {
+			t.Errorf("owned BodyString after Release = %q, want %q", resp.BodyString(), responseJSON)
+		}
+		if resp.BodyBytes() != nil {
+			t.Error("fasthttp owned lane must keep BodyBytes nil")
+		}
+	})
+
+	// Borrowed fasthttp ExecuteBorrowed response: Release returns the pooled
+	// storage and clears the view; double-release stays safe.
+	t.Run("borrowed-fasthttp-releases-storage", func(t *testing.T) {
+		c := withFastClient(t, server.Client())
+		resp, err := c.ExecuteBorrowed(context.Background(), req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !resp.borrowed() {
+			t.Fatal("fasthttp ExecuteBorrowed must return a borrowed response")
+		}
+		if resp.BodyString() != responseJSON {
+			t.Errorf("borrowed BodyString = %q, want %q", resp.BodyString(), responseJSON)
+		}
+		resp.Release()
+		if resp.borrowed() {
+			t.Error("Release must clear borrowed pooled storage (fastResp/drainBuf)")
+		}
+		if resp.BodyString() != "" {
+			t.Errorf("borrowed BodyString after Release = %q, want empty", resp.BodyString())
+		}
+		resp.Release() // idempotent / double-release-safe
 	})
 }
 

--- a/bamlutils/llmhttp/body_bytes_test.go
+++ b/bamlutils/llmhttp/body_bytes_test.go
@@ -70,7 +70,8 @@ func TestExecuteNetHTTPPopulatesBodyBytes(t *testing.T) {
 // by ExecuteBorrowed across both fasthttp lanes and net/http: the body is
 // correct before Release, BodyBytes stays nil on the fasthttp lanes (extractor
 // routing invariant) and non-nil on net/http, Release is idempotent, and the
-// accessors fail closed (empty) after Release.
+// borrowed fasthttp accessors fail closed (empty) after Release while the owned
+// net/http response keeps its accessors valid (Release is a no-op for it).
 func TestExecuteBorrowedContract(t *testing.T) {
 	const responseJSON = `{"choices":[{"message":{"content":"Hello world"}}]}`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/bamlutils/llmhttp/body_bytes_test.go
+++ b/bamlutils/llmhttp/body_bytes_test.go
@@ -31,18 +31,19 @@ func TestExecuteNetHTTPPopulatesBodyBytes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if resp.BodyBytes == nil {
+		defer resp.Release()
+		if resp.BodyBytes() == nil {
 			t.Fatal("net/http unary success must populate BodyBytes")
 		}
-		if string(resp.BodyBytes) != responseJSON {
-			t.Errorf("BodyBytes = %q, want %q", resp.BodyBytes, responseJSON)
+		if string(resp.BodyBytes()) != responseJSON {
+			t.Errorf("BodyBytes = %q, want %q", resp.BodyBytes(), responseJSON)
 		}
-		if resp.Body != responseJSON {
-			t.Errorf("Body = %q, want %q", resp.Body, responseJSON)
+		if resp.BodyString() != responseJSON {
+			t.Errorf("Body = %q, want %q", resp.BodyString(), responseJSON)
 		}
-		// Body must be a zero-copy view over BodyBytes.
-		if unsafe.StringData(resp.Body) != unsafe.SliceData(resp.BodyBytes) {
-			t.Error("Body must alias BodyBytes backing array (zero-copy)")
+		// BodyString must be a zero-copy view over BodyBytes.
+		if unsafe.StringData(resp.BodyString()) != unsafe.SliceData(resp.BodyBytes()) {
+			t.Error("BodyString must alias BodyBytes backing array (zero-copy)")
 		}
 	})
 
@@ -52,16 +53,141 @@ func TestExecuteNetHTTPPopulatesBodyBytes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// fasthttp response storage is pooled/released, so its body is an
-		// owned copy and BodyBytes stays nil — the orchestrator falls back to
-		// the string extractor for this lane.
-		if resp.BodyBytes != nil {
-			t.Errorf("fasthttp lane must leave BodyBytes nil, got %d bytes", len(resp.BodyBytes))
+		defer resp.Release()
+		// The fasthttp lane leaves BodyBytes nil (exposeBytes=false) so the
+		// orchestrator falls back to the string extractor for this lane,
+		// regardless of borrow vs owned. Execute returns an owned copy here.
+		if resp.BodyBytes() != nil {
+			t.Errorf("fasthttp lane must leave BodyBytes nil, got %d bytes", len(resp.BodyBytes()))
 		}
-		if resp.Body != responseJSON {
-			t.Errorf("Body = %q, want %q", resp.Body, responseJSON)
+		if resp.BodyString() != responseJSON {
+			t.Errorf("Body = %q, want %q", resp.BodyString(), responseJSON)
 		}
 	})
+}
+
+// TestExecuteBorrowedContract exercises the consumer-managed borrow returned
+// by ExecuteBorrowed across both fasthttp lanes and net/http: the body is
+// correct before Release, BodyBytes stays nil on the fasthttp lanes (extractor
+// routing invariant) and non-nil on net/http, Release is idempotent, and the
+// accessors fail closed (empty) after Release.
+func TestExecuteBorrowedContract(t *testing.T) {
+	const responseJSON = `{"choices":[{"message":{"content":"Hello world"}}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, responseJSON)
+	}))
+	defer server.Close()
+	req := &Request{URL: server.URL, Method: "POST", Body: `{}`}
+
+	// fasthttp buffered lane: background ctx + nil onSuccess.
+	t.Run("fasthttp-buffered", func(t *testing.T) {
+		c := withFastClient(t, server.Client())
+		resp, err := c.ExecuteBorrowed(context.Background(), req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.BodyBytes() != nil {
+			t.Errorf("fasthttp borrow must keep BodyBytes nil, got %d bytes", len(resp.BodyBytes()))
+		}
+		if resp.BodyString() != responseJSON {
+			t.Errorf("BodyString = %q, want %q", resp.BodyString(), responseJSON)
+		}
+		resp.Release()
+		resp.Release() // idempotent
+		if resp.BodyString() != "" {
+			t.Errorf("BodyString after Release = %q, want empty", resp.BodyString())
+		}
+		if resp.BodyBytes() != nil {
+			t.Error("BodyBytes after Release must be nil")
+		}
+	})
+
+	// fasthttp streamed-header lane: non-nil onSuccess selects it.
+	t.Run("fasthttp-streamed", func(t *testing.T) {
+		c := withFastClient(t, server.Client())
+		var fired bool
+		resp, err := c.ExecuteBorrowed(context.Background(), req, func() { fired = true })
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !fired {
+			t.Error("onSuccess should have fired on the streamed lane")
+		}
+		if resp.BodyBytes() != nil {
+			t.Errorf("fasthttp borrow must keep BodyBytes nil, got %d bytes", len(resp.BodyBytes()))
+		}
+		if resp.BodyString() != responseJSON {
+			t.Errorf("BodyString = %q, want %q", resp.BodyString(), responseJSON)
+		}
+		if err := resp.Close(); err != nil {
+			t.Errorf("Close returned %v, want nil", err)
+		}
+		if resp.BodyString() != "" {
+			t.Errorf("BodyString after Close = %q, want empty", resp.BodyString())
+		}
+	})
+
+	// net/http lane: the body is already owned (Release is a no-op), but the
+	// borrow API still applies and BodyBytes is exposed.
+	t.Run("nethttp", func(t *testing.T) {
+		c := NewClientWithOptions(ClientOptions{Mode: ClientModeNetHTTP})
+		resp, err := c.ExecuteBorrowed(context.Background(), req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.BodyBytes() == nil {
+			t.Fatal("net/http unary success must populate BodyBytes")
+		}
+		if resp.BodyString() != responseJSON {
+			t.Errorf("BodyString = %q, want %q", resp.BodyString(), responseJSON)
+		}
+		resp.Release()
+		if resp.BodyBytes() != nil {
+			t.Error("BodyBytes after Release must be nil")
+		}
+	})
+}
+
+// TestExecuteOwnedSurvivesPoolReuse pins the safe-default contract: the owned
+// Response returned by Execute on the fasthttp buffered lane keeps a valid body
+// even after subsequent requests churn the fasthttp response pool — i.e. own()
+// really copied out of the pooled buffer rather than aliasing it.
+func TestExecuteOwnedSurvivesPoolReuse(t *testing.T) {
+	const responseJSON = `{"choices":[{"message":{"content":"Hello world"}}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, responseJSON)
+	}))
+	defer server.Close()
+	req := &Request{URL: server.URL, Method: "POST", Body: `{}`}
+
+	c := withFastClient(t, server.Client())
+	resp, err := c.Execute(context.Background(), req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Release()
+	owned := resp.BodyString()
+
+	// Churn the pool: many more requests whose responses recycle the same
+	// pooled fasthttp.Response buffers the first owned copy was taken from.
+	for i := 0; i < 50; i++ {
+		r2, err := c.ExecuteBorrowed(context.Background(), req, nil)
+		if err != nil {
+			t.Fatalf("churn request %d failed: %v", i, err)
+		}
+		r2.Release()
+	}
+
+	if owned != responseJSON {
+		t.Errorf("owned body corrupted by pool reuse: %q, want %q", owned, responseJSON)
+	}
+	if resp.BodyString() != responseJSON {
+		t.Errorf("owned BodyString corrupted by pool reuse: %q, want %q", resp.BodyString(), responseJSON)
+	}
 }
 
 // TestBytesToBodyStringZeroCopy proves the net/http unary success path no

--- a/bamlutils/llmhttp/fast_backend.go
+++ b/bamlutils/llmhttp/fast_backend.go
@@ -81,11 +81,15 @@ func fastDeadline(ctx context.Context) time.Time {
 func (c *Client) executeFastBuffered(ctx context.Context, req *Request, rewrittenURL string, hc *fasthttp.HostClient) (*Response, error) {
 	fReq := fasthttp.AcquireRequest()
 	fResp := fasthttp.AcquireResponse()
+	// The request is never borrowed past Do, so release it promptly. The
+	// response, by contrast, is NOT released with a defer: on success it backs
+	// the borrowed Response and is released by Response.Release; every error
+	// path below releases it explicitly before returning.
 	defer fasthttp.ReleaseRequest(fReq)
-	defer fasthttp.ReleaseResponse(fResp)
 	buildFastRequest(fReq, req, rewrittenURL)
 
 	if err := hc.DoDeadline(fReq, fResp, fastDeadline(ctx)); err != nil {
+		fasthttp.ReleaseResponse(fResp)
 		if errors.Is(err, fasthttp.ErrBodyTooLarge) {
 			// Body exceeded the OOM backstop (maxBufferedResponseBackstop),
 			// well above MaxResponseBodyBytes. We can't read status, so report
@@ -107,13 +111,16 @@ func (c *Client) executeFastBuffered(ctx context.Context, req *Request, rewritte
 	// matching the net/http and streamed error-body policy. The buffered host's
 	// MaxResponseBodySize is only an OOM backstop, so a non-2xx body larger
 	// than MaxResponseBodyBytes still reaches here and is capped (preserving
-	// the error contract — see B2 / maxBufferedResponseBackstop).
+	// the error contract — see B2 / maxBufferedResponseBackstop). The body is
+	// copied into the error (small/capped), so the response is released here.
 	if status < 200 || status >= 300 {
 		body := fResp.Body()
 		if len(body) > MaxErrorBodyBytes {
 			body = body[:MaxErrorBodyBytes]
 		}
-		return nil, &HTTPError{StatusCode: status, Body: string(body)}
+		httpErr := &HTTPError{StatusCode: status, Body: string(body)}
+		fasthttp.ReleaseResponse(fResp)
+		return nil, httpErr
 	}
 
 	// Success: enforce the real MaxResponseBodyBytes limit in code (strictly
@@ -123,14 +130,22 @@ func (c *Client) executeFastBuffered(ctx context.Context, req *Request, rewritte
 	// truncated.
 	body := fResp.Body()
 	if len(body) > MaxResponseBodyBytes {
+		fasthttp.ReleaseResponse(fResp)
 		return nil, fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", MaxResponseBodyBytes)
 	}
 
-	// onSuccess is nil in this lane by construction (executeFast gates on it).
+	// Success borrow: body aliases fResp.Body(), valid until Response.Release
+	// returns fResp to the pool. fResp's StreamResponseBody=false means the
+	// connection was already read and released before DoDeadline returned, so
+	// holding fResp here pins only the pooled response buffer, not the conn.
+	// BodyBytes stays unexposed (exposeBytes=false) so the orchestrator keeps
+	// routing the fasthttp lane through the string extractor. onSuccess is nil
+	// in this lane by construction (executeFast gates on it).
 	return &Response{
 		StatusCode: status,
 		Headers:    fastHeadersToHTTP(&fResp.Header),
-		Body:       string(body),
+		body:       body,
+		fastResp:   fResp,
 	}, nil
 }
 
@@ -224,15 +239,23 @@ func (c *Client) executeFastStreamed(ctx context.Context, req *Request, rewritte
 		onSuccess()
 	}
 
-	body, err := drainFastBodyLimited(ctx, fResp, MaxResponseBodyBytes)
+	buf, err := drainFastBodyLimited(ctx, fResp, MaxResponseBodyBytes)
 	if err != nil {
 		return nil, err
 	}
 
+	// The drained body lives in the pooled buf, independent of fResp — so the
+	// deferred ReleaseRequest/ReleaseResponse above can return fResp to the pool
+	// on function return (the connection was already drained to EOF and released
+	// by drainFastBodyLimited's CloseBodyStream). The borrowed Response holds
+	// only buf; Response.Release returns it to fastBodyBufPool. Headers are
+	// converted here, before the defers run. BodyBytes stays unexposed so the
+	// orchestrator keeps routing this lane through the string extractor.
 	return &Response{
 		StatusCode: status,
 		Headers:    fastHeadersToHTTP(&fResp.Header),
-		Body:       body,
+		body:       buf.Bytes(),
+		drainBuf:   buf,
 	}, nil
 }
 
@@ -329,6 +352,18 @@ var fastBodyBufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
 // retained footprint bounded.
 const maxPooledFastBody = 1 << 20
 
+// returnFastBodyBuf returns a drain buffer to fastBodyBufPool, dropping it when
+// oversized so an occasional large body cannot pin large memory in the pool. It
+// is idempotent against nil. On the streamed unary success path this runs from
+// Response.Release (the consumer-managed borrow), NOT before return, so the
+// borrowed buf.Bytes() stays valid until the consumer is done; on the drain
+// error/oversize paths it runs immediately since no borrow is handed out.
+func returnFastBodyBuf(buf *bytes.Buffer) {
+	if buf != nil && buf.Cap() <= maxPooledFastBody {
+		fastBodyBufPool.Put(buf)
+	}
+}
+
 // drainFastBodyLimited reads a streamed unary response body up to maxBytes,
 // synchronously (no per-request goroutine). It drains BodyStream into a pooled
 // scratch buffer with a maxBytes+1 limit so a body exceeding the cap is
@@ -342,25 +377,29 @@ const maxPooledFastBody = 1 << 20
 // having no real mid-flight abort. awaitCtxIfPastDeadline still normalises a
 // deadline-race error to ctx.Err() so downstream cancellation suppression stays
 // consistent.
-func drainFastBodyLimited(ctx context.Context, resp *fasthttp.Response, maxBytes int) (string, error) {
+//
+// On success it returns a pooled *bytes.Buffer whose Bytes() back the borrowed
+// response body; the caller hands ownership to Response.Release (which calls
+// returnFastBodyBuf). On every error path it returns the buffer to the pool
+// itself and returns a nil buffer, so no borrow ever escapes a failed drain.
+func drainFastBodyLimited(ctx context.Context, resp *fasthttp.Response, maxBytes int) (*bytes.Buffer, error) {
+	buf := fastBodyBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+
 	stream := resp.BodyStream()
 	if stream == nil {
 		// Body already buffered (defensive — the streaming host should always
-		// yield a stream). One copy, with the same strictly-greater cap check.
+		// yield a stream). Copy into the pooled buffer (the fasthttp response is
+		// released by executeFastStreamed on return, so we cannot alias it),
+		// with the same strictly-greater cap check.
 		body := resp.Body()
 		if len(body) > maxBytes {
-			return "", fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", maxBytes)
+			returnFastBodyBuf(buf)
+			return nil, fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", maxBytes)
 		}
-		return string(body), nil
+		buf.Write(body)
+		return buf, nil
 	}
-
-	buf := fastBodyBufPool.Get().(*bytes.Buffer)
-	buf.Reset()
-	defer func() {
-		if buf.Cap() <= maxPooledFastBody {
-			fastBodyBufPool.Put(buf)
-		}
-	}()
 
 	// LimitReader caps at maxBytes+1. If the body is <= maxBytes the underlying
 	// stream reaches EOF and the connection is clean → poolable. If we stop at
@@ -369,27 +408,29 @@ func drainFastBodyLimited(ctx context.Context, resp *fasthttp.Response, maxBytes
 	// that pooled conn would read leftover garbage (B1).
 	_, err := buf.ReadFrom(io.LimitReader(stream, int64(maxBytes)+1))
 	if err != nil {
+		returnFastBodyBuf(buf)
 		closeFastConnDiscard(resp)
 		// fasthttp's per-conn SetDeadline (installed by DoDeadline) can fire a
 		// tick ahead of the Go ctx timer. If we're past the deadline, wait
 		// briefly for the ctx timer to land and surface ctx.Err() so the
 		// orchestrator's trySend cancellation suppression stays consistent.
 		if ctxErr := awaitCtxIfPastDeadline(ctx); ctxErr != nil {
-			return "", ctxErr
+			return nil, ctxErr
 		}
 		if te := classifyTransportErr(err, "llmhttp: failed to read response body", false); te != nil {
-			return "", te
+			return nil, te
 		}
-		return "", fmt.Errorf("llmhttp: failed to read response body: %w", err)
+		return nil, fmt.Errorf("llmhttp: failed to read response body: %w", err)
 	}
 	if buf.Len() > maxBytes {
 		// Oversize: we stopped before EOF, so the conn is dirty — discard it.
+		returnFastBodyBuf(buf)
 		closeFastConnDiscard(resp)
-		return "", fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", maxBytes)
+		return nil, fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", maxBytes)
 	}
 	// Full body read to EOF: the connection is clean and can return to the pool.
 	_ = resp.CloseBodyStream()
-	return buf.String(), nil
+	return buf, nil
 }
 
 // closeFastConnDiscard closes a streamed fasthttp response body in a way that

--- a/bamlutils/llmhttp/fast_backend_test.go
+++ b/bamlutils/llmhttp/fast_backend_test.go
@@ -39,11 +39,12 @@ func TestFastExecute_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Release()
 	if resp.StatusCode != 200 {
 		t.Errorf("status %d, want 200", resp.StatusCode)
 	}
-	if resp.Body != responseJSON {
-		t.Errorf("body %q, want %q", resp.Body, responseJSON)
+	if resp.BodyString() != responseJSON {
+		t.Errorf("body %q, want %q", resp.BodyString(), responseJSON)
 	}
 	if resp.Headers.Get("Content-Type") != "application/json" {
 		t.Errorf("Content-Type missing or wrong: %q", resp.Headers.Get("Content-Type"))

--- a/bamlutils/llmhttp/llmhttp.go
+++ b/bamlutils/llmhttp/llmhttp.go
@@ -178,6 +178,14 @@ func (r *Response) Release() {
 		return
 	}
 	r.released = true
+	// Owned responses (net/http, or a copy produced by Execute) hold no pooled
+	// storage, so Release is a true no-op for them: leave body / exposeBytes
+	// intact so a `defer resp.Release()` does not invalidate an owned body. Only
+	// a genuinely borrowed response returns its pooled storage and clears the
+	// now-dangling body view.
+	if !r.borrowed() {
+		return
+	}
 	r.body = nil
 	if r.fastResp != nil {
 		fasthttp.ReleaseResponse(r.fastResp)

--- a/bamlutils/llmhttp/llmhttp.go
+++ b/bamlutils/llmhttp/llmhttp.go
@@ -9,6 +9,7 @@
 package llmhttp
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -22,6 +23,8 @@ import (
 	"sync/atomic"
 	"time"
 	"unsafe"
+
+	"github.com/valyala/fasthttp"
 
 	"github.com/invakid404/baml-rest/bamlutils/sseclient"
 	"github.com/invakid404/baml-rest/bamlutils/urlrewrite"
@@ -78,6 +81,24 @@ func (s *StreamResponse) Close() {
 
 // Response represents a completed non-streaming HTTP response from an LLM
 // provider. Unlike StreamResponse, the full body has already been read.
+//
+// # Lifetime / borrow contract
+//
+// A Response can hold a body that BORROWS pooled transport storage (the
+// fasthttp response buffer, or a pooled drain buffer). Such a Response is
+// produced only by Client.ExecuteBorrowed; the body accessors (BodyString /
+// BodyBytes) then return data that is valid ONLY until Release/Close is
+// called, after which the storage returns to its pool and may be overwritten.
+// The consumer MUST call Release (typically `defer resp.Release()`) and MUST
+// NOT retain any returned string/[]byte past that point. Anything that must
+// outlive the response — raw/reasoning text crossing a retry boundary, an
+// error diagnostic — must be copied before Release.
+//
+// Client.Execute (the default) never returns a borrow: its body is an owned
+// copy (net/http already owns its io.ReadAll buffer; the fasthttp lanes are
+// materialized into an owned copy before return), so the accessors stay valid
+// for the life of the value and Release is a harmless no-op. External callers
+// that do not want to manage a borrow should use Execute.
 type Response struct {
 	// StatusCode is the HTTP response status code.
 	StatusCode int
@@ -85,22 +106,117 @@ type Response struct {
 	// Headers are the HTTP response headers.
 	Headers http.Header
 
-	// Body is the complete response body as a string.
-	//
-	// On the net/http unary path Body is a zero-copy view over BodyBytes
-	// (see bytesToBodyString): the two share the same backing array, so
-	// callers MUST NOT mutate BodyBytes while Body is in use. On the
-	// fasthttp unary path Body is an owned copy of the (pooled) fasthttp
-	// response body and BodyBytes is nil.
-	Body string
+	// body is the complete response body bytes. On owned responses (Execute,
+	// or the net/http lane) it is valid for the life of the Response; on a
+	// borrowed response (ExecuteBorrowed fasthttp lanes) it aliases pooled
+	// storage and is valid only until Release/Close. Stored privately so
+	// Release can invalidate it — a stale exported field would be a
+	// use-after-release footgun.
+	body []byte
 
-	// BodyBytes is the complete response body as caller-owned bytes,
-	// populated only on the net/http unary success path where io.ReadAll
-	// already returns a fresh, owned []byte. It lets callers parse the
-	// body without forcing a whole-body []byte->string copy (e.g. via
-	// gjson.GetBytes). Nil on the fasthttp unary path and on error/stream
-	// responses. Treat as read-only: Body aliases this backing array.
-	BodyBytes []byte
+	// exposeBytes reports whether BodyBytes returns body or nil. It is true
+	// only on the net/http unary lane, where io.ReadAll already owns a fresh
+	// []byte; the fasthttp lanes leave it false so BodyBytes stays nil and the
+	// orchestrator keeps routing them through the string extractor (the
+	// per-backend extractor-routing invariant, see body_bytes_test.go). This
+	// is independent of borrow vs owned.
+	exposeBytes bool
+
+	// fastResp / drainBuf hold the pooled transport storage backing body on a
+	// borrowed response; Release returns it to its pool. At most one is
+	// non-nil. Both nil means the body is owned (the net/http lane, or a copy
+	// produced by Execute) and Release is a no-op. These are concrete fields
+	// rather than a release closure so ExecuteBorrowed allocates nothing per
+	// request beyond the Response itself — the point of the borrow is to drop
+	// the full-body copy, not trade it for a closure.
+	fastResp *fasthttp.Response // buffered fast lane: fasthttp.ReleaseResponse
+	drainBuf *bytes.Buffer      // streamed fast lane: returnFastBodyBuf
+
+	// released guards Release/Close against double-free and makes the
+	// accessors fail closed (empty) after release.
+	released bool
+}
+
+// borrowed reports whether r holds pooled storage that Release must return.
+func (r *Response) borrowed() bool {
+	return r != nil && (r.fastResp != nil || r.drainBuf != nil)
+}
+
+// BodyString returns the complete response body as a string. It is a
+// zero-copy view over the body bytes (see bytesToBodyString), so callers MUST
+// NOT mutate the body while the string is in use. On a borrowed response
+// (ExecuteBorrowed) the returned string is valid only until Release/Close;
+// on an owned response (Execute) it is valid for the life of the Response.
+func (r *Response) BodyString() string {
+	if r == nil {
+		return ""
+	}
+	return bytesToBodyString(r.body)
+}
+
+// BodyBytes returns the complete response body as bytes on the net/http unary
+// lane (where io.ReadAll already owns a fresh []byte), or nil on the fasthttp
+// lanes and on a released response. The orchestrator branches on a non-nil
+// BodyBytes to select the byte extractor, so this per-backend contract must
+// hold. Treat as read-only: BodyString aliases the same backing array. On a
+// borrowed response the slice is valid only until Release/Close.
+func (r *Response) BodyBytes() []byte {
+	if r == nil || !r.exposeBytes {
+		return nil
+	}
+	return r.body
+}
+
+// Release returns any pooled storage backing the response body to its pool and
+// invalidates BodyString/BodyBytes (they return empty/nil afterwards). It is
+// idempotent and always safe to call, including on owned responses (where it
+// is a no-op) and on nil. Callers of ExecuteBorrowed MUST call it; the
+// canonical pattern is `defer resp.Release()` immediately after the error
+// check.
+func (r *Response) Release() {
+	if r == nil || r.released {
+		return
+	}
+	r.released = true
+	r.body = nil
+	if r.fastResp != nil {
+		fasthttp.ReleaseResponse(r.fastResp)
+		r.fastResp = nil
+	}
+	if r.drainBuf != nil {
+		returnFastBodyBuf(r.drainBuf)
+		r.drainBuf = nil
+	}
+}
+
+// Close is an io.Closer-style alias for Release; it always returns nil. It
+// lets a Response satisfy `func() error` close-on-defer call sites.
+func (r *Response) Close() error {
+	r.Release()
+	return nil
+}
+
+// own returns an owned copy of r with any borrowed pooled storage released, so
+// the result is safe to hold indefinitely. For an already-owned response (the
+// net/http lane, or a body Execute already copied) it returns r unchanged. For
+// a borrowed response it copies the body into a fresh caller-owned []byte,
+// releases the borrow, and returns a new owned Response preserving
+// StatusCode/Headers and the exposeBytes routing flag. This backs the safe
+// Client.Execute path; ExecuteBorrowed skips it.
+func (r *Response) own() *Response {
+	if !r.borrowed() {
+		return r
+	}
+	owned := make([]byte, len(r.body))
+	copy(owned, r.body)
+	out := &Response{
+		StatusCode:  r.StatusCode,
+		Headers:     r.Headers,
+		body:        owned,
+		exposeBytes: r.exposeBytes,
+	}
+	r.Release()
+	return out
 }
 
 // bytesToBodyString returns a string that shares body's backing array
@@ -649,7 +765,40 @@ const DefaultCallTimeout = 5 * time.Minute
 // available.
 //
 // On error (non-2xx status, connection failure, timeout), an error is returned.
+//
+// The returned Response is OWNED: its body is safe to hold indefinitely and
+// Release is a no-op (see Response's lifetime contract). Callers on the hot
+// path that can release promptly should prefer ExecuteBorrowed to avoid the
+// extra owned copy on the fasthttp lanes.
 func (c *Client) Execute(ctx context.Context, req *Request, onSuccess func()) (*Response, error) {
+	resp, err := c.executeBorrow(ctx, req, onSuccess)
+	if err != nil {
+		return nil, err
+	}
+	// Materialize an owned copy so external/non-borrow callers never have to
+	// manage a pooled-buffer lifetime. own() is free on the net/http lane.
+	return resp.own(), nil
+}
+
+// ExecuteBorrowed behaves exactly like Execute but returns a BORROWED Response
+// on the fasthttp lanes: the body accessors alias pooled transport storage and
+// are valid only until Release/Close. This removes the self-inflicted
+// full-body copy the fasthttp buffered lane otherwise pays (wire→fasthttp
+// buffer, then a second copy into an owned string). The consumer MUST call
+// Release when done and MUST copy anything that has to outlive the response
+// before releasing. See Response's lifetime contract.
+//
+// The net/http lane and error responses are unaffected — their bodies are
+// already owned (Release is a no-op there), so the borrow is opt-in only for
+// the lane where it actually saves a copy.
+func (c *Client) ExecuteBorrowed(ctx context.Context, req *Request, onSuccess func()) (*Response, error) {
+	return c.executeBorrow(ctx, req, onSuccess)
+}
+
+// executeBorrow is the shared unary dispatch core. It returns the body in its
+// natural per-lane form, which may borrow pooled storage (fasthttp); Execute
+// wraps it with own() for the safe path, ExecuteBorrowed returns it directly.
+func (c *Client) executeBorrow(ctx context.Context, req *Request, onSuccess func()) (*Response, error) {
 	if c == nil || c.httpClient == nil {
 		return nil, fmt.Errorf("llmhttp: nil client")
 	}
@@ -754,15 +903,16 @@ func (c *Client) Execute(ctx context.Context, req *Request, onSuccess func()) (*
 		return nil, fmt.Errorf("llmhttp: response body exceeds maximum size (%d bytes)", MaxResponseBodyBytes)
 	}
 
-	// Expose the io.ReadAll buffer as caller-owned BodyBytes and present
-	// Body as a zero-copy view over it. This drops the whole-body
-	// []byte->string copy on the hot unary path; downstream extraction
-	// reads BodyBytes directly via gjson.GetBytes (see buildrequest).
+	// The io.ReadAll buffer is already a fresh, caller-owned []byte, so this
+	// lane is "borrowed" only nominally: release is nil (nothing to free) and
+	// BodyBytes is exposed so downstream extraction reads it directly via
+	// gjson.GetBytes (see buildrequest), with BodyString a zero-copy view over
+	// it. own() therefore returns it unchanged for the safe Execute path.
 	return &Response{
-		StatusCode: resp.StatusCode,
-		Headers:    resp.Header,
-		Body:       bytesToBodyString(body),
-		BodyBytes:  body,
+		StatusCode:  resp.StatusCode,
+		Headers:     resp.Header,
+		body:        body,
+		exposeBytes: true,
 	}, nil
 }
 

--- a/bamlutils/llmhttp/llmhttp_after_bench_test.go
+++ b/bamlutils/llmhttp/llmhttp_after_bench_test.go
@@ -42,12 +42,15 @@ func wrappedFastBufferedDriver(_ testing.TB, m *mockServer) controlDoFunc {
 	req := m.request()
 	ctx := context.Background()
 	return func() error {
-		resp, err := client.Execute(ctx, req, nil)
+		resp, err := client.ExecuteBorrowed(ctx, req, nil)
 		if err != nil {
 			return err
 		}
-		if resp.Body != m.body {
-			return fmt.Errorf("wf-buffered: body mismatch (%d vs %d bytes)", len(resp.Body), len(m.body))
+		ok := resp.BodyString() == m.body
+		got := len(resp.BodyString())
+		resp.Release()
+		if !ok {
+			return fmt.Errorf("wf-buffered: body mismatch (%d vs %d bytes)", got, len(m.body))
 		}
 		return nil
 	}
@@ -65,12 +68,15 @@ func wrappedFastStreamedDriver(tb testing.TB, m *mockServer) controlDoFunc {
 	// per-request atomic overhead to the measured lane.
 	onSuccess := func() {}
 	return func() error {
-		resp, err := client.Execute(ctx, req, onSuccess)
+		resp, err := client.ExecuteBorrowed(ctx, req, onSuccess)
 		if err != nil {
 			return err
 		}
-		if resp.Body != m.body {
-			return fmt.Errorf("wf-streamed: body mismatch (%d vs %d bytes)", len(resp.Body), len(m.body))
+		ok := resp.BodyString() == m.body
+		got := len(resp.BodyString())
+		resp.Release()
+		if !ok {
+			return fmt.Errorf("wf-streamed: body mismatch (%d vs %d bytes)", got, len(m.body))
 		}
 		return nil
 	}

--- a/bamlutils/llmhttp/llmhttp_bench_test.go
+++ b/bamlutils/llmhttp/llmhttp_bench_test.go
@@ -181,10 +181,11 @@ func warmup(tb testing.TB, client *Client, m *mockServer, conc int) {
 					failed.Store(true)
 					return
 				}
-				if resp.Body != m.body {
-					tb.Errorf("warmup body mismatch: got %d bytes, want %d", len(resp.Body), len(m.body))
+				if resp.BodyString() != m.body {
+					tb.Errorf("warmup body mismatch: got %d bytes, want %d", len(resp.BodyString()), len(m.body))
 					failed.Store(true)
 				}
+				resp.Release()
 			}()
 		}
 		wg.Wait()
@@ -252,14 +253,20 @@ func BenchmarkExecute(b *testing.B) {
 							defer wg.Done()
 							req := m.request()
 							for atomic.AddInt64(&remaining, -1) >= 0 {
-								resp, err := client.Execute(ctx, req, nil)
+								// ExecuteBorrowed exercises the consumer-managed
+								// borrow lane this benchmark exists to measure: on
+								// fasthttp the buffered/streamed body is borrowed
+								// (no owned copy) and freed by Release. BodyString
+								// is a zero-copy view valid until Release.
+								resp, err := client.ExecuteBorrowed(ctx, req, nil)
 								if err != nil {
 									errCount.Add(1)
 									continue
 								}
-								if resp.Body != m.body {
+								if resp.BodyString() != m.body {
 									errCount.Add(1)
 								}
+								resp.Release()
 							}
 						}()
 					}
@@ -329,16 +336,17 @@ func runLoad(tb testing.TB, client *Client, m *mockServer, bc backendCase, size 
 					return
 				}
 				t0 := time.Now()
-				resp, err := client.Execute(ctx, req, nil)
+				resp, err := client.ExecuteBorrowed(ctx, req, nil)
 				lat := time.Since(t0)
 				latencies[i] = lat
 				if err != nil {
 					errCount.Add(1)
 					continue
 				}
-				if resp.Body != m.body {
+				if resp.BodyString() != m.body {
 					errCount.Add(1)
 				}
+				resp.Release()
 			}
 		}()
 	}

--- a/bamlutils/llmhttp/llmhttp_control_bench_test.go
+++ b/bamlutils/llmhttp/llmhttp_control_bench_test.go
@@ -159,12 +159,15 @@ func wrappedDriver(mode ClientMode, m *mockServer) controlDoFunc {
 	req := m.request()
 	ctx := context.Background()
 	return func() error {
-		resp, err := client.Execute(ctx, req, nil)
+		resp, err := client.ExecuteBorrowed(ctx, req, nil)
 		if err != nil {
 			return err
 		}
-		if resp.Body != m.body {
-			return fmt.Errorf("wrapped: body mismatch (%d vs %d bytes)", len(resp.Body), len(m.body))
+		ok := resp.BodyString() == m.body
+		got := len(resp.BodyString())
+		resp.Release()
+		if !ok {
+			return fmt.Errorf("wrapped: body mismatch (%d vs %d bytes)", got, len(m.body))
 		}
 		return nil
 	}

--- a/bamlutils/llmhttp/llmhttp_test.go
+++ b/bamlutils/llmhttp/llmhttp_test.go
@@ -413,12 +413,13 @@ func TestExecuteSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Release()
 
 	if resp.StatusCode != 200 {
 		t.Errorf("expected status 200, got %d", resp.StatusCode)
 	}
-	if resp.Body != responseJSON {
-		t.Errorf("expected body %q, got %q", responseJSON, resp.Body)
+	if resp.BodyString() != responseJSON {
+		t.Errorf("expected body %q, got %q", responseJSON, resp.BodyString())
 	}
 	if resp.Headers.Get("Content-Type") != "application/json" {
 		t.Errorf("expected Content-Type application/json, got %q", resp.Headers.Get("Content-Type"))
@@ -600,8 +601,9 @@ func TestExecuteNilContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected nil context to be handled gracefully, got error: %v", err)
 	}
-	if resp.Body != `{"ok":true}` {
-		t.Errorf("unexpected body: %q", resp.Body)
+	defer resp.Release()
+	if resp.BodyString() != `{"ok":true}` {
+		t.Errorf("unexpected body: %q", resp.BodyString())
 	}
 }
 
@@ -640,8 +642,9 @@ func TestExecuteEmptyBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if resp.Body != `{"result":"ok"}` {
-		t.Errorf("unexpected body: %q", resp.Body)
+	defer resp.Release()
+	if resp.BodyString() != `{"result":"ok"}` {
+		t.Errorf("unexpected body: %q", resp.BodyString())
 	}
 }
 
@@ -689,8 +692,9 @@ func TestExecuteExactlyAtLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error for body at limit: %v", err)
 	}
-	if len(resp.Body) != MaxResponseBodyBytes {
-		t.Errorf("expected body length %d, got %d", MaxResponseBodyBytes, len(resp.Body))
+	defer resp.Release()
+	if len(resp.BodyString()) != MaxResponseBodyBytes {
+		t.Errorf("expected body length %d, got %d", MaxResponseBodyBytes, len(resp.BodyString()))
 	}
 }
 
@@ -766,8 +770,9 @@ func TestExecuteDefaultTimeoutInjected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if resp.Body != `{"ok":true}` {
-		t.Errorf("unexpected body: %q", resp.Body)
+	defer resp.Release()
+	if resp.BodyString() != `{"ok":true}` {
+		t.Errorf("unexpected body: %q", resp.BodyString())
 	}
 
 	if !capture.hasDeadline {
@@ -813,8 +818,9 @@ func TestExecuteCallerDeadlinePreserved(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if resp.Body != `{"ok":true}` {
-		t.Errorf("unexpected body: %q", resp.Body)
+	defer resp.Release()
+	if resp.BodyString() != `{"ok":true}` {
+		t.Errorf("unexpected body: %q", resp.BodyString())
 	}
 
 	if !capture.hasDeadline {
@@ -852,11 +858,12 @@ func TestExecuteOnSuccessCallbackFired(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Release()
 	if !called {
 		t.Fatal("onSuccess callback was not fired on 2xx response")
 	}
-	if resp.Body != `{"ok":true}` {
-		t.Errorf("unexpected body: %q", resp.Body)
+	if resp.BodyString() != `{"ok":true}` {
+		t.Errorf("unexpected body: %q", resp.BodyString())
 	}
 }
 
@@ -895,8 +902,9 @@ func TestExecuteOnSuccessFiresBeforeBodyRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if resp.Body != `{"ok":true}` {
-		t.Errorf("unexpected body: %q", resp.Body)
+	defer resp.Release()
+	if resp.BodyString() != `{"ok":true}` {
+		t.Errorf("unexpected body: %q", resp.BodyString())
 	}
 
 	// Assert the handler saw the callback BEFORE it sent the body.

--- a/bamlutils/llmhttp/wrapper_fix_test.go
+++ b/bamlutils/llmhttp/wrapper_fix_test.go
@@ -60,8 +60,9 @@ func TestFastBufferedLaneSizeLimit(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error for body at limit: %v", err)
 			}
-			if len(resp.Body) != tc.size {
-				t.Errorf("expected body length %d, got %d", tc.size, len(resp.Body))
+			defer resp.Release()
+			if len(resp.BodyString()) != tc.size {
+				t.Errorf("expected body length %d, got %d", tc.size, len(resp.BodyString()))
 			}
 		})
 	}
@@ -97,8 +98,9 @@ func TestFastBufferedLaneNoPerRequestGoroutine(t *testing.T) {
 		if err != nil {
 			t.Fatalf("request %d failed: %v", i, err)
 		}
-		if resp.Body != `{"ok":true}` {
-			t.Fatalf("request %d body mismatch: %q", i, resp.Body)
+		defer resp.Release()
+		if resp.BodyString() != `{"ok":true}` {
+			t.Fatalf("request %d body mismatch: %q", i, resp.BodyString())
 		}
 	}
 	runtime.GC()
@@ -140,8 +142,9 @@ func TestFastStreamedLaneOnSuccessBeforeBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if resp.Body != `{"ok":true}` {
-		t.Errorf("unexpected body: %q", resp.Body)
+	defer resp.Release()
+	if resp.BodyString() != `{"ok":true}` {
+		t.Errorf("unexpected body: %q", resp.BodyString())
 	}
 	if seen := <-seenBeforeBody; !seen {
 		t.Fatal("onSuccess did not fire before the body on the streamed fasthttp lane")
@@ -296,8 +299,9 @@ func assertCleanConnReuse(t *testing.T, c *Client, url, normal string, onSuccess
 		if err != nil {
 			t.Fatalf("follow-up request %d failed (dirty pooled conn?): %v", i, err)
 		}
-		if resp.Body != normal {
-			t.Fatalf("follow-up request %d got corrupted body (dirty pooled conn?): %q", i, resp.Body)
+		defer resp.Release()
+		if resp.BodyString() != normal {
+			t.Fatalf("follow-up request %d got corrupted body (dirty pooled conn?): %q", i, resp.BodyString())
 		}
 	}
 }
@@ -410,8 +414,9 @@ func TestFastStreamedConnReuseAfterErrorBodyReadError(t *testing.T) {
 		if ferr != nil {
 			continue // tolerate a transient stale-keepalive close
 		}
-		if resp.Body != normal {
-			t.Fatalf("follow-up %d returned corrupted body (dirty pooled conn?): %q", i, resp.Body)
+		defer resp.Release()
+		if resp.BodyString() != normal {
+			t.Fatalf("follow-up %d returned corrupted body (dirty pooled conn?): %q", i, resp.BodyString())
 		}
 		gotClean = true
 	}
@@ -445,8 +450,9 @@ func TestFastBufferedLaneConcurrent(t *testing.T) {
 					errs <- err
 					return
 				}
-				if resp.Body != want {
-					errs <- fmt.Errorf("body mismatch: %q", resp.Body)
+				defer resp.Release()
+				if resp.BodyString() != want {
+					errs <- fmt.Errorf("body mismatch: %q", resp.BodyString())
 					return
 				}
 			}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
Stage 1 of the **#487** unary-response memory effort. Makes `llmhttp.Response` a **consumer-managed borrow** so the fasthttp unary lanes stop paying the self-inflicted *second* full-body copy.

## Why

In the must-retain case the fasthttp **buffered** lane copied the body twice:
1. wire → fasthttp pooled buffer inside `HostClient.Do`
2. `string(body)` at `fast_backend.go` — because llmhttp called `ReleaseResponse` *before returning*.

That second copy is a **choice** (release-before-return), not a fasthttp constraint. net/http already does one copy. Defer the release to the consumer and the extra copy disappears.

## Borrow / release contract

- `Response`'s body is now **private storage** behind accessors: `BodyString()`, `BodyBytes()`, plus `Release()` / `Close()`. On a borrowed response the returned string/bytes are valid **only until Release/Close**; the accessors fail closed (empty/nil) after release. `Release` is **idempotent** and always safe (including nil and owned responses).
- **`ExecuteBorrowed(ctx, req, onSuccess)`** returns a borrow: on fasthttp the body aliases pooled transport storage and the consumer **MUST** `defer resp.Release()` and copy anything that must outlive the response before releasing.
- **`Execute(ctx, req, onSuccess)`** is **unchanged for callers**: it returns an **OWNED** copy (`own()` materializes a fresh buffer and releases the borrow), so external / non-borrow callers never manage a pooled lifetime and `Release` is a harmless no-op. **The borrow is opt-in** — the BAML/dynclient public surface (which never exposes `llmhttp.Response`) keeps no pooled-lifetime footgun.

`Release` uses concrete `fastResp`/`drainBuf` fields rather than a release closure, so `ExecuteBorrowed` allocates nothing per request beyond the `Response` itself.

## Per-lane copy count (must-retain success)

| Lane | Before | After (`ExecuteBorrowed`) |
|---|---|---|
| fasthttp **buffered** | `2B` (`Do` buffer + `string(body)`) | **`1B`** — body aliases retained `fResp.Body()`; `Release` → `ReleaseResponse`. Request released promptly. `StreamResponseBody=false` already drained+released the conn, so only the pooled response buffer is held (not the connection). |
| fasthttp **streamed** | `2B` (drain buffer + `buf.String()`) | **`1B`** — `drainFastBodyLimited` returns the pooled `*bytes.Buffer`; `Release` returns it to `fastBodyBufPool`. `fResp` released on return (body lives in the buffer). All connection-discard correctness preserved exactly (oversize/read-error → discard dirty conn; clean EOF → poolable). |
| net/http | `1B` (`io.ReadAll`) | `1B` — unchanged owned buffer behind the same contract; `Release` is a no-op, `BodyBytes()` exposed. |
| error (non-2xx) | capped copy | capped copy — unchanged, no borrow. |

`exposeBytes` preserves the per-backend **extractor-routing invariant** (net/http → byte extractor, fasthttp → string extractor); extraction semantics are **unchanged** (Stage 3 territory).

## In-repo migration

- All `llmhttp.Execute` consumers, tests, and benches now use `BodyString()`/`BodyBytes()` and `defer resp.Release()`.
- The BuildRequest orchestrator keeps the **owned** `Execute` for now (Release is a no-op there) — **Stage 2** will switch `tryOneChild` to `ExecuteBorrowed` with copy-before-escape for raw/reasoning/error text that crosses the retry boundary.
- New tests pin the borrow contract across both fasthttp lanes + net/http (correct body before release, `BodyBytes()` routing, idempotent release, fail-closed accessors) and that the owned `Execute` body survives fasthttp pool churn.

## Benchmark delta (`BenchmarkExecuteAfter`, medium ~64 KB body, c256, M4, steady-state)

| Lane | Before | After |
|---|---|---|
| `wf-buffered/medium` | 77 allocs/op, ~84 KB B/op | **76 allocs/op, ~3.8 KB B/op** |
| `wf-streamed/medium` | 85 allocs/op, ~80 KB B/op | **84 allocs/op, ~4.4 KB B/op** |

One full-body allocation dropped on each fasthttp lane (B/op falls by the entire body size; allocs/op −1).

## Validation

- `gofmt -l` clean on touched files; `go vet ./bamlutils/llmhttp ./bamlutils/buildrequest` clean.
- `go test -race -count=1 ./bamlutils/llmhttp ./bamlutils/buildrequest` pass.
- `go build -o /tmp/wk ./cmd/worker/` OK; `go build ./...` across root/bamlutils/dynclient OK.
- `go run ./cmd/embed` and `go run ./dynclient/cmd/genadapter` produce **no drift** (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ExecuteBorrowed` to support borrowed-response execution scenarios.
  * Added `Response.BodyString()` / `Response.BodyBytes()` accessors with clearer lifetime behavior.
* **Refactors**
  * Updated response ownership/lifecycle handling across transports, including consistent `Release()`/`Close()` usage.
  * Improved fasthttp body draining and pooling/ownership semantics for more predictable memory behavior.
* **Bug Fixes**
  * Corrected response extraction routing and error-body construction to align with string/byte accessor availability.
* **Tests**
  * Updated validations to use `BodyString()` and to properly release responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->