### PR TITLE
fix(pool): restart genuinely-failed worker in Parse when retryable error races caller cancel (#506)

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1171,19 +1171,43 @@ func (p *Pool) Parse(ctx context.Context, methodName string, inputJSON []byte) (
 			return result, nil
 		}
 
-		// Don't retry if the caller cancelled
-		if ctx.Err() != nil {
+		workerFailed := isRetryableWorkerError(err)
+		callerCancelled := ctx.Err() != nil
+
+		// A genuinely-failed worker must be replaced for FUTURE requests
+		// even when THIS caller cancelled. Classify and restart the dead
+		// worker BEFORE the caller-cancel early return below, mirroring
+		// Pool.CallStream's setup path (the #505 fix): the callerCancelled
+		// check then only suppresses a RETRY of this request, never the
+		// restart. Without this, a retryable worker failure that races a
+		// caller cancellation would skip dispatchRestart and leave the dead
+		// worker in the pool until the health checker or a future request
+		// surfaces it (issue #506).
+		//
+		// Skip the restart for cancellation-shaped errors when the caller
+		// also cancelled — that's just gRPC propagating the caller's
+		// context, not a worker death. This guards against the inverse
+		// (#505-style) over-restart: a healthy worker returning
+		// context.Canceled / codes.Canceled solely because the caller went
+		// away must NOT be torn down. Use the parent caller ctx (not
+		// attemptCtx) — cleanup() above cancels attemptCtx, so it can't
+		// distinguish caller cancellation from our own teardown.
+		if workerFailed && !(callerCancelled && isCallerCancellationError(err)) {
+			handle.healthy.Store(false)
+			p.dispatchRestart(handle)
+		}
+
+		// Caller cancelled — don't retry, the caller is gone. The restart
+		// above (if triggered) already ensured pool health.
+		if callerCancelled {
 			return nil, err
 		}
 
-		if isRetryableWorkerError(err) {
-			handle.healthy.Store(false)
-
+		if workerFailed {
 			handle.logger.Info().
 				Int("attempt", attempt+1).
 				Err(err).
 				Msg("Retrying parse after worker failure")
-			p.dispatchRestart(handle)
 			lastFailed = handle
 			lastErr = err
 			continue

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -2021,6 +2021,58 @@ func TestParseNonRetryableError(t *testing.T) {
 	}
 }
 
+// TestParseRetryableErrorWithCallerCancel verifies that when worker.Parse
+// returns a retryable worker error (worker dead) and the caller's context
+// is ALSO already cancelled at the point Pool.Parse classifies the error,
+// the dead worker is STILL restarted. This is the mirror of
+// TestCallStreamSetupUnavailableWithCallerCancel for the unary Parse path
+// (issue #506): the early `if ctx.Err() != nil { return }` must not be
+// allowed to skip the restart of a genuinely-failed worker.
+//
+// The reproduction is deterministic because Parse is sequential (no select
+// race): parseFn cancels the caller context BEFORE returning Unavailable,
+// so ctx.Err() is guaranteed set when Pool.Parse reaches the classify/restart
+// decision. On pre-fix code the early ctx.Err() return fires first and the
+// restart is skipped (no replacement worker is ever created → this test
+// blocks on `restarted` and fails). With the fix, dispatchRestart runs
+// before the caller-cancel early return.
+func TestParseRetryableErrorWithCallerCancel(t *testing.T) {
+	ctx := newManualCancelContext()
+	restarted := make(chan struct{}, 1)
+	var restartSignal sync.Once
+
+	factory := func(id int) (*workerHandle, error) {
+		w := newMockWorker()
+		w.parseFn = func(context.Context, string, []byte) (*workerplugin.ParseResult, error) {
+			// Cancel the caller context first, THEN return a retryable
+			// worker error. At the point Pool.Parse classifies the error,
+			// ctx.Err() is already set, yet the worker genuinely failed —
+			// the dead worker must still be restarted.
+			ctx.cancel(context.Canceled)
+			return nil, status.Error(codes.Unavailable, "worker died")
+		}
+		return newMockHandle(id, w), nil
+	}
+
+	p := newTestPool(t, 1, factory)
+	p.newWorker = func(id int) (*workerHandle, error) {
+		restartSignal.Do(func() { close(restarted) })
+		return newMockHandle(id, newMockWorker()), nil
+	}
+	defer p.Close()
+
+	_, err := p.Parse(ctx, "Test", []byte(`{}`))
+	if err == nil {
+		t.Fatal("Parse should return an error when the worker fails and caller cancels")
+	}
+
+	select {
+	case <-restarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker should restart after retryable error even when caller cancelled")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Tests: CallStream edge cases
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Fixes #506 — the mirror image of #505, in `Pool.Parse`.

## Red reproduction (deterministic, before the fix)

`Pool.Parse` returned early on caller cancellation **before** classifying the error as a retryable worker failure, so it could fail to restart a genuinely-dead worker. The new test `TestParseRetryableErrorWithCallerCancel` is the missing Parse analogue of `TestCallStreamSetupUnavailableWithCallerCancel`.

It is deterministic because Parse is **sequential** (no `select` race): the mock `parseFn` cancels the caller context *first*, then returns `codes.Unavailable`. So at the point `Pool.Parse` classifies the error, `ctx.Err()` is guaranteed set, yet the worker genuinely failed — no production seam needed.

On unmodified code the early `if ctx.Err() != nil { return }` (`pool/pool.go:1175`) fires before the `isRetryableWorkerError` → `dispatchRestart` check, so the replacement worker is never created and the test blocks out:

```
=== RUN   TestParseRetryableErrorWithCallerCancel
    pool_test.go:2072: worker should restart after retryable error even when caller cancelled
--- FAIL: TestParseRetryableErrorWithCallerCancel (2.00s)
FAIL	github.com/invakid404/baml-rest/pool	2.549s
```

## The fix

Restructure `Pool.Parse` to mirror `Pool.CallStream`'s post-#505 setup path (`pool/pool.go:1403–1444`): classify the error and `dispatchRestart` the dead worker **before** the caller-cancel early return. The `callerCancelled` check then only suppresses a **retry** of this request, never the restart — a genuinely-failed worker is replaced for future requests regardless of whether *this* caller gave up.

Critically, the restart is skipped for cancellation-shaped errors when the caller also cancelled — `!(callerCancelled && isCallerCancellationError(err))` — exactly as CallStream does at `pool.go:1417`. That guards against the inverse, #505-style over-restart: a healthy worker returning `context.Canceled`/`codes.Canceled` solely because the caller went away must not be torn down. Non-retryable + cancel behavior is unchanged.

## No-regression evidence (after the fix)

```
=== RUN   TestParseRetryableErrorWithCallerCancel
--- PASS: TestParseRetryableErrorWithCallerCancel (0.00s)
```

- `gofmt -l` — clean
- `go vet ./pool/...` — clean
- `go test -race -count=20 ./pool/` — `ok` (63s); all existing cancel/retry tests stay green
- `go build -o /tmp/wk ./cmd/worker/` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling when a parse attempt fails and the caller has already cancelled the request.
  * Ensured worker recovery still happens after certain retryable failures, helping future requests continue to be served normally.
  * Prevented unnecessary retries for the cancelled request itself while preserving recovery behavior in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->