### PR TITLE
perf(build): warm per-batch static-oracle builds via dep prewarm before baml_src (#470)

### DIFF
--- a/cmd/build/Dockerfile.tmpl
+++ b/cmd/build/Dockerfile.tmpl
@@ -64,14 +64,14 @@ RUN go install golang.org/x/tools/cmd/goimports@latest
 # Set up working directories
 WORKDIR /workspace
 
-# Copy build script
+# Copy build scripts
 COPY build.sh /workspace/build.sh
-RUN chmod +x /workspace/build.sh
+COPY prewarm.sh /workspace/prewarm.sh
+RUN chmod +x /workspace/build.sh /workspace/prewarm.sh
 
-# Copy user's baml_src
-COPY baml_src /workspace/baml_src
-
-# Copy baml_rest sources
+# Copy baml_rest sources (stable across batches; copied before baml_src so the
+# dependency-prewarm layer below is keyed only on these sources and the build
+# matrix env, not on the per-batch generated baml_src)
 COPY baml_rest /workspace/baml_rest
 
 {{- if .bamlSource }}
@@ -137,6 +137,24 @@ ENV SUBPROCESS="true"
 {{- if .baseURLRewrites }}
 ENV BAML_REST_BASE_URL_REWRITES="{{ .baseURLRewrites }}"
 {{- end }}
+
+# Warm caches with the source-independent portion of the build (Go module
+# downloads, npm package downloads, and Go build-cache population). The build
+# env above is set first so this layer's cache key reflects every axis the final
+# build depends on (BAML/adapter version, target arch, build tags, baml-source
+# mode); only a change to one of those — not a per-batch baml_src — invalidates
+# it. The cache locations match build.sh exactly so the warmed directories are
+# the ones build.sh reads.
+{{- if .noCacheMount }}
+RUN /workspace/prewarm.sh
+{{- else }}
+RUN --mount=type=cache,target=/cache \
+    /workspace/prewarm.sh
+{{- end }}
+
+# Copy user's baml_src (per-batch generated source; only the layers below this
+# point rebuild when it changes)
+COPY baml_src /workspace/baml_src
 
 # Run build
 {{- if .noCacheMount }}

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -19,9 +19,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	"github.com/containerd/platforms"
-	"github.com/bytedance/sonic"
 	"github.com/docker/buildx/util/progress"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	buildkitclient "github.com/moby/buildkit/client"
@@ -47,6 +47,9 @@ var dockerfileDockerTemplateInput string
 
 //go:embed build.sh
 var buildScript string
+
+//go:embed prewarm.sh
+var prewarmScript string
 
 type fileWriter interface {
 	WriteFile(name string, data io.Reader, size int64, mode int64) error
@@ -558,6 +561,19 @@ func buildDocker(bamlSrcPath, bamlVersion, adapterVersion string, keepSource str
 
 	if _, err := tarWriter.Write([]byte(buildScript)); err != nil {
 		return fmt.Errorf("failed to write build.sh to build context: %w", err)
+	}
+
+	prewarmScriptHeader := tar.Header{
+		Name: "prewarm.sh",
+		Mode: 0755,
+		Size: int64(len(prewarmScript)),
+	}
+	if err := tarWriter.WriteHeader(&prewarmScriptHeader); err != nil {
+		return fmt.Errorf("failed to write prewarm.sh header to build context: %w", err)
+	}
+
+	if _, err := tarWriter.Write([]byte(prewarmScript)); err != nil {
+		return fmt.Errorf("failed to write prewarm.sh to build context: %w", err)
 	}
 
 	for path, source := range bamlrest.Sources {

--- a/cmd/build/prewarm.sh
+++ b/cmd/build/prewarm.sh
@@ -138,6 +138,16 @@ done
 echo "Regenerating embed.go..."
 go run cmd/embed/main.go || echo "prewarm: embed regen failed (continuing)"
 
+# Detect a provided custom BAML Go library via the .provided marker, exactly as
+# build.sh does. The Dockerfile copies the module into custom_baml_go_lib and
+# touches .provided before this layer runs (e.g. --baml-source builds), and that
+# marker — not the env var — is how build.sh discovers it, so the marker path
+# takes precedence here too.
+CUSTOM_BAML_GO_LIB_PATH="${USER_CONTEXT_PATH}/custom_baml_go_lib"
+if [ -f "${CUSTOM_BAML_GO_LIB_PATH}/.provided" ]; then
+    export CUSTOM_BAML_GO_LIB="${CUSTOM_BAML_GO_LIB_PATH}"
+fi
+
 # Pin the BAML Go dependency the same way build.sh does so the module graph
 # resolves to the cell's version before downloading.
 if [ -n "${CUSTOM_BAML_GO_LIB:-}" ]; then

--- a/cmd/build/prewarm.sh
+++ b/cmd/build/prewarm.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Prewarm script for BAML REST API Docker builds.
+#
+# Runs the source-INDEPENDENT portion of the build so that the expensive,
+# per-batch-invariant work — Go module downloads, the npm BAML package
+# download, and Go build-cache population — lands in a Docker layer built
+# BEFORE the user's baml_src is copied in. That layer is keyed only on the
+# stable baml_rest sources and the build matrix env (BAML_VERSION,
+# ADAPTER_VERSION, TARGETARCH, build tags, baml-source mode), so it is reused
+# across batches whose only difference is baml_src; build.sh then redoes just
+# the source-dependent steps (client generation, introspection, final compile).
+#
+# This is best-effort cache warming: individual warming steps may fail without
+# failing the image build (note the absence of `set -e`). Go's build/module
+# caches and npm's cache are content-addressed, so a partial or skipped warm
+# only costs build speed, never correctness — build.sh recomputes anything that
+# is missing or stale. The cache layout and module/adapter preparation below
+# mirror build.sh so the warmed entries are the ones build.sh actually reuses.
+set -uo pipefail
+
+# These are guaranteed by the Dockerfile env block; bail out cleanly (without
+# failing the build) if a caller invokes prewarm without them.
+if [ -z "${BAML_VERSION:-}" ] || [ -z "${ADAPTER_VERSION:-}" ] || [ -z "${USER_CONTEXT_PATH:-}" ]; then
+    echo "prewarm: required build env not set, skipping cache warm"
+    exit 0
+fi
+
+# --- Cache layout (identical to build.sh) ----------------------------------
+CACHE_DIR="${CACHE_DIR:-/cache}"
+
+# TARGETARCH is set by Docker during the build; normalize uname fallbacks the
+# same way build.sh does so the per-arch cache paths line up.
+TARGETARCH="${TARGETARCH:-$(uname -m)}"
+case "${TARGETARCH}" in
+    x86_64) TARGETARCH="amd64" ;;
+    aarch64) TARGETARCH="arm64" ;;
+esac
+
+export NPM_CONFIG_CACHE="${CACHE_DIR}/npm/${TARGETARCH}"
+export GOMODCACHE="${CACHE_DIR}/go/mod"
+export GOCACHE="${CACHE_DIR}/go/build"
+export BAML_CACHE_DIR="${CACHE_DIR}/baml-shared-lib/${BAML_VERSION}/${TARGETARCH}"
+
+mkdir -p "${NPM_CONFIG_CACHE}" "${GOMODCACHE}" "${GOCACHE}" "${BAML_CACHE_DIR}"
+
+# --- Go build tags (identical to build.sh) ---------------------------------
+# Warmed GOCACHE entries are tag-sensitive, so compile the prewarm tree with the
+# same tags the final build uses.
+BUILD_TAGS=""
+if [ "${DEBUG_BUILD:-false}" = "true" ]; then
+    BUILD_TAGS="${BUILD_TAGS:+${BUILD_TAGS},}debug"
+fi
+if [ "${UNARY_SERVER:-false}" = "true" ]; then
+    BUILD_TAGS="${BUILD_TAGS:+${BUILD_TAGS},}unaryserver"
+fi
+if [ "${SUBPROCESS:-true}" = "true" ]; then
+    BUILD_TAGS="${BUILD_TAGS:+${BUILD_TAGS},}subprocess"
+fi
+GO_BUILD_TAGS=""
+if [ -n "${BUILD_TAGS}" ]; then
+    GO_BUILD_TAGS="-tags=${BUILD_TAGS}"
+fi
+
+echo "============================================"
+echo "BAML REST API Prewarm"
+echo "============================================"
+echo "Target Architecture: ${TARGETARCH}"
+echo "BAML Version: ${BAML_VERSION}"
+echo "Adapter Version: ${ADAPTER_VERSION}"
+echo "Cache Directory: ${CACHE_DIR}"
+echo "Build Tags: ${BUILD_TAGS:-<none>}"
+echo "============================================"
+
+# --- npm/npx warm ----------------------------------------------------------
+# Pre-fetch the BAML npm package so build.sh's `npx ... generate` hits the npm
+# cache instead of the network. Skipped for baml-source builds, which use the
+# locally built CLI (BAML_CLI_PATH) rather than npx.
+if [ -z "${BAML_CLI_PATH:-}" ]; then
+    if command -v npx &> /dev/null; then
+        echo "Prewarming npm cache for @boundaryml/baml@${BAML_VERSION}..."
+        npx --yes "@boundaryml/baml@${BAML_VERSION}" --version || \
+            echo "prewarm: npm warm failed (continuing)"
+    fi
+fi
+
+# --- Go module + build cache warm ------------------------------------------
+# Work on a throwaway copy of baml_rest. build.sh re-copies the pristine tree
+# into its own working directory, so the module-graph edits below never leak
+# into the real build.
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+if ! cp -r "${USER_CONTEXT_PATH}/baml_rest" "${WORK_DIR}/baml_rest"; then
+    echo "prewarm: failed to stage baml_rest, skipping Go warm"
+    exit 0
+fi
+cd "${WORK_DIR}/baml_rest" || exit 0
+
+# Strip dynclient workspace/module references (mirrors build.sh). The embedded
+# server-only bundle excludes the dynclient module, and `go work` validates all
+# use entries before any command runs, so these refs must go before `go work
+# sync` below. Guarded on the absence of dynclient/ so a dev checkout (where the
+# module is present) is left untouched.
+if [ ! -d dynclient ]; then
+    echo "Stripping dynclient workspace/module references..."
+    go work edit \
+        -dropuse=./dynclient \
+        -dropuse=./dynclient/baml-patched || true
+    go mod edit \
+        -droprequire github.com/invakid404/baml-rest/dynclient \
+        -droprequire github.com/invakid404/baml-rest/dynclient/baml-patched \
+        -dropreplace github.com/invakid404/baml-rest/dynclient \
+        -dropreplace github.com/invakid404/baml-rest/dynclient/baml-patched || true
+fi
+
+# Prune non-selected adapters (keyed on ADAPTER_VERSION, not baml_src). Each
+# adapter pins a different github.com/boundaryml/baml version; dropping the
+# others lets Minimum Version Selection resolve baml to the cell's BAML_VERSION,
+# so the warmed build cache matches the version the final build compiles
+# against. Only the directories and root replace/require entries are touched —
+# the per-adapter go.mod pins are never modified, preserving the pin matrix.
+SELECTED_ADAPTER="$(basename "${ADAPTER_VERSION}")"
+echo "Selected adapter: ${SELECTED_ADAPTER}"
+for adapter_dir in adapters/adapter_v*/; do
+    [ -d "${adapter_dir}" ] || continue
+    adapter_name="$(basename "${adapter_dir}")"
+    if [ "${adapter_name}" != "${SELECTED_ADAPTER}" ]; then
+        echo "  Pruning ${adapter_name}..."
+        rm -rf "${adapter_dir}"
+        go mod edit \
+            -droprequire "github.com/invakid404/baml-rest/adapters/${adapter_name}" \
+            -dropreplace "github.com/invakid404/baml-rest/adapters/${adapter_name}" || true
+    fi
+done
+
+# Regenerate embed.go so the root package embeds only the surviving adapter,
+# matching build.sh (this also compiles cmd/embed and its deps into GOCACHE).
+echo "Regenerating embed.go..."
+go run cmd/embed/main.go || echo "prewarm: embed regen failed (continuing)"
+
+# Pin the BAML Go dependency the same way build.sh does so the module graph
+# resolves to the cell's version before downloading.
+if [ -n "${CUSTOM_BAML_GO_LIB:-}" ]; then
+    go work edit -replace "github.com/boundaryml/baml=${CUSTOM_BAML_GO_LIB}" || true
+else
+    echo "Fetching github.com/boundaryml/baml@${BAML_VERSION}..."
+    go get "github.com/boundaryml/baml@${BAML_VERSION}" || \
+        echo "prewarm: go get baml failed (continuing)"
+fi
+
+# Download the workspace module graph into GOMODCACHE.
+echo "Syncing Go workspace (module download)..."
+go work sync || echo "prewarm: go work sync failed (continuing)"
+
+# Warm GOCACHE for the dependency tree. The committed introspected stub imports
+# only bamlutils (no generated baml_client), so the server commands compile here
+# without the per-batch client. When build.sh later regenerates the client and
+# introspection, only the client-dependent leaves recompile — the deep
+# dependency tree stays cached.
+echo "Warming Go build cache..."
+# shellcheck disable=SC2086
+go build ${GO_BUILD_TAGS} \
+    ./cmd/worker/ \
+    ./cmd/serve/ \
+    ./cmd/schema/ \
+    ./cmd/introspect/ \
+    ./cmd/hacks/ || echo "prewarm: build-cache warm incomplete (continuing)"
+
+echo "============================================"
+echo "Prewarm complete"
+echo "============================================"
+exit 0

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -761,6 +761,22 @@ func createBAMLRestBuildContext(opts SetupOptions) (io.ReadSeeker, error) {
 		return nil, err
 	}
 
+	// Get prewarm.sh from embedded sources
+	prewarmScript, err := getPrewarmScript()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get prewarm script: %w", err)
+	}
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "prewarm.sh",
+		Mode: 0755,
+		Size: int64(len(prewarmScript)),
+	}); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write(prewarmScript); err != nil {
+		return nil, err
+	}
+
 	// Add baml_rest sources from embedded FS
 	for path, source := range bamlrest.Sources {
 		if err := copyFSToTar(source, tw, "baml_rest/"+path); err != nil {
@@ -852,6 +868,16 @@ func getBuildScript() ([]byte, error) {
 	}
 
 	return fs.ReadFile(rootFS, "cmd/build/build.sh")
+}
+
+func getPrewarmScript() ([]byte, error) {
+	// The prewarm script is in cmd/build/prewarm.sh within the root embedded FS
+	rootFS, ok := bamlrest.Sources["."]
+	if !ok {
+		return nil, fmt.Errorf("root source not found in embedded sources")
+	}
+
+	return fs.ReadFile(rootFS, "cmd/build/prewarm.sh")
 }
 
 func getDockerfileTemplate() ([]byte, error) {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## What

Makes the expensive, source-independent work in the per-batch baml-rest image build reusable across static-oracle batches by moving it **before** `COPY baml_src`, so only truly source-dependent layers rebuild each batch.

Previously the rendered Dockerfile copied the per-batch generated `baml_src` near the top of the builder stage, ahead of `COPY baml_rest` and the build env. Because Docker's classic cache is parent-layer based, each batch's differing `baml_src` invalidated every layer below it — including the full `RUN build.sh`, which re-downloads Go modules + the npm BAML package and recompiles the entire server every batch (~110s baseline).

## How

**Layer reorder (`cmd/build/Dockerfile.tmpl`)** — the builder stage now copies all source-independent inputs first, then prewarms, then copies the per-batch source:

```
WORKDIR /workspace
COPY build.sh + prewarm.sh ; chmod
COPY baml_rest                       # stable across batches
COPY custom/prebuilt baml lib        # stable per matrix axis
ENV BAML_VERSION / ADAPTER_VERSION / build tags / modes …   # cache key
RUN /workspace/prewarm.sh            # ← shared across batches
COPY baml_src                        # ← per-batch (only layers below rebuild)
RUN /workspace/build.sh
```

**New `cmd/build/prewarm.sh`** runs the source-INDEPENDENT slice of the build into the same `/cache` locations `build.sh` reads:
- npm package fetch (`npx --yes @boundaryml/baml@<ver> --version`) → warms `NPM_CONFIG_CACHE`
- Go module download (`go get github.com/boundaryml/baml@<ver>` + `go work sync`) → warms `GOMODCACHE`
- Go build-cache population (`go build` of the server commands using the committed `introspected` stub, which imports no generated client) → warms `GOCACHE`

It mirrors `build.sh`'s cache layout, dynclient stripping, and adapter-version pruning so the warmed module graph + build cache match what `build.sh` later compiles. It is **best-effort**: any warming step may fail without failing the image build, because Go's and npm's caches are content-addressed — a partial/stale warm is a speed concern only, never a correctness one. All `baml_client`-dependent work (client generation, introspection, adapter/schema gen, final compile) stays in `build.sh`.

`build.sh` itself is unchanged. `prewarm.sh` is embedded alongside it and added to both the CLI (`cmd/build/main.go`) and integration testcontainers (`integration/testutil/container.go`) build contexts.

### Cache-identity correctness
The prewarm `RUN` sits **below** the build env, so its cache key depends on every axis the final build depends on — `BAML_VERSION`, `ADAPTER_VERSION`, `TARGETARCH`, `DEBUG_BUILD`/`UNARY_SERVER`/`SUBPROCESS` (via build tags), and baml-source/prebuilt-cffi mode. A change to any of those invalidates the prewarm layer; a per-batch `baml_src` does not. Adapter pruning drops only the non-selected adapters' root replace/require entries (the per-adapter `go.mod` pins are never touched), so MVS resolves baml to the cell's version and the per-adapter pin matrix is preserved.

### Scope
Option 2 from the #470 investigation only. BuildKit is **not** enabled in testcontainers and `noCacheMount` is unchanged (Option 1 is proven-blocked by the warm-image `docker save`/`load` digest behavior, PR #472). Both the classic-builder (`RUN build.sh`) and BuildKit (`--mount=type=cache`) branches are preserved for both the prewarm and build stages.

## Validation
- `gofmt -l` clean; `go vet ./...` and `go vet -tags subprocess ./...` clean; `go build ./cmd/build/...` OK; `embed.go` regen shows no drift (`cmd/build` is embedded as a directory).
- **Real classic-builder (`noCacheMount`) Docker build, cross-batch cache hit proven:**
  - Build 1 (cold): `prewarm.sh` ran end-to-end (npm warm → dynclient strip → prune adapters 215/219, keep 204 → embed regen → `go get baml@0.214.0` → `go work sync` → build-cache warm), then `build.sh` succeeded. Exit 0.
  - Build 2 (only `baml_src` changed): `Step …/34 : RUN /workspace/prewarm.sh ---> Using cache`; only `COPY baml_src` + `RUN build.sh` re-executed. Warm `build.sh` completed in ~13s.

Note: the local "cold" build benefited from a warm host base-image/Go-proxy cache, so **absolute** per-batch timing defers to the nightly `workflow_dispatch` run per the issue's validation plan; the cross-batch cache-reuse mechanism (the core of #470) is what's demonstrated here.

Fixes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Docker build caching by warming dependency and build caches before copying batch-specific generated sources.
  * Docker build contexts now include a prewarm helper script to accelerate image builds.

* **Bug Fixes**
  * Cache warming is now best-effort: if warming steps fail or prerequisites are missing, the build still proceeds.
  * Reduced unnecessary rebuilds by aligning warmed build settings with the eventual build configuration.

* **Tests**
  * Updated integration test container build context generation to include the new helper script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->