### PR TITLE
test(bamlfuzz): native-vs-BAML differential parsing harness (#523)

### DIFF
--- a/adapters/common/codegen/bamlfuzz/case.go
+++ b/adapters/common/codegen/bamlfuzz/case.go
@@ -43,6 +43,12 @@ const (
 	// walker-computed value: BAML passes reasoning through untouched, so
 	// the oracle proves preservation + separation, not reasoning parsing.
 	OracleReasoning OracleMode = "reasoning"
+	// OracleParseDiff: drive the same raw model text through a BAML
+	// parser (oracle) and a registered native parser (candidate) and
+	// diff their final / parse-stream outcomes directly, bypassing the
+	// call path. Backs the native-vs-BAML differential parsing harness
+	// and the JSONish recovery corpus.
+	OracleParseDiff OracleMode = "parse_diff"
 )
 
 // CaseMetadata is per-case provenance that's useful to a developer

--- a/adapters/common/codegen/bamlfuzz/envelope_parse.go
+++ b/adapters/common/codegen/bamlfuzz/envelope_parse.go
@@ -1,0 +1,98 @@
+package bamlfuzz
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ParseDiffFailureEnvelope captures the full context around a
+// native-vs-BAML differential parse disagreement (or a BAML-vs-checked-in
+// expectation mismatch). It is the parse-harness analogue of the
+// dynamic/static/streaming oracle envelopes: enough context to replay and
+// triage one failing parse without re-deriving the case.
+//
+// One envelope describes one comparison. For a streaming case the
+// per-prefix legs each get their own envelope; PrefixIndex / PrefixName
+// identify which accumulated prefix this envelope is for (PrefixIndex is
+// -1 for a final-parse leg). Raw is the exact text that was parsed.
+//
+// Expected, when present, is the checked-in `want` the BAML outcome was
+// characterized against; ExpectedStatus records its success/error token.
+// BAML and Native are the captured ParseOutcomes; the diff slices and the
+// human-readable Failures mirror ParseDiffResult.
+type ParseDiffFailureEnvelope struct {
+	GeneratorVersion    string     `json:"generator_version"`
+	GeneratedAt         string     `json:"generated_at"`
+	CaseIndex           int        `json:"case_index"`
+	CaseName            string     `json:"case_name"`
+	OracleMode          OracleMode `json:"oracle_mode"`
+	PreserveSchemaOrder bool       `json:"preserve_schema_order"`
+	Schema              FuzzSchema `json:"schema"`
+
+	// Stream is true when the leg was a parse-stream comparison over an
+	// accumulated prefix; false for a final parse.
+	Stream bool `json:"stream"`
+	// PrefixIndex / PrefixName identify the streaming prefix this envelope
+	// covers. PrefixIndex is -1 for a final-parse leg.
+	PrefixIndex int    `json:"prefix_index"`
+	PrefixName  string `json:"prefix_name,omitempty"`
+	// Raw is the exact model text that was parsed (full response for a
+	// final parse, accumulated prefix for a stream leg).
+	Raw string `json:"raw"`
+
+	// ExpectedStatus / Expected hold the checked-in `want` outcome the
+	// BAML leg was characterized against, when the comparison was
+	// BAML-vs-corpus. Empty for a pure native-vs-BAML diff.
+	ExpectedStatus string          `json:"expected_status,omitempty"`
+	Expected       json.RawMessage `json:"expected,omitempty"`
+
+	SkippedNative bool         `json:"skipped_native,omitempty"`
+	BAML          ParseOutcome `json:"baml"`
+	Native        ParseOutcome `json:"native,omitempty"`
+
+	SemanticDiff []SemanticDiffEntry    `json:"semantic_diff,omitempty"`
+	OrderDiff    []SchemaOrderDiffEntry `json:"order_diff,omitempty"`
+	Failures     []string               `json:"failures,omitempty"`
+
+	ReplayPath   string `json:"replay_path"`
+	Reproduction string `json:"reproduction,omitempty"`
+}
+
+// WriteParseDiffReplayArtifact writes a ParseDiffFailureEnvelope to `dir`
+// as a JSON file. Same on-disk format as WriteReplayArtifact (2-space
+// indent, deterministic basename via sanitizeArtifactBasename);
+// envelope.ReplayPath is stamped with the resulting path so the t.Errorf
+// message can point at the artifact. For a streaming leg the prefix index
+// is folded into the basename so per-prefix failures of one case don't
+// clobber each other.
+func WriteParseDiffReplayArtifact(dir string, envelope *ParseDiffFailureEnvelope) (string, error) {
+	if envelope == nil {
+		return "", fmt.Errorf("bamlfuzz: nil envelope")
+	}
+	if envelope.GeneratorVersion == "" {
+		envelope.GeneratorVersion = GeneratorVersion
+	}
+	if envelope.GeneratedAt == "" {
+		envelope.GeneratedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("bamlfuzz: mkdir %s: %w", dir, err)
+	}
+	name := sanitizeArtifactBasename(envelope.CaseName, envelope.CaseIndex)
+	if envelope.PrefixIndex >= 0 {
+		name = fmt.Sprintf("%s_prefix_%d", name, envelope.PrefixIndex)
+	}
+	path := filepath.Join(dir, name+".json")
+	envelope.ReplayPath = path
+	buf, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("bamlfuzz: marshal envelope: %w", err)
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		return "", fmt.Errorf("bamlfuzz: write %s: %w", path, err)
+	}
+	return path, nil
+}

--- a/adapters/common/codegen/bamlfuzz/envelope_parse.go
+++ b/adapters/common/codegen/bamlfuzz/envelope_parse.go
@@ -51,7 +51,12 @@ type ParseDiffFailureEnvelope struct {
 
 	SkippedNative bool         `json:"skipped_native,omitempty"`
 	BAML          ParseOutcome `json:"baml"`
-	Native        ParseOutcome `json:"native,omitempty"`
+	// Native is a pointer so an absent/skipped native leg is omitted from
+	// the JSON entirely. A non-pointer ParseOutcome would not be elided by
+	// encoding/json (omitempty does not apply to a zero-value struct), and
+	// ParseOutcome.Parser is non-omitempty, so a BAML-only failure envelope
+	// would otherwise emit a misleading {"parser":""} native stub.
+	Native *ParseOutcome `json:"native,omitempty"`
 
 	SemanticDiff []SemanticDiffEntry    `json:"semantic_diff,omitempty"`
 	OrderDiff    []SchemaOrderDiffEntry `json:"order_diff,omitempty"`

--- a/adapters/common/codegen/bamlfuzz/parse_diff.go
+++ b/adapters/common/codegen/bamlfuzz/parse_diff.go
@@ -200,6 +200,16 @@ func parseOutcome(name string, res ParseResult, err error) ParseOutcome {
 // expected output, must surface here. `side` is copied verbatim onto each
 // emitted entry. Either input being empty is a decode error, mirroring
 // SemanticDiff's contract.
+//
+// strictDiffAny / strictDeepEqual are a deliberately separate recursion
+// from envelope.go's semanticDiff / diffAny / deepEqualSemantic, not an
+// accidental copy. The shared comparator unconditionally applies the
+// lenient boundaryml/baml#3690 extra-null tolerance; the native-vs-BAML
+// leg requires exact equality and must NOT inherit it. Folding the two
+// behind a shared `nullStrict` mode is deferred precisely to avoid
+// re-entangling the strict and lenient paths and risking the tolerance
+// leaking back into this comparator — the small duplication buys that
+// safety property.
 func SemanticDiffStrict(side string, a, b json.RawMessage) ([]SemanticDiffEntry, error) {
 	av, err := decodeAny(a)
 	if err != nil {

--- a/adapters/common/codegen/bamlfuzz/parse_diff.go
+++ b/adapters/common/codegen/bamlfuzz/parse_diff.go
@@ -162,6 +162,18 @@ func DiffParserPrefixes(ctx context.Context, baml, native Parser, req ParseReque
 	return out
 }
 
+// NativeOutcome returns a pointer to the candidate's outcome, or nil when
+// the native leg was skipped or never ran (its Parser name is unset).
+// Envelope constructors use it so an absent native leg is omitted from the
+// failure JSON instead of emitting an empty {"parser":""} stub.
+func (r ParseDiffResult) NativeOutcome() *ParseOutcome {
+	if r.SkippedNative || r.Native.Parser == "" {
+		return nil
+	}
+	n := r.Native
+	return &n
+}
+
 // parseOutcome packages a parser's (result, error) into a ParseOutcome.
 // On error only Error is set (diagnostic text); on success only JSON.
 func parseOutcome(name string, res ParseResult, err error) ParseOutcome {

--- a/adapters/common/codegen/bamlfuzz/parse_diff.go
+++ b/adapters/common/codegen/bamlfuzz/parse_diff.go
@@ -1,0 +1,295 @@
+package bamlfuzz
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ParseOutcome records what one parser did with a request: its name, the
+// JSON it produced on success, or its error text on failure. Error is
+// diagnostic only — the comparator gates on success/error parity, never
+// on exact error strings — so a parser is free to put whatever is useful
+// for triage there.
+type ParseOutcome struct {
+	Parser string          `json:"parser"`
+	JSON   json.RawMessage `json:"json,omitempty"`
+	Error  string          `json:"error,omitempty"`
+}
+
+// ParseDiffResult is the outcome of comparing the BAML parser against the
+// candidate (native) parser for one raw string. A result with an empty
+// Failures slice is a pass. SkippedNative is true when the native parser
+// returned ErrParserUnavailable, in which case the differential leg
+// passes vacuously (BAML's own outcome is still captured for forensics).
+type ParseDiffResult struct {
+	// SkippedNative is set when the native parser declined the request
+	// (ErrParserUnavailable). The leg passes; only BAML ran.
+	SkippedNative bool `json:"skipped_native,omitempty"`
+	// BAML is the oracle/reference outcome. Always populated unless the
+	// BAML parser itself was unavailable (a harness failure).
+	BAML ParseOutcome `json:"baml"`
+	// Native is the candidate outcome. Zero-valued when SkippedNative.
+	Native ParseOutcome `json:"native,omitempty"`
+	// SemanticDiff lists the strict JSON disagreements between BAML
+	// (reference) and native (actual). Empty unless both succeeded and
+	// their JSON differed.
+	SemanticDiff []SemanticDiffEntry `json:"semantic_diff,omitempty"`
+	// OrderDiff lists schema-aware key-order disagreements, populated only
+	// when PreserveSchemaOrder is true and both legs succeeded.
+	OrderDiff []SchemaOrderDiffEntry `json:"order_diff,omitempty"`
+	// Failures is the human-readable list of why this leg failed. Empty
+	// means the differential passed.
+	Failures []string `json:"failures,omitempty"`
+}
+
+// DiffParsers runs the native-vs-BAML differential for one raw string.
+// BAML is the oracle: its outcome is the reference every comparison is
+// taken against. The comparison algorithm is:
+//
+//  1. Call the BAML parser with req. ErrParserUnavailable here is a
+//     harness failure (BAML must service the legs it claims to cover).
+//  2. Call the native parser with the identical req.
+//  3. If native returns ErrParserUnavailable, mark SkippedNative and pass.
+//  4. Success/error parity: both error → pass; exactly one errors → fail.
+//  5. Both succeed: reject empty JSON on either side, then strict-compare
+//     the normalized JSON (no boundaryml/baml#3690 null tolerance — the
+//     native parser must match BAML's observed behavior exactly), and when
+//     PreserveSchemaOrder is true run a schema-aware key-order check with
+//     BAML as expected and native as actual.
+//
+// choices mirrors CaseMetadata.UnionChoices and is only consulted by the
+// order check. The function is pure: it returns the result and never
+// fails a test itself — callers decide whether a non-empty Failures slice
+// fails and where to write an envelope.
+func DiffParsers(ctx context.Context, baml, native Parser, req ParseRequest, choices map[string]UnionChoice) ParseDiffResult {
+	var res ParseDiffResult
+
+	bamlRes, bamlErr := baml.Parse(ctx, req)
+	res.BAML = parseOutcome(baml.Name(), bamlRes, bamlErr)
+	if errors.Is(bamlErr, ErrParserUnavailable) {
+		// BAML declining is an integrity failure, not a normal parse
+		// error: the harness only drives BAML over legs it covers.
+		res.Failures = append(res.Failures, fmt.Sprintf("BAML parser %q unavailable: %v", baml.Name(), bamlErr))
+		return res
+	}
+
+	natRes, natErr := native.Parse(ctx, req)
+	if errors.Is(natErr, ErrParserUnavailable) {
+		res.SkippedNative = true
+		return res
+	}
+	res.Native = parseOutcome(native.Name(), natRes, natErr)
+
+	bamlOK := bamlErr == nil
+	natOK := natErr == nil
+	switch {
+	case !bamlOK && !natOK:
+		// Both rejected the input — parity holds, nothing more to compare.
+		return res
+	case bamlOK && !natOK:
+		res.Failures = append(res.Failures, fmt.Sprintf("parity: BAML succeeded but native %q errored: %v", native.Name(), natErr))
+		return res
+	case !bamlOK && natOK:
+		res.Failures = append(res.Failures, fmt.Sprintf("parity: BAML errored but native %q succeeded: %v", native.Name(), bamlErr))
+		return res
+	}
+
+	// Both succeeded: a success must carry real JSON.
+	if len(bamlRes.JSON) == 0 {
+		res.Failures = append(res.Failures, "BAML reported success with empty JSON")
+	}
+	if len(natRes.JSON) == 0 {
+		res.Failures = append(res.Failures, fmt.Sprintf("native %q reported success with empty JSON", native.Name()))
+	}
+	if len(res.Failures) > 0 {
+		return res
+	}
+
+	diff, err := SemanticDiffStrict("baml_vs_native", bamlRes.JSON, natRes.JSON)
+	if err != nil {
+		res.Failures = append(res.Failures, fmt.Sprintf("baml_vs_native semantic diff: %v", err))
+		return res
+	}
+	if len(diff) > 0 {
+		res.SemanticDiff = diff
+		res.Failures = append(res.Failures, "baml ≠ native (semantic)")
+	}
+
+	if req.PreserveSchemaOrder {
+		odiff, oerr := SchemaOrderDiffWithChoices("baml_vs_native", req.Schema, bamlRes.JSON, natRes.JSON, choices)
+		switch {
+		case errors.Is(oerr, ErrSchemaOrderUnsupported):
+			res.Failures = append(res.Failures, fmt.Sprintf("baml_vs_native schema order unsupported: %v", oerr))
+		case oerr != nil:
+			res.Failures = append(res.Failures, fmt.Sprintf("baml_vs_native schema order: %v", oerr))
+		case len(odiff) > 0:
+			res.OrderDiff = odiff
+			res.Failures = append(res.Failures, "baml ≠ native (order)")
+		}
+	}
+
+	return res
+}
+
+// DiffParserPrefixes runs DiffParsers over a growing sequence of
+// accumulated raw prefixes, in stream mode. Every prefix is fed to both
+// parsers and compared on its own — early accept/reject behavior is part
+// of the spec, so the final prefix is not privileged. Each prefixes[i] is
+// expected to extend prefixes[i-1]; a prefix that does not is still diffed
+// but its result carries a leading monotonicity failure so a malformed
+// corpus is caught rather than silently masking a real divergence.
+//
+// req is the template: its Raw is overridden per prefix and Stream is
+// forced true. choices is passed through to each per-prefix order check.
+func DiffParserPrefixes(ctx context.Context, baml, native Parser, req ParseRequest, prefixes []string, choices map[string]UnionChoice) []ParseDiffResult {
+	out := make([]ParseDiffResult, 0, len(prefixes))
+	for i, prefix := range prefixes {
+		preq := req
+		preq.Raw = prefix
+		preq.Stream = true
+		res := DiffParsers(ctx, baml, native, preq, choices)
+		if i > 0 && !strings.HasPrefix(prefix, prefixes[i-1]) {
+			res.Failures = append([]string{
+				fmt.Sprintf("prefix[%d] does not extend prefix[%d]: %q is not prefixed by %q", i, i-1, prefix, prefixes[i-1]),
+			}, res.Failures...)
+		}
+		out = append(out, res)
+	}
+	return out
+}
+
+// parseOutcome packages a parser's (result, error) into a ParseOutcome.
+// On error only Error is set (diagnostic text); on success only JSON.
+func parseOutcome(name string, res ParseResult, err error) ParseOutcome {
+	o := ParseOutcome{Parser: name}
+	if err != nil {
+		o.Error = err.Error()
+		return o
+	}
+	o.JSON = res.JSON
+	return o
+}
+
+// SemanticDiffStrict reports the path-level disagreements between two JSON
+// blobs with no tolerance whatsoever. Unlike SemanticDiff (which forgives
+// boundaryml/baml#3690 leaked null keys on the actual side) and
+// SemanticDiffWithSchema (which additionally forgives literal escape-level
+// mismatches), the strict comparator treats every structural and scalar
+// difference — including an extra or missing null-valued key — as a real
+// disagreement.
+//
+// This is the comparator for native-vs-BAML: BAML is the observed
+// behavior the native parser must reproduce exactly, so any divergence,
+// including one BAML's own surface tolerates against the walker's
+// expected output, must surface here. `side` is copied verbatim onto each
+// emitted entry. Either input being empty is a decode error, mirroring
+// SemanticDiff's contract.
+func SemanticDiffStrict(side string, a, b json.RawMessage) ([]SemanticDiffEntry, error) {
+	av, err := decodeAny(a)
+	if err != nil {
+		return nil, fmt.Errorf("decode a: %w", err)
+	}
+	bv, err := decodeAny(b)
+	if err != nil {
+		return nil, fmt.Errorf("decode b: %w", err)
+	}
+	var out []SemanticDiffEntry
+	strictDiffAny(&out, side, "$", av, bv)
+	return out, nil
+}
+
+// strictDiffAny appends path-level disagreements between `a` (reference)
+// and `b` (actual) to `out`, with no null-key or literal-escape tolerance.
+func strictDiffAny(out *[]SemanticDiffEntry, side, path string, a, b any) {
+	if strictDeepEqual(a, b) {
+		return
+	}
+	switch av := a.(type) {
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok {
+			*out = append(*out, SemanticDiffEntry{Side: side, Path: path, Got: a, Want: b})
+			return
+		}
+		keys := make(map[string]struct{}, len(av)+len(bv))
+		for k := range av {
+			keys[k] = struct{}{}
+		}
+		for k := range bv {
+			keys[k] = struct{}{}
+		}
+		sortedKeys := make([]string, 0, len(keys))
+		for k := range keys {
+			sortedKeys = append(sortedKeys, k)
+		}
+		sort.Strings(sortedKeys)
+		for _, k := range sortedKeys {
+			av1, ok1 := av[k]
+			bv1, ok2 := bv[k]
+			if !ok1 || !ok2 {
+				*out = append(*out, SemanticDiffEntry{Side: side, Path: path + "." + k, Got: av1, Want: bv1})
+				continue
+			}
+			strictDiffAny(out, side, path+"."+k, av1, bv1)
+		}
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			*out = append(*out, SemanticDiffEntry{Side: side, Path: path, Got: a, Want: b})
+			return
+		}
+		for i := range av {
+			strictDiffAny(out, side, fmt.Sprintf("%s[%d]", path, i), av[i], bv[i])
+		}
+	default:
+		*out = append(*out, SemanticDiffEntry{Side: side, Path: path, Got: a, Want: b})
+	}
+}
+
+// strictDeepEqual is structural JSON equality modulo object key ordering
+// only — no null-key tolerance. Two objects are equal iff they carry the
+// identical key set and every value is strictDeepEqual.
+func strictDeepEqual(a, b any) bool {
+	switch av := a.(type) {
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for k, v := range av {
+			rv, present := bv[k]
+			if !present || !strictDeepEqual(v, rv) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !strictDeepEqual(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	case float64:
+		bv, ok := b.(float64)
+		return ok && av == bv
+	case string:
+		bv, ok := b.(string)
+		return ok && av == bv
+	case bool:
+		bv, ok := b.(bool)
+		return ok && av == bv
+	case nil:
+		return b == nil
+	default:
+		return false
+	}
+}

--- a/adapters/common/codegen/bamlfuzz/parse_diff_test.go
+++ b/adapters/common/codegen/bamlfuzz/parse_diff_test.go
@@ -201,6 +201,31 @@ func TestDiffParserPrefixesGrowthAndDiff(t *testing.T) {
 	}
 }
 
+// typedNilParser exists only to construct a typed-nil Parser (a nil
+// *typedNilParser wrapped in the interface) for the registry guard test.
+type typedNilParser struct{}
+
+func (*typedNilParser) Name() string { return "typed_nil" }
+func (*typedNilParser) Parse(context.Context, ParseRequest) (ParseResult, error) {
+	return ParseResult{}, nil
+}
+
+// A typed-nil parser (non-nil interface wrapping a nil pointer) must be
+// rejected like an untyped nil — otherwise DiffParsers would later panic
+// calling Parse/Name on the nil receiver.
+func TestRegisterNativeParserRejectsTypedNil(t *testing.T) {
+	var p *typedNilParser // nil pointer, but Parser(p) is a non-nil interface
+	restore := RegisterNativeParser(p)
+	defer restore()
+	got := RegisteredNativeParser()
+	if _, ok := got.(NoopParser); !ok {
+		t.Fatalf("typed-nil parser must fall back to NoopParser, got %T", got)
+	}
+	if got.Name() != "native_stub" {
+		t.Fatalf("expected native_stub after typed-nil registration, got %q", got.Name())
+	}
+}
+
 func TestRegisterNativeParserRoundTrip(t *testing.T) {
 	if _, ok := RegisteredNativeParser().(NoopParser); !ok {
 		t.Fatalf("default registered parser should be NoopParser, got %T", RegisteredNativeParser())

--- a/adapters/common/codegen/bamlfuzz/parse_diff_test.go
+++ b/adapters/common/codegen/bamlfuzz/parse_diff_test.go
@@ -1,0 +1,228 @@
+package bamlfuzz
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// fakeParser is a scripted Parser for the differential unit tests. It
+// returns a fixed JSON / error regardless of the request, so each test
+// can pin one (BAML, native) outcome pair and assert how DiffParsers
+// reconciles them.
+type fakeParser struct {
+	name string
+	json json.RawMessage
+	err  error
+}
+
+func (p fakeParser) Name() string { return p.name }
+
+func (p fakeParser) Parse(context.Context, ParseRequest) (ParseResult, error) {
+	if p.err != nil {
+		return ParseResult{}, p.err
+	}
+	return ParseResult{JSON: p.json}, nil
+}
+
+// twoFieldSchema is a tiny Root{a:string, b:string} schema used by the
+// order-mismatch case; declaration order is a, then b.
+func twoFieldSchema() FuzzSchema {
+	return FuzzSchema{
+		Classes: []FuzzClass{{
+			Name: "Root",
+			Properties: []FuzzProperty{
+				{Name: "a", Type: FuzzType{Kind: KindString}},
+				{Name: "b", Type: FuzzType{Kind: KindString}},
+			},
+		}},
+		RootClass: "Root",
+	}
+}
+
+func TestDiffParsersNoopNativeSkips(t *testing.T) {
+	baml := fakeParser{name: "baml", json: json.RawMessage(`{"name":"Ada"}`)}
+	res := DiffParsers(context.Background(), baml, NoopParser{}, ParseRequest{Raw: "x"}, nil)
+	if !res.SkippedNative {
+		t.Fatalf("expected SkippedNative=true with NoopParser, got %+v", res)
+	}
+	if len(res.Failures) != 0 {
+		t.Fatalf("expected no failures on native skip, got %v", res.Failures)
+	}
+	if res.BAML.JSON == nil {
+		t.Fatalf("expected BAML outcome captured even when native skipped")
+	}
+}
+
+func TestDiffParsersBothSucceedMatch(t *testing.T) {
+	js := json.RawMessage(`{"name":"Ada","age":36}`)
+	// Key order differs but PreserveSchemaOrder is off → semantic match.
+	baml := fakeParser{name: "baml", json: js}
+	native := fakeParser{name: "native", json: json.RawMessage(`{"age":36,"name":"Ada"}`)}
+	res := DiffParsers(context.Background(), baml, native, ParseRequest{Raw: "x"}, nil)
+	if len(res.Failures) != 0 {
+		t.Fatalf("expected match, got failures %v (diff %v)", res.Failures, res.SemanticDiff)
+	}
+	if res.SkippedNative {
+		t.Fatalf("native should not be skipped when it returns a real result")
+	}
+}
+
+func TestDiffParsersBothErrorPass(t *testing.T) {
+	baml := fakeParser{name: "baml", err: errors.New("baml: truncated input")}
+	native := fakeParser{name: "native", err: errors.New("native: unexpected eof")}
+	res := DiffParsers(context.Background(), baml, native, ParseRequest{Raw: "x"}, nil)
+	if len(res.Failures) != 0 {
+		t.Fatalf("both-error should pass parity, got %v", res.Failures)
+	}
+	if res.BAML.Error == "" || res.Native.Error == "" {
+		t.Fatalf("expected both error strings captured, got %+v", res)
+	}
+}
+
+func TestDiffParsersBamlSuccessNativeError(t *testing.T) {
+	baml := fakeParser{name: "baml", json: json.RawMessage(`{"name":"Ada"}`)}
+	native := fakeParser{name: "native", err: errors.New("native: rejected")}
+	res := DiffParsers(context.Background(), baml, native, ParseRequest{Raw: "x"}, nil)
+	if len(res.Failures) == 0 {
+		t.Fatalf("expected parity failure when BAML succeeds and native errors")
+	}
+}
+
+func TestDiffParsersBamlErrorNativeSuccess(t *testing.T) {
+	baml := fakeParser{name: "baml", err: errors.New("baml: rejected")}
+	native := fakeParser{name: "native", json: json.RawMessage(`{"name":"Ada"}`)}
+	res := DiffParsers(context.Background(), baml, native, ParseRequest{Raw: "x"}, nil)
+	if len(res.Failures) == 0 {
+		t.Fatalf("expected parity failure when BAML errors and native succeeds")
+	}
+}
+
+func TestDiffParsersJSONMismatch(t *testing.T) {
+	baml := fakeParser{name: "baml", json: json.RawMessage(`{"name":"Ada","age":36}`)}
+	native := fakeParser{name: "native", json: json.RawMessage(`{"name":"Ada","age":37}`)}
+	res := DiffParsers(context.Background(), baml, native, ParseRequest{Raw: "x"}, nil)
+	if len(res.Failures) == 0 {
+		t.Fatalf("expected semantic-mismatch failure")
+	}
+	if len(res.SemanticDiff) == 0 {
+		t.Fatalf("expected a SemanticDiff entry for the differing field")
+	}
+}
+
+// A leaked null key on the native side must NOT be tolerated by the
+// strict comparator (unlike SemanticDiff for the call oracles).
+func TestDiffParsersStrictRejectsExtraNullKey(t *testing.T) {
+	baml := fakeParser{name: "baml", json: json.RawMessage(`{"name":"Ada"}`)}
+	native := fakeParser{name: "native", json: json.RawMessage(`{"name":"Ada","extra":null}`)}
+	res := DiffParsers(context.Background(), baml, native, ParseRequest{Raw: "x"}, nil)
+	if len(res.Failures) == 0 || len(res.SemanticDiff) == 0 {
+		t.Fatalf("strict comparator must flag an extra null key, got %+v", res)
+	}
+}
+
+func TestDiffParsersOrderMismatch(t *testing.T) {
+	schema := twoFieldSchema()
+	// Same key set, both valid, but native flips declaration order.
+	baml := fakeParser{name: "baml", json: json.RawMessage(`{"a":"x","b":"y"}`)}
+	native := fakeParser{name: "native", json: json.RawMessage(`{"b":"y","a":"x"}`)}
+	req := ParseRequest{Raw: "x", Schema: schema, PreserveSchemaOrder: true}
+	res := DiffParsers(context.Background(), baml, native, req, nil)
+	if len(res.OrderDiff) == 0 {
+		t.Fatalf("expected an OrderDiff entry for the flipped key order, got %+v", res)
+	}
+	hasOrderFailure := false
+	for _, f := range res.Failures {
+		if f == "baml ≠ native (order)" {
+			hasOrderFailure = true
+		}
+	}
+	if !hasOrderFailure {
+		t.Fatalf("expected an order failure reason, got %v", res.Failures)
+	}
+}
+
+// With PreserveSchemaOrder off, the same flipped order is a pass: only
+// semantic equality is gated.
+func TestDiffParsersOrderIgnoredWhenPreserveOff(t *testing.T) {
+	schema := twoFieldSchema()
+	baml := fakeParser{name: "baml", json: json.RawMessage(`{"a":"x","b":"y"}`)}
+	native := fakeParser{name: "native", json: json.RawMessage(`{"b":"y","a":"x"}`)}
+	req := ParseRequest{Raw: "x", Schema: schema, PreserveSchemaOrder: false}
+	res := DiffParsers(context.Background(), baml, native, req, nil)
+	if len(res.Failures) != 0 {
+		t.Fatalf("preserve-off flipped order should pass, got %v", res.Failures)
+	}
+}
+
+func TestDiffParsersBamlUnavailableIsHarnessFailure(t *testing.T) {
+	baml := fakeParser{name: "baml", err: ErrParserUnavailable}
+	res := DiffParsers(context.Background(), baml, NoopParser{}, ParseRequest{Raw: "x"}, nil)
+	if res.SkippedNative {
+		t.Fatalf("BAML-unavailable must not be a native skip")
+	}
+	if len(res.Failures) == 0 {
+		t.Fatalf("BAML ErrParserUnavailable must be a harness failure")
+	}
+}
+
+func TestDiffParsersBothSucceedEmptyJSONFails(t *testing.T) {
+	baml := fakeParser{name: "baml", json: json.RawMessage(``)}
+	native := fakeParser{name: "native", json: json.RawMessage(`{"name":"Ada"}`)}
+	res := DiffParsers(context.Background(), baml, native, ParseRequest{Raw: "x"}, nil)
+	if len(res.Failures) == 0 {
+		t.Fatalf("empty BAML JSON on a reported success must fail")
+	}
+}
+
+func TestDiffParserPrefixesGrowthAndDiff(t *testing.T) {
+	// Both parsers echo the same final JSON regardless of prefix, so the
+	// per-prefix diffs all pass; the monotonicity assertion is the focus.
+	js := json.RawMessage(`{"name":"Ada"}`)
+	baml := fakeParser{name: "baml", json: js}
+	native := fakeParser{name: "native", json: js}
+	good := []string{"{", `{"name"`, `{"name":"Ada"}`}
+	results := DiffParserPrefixes(context.Background(), baml, native, ParseRequest{}, good, nil)
+	if len(results) != len(good) {
+		t.Fatalf("expected %d results, got %d", len(good), len(results))
+	}
+	for i, r := range results {
+		if len(r.Failures) != 0 {
+			t.Fatalf("prefix %d unexpectedly failed: %v", i, r.Failures)
+		}
+	}
+
+	// A non-growing sequence must flag the offending step.
+	bad := []string{`{"name"`, "{"}
+	badRes := DiffParserPrefixes(context.Background(), baml, native, ParseRequest{}, bad, nil)
+	if len(badRes) != 2 || len(badRes[1].Failures) == 0 {
+		t.Fatalf("expected monotonicity failure on shrinking prefix, got %+v", badRes)
+	}
+}
+
+func TestRegisterNativeParserRoundTrip(t *testing.T) {
+	if _, ok := RegisteredNativeParser().(NoopParser); !ok {
+		t.Fatalf("default registered parser should be NoopParser, got %T", RegisteredNativeParser())
+	}
+	fake := fakeParser{name: "fake"}
+	restore := RegisterNativeParser(fake)
+	if got := RegisteredNativeParser(); got.Name() != "fake" {
+		t.Fatalf("expected fake parser registered, got %q", got.Name())
+	}
+	restore()
+	if _, ok := RegisteredNativeParser().(NoopParser); !ok {
+		t.Fatalf("restore should reinstate NoopParser, got %T", RegisteredNativeParser())
+	}
+	// Idempotent restore must not corrupt the registry.
+	restore()
+	if _, ok := RegisteredNativeParser().(NoopParser); !ok {
+		t.Fatalf("second restore must be a no-op, got %T", RegisteredNativeParser())
+	}
+	// nil registration falls back to NoopParser.
+	restore2 := RegisterNativeParser(nil)
+	defer restore2()
+	if _, ok := RegisteredNativeParser().(NoopParser); !ok {
+		t.Fatalf("nil registration should install NoopParser, got %T", RegisteredNativeParser())
+	}
+}

--- a/adapters/common/codegen/bamlfuzz/parse_recovery_case.go
+++ b/adapters/common/codegen/bamlfuzz/parse_recovery_case.go
@@ -1,8 +1,10 @@
 package bamlfuzz
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -101,7 +103,19 @@ func LoadParseRecoveryCorpus(dir string) ([]ParseRecoveryCase, error) {
 			return nil, fmt.Errorf("%s: %w", name, err)
 		}
 		var c ParseRecoveryCase
-		if err := json.Unmarshal(data, &c); err != nil {
+		// Decode strictly: a typo'd corpus key must fail fast rather than
+		// being silently dropped (plain json.Unmarshal accepts unknown
+		// fields). Mirror json.Unmarshal's single-document, no-trailing-data
+		// contract by confirming the stream is at EOF after the one case.
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&c); err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		if err := dec.Decode(&struct{}{}); err != io.EOF {
+			if err == nil {
+				return nil, fmt.Errorf("%s: unexpected trailing JSON after case object", name)
+			}
 			return nil, fmt.Errorf("%s: %w", name, err)
 		}
 		if c.Name == "" {

--- a/adapters/common/codegen/bamlfuzz/parse_recovery_case.go
+++ b/adapters/common/codegen/bamlfuzz/parse_recovery_case.go
@@ -1,0 +1,113 @@
+package bamlfuzz
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Parse recovery status tokens. A case's expected outcome is one of
+// these: BAML either recovered typed JSON from the (often JSONish) raw
+// text, or it rejected the input. The harness gates on this success/error
+// parity, not on exact error strings.
+const (
+	ParseStatusSuccess = "success"
+	ParseStatusError   = "error"
+)
+
+// ParseExpected is the checked-in expected outcome for a parse-recovery
+// case (or one of its streaming prefixes). Status is "success" or "error".
+// JSON is the expected typed JSON when Status is "success"; it is empty
+// for an "error" expectation. These values are BAML's *observed* behavior
+// — BAML is the oracle and the corpus records what it actually does, not
+// what JSON-the-spec would prescribe.
+type ParseExpected struct {
+	Status string          `json:"status"`
+	JSON   json.RawMessage `json:"json,omitempty"`
+}
+
+// IsSuccess reports whether the expectation is a successful parse.
+func (e ParseExpected) IsSuccess() bool { return e.Status == ParseStatusSuccess }
+
+// ParseRecoveryPrefix is one accumulated raw prefix in a streaming
+// recovery case. Raw is the full accumulated text at this step (not a
+// delta), so replay is independent of any chunk-size code. Want is the
+// expected stream-parse outcome for that prefix.
+type ParseRecoveryPrefix struct {
+	Name string        `json:"name"`
+	Raw  string        `json:"raw"`
+	Want ParseExpected `json:"want"`
+}
+
+// ParseRecoveryCase is one JSONish recovery corpus entry. A case is
+// either a final-parse case (Raw + Want) or a streaming case (Prefixes),
+// or both. The schema gives the parsers a typed target; PreserveSchemaOrder
+// selects whether the key-order check runs when the case is diffed against
+// a registered native parser.
+type ParseRecoveryCase struct {
+	Name                string                `json:"name"`
+	Description         string                `json:"description,omitempty"`
+	PreserveSchemaOrder bool                  `json:"preserve_schema_order"`
+	Schema              FuzzSchema            `json:"schema"`
+	Raw                 string                `json:"raw,omitempty"`
+	Want                ParseExpected         `json:"want,omitempty"`
+	Prefixes            []ParseRecoveryPrefix `json:"prefixes,omitempty"`
+}
+
+// HasFinal reports whether the case carries a final-parse leg (a Want
+// with a non-empty Status). A streaming-only case has no final leg.
+func (c ParseRecoveryCase) HasFinal() bool { return c.Want.Status != "" }
+
+// HasPrefixes reports whether the case carries a streaming-prefix leg.
+func (c ParseRecoveryCase) HasPrefixes() bool { return len(c.Prefixes) > 0 }
+
+// PrefixRaws returns the accumulated raw strings of the streaming
+// prefixes in order, the slice DiffParserPrefixes consumes.
+func (c ParseRecoveryCase) PrefixRaws() []string {
+	out := make([]string, len(c.Prefixes))
+	for i, p := range c.Prefixes {
+		out[i] = p.Raw
+	}
+	return out
+}
+
+// LoadParseRecoveryCorpus reads every `*.json` file under dir and decodes
+// each as a ParseRecoveryCase, returning them sorted by filename so test
+// subtests run in a stable, lexicographic order. A case whose Name field
+// is empty inherits the filename (sans `.json`). The `_artifacts` output
+// directory and any other subdirectory are skipped.
+func LoadParseRecoveryCorpus(dir string) ([]ParseRecoveryCase, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+
+	out := make([]ParseRecoveryCase, 0, len(names))
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		var c ParseRecoveryCase
+		if err := json.Unmarshal(data, &c); err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		if c.Name == "" {
+			c.Name = strings.TrimSuffix(name, ".json")
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}

--- a/adapters/common/codegen/bamlfuzz/parse_recovery_corpus_test.go
+++ b/adapters/common/codegen/bamlfuzz/parse_recovery_corpus_test.go
@@ -1,0 +1,98 @@
+package bamlfuzz
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// parseRecoveryCorpusDir is the on-disk JSONish recovery corpus, relative
+// to this package directory. The integration harness loads the same
+// directory via its repo-root-relative path.
+const parseRecoveryCorpusDir = "../testdata/bamlfuzz/parse_recovery"
+
+// TestParseRecoveryCorpusWellFormed loads the checked-in corpus and pins
+// the structural invariants the integration harness relies on, without
+// needing BAML or Docker: every case names a root class, a final-parse
+// case's want is internally consistent (success ⟺ JSON present), and a
+// streaming case's prefixes grow monotonically. This is the local guard
+// that a hand-edited corpus file stays loadable and replayable.
+func TestParseRecoveryCorpusWellFormed(t *testing.T) {
+	corpus, err := LoadParseRecoveryCorpus(parseRecoveryCorpusDir)
+	if err != nil {
+		t.Fatalf("load parse recovery corpus: %v", err)
+	}
+	if len(corpus) == 0 {
+		t.Fatalf("parse recovery corpus at %s is empty", parseRecoveryCorpusDir)
+	}
+
+	for _, c := range corpus {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			if c.Schema.RootClass == "" && c.Schema.RootType == nil {
+				t.Errorf("case %q: schema has neither root_class nor root_type", c.Name)
+			}
+			if c.Schema.RootClass != "" {
+				if _, ok := c.Schema.FindClass(c.Schema.RootClass); !ok {
+					t.Errorf("case %q: root_class %q not present in schema", c.Name, c.Schema.RootClass)
+				}
+			}
+			if !c.HasFinal() && !c.HasPrefixes() {
+				t.Errorf("case %q: neither a final (raw+want) nor a streaming (prefixes) leg", c.Name)
+			}
+
+			if c.HasFinal() {
+				validateExpected(t, c.Name+".want", c.Want)
+				if c.Raw == "" {
+					t.Errorf("case %q: final leg present but raw is empty", c.Name)
+				}
+			}
+
+			if c.HasPrefixes() {
+				validatePrefixGrowth(t, c)
+				for i, p := range c.Prefixes {
+					if p.Raw == "" {
+						t.Errorf("case %q prefix[%d] %q: empty raw", c.Name, i, p.Name)
+					}
+					validateExpected(t, c.Name+".prefix["+p.Name+"].want", p.Want)
+				}
+			}
+		})
+	}
+}
+
+// validateExpected asserts a ParseExpected's status/JSON are consistent:
+// status must be one of the two tokens, a success carries decodable JSON,
+// and an error carries none.
+func validateExpected(t *testing.T, label string, e ParseExpected) {
+	t.Helper()
+	switch e.Status {
+	case ParseStatusSuccess:
+		if len(e.JSON) == 0 {
+			t.Errorf("%s: status=success but json is empty", label)
+			return
+		}
+		var v any
+		if err := json.Unmarshal(e.JSON, &v); err != nil {
+			t.Errorf("%s: status=success but json does not decode: %v", label, err)
+		}
+	case ParseStatusError:
+		if len(e.JSON) != 0 {
+			t.Errorf("%s: status=error must not carry json", label)
+		}
+	default:
+		t.Errorf("%s: unknown status %q (want %q or %q)", label, e.Status, ParseStatusSuccess, ParseStatusError)
+	}
+}
+
+// validatePrefixGrowth asserts each accumulated prefix extends the prior
+// one — the same monotonicity DiffParserPrefixes enforces at runtime.
+func validatePrefixGrowth(t *testing.T, c ParseRecoveryCase) {
+	t.Helper()
+	for i := 1; i < len(c.Prefixes); i++ {
+		if !strings.HasPrefix(c.Prefixes[i].Raw, c.Prefixes[i-1].Raw) {
+			t.Errorf("case %q: prefix[%d] %q does not extend prefix[%d] %q",
+				c.Name, i, c.Prefixes[i].Name, i-1, c.Prefixes[i-1].Name)
+		}
+	}
+}

--- a/adapters/common/codegen/bamlfuzz/parse_recovery_corpus_test.go
+++ b/adapters/common/codegen/bamlfuzz/parse_recovery_corpus_test.go
@@ -2,6 +2,8 @@ package bamlfuzz
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -58,6 +60,42 @@ func TestParseRecoveryCorpusWellFormed(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestLoadParseRecoveryCorpusStrictDecode pins the strict-decode contract:
+// a typo'd / unknown corpus key and trailing JSON after the case object are
+// both hard load errors, so a malformed fixture fails fast instead of being
+// silently accepted with the bad key dropped.
+func TestLoadParseRecoveryCorpusStrictDecode(t *testing.T) {
+	const good = `{"name":"x","schema":{"classes":[{"name":"Root",` +
+		`"properties":[{"name":"a","type":{"kind":"string"}}]}],"root_class":"Root"},` +
+		`"raw":"{}","want":{"status":"error"}}`
+
+	cases := map[string]string{
+		"unknown_field": `{"name":"x","bogus_key":1}`,
+		"trailing_data": good + `{"name":"y"}`,
+	}
+	for label, body := range cases {
+		label, body := label, body
+		t.Run(label, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "00_bad.json"), []byte(body), 0o644); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+			if _, err := LoadParseRecoveryCorpus(dir); err == nil {
+				t.Fatalf("expected load error for %s, got nil", label)
+			}
+		})
+	}
+
+	// A well-formed single document still loads cleanly.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "00_ok.json"), []byte(good), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if _, err := LoadParseRecoveryCorpus(dir); err != nil {
+		t.Fatalf("well-formed corpus must load, got %v", err)
 	}
 }
 

--- a/adapters/common/codegen/bamlfuzz/parser.go
+++ b/adapters/common/codegen/bamlfuzz/parser.go
@@ -1,0 +1,130 @@
+package bamlfuzz
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+)
+
+// ErrParserUnavailable is the sentinel a Parser returns when it cannot
+// service a request — either because it is the no-op stub (no native
+// parser has been registered yet) or because the request shape is one
+// the parser does not implement (e.g. the dynamic BAML adapter declining
+// a Stream request before direct parse-stream is plumbed).
+//
+// The differential comparator treats ErrParserUnavailable from the
+// *candidate* (native) parser as a skip/pass, not a parser success. The
+// same error from the *BAML* (oracle) parser is a harness failure: BAML
+// is supposed to be able to parse everything the harness throws at it on
+// the legs it claims to cover.
+var ErrParserUnavailable = errors.New("bamlfuzz: parser unavailable")
+
+// ParseRequest is the input to a Parser: a schema, the exact raw model
+// text to parse against it, and the parse-mode flags. The harness drives
+// BAML and any registered native parser through the identical request so
+// a divergence is attributable to the parser, not the inputs.
+type ParseRequest struct {
+	// Schema is the IR the raw text is parsed against.
+	Schema FuzzSchema
+	// Raw is the exact model text fed to the parser — a complete
+	// response for a final parse, or an accumulated prefix for a stream
+	// parse. It is passed verbatim; the parser does no extraction or
+	// trimming the harness has not already applied.
+	Raw string
+	// Stream selects parse-stream semantics. Stream=false returns the
+	// final typed JSON; Stream=true returns the partial typed JSON BAML's
+	// parse-stream would emit for this raw prefix.
+	Stream bool
+	// PreserveSchemaOrder mirrors the dynamic endpoints' preserve flag:
+	// when true the returned JSON's object keys follow schema declaration
+	// order, so the comparator can run a schema-aware key-order check.
+	PreserveSchemaOrder bool
+}
+
+// ParseResult is a Parser's successful output: the typed JSON in the
+// flattened shape the dynamic endpoints expose (no DynamicProperties
+// wrapper). A non-nil error from Parse means JSON is not meaningful.
+type ParseResult struct {
+	JSON json.RawMessage
+}
+
+// Parser is the pluggable parse backend the differential harness drives.
+// Two implementations matter: a BAML adapter (the oracle/reference) and,
+// once it exists, a native parser (the candidate). The interface lives in
+// bamlfuzz rather than dynclient so a native parser can satisfy it
+// without depending on BAML client concepts.
+//
+// Contract:
+//   - Parse is given the FuzzSchema, the exact raw model text, and the
+//     parse-mode flags via ParseRequest.
+//   - A successful result carries valid JSON in the flattened dynamic
+//     shape; the harness compares success/error parity and normalized
+//     JSON, never exact error strings.
+//   - Returning ErrParserUnavailable signals "I do not service this
+//     request"; the comparator skips the native leg on that sentinel and
+//     fails the harness on it from the BAML leg.
+type Parser interface {
+	Name() string
+	Parse(ctx context.Context, req ParseRequest) (ParseResult, error)
+}
+
+// NoopParser is the default registered native parser. It services no
+// request, always returning ErrParserUnavailable, so the differential
+// leg is a no-op pass until a real native parser is registered. The
+// moment one is, the same corpus and oracle cases become live
+// native-vs-BAML differentials with no harness rewrite.
+type NoopParser struct{}
+
+// Name identifies the stub in diff output and envelopes.
+func (NoopParser) Name() string { return "native_stub" }
+
+// Parse always declines, signalling the comparator to skip the native leg.
+func (NoopParser) Parse(context.Context, ParseRequest) (ParseResult, error) {
+	return ParseResult{}, ErrParserUnavailable
+}
+
+// nativeParserRegistry holds the process-wide native parser the harness
+// diffs BAML against. It defaults to NoopParser so a caller that never
+// registers a real parser still gets a well-defined skip/pass leg.
+var nativeParserRegistry = struct {
+	mu sync.RWMutex
+	p  Parser
+}{p: NoopParser{}}
+
+// RegisterNativeParser installs p as the process-wide native parser the
+// differential harness diffs against and returns a restore func that
+// reinstalls whatever was registered before. The restore func is
+// idempotent. Passing a nil parser resets the registry to NoopParser so
+// the harness never holds a nil candidate.
+//
+// The returned restore is intended for `defer restore()` in a test that
+// swaps in a fake or a real native parser for the duration of the test.
+func RegisterNativeParser(p Parser) (restore func()) {
+	if p == nil {
+		p = NoopParser{}
+	}
+	nativeParserRegistry.mu.Lock()
+	prev := nativeParserRegistry.p
+	nativeParserRegistry.p = p
+	nativeParserRegistry.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			nativeParserRegistry.mu.Lock()
+			nativeParserRegistry.p = prev
+			nativeParserRegistry.mu.Unlock()
+		})
+	}
+}
+
+// RegisteredNativeParser returns the currently registered native parser,
+// never nil. With no registration it is the NoopParser, so callers can
+// unconditionally pass the result to DiffParsers and rely on the
+// ErrParserUnavailable skip path.
+func RegisteredNativeParser() Parser {
+	nativeParserRegistry.mu.RLock()
+	defer nativeParserRegistry.mu.RUnlock()
+	return nativeParserRegistry.p
+}

--- a/adapters/common/codegen/bamlfuzz/parser.go
+++ b/adapters/common/codegen/bamlfuzz/parser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"sync"
 )
 
@@ -95,13 +96,15 @@ var nativeParserRegistry = struct {
 // RegisterNativeParser installs p as the process-wide native parser the
 // differential harness diffs against and returns a restore func that
 // reinstalls whatever was registered before. The restore func is
-// idempotent. Passing a nil parser resets the registry to NoopParser so
-// the harness never holds a nil candidate.
+// idempotent. Passing a nil parser — an untyped nil, or a typed-nil such
+// as a nil `*SomeParser` (a non-nil interface wrapping a nil pointer) —
+// resets the registry to NoopParser, so the harness never holds a
+// candidate that panics the moment DiffParsers calls Parse / Name.
 //
 // The returned restore is intended for `defer restore()` in a test that
 // swaps in a fake or a real native parser for the duration of the test.
 func RegisterNativeParser(p Parser) (restore func()) {
-	if p == nil {
+	if isNilParser(p) {
 		p = NoopParser{}
 	}
 	nativeParserRegistry.mu.Lock()
@@ -116,6 +119,25 @@ func RegisterNativeParser(p Parser) (restore func()) {
 			nativeParserRegistry.p = prev
 			nativeParserRegistry.mu.Unlock()
 		})
+	}
+}
+
+// isNilParser reports whether p is unusable as a candidate: an untyped
+// nil interface, or a typed-nil whose underlying value is a nilable kind
+// (pointer, map, chan, func, slice, interface) that is itself nil. The
+// latter is a non-nil interface — `p == nil` is false — but calling any
+// method that dereferences the receiver would panic, so it must be
+// treated like a missing registration.
+func isNilParser(p Parser) bool {
+	if p == nil {
+		return true
+	}
+	v := reflect.ValueOf(p)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Chan, reflect.Func, reflect.Slice, reflect.Interface:
+		return v.IsNil()
+	default:
+		return false
 	}
 }
 

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/.gitignore
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/.gitignore
@@ -1,0 +1,1 @@
+_artifacts/

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/00_markdown_fence_object.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/00_markdown_fence_object.json
@@ -1,0 +1,22 @@
+{
+  "name": "markdown_fence_object",
+  "description": "BAML accepts JSON inside a ```json markdown fence. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "age", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "```json\n{\"name\":\"Ada\",\"age\":36}\n```",
+  "want": {
+    "status": "success",
+    "json": {"name": "Ada", "age": 36}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/01_prose_before_after_json.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/01_prose_before_after_json.json
@@ -1,0 +1,22 @@
+{
+  "name": "prose_before_after_json",
+  "description": "Natural-language prose surrounds the JSON object; BAML extracts the embedded object. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "age", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "Sure! Here is the person you asked for:\n{\"name\":\"Ada\",\"age\":36}\nLet me know if you need anything else.",
+  "want": {
+    "status": "success",
+    "json": {"name": "Ada", "age": 36}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/02_trailing_commas.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/02_trailing_commas.json
@@ -1,0 +1,22 @@
+{
+  "name": "trailing_commas",
+  "description": "Object and nested list carry trailing commas; BAML's JSONish parser tolerates them. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "tags", "type": {"kind": "list", "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"name\":\"Ada\",\"tags\":[\"x\",\"y\",],}",
+  "want": {
+    "status": "success",
+    "json": {"name": "Ada", "tags": ["x", "y"]}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/03_unquoted_keys.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/03_unquoted_keys.json
@@ -1,0 +1,22 @@
+{
+  "name": "unquoted_keys",
+  "description": "JS-style unquoted object keys; BAML's JSONish parser accepts them. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "age", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{name: \"Ada\", age: 36}",
+  "want": {
+    "status": "success",
+    "json": {"name": "Ada", "age": 36}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/04_single_quotes.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/04_single_quotes.json
@@ -1,0 +1,22 @@
+{
+  "name": "single_quotes",
+  "description": "Single-quoted keys and string values; BAML's JSONish parser normalizes them. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "age", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{'name': 'Ada', 'age': 36}",
+  "want": {
+    "status": "success",
+    "json": {"name": "Ada", "age": 36}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/05_truncated_final_error.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/05_truncated_final_error.json
@@ -1,0 +1,21 @@
+{
+  "name": "truncated_final_error",
+  "description": "Genuinely truncated JSON cut off mid-value. want is BAML's observed final-parse outcome — recorded as captured (success-with-coercion or error).",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "age", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"name\":\"Ada\",\"age\":",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/06_mixed_jsonish.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/06_mixed_jsonish.json
@@ -1,0 +1,22 @@
+{
+  "name": "mixed_jsonish",
+  "description": "Composed recovery: markdown fence + prose + unquoted keys + single quotes together. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "age", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "Here you go:\n```json\n{name: 'Ada', age: 36}\n```\nThat's the record.",
+  "want": {
+    "status": "success",
+    "json": {"name": "Ada", "age": 36}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/20_streaming_growing_object.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/20_streaming_growing_object.json
@@ -1,0 +1,26 @@
+{
+  "name": "streaming_growing_object",
+  "description": "Accumulated prefixes grow through { , key, colon, partial string, full string, next key, full object. STREAMING DIFFERENTIAL IS BLOCKED ON DIRECT PARSE-STREAM EXPOSURE (deferred): the per-prefix `want` values are NOT yet BAML-characterized and the harness does not gate on them today — only the corpus format and prefix-growth monotonicity are exercised.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "age", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "prefixes": [
+    {"name": "open_brace", "raw": "{", "want": {"status": "error"}},
+    {"name": "first_key", "raw": "{\"name\"", "want": {"status": "error"}},
+    {"name": "colon", "raw": "{\"name\":", "want": {"status": "error"}},
+    {"name": "partial_string", "raw": "{\"name\":\"Ad", "want": {"status": "success", "json": {"name": "Ad", "age": null}}},
+    {"name": "full_string", "raw": "{\"name\":\"Ada\"", "want": {"status": "success", "json": {"name": "Ada", "age": null}}},
+    {"name": "second_key", "raw": "{\"name\":\"Ada\",\"age\"", "want": {"status": "success", "json": {"name": "Ada", "age": null}}},
+    {"name": "full_object", "raw": "{\"name\":\"Ada\",\"age\":36}", "want": {"status": "success", "json": {"name": "Ada", "age": 36}}}
+  ]
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/21_streaming_markdown_fence.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/21_streaming_markdown_fence.json
@@ -1,0 +1,24 @@
+{
+  "name": "streaming_markdown_fence",
+  "description": "Accumulated prefixes enter prose, open a ```json fence, build the object, then close the fence. STREAMING DIFFERENTIAL IS BLOCKED ON DIRECT PARSE-STREAM EXPOSURE (deferred): the per-prefix `want` values are NOT yet BAML-characterized and the harness does not gate on them today — only the corpus format and prefix-growth monotonicity are exercised.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "age", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "prefixes": [
+    {"name": "prose", "raw": "Here you go:\n", "want": {"status": "error"}},
+    {"name": "fence_open", "raw": "Here you go:\n```json\n", "want": {"status": "error"}},
+    {"name": "object_partial", "raw": "Here you go:\n```json\n{\"name\":\"Ada\"", "want": {"status": "success", "json": {"name": "Ada", "age": null}}},
+    {"name": "object_full", "raw": "Here you go:\n```json\n{\"name\":\"Ada\",\"age\":36}", "want": {"status": "success", "json": {"name": "Ada", "age": 36}}},
+    {"name": "fence_close", "raw": "Here you go:\n```json\n{\"name\":\"Ada\",\"age\":36}\n```", "want": {"status": "success", "json": {"name": "Ada", "age": 36}}}
+  ]
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/22_streaming_truncated_string.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/22_streaming_truncated_string.json
@@ -1,0 +1,22 @@
+{
+  "name": "streaming_truncated_string",
+  "description": "Accumulated prefixes stop inside a string value and then complete it. STREAMING DIFFERENTIAL IS BLOCKED ON DIRECT PARSE-STREAM EXPOSURE (deferred): the per-prefix `want` values are NOT yet BAML-characterized and the harness does not gate on them today — only the corpus format and prefix-growth monotonicity are exercised.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "prefixes": [
+    {"name": "open", "raw": "{\"name\":\"", "want": {"status": "success", "json": {"name": ""}}},
+    {"name": "mid_string", "raw": "{\"name\":\"Ad", "want": {"status": "success", "json": {"name": "Ad"}}},
+    {"name": "closed_string", "raw": "{\"name\":\"Ada\"", "want": {"status": "success", "json": {"name": "Ada"}}},
+    {"name": "closed_object", "raw": "{\"name\":\"Ada\"}", "want": {"status": "success", "json": {"name": "Ada"}}}
+  ]
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/23_streaming_trailing_comma.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/23_streaming_trailing_comma.json
@@ -1,0 +1,23 @@
+{
+  "name": "streaming_trailing_comma",
+  "description": "Accumulated prefixes build a list with a trailing comma before the closing bracket/brace. STREAMING DIFFERENTIAL IS BLOCKED ON DIRECT PARSE-STREAM EXPOSURE (deferred): the per-prefix `want` values are NOT yet BAML-characterized and the harness does not gate on them today — only the corpus format and prefix-growth monotonicity are exercised.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "tags", "type": {"kind": "list", "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "prefixes": [
+    {"name": "list_open", "raw": "{\"name\":\"Ada\",\"tags\":[\"x\"", "want": {"status": "success", "json": {"name": "Ada", "tags": ["x"]}}},
+    {"name": "trailing_comma", "raw": "{\"name\":\"Ada\",\"tags\":[\"x\",\"y\",", "want": {"status": "success", "json": {"name": "Ada", "tags": ["x", "y"]}}},
+    {"name": "list_closed", "raw": "{\"name\":\"Ada\",\"tags\":[\"x\",\"y\",]", "want": {"status": "success", "json": {"name": "Ada", "tags": ["x", "y"]}}},
+    {"name": "object_closed", "raw": "{\"name\":\"Ada\",\"tags\":[\"x\",\"y\",]}", "want": {"status": "success", "json": {"name": "Ada", "tags": ["x", "y"]}}}
+  ]
+}

--- a/integration/bamlfuzz_dynamic_test.go
+++ b/integration/bamlfuzz_dynamic_test.go
@@ -316,6 +316,14 @@ func runDynamicOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Oracle
 	}
 	envelope.DynamicSchema = &lowered
 
+	// Issue 523: direct final-parse differential leg. Parse the exact mock
+	// content through BAML directly and (a) anchor it against the walker's
+	// Expected, (b) diff it against any registered native parser. With the
+	// default NoopParser the native leg is a vacuous skip, so this is a
+	// no-op-pass today and becomes a live native-vs-BAML differential the
+	// moment a real native parser registers — no harness rewrite.
+	runDynamicParseDiffLeg(t, dyn, c, caseIdx)
+
 	scenarioID := fmt.Sprintf("bamlfuzz-dyn-%s", scenarioSafe(c.Name))
 	envelope.MockLLMScenarioID = scenarioID
 	registerCtx, registerCancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -303,7 +303,7 @@ func runDynamicParseDiffLeg(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Orac
 				PreserveSchemaOrder: c.PreserveSchemaOrder, Schema: c.Schema,
 				PrefixIndex: -1, Raw: string(c.MockLLMContent),
 				ExpectedStatus: bamlfuzz.ParseStatusSuccess, Expected: c.Expected,
-				SkippedNative: res.SkippedNative, BAML: res.BAML, Native: res.Native,
+				SkippedNative: res.SkippedNative, BAML: res.BAML, Native: res.NativeOutcome(),
 				SemanticDiff: res.SemanticDiff, OrderDiff: res.OrderDiff, Failures: res.Failures,
 			}
 			dumpParseDiffAndFail(t, dynamicOracleArtifactDir, env, strings.Join(res.Failures, "; "))
@@ -348,7 +348,7 @@ func parseDiffEnvelope(c bamlfuzz.ParseRecoveryCase, idx, prefixIdx int, prefixN
 		Stream: stream, PrefixIndex: prefixIdx, PrefixName: prefixName, Raw: raw,
 		SkippedNative: res.SkippedNative,
 		BAML:          res.BAML,
-		Native:        res.Native,
+		Native:        res.NativeOutcome(),
 		SemanticDiff:  res.SemanticDiff,
 		OrderDiff:     res.OrderDiff,
 		Failures:      res.Failures,

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -1,0 +1,369 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/bamlfuzz"
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/dynclient"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// parseRecoveryCorpusDir is the in-tree JSONish recovery corpus. The
+// bamlfuzz package lives under adapters/common; package integration reaches
+// it via a repo-root-relative path, matching the dynamic/static corpora.
+const parseRecoveryCorpusDir = "../adapters/common/codegen/testdata/bamlfuzz/parse_recovery"
+
+// parseRecoveryArtifactDir is where parse-diff failure envelopes land on
+// failure or with BAMLFUZZ_KEEP_ARTIFACTS=1. Gitignored like the other
+// bamlfuzz oracle artifact dirs.
+const parseRecoveryArtifactDir = "../adapters/common/codegen/testdata/bamlfuzz/parse_recovery/_artifacts"
+
+// bamlDynamicParser adapts dynclient's final dynamic parse to the
+// bamlfuzz.Parser interface so the differential harness can drive BAML as
+// the oracle. It covers final parse only: parse-stream over accumulated
+// prefixes is not yet exposed by dynclient/worker, so a Stream request is
+// declined with ErrParserUnavailable (the streaming differential is
+// deferred — see the scope's blocked-on-plumbing note).
+type bamlDynamicParser struct {
+	dyn *dynclient.Client
+}
+
+// Name identifies the BAML oracle leg in diff output and envelopes.
+func (p bamlDynamicParser) Name() string { return "baml_dynamic" }
+
+// Parse drives dynclient.DynamicParse for a final parse. The returned
+// JSON is the flattened, absent-optional-injected, order-normalized
+// payload the dynamic endpoints expose — exactly the shape a native
+// parser must reproduce. Stream requests are declined (deferred).
+func (p bamlDynamicParser) Parse(ctx context.Context, req bamlfuzz.ParseRequest) (bamlfuzz.ParseResult, error) {
+	if req.Stream {
+		return bamlfuzz.ParseResult{}, bamlfuzz.ErrParserUnavailable
+	}
+	lowered, err := bamlfuzz.LowerToDynamicSchema(req.Schema)
+	if err != nil {
+		return bamlfuzz.ParseResult{}, err
+	}
+	preserve := req.PreserveSchemaOrder
+	resp, err := p.dyn.DynamicParse(ctx, dynclient.ParseRequest{
+		Raw:                 req.Raw,
+		OutputSchema:        &lowered,
+		PreserveSchemaOrder: &preserve,
+	})
+	if err != nil {
+		return bamlfuzz.ParseResult{}, err
+	}
+	return bamlfuzz.ParseResult{JSON: append(json.RawMessage(nil), resp.Data...)}, nil
+}
+
+// TestBamlfuzzParseRecovery characterizes BAML's JSONish final-parse
+// recovery behavior against the checked-in corpus and, when a native
+// parser is registered, diffs native against BAML. BAML is the oracle:
+// each case's `want` is BAML's observed outcome, so the gating leg asserts
+// the live BAML parse still matches the recorded outcome (a drift detector
+// for BAML behavior changes), and the differential leg holds any future
+// native parser to BAML's exact behavior.
+//
+// With the default NoopParser the differential leg is a vacuous skip, so
+// today the test is a pure BAML characterization. Streaming-prefix cases
+// validate corpus format + prefix-growth monotonicity but skip the
+// per-prefix differential, which is blocked on direct parse-stream
+// exposure (deferred).
+//
+// Run with BAMLFUZZ_PARSE_CAPTURE=1 to log BAML's observed final-parse
+// outcomes instead of gating — used to (re)capture the corpus `want`
+// values when adding cases or after an intentional BAML behavior change.
+func TestBamlfuzzParseRecovery(t *testing.T) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		t.Skip("Skipping: dynamic endpoints require BAML >= 0.215.0")
+	}
+	dynclientCallGate(t)
+
+	corpus, err := bamlfuzz.LoadParseRecoveryCorpus(parseRecoveryCorpusDir)
+	if err != nil {
+		t.Fatalf("load parse recovery corpus from %s: %v", parseRecoveryCorpusDir, err)
+	}
+	if len(corpus) == 0 {
+		t.Fatalf("parse recovery corpus at %s is empty", parseRecoveryCorpusDir)
+	}
+
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		t.Fatalf("NewDynclient: %v", err)
+	}
+	baml := bamlDynamicParser{dyn: dyn}
+	native := bamlfuzz.RegisteredNativeParser()
+	capture := os.Getenv("BAMLFUZZ_PARSE_CAPTURE") == "1"
+
+	for i, c := range corpus {
+		i := i
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			runParseRecoveryCase(t, baml, native, c, i, capture)
+		})
+	}
+}
+
+// runParseRecoveryCase drives the final and/or streaming legs of one
+// recovery case.
+func runParseRecoveryCase(t *testing.T, baml, native bamlfuzz.Parser, c bamlfuzz.ParseRecoveryCase, idx int, capture bool) {
+	t.Helper()
+
+	if c.HasFinal() {
+		t.Run("final", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			req := bamlfuzz.ParseRequest{
+				Schema:              c.Schema,
+				Raw:                 c.Raw,
+				Stream:              false,
+				PreserveSchemaOrder: c.PreserveSchemaOrder,
+			}
+
+			bamlRes, bamlErr := baml.Parse(ctx, req)
+			if capture {
+				logObservedOutcome(t, "final", c.Raw, bamlRes, bamlErr)
+			} else {
+				characterizeFinal(t, c, idx, bamlRes, bamlErr)
+			}
+
+			// Native-vs-BAML differential. choices is nil: recovery
+			// schemas carry no unions, so the order check needs none.
+			res := bamlfuzz.DiffParsers(ctx, baml, native, req, nil)
+			if !res.SkippedNative && len(res.Failures) > 0 {
+				dumpParseDiffAndFail(t, parseRecoveryArtifactDir, parseDiffEnvelope(c, idx, -1, "", c.Raw, false, res), strings.Join(res.Failures, "; "))
+			}
+		})
+	}
+
+	if c.HasPrefixes() {
+		t.Run("streaming", func(t *testing.T) {
+			// Exercise the corpus-format invariant: accumulated prefixes
+			// must grow. This holds independent of any BAML plumbing.
+			raws := c.PrefixRaws()
+			for i := 1; i < len(raws); i++ {
+				if !strings.HasPrefix(raws[i], raws[i-1]) {
+					t.Errorf("prefix[%d] %q does not extend prefix[%d] %q",
+						i, c.Prefixes[i].Name, i-1, c.Prefixes[i-1].Name)
+				}
+			}
+			// The per-prefix native-vs-BAML differential needs direct
+			// BAML parse-stream over arbitrary accumulated prefixes, which
+			// dynclient/worker do not yet expose. The corpus + harness
+			// format are in place (DiffParserPrefixes); wiring the live
+			// differential is deferred to the parse-stream plumbing PR.
+			t.Skip("streaming parse-stream differential blocked on direct parse-stream exposure (deferred)")
+		})
+	}
+}
+
+// characterizeFinal gates the live BAML final parse against the recorded
+// `want`: status (success/error) parity, plus strict JSON + key-order
+// equality on a successful parse. `want` is BAML's own captured output, so
+// strict equality is correct — a divergence means BAML's parse behavior
+// drifted from the checked-in characterization.
+func characterizeFinal(t *testing.T, c bamlfuzz.ParseRecoveryCase, idx int, res bamlfuzz.ParseResult, parseErr error) {
+	t.Helper()
+	observed := bamlfuzz.ParseStatusSuccess
+	if parseErr != nil {
+		observed = bamlfuzz.ParseStatusError
+	}
+	if observed != c.Want.Status {
+		outcome := bamlfuzz.ParseOutcome{Parser: "baml_dynamic"}
+		if parseErr != nil {
+			outcome.Error = parseErr.Error()
+		} else {
+			outcome.JSON = res.JSON
+		}
+		env := &bamlfuzz.ParseDiffFailureEnvelope{
+			CaseIndex: idx, CaseName: c.Name, OracleMode: bamlfuzz.OracleParseDiff,
+			PreserveSchemaOrder: c.PreserveSchemaOrder, Schema: c.Schema,
+			PrefixIndex: -1, Raw: c.Raw,
+			ExpectedStatus: c.Want.Status, Expected: c.Want.JSON,
+			BAML:     outcome,
+			Failures: []string{fmt.Sprintf("status parity: want %q, BAML produced %q", c.Want.Status, observed)},
+		}
+		dumpParseDiffAndFail(t, parseRecoveryArtifactDir, env, fmt.Sprintf("BAML status %q ≠ want %q", observed, c.Want.Status))
+		return
+	}
+	if !c.Want.IsSuccess() {
+		return // both errored — parity holds, no payload to compare.
+	}
+	diff, err := bamlfuzz.SemanticDiffStrict("want_vs_baml", c.Want.JSON, res.JSON)
+	if err != nil {
+		t.Errorf("characterize %q: semantic diff: %v", c.Name, err)
+		return
+	}
+	var failures []string
+	if len(diff) > 0 {
+		failures = append(failures, "want ≠ BAML (semantic)")
+	}
+	var orderDiff []bamlfuzz.SchemaOrderDiffEntry
+	if c.PreserveSchemaOrder {
+		od, oerr := bamlfuzz.SchemaOrderDiff("want_vs_baml", c.Schema, c.Want.JSON, res.JSON)
+		if oerr != nil {
+			failures = append(failures, fmt.Sprintf("schema order: %v", oerr))
+		} else if len(od) > 0 {
+			orderDiff = od
+			failures = append(failures, "want ≠ BAML (order)")
+		}
+	}
+	if len(failures) == 0 {
+		return
+	}
+	env := &bamlfuzz.ParseDiffFailureEnvelope{
+		CaseIndex: idx, CaseName: c.Name, OracleMode: bamlfuzz.OracleParseDiff,
+		PreserveSchemaOrder: c.PreserveSchemaOrder, Schema: c.Schema,
+		PrefixIndex: -1, Raw: c.Raw,
+		ExpectedStatus: c.Want.Status, Expected: c.Want.JSON,
+		BAML:         bamlfuzz.ParseOutcome{Parser: "baml_dynamic", JSON: res.JSON},
+		SemanticDiff: diff,
+		OrderDiff:    orderDiff,
+		Failures:     failures,
+	}
+	dumpParseDiffAndFail(t, parseRecoveryArtifactDir, env, strings.Join(failures, "; "))
+}
+
+// runDynamicParseDiffLeg runs the issue-523 direct final-parse leg on an
+// OracleCase: it parses the exact mock content through BAML directly,
+// confirms the result matches the walker's Expected (using the same
+// lenient #3690-tolerant comparators the call legs use), and diffs it
+// against any registered native parser. With the default NoopParser the
+// native differential is a vacuous skip, so today this leg only adds the
+// BAML-direct-parse-vs-Expected anchor on top of the existing call/REST
+// legs. The moment a native parser registers, the same corpus + rapid
+// cases become live native-vs-BAML differentials.
+func runDynamicParseDiffLeg(t *testing.T, dyn *dynclient.Client, c bamlfuzz.OracleCase, idx int) {
+	t.Helper()
+	t.Run("parse_diff", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		baml := bamlDynamicParser{dyn: dyn}
+		native := bamlfuzz.RegisteredNativeParser()
+		req := bamlfuzz.ParseRequest{
+			Schema:              c.Schema,
+			Raw:                 string(c.MockLLMContent),
+			Stream:              false,
+			PreserveSchemaOrder: c.PreserveSchemaOrder,
+		}
+
+		bamlRes, bamlErr := baml.Parse(ctx, req)
+		if bamlErr != nil {
+			env := dynParseDiffEnvelope(c, idx,
+				bamlfuzz.ParseOutcome{Parser: baml.Name(), Error: bamlErr.Error()},
+				nil, nil, []string{fmt.Sprintf("BAML direct parse errored: %v", bamlErr)})
+			dumpParseDiffAndFail(t, dynamicOracleArtifactDir, env, fmt.Sprintf("BAML direct parse errored: %v", bamlErr))
+			return
+		}
+
+		var (
+			failures []string
+			semDiff  []bamlfuzz.SemanticDiffEntry
+			ordDiff  []bamlfuzz.SchemaOrderDiffEntry
+		)
+		if diff, err := bamlfuzz.SemanticDiff("expected_vs_baml_parse", c.Expected, bamlRes.JSON); err != nil {
+			failures = append(failures, fmt.Sprintf("expected_vs_baml_parse diff: %v", err))
+		} else if len(diff) > 0 {
+			semDiff = diff
+			failures = append(failures, "expected ≠ baml_parse")
+		}
+		if c.PreserveSchemaOrder {
+			od, oerr := bamlfuzz.SchemaOrderDiffWithChoices("expected_vs_baml_parse", c.Schema, c.Expected, bamlRes.JSON, c.Metadata.UnionChoices)
+			switch {
+			case errors.Is(oerr, bamlfuzz.ErrSchemaOrderUnsupported):
+				failures = append(failures, fmt.Sprintf("schema order unsupported: %v", oerr))
+			case oerr != nil:
+				failures = append(failures, fmt.Sprintf("schema order: %v", oerr))
+			case len(od) > 0:
+				ordDiff = od
+				failures = append(failures, "expected ≠ baml_parse (order)")
+			}
+		}
+		if len(failures) > 0 {
+			env := dynParseDiffEnvelope(c, idx,
+				bamlfuzz.ParseOutcome{Parser: baml.Name(), JSON: bamlRes.JSON}, semDiff, ordDiff, failures)
+			dumpParseDiffAndFail(t, dynamicOracleArtifactDir, env, strings.Join(failures, "; "))
+			return
+		}
+
+		// Native-vs-BAML differential (NoopParser → SkippedNative today).
+		res := bamlfuzz.DiffParsers(ctx, baml, native, req, c.Metadata.UnionChoices)
+		if !res.SkippedNative && len(res.Failures) > 0 {
+			env := &bamlfuzz.ParseDiffFailureEnvelope{
+				CaseIndex: idx, CaseName: c.Name, OracleMode: bamlfuzz.OracleParseDiff,
+				PreserveSchemaOrder: c.PreserveSchemaOrder, Schema: c.Schema,
+				PrefixIndex: -1, Raw: string(c.MockLLMContent),
+				ExpectedStatus: bamlfuzz.ParseStatusSuccess, Expected: c.Expected,
+				SkippedNative: res.SkippedNative, BAML: res.BAML, Native: res.Native,
+				SemanticDiff: res.SemanticDiff, OrderDiff: res.OrderDiff, Failures: res.Failures,
+			}
+			dumpParseDiffAndFail(t, dynamicOracleArtifactDir, env, strings.Join(res.Failures, "; "))
+		}
+	})
+}
+
+// dynParseDiffEnvelope builds a ParseDiffFailureEnvelope for the dynamic
+// oracle's direct-parse leg, where BAML is compared against the walker's
+// Expected rather than a native parser.
+func dynParseDiffEnvelope(c bamlfuzz.OracleCase, idx int, baml bamlfuzz.ParseOutcome, semDiff []bamlfuzz.SemanticDiffEntry, ordDiff []bamlfuzz.SchemaOrderDiffEntry, failures []string) *bamlfuzz.ParseDiffFailureEnvelope {
+	return &bamlfuzz.ParseDiffFailureEnvelope{
+		CaseIndex: idx, CaseName: c.Name, OracleMode: bamlfuzz.OracleParseDiff,
+		PreserveSchemaOrder: c.PreserveSchemaOrder, Schema: c.Schema,
+		PrefixIndex: -1, Raw: string(c.MockLLMContent),
+		ExpectedStatus: bamlfuzz.ParseStatusSuccess, Expected: c.Expected,
+		BAML:         baml,
+		SemanticDiff: semDiff,
+		OrderDiff:    ordDiff,
+		Failures:     failures,
+	}
+}
+
+// logObservedOutcome prints BAML's observed parse outcome in a stable,
+// greppable form so a developer running BAMLFUZZ_PARSE_CAPTURE=1 can copy
+// the values into the corpus `want`. Not a gate.
+func logObservedOutcome(t *testing.T, leg, raw string, res bamlfuzz.ParseResult, parseErr error) {
+	t.Helper()
+	if parseErr != nil {
+		t.Logf("CAPTURE %s raw=%q -> status=error err=%v", leg, raw, parseErr)
+		return
+	}
+	t.Logf("CAPTURE %s raw=%q -> status=success json=%s", leg, raw, string(res.JSON))
+}
+
+// parseDiffEnvelope builds a ParseDiffFailureEnvelope from a
+// ParseDiffResult for the native-vs-BAML differential leg.
+func parseDiffEnvelope(c bamlfuzz.ParseRecoveryCase, idx, prefixIdx int, prefixName, raw string, stream bool, res bamlfuzz.ParseDiffResult) *bamlfuzz.ParseDiffFailureEnvelope {
+	return &bamlfuzz.ParseDiffFailureEnvelope{
+		CaseIndex: idx, CaseName: c.Name, OracleMode: bamlfuzz.OracleParseDiff,
+		PreserveSchemaOrder: c.PreserveSchemaOrder, Schema: c.Schema,
+		Stream: stream, PrefixIndex: prefixIdx, PrefixName: prefixName, Raw: raw,
+		SkippedNative: res.SkippedNative,
+		BAML:          res.BAML,
+		Native:        res.Native,
+		SemanticDiff:  res.SemanticDiff,
+		OrderDiff:     res.OrderDiff,
+		Failures:      res.Failures,
+	}
+}
+
+// dumpParseDiffAndFail writes the envelope to the given artifact dir and
+// fails the test with a message pointing at the replay path.
+func dumpParseDiffAndFail(t *testing.T, dir string, env *bamlfuzz.ParseDiffFailureEnvelope, msg string) {
+	t.Helper()
+	path, err := bamlfuzz.WriteParseDiffReplayArtifact(dir, env)
+	if err != nil {
+		t.Errorf("write parse-diff artifact: %v", err)
+		t.Errorf("%s", msg)
+		return
+	}
+	t.Errorf("%s\nreplay: %s", msg, path)
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
Implements the **smallest valuable first PR** of issue #523 (de-BAML P1: native-vs-BAML differential parsing harness). Pure test/harness infrastructure — no production behavior change.

## What this adds

A pluggable parse-differential harness in `adapters/common/codegen/bamlfuzz/`. BAML is the oracle; a future native parser is the candidate. Today the registry defaults to a `NoopParser`, so every differential leg is a **no-op pass** — and becomes a live native-vs-BAML differential the moment a real parser registers, with no harness rewrite.

### bamlfuzz package
- **`parser.go`** — `Parser` interface (`Schema`+`Raw`+`Stream` → typed JSON / error), `ParseRequest`/`ParseResult`, `ErrParserUnavailable`, `NoopParser`, and the `RegisterNativeParser`/`RegisteredNativeParser` registry. Lives in `bamlfuzz`, not `dynclient`, so a native SAP need not depend on BAML client concepts.
- **`parse_diff.go`** — `DiffParsers` + `DiffParserPrefixes`: success/error parity, **strict** semantic JSON (`SemanticDiffStrict` — no boundaryml/baml#3690 null-leak tolerance, so native must match BAML *exactly*), schema-aware key order when preserve-order. Native `ErrParserUnavailable` ⇒ skip/pass; BAML `ErrParserUnavailable` ⇒ harness failure. Prefix mode asserts accumulated prefixes grow monotonically.
- **`parse_recovery_case.go`** — JSONish recovery corpus structs + loader.
- **`envelope_parse.go`** — `ParseDiffFailureEnvelope` + writer, parallel to the dynamic/static/streaming envelopes.
- **`case.go`** — adds the `OracleParseDiff` mode constant.

### Unit tests (fake parsers, no Docker)
`parse_diff_test.go`: no-op skip, both-error parity, BAML-success/native-error and the reverse, JSON mismatch, **strict extra-null rejection**, order mismatch (+ ignored when preserve-off), BAML-unavailable harness failure, empty-JSON failure, prefix monotonicity, registry round-trip. `parse_recovery_corpus_test.go`: Docker-free corpus well-formedness + prefix-growth guard.

### Corpus — `testdata/bamlfuzz/parse_recovery/`
7 final-parse cases (markdown fence, prose, trailing commas, unquoted keys, single quotes, truncation, mixed JSONish) + 4 streaming-prefix cases, plus the `_artifacts/` gitignore convention.

### Integration wiring
- **`bamlfuzz_parse_recovery_test.go`** — `bamlDynamicParser` adapter (drives `dynclient.DynamicParse`), the recovery characterization test (BAML-vs-`want` gating + native differential), the shared dynamic parse-diff leg, and a `BAMLFUZZ_PARSE_CAPTURE=1` capture mode.
- **`bamlfuzz_dynamic_test.go`** — after lowering each dynamic-safe case, runs the direct final parse on `string(c.MockLLMContent)`: BAML-vs-`Expected` anchor + native differential (no-op skip today).

## How the corpus `want` values were captured
All 7 final-parse `want` values are **BAML's actual observed final-parse outcomes**, captured by running BAML (0.223.0) as the oracle via `BAMLFUZZ_PARSE_CAPTURE=1` and committing what BAML produced — e.g. unquoted keys / single quotes / fences all coerce to `{"name":"Ada","age":36}`, and truncated input is rejected (`Missing required field: age`). No `want` value was guessed; every one was confirmed against live BAML in gating mode.

## Deferred (per approved scope)
- Direct `DynamicParseStream` / worker parse-stream plumbing → so the **streaming differential is blocked-on-plumbing**: the corpus format + prefix-growth invariant are in place and exercised, but per-prefix `want` values are explicitly *not* yet BAML-characterized and the streaming leg `t.Skip`s. (Documented in each streaming case's description.)
- Static-source BAML parse adapter for self-ref / mutual-cycle / raw-root schemas.
- Random JSONish mutation generator; error-text taxonomy; native SAP package.

## Validation
- `gofmt -l` clean; `go vet ./...` and `go vet -tags integration ./...` clean; `go build ./...` clean; integration tests compile; no embed drift.
- `go test ./codegen/bamlfuzz/...` (adapters/common) — unit tests pass with the no-op native parser.
- Docker integration run (BAML 0.223.0): `TestBamlfuzzParseRecovery` + `TestBamlfuzzDynamicOracle` → **72 PASS, 5 SKIP, 0 FAIL**. The new `parse_diff` leg passes on all 16 dynamic corpus + 8 rapid cases (incl. unions and preserve-order); recovery final legs all pass against captured `want`; streaming legs skip as designed.

Fixes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expanded parse-recovery test coverage for JSON-ish and streaming inputs (including prefix growth scenarios) with strict corpus validation.
  * Introduced native-vs-BAML differential parsing with strict semantic/schema-order comparisons and generated replay artifacts on mismatches.
  * Added support for an additional parse-differential oracle mode and deterministic replay artifact writing.

* **Bug Fixes**
  * Strengthened parity rules for success/error outcomes, including failing empty successful parses and stricter JSON diff behavior.
  * Improved schema-order diff reporting when schema order preservation is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->