### PR TITLE
docs(readme): recommend BAML v0.223.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ tolerance for losing in-flight requests when the process crashes.
 
 ## Known broken versions
 
-Recommended version: **v0.221.0**
+Recommended version: **v0.223.0**
 
 The BuildRequest code path (`BAML_REST_USE_BUILD_REQUEST=true`) requires
 BAML **v0.219.0** or newer. Older BAML versions remain functional via the


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
Bumps the recommended BAML version in the README from **v0.221.0** to **v0.223.0**.

0.223.0 was just adopted as the dynclient `.latest` (#499) and passed the full bamlfuzz nightly across all supported BAML versions (0.214 → 0.223, all fuzz targets, 0 failures), so the recommendation can move forward. The README hadn't been updated since v0.221.0.

Doc-only change; no code impact.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Known broken versions” section to reflect the latest recommended version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->