### PR TITLE
chore(release): prepare Go module versions for 0.0.48

### DIFF
--- a/adapters/adapter_v0_204_0/go.mod
+++ b/adapters/adapter_v0_204_0/go.mod
@@ -37,8 +37,8 @@ require (
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/gjson v0.1.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.47 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.47 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.48 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.48 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect

--- a/adapters/adapter_v0_215_0/go.mod
+++ b/adapters/adapter_v0_215_0/go.mod
@@ -31,8 +31,8 @@ require (
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/gjson v0.1.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.47 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.47 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.48 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.48 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect

--- a/adapters/adapter_v0_219_0/go.mod
+++ b/adapters/adapter_v0_219_0/go.mod
@@ -31,8 +31,8 @@ require (
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/gjson v0.1.1 // indirect
 	github.com/dave/jennifer v1.7.1 // indirect
-	github.com/invakid404/baml-rest/bamlutils v0.0.47 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.47 // indirect
+	github.com/invakid404/baml-rest/bamlutils v0.0.48 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.48 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect

--- a/adapters/common/go.mod
+++ b/adapters/common/go.mod
@@ -5,8 +5,8 @@ go 1.26.3
 require (
 	github.com/boundaryml/baml v0.204.0
 	github.com/dave/jennifer v1.7.1
-	github.com/invakid404/baml-rest/bamlutils v0.0.47
-	github.com/invakid404/baml-rest/introspected v0.0.47
+	github.com/invakid404/baml-rest/bamlutils v0.0.48
+	github.com/invakid404/baml-rest/introspected v0.0.48
 	github.com/stoewer/go-strcase v1.3.1
 	pgregory.net/rapid v1.3.0
 )

--- a/dynclient/go.mod
+++ b/dynclient/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/enriquebris/goconcurrentqueue v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gregwebs/go-recovery v0.4.1
-	github.com/invakid404/baml-rest/adapters/common v0.0.47
-	github.com/invakid404/baml-rest/bamlutils v0.0.47
-	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.47
-	github.com/invakid404/baml-rest/worker v0.0.47
-	github.com/invakid404/baml-rest/workerplugin v0.0.47
+	github.com/invakid404/baml-rest/adapters/common v0.0.48
+	github.com/invakid404/baml-rest/bamlutils v0.0.48
+	github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.48
+	github.com/invakid404/baml-rest/worker v0.0.48
+	github.com/invakid404/baml-rest/workerplugin v0.0.48
 	github.com/prometheus/client_golang v1.23.2
 )
 
@@ -46,7 +46,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.8.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
-	github.com/invakid404/baml-rest/introspected v0.0.47 // indirect
+	github.com/invakid404/baml-rest/introspected v0.0.48 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect

--- a/introspected/go.mod
+++ b/introspected/go.mod
@@ -2,7 +2,7 @@ module github.com/invakid404/baml-rest/introspected
 
 go 1.26.3
 
-require github.com/invakid404/baml-rest/bamlutils v0.0.47
+require github.com/invakid404/baml-rest/bamlutils v0.0.48
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect

--- a/pool/go.mod
+++ b/pool/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/gregwebs/go-recovery v0.4.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
-	github.com/invakid404/baml-rest/bamlutils v0.0.47
-	github.com/invakid404/baml-rest/workerplugin v0.0.47
+	github.com/invakid404/baml-rest/bamlutils v0.0.48
+	github.com/invakid404/baml-rest/workerplugin v0.0.48
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1
 	google.golang.org/grpc v1.81.1

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -4,8 +4,8 @@ go 1.26.3
 
 require (
 	github.com/bytedance/sonic v1.15.2
-	github.com/invakid404/baml-rest/bamlutils v0.0.47
-	github.com/invakid404/baml-rest/workerplugin v0.0.47
+	github.com/invakid404/baml-rest/bamlutils v0.0.48
+	github.com/invakid404/baml-rest/workerplugin v0.0.48
 	github.com/prometheus/client_golang v1.23.2
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )

--- a/workerplugin/go.mod
+++ b/workerplugin/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/hashicorp/go-plugin v1.8.0
-	github.com/invakid404/baml-rest/bamlutils v0.0.47
+	github.com/invakid404/baml-rest/bamlutils v0.0.48
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
RELEASE.md **Step 1 — release-prep** for product release **0.0.48**.

Rewrites every first-party `require` across the published Go modules from the dev-time `v0.0.0-…` placeholders to `v0.0.48`, via `scripts/release-prep.sh 0.0.48`, so `go get` from downstream consumers resolves through the real per-module tags cut in Step 6. Local `replace` directives are intentionally kept (ignored by consumers; keep local dev ergonomic).

Files: the 6 published-module `go.mod`s + `pool/go.mod` + the 3 `adapters/adapter_v0_*` pin-matrix `go.mod`s (refreshed by `sync.sh`). `go.work.sum` deliberately excluded.

Verified locally: `go build ./...`, `go vet ./...`, and `(cd dynclient && GOWORK=off go test ./...)` all clean. Once this merges, the product tag `0.0.48` is cut from the merge commit (RELEASE.md Step 4), then the additive Go-module tags (Step 6).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several Go module dependencies across adapters, client, pool, worker, and related components.
  * Bumped shared internal package versions from `v0.0.47` to `v0.0.48` for consistency across the codebase.
  * No user-facing API changes or functional behavior updates were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->