### PR TITLE
fix(pool): don't restart healthy worker on silent stream EOF racing caller cancel (#505)

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -265,6 +265,14 @@ type Pool struct {
 	shutdownCancel     context.CancelFunc                  // cancels shutdownCtx
 	newWorker          func(id int) (*workerHandle, error) // override for testing; nil in production
 	beforeRestartStart func()
+	// onSilentStreamEOF is a test-only seam fired on the CallStream
+	// silent channel-close path (worker result channel closed with no
+	// terminal/error frame) after cleanup() and before the restart
+	// decision. It lets a test deterministically interleave caller
+	// cancellation into the exact window where the cancel-vs-close race
+	// lives, without relying on select-arm scheduling luck. nil in
+	// production.
+	onSilentStreamEOF func()
 
 	// admissionMu serialises Shutdown's draining transition with
 	// beginLogicalRequest. A request that observes draining=false
@@ -1567,6 +1575,34 @@ func (p *Pool) CallStream(ctx context.Context, methodName string, inputJSON []by
 			}
 
 			cleanup()
+
+			// Test-only seam: fires on the silent channel-close path
+			// (no terminal/error frame) in the window between cleanup and
+			// the restart decision, so a test can deterministically observe
+			// and cancel the caller context here. Gated on !shouldRetry so
+			// it only triggers for genuine silent EOF, never for an
+			// explicit retryable mid-stream error. nil in production.
+			if !shouldRetry && p.onSilentStreamEOF != nil {
+				p.onSilentStreamEOF()
+			}
+
+			// A silent channel close (no terminal/error frame) that races a
+			// caller cancellation must NOT be treated as a worker death: the
+			// worker is healthy, the client simply went away, and the close
+			// arm of the stream-loop select can win even when ctx is already
+			// done. Suppress the restart in that case. Use the parent caller
+			// ctx, not attemptCtx — cleanup() above cancels attemptCtx, so it
+			// is contaminated by local teardown and can't distinguish caller
+			// cancellation from our own cleanup.
+			//
+			// This is gated on !shouldRetry so it only covers silent EOF:
+			// explicit retryable worker errors (shouldRetry) still restart
+			// even when the caller cancelled, because a genuinely dead worker
+			// must be replaced. The ctx.Err() check below the restart stays
+			// in place to avoid starting another attempt after such an error.
+			if !shouldRetry && ctx.Err() != nil {
+				return
+			}
 
 			// Reaching here means either a mid-stream retryable error or an
 			// unexpected EOF (channel closed without terminal). Both are

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -2538,6 +2538,85 @@ func TestCallStreamClientCancelUnexpectedCloseDoesNotRestartWorker(t *testing.T)
 	}
 }
 
+// TestCallStreamSilentEOFRacingCallerCancelDoesNotRestartWorker is the
+// DETERMINISTIC reproduction of issue #505. Unlike the probabilistic
+// TestCallStreamClientCancelUnexpectedCloseDoesNotRestartWorker above
+// (which depends on select-arm scheduling luck and does not reliably
+// reproduce), this test forces the exact ordering:
+//
+//  1. The worker result channel closes with NO terminal/error frame
+//     while the caller context is STILL live, so the stream loop
+//     deterministically takes the silent-EOF (close) select arm rather
+//     than the ctx.Done() arm.
+//  2. The onSilentStreamEOF seam fires in that close path, AFTER
+//     cleanup() and BEFORE the restart decision, and the test cancels
+//     the caller context synchronously inside it.
+//
+// So when CallStream reaches the restart decision, the caller context is
+// guaranteed already cancelled AND the path taken is guaranteed the
+// silent-close path. On the unfixed code this dispatches a spurious
+// restart of a perfectly healthy worker; the fix suppresses it.
+func TestCallStreamSilentEOFRacingCallerCancelDoesNotRestartWorker(t *testing.T) {
+	var factoryCalls atomic.Int32
+
+	factory := func(id int) (*workerHandle, error) {
+		factoryCalls.Add(1)
+		w := newMockWorker()
+		w.callStreamFn = func(_ context.Context, _ string, _ []byte, _ bamlutils.StreamMode) (<-chan *workerplugin.StreamResult, error) {
+			// Close immediately with no terminal/error frame. The caller
+			// context is still live at this point, so the stream loop's
+			// select picks the closed-channel arm deterministically.
+			ch := make(chan *workerplugin.StreamResult)
+			close(ch)
+			return ch, nil
+		}
+		return newMockHandle(id, w), nil
+	}
+
+	p := newTestPool(t, 1, factory)
+	defer p.Close()
+	original := p.workers[0]
+	factoryCalls.Store(0)
+
+	ctx := newManualCancelContext()
+
+	// The seam fires on the silent-close path, after cleanup() and before
+	// the restart decision. Cancelling here makes ctx.Err() != nil exactly
+	// when the restart decision is evaluated — the race window, forced.
+	var hookFired atomic.Bool
+	p.onSilentStreamEOF = func() {
+		hookFired.Store(true)
+		ctx.cancel(context.Canceled)
+	}
+
+	results, err := p.CallStream(ctx, "Test", []byte(`{}`), bamlutils.StreamModeStream)
+	if err != nil {
+		t.Fatalf("CallStream setup failed: %v", err)
+	}
+
+	requireCompleteWithin(t, 2*time.Second, func() {
+		for result := range results {
+			workerplugin.ReleaseStreamResult(result)
+		}
+	})
+	requireCompleteWithin(t, time.Second, func() {
+		p.restartWG.Wait()
+	})
+
+	if !hookFired.Load() {
+		t.Fatal("silent-EOF seam never fired — test did not exercise the close path")
+	}
+	if calls := factoryCalls.Load(); calls != 0 {
+		t.Fatalf("spurious restart: expected 0 replacement starts after caller cancel racing silent close, got %d", calls)
+	}
+	if p.workers[0] != original {
+		t.Fatal("healthy worker was replaced after caller cancel racing silent close")
+	}
+	if !original.healthy.Load() {
+		t.Fatal("healthy worker was marked unhealthy after caller cancel racing silent close")
+	}
+}
+
 // TestCallStreamCallerCancelWithNonRetryableSetupError verifies that
 // a caller cancellation racing with a non-retryable setup error (like
 // InvalidArgument) does NOT trigger a spurious worker restart. The
@@ -3881,9 +3960,9 @@ func TestCallStreamOutcomeMetadataPreventsHungKill(t *testing.T) {
 	// a terminal frame; reading the pooled struct after Release would
 	// race with the next pool.Get caller.
 	var (
-		lastKind    workerplugin.StreamResultKind
-		sawAny      bool
-		sawOutcome  bool
+		lastKind   workerplugin.StreamResultKind
+		sawAny     bool
+		sawOutcome bool
 	)
 	requireCompleteWithin(t, 2*time.Second, func() {
 		for r := range results {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Fixes #505.

## The reproduction (red first)

`Pool.CallStream`'s silent-EOF path — the worker result channel closes with **no** terminal/error frame — decided to restart based purely on which `select` arm won, and only checked the parent `ctx.Err()` **after** the restart had already been dispatched (`pool/pool.go` ~:1569–:1589). When a client cancellation races a no-terminal close, both the `ctx.Done()` arm and the closed-`results` arm are ready, Go may pick the close arm, and a perfectly healthy worker is marked unhealthy, killed, and replaced — interrupting unrelated in-flight requests on that handle.

The existing `TestCallStreamClientCancelUnexpectedCloseDoesNotRestartWorker` only reproduces this probabilistically (it depends on select-arm scheduling; the scope's `-count=100` did not reproduce locally). That is not good enough to prove the bug or the fix.

New test `TestCallStreamSilentEOFRacingCallerCancelDoesNotRestartWorker` makes it **deterministic** by forcing the exact ordering:

1. The mock worker returns a result channel that is **closed immediately with no terminal/error frame**, while the caller ctx is still live — so the stream-loop `select` deterministically takes the silent-close arm, never the `ctx.Done()` arm.
2. A minimal test-only seam, `onSilentStreamEOF` (nil in production, same pattern as the existing `beforeRestartStart` hook), fires in the window **after `cleanup()` and before the restart decision**. The test cancels the caller ctx **synchronously inside it**, so `ctx.Err() != nil` is guaranteed exactly when the restart decision runs.

This removes all scheduling luck: the silent-close path is always taken, and the caller ctx is always already cancelled at the decision point — the precise race window, forced.

**Before the fix (red), reliably:**

```
$ go test -race -run '^TestCallStreamSilentEOFRacingCallerCancelDoesNotRestartWorker$' -count=50 ./pool/
--- FAIL: TestCallStreamSilentEOFRacingCallerCancelDoesNotRestartWorker (0.00s)
    pool_test.go:2610: spurious restart: expected 0 replacement starts after caller cancel racing silent close, got 1
FAIL
FAIL	github.com/invakid404/baml-rest/pool	0.327s
```

(fails on every run, not 1-in-100).

## The fix

After `cleanup()` on the silent-close path, return early when the parent caller ctx is cancelled, **before** marking the handle unhealthy / dispatching restart:

```go
cleanup()

if !shouldRetry && ctx.Err() != nil {
    return
}

currentHandle.healthy.Store(false)
...
p.dispatchRestart(currentHandle)
```

- Uses the **parent** `ctx.Err()`, not `attemptCtx` — `cleanup()` cancels `attemptCtx` (via `trackRequest`), so it can't distinguish caller cancellation from our own teardown.
- Gated on `!shouldRetry`, so explicit retryable worker errors racing a cancel **still restart** — a genuinely dead worker must be replaced.
- The existing post-restart `ctx.Err()` guard is preserved.

Explicit error frames were already handled correctly (`isCallerCancellationError`); only the silent-close path was vulnerable.

**After the fix (green):**

```
$ go test -race -run '^TestCallStreamSilentEOFRacingCallerCancelDoesNotRestartWorker$' -count=100 ./pool/
ok  	github.com/invakid404/baml-rest/pool	1.546s
```

## No-regression evidence

The sibling tests that **require** a restart on real worker failure racing a cancel stay green (20/20 each, `-race`):

```
20 --- PASS: TestCallStreamSilentEOFRacingCallerCancelDoesNotRestartWorker
20 --- PASS: TestCallStreamSetupUnavailableWithCallerCancel       # worker died (Unavailable) + cancel -> MUST restart
20 --- PASS: TestCallStreamDrainCatchesSecondInSequenceError
20 --- PASS: TestCallStreamClientCancelUnexpectedCloseDoesNotRestartWorker
20 --- PASS: TestCallStreamCallerCancelWithNonRetryableSetupError
```

Full pool package:

```
$ go test -race -count=20 ./pool/
ok  	github.com/invakid404/baml-rest/pool	62.876s
```

`gofmt -l` clean, `go vet ./pool/...` clean, `go build -o /tmp/wk ./cmd/worker/` OK. `go run ./cmd/embed` (embed regen) is idempotent — no `embed.go` changes; this is a logic-only edit to `pool/pool.go`, structurally independent of the schema-driven dynclient codegen.

## Out of scope (tracked separately)

The scope flagged a separate, opposite asymmetry in `Pool.Parse` (`pool/pool.go:1166–1168` returns on `ctx.Err()` before checking `isRetryableWorkerError` → could **miss** a needed restart). Left untouched here per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an edge case where a stream closing silently could incorrectly trigger a worker restart if the caller canceled at the same time.
  * Improved stability so interrupted stream calls keep the existing worker in place instead of replacing it unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->