### PR TITLE
feat(pool): worker-panic observability — surface subprocess stderr + static-oracle log dump (#450)

### DIFF
--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -26,6 +26,7 @@
 package integration
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -596,6 +597,7 @@ func dumpStaticEnvLogs(t *testing.T, batchLabel string, env *testutil.TestEnviro
 func dumpContainerLogTail(t *testing.T, marker string, container testcontainers.Container) {
 	t.Helper()
 	if container == nil {
+		t.Logf("=== %s === (container is nil)", marker)
 		return
 	}
 
@@ -609,28 +611,30 @@ func dumpContainerLogTail(t *testing.T, marker string, container testcontainers.
 	}
 	defer rc.Close()
 
-	data, err := io.ReadAll(rc)
-	if err != nil {
+	// Stream the logs through a fixed-size ring of the last
+	// staticLogTailLines lines instead of buffering the whole log into
+	// memory: a crash-looping or verbose worker could otherwise emit
+	// megabytes before we trim. Only the retained tail is ever held
+	// (mirrors the bounded ring buffer #1 uses on the worker stderr).
+	ring := make([]string, 0, staticLogTailLines)
+	scanner := bufio.NewScanner(rc)
+	// Raise the per-line limit well above bufio's 64KB default so a
+	// single long log line (e.g. a wide panic frame) doesn't abort the
+	// scan with ErrTooLong.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if len(ring) == staticLogTailLines {
+			ring = ring[1:]
+		}
+		ring = append(ring, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
 		t.Logf("=== %s === (failed to read logs: %v)", marker, err)
 		return
 	}
 
-	tail := lastLines(string(data), staticLogTailLines)
+	tail := strings.Join(ring, "\n")
 	t.Logf("=== %s (last %d lines) ===\n%s\n=== end %s ===", marker, staticLogTailLines, tail, marker)
-}
-
-// lastLines returns the last n newline-delimited lines of s. A single
-// trailing newline is ignored so it does not count as an empty final
-// line; if s has n or fewer lines it is returned (trimmed) unchanged.
-func lastLines(s string, n int) string {
-	if n <= 0 || s == "" {
-		return s
-	}
-	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
-	if len(lines) <= n {
-		return strings.Join(lines, "\n")
-	}
-	return strings.Join(lines[len(lines)-n:], "\n")
 }
 
 func terminateStaticEnv(t *testing.T, env *testutil.TestEnvironment) {

--- a/integration/bamlfuzz_static_test.go
+++ b/integration/bamlfuzz_static_test.go
@@ -42,6 +42,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/testcontainers/testcontainers-go"
 	"pgregory.net/rapid"
 
 	"github.com/invakid404/baml-rest/adapters/common/codegen/bamlfuzz"
@@ -274,6 +275,18 @@ func runStaticBatch(t *testing.T, cases []bamlfuzz.OracleCase, batchLabel string
 		return
 	}
 	defer terminateStaticEnv(t, env)
+	// On ANY case failure in this batch, dump the dedicated per-batch
+	// container logs BEFORE teardown so CI shows the underlying worker
+	// panic/stack, not just the bare gRPC EOF the host surfaces (issue
+	// #450). Registered after the terminate defer so it runs first
+	// (LIFO). A failed t.Run marks this parent test failed, so
+	// t.Failed() here is true iff at least one case below failed —
+	// bounded, once per batch, and silent on a fully green batch.
+	defer func() {
+		if t.Failed() {
+			dumpStaticEnvLogs(t, batchLabel, env)
+		}
+	}()
 
 	mockClient := mockllm.NewClient(env.MockLLMURL)
 	bamlClient := testutil.NewBAMLRestClient(env.BAMLRestURL)
@@ -552,6 +565,72 @@ func setupStaticEnv(bamlSrcDir string) (*testutil.TestEnvironment, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.SetupBudget(opts))
 	defer cancel()
 	return testutil.Setup(ctx, opts)
+}
+
+// staticLogTailLines bounds the per-batch container log dump so a
+// failure surfaces the panic stack and the preceding worker
+// restart/error context without drowning CI in the full container
+// history.
+const staticLogTailLines = 400
+
+// dumpStaticEnvLogs dumps the dedicated per-batch container logs for a
+// FAILED static-oracle batch so CI shows the underlying worker panic
+// rather than just the bare gRPC EOF the host surfaces (issue #450).
+// Each container is bounded to the last staticLogTailLines lines; this
+// is called at most once per batch, before terminateStaticEnv tears the
+// env down. The suite-level dumpContainerLogs only targets the global
+// TestEnv, so static oracle's per-batch envs need this dedicated dump.
+func dumpStaticEnvLogs(t *testing.T, batchLabel string, env *testutil.TestEnvironment) {
+	t.Helper()
+	if env == nil {
+		return
+	}
+	dumpContainerLogTail(t, fmt.Sprintf("static oracle baml-rest logs: %s", batchLabel), env.BAMLRest)
+	dumpContainerLogTail(t, fmt.Sprintf("static oracle mock-llm logs: %s", batchLabel), env.MockLLM)
+}
+
+// dumpContainerLogTail fetches a container's logs with a short timeout
+// and writes the last staticLogTailLines lines to the test log under a
+// clear marker. A nil container or a fetch/read error is reported but
+// never fatal — diagnostics must not themselves break the teardown path.
+func dumpContainerLogTail(t *testing.T, marker string, container testcontainers.Container) {
+	t.Helper()
+	if container == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	rc, err := container.Logs(ctx)
+	if err != nil {
+		t.Logf("=== %s === (failed to get logs: %v)", marker, err)
+		return
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Logf("=== %s === (failed to read logs: %v)", marker, err)
+		return
+	}
+
+	tail := lastLines(string(data), staticLogTailLines)
+	t.Logf("=== %s (last %d lines) ===\n%s\n=== end %s ===", marker, staticLogTailLines, tail, marker)
+}
+
+// lastLines returns the last n newline-delimited lines of s. A single
+// trailing newline is ignored so it does not count as an empty final
+// line; if s has n or fewer lines it is returned (trimmed) unchanged.
+func lastLines(s string, n int) string {
+	if n <= 0 || s == "" {
+		return s
+	}
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) <= n {
+		return strings.Join(lines, "\n")
+	}
+	return strings.Join(lines[len(lines)-n:], "\n")
 }
 
 func terminateStaticEnv(t *testing.T, env *testutil.TestEnvironment) {

--- a/pool/embed.go
+++ b/pool/embed.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed config_inprocess.go config_subprocess.go embed.go go.mod go.sum hclogzerolog.go native_stacks_inprocess.go native_stacks_subprocess.go pool.go recover_inprocess.go worker_start_common.go worker_start_inprocess.go worker_start_subprocess.go
+//go:embed config_inprocess.go config_subprocess.go embed.go go.mod go.sum hclogzerolog.go native_stacks_inprocess.go native_stacks_subprocess.go pool.go recover_inprocess.go stderr_tail.go worker_start_common.go worker_start_inprocess.go worker_start_subprocess.go
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -320,6 +320,13 @@ type workerHandle struct {
 	restartDone    chan struct{} // closed when the current restart cycle completes; nil when idle
 	inFlightMu     sync.RWMutex
 	inFlightReq    map[uint64]*inFlightRequest
+	// stderrTail captures the subprocess worker's most recent stderr
+	// (a bounded ring buffer) so a worker crash's panic/stack can be
+	// appended to the terminal pool error surfaced to the host (issue
+	// #450). Only populated by subprocess startup; nil in in-process
+	// builds — there is no separate process, so withWorkerStderr is a
+	// clean no-op there.
+	stderrTail *stderrRingBuffer
 }
 
 // kill releases worker-side resources and tears down build-mode-
@@ -1157,7 +1164,7 @@ func (p *Pool) Parse(ctx context.Context, methodName string, inputJSON []byte) (
 			// awaitAnyRestart / getWorkerAccepted), matching the
 			// pre-loop tail in Pool.CallStream.
 			if lastErr != nil {
-				return nil, fmt.Errorf("%w: retry failed, no workers available: %w (previous: %v)", ErrPoolRetriesExhausted, err, lastErr)
+				return nil, withWorkerStderr(fmt.Errorf("%w: retry failed, no workers available: %w (previous: %v)", ErrPoolRetriesExhausted, err, lastErr), lastFailed)
 			}
 			return nil, err
 		}
@@ -1217,7 +1224,7 @@ func (p *Pool) Parse(ctx context.Context, methodName string, inputJSON []byte) (
 		return nil, err
 	}
 
-	return nil, fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, lastErr)
+	return nil, withWorkerStderr(fmt.Errorf("%w: %w", ErrPoolRetriesExhausted, lastErr), lastFailed)
 }
 
 // Call executes a BAML method and returns the final result.
@@ -1406,7 +1413,7 @@ func (p *Pool) CallStream(ctx context.Context, methodName string, inputJSON []by
 					if ctx.Err() != nil {
 						sendErr = fmt.Errorf("retry failed, no workers available: %w (pool error: %v)", ctx.Err(), err)
 					} else {
-						sendErr = fmt.Errorf("%w: retry failed, no workers available: %w", ErrPoolRetriesExhausted, err)
+						sendErr = withWorkerStderr(fmt.Errorf("%w: retry failed, no workers available: %w", ErrPoolRetriesExhausted, err), lastFailed)
 					}
 					sendStreamError(ctx, wrappedResults, sendErr)
 					return
@@ -1667,6 +1674,7 @@ func (p *Pool) CallStream(ctx context.Context, methodName string, inputJSON []by
 		} else {
 			exhaustedErr = fmt.Errorf("%w (no terminal stream frame)", ErrPoolRetriesExhausted)
 		}
+		exhaustedErr = withWorkerStderr(exhaustedErr, lastFailed)
 		sendStreamError(ctx, wrappedResults, exhaustedErr)
 	}()
 

--- a/pool/stderr_tail.go
+++ b/pool/stderr_tail.go
@@ -62,12 +62,16 @@ func (r *stderrRingBuffer) Write(p []byte) (int, error) {
 		i := bytes.IndexByte(rest, '\n')
 		if i < 0 {
 			r.partial = append(r.partial, rest...)
-			// Bound the partial accumulator too: a producer that never
-			// emits a newline must not grow it without limit. Keep the
-			// most recent maxBytes (where the crash text most likely is).
+			// Bound the partial accumulator: a producer that never emits a
+			// newline must not grow it without limit. Keep the most recent
+			// maxBytes (where the crash text most likely is).
 			if len(r.partial) > r.maxBytes {
 				r.partial = append(r.partial[:0], r.partial[len(r.partial)-r.maxBytes:]...)
 			}
+			// snapshot() appends this partial as one extra line, so evict
+			// retained lines to keep the partial-inclusive total within
+			// both caps.
+			r.enforceBounds()
 			break
 		}
 		// string(...) copies, so reusing partial's backing array next
@@ -80,14 +84,37 @@ func (r *stderrRingBuffer) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-// appendLine adds one completed line and evicts the oldest lines until
-// both the line-count and byte-count bounds hold. At least one line is
-// always retained even if it alone exceeds maxBytes, so the freshest
-// output is never dropped entirely.
+// appendLine adds one completed line and re-establishes both bounds. A
+// single line longer than maxBytes (one huge newline-terminated Write)
+// is truncated to its TAIL — the freshest bytes, where the panic
+// message/stack frames live — so it can never retain an arbitrarily
+// large string.
 func (r *stderrRingBuffer) appendLine(line string) {
+	if len(line) > r.maxBytes {
+		line = line[len(line)-r.maxBytes:]
+	}
 	r.lines = append(r.lines, line)
 	r.curBytes += len(line)
-	for len(r.lines) > r.maxLines || (r.curBytes > r.maxBytes && len(r.lines) > 1) {
+	r.enforceBounds()
+}
+
+// enforceBounds evicts the oldest retained lines until the snapshot —
+// the kept lines PLUS, when present, the unterminated partial as one
+// extra trailing line — fits within BOTH the line-count and byte-count
+// caps. Accounting for the partial here (not just the completed lines)
+// is what guarantees any sequence of Writes yields a snapshot of at most
+// maxLines lines and maxBytes content bytes. At least the freshest unit
+// (the newest line, or the partial when all lines are evicted) always
+// survives, since each individual line and the partial are themselves
+// capped at maxBytes.
+func (r *stderrRingBuffer) enforceBounds() {
+	extraLines := 0
+	if len(r.partial) > 0 {
+		extraLines = 1
+	}
+	extraBytes := len(r.partial)
+	for len(r.lines) > 0 &&
+		(len(r.lines)+extraLines > r.maxLines || r.curBytes+extraBytes > r.maxBytes) {
 		r.curBytes -= len(r.lines[0])
 		r.lines = r.lines[1:]
 	}

--- a/pool/stderr_tail.go
+++ b/pool/stderr_tail.go
@@ -1,0 +1,142 @@
+package pool
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+const (
+	// stderrTailMaxLines bounds the worker stderr ring buffer to the
+	// most recent N lines. A panic header plus its goroutine stack and
+	// the surrounding worker restart/error context fit comfortably;
+	// older lines are dropped.
+	stderrTailMaxLines = 100
+
+	// stderrTailMaxBytes caps total retained bytes regardless of line
+	// count, so a worker emitting pathologically long lines (or no
+	// newlines at all) can never grow the buffer without bound.
+	stderrTailMaxBytes = 64 * 1024
+)
+
+// stderrRingBuffer is a thread-safe, bounded ring buffer that retains
+// the most recent stderr output of a subprocess worker. It implements
+// io.Writer so it can be attached to go-plugin's ClientConfig.Stderr
+// and SyncStderr drains. Only the last stderrTailMaxLines lines (and at
+// most stderrTailMaxBytes bytes) are kept; older output is discarded as
+// new lines arrive, so the buffer never grows without bound.
+//
+// It is consulted only on terminal worker-infrastructure failures (see
+// withWorkerStderr), so the steady-state cost is a bounded set of line
+// strings per live worker and nothing on the happy path.
+type stderrRingBuffer struct {
+	mu       sync.Mutex
+	lines    []string // most-recent-last, bounded by maxLines/maxBytes
+	curBytes int      // running sum of len(lines)
+	partial  []byte   // bytes after the last newline, not yet a full line
+	maxLines int
+	maxBytes int
+}
+
+func newStderrRingBuffer() *stderrRingBuffer {
+	return &stderrRingBuffer{
+		maxLines: stderrTailMaxLines,
+		maxBytes: stderrTailMaxBytes,
+	}
+}
+
+// Write splits p into newline-delimited lines and retains the most
+// recent ones. Partial trailing data (no newline yet) is buffered until
+// the rest of the line arrives. It never returns an error and always
+// reports the full length consumed, so go-plugin's stderr-drain
+// goroutine is never stalled by the sink.
+func (r *stderrRingBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	rest := p
+	for {
+		i := bytes.IndexByte(rest, '\n')
+		if i < 0 {
+			r.partial = append(r.partial, rest...)
+			// Bound the partial accumulator too: a producer that never
+			// emits a newline must not grow it without limit. Keep the
+			// most recent maxBytes (where the crash text most likely is).
+			if len(r.partial) > r.maxBytes {
+				r.partial = append(r.partial[:0], r.partial[len(r.partial)-r.maxBytes:]...)
+			}
+			break
+		}
+		// string(...) copies, so reusing partial's backing array next
+		// iteration is safe.
+		line := string(append(r.partial, rest[:i]...))
+		r.partial = r.partial[:0]
+		r.appendLine(line)
+		rest = rest[i+1:]
+	}
+	return n, nil
+}
+
+// appendLine adds one completed line and evicts the oldest lines until
+// both the line-count and byte-count bounds hold. At least one line is
+// always retained even if it alone exceeds maxBytes, so the freshest
+// output is never dropped entirely.
+func (r *stderrRingBuffer) appendLine(line string) {
+	r.lines = append(r.lines, line)
+	r.curBytes += len(line)
+	for len(r.lines) > r.maxLines || (r.curBytes > r.maxBytes && len(r.lines) > 1) {
+		r.curBytes -= len(r.lines[0])
+		r.lines = r.lines[1:]
+	}
+}
+
+// snapshot returns the retained stderr tail as a single newline-joined
+// string and the number of lines it contains. A non-empty partial
+// trailing line (output not yet newline-terminated, e.g. a worker that
+// died mid-line) is included as a final line so a panic header that
+// never got its trailing newline still surfaces.
+func (r *stderrRingBuffer) snapshot() (string, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.lines) == 0 && len(r.partial) == 0 {
+		return "", 0
+	}
+
+	out := make([]string, 0, len(r.lines)+1)
+	out = append(out, r.lines...)
+	if len(r.partial) > 0 {
+		out = append(out, string(r.partial))
+	}
+	return strings.Join(out, "\n"), len(out)
+}
+
+// withWorkerStderr appends the failed worker's captured stderr tail to a
+// terminal pool error so the host sees the underlying panic/stack right
+// next to the bare transport symptom (Unavailable / "error reading from
+// server: EOF") instead of having to dig through worker logs (issue
+// #450). It is a no-op when:
+//   - err is nil,
+//   - h is nil (no failed handle was recorded for this attempt), or
+//   - the handle has no captured stderr — in-process builds never
+//     populate one, and a subprocess worker that died before emitting
+//     anything has an empty buffer.
+//
+// The original error is wrapped with %w, so errors.Is(err,
+// ErrPoolRetriesExhausted) and any embedded gRPC status remain intact.
+// Call this ONLY on terminal retry-exhaustion / no-worker-available
+// paths — never on the happy path or per-attempt retries — to keep the
+// tail out of normal-operation logs.
+func withWorkerStderr(err error, h *workerHandle) error {
+	if err == nil || h == nil || h.stderrTail == nil {
+		return err
+	}
+	tail, n := h.stderrTail.snapshot()
+	if tail == "" {
+		return err
+	}
+	return fmt.Errorf("%w\n--- worker %d stderr (last %d lines) ---\n%s", err, h.id, n, tail)
+}

--- a/pool/stderr_tail_test.go
+++ b/pool/stderr_tail_test.go
@@ -1,0 +1,170 @@
+package pool
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// newTestRing builds a ring buffer with explicit small bounds so the
+// eviction behaviour can be exercised without writing thousands of
+// lines or megabytes of data.
+func newTestRing(maxLines, maxBytes int) *stderrRingBuffer {
+	return &stderrRingBuffer{maxLines: maxLines, maxBytes: maxBytes}
+}
+
+func TestStderrRingBuffer_KeepsLastNLines(t *testing.T) {
+	r := newTestRing(3, 1<<20)
+	for i := 0; i < 10; i++ {
+		fmt.Fprintf(r, "line-%d\n", i)
+	}
+
+	got, n := r.snapshot()
+	if want := "line-7\nline-8\nline-9"; got != want {
+		t.Fatalf("snapshot = %q, want %q", got, want)
+	}
+	if n != 3 {
+		t.Fatalf("line count = %d, want 3", n)
+	}
+}
+
+func TestStderrRingBuffer_ByteCapBounded(t *testing.T) {
+	// maxBytes well below total written: the buffer must never retain
+	// more than maxBytes (plus at most one straddling line).
+	r := newTestRing(1000, 64)
+	for i := 0; i < 200; i++ {
+		fmt.Fprintf(r, "0123456789-%03d\n", i) // 15 bytes/line
+	}
+
+	r.mu.Lock()
+	curBytes := r.curBytes
+	lineSum := 0
+	for _, l := range r.lines {
+		lineSum += len(l)
+	}
+	r.mu.Unlock()
+
+	if curBytes != lineSum {
+		t.Fatalf("curBytes accounting drifted: tracked %d, actual %d", curBytes, lineSum)
+	}
+	// At least one line is always retained even past the cap, so the
+	// bound is maxBytes + one line's worth, never unbounded.
+	if curBytes > 64+15 {
+		t.Fatalf("retained %d bytes, exceeds bound (maxBytes=64 + one line)", curBytes)
+	}
+	// The freshest line must always survive.
+	if got, _ := r.snapshot(); !strings.Contains(got, "0123456789-199") {
+		t.Fatalf("most recent line dropped; snapshot=%q", got)
+	}
+}
+
+func TestStderrRingBuffer_ReassemblesChunkedLine(t *testing.T) {
+	r := newTestRing(10, 1<<20)
+	// A single logical line split across several Write calls, the last
+	// chunk carrying the newline.
+	r.Write([]byte("panic: "))
+	r.Write([]byte("RangeAny called using nil "))
+	r.Write([]byte("*OrderedMap pointer\n"))
+
+	got, n := r.snapshot()
+	if want := "panic: RangeAny called using nil *OrderedMap pointer"; got != want {
+		t.Fatalf("snapshot = %q, want %q", got, want)
+	}
+	if n != 1 {
+		t.Fatalf("line count = %d, want 1", n)
+	}
+}
+
+func TestStderrRingBuffer_IncludesUnterminatedPartial(t *testing.T) {
+	// A worker that dies mid-line never emits the trailing newline; the
+	// partial must still surface (that's often the panic header itself).
+	r := newTestRing(10, 1<<20)
+	r.Write([]byte("first\n"))
+	r.Write([]byte("panic: boom (no newline)"))
+
+	got, n := r.snapshot()
+	if want := "first\npanic: boom (no newline)"; got != want {
+		t.Fatalf("snapshot = %q, want %q", got, want)
+	}
+	if n != 2 {
+		t.Fatalf("line count = %d, want 2", n)
+	}
+}
+
+func TestStderrRingBuffer_EmptySnapshot(t *testing.T) {
+	r := newStderrRingBuffer()
+	if got, n := r.snapshot(); got != "" || n != 0 {
+		t.Fatalf("empty snapshot = (%q, %d), want (\"\", 0)", got, n)
+	}
+}
+
+// TestStderrRingBuffer_ConcurrentWrites stresses the mutex under -race:
+// go-plugin drives Stderr and SyncStderr from independent goroutines, so
+// concurrent Write calls must be safe and the buffer must stay bounded.
+func TestStderrRingBuffer_ConcurrentWrites(t *testing.T) {
+	r := newTestRing(50, 1<<20)
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				fmt.Fprintf(r, "w%d-line-%d\n", w, i)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	_, n := r.snapshot()
+	if n > 50 {
+		t.Fatalf("retained %d lines, exceeds maxLines=50", n)
+	}
+}
+
+func TestWithWorkerStderr_AppendsTailAndPreservesSentinel(t *testing.T) {
+	const marker = "panic: RangeAny called using nil *OrderedMap pointer"
+
+	h := &workerHandle{id: 7, stderrTail: newStderrRingBuffer()}
+	fmt.Fprintf(h.stderrTail, "goroutine 1 [running]:\n%s\n", marker)
+
+	// Mirror the production terminal-exhaustion wrap.
+	base := fmt.Errorf("%w: %w", ErrPoolRetriesExhausted,
+		errors.New("rpc error: code = Unavailable desc = error reading from server: EOF"))
+	got := withWorkerStderr(base, h)
+
+	if !strings.Contains(got.Error(), marker) {
+		t.Fatalf("surfaced error missing stderr tail marker; got:\n%s", got.Error())
+	}
+	if !strings.Contains(got.Error(), "worker 7 stderr") {
+		t.Fatalf("surfaced error missing worker-id delimiter; got:\n%s", got.Error())
+	}
+	// The sentinel chain must survive the wrap so HTTP classification
+	// still sees worker_unavailable.
+	if !errors.Is(got, ErrPoolRetriesExhausted) {
+		t.Fatalf("withWorkerStderr broke errors.Is(ErrPoolRetriesExhausted)")
+	}
+}
+
+func TestWithWorkerStderr_Noop(t *testing.T) {
+	base := fmt.Errorf("%w", ErrPoolRetriesExhausted)
+
+	cases := map[string]*workerHandle{
+		"nil handle": nil,
+		"nil tail":   {id: 1},
+		"empty tail": {id: 2, stderrTail: newStderrRingBuffer()},
+	}
+	for name, h := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := withWorkerStderr(base, h); got != base {
+				t.Fatalf("expected unchanged error, got: %v", got)
+			}
+		})
+	}
+
+	// nil error stays nil regardless of handle.
+	if got := withWorkerStderr(nil, &workerHandle{id: 3, stderrTail: newStderrRingBuffer()}); got != nil {
+		t.Fatalf("withWorkerStderr(nil, ...) = %v, want nil", got)
+	}
+}

--- a/pool/stderr_tail_test.go
+++ b/pool/stderr_tail_test.go
@@ -60,6 +60,85 @@ func TestStderrRingBuffer_ByteCapBounded(t *testing.T) {
 	}
 }
 
+// assertWithinCaps fails if the buffer's snapshot exceeds either cap.
+// It checks the snapshot-visible totals (lines including the partial,
+// and content bytes excluding the join separators), which is exactly
+// what the host surfaces.
+func assertWithinCaps(t *testing.T, r *stderrRingBuffer) {
+	t.Helper()
+	snap, n := r.snapshot()
+	if n > r.maxLines {
+		t.Fatalf("snapshot has %d lines, exceeds maxLines=%d", n, r.maxLines)
+	}
+	// Content bytes = joined length minus the (n-1) "\n" separators.
+	contentBytes := len(snap)
+	if n > 1 {
+		contentBytes -= n - 1
+	}
+	if contentBytes > r.maxBytes {
+		t.Fatalf("snapshot has %d content bytes, exceeds maxBytes=%d", contentBytes, r.maxBytes)
+	}
+}
+
+// TestStderrRingBuffer_StrictCapsUnderAdversarialInput proves the
+// "last N lines / M bytes" contract holds for the two pathological
+// shapes that previously broke it: (i) a single line larger than the
+// byte cap, and (ii) more than the line cap of short lines followed by
+// an unterminated partial (which snapshot includes as an extra line).
+func TestStderrRingBuffer_StrictCapsUnderAdversarialInput(t *testing.T) {
+	const (
+		maxLines = 100
+		maxBytes = 64 * 1024
+	)
+
+	t.Run("single oversized line", func(t *testing.T) {
+		r := newTestRing(maxLines, maxBytes)
+		// One newline-terminated line ~3x the byte cap.
+		big := strings.Repeat("A", 3*maxBytes)
+		r.Write([]byte(big + "\n"))
+		assertWithinCaps(t, r)
+
+		// The TAIL is what's kept: the freshest bytes survive.
+		snap, _ := r.snapshot()
+		if !strings.HasSuffix(big, snap) {
+			t.Fatalf("retained content is not the tail of the input line")
+		}
+	})
+
+	t.Run("over line-cap then trailing partial", func(t *testing.T) {
+		r := newTestRing(maxLines, maxBytes)
+		for i := 0; i < 150; i++ {
+			fmt.Fprintf(r, "short-line-%d\n", i)
+		}
+		// Unterminated partial on top of an already-full ring — this is
+		// the case that used to yield maxLines+1 lines / ~2x bytes.
+		r.Write([]byte("panic: still being written"))
+		assertWithinCaps(t, r)
+
+		snap, _ := r.snapshot()
+		if !strings.HasSuffix(snap, "panic: still being written") {
+			t.Fatalf("partial line not surfaced as final snapshot line; got:\n%s", snap)
+		}
+	})
+
+	t.Run("oversized partial alone", func(t *testing.T) {
+		r := newTestRing(maxLines, maxBytes)
+		// A partial larger than the byte cap, never newline-terminated.
+		r.Write([]byte(strings.Repeat("B", 5*maxBytes)))
+		assertWithinCaps(t, r)
+	})
+
+	t.Run("mixed: oversized line then more lines then partial", func(t *testing.T) {
+		r := newTestRing(maxLines, maxBytes)
+		r.Write([]byte(strings.Repeat("C", 2*maxBytes) + "\n"))
+		for i := 0; i < 200; i++ {
+			fmt.Fprintf(r, "follow-%d\n", i)
+		}
+		r.Write([]byte("trailing partial no newline"))
+		assertWithinCaps(t, r)
+	})
+}
+
 func TestStderrRingBuffer_ReassemblesChunkedLine(t *testing.T) {
 	r := newTestRing(10, 1<<20)
 	// A single logical line split across several Write calls, the last

--- a/pool/worker_start_subprocess.go
+++ b/pool/worker_start_subprocess.go
@@ -71,6 +71,16 @@ func (p *Pool) startWorkerWithStop(id int, stop <-chan struct{}) (*workerHandle,
 	// Create a zerolog-backed hclog for plugin communication
 	pluginLogger := newHclogZerolog(p.logger.With().Int("worker", id).Logger())
 
+	// Capture the worker subprocess's stderr into a bounded ring buffer
+	// so a crash's panic/stack can be appended to the terminal pool
+	// error the host sees (issue #450). go-plugin drains the original
+	// subprocess stderr to ClientConfig.Stderr line-by-line; after the
+	// worker calls goplugin.Serve it redirects os.Stderr to the
+	// SyncStderr stdio channel, so a Go panic written post-Serve lands
+	// there instead — capture both into the same (thread-safe) buffer.
+	// Both default to io.Discard, so without this the panic text is lost.
+	stderrTail := newStderrRingBuffer()
+
 	client := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: workerplugin.Handshake,
 		Plugins:         p.pluginMap(),
@@ -80,6 +90,8 @@ func (p *Pool) startWorkerWithStop(id int, stop <-chan struct{}) (*workerHandle,
 		},
 		Logger:          pluginLogger,
 		GRPCDialOptions: workerplugin.GRPCDialOptions(),
+		Stderr:          stderrTail,
+		SyncStderr:      stderrTail,
 	})
 
 	select {
@@ -91,7 +103,7 @@ func (p *Pool) startWorkerWithStop(id int, stop <-chan struct{}) (*workerHandle,
 
 	resultCh := make(chan workerStartResult, 1)
 	go func() {
-		handle, err := p.finishWorkerStartup(id, client)
+		handle, err := p.finishWorkerStartup(id, client, stderrTail)
 		resultCh <- workerStartResult{handle: handle, err: err}
 	}()
 
@@ -123,7 +135,7 @@ func (p *Pool) startWorkerWithStop(id int, stop <-chan struct{}) (*workerHandle,
 	}
 }
 
-func (p *Pool) finishWorkerStartup(id int, client *plugin.Client) (*workerHandle, error) {
+func (p *Pool) finishWorkerStartup(id int, client *plugin.Client, stderrTail *stderrRingBuffer) (*workerHandle, error) {
 	rpcClient, err := client.Client()
 	if err != nil {
 		client.Kill()
@@ -156,6 +168,7 @@ func (p *Pool) finishWorkerStartup(id int, client *plugin.Client) (*workerHandle
 		killFn:      client.Kill,
 		worker:      worker,
 		inFlightReq: make(map[uint64]*inFlightRequest),
+		stderrTail:  stderrTail,
 	}
 	if reattach := client.ReattachConfig(); reattach != nil {
 		h.nativePid = reattach.Pid


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Fixes #450.

When a BAML worker subprocess panics, the host previously only saw the bare transport symptom:

```
pool retries exhausted: rpc error: code = Unavailable desc = error reading from server: EOF
```

The real panic/stack lived in the worker's stderr but was never surfaced, turning crashes (e.g. #448's nil `*OrderedMap` panic) into multi-hour root-causes. This PR implements improvements **#1** and **#2** from the issue. **#3 (callback-boundary recovery) is deferred to #517** — the patched BAML fork (`dynclient/baml-patched`) is untouched.

## #1 — Worker stderr capture → tail in the surfaced error (production)

- **`pool/stderr_tail.go`** — `stderrRingBuffer`: a thread-safe, bounded ring buffer (`io.Writer`) keeping the last **100 lines / 64 KB** of worker stderr. It splits arbitrary write chunks into lines, reassembles lines split across writes, retains an unterminated trailing partial (the panic header often has no newline yet when the worker dies), and always keeps at least the freshest line — so it **never grows unbounded**.
- **`pool/worker_start_subprocess.go`** — the buffer is attached to go-plugin's `ClientConfig.Stderr` **and** `SyncStderr` (both default to `io.Discard`). go-plugin drains the original subprocess stderr to `Stderr`; after the worker calls `goplugin.Serve` it redirects `os.Stderr` to the `SyncStderr` stdio channel, so a Go panic written post-`Serve` lands there — both are captured into the same buffer. The handle stores it on a new `workerHandle.stderrTail` field.
- **`pool/pool.go`** — `withWorkerStderr(err, handle)` appends the captured tail (clearly delimited: `--- worker N stderr (last K lines) ---`) to the **terminal** error at the four retry-exhaustion / no-worker sites in `Pool.Parse` and `Pool.CallStream`. It wraps with `%w`, so `errors.Is(err, ErrPoolRetriesExhausted)` and any embedded gRPC status are preserved. It is attached **only on those error paths** — never on the happy path or per-attempt retries, so no normal-operation log spam.
- **In-process builds**: `stderrTail` is never populated (there is no separate process), so `withWorkerStderr` is a clean no-op. Wiring lives entirely in the `subprocess`-tagged start file; the buffer/field/helper are build-neutral.

### Test evidence (`pool/stderr_tail_test.go`, runs in default `go test`)

- `TestStderrRingBuffer_KeepsLastNLines` — last-N bounding + order.
- `TestStderrRingBuffer_ByteCapBounded` — byte cap enforced, accounting consistent, freshest line always retained.
- `TestStderrRingBuffer_ReassemblesChunkedLine` — a line split across multiple `Write`s reassembles.
- `TestStderrRingBuffer_IncludesUnterminatedPartial` — worker dying mid-line still surfaces the partial.
- `TestStderrRingBuffer_ConcurrentWrites` — concurrent `Stderr`/`SyncStderr` writers under `-race`, stays bounded.
- `TestWithWorkerStderr_AppendsTailAndPreservesSentinel` — the surfaced pool error **contains the panic marker** and still satisfies `errors.Is(ErrPoolRetriesExhausted)`.
- `TestWithWorkerStderr_Noop` — nil handle / nil tail / empty tail / nil error are all no-ops.

```
$ go test -race ./pool/...
ok  github.com/invakid404/baml-rest/pool
```

## #2 — bamlfuzz static-oracle per-batch container log dump (CI/integration-only)

- **`integration/bamlfuzz_static_test.go`** — on **any** case failure in a static batch, `dumpStaticEnvLogs` dumps the dedicated per-batch `env.BAMLRest` + `env.MockLLM` container logs so CI shows the underlying worker panic, not just the EOF. Bounded to the **last 400 lines** per container (`lastLines`), **once per batch**, under a clear `=== static oracle baml-rest logs: <batch> ===` marker. The existing suite-level `dumpContainerLogs` only targets the global `TestEnv`, so per-batch envs needed this dedicated dump.
- Wired via a `defer func(){ if t.Failed() { ... } }()` in `runStaticBatch`, registered **after** the `terminateStaticEnv` defer so it runs **before** teardown (LIFO). A failed `t.Run` marks the parent failed, so it fires iff at least one case failed — silent on a green batch. Setup/build-failure capture is out of scope (runtime/case failures only).

## Validation

- `gofmt -l` clean; `go vet ./pool/...`, `go vet -tags subprocess ./pool/... ./workerplugin/...`, `go vet -tags integration ./integration/...` all clean.
- `go test -race ./pool/...` ✅
- `go build -o /tmp/wk ./cmd/worker/` and `go build -tags subprocess ./...` both compile.
- New `pool/stderr_tail.go` is under an embedded module, so `go run ./cmd/embed` + `go run ./dynclient/cmd/genadapter` were run (added `stderr_tail.go` to `pool/embed.go`'s embed list; test file excluded) and confirmed idempotent. Worker plugin rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pool/retry error reporting by appending a bounded tail of the worker subprocess stderr when available, while preserving sentinel/typed error semantics.
  * Enhanced static integration failure diagnostics by automatically attaching the last portion of relevant container logs for failed static oracle batches (non-fatal on missing/failed log retrieval).
* **Tests**
  * Added comprehensive coverage for bounded stderr tail behavior (line/byte caps, chunked lines, partial data, concurrency) and for stderr tail error-wrapping/no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->