### PR TITLE
test(integration): mockllm serves HTTPS/h2 so the auto arm exercises ALPN selection (#485)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,11 +40,15 @@ jobs:
           #      http-client value).
           #
           # The "auto" value exercises the default dispatch path (ALPN
-          # probe on HTTPS, fasthttp short-circuit on plain http); the
-          # mockllm used in integration tests is plain HTTP so auto and
-          # fasthttp hit the same backend, but keeping auto in the
-          # matrix guards against accidentally breaking the default-mode
-          # wiring.
+          # probe on HTTPS, fasthttp short-circuit on plain http). mockllm
+          # now also serves an HTTPS/h2 lane (:8443) alongside plaintext
+          # :8080, and TestHTTPClientALPNSelection points the BuildRequest
+          # path at it: auto/nethttp negotiate h2 via ALPN → net/http while
+          # fasthttp falls back to http/1.1, asserted per arm via the
+          # protocol the mock observes. So "auto" genuinely takes the
+          # ALPN → h2 → net/http branch and is no longer indistinguishable
+          # from fasthttp — the auto-selection path is real coverage, not
+          # just a guard against breaking the default-mode wiring.
           matrix=$(jq -c '
             def parseVer: split(".") | map(tonumber);
             def supportsBuildRequest: parseVer | .[0] > 0 or (.[0] == 0 and .[1] >= 219);

--- a/integration/http_client_alpn_test.go
+++ b/integration/http_client_alpn_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/invakid404/baml-rest/integration/mockllm"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// TestHTTPClientALPNSelection is the real ALPN-selection coverage the
+// http-client matrix axis was added for (#485). The shared mock serves an
+// HTTPS/h2 lane on :8443 alongside the plaintext :8080 lane; this test points
+// the BuildRequest path at the HTTPS lane and asserts which transport the
+// worker's llmhttp backend actually negotiated, observed as the HTTP protocol
+// version the mock received:
+//
+//   - auto    → ALPN probe negotiates h2 → net/http  → server sees HTTP/2.0
+//   - nethttp → forced net/http (speaks h2)          → server sees HTTP/2.0
+//   - fasthttp→ forced fasthttp (no ALPN, h1 only)   → server sees HTTP/1.1
+//
+// Against plaintext http:// the auto selector short-circuits to fasthttp, so
+// auto and fasthttp were indistinguishable; over HTTPS auto genuinely takes
+// the ALPN → h2 → net/http branch, de-duplicating auto vs fasthttp.
+//
+// Gated on the BuildRequest path because only it dispatches LLM calls through
+// the Go llmhttp client (BAML_REST_HTTP_CLIENT is a no-op on the legacy
+// CallStream path, which uses the BAML runtime's own HTTP stack and would not
+// trust the mock's self-signed cert). The versioned matrix only runs the
+// auto/fasthttp arms on BuildRequest cells anyway.
+func TestHTTPClientALPNSelection(t *testing.T) {
+	if !ActuallyBuildRequest() {
+		t.Skip("http-client selection only applies to the BuildRequest path (llmhttp); skipping on legacy CallStream")
+	}
+	if TestEnv.MockLLMInternalTLS == "" {
+		t.Skip("mock HTTPS/h2 lane not configured")
+	}
+
+	// The host BAML_REST_HTTP_CLIENT (CI http-client axis) is forwarded into
+	// the container, so it also names the backend the worker resolved. Empty
+	// or any non-"fasthttp" value resolves to auto/nethttp, both of which
+	// speak h2.
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv(testutil.HTTPClientSelectorEnvVar)))
+	wantProto := "HTTP/2.0"
+	if mode == "fasthttp" {
+		wantProto = "HTTP/1.1"
+	}
+
+	waitForHealthy(t, 30*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const scenarioID = "alpn-selection"
+	scenario := &mockllm.Scenario{
+		ID:             scenarioID,
+		Provider:       "openai",
+		Content:        "Hello, World!",
+		ChunkSize:      0, // non-streaming: the fiber adaptor on the TLS lane buffers responses
+		InitialDelayMs: 0,
+	}
+	if err := MockClient.RegisterScenario(ctx, scenario); err != nil {
+		t.Fatalf("Failed to register scenario: %v", err)
+	}
+
+	resp, err := BAMLClient.Call(ctx, testutil.CallRequest{
+		Method: "GetGreeting",
+		Input:  map[string]any{"name": "World"},
+		Options: &testutil.BAMLOptions{
+			// Point the client at the HTTPS/h2 lane so the llmhttp backend
+			// runs its real TLS/ALPN decision instead of the plaintext
+			// fasthttp short-circuit.
+			ClientRegistry: testutil.CreateTestClient(TestEnv.MockLLMInternalTLS, scenarioID),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Call over HTTPS mock failed: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, resp.Error)
+	}
+	var result string
+	if err := sonic.Unmarshal(resp.Body, &result); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if result != "Hello, World!" {
+		t.Errorf("Expected 'Hello, World!', got %q", result)
+	}
+
+	// Confirm the request really went through the BuildRequest/llmhttp layer
+	// (not legacy), otherwise the protocol assertion would not reflect the
+	// http-client selection.
+	testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
+
+	gotProto, err := MockClient.GetLastProtocol(ctx, scenarioID)
+	if err != nil {
+		t.Fatalf("Failed to read recorded protocol from mock: %v", err)
+	}
+	if gotProto != wantProto {
+		t.Fatalf("http-client=%q: mock observed %s, want %s (auto/nethttp negotiate h2 via ALPN → net/http; fasthttp uses http/1.1)",
+			mode, gotProto, wantProto)
+	}
+}

--- a/integration/mockllm/Dockerfile
+++ b/integration/mockllm/Dockerfile
@@ -21,6 +21,8 @@ RUN apk --no-cache add ca-certificates
 COPY --from=builder /mockllm /mockllm
 
 ENV ADDR=:8080
-EXPOSE 8080
+# 8080 = plaintext HTTP; 8443 = optional HTTPS/h2 lane (enabled when the
+# integration harness supplies MOCK_LLM_TLS_CERT_PEM/KEY_PEM).
+EXPOSE 8080 8443
 
 CMD ["/mockllm"]

--- a/integration/mockllm/cmd/main.go
+++ b/integration/mockllm/cmd/main.go
@@ -27,6 +27,20 @@ func main() {
 		log.Fatalf("Failed to start server: %v", err)
 	}
 
+	// Optional HTTPS/h2 listener. When the integration harness supplies a
+	// PEM cert + key, also serve the app over TLS with ALPN advertising h2,
+	// so the llmhttp `auto` selector can negotiate h2 and pick net/http.
+	if certPEM, keyPEM := os.Getenv("MOCK_LLM_TLS_CERT_PEM"), os.Getenv("MOCK_LLM_TLS_KEY_PEM"); certPEM != "" && keyPEM != "" {
+		tlsAddr := os.Getenv("MOCK_LLM_TLS_ADDR")
+		if tlsAddr == "" {
+			tlsAddr = ":8443"
+		}
+		log.Printf("Starting mock LLM TLS (h2) listener on %s", tlsAddr)
+		if err := server.StartTLS(tlsAddr, certPEM, keyPEM); err != nil {
+			log.Fatalf("Failed to start TLS listener: %v", err)
+		}
+	}
+
 	// Wait for shutdown signal
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)

--- a/integration/mockllm/scenario.go
+++ b/integration/mockllm/scenario.go
@@ -67,6 +67,11 @@ type ScenarioStore struct {
 	scenarios     map[string]*Scenario
 	requestCounts map[string]int              // tracks request count per scenario ID
 	lastRequests  map[string]*CapturedRequest // stores the last request per scenario ID
+	// lastProtocols records the HTTP protocol (e.g. "HTTP/2.0", "HTTP/1.1")
+	// of the most recent LLM request per scenario ID, observed at the
+	// net/http TLS listener. It is the assertion signal for the http-client
+	// ALPN selection test: h2 ⇒ net/http won ALPN, http/1.1 ⇒ fasthttp.
+	lastProtocols map[string]string
 }
 
 // NewScenarioStore creates a new empty scenario store.
@@ -75,6 +80,7 @@ func NewScenarioStore() *ScenarioStore {
 		scenarios:     make(map[string]*Scenario),
 		requestCounts: make(map[string]int),
 		lastRequests:  make(map[string]*CapturedRequest),
+		lastProtocols: make(map[string]string),
 	}
 }
 
@@ -86,6 +92,7 @@ func (s *ScenarioStore) Register(scenario *Scenario) {
 	s.scenarios[scenario.ID] = scenario
 	s.requestCounts[scenario.ID] = 0
 	delete(s.lastRequests, scenario.ID)
+	delete(s.lastProtocols, scenario.ID)
 }
 
 // Get retrieves a scenario by ID.
@@ -142,6 +149,25 @@ func (s *ScenarioStore) GetLastRequest(id string) (*CapturedRequest, bool) {
 	return req, ok
 }
 
+// RecordProtocol stores the HTTP protocol of the most recent LLM request
+// for a scenario (e.g. "HTTP/2.0", "HTTP/1.1"). Recorded by the TLS
+// listener's middleware so tests can assert which transport the worker's
+// llmhttp backend negotiated via ALPN.
+func (s *ScenarioStore) RecordProtocol(id, proto string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastProtocols[id] = proto
+}
+
+// GetLastProtocol returns the protocol of the last LLM request observed for
+// a scenario, and whether one was recorded.
+func (s *ScenarioStore) GetLastProtocol(id string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	proto, ok := s.lastProtocols[id]
+	return proto, ok
+}
+
 // GetRequestCount returns the number of requests received for a scenario.
 func (s *ScenarioStore) GetRequestCount(id string) int {
 	s.mu.RLock()
@@ -185,6 +211,7 @@ func (s *ScenarioStore) Delete(id string) bool {
 	delete(s.scenarios, id)
 	delete(s.requestCounts, id)
 	delete(s.lastRequests, id)
+	delete(s.lastProtocols, id)
 	return existed
 }
 
@@ -195,6 +222,7 @@ func (s *ScenarioStore) Clear() {
 	s.scenarios = make(map[string]*Scenario)
 	s.requestCounts = make(map[string]int)
 	s.lastRequests = make(map[string]*CapturedRequest)
+	s.lastProtocols = make(map[string]string)
 }
 
 // List returns all registered scenarios.

--- a/integration/mockllm/server.go
+++ b/integration/mockllm/server.go
@@ -4,10 +4,13 @@ package mockllm
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,6 +21,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/middleware/adaptor"
 )
 
 // Server is a mock LLM server for integration testing.
@@ -26,6 +30,12 @@ type Server struct {
 	app   *fiber.App
 	addr  string
 	debug bool
+
+	// h2srv is the optional net/http TLS listener that serves the same
+	// fiber app over HTTPS with ALPN advertising h2 + http/1.1. fasthttp
+	// (the plaintext :8080 listener) cannot speak HTTP/2, so the TLS lane
+	// runs through net/http via the fiber adaptor. Nil unless StartTLS ran.
+	h2srv *http.Server
 }
 
 // NewServer creates a new mock LLM server.
@@ -46,6 +56,7 @@ func NewServer(addr string) *Server {
 	app.Get("/_admin/health", s.handleHealth)
 
 	app.Get("/_admin/scenarios/:id/last-request", s.handleGetLastRequest)
+	app.Get("/_admin/scenarios/:id/last-protocol", s.handleGetLastProtocol)
 	app.Get("/_admin/scenarios/:id/request-count", s.handleGetRequestCount)
 	app.Post("/_admin/scenarios/:id/reset-count", s.handleResetRequestCount)
 
@@ -78,9 +89,105 @@ func (s *Server) Start() error {
 	return nil
 }
 
-// Shutdown gracefully shuts down the server.
+// StartTLS starts an additional net/http listener serving the same fiber
+// app over TLS, with ALPN advertising "h2" then "http/1.1". This is the
+// opt-in HTTPS/h2 lane the integration http-client ALPN test points at: an
+// llmhttp `auto`/`nethttp` backend negotiates h2 (→ net/http) while a
+// `fasthttp` backend, which offers no ALPN, falls back to http/1.1. The
+// plaintext :8080 fiber listener is unaffected, so the rest of the suite
+// keeps using HTTP unchanged.
+//
+// certPEM/keyPEM are a PEM-encoded cert + private key (self-signed at test
+// setup, SAN covering the dial host). HTTP/2 is auto-enabled by net/http's
+// ServeTLS because NextProtos contains "h2" and TLSNextProto is left nil.
+func (s *Server) StartTLS(addr, certPEM, keyPEM string) error {
+	cert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+	if err != nil {
+		return fmt.Errorf("failed to load TLS keypair: %w", err)
+	}
+
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: s.recordProtocol(adaptor.FiberApp(s.app)),
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			NextProtos:   []string{"h2", "http/1.1"},
+			MinVersion:   tls.VersionTLS12,
+		},
+	}
+	s.h2srv = srv
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", addr, err)
+	}
+
+	go func() {
+		// Certs live in TLSConfig, so the file args are empty.
+		if err := srv.ServeTLS(ln, "", ""); err != nil && err != http.ErrServerClosed {
+			log.Printf("Mock LLM TLS server error: %v", err)
+		}
+	}()
+	return nil
+}
+
+// recordProtocol wraps the TLS handler to capture, per scenario (model),
+// the HTTP protocol of each LLM request before delegating to the fiber
+// adaptor. This is the assertion signal for the ALPN selection test: the
+// fiber/fasthttp adaptor flattens everything to HTTP/1.1 internally, so the
+// real negotiated protocol (r.Proto) must be read here at the net/http edge.
+func (s *Server) recordProtocol(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isLLMEndpoint(r.URL.Path) && r.Body != nil {
+			body, err := io.ReadAll(r.Body)
+			if err == nil {
+				// Restore the body for the downstream adaptor; ContentLength
+				// is unchanged so the conversion still reads the full payload.
+				r.Body = io.NopCloser(bytes.NewReader(body))
+				if model := peekModel(body); model != "" {
+					s.store.RecordProtocol(model, r.Proto)
+					s.log("recorded protocol %s for model %s", r.Proto, model)
+				}
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isLLMEndpoint reports whether path is one of the mock's LLM completion
+// endpoints (the only routes the worker's llmhttp backend dials).
+func isLLMEndpoint(path string) bool {
+	switch path {
+	case "/v1/chat/completions", "/chat/completions", "/v1/messages":
+		return true
+	default:
+		return false
+	}
+}
+
+// peekModel extracts the top-level "model" field shared by the OpenAI and
+// Anthropic request shapes, used to key the recorded protocol by scenario.
+func peekModel(body []byte) string {
+	var m struct {
+		Model string `json:"model"`
+	}
+	if err := sonic.Unmarshal(body, &m); err != nil {
+		return ""
+	}
+	return m.Model
+}
+
+// Shutdown gracefully shuts down the server (both the plaintext fiber
+// listener and the optional TLS listener).
 func (s *Server) Shutdown(ctx context.Context) error {
-	return s.app.ShutdownWithContext(ctx)
+	var tlsErr error
+	if s.h2srv != nil {
+		tlsErr = s.h2srv.Shutdown(ctx)
+	}
+	if err := s.app.ShutdownWithContext(ctx); err != nil {
+		return err
+	}
+	return tlsErr
 }
 
 // Addr returns the server's address.
@@ -160,6 +267,20 @@ func (s *Server) handleGetLastRequest(c fiber.Ctx) error {
 	return c.Send(req.Body)
 }
 
+func (s *Server) handleGetLastProtocol(c fiber.Ctx) error {
+	id := c.Params("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).SendString("scenario ID is required")
+	}
+
+	proto, ok := s.store.GetLastProtocol(id)
+	if !ok {
+		return c.Status(fiber.StatusNotFound).SendString("no protocol captured for scenario")
+	}
+
+	return c.JSON(fiber.Map{"protocol": proto})
+}
+
 func (s *Server) handleGetRequestCount(c fiber.Ctx) error {
 	id := c.Params("id")
 	if id == "" {
@@ -192,7 +313,7 @@ type chatCompletionsRequest struct {
 }
 
 type chatMessage struct {
-	Role    string          `json:"role"`
+	Role    string             `json:"role"`
 	Content stdjson.RawMessage `json:"content"` // Can be string or array of content parts
 }
 
@@ -700,6 +821,35 @@ func (c *Client) GetRequestCount(ctx context.Context, scenarioID string) (int, e
 		return 0, fmt.Errorf("failed to decode response: %w", err)
 	}
 	return result.Count, nil
+}
+
+// GetLastProtocol returns the HTTP protocol (e.g. "HTTP/2.0", "HTTP/1.1")
+// of the last LLM request the mock's TLS listener observed for a scenario.
+// Used by the http-client ALPN test to assert which llmhttp backend the
+// worker negotiated: h2 ⇒ net/http (auto won ALPN / nethttp), http/1.1 ⇒
+// fasthttp.
+func (c *Client) GetLastProtocol(ctx context.Context, scenarioID string) (string, error) {
+	escapedID := url.PathEscape(scenarioID)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/_admin/scenarios/%s/last-protocol", c.baseURL, escapedID), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+	var result struct {
+		Protocol string `json:"protocol"`
+	}
+	if err := sonic.ConfigDefault.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+	return result.Protocol, nil
 }
 
 // ResetRequestCount resets the request counter for a scenario to zero.

--- a/integration/mockllm/server.go
+++ b/integration/mockllm/server.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -184,10 +185,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if s.h2srv != nil {
 		tlsErr = s.h2srv.Shutdown(ctx)
 	}
-	if err := s.app.ShutdownWithContext(ctx); err != nil {
-		return err
-	}
-	return tlsErr
+	fiberErr := s.app.ShutdownWithContext(ctx)
+	// Join so a TLS-shutdown error isn't dropped when the fiber shutdown
+	// also fails. errors.Join(nil, nil) is nil, so the common nil-h2srv
+	// happy path and single-error cases are unchanged.
+	return errors.Join(tlsErr, fiberErr)
 }
 
 // Addr returns the server's address.

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -37,6 +37,16 @@ const (
 	// MockLLMInternalPort is the port the mock server listens on inside Docker
 	MockLLMInternalPort = "8080/tcp"
 
+	// MockLLMTLSInternalPort is the port the mock server's HTTPS/h2 listener
+	// uses inside Docker. Reached by the worker over the docker network (no
+	// host mapping required); exposed for parity/debuggability only.
+	MockLLMTLSInternalPort = "8443/tcp"
+
+	// mockLLMCAContainerPath is where the self-signed mock CA is mounted in
+	// the baml-rest container. SSL_CERT_FILE points the Go llmhttp client's
+	// system cert pool at it so the worker trusts the mock's HTTPS listener.
+	mockLLMCAContainerPath = "/etc/mockllm-ca.pem"
+
 	// BAMLRestInternalPort is the port baml-rest listens on inside Docker
 	BAMLRestInternalPort = "8080/tcp"
 
@@ -46,13 +56,14 @@ const (
 
 // TestEnvironment holds the running test containers and network.
 type TestEnvironment struct {
-	Network          *testcontainers.DockerNetwork
-	MockLLM          testcontainers.Container
-	BAMLRest         testcontainers.Container
-	MockLLMURL       string // URL to reach mock server from host (http://localhost:xxxxx)
-	BAMLRestURL      string // URL to reach baml-rest from host (http://localhost:xxxxx)
-	BAMLRestUnaryURL string // URL to reach unary server from host (http://localhost:xxxxx)
-	MockLLMInternal  string // URL to reach mock server from baml-rest (http://mockllm:8080)
+	Network            *testcontainers.DockerNetwork
+	MockLLM            testcontainers.Container
+	BAMLRest           testcontainers.Container
+	MockLLMURL         string // URL to reach mock server from host (http://localhost:xxxxx)
+	BAMLRestURL        string // URL to reach baml-rest from host (http://localhost:xxxxx)
+	BAMLRestUnaryURL   string // URL to reach unary server from host (http://localhost:xxxxx)
+	MockLLMInternal    string // URL to reach mock server from baml-rest (http://mockllm:8080)
+	MockLLMInternalTLS string // HTTPS/h2 URL to reach mock server from baml-rest (https://mockllm:8443)
 }
 
 // Terminate shuts down all containers and network.
@@ -419,6 +430,16 @@ func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error)
 		}
 	}()
 
+	// Generate a self-signed cert for the mock's HTTPS/h2 lane. The SAN
+	// covers the docker-network alias the worker dials ("mockllm") plus
+	// loopback names. The same PEM is served by the mock and mounted into
+	// baml-rest as the trust anchor (it is its own CA).
+	mockCertPEM, mockKeyPEM, err := GenerateMockTLSCert([]string{MockLLMContainerName, "localhost", "127.0.0.1"})
+	if err != nil {
+		runSetupCleanup(env.Terminate)
+		return nil, fmt.Errorf("failed to generate mock TLS cert: %w", err)
+	}
+
 	// Create Docker network
 	net, err := network.New(ctx)
 	if err != nil {
@@ -427,7 +448,7 @@ func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error)
 	env.Network = net
 
 	// Start mock LLM server
-	mockLLM, err := startMockLLMContainer(ctx, net.Name)
+	mockLLM, err := startMockLLMContainer(ctx, net.Name, mockCertPEM, mockKeyPEM)
 	if err != nil {
 		runSetupCleanup(env.Terminate)
 		return nil, fmt.Errorf("failed to start mock LLM container: %w", err)
@@ -447,9 +468,10 @@ func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error)
 	}
 	env.MockLLMURL = fmt.Sprintf("http://%s:%s", mockHost, mockPort.Port())
 	env.MockLLMInternal = fmt.Sprintf("http://%s:8080", MockLLMContainerName)
+	env.MockLLMInternalTLS = fmt.Sprintf("https://%s:8443", MockLLMContainerName)
 
 	// Build and start baml-rest container
-	bamlRest, err := startBAMLRestContainer(ctx, net.Name, opts)
+	bamlRest, err := startBAMLRestContainer(ctx, net.Name, opts, mockCertPEM)
 	if err != nil {
 		runSetupCleanup(env.Terminate)
 		return nil, fmt.Errorf("failed to start baml-rest container: %w", err)
@@ -481,7 +503,7 @@ func setupOnce(ctx context.Context, opts SetupOptions) (*TestEnvironment, error)
 	return env, nil
 }
 
-func startMockLLMContainer(ctx context.Context, networkName string) (testcontainers.Container, error) {
+func startMockLLMContainer(ctx context.Context, networkName string, certPEM, keyPEM []byte) (testcontainers.Container, error) {
 	// Build context from the mockllm directory
 	buildCtx, err := createMockLLMBuildContext()
 	if err != nil {
@@ -494,10 +516,17 @@ func startMockLLMContainer(ctx context.Context, networkName string) (testcontain
 			Dockerfile:     "integration/mockllm/Dockerfile",
 			PrintBuildLog:  true, // Enable build log output to see compilation errors
 		},
-		ExposedPorts: []string{MockLLMInternalPort},
+		ExposedPorts: []string{MockLLMInternalPort, MockLLMTLSInternalPort},
 		Networks:     []string{networkName},
 		NetworkAliases: map[string][]string{
 			networkName: {MockLLMContainerName},
+		},
+		// Supplying the cert/key turns on the mock's HTTPS/h2 listener on
+		// :8443 (see integration/mockllm/cmd/main.go); the plaintext :8080
+		// lane is unaffected so the rest of the suite is unchanged.
+		Env: map[string]string{
+			"MOCK_LLM_TLS_CERT_PEM": string(certPEM),
+			"MOCK_LLM_TLS_KEY_PEM":  string(keyPEM),
 		},
 		WaitingFor: wait.ForHTTP("/_admin/health").WithPort(MockLLMInternalPort).WithStartupTimeout(30 * time.Second),
 	}
@@ -548,11 +577,18 @@ func createMockLLMBuildContext() (io.ReadSeeker, error) {
 	return bytes.NewReader(buf.Bytes()), nil
 }
 
-func startBAMLRestContainer(ctx context.Context, networkName string, opts SetupOptions) (testcontainers.Container, error) {
+func startBAMLRestContainer(ctx context.Context, networkName string, opts SetupOptions, mockCAPEM []byte) (testcontainers.Container, error) {
 	buildCtx, err := createBAMLRestBuildContext(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create baml-rest build context: %w", err)
 	}
+
+	// Trust the mock's self-signed HTTPS cert: mount it and point the Go
+	// llmhttp client's system cert pool at it via SSL_CERT_FILE (honored by
+	// crypto/x509 on Linux for both the net/http and fasthttp backends).
+	// Harmless for the plaintext lane — no other HTTPS calls happen in tests.
+	containerEnv := buildContainerEnv(opts)
+	containerEnv["SSL_CERT_FILE"] = mockLLMCAContainerPath
 
 	exposedPorts := []string{BAMLRestInternalPort}
 	cmd := []string{"--sse-keepalive-interval=100ms"}
@@ -581,7 +617,14 @@ func startBAMLRestContainer(ctx context.Context, networkName string, opts SetupO
 		NetworkAliases: map[string][]string{
 			networkName: {BAMLRestContainerName},
 		},
-		Env: buildContainerEnv(opts),
+		Env: containerEnv,
+		Files: []testcontainers.ContainerFile{
+			{
+				Reader:            bytes.NewReader(mockCAPEM),
+				ContainerFilePath: mockLLMCAContainerPath,
+				FileMode:          0o644,
+			},
+		},
 		HostConfigModifier: func(hc *container.HostConfig) {
 			if hc.Sysctls == nil {
 				hc.Sysctls = make(map[string]string)

--- a/integration/testutil/tls.go
+++ b/integration/testutil/tls.go
@@ -1,0 +1,67 @@
+//go:build integration
+
+package testutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+// GenerateMockTLSCert produces a self-signed certificate + private key (both
+// PEM-encoded) for the mock LLM server's HTTPS/h2 listener. The certificate
+// is its own CA, so the same PEM serves as both the server certificate and
+// the trust anchor the baml-rest container mounts via SSL_CERT_FILE.
+//
+// hosts populate the Subject Alternative Name extension: IP literals become
+// IPAddresses, everything else a DNS name. The worker dials the mock by its
+// docker-network alias ("mockllm"), so that name must be present.
+func GenerateMockTLSCert(hosts []string) (certPEM, keyPEM []byte, err error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 62))
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate serial: %w", err)
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "mockllm"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			tmpl.IPAddresses = append(tmpl.IPAddresses, ip)
+		} else {
+			tmpl.DNSNames = append(tmpl.DNSNames, h)
+		}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create certificate: %w", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal key: %w", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, nil
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Fixes #485.

## Problem

The integration `http-client` matrix axis (`auto`/`nethttp`/`fasthttp`) was made real in #484, but `integration/mockllm` served only **plaintext HTTP**. The llmhttp `auto` selector (`bamlutils/llmhttp/cache.go`) short-circuits plain `http://` straight to fasthttp, so against the mock `auto` and `fasthttp` collapsed to the same backend and the ALPN → `h2` → net/http branch was never exercised.

## What this does

Adds an **opt-in HTTPS/h2 lane** to the mock plus a dedicated assertion test — minimal blast radius (the plaintext lane is untouched, so the rest of the suite is unchanged).

### How h2 is served
fasthttp (the fiber backend) can't speak HTTP/2, so the mock now starts an **additional `net/http` TLS listener on `:8443`** serving the same fiber app via `adaptor.FiberApp`, with `tls.Config{NextProtos: ["h2","http/1.1"]}` (HTTP/2 auto-enabled by `ServeTLS`). The plaintext `:8080` fiber listener is unchanged. The TLS lane is enabled only when the harness supplies a cert/key via env.

### How cert trust is wired
All providers used in the suite (openai/openai-generic/anthropic) are BuildRequest-supported, so on the BuildRequest path every LLM call goes through the **Go llmhttp client**, which uses the system cert pool. The harness:
- generates a self-signed cert at setup (SAN: `mockllm`, `localhost`, `127.0.0.1`; it is its own CA),
- serves it from the mock (`MOCK_LLM_TLS_CERT_PEM`/`KEY_PEM`),
- mounts it into the baml-rest container and sets **`SSL_CERT_FILE`**, which `crypto/x509` honors on Linux for both the net/http and fasthttp backends.

No BAML-runtime/fork trust changes were needed.

### How `auto → net/http` is asserted
There's no per-request backend header, so the decisive observable is the **HTTP protocol the mock receives** (h2 ⇒ net/http won ALPN; http/1.1 ⇒ fasthttp). The TLS listener records it per scenario, exposed via `GET /_admin/scenarios/:id/last-protocol`. `TestHTTPClientALPNSelection` points the BuildRequest path at `https://mockllm:8443` and asserts, per the current `BAML_REST_HTTP_CLIENT` mode:

| mode | mock observes |
|------|---------------|
| `auto` | `HTTP/2.0` (ALPN → h2 → net/http) |
| `nethttp` | `HTTP/2.0` |
| `fasthttp` | `HTTP/1.1` |

The test is gated to the BuildRequest path (the only path that dispatches through llmhttp). The de-dup note in `.github/workflows/integration-tests.yml` is updated to reflect that the auto-selection path is now genuine coverage.

## Validation
- `gofmt -l`, `go build ./...`, `go vet ./...`, `go vet -tags integration ./...` — all clean.
- Integration tests compile (`go test -tags integration -c -o /dev/null ./integration`).
- `mockllm` package tests pass.
- Verified the core mechanism **in-process** (no Docker): an h2-capable client negotiates `HTTP/2.0` (recorded as `HTTP/2.0`) and an h1-only client gets `HTTP/1.1` (recorded as `HTTP/1.1`) against `StartTLS`.
- The full Dockerized auto-cell run is **deferred to CI** (requires building the baml-rest image); CI will confirm `auto` now selects net/http end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional HTTPS (HTTP/2) lane to the mock integration service alongside the existing plaintext lane.
  * Updated the integration test harness to auto-generate and trust a temporary TLS certificate for the secure lane.
* **Bug Fixes**
  * Added integration coverage to confirm the client’s “auto” transport negotiates the expected protocol, while explicitly selecting plaintext behaves as intended.
  * Enhanced test diagnostics by recording and exposing the last negotiated protocol per scenario.
* **Chores**
  * Refreshed workflow commentary to match the current integration-test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->