### PR TITLE
test(bamlfuzz): deflake MapArm coverage-sentinel family (#498)

### DIFF
--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"reflect"
 	"strconv"
@@ -2256,6 +2257,105 @@ func assertOverCapMapArmPruned(t *testing.T, schema FuzzSchema, unionFT FuzzType
 	}
 }
 
+// assertMapArmDrawsNonEmpty drives the REAL generator down the map arm
+// of unionFT and asserts the value it produces at the map leaf is
+// non-empty — deterministically, with zero dependence on a random rapid
+// draw reaching that leaf (the gap the gate/candidate predicates alone
+// left, and the flake the old post-loop sentinel carried).
+//
+// It runs drawUnion against an all-zero bitstream via rapid.MakeFuzz.
+// Every draw then takes its minimum: each variant pick resolves to
+// candidate index 0 (the map-reaching arm), drawOptionalShape resolves
+// to OptionalPresent (idx 0), and drawMap's length resolves to minLen.
+// So the draw threads the full picked path —
+// outer-union → [present-optional →] [nested-union arm 0 →] … → map leaf
+// — on every run, exercising drawUnion's non-empty gate
+// (generator.go:514) and drawArmEnsuringMapNonEmpty's minLen=1 map draw
+// (generator.go:686). The leaf reached by descending the picked
+// variants / present optionals must be a map with len>=1. Each of the
+// three ways the production code could emit an ambiguous empty map makes
+// this fail deterministically under the all-zero drive:
+//   - the gate skips the non-empty branch → drawValueForType draws the
+//     map with minLen=0 → length 0 → empty;
+//   - drawArmEnsuringMapNonEmpty stops forwarding the constraint into a
+//     nested union/optional → the picked path no longer lands on the
+//     constrained map leaf;
+//   - drawMap's minLen drops to 0 → length 0 → empty.
+//
+// rapid is pinned at v1.3.0, whose all-zero draw is the range minimum;
+// the buffer is far larger than these shapes consume, so the drive never
+// overruns (an overrun would surface as a SKIP, not a silent pass).
+func assertMapArmDrawsNonEmpty(t *testing.T, schema FuzzSchema, unionFT FuzzType) {
+	t.Helper()
+	var got FuzzValue
+	ran := false
+	input := make([]byte, 1<<16) // all-zero bitstream; ample for these shapes
+	rapid.MakeFuzz(func(rt *rapid.T) {
+		ctx := &valueDrawCtx{schema: schema, depth: make(map[string]int)}
+		got = ctx.drawUnion(rt, unionFT, "v")
+		ran = true
+	})(t, input)
+	if !ran {
+		t.Fatalf("all-zero drive did not run drawUnion (bitstream overrun?) — non-empty-map invariant unverified")
+	}
+	leaf := mapLeafThroughPickedPath(t, got)
+	if leaf.Kind != KindMap {
+		t.Fatalf("all-zero drive descended to %s, not a map — drawUnion's non-empty gate or drawArmEnsuringMapNonEmpty's descent did not select the map leaf (picked path: %s)", leaf.Kind, describePickedPath(got))
+	}
+	if len(leaf.MapEntries) == 0 {
+		t.Fatalf("map arm drew an empty map at minLen — drawArmEnsuringMapNonEmpty/drawMap is not enforcing minLen>=1; empty {} is ambiguous with the class sibling under BAML coercion")
+	}
+}
+
+// mapLeafThroughPickedPath descends a drawn value through the picked
+// union variant and present-optional inner — the transparent wrappers
+// drawArmEnsuringMapNonEmpty forwards the non-empty constraint through —
+// and returns the value at the leaf. A non-present optional or a missing
+// variant returns that wrapper itself, so the caller observes a non-map
+// leaf and fails. Bounded so a malformed value cannot loop.
+func mapLeafThroughPickedPath(t *testing.T, v FuzzValue) FuzzValue {
+	t.Helper()
+	for i := 0; i < MaxTypeDepth+2; i++ {
+		switch v.Kind {
+		case KindUnion:
+			if v.Variant == nil {
+				return v
+			}
+			v = *v.Variant
+		case KindOptional:
+			if v.OptionalShape != OptionalPresent || v.Inner == nil {
+				return v
+			}
+			v = *v.Inner
+		default:
+			return v
+		}
+	}
+	t.Fatalf("picked-path descent exceeded the depth bound without reaching a leaf")
+	return FuzzValue{}
+}
+
+// describePickedPath renders the picked path of a drawn value for
+// assertion failure messages, e.g. union#0(opt-present(map(len=0))).
+func describePickedPath(v FuzzValue) string {
+	switch v.Kind {
+	case KindUnion:
+		if v.Variant == nil {
+			return fmt.Sprintf("union#%d<nil>", v.VariantIndex)
+		}
+		return fmt.Sprintf("union#%d(%s)", v.VariantIndex, describePickedPath(*v.Variant))
+	case KindOptional:
+		if v.OptionalShape != OptionalPresent || v.Inner == nil {
+			return fmt.Sprintf("opt[%s]", v.OptionalShape)
+		}
+		return fmt.Sprintf("opt-present(%s)", describePickedPath(*v.Inner))
+	case KindMap:
+		return fmt.Sprintf("map(len=%d)", len(v.MapEntries))
+	default:
+		return string(v.Kind)
+	}
+}
+
 // TestValueGenMapArmWithClassSiblingNeverEmpty is the durable
 // regression guard. With a union whose map arm has a class-reachable
 // sibling, ValueGen must never produce an empty map for the picked
@@ -2275,6 +2375,9 @@ func TestValueGenMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	// the non-empty path and retained as a candidate, regardless of any
 	// rapid draw.
 	assertMapArmNonEmptyGateEngages(t, schema, unionFT, 0, []int{0, 1})
+	// And drive the real generator down that arm: the map leaf it produces
+	// must be non-empty.
+	assertMapArmDrawsNonEmpty(t, schema, unionFT)
 
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
@@ -2349,6 +2452,9 @@ func TestValueGenOptionalMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	// the optional wrapper, so the gate engages and a present optional is
 	// held non-empty — no dependence on the rapid draw reaching the leaf.
 	assertMapArmNonEmptyGateEngages(t, schema, unionFT, 0, []int{0, 1})
+	// And drive the real generator through outer-union → present-optional →
+	// map leaf: the leaf must be non-empty.
+	assertMapArmDrawsNonEmpty(t, schema, unionFT)
 
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
@@ -2436,6 +2542,9 @@ func TestValueGenNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	// non-empty against the outer class sibling — no dependence on the
 	// rapid draw reaching outer→nested→map.
 	assertMapArmNonEmptyGateEngages(t, schema, unionFT, 0, []int{0, 1})
+	// And drive the real generator through outer-union → nested-union →
+	// map leaf: the leaf must be non-empty.
+	assertMapArmDrawsNonEmpty(t, schema, unionFT)
 
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
@@ -2522,6 +2631,9 @@ func TestValueGenOptionalNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.
 	// a present compound is held non-empty — no dependence on the rapid
 	// draw reaching outer→optional(present)→nested→map.
 	assertMapArmNonEmptyGateEngages(t, schema, unionFT, 0, []int{0, 1})
+	// And drive the real generator through outer-union → present-optional →
+	// nested-union → map leaf: the leaf must be non-empty.
+	assertMapArmDrawsNonEmpty(t, schema, unionFT)
 
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
@@ -2619,6 +2731,9 @@ func TestValueGenDeepNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	// class sibling — no dependence on the rapid draw threading
 	// outer→middle→innermost→map.
 	assertMapArmNonEmptyGateEngages(t, schema, unionFT, 0, []int{0, 1})
+	// And drive the real generator through both nested-union levels to the
+	// map leaf: the leaf must be non-empty.
+	assertMapArmDrawsNonEmpty(t, schema, unionFT)
 
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
@@ -2803,6 +2918,10 @@ func TestValueGenRecursiveFallbackMapArmWithClassSiblingNeverEmpty(t *testing.T)
 	// At the cap the map arm is forced to a clamped `{}` and must be pruned
 	// so the fallback picks the terminating class_ref sibling instead.
 	assertOverCapMapArmPruned(t, schema, unionFT, 0, 1, "A")
+	// And drive the real generator down the below-cap map arm: the root map
+	// leaf it produces must be non-empty (the recursive value draw
+	// terminates via the over-cap prune above).
+	assertMapArmDrawsNonEmpty(t, schema, unionFT)
 
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")

--- a/adapters/common/codegen/bamlfuzz/union_test.go
+++ b/adapters/common/codegen/bamlfuzz/union_test.go
@@ -2157,14 +2157,125 @@ func fixtureSchemaMapVsClassSiblingUnion() FuzzSchema {
 	})
 }
 
+// fixtureFieldUnion returns the type of className.fieldName from an
+// analysed fixture schema so the deterministic gate assertions below run
+// against the exact FuzzType drawUnion sees, rather than a hand-rebuilt
+// copy that could drift from the fixture.
+func fixtureFieldUnion(t *testing.T, schema FuzzSchema, className, fieldName string) FuzzType {
+	t.Helper()
+	for _, cls := range schema.Classes {
+		if cls.Name != className {
+			continue
+		}
+		for _, p := range cls.Properties {
+			if p.Name == fieldName {
+				return p.Type
+			}
+		}
+	}
+	t.Fatalf("fixture missing %s.%s field", className, fieldName)
+	return FuzzType{}
+}
+
+// assertMapArmNonEmptyGateEngages pins, deterministically and on every
+// run, that drawUnion routes variant `mapArm` of `unionFT` through
+// drawArmEnsuringMapNonEmpty (the non-empty-map path) instead of the
+// unconstrained draw. drawUnion's gate is
+//
+//	pickedArmReachesMapThroughTransparent(arm, 0) && unionHasClassReachableSibling(ft, idx)
+//
+// so for the map arm both conjuncts must hold: the arm reaches a map
+// leaf through whatever transparent wrappers (optional / nested union /
+// deep nesting) this shape stacks, and a sibling reaches a class so an
+// empty `{}` would be ambiguous under BAML coercion. The candidate
+// filter must also retain the map arm: armForcesEmptyMap is false for
+// these shallow shapes (the map inner never blows the recursion cap),
+// so the class-driven prune keeps it selectable. Asserting these
+// decision points is the deterministic replacement for the flaky
+// post-loop coverage sentinel, whose firing depended on the random
+// rapid draw reaching the map leaf within budget (#389 → #417).
+func assertMapArmNonEmptyGateEngages(t *testing.T, schema FuzzSchema, unionFT FuzzType, mapArm int, wantCandidates []int) {
+	t.Helper()
+	// First gate conjunct: the picked arm reaches a map leaf through the
+	// shape's transparent wrappers, so its drawn value can render as the
+	// bare `{}` that collides with a class sibling.
+	if !pickedArmReachesMapThroughTransparent(unionFT.Variants[mapArm], 0) {
+		t.Fatalf("pickedArmReachesMapThroughTransparent(arm %d) = false; want true (arm reaches a map leaf through transparent wrappers)", mapArm)
+	}
+	// Second gate conjunct: a sibling reaches a class, so the empty-map
+	// ambiguity is real and the non-empty constraint must engage. Both
+	// conjuncts true ⇒ drawUnion takes the ensure-non-empty branch and
+	// drawArmEnsuringMapNonEmpty draws the map leaf with minLen=1.
+	if !unionHasClassReachableSibling(unionFT, mapArm) {
+		t.Fatalf("unionHasClassReachableSibling(union, %d) = false; want true (a sibling reaches a class — empty {} would be ambiguous)", mapArm)
+	}
+	// The candidate filter's class-driven prune is active here (a class is
+	// reachable in the union) ...
+	if !unionHasClassReachableArm(unionFT) {
+		t.Fatalf("unionHasClassReachableArm(union) = false; want true (class reachable ⇒ candidate prune active)")
+	}
+	// ... yet it must not drop the map arm: armForcesEmptyMap is false for
+	// this shallow shape, so the map arm stays selectable and, once
+	// picked, is held non-empty by the gate above. (Were the arm forced to
+	// a depth-clamped `{}` it would be pruned instead — that is the other
+	// half of the invariant, exercised by the *MayBeEmpty / *WithoutClass
+	// tests.)
+	ctx := &valueDrawCtx{schema: schema, depth: make(map[string]int)}
+	candidates := ctx.unionDrawCandidates(unionFT, false)
+	if !reflect.DeepEqual(candidates, wantCandidates) {
+		t.Fatalf("unionDrawCandidates(union, false) = %v; want %v (map arm retained — it does not force an empty map)", candidates, wantCandidates)
+	}
+}
+
+// assertOverCapMapArmPruned pins the recursion-cap fallback,
+// deterministically and on every run: once the map arm's inner type
+// would blow the per-class recursion cap, drawing it is forced to a
+// depth-clamped empty `{}`. With a class_ref sibling present that `{}`
+// is byte-identical to a null-materialized class instance — which BAML
+// coerces to the class arm — so the candidate filter must DROP the
+// forced-empty map arm and leave only the class-reachable sibling
+// selectable. Seeding the draw context's depth at the cap for the
+// recursive class simulates the over-cap leaf without relying on the
+// rapid draw recursing deep enough to hit the clamp; that statistical
+// dependence was the #389/#498 flake the post-loop `exercised` sentinel
+// carried.
+func assertOverCapMapArmPruned(t *testing.T, schema FuzzSchema, unionFT FuzzType, mapArm, classArm int, recursiveClass string) {
+	t.Helper()
+	ctx := &valueDrawCtx{schema: schema, depth: map[string]int{recursiveClass: MaxValueRecursion}}
+	// The over-cap map arm really is forced to a clamped empty map ...
+	if !ctx.armForcesEmptyMap(unionFT.Variants[mapArm], 0) {
+		t.Fatalf("armForcesEmptyMap(arm %d) = false at the recursion cap; want true (map inner over the cap forces a clamped {})", mapArm)
+	}
+	// ... so it must be pruned, leaving the terminating class_ref sibling
+	// as the only candidate. Were the prune to miss, the draw could fall
+	// back to the forced-empty map arm and emit the ambiguous {}.
+	candidates := ctx.unionDrawCandidates(unionFT, false)
+	want := []int{classArm}
+	if !reflect.DeepEqual(candidates, want) {
+		t.Fatalf("unionDrawCandidates(union, false) at the recursion cap = %v; want %v (forced-empty map arm pruned, class sibling retained)", candidates, want)
+	}
+}
+
 // TestValueGenMapArmWithClassSiblingNeverEmpty is the durable
 // regression guard. With a union whose map arm has a class-reachable
 // sibling, ValueGen must never produce an empty map for the picked
 // map arm — otherwise the walker's Expected (`{}`) diverges from BAML
 // (which coerces `{}` to the class arm with null-filled fields).
+//
+// The non-empty-map invariant is asserted deterministically via
+// assertMapArmNonEmptyGateEngages (drawUnion's gate engages and the
+// candidate filter retains the map arm). The retained rapid.Check is
+// panic-only — it exercises ValueGen on the shape for breadth and fails
+// only if an empty map is actually drawn; it carries no statistical
+// post-loop coverage sentinel (the #389 flake source #417 removed).
 func TestValueGenMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	schema := fixtureSchemaMapVsClassSiblingUnion()
-	var exercised bool
+	unionFT := fixtureFieldUnion(t, schema, "Outer", "f")
+	// Deterministic invariant: the direct map arm (index 0) is gated onto
+	// the non-empty path and retained as a candidate, regardless of any
+	// rapid draw.
+	assertMapArmNonEmptyGateEngages(t, schema, unionFT, 0, []int{0, 1})
+
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
 		fv, ok := v.LookupField("f")
@@ -2180,14 +2291,10 @@ func TestValueGenMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 		if fv.Variant.Kind != KindMap {
 			rt.Fatalf("union arm 0 expected to be a map value, got %v", fv.Variant.Kind)
 		}
-		exercised = true
 		if len(fv.Variant.MapEntries) == 0 {
 			rt.Fatalf("map arm produced an empty map — ambiguous with class sibling under BAML coercion")
 		}
 	})
-	if !exercised {
-		t.Fatalf("rapid budget never picked the direct map arm — coverage sentinel never fired; non-empty-map invariant unverified")
-	}
 }
 
 // fixtureSchemaOptionalMapVsClassSiblingUnion mirrors
@@ -2237,7 +2344,12 @@ func fixtureSchemaOptionalMapVsClassSiblingUnion() FuzzSchema {
 // coercion to remain unambiguous.
 func TestValueGenOptionalMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	schema := fixtureSchemaOptionalMapVsClassSiblingUnion()
-	var exercised bool
+	unionFT := fixtureFieldUnion(t, schema, "Outer", "f")
+	// Deterministic invariant: the optional<map> arm reaches a map through
+	// the optional wrapper, so the gate engages and a present optional is
+	// held non-empty — no dependence on the rapid draw reaching the leaf.
+	assertMapArmNonEmptyGateEngages(t, schema, unionFT, 0, []int{0, 1})
+
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
 		fv, ok := v.LookupField("f")
@@ -2262,14 +2374,10 @@ func TestValueGenOptionalMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 		if fv.Variant.Inner.Kind != KindMap {
 			rt.Fatalf("present optional expected map at leaf, got %v", fv.Variant.Inner.Kind)
 		}
-		exercised = true
 		if len(fv.Variant.Inner.MapEntries) == 0 {
 			rt.Fatalf("present optional<map> drew empty map — ambiguous with class sibling under BAML coercion")
 		}
 	})
-	if !exercised {
-		t.Fatalf("rapid budget never reached present-optional<map> leaf — coverage sentinel never fired; non-empty-map invariant unverified")
-	}
 }
 
 // fixtureSchemaNestedUnionMapVsClassSibling pins the nested-union
@@ -2322,7 +2430,13 @@ func fixtureSchemaNestedUnionMapVsClassSibling() FuzzSchema {
 // reachable sibling.
 func TestValueGenNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	schema := fixtureSchemaNestedUnionMapVsClassSibling()
-	var exercised bool
+	unionFT := fixtureFieldUnion(t, schema, "Outer", "f")
+	// Deterministic invariant: the nested-union arm reaches a map through
+	// the inner union, so the gate engages and the nested map leaf is held
+	// non-empty against the outer class sibling — no dependence on the
+	// rapid draw reaching outer→nested→map.
+	assertMapArmNonEmptyGateEngages(t, schema, unionFT, 0, []int{0, 1})
+
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
 		fv, ok := v.LookupField("f")
@@ -2347,14 +2461,10 @@ func TestValueGenNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 		if fv.Variant.Variant.Kind != KindMap {
 			rt.Fatalf("nested union arm 0 expected to be a map value, got %v", fv.Variant.Variant.Kind)
 		}
-		exercised = true
 		if len(fv.Variant.Variant.MapEntries) == 0 {
 			rt.Fatalf("nested-union map arm produced an empty map — ambiguous with outer class sibling under BAML coercion")
 		}
 	})
-	if !exercised {
-		t.Fatalf("rapid budget never reached nested-union map leaf — coverage sentinel never fired; non-empty-map invariant unverified")
-	}
 }
 
 // fixtureSchemaOptionalNestedUnionMapVsClassSibling layers an
@@ -2406,7 +2516,13 @@ func fixtureSchemaOptionalNestedUnionMapVsClassSibling() FuzzSchema {
 // empty.
 func TestValueGenOptionalNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	schema := fixtureSchemaOptionalNestedUnionMapVsClassSibling()
-	var exercised bool
+	unionFT := fixtureFieldUnion(t, schema, "Outer", "f")
+	// Deterministic invariant: the optional<nested-union> arm reaches a map
+	// through both an optional and a nested union, so the gate engages and
+	// a present compound is held non-empty — no dependence on the rapid
+	// draw reaching outer→optional(present)→nested→map.
+	assertMapArmNonEmptyGateEngages(t, schema, unionFT, 0, []int{0, 1})
+
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
 		fv, ok := v.LookupField("f")
@@ -2440,14 +2556,10 @@ func TestValueGenOptionalNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.
 		if fv.Variant.Inner.Variant.Kind != KindMap {
 			rt.Fatalf("nested union arm 0 expected to be a map value, got %v", fv.Variant.Inner.Variant.Kind)
 		}
-		exercised = true
 		if len(fv.Variant.Inner.Variant.MapEntries) == 0 {
 			rt.Fatalf("optional+nested-union map arm produced an empty map — ambiguous with outer class sibling under BAML coercion")
 		}
 	})
-	if !exercised {
-		t.Fatalf("rapid budget never reached optional+nested-union map leaf — coverage sentinel never fired; non-empty-map invariant unverified")
-	}
 }
 
 // fixtureSchemaDeepNestedUnionMapVsClassSibling stacks two levels of
@@ -2500,7 +2612,14 @@ func fixtureSchemaDeepNestedUnionMapVsClassSibling() FuzzSchema {
 // outer → middle → innermost → map, the leaf map must be non-empty.
 func TestValueGenDeepNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	schema := fixtureSchemaDeepNestedUnionMapVsClassSibling()
-	var exercised bool
+	unionFT := fixtureFieldUnion(t, schema, "Outer", "f")
+	// Deterministic invariant: the map leaf sits two nested-union levels
+	// deep, yet the gate's reach walk descends through both, so the gate
+	// engages and the deep leaf is held non-empty against the outermost
+	// class sibling — no dependence on the rapid draw threading
+	// outer→middle→innermost→map.
+	assertMapArmNonEmptyGateEngages(t, schema, unionFT, 0, []int{0, 1})
+
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
 		fv, ok := v.LookupField("f")
@@ -2531,14 +2650,10 @@ func TestValueGenDeepNestedUnionMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 		if leaf.Kind != KindMap {
 			rt.Fatalf("innermost arm 0 expected map value, got %v", leaf.Kind)
 		}
-		exercised = true
 		if len(leaf.MapEntries) == 0 {
 			rt.Fatalf("deep-nested map arm produced an empty map — ambiguous with outermost class sibling under BAML coercion")
 		}
 	})
-	if !exercised {
-		t.Fatalf("rapid budget never reached deep-nested map leaf — coverage sentinel never fired; non-empty-map invariant unverified")
-	}
 }
 
 // TestValueGenMapArmWithoutClassSiblingMayBeEmpty pins the fix's
@@ -2659,44 +2774,40 @@ func fixtureSchemaRecursiveUnionMapClampClassSibling() FuzzSchema {
 	})
 }
 
-// recursiveFallbackExercised reports whether the draw populated the
-// root union's map arm. Each map entry is a depth-2 A instance whose
-// own union sits over the recursion cap on both arms — the fallback
-// the regression guards. A non-empty root map therefore proves the
-// clamp path was reached, so the assertion below actually covered it.
-func recursiveFallbackExercised(v FuzzValue) bool {
-	fv, ok := v.LookupField("f")
-	if !ok || fv.Kind != KindUnion || fv.Variant == nil {
-		return false
-	}
-	if fv.VariantIndex != 0 || fv.Variant.Kind != KindMap {
-		return false
-	}
-	return len(fv.Variant.MapEntries) > 0
-}
-
 // TestValueGenRecursiveFallbackMapArmWithClassSiblingNeverEmpty is the
 // deterministic regression for the recursion-cap fallback Codex found
-// in r3. When the union's safe-arm set empties (every arm over the
-// cap) and a class_ref sibling is present, the draw must not fall back
-// to the map arm and render a depth-clamped `{}` — BAML coerces that
-// empty map to the class sibling, diverging from the walker's recorded
-// map choice. Before the picker-level fix this fixture draws empty
-// ambiguous maps at the depth-2 union; after it, the fallback picks
-// the terminating class_ref arm and the leaf invariant holds.
+// in r3. The fixture's class A has field `f: union[map<string,A>, B]`
+// and B reaches A again, so at depth 2 BOTH union arms are over the
+// per-class recursion cap. The safe-arm set empties and the draw falls
+// back to the full index range; with a class_ref sibling present, the
+// map arm (forced to a depth-clamped `{}`) must be pruned so the
+// fallback lands on the terminating class_ref arm — otherwise the
+// empty `{}` coerces to the class sibling, diverging from the walker's
+// recorded map choice.
+//
+// The invariant is asserted deterministically: assertOverCapMapArmPruned
+// seeds the draw context's depth at the cap and proves the forced map
+// arm is dropped from the candidate set, leaving only the class arm.
+// assertMapArmNonEmptyGateEngages covers the below-cap case (map arm
+// live and gated non-empty). Neither depends on the rapid draw recursing
+// to the depth-2 clamp — the statistical reach the removed post-loop
+// `exercised` sentinel relied on, and the #498 flake source. The
+// retained rapid.Check is panic-only: walkValueForMapArmAmbiguity fails
+// only if a drawn value actually exhibits the ambiguity.
 func TestValueGenRecursiveFallbackMapArmWithClassSiblingNeverEmpty(t *testing.T) {
 	schema := fixtureSchemaRecursiveUnionMapClampClassSibling()
-	var exercised bool
+	unionFT := fixtureFieldUnion(t, schema, "A", "f")
+	// Below the cap the map arm is a live candidate and held non-empty by
+	// the gate (the same family invariant as the sibling tests).
+	assertMapArmNonEmptyGateEngages(t, schema, unionFT, 0, []int{0, 1})
+	// At the cap the map arm is forced to a clamped `{}` and must be pruned
+	// so the fallback picks the terminating class_ref sibling instead.
+	assertOverCapMapArmPruned(t, schema, unionFT, 0, 1, "A")
+
 	rapid.Check(t, func(rt *rapid.T) {
 		v := ValueGen(schema).Draw(rt, "v")
-		if recursiveFallbackExercised(v) {
-			exercised = true
-		}
 		walkValueForMapArmAmbiguity(rt, schema.EffectiveRoot(), v, schema)
 	})
-	if !exercised {
-		t.Fatalf("rapid budget never reached the depth-clamped fallback union — coverage sentinel never fired; regression unverified")
-	}
 }
 
 // raiseRapidChecksFloor lifts the rapid check budget for the calling


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
Fixes #498.

## Problem

`adapters/common/codegen/bamlfuzz/union_test.go` carries a **family** of statistical coverage-sentinel tests that flake. Each runs `rapid.Check(...)` to draw random shapes, then has a post-loop assertion:

```go
if !exercised { t.Fatalf("rapid budget never reached <leaf> — coverage sentinel never fired; non-empty-map invariant unverified") }
```

`exercised` is true only when the random draw distribution reaches one specific leaf (a map arm with a class sibling, at some optional/nested-union/deep-nesting depth) within the rapid budget. When the distribution misses that leaf, the sentinel never fires and the test **false-fails** even though the production value-gen code is correct — the exact #389 anti-pattern. #498 caught `TestValueGenOptionalNestedUnionMapArmWithClassSiblingNeverEmpty` flaking in CI (passed on rerun).

#417 deflaked the sibling `...WithoutClassSiblingMayBeEmpty` test with a deterministic invariant check but left this family unconverted.

## Fix (mirror #417)

Replace each statistical post-loop sentinel with a **deterministic invariant check** of the exact production gate `drawUnion` uses, then keep the `rapid.Check` body **panic-only** (no `if !exercised`). The non-empty-map invariant is now verified on **every run** with zero dependence on the rapid budget.

### Converted sentinels (6)

| Test | Deterministic invariant now checked |
|---|---|
| `TestValueGenMapArmWithClassSiblingNeverEmpty` | gate engages for the **direct** map arm |
| `TestValueGenOptionalMapArmWithClassSiblingNeverEmpty` | gate engages through an **optional** wrapper |
| `TestValueGenNestedUnionMapArmWithClassSiblingNeverEmpty` | gate engages through a **nested union** |
| `TestValueGenOptionalNestedUnionMapArmWithClassSiblingNeverEmpty` | gate engages through **optional + nested union** (the one that flaked CI) |
| `TestValueGenDeepNestedUnionMapArmWithClassSiblingNeverEmpty` | gate engages through **two** nested-union levels |
| `TestValueGenRecursiveFallbackMapArmWithClassSiblingNeverEmpty` | **recursion-cap fallback**: forced-empty map arm is pruned |

The first five are scoped in the issue; the sixth matches the same `TestValueGen.*MapArm.*ClassSiblingNeverEmpty` regex and carried the identical `if !exercised` flake, so it is converted in the same pass (confirmed with the issue author) to make the whole family flake-free.

### What each helper asserts

`drawUnion` (generator.go:514) gates the non-empty draw on:
```go
if pickedArmReachesMapThroughTransparent(arm, 0) && unionHasClassReachableSibling(ft, idx) { ...drawArmEnsuringMapNonEmpty... }
```
For these shapes **both conjuncts are true** (the mirror image of #417, where the sibling conjunct was false).

- **`assertMapArmNonEmptyGateEngages`** asserts, deterministically: `pickedArmReachesMapThroughTransparent(mapArm, 0) == true` (the arm reaches a map leaf through this shape's transparent wrappers), `unionHasClassReachableSibling(union, mapArm) == true` (a sibling reaches a class, so `{}` is ambiguous under BAML coercion), `unionHasClassReachableArm(union) == true` (the class-driven prune is active), and `unionDrawCandidates(union, false) == [0, 1]` (the prune does **not** drop the map arm — it does not force an empty map). Together these prove `drawUnion` routes a picked map arm through `drawArmEnsuringMapNonEmpty`, which draws the map leaf with `minLen=1`.

- **`assertOverCapMapArmPruned`** (recursion-cap test) seeds the draw context's `depth` at `MaxValueRecursion` for the recursive class, then asserts `armForcesEmptyMap(mapArm, 0) == true` (the over-cap map inner forces a depth-clamped `{}`) and `unionDrawCandidates(union, false) == [classArm]` (the forced-empty map arm is pruned, so the fallback lands on the terminating class_ref sibling instead of emitting the ambiguous `{}`).

The retained `rapid.Check` bodies are panic-only: they exercise `ValueGen`/`walkValueForMapArmAmbiguity` on the shape for breadth and fail only if an empty map is **actually** drawn.

## The checks have teeth

Verified by temporarily breaking production and observing failures (reverted):

- **Neuter the prune** (`armForcesEmptyMap` → always `false`, the pre-fix recursion-cap bug): `assertOverCapMapArmPruned` fails **deterministically every run** — `armForcesEmptyMap(arm 0) = false at the recursion cap; want true`.
- **Drop the non-empty constraint** (`drawArmEnsuringMapNonEmpty` map leaf `minLen` 1 → 0): the panic-only `rapid.Check`s catch the empty map — `deep-nested map arm produced an empty map — ambiguous with outermost class sibling`.

So an empty map produced for any of these shapes is caught — by the deterministic decision asserts (gate/prune regressions) or the panic-only draw (constraint regression).

## Validation

From `adapters/common`:

- `GOWORK=off go test -run 'TestValueGen.*MapArm.*ClassSiblingNeverEmpty' -count=200 ./codegen/bamlfuzz/` → **ok** (passes every run, no budget-dependent flake)
- `GOWORK=off go test -run 'TestValueGen.*MapArm.*ClassSiblingNeverEmpty' -count=200 -race ./codegen/bamlfuzz/` → **ok**
- `GOWORK=off go test ./codegen/bamlfuzz/ -count=1` → **ok**
- `gofmt -l` clean, `GOWORK=off go vet ./codegen/bamlfuzz/` clean

Test-only change in `adapters/common/codegen/bamlfuzz`; no production code touched, no `.go` files added/renamed under `bamlutils`/`pool`/etc., so no embed/dynclient regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved regression coverage for union handling using deterministic assertions.
  * Replaced flaky “branch hit” style checks with stable validations, reducing false negatives.
  * Added coverage for map arms across direct, optional, nested, optional+nested, and deep nested union scenarios.
  * Added targeted checks for recursion-limit fallback behavior to ensure correct pruning and non-empty map outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->