### PR TITLE
ci(bamlfuzz): tolerate Go native-fuzz coordinator deadline at the fuzztime boundary (#526)

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -438,13 +438,20 @@ jobs:
         # failAndDump / failStaticAndDump / failAndDumpInvalid.
         env:
           BAMLFUZZ_KEEP_ARTIFACTS: ""
-        run: |
-          go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 80m \
-            -run='^$' \
-            -fuzz='^${{ matrix.target }}$' \
-            -fuzztime="${FUZZTIME}" \
-            ./integration \
-            -test.fuzzcachedir="$(pwd)/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache"
+          # Drives scripts/run-bamlfuzz-native.sh, which runs the identical
+          # `go test -fuzz` invocation but routes the result through
+          # scripts/bamlfuzz-boundary-guard.sh. The guard tolerates ONLY the
+          # Go fuzz coordinator's own -fuzztime boundary deadline (issue #526)
+          # — a Go-stdlib fuzzing artifact at the budget edge that produces no
+          # crasher input and no replay envelope. Every other failure shape
+          # (reproducible inputs, parity mismatches, real oracle deadlines,
+          # hangs) propagates unchanged, so the cell still fails, uploads
+          # replay artifacts, and comments on the sticky issue. The guard is
+          # target-parameterized via BAMLFUZZ_FUNCTION so it covers every
+          # native-fuzz cell (Dynamic / InvalidDynamic / InvalidJSONCoercion);
+          # Static and Streaming run under -run below and are unaffected.
+          BAMLFUZZ_FUNCTION: ${{ matrix.target }}
+        run: ./scripts/run-bamlfuzz-native.sh
 
       - name: Static oracle (-run, no fuzz watchdog) (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }})
         if: ${{ env.MODE == 'fuzz' && matrix.target == 'FuzzBamlfuzzStatic' }}

--- a/integration/bamlfuzz_invalid_test.go
+++ b/integration/bamlfuzz_invalid_test.go
@@ -367,7 +367,18 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 		return
 	}
 	if libErr != nil && (errors.Is(libErr, context.Canceled) || errors.Is(libErr, context.DeadlineExceeded)) {
-		t.Fatalf("harness failure: dynclient context (case=%s mutation=%s): %v", c.Name, c.Mutation, libErr)
+		// Harness/transport failure, not an oracle disagreement — but it must
+		// still be DURABLE on disk. At the -fuzztime boundary the Go fuzz
+		// coordinator drops the worker's RPC result, and worker stdout/stderr
+		// are wired to /dev/null, so a bare t.Fatal here would surface only as
+		// the coordinator's own "context deadline exceeded" line — the exact
+		// shape scripts/bamlfuzz-boundary-guard.sh tolerates (issue #526).
+		// Routing through failAndDumpInvalid writes a replay artifact, the one
+		// signal that survives the boundary; the "harness failure:" text is a
+		// secondary, guard-rejected marker for the non-boundary case.
+		envelope.DynclientError = libErr.Error()
+		failAndDumpInvalid(t, artifactDir, envelope, "harness failure: dynclient context (case=%s mutation=%s): %v", c.Name, c.Mutation, libErr)
+		return
 	}
 	var dynSuccess bool
 	switch {
@@ -400,7 +411,13 @@ func runInvalidOracleCase(t *testing.T, dyn *dynclient.Client, c bamlfuzz.Invali
 		return
 	}
 	if err != nil {
-		t.Fatalf("harness failure: REST transport (case=%s mutation=%s): %v", c.Name, c.Mutation, err)
+		// Harness/transport failure — dump a durable envelope for the same
+		// boundary-safety reason as the dynclient leg above (issue #526): the
+		// _artifacts file is the only signal that survives the coordinator's
+		// drop of the worker result at the -fuzztime boundary.
+		envelope.RESTError = err.Error()
+		failAndDumpInvalid(t, artifactDir, envelope, "harness failure: REST transport (case=%s mutation=%s): %v", c.Name, c.Mutation, err)
+		return
 	}
 	if restResp == nil {
 		envelope.RESTError = "nil response from BAMLClient.DynamicCallJSON"

--- a/scripts/bamlfuzz-boundary-guard.sh
+++ b/scripts/bamlfuzz-boundary-guard.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# bamlfuzz-boundary-guard.sh
+#
+# Decide whether a FAILED native `go test -fuzz` run is the benign Go fuzz
+# *coordinator* -fuzztime boundary deadline (issue #526) and may be
+# tolerated, or a real failure that must propagate.
+#
+# Background (issue #526): when `-fuzztime` elapses, Go's fuzz coordinator
+# creates its own context.WithTimeout(ctx, fuzztime). If a worker is still
+# inside / returning from an exec at the exact budget boundary, the
+# coordinator can return context.DeadlineExceeded while blocked on the
+# worker RPC. The testing package then prints that bare error and marks the
+# fuzz target FAILED — even though no crasher input and no oracle replay
+# envelope were produced. That is a Go-stdlib fuzzing boundary artifact, not
+# a reproducible failure: there is no saved input to retry and no parity
+# mismatch to investigate.
+#
+# This guard tolerates ONLY that exact shape. It is target-parameterized so
+# it works for every native-fuzz cell (FuzzBamlfuzzDynamic,
+# FuzzBamlfuzzInvalidDynamic, FuzzBamlfuzzInvalidJSONCoercion). It can NEVER
+# mask:
+#   * a reproducible input  -> rejected by `Failing input written to`
+#   * a parity mismatch     -> rejected by replay/repro + semantic markers
+#   * a real oracle deadline-> rejected by oracle-body error markers
+#                              (those route through failAndDump, which always
+#                               prints repro:/replay:)
+#   * a hang / deadlock     -> never reaches the completed-budget boundary
+#                              shape (unchanged execs + (0/sec) at fuzztime);
+#                              `go test -timeout` / the job timeout still fire
+#
+# Usage:
+#   bamlfuzz-boundary-guard.sh <logfile> <go_test_exit_code> <target> <fuzztime> [artifact_root]
+#
+# Exit 0  -> go test passed, OR the failure is the tolerable #526 boundary
+#            (a loud BAMLFUZZ: line is printed in that case).
+# Exit !0 -> a real failure; the original go-test exit code is propagated.
+#
+# Kept as a standalone script (not inline workflow shell) so it is testable
+# against fixed sample logs — see bamlfuzz-boundary-guard_test.sh.
+set -uo pipefail
+
+log="${1:?logfile required}"
+exit_code="${2:?go test exit code required}"
+target="${3:?target required}"
+fuzztime="${4:?fuzztime required}"
+artifact_root="${5:-adapters/common/codegen/testdata/bamlfuzz}"
+
+# A passing run is nothing to tolerate.
+if [ "$exit_code" -eq 0 ]; then
+  exit 0
+fi
+
+# Refuse to tolerate: surface the reason on stderr and propagate the
+# original go-test exit code so the CI step fails on the real failure.
+propagate() {
+  echo "BAMLFUZZ-GUARD: NOT tolerating native-fuzz failure (${1}); propagating exit ${exit_code}." >&2
+  exit "$exit_code"
+}
+
+if [ ! -f "$log" ]; then
+  propagate "log file ${log} is missing"
+fi
+
+# ---------------------------------------------------------------------------
+# (1) Exactly one test failed, and it is our target. A second FAIL line (or a
+#     FAIL for some other test) means more than the coordinator boundary went
+#     wrong — never tolerate that. This also enforces "suppress at most one
+#     boundary error per invocation".
+# ---------------------------------------------------------------------------
+fail_count="$(grep -c -- '--- FAIL: ' "$log" || true)"
+if [ "${fail_count:-0}" -ne 1 ]; then
+  propagate "expected exactly one '--- FAIL:' line, found ${fail_count:-0}"
+fi
+if ! grep -qF -- "--- FAIL: ${target} (" "$log"; then
+  propagate "the single FAIL line is not for target ${target}"
+fi
+
+# ---------------------------------------------------------------------------
+# (2) A BARE 'context deadline exceeded' line — the coordinator's own printed
+#     error (testing/fuzz.go prints the non-crasher error verbatim on its own
+#     line). An oracle-body deadline is embedded inside a longer message
+#     (e.g. "dynclient errored: ... context deadline exceeded") and is caught
+#     by the marker scan below; a whole-line match here distinguishes the two.
+# ---------------------------------------------------------------------------
+if ! grep -qxE '[[:space:]]*context deadline exceeded[[:space:]]*' "$log"; then
+  propagate "no bare 'context deadline exceeded' line"
+fi
+
+# ---------------------------------------------------------------------------
+# (3) No oracle-body / replay / crasher markers anywhere. Each marker means a
+#     real, attributable failure that MUST surface. failAndDump and
+#     failAndDumpInvalid (integration/bamlfuzz_dynamic_test.go,
+#     integration/bamlfuzz_invalid_test.go) always print `repro:` and either
+#     `replay:` or `write replay artifact:`, so those three alone catch every
+#     oracle-body failure for all native-fuzz targets; the rest are
+#     defense-in-depth against the specific failure texts.
+# ---------------------------------------------------------------------------
+reject_markers=(
+  'Failing input written to'   # Go fuzz wrote a reproducible crasher input
+  'repro:'                     # every failAndDump / failAndDumpInvalid path prints this
+  'replay:'                    # ditto (artifact write succeeded)
+  'write replay artifact:'     # ditto (artifact write failed)
+  'dynclient errored:'         # oracle-body dynclient error
+  'REST errored'               # oracle-body REST error ("REST errored (status N): ...")
+  'register scenario:'         # mock scenario registration error
+  'schema key order mismatch'  # preserve-order parity failure
+  'schema order'               # schema-order unsupported / error
+  ' diff:'                     # semantic-diff decode error (expected_vs_* diff:)
+  '≠'                          # semantic mismatch (expected ≠ dynclient, dynclient ≠ REST, ...)
+)
+for m in "${reject_markers[@]}"; do
+  if grep -qF -- "$m" "$log"; then
+    propagate "log contains oracle/crasher marker: ${m}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# (4) The fuzz budget actually COMPLETED in the boundary shape: a
+#     'fuzz: elapsed:' progress line at/after the configured fuzztime, with
+#     (0/sec) and an exec count unchanged from the prior progress line. A real
+#     per-input stall or a hang never reaches this completed-budget shape.
+# ---------------------------------------------------------------------------
+elapsed_lines=()
+while IFS= read -r line; do
+  elapsed_lines+=("$line")
+done < <(grep -E 'fuzz: elapsed:' "$log" || true)
+
+if [ "${#elapsed_lines[@]}" -lt 2 ]; then
+  propagate "fewer than two 'fuzz: elapsed:' progress lines"
+fi
+
+# Convert a Go duration string (e.g. 15m, 15m0s, 15m1s, 1h0m0s, 30s) to
+# whole seconds. Fractional seconds are floored; only integer progress
+# durations appear on `fuzz: elapsed:` lines.
+dur_to_secs() {
+  local d="$1" total=0
+  [[ "$d" =~ ([0-9]+)h ]] && total=$(( total + BASH_REMATCH[1] * 3600 ))
+  [[ "$d" =~ ([0-9]+)m ]] && total=$(( total + BASH_REMATCH[1] * 60 ))
+  [[ "$d" =~ ([0-9]+)s ]] && total=$(( total + BASH_REMATCH[1] ))
+  echo "$total"
+}
+exec_of()    { sed -E 's/.*execs: ([0-9]+).*/\1/' <<<"$1"; }
+elapsed_of() { sed -E 's/.*elapsed: ([^,]+),.*/\1/' <<<"$1"; }
+
+# Last progress line carrying the (0/sec) boundary marker.
+boundary_idx=-1
+for i in "${!elapsed_lines[@]}"; do
+  if [[ "${elapsed_lines[$i]}" == *"(0/sec)"* ]]; then
+    boundary_idx="$i"
+  fi
+done
+if [ "$boundary_idx" -lt 1 ]; then
+  propagate "no '(0/sec)' boundary progress line preceded by another progress line"
+fi
+
+boundary_line="${elapsed_lines[$boundary_idx]}"
+prev_line="${elapsed_lines[$((boundary_idx - 1))]}"
+b_exec="$(exec_of "$boundary_line")"
+p_exec="$(exec_of "$prev_line")"
+if [ "$b_exec" != "$p_exec" ]; then
+  propagate "exec count changed at the (0/sec) boundary (${p_exec} -> ${b_exec}); not a completed-budget stall"
+fi
+
+want_secs="$(dur_to_secs "$fuzztime")"
+have_secs="$(dur_to_secs "$(elapsed_of "$boundary_line")")"
+if [ "${want_secs:-0}" -le 0 ]; then
+  propagate "could not parse fuzztime '${fuzztime}'"
+fi
+if [ "${have_secs:-0}" -lt "$want_secs" ]; then
+  propagate "boundary elapsed ${have_secs}s < configured fuzztime ${want_secs}s; budget did not complete"
+fi
+
+# ---------------------------------------------------------------------------
+# (5) No replay artifact was written under any <target>/_artifacts/ dir. The
+#     workflow uploads these on failure; their absence confirms no oracle case
+#     produced an envelope (parity mismatches always write one before failing).
+# ---------------------------------------------------------------------------
+if [ -d "$artifact_root" ]; then
+  while IFS= read -r d; do
+    [ -n "$d" ] || continue
+    if [ -n "$(find "$d" -type f -print -quit 2>/dev/null)" ]; then
+      propagate "replay artifact present under ${d}"
+    fi
+  done < <(find "$artifact_root" -type d -name _artifacts 2>/dev/null || true)
+fi
+
+# All conditions held: this is the issue #526 coordinator-boundary artifact.
+echo "BAMLFUZZ: tolerated Go native fuzz coordinator deadline at fuzztime boundary; no crasher or replay envelope produced; see issue #526."
+exit 0

--- a/scripts/bamlfuzz-boundary-guard.sh
+++ b/scripts/bamlfuzz-boundary-guard.sh
@@ -131,15 +131,39 @@ if [ "${#elapsed_lines[@]}" -lt 2 ]; then
   propagate "fewer than two 'fuzz: elapsed:' progress lines"
 fi
 
-# Convert a Go duration string (e.g. 15m, 15m0s, 15m1s, 1h0m0s, 30s) to
-# whole seconds. Fractional seconds are floored; only integer progress
-# durations appear on `fuzz: elapsed:` lines.
-dur_to_secs() {
-  local d="$1" total=0
-  [[ "$d" =~ ([0-9]+)h ]] && total=$(( total + BASH_REMATCH[1] * 3600 ))
-  [[ "$d" =~ ([0-9]+)m ]] && total=$(( total + BASH_REMATCH[1] * 60 ))
-  [[ "$d" =~ ([0-9]+)s ]] && total=$(( total + BASH_REMATCH[1] ))
-  echo "$total"
+# Parse a full Go duration string to integer NANOSECONDS, supporting
+# FRACTIONAL units (e.g. 15.5m, 59.9s, 0.5h, 1h2.5m) as well as the integer
+# forms Go fuzz prints (15m, 15m0s, 15m1s, 1h0m0s, 30s). Prints the ns value
+# and exits 0; exits 1 on an empty, malformed, or partially-consumed string so
+# the caller can fail closed. Go durations are integer nanoseconds and stay
+# well under 2^53, so the double math is exact for any realistic fuzztime.
+# A whole-string parser is required: the previous unanchored h/m/s substring
+# match mis-read 15.5m as 300s, which fail-OPEN tolerated a short run (#526
+# follow-up). awk handles the float math portably (no bc dependency).
+parse_go_duration_ns() {
+  awk -v s="$1" '
+    BEGIN {
+      if (s == "") exit 1
+      c = substr(s, 1, 1)
+      if (c == "+" || c == "-") s = substr(s, 2)
+      if (s == "") exit 1
+      total = 0.0; found = 0
+      while (length(s) > 0) {
+        if (match(s, /^([0-9]+(\.[0-9]*)?|\.[0-9]+)/) == 0) exit 1
+        num = substr(s, 1, RLENGTH) + 0
+        s = substr(s, RLENGTH + 1)
+        if      (substr(s, 1, 2) == "ns") { mult = 1;      s = substr(s, 3) }
+        else if (substr(s, 1, 2) == "us") { mult = 1e3;    s = substr(s, 3) }
+        else if (substr(s, 1, 2) == "ms") { mult = 1e6;    s = substr(s, 3) }
+        else if (substr(s, 1, 1) == "s")  { mult = 1e9;    s = substr(s, 2) }
+        else if (substr(s, 1, 1) == "m")  { mult = 60e9;   s = substr(s, 2) }
+        else if (substr(s, 1, 1) == "h")  { mult = 3600e9; s = substr(s, 2) }
+        else exit 1
+        total += num * mult; found = 1
+      }
+      if (!found) exit 1
+      printf "%.0f\n", total
+    }'
 }
 exec_of()    { sed -E 's/.*execs: ([0-9]+).*/\1/' <<<"$1"; }
 elapsed_of() { sed -E 's/.*elapsed: ([^,]+),.*/\1/' <<<"$1"; }
@@ -169,13 +193,21 @@ if [ "$b_exec" != "$p_exec" ]; then
   propagate "exec count changed at the (0/sec) boundary (${p_exec} -> ${b_exec}); not a completed-budget stall"
 fi
 
-want_secs="$(dur_to_secs "$fuzztime")"
-have_secs="$(dur_to_secs "$(elapsed_of "$boundary_line")")"
-if [ "${want_secs:-0}" -le 0 ]; then
-  propagate "could not parse fuzztime '${fuzztime}'"
+elapsed_tok="$(elapsed_of "$boundary_line")"
+# Parse both to exact nanoseconds; a parse failure fails closed (propagate),
+# never silently zero. Comparing in nanoseconds (not truncated seconds) keeps
+# a fractional fuzztime like 15.5m from fail-OPEN tolerating a 15m1s run.
+if ! want_ns="$(parse_go_duration_ns "$fuzztime")"; then
+  propagate "could not parse configured fuzztime '${fuzztime}'"
 fi
-if [ "${have_secs:-0}" -lt "$want_secs" ]; then
-  propagate "boundary elapsed ${have_secs}s < configured fuzztime ${want_secs}s; budget did not complete"
+if ! have_ns="$(parse_go_duration_ns "$elapsed_tok")"; then
+  propagate "could not parse boundary elapsed '${elapsed_tok}'"
+fi
+if [ "$want_ns" -le 0 ]; then
+  propagate "configured fuzztime '${fuzztime}' is non-positive"
+fi
+if [ "$have_ns" -lt "$want_ns" ]; then
+  propagate "boundary elapsed ${elapsed_tok} (${have_ns}ns) < configured fuzztime ${fuzztime} (${want_ns}ns); budget did not complete"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/bamlfuzz-boundary-guard.sh
+++ b/scripts/bamlfuzz-boundary-guard.sh
@@ -154,6 +154,12 @@ done
 if [ "$boundary_idx" -lt 1 ]; then
   propagate "no '(0/sec)' boundary progress line preceded by another progress line"
 fi
+# The (0/sec) line MUST be the terminal progress line: any further
+# 'fuzz: elapsed:' line after it means fuzzing kept going, so this was not the
+# completed-budget shutdown shape. Fail closed.
+if [ "$boundary_idx" -ne $(( ${#elapsed_lines[@]} - 1 )) ]; then
+  propagate "(0/sec) line at index ${boundary_idx} is not the final progress line ($(( ${#elapsed_lines[@]} - 1 ))); fuzzing continued after it"
+fi
 
 boundary_line="${elapsed_lines[$boundary_idx]}"
 prev_line="${elapsed_lines[$((boundary_idx - 1))]}"
@@ -176,15 +182,19 @@ fi
 # (5) No replay artifact was written under any <target>/_artifacts/ dir. The
 #     workflow uploads these on failure; their absence confirms no oracle case
 #     produced an envelope (parity mismatches always write one before failing).
+#     A missing artifact root means we cannot make that determination, so fail
+#     closed — do NOT fall through to tolerate. Preexisting _artifacts subdirs
+#     are NOT required: the failure writers create them on demand.
 # ---------------------------------------------------------------------------
-if [ -d "$artifact_root" ]; then
-  while IFS= read -r d; do
-    [ -n "$d" ] || continue
-    if [ -n "$(find "$d" -type f -print -quit 2>/dev/null)" ]; then
-      propagate "replay artifact present under ${d}"
-    fi
-  done < <(find "$artifact_root" -type d -name _artifacts 2>/dev/null || true)
+if [ ! -d "$artifact_root" ]; then
+  propagate "artifact root ${artifact_root} is missing; cannot confirm no replay envelope"
 fi
+while IFS= read -r d; do
+  [ -n "$d" ] || continue
+  if [ -n "$(find "$d" -type f -print -quit 2>/dev/null)" ]; then
+    propagate "replay artifact present under ${d}"
+  fi
+done < <(find "$artifact_root" -type d -name _artifacts 2>/dev/null || true)
 
 # All conditions held: this is the issue #526 coordinator-boundary artifact.
 echo "BAMLFUZZ: tolerated Go native fuzz coordinator deadline at fuzztime boundary; no crasher or replay envelope produced; see issue #526."

--- a/scripts/bamlfuzz-boundary-guard.sh
+++ b/scripts/bamlfuzz-boundary-guard.sh
@@ -104,6 +104,7 @@ reject_markers=(
   'dynclient errored:'         # oracle-body dynclient error
   'REST errored'               # oracle-body REST error ("REST errored (status N): ...")
   'register scenario:'         # mock scenario registration error
+  'harness failure:'           # invalid-oracle harness/transport failure (now also dumps an artifact)
   'schema key order mismatch'  # preserve-order parity failure
   'schema order'               # schema-order unsupported / error
   ' diff:'                     # semantic-diff decode error (expected_vs_* diff:)

--- a/scripts/bamlfuzz-boundary-guard.sh
+++ b/scripts/bamlfuzz-boundary-guard.sh
@@ -144,8 +144,13 @@ parse_go_duration_ns() {
   awk -v s="$1" '
     BEGIN {
       if (s == "") exit 1
+      # Only a leading "+" (or no sign) is allowed. A negative duration is
+      # meaningless for this completed-budget guard (and `go test
+      # -fuzztime=-15m` is itself invalid), so reject it as unparseable — the
+      # caller then fails closed via "could not parse ...".
       c = substr(s, 1, 1)
-      if (c == "+" || c == "-") s = substr(s, 2)
+      if (c == "-") exit 1
+      if (c == "+") s = substr(s, 2)
       if (s == "") exit 1
       total = 0.0; found = 0
       while (length(s) > 0) {

--- a/scripts/bamlfuzz-boundary-guard.sh
+++ b/scripts/bamlfuzz-boundary-guard.sh
@@ -221,12 +221,34 @@ fi
 if [ ! -d "$artifact_root" ]; then
   propagate "artifact root ${artifact_root} is missing; cannot confirm no replay envelope"
 fi
+# The scan must FAIL CLOSED: a find error (e.g. an unreadable subtree) must not
+# be swallowed and read as "no envelope". Capture find's exit status — never
+# mask it with `2>/dev/null || true` — and propagate on any error.
+artifacts_dirs="$(mktemp)"
+if ! find "$artifact_root" -type d -name _artifacts -print >"$artifacts_dirs" 2>/dev/null; then
+  rm -f "$artifacts_dirs"
+  propagate "artifact scan failed under ${artifact_root}; cannot confirm no replay envelope"
+fi
+# Slurp the discovered dirs into an array and drop the temp file BEFORE
+# iterating, so we never read and write the same file together.
+artifacts_list=()
 while IFS= read -r d; do
-  [ -n "$d" ] || continue
-  if [ -n "$(find "$d" -type f -print -quit 2>/dev/null)" ]; then
-    propagate "replay artifact present under ${d}"
-  fi
-done < <(find "$artifact_root" -type d -name _artifacts 2>/dev/null || true)
+  [ -n "$d" ] && artifacts_list+=("$d")
+done <"$artifacts_dirs"
+rm -f "$artifacts_dirs"
+
+if [ "${#artifacts_list[@]}" -gt 0 ]; then
+  for d in "${artifacts_list[@]}"; do
+    # Checked per-dir scan: a find error here also fails closed (status checked
+    # directly via the assignment, not masked).
+    if ! found_file="$(find "$d" -type f -print -quit 2>/dev/null)"; then
+      propagate "artifact scan failed under ${d}; cannot confirm no replay envelope"
+    fi
+    if [ -n "$found_file" ]; then
+      propagate "replay artifact present under ${d}"
+    fi
+  done
+fi
 
 # All conditions held: this is the issue #526 coordinator-boundary artifact.
 echo "BAMLFUZZ: tolerated Go native fuzz coordinator deadline at fuzztime boundary; no crasher or replay envelope produced; see issue #526."

--- a/scripts/bamlfuzz-boundary-guard_test.sh
+++ b/scripts/bamlfuzz-boundary-guard_test.sh
@@ -20,17 +20,24 @@ pass=0
 fail=0
 
 # run_case <name> <logfile> <go_exit> <want_guard_exit> <target> <artifact_mode> [expect_loud]
-#   artifact_mode: "empty" (clean dir) | "with-artifact" (a _artifacts file exists)
+#   artifact_mode: "empty" (clean dir)
+#                | "with-artifact[:<subdir>]" (a <subdir>/_artifacts file exists;
+#                                              subdir defaults to "dynamic")
 #   expect_loud:   non-empty -> require the tolerated BAMLFUZZ: line on stdout
 run_case() {
   local name="$1" logf="$2" code="$3" want="$4" tgt="$5" artmode="$6" loud="${7:-}"
-  local artroot out got ok=1
+  local artroot out got ok=1 subdir
 
   artroot="$(mktemp -d)"
-  if [ "$artmode" = "with-artifact" ]; then
-    mkdir -p "${artroot}/dynamic/_artifacts"
-    printf '{}' > "${artroot}/dynamic/_artifacts/fuzz.json"
-  fi
+  case "$artmode" in
+    with-artifact*)
+      subdir="${artmode#with-artifact}"
+      subdir="${subdir#:}"
+      subdir="${subdir:-dynamic}"
+      mkdir -p "${artroot}/${subdir}/_artifacts"
+      printf '{}' > "${artroot}/${subdir}/_artifacts/fuzz.json"
+      ;;
+  esac
 
   out="$("$guard" "${fixtures}/${logf}" "$code" "$tgt" "15m" "$artroot" 2>&1)"
   got=$?
@@ -66,6 +73,10 @@ run_case "dynclient errored: propagates"           dynclient_errored.log 1 1 Fuz
 run_case "REST errored propagates"                 rest_errored.log      1 1 FuzzBamlfuzzDynamic            empty
 run_case "register scenario: propagates"           register_scenario.log 1 1 FuzzBamlfuzzDynamic            empty
 run_case "semantic mismatch (≠) propagates"        semantic_neq.log      1 1 FuzzBamlfuzzDynamic            empty
+# Invalid-oracle harness/transport failure (invalid_test.go:370/403). The
+# "harness failure:" marker must force propagation even when it surfaces at
+# the boundary (near-boundary case where the worker result was not dropped).
+run_case "harness-failure marker propagates"       harness_failure_marker.log 1 1 FuzzBamlfuzzInvalidDynamic empty
 
 # --- propagate: budget / boundary-shape violations -------------------------
 run_case "CDE before full budget propagates"       cde_before_budget.log 1 1 FuzzBamlfuzzDynamic            empty
@@ -76,6 +87,11 @@ run_case "execs changed at boundary propagates"    execs_changed.log     1 1 Fuz
 run_case "multiple FAIL lines propagate"           multi_fail.log        1 1 FuzzBamlfuzzDynamic            empty
 run_case "FAIL for a different target propagates"  wrong_target.log      1 1 FuzzBamlfuzzDynamic            empty
 run_case "replay artifact on disk propagates"      boundary_526.log      1 1 FuzzBamlfuzzDynamic            with-artifact
+# The TRUE boundary-drop case for the invalid harness paths: the worker
+# result (and any marker) is dropped, so the log is the pure #526 shape with
+# NO oracle marker — but failAndDumpInvalid wrote an _artifacts file that
+# survives on disk. The artifact check is the durable backstop here.
+run_case "invalid artifact (boundary drop) propagates" boundary_invalid.log 1 1 FuzzBamlfuzzInvalidJSONCoercion with-artifact:invalid_json_coercion
 
 echo "---"
 echo "passed=${pass} failed=${fail}"

--- a/scripts/bamlfuzz-boundary-guard_test.sh
+++ b/scripts/bamlfuzz-boundary-guard_test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# bamlfuzz-boundary-guard_test.sh
+#
+# Fixture tests for bamlfuzz-boundary-guard.sh. Runs the guard against saved
+# `go test -fuzz` log snippets (scripts/testdata/bamlfuzz-guard/) and asserts
+# the tolerate-vs-propagate decision for each. Pure bash; no Docker, no Go —
+# runnable in CI directly.
+#
+# Each rejection fixture isolates a single failing condition (it otherwise
+# carries the tolerable #526 boundary shape) so a regression in any one
+# guard check is caught individually.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+guard="${here}/bamlfuzz-boundary-guard.sh"
+fixtures="${here}/testdata/bamlfuzz-guard"
+
+pass=0
+fail=0
+
+# run_case <name> <logfile> <go_exit> <want_guard_exit> <target> <artifact_mode> [expect_loud]
+#   artifact_mode: "empty" (clean dir) | "with-artifact" (a _artifacts file exists)
+#   expect_loud:   non-empty -> require the tolerated BAMLFUZZ: line on stdout
+run_case() {
+  local name="$1" logf="$2" code="$3" want="$4" tgt="$5" artmode="$6" loud="${7:-}"
+  local artroot out got ok=1
+
+  artroot="$(mktemp -d)"
+  if [ "$artmode" = "with-artifact" ]; then
+    mkdir -p "${artroot}/dynamic/_artifacts"
+    printf '{}' > "${artroot}/dynamic/_artifacts/fuzz.json"
+  fi
+
+  out="$("$guard" "${fixtures}/${logf}" "$code" "$tgt" "15m" "$artroot" 2>&1)"
+  got=$?
+  rm -rf "$artroot"
+
+  [ "$got" -eq "$want" ] || ok=0
+  if [ -n "$loud" ]; then
+    grep -qF "BAMLFUZZ: tolerated Go native fuzz coordinator deadline" <<<"$out" || ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "ok   - ${name} (exit ${got})"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - ${name}: got exit ${got}, want ${want}"
+    while IFS= read -r diag_line; do
+      echo "       | ${diag_line}"
+    done <<<"$out"
+    fail=$((fail + 1))
+  fi
+}
+
+# --- tolerate ---------------------------------------------------------------
+run_case "green go test passes through"            green.log             0 0 FuzzBamlfuzzDynamic            empty
+run_case "#526 boundary tolerated (Dynamic)"       boundary_526.log      1 0 FuzzBamlfuzzDynamic            empty loud
+run_case "#526 boundary tolerated (Invalid cell)"  boundary_invalid.log  1 0 FuzzBamlfuzzInvalidJSONCoercion empty loud
+
+# --- propagate: reproducible input / parity / oracle markers ---------------
+run_case "reproducible crasher propagates"         failing_input.log     1 1 FuzzBamlfuzzDynamic            empty
+run_case "replay: marker propagates"               replay.log            1 1 FuzzBamlfuzzDynamic            empty
+run_case "write replay artifact: propagates"       write_replay.log      1 1 FuzzBamlfuzzDynamic            empty
+run_case "dynclient errored: propagates"           dynclient_errored.log 1 1 FuzzBamlfuzzDynamic            empty
+run_case "REST errored propagates"                 rest_errored.log      1 1 FuzzBamlfuzzDynamic            empty
+run_case "register scenario: propagates"           register_scenario.log 1 1 FuzzBamlfuzzDynamic            empty
+run_case "semantic mismatch (≠) propagates"        semantic_neq.log      1 1 FuzzBamlfuzzDynamic            empty
+
+# --- propagate: budget / boundary-shape violations -------------------------
+run_case "CDE before full budget propagates"       cde_before_budget.log 1 1 FuzzBamlfuzzDynamic            empty
+run_case "missing (0/sec) shape propagates"        no_zerosec.log        1 1 FuzzBamlfuzzDynamic            empty
+run_case "execs changed at boundary propagates"    execs_changed.log     1 1 FuzzBamlfuzzDynamic            empty
+
+# --- propagate: structural / state violations ------------------------------
+run_case "multiple FAIL lines propagate"           multi_fail.log        1 1 FuzzBamlfuzzDynamic            empty
+run_case "FAIL for a different target propagates"  wrong_target.log      1 1 FuzzBamlfuzzDynamic            empty
+run_case "replay artifact on disk propagates"      boundary_526.log      1 1 FuzzBamlfuzzDynamic            with-artifact
+
+echo "---"
+echo "passed=${pass} failed=${fail}"
+[ "$fail" -eq 0 ]

--- a/scripts/bamlfuzz-boundary-guard_test.sh
+++ b/scripts/bamlfuzz-boundary-guard_test.sh
@@ -23,13 +23,21 @@ fail=0
 #   artifact_mode: "empty" (clean dir)
 #                | "with-artifact[:<subdir>]" (a <subdir>/_artifacts file exists;
 #                                              subdir defaults to "dynamic")
-#   expect_loud:   non-empty -> require the tolerated BAMLFUZZ: line on stdout
+#   artifact_mode "missing-root" -> point the guard at a nonexistent root
+#   expect_loud:   non-empty -> require the tolerated BAMLFUZZ: line on STDOUT
+#                  (stdout/stderr are captured separately so this enforces the
+#                  guard's stdout-only contract for the loud tolerated line)
 run_case() {
   local name="$1" logf="$2" code="$3" want="$4" tgt="$5" artmode="$6" loud="${7:-}"
-  local artroot out got ok=1 subdir
+  local artroot out errf outf got ok=1 subdir
 
   artroot="$(mktemp -d)"
   case "$artmode" in
+    missing-root)
+      # Hand the guard a path that does not exist (F4 fail-closed check).
+      rm -rf "$artroot"
+      artroot="${artroot}/does-not-exist"
+      ;;
     with-artifact*)
       subdir="${artmode#with-artifact}"
       subdir="${subdir#:}"
@@ -39,13 +47,18 @@ run_case() {
       ;;
   esac
 
-  out="$("$guard" "${fixtures}/${logf}" "$code" "$tgt" "15m" "$artroot" 2>&1)"
+  # Capture stdout and stderr SEPARATELY so the loud-line assertion can be
+  # made against stdout only (the guard echoes the tolerated line to stdout;
+  # propagate diagnostics go to stderr).
+  outf="$(mktemp)"
+  errf="$(mktemp)"
+  "$guard" "${fixtures}/${logf}" "$code" "$tgt" "15m" "$artroot" >"$outf" 2>"$errf"
   got=$?
-  rm -rf "$artroot"
+  [ "$artmode" = "missing-root" ] || rm -rf "$artroot"
 
   [ "$got" -eq "$want" ] || ok=0
   if [ -n "$loud" ]; then
-    grep -qF "BAMLFUZZ: tolerated Go native fuzz coordinator deadline" <<<"$out" || ok=0
+    grep -qF "BAMLFUZZ: tolerated Go native fuzz coordinator deadline" "$outf" || ok=0
   fi
 
   if [ "$ok" -eq 1 ]; then
@@ -53,11 +66,13 @@ run_case() {
     pass=$((pass + 1))
   else
     echo "FAIL - ${name}: got exit ${got}, want ${want}"
+    out="$(cat "$outf" "$errf")"
     while IFS= read -r diag_line; do
       echo "       | ${diag_line}"
     done <<<"$out"
     fail=$((fail + 1))
   fi
+  rm -f "$outf" "$errf"
 }
 
 # --- tolerate ---------------------------------------------------------------
@@ -82,6 +97,9 @@ run_case "harness-failure marker propagates"       harness_failure_marker.log 1 
 run_case "CDE before full budget propagates"       cde_before_budget.log 1 1 FuzzBamlfuzzDynamic            empty
 run_case "missing (0/sec) shape propagates"        no_zerosec.log        1 1 FuzzBamlfuzzDynamic            empty
 run_case "execs changed at boundary propagates"    execs_changed.log     1 1 FuzzBamlfuzzDynamic            empty
+# F3: a progress line AFTER the (0/sec) line means fuzzing kept going — the
+# (0/sec) was not the terminal completed-budget shape. Fail closed.
+run_case "progress after (0/sec) propagates"       progress_after_zerosec.log 1 1 FuzzBamlfuzzDynamic       empty
 
 # --- propagate: structural / state violations ------------------------------
 run_case "multiple FAIL lines propagate"           multi_fail.log        1 1 FuzzBamlfuzzDynamic            empty
@@ -92,6 +110,11 @@ run_case "replay artifact on disk propagates"      boundary_526.log      1 1 Fuz
 # NO oracle marker — but failAndDumpInvalid wrote an _artifacts file that
 # survives on disk. The artifact check is the durable backstop here.
 run_case "invalid artifact (boundary drop) propagates" boundary_invalid.log 1 1 FuzzBamlfuzzInvalidJSONCoercion with-artifact:invalid_json_coercion
+# F4: a missing artifact root means we can't confirm "no replay envelope" —
+# fail closed instead of falling through to tolerate.
+run_case "missing artifact root propagates"        boundary_526.log      1 1 FuzzBamlfuzzDynamic            missing-root
+# F2: a non-1 go test exit code is propagated verbatim (not coerced to 1).
+run_case "non-1 go test exit propagates"           no_zerosec.log        2 2 FuzzBamlfuzzDynamic            empty
 
 echo "---"
 echo "passed=${pass} failed=${fail}"

--- a/scripts/bamlfuzz-boundary-guard_test.sh
+++ b/scripts/bamlfuzz-boundary-guard_test.sh
@@ -27,8 +27,9 @@ fail=0
 #   expect_loud:   non-empty -> require the tolerated BAMLFUZZ: line on STDOUT
 #                  (stdout/stderr are captured separately so this enforces the
 #                  guard's stdout-only contract for the loud tolerated line)
+#   fuzztime (arg 8): configured fuzztime passed to the guard (default 15m)
 run_case() {
-  local name="$1" logf="$2" code="$3" want="$4" tgt="$5" artmode="$6" loud="${7:-}"
+  local name="$1" logf="$2" code="$3" want="$4" tgt="$5" artmode="$6" loud="${7:-}" fz="${8:-15m}"
   local artroot out errf outf got ok=1 subdir
 
   artroot="$(mktemp -d)"
@@ -52,7 +53,7 @@ run_case() {
   # propagate diagnostics go to stderr).
   outf="$(mktemp)"
   errf="$(mktemp)"
-  "$guard" "${fixtures}/${logf}" "$code" "$tgt" "15m" "$artroot" >"$outf" 2>"$errf"
+  "$guard" "${fixtures}/${logf}" "$code" "$tgt" "$fz" "$artroot" >"$outf" 2>"$errf"
   got=$?
   [ "$artmode" = "missing-root" ] || rm -rf "$artroot"
 
@@ -100,6 +101,19 @@ run_case "execs changed at boundary propagates"    execs_changed.log     1 1 Fuz
 # F3: a progress line AFTER the (0/sec) line means fuzzing kept going — the
 # (0/sec) was not the terminal completed-budget shape. Fail closed.
 run_case "progress after (0/sec) propagates"       progress_after_zerosec.log 1 1 FuzzBamlfuzzDynamic       empty
+
+# --- fractional / malformed fuzztime (Go-duration parser) ------------------
+# Proven fail-open hole: FUZZTIME=15.5m (=930s) with elapsed 15m1s (=901s) —
+# 901 < 930, the budget did NOT complete, so it must PROPAGATE. The old
+# truncating parser read 15.5m as 300s and wrongly tolerated.
+run_case "fractional fuzztime short run propagates" boundary_526.log    1 1 FuzzBamlfuzzDynamic            empty "" 15.5m
+# No regression: integer fuzztime with elapsed exactly at / past budget.
+run_case "15m vs 15m0s tolerates"                  boundary_15m0s.log   1 0 FuzzBamlfuzzDynamic            empty loud 15m
+run_case "15m vs 15m1s tolerates"                  boundary_526.log     1 0 FuzzBamlfuzzDynamic            empty loud 15m
+# Fractional fuzztime that genuinely completed: 14.5m (=870s) vs 15m1s (901s).
+run_case "fractional fuzztime completed tolerates" boundary_526.log     1 0 FuzzBamlfuzzDynamic            empty loud 14.5m
+# Malformed fuzztime must fail closed.
+run_case "malformed fuzztime propagates"           boundary_526.log     1 1 FuzzBamlfuzzDynamic            empty "" 15x
 
 # --- propagate: structural / state violations ------------------------------
 run_case "multiple FAIL lines propagate"           multi_fail.log        1 1 FuzzBamlfuzzDynamic            empty

--- a/scripts/bamlfuzz-boundary-guard_test.sh
+++ b/scripts/bamlfuzz-boundary-guard_test.sh
@@ -33,6 +33,13 @@ run_case() {
   local artroot out errf outf got ok=1 subdir
 
   artroot="$(mktemp -d)"
+  outf="$(mktemp)"
+  errf="$(mktemp)"
+  # Clean up this case's temp files/dir on return — even on a mid-run failure,
+  # so the harness stays correct (and leak-free) if errexit is ever enabled.
+  # shellcheck disable=SC2064  # expand artroot/outf/errf now, by design
+  trap "rm -rf '$artroot' '$outf' '$errf'" RETURN
+
   case "$artmode" in
     missing-root)
       # Hand the guard a path that does not exist (F4 fail-closed check).
@@ -50,12 +57,13 @@ run_case() {
 
   # Capture stdout and stderr SEPARATELY so the loud-line assertion can be
   # made against stdout only (the guard echoes the tolerated line to stdout;
-  # propagate diagnostics go to stderr).
-  outf="$(mktemp)"
-  errf="$(mktemp)"
-  "$guard" "${fixtures}/${logf}" "$code" "$tgt" "$fz" "$artroot" >"$outf" 2>"$errf"
-  got=$?
-  [ "$artmode" = "missing-root" ] || rm -rf "$artroot"
+  # propagate diagnostics go to stderr). Invoke as a non-aborting conditional
+  # so a nonzero guard exit never trips errexit if it is ever enabled.
+  if "$guard" "${fixtures}/${logf}" "$code" "$tgt" "$fz" "$artroot" >"$outf" 2>"$errf"; then
+    got=0
+  else
+    got=$?
+  fi
 
   [ "$got" -eq "$want" ] || ok=0
   if [ -n "$loud" ]; then
@@ -73,7 +81,55 @@ run_case() {
     done <<<"$out"
     fail=$((fail + 1))
   fi
-  rm -f "$outf" "$errf"
+  # temp files/dir removed by the RETURN trap set above
+}
+
+# N2: an artifact_root containing an UNREADABLE subtree (with an _artifacts
+# file inside) makes the find scan error. The guard must FAIL CLOSED (propagate
+# nonzero), not silently conclude "no replay envelope" and tolerate.
+#
+# This is permission-based: under a uid that bypasses permissions (root, as in
+# some container CI) chmod 000 does not make find error, so the scan-failure
+# path is unreachable. We detect that and SKIP rather than emit a false pass —
+# the assertion still runs in the normal (non-root) case, including GitHub's
+# ubuntu-latest runners.
+run_unreadable_subtree_case() {
+  local name="$1"
+  local artroot outf errf got ok=1
+  artroot="$(mktemp -d)"
+  outf="$(mktemp)"
+  errf="$(mktemp)"
+  # shellcheck disable=SC2064  # expand now, by design; chmod restores perms first
+  trap "chmod -R u+rwx '$artroot' 2>/dev/null; rm -rf '$artroot' '$outf' '$errf'" RETURN
+
+  mkdir -p "${artroot}/sub/dynamic/_artifacts"
+  printf '{}' > "${artroot}/sub/dynamic/_artifacts/fuzz.json"
+  chmod 000 "${artroot}/sub"
+
+  # If find can still traverse the 000 subtree, permissions aren't enforced for
+  # this uid — the scan-failure path can't be exercised, so skip.
+  if find "${artroot}" -type d -name _artifacts -print >/dev/null 2>&1; then
+    echo "skip - ${name} (find did not error; permissions not enforced, likely root)"
+    return
+  fi
+
+  if "$guard" "${fixtures}/boundary_526.log" 1 FuzzBamlfuzzDynamic 15m "${artroot}" >"$outf" 2>"$errf"; then
+    got=0
+  else
+    got=$?
+  fi
+
+  [ "$got" -ne 0 ] || ok=0   # MUST propagate (nonzero), never tolerate
+  if [ "$ok" -eq 1 ]; then
+    echo "ok   - ${name} (exit ${got})"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - ${name}: got exit ${got}, want nonzero (fail closed)"
+    while IFS= read -r diag_line; do
+      echo "       | ${diag_line}"
+    done <<<"$(cat "$outf" "$errf")"
+    fail=$((fail + 1))
+  fi
 }
 
 # --- tolerate ---------------------------------------------------------------
@@ -127,6 +183,8 @@ run_case "invalid artifact (boundary drop) propagates" boundary_invalid.log 1 1 
 # F4: a missing artifact root means we can't confirm "no replay envelope" —
 # fail closed instead of falling through to tolerate.
 run_case "missing artifact root propagates"        boundary_526.log      1 1 FuzzBamlfuzzDynamic            missing-root
+# N2: an unreadable subtree makes the artifact scan error -> fail closed.
+run_unreadable_subtree_case "unreadable artifact subtree propagates"
 # F2: a non-1 go test exit code is propagated verbatim (not coerced to 1).
 run_case "non-1 go test exit propagates"           no_zerosec.log        2 2 FuzzBamlfuzzDynamic            empty
 

--- a/scripts/bamlfuzz-boundary-guard_test.sh
+++ b/scripts/bamlfuzz-boundary-guard_test.sh
@@ -170,6 +170,8 @@ run_case "15m vs 15m1s tolerates"                  boundary_526.log     1 0 Fuzz
 run_case "fractional fuzztime completed tolerates" boundary_526.log     1 0 FuzzBamlfuzzDynamic            empty loud 14.5m
 # Malformed fuzztime must fail closed.
 run_case "malformed fuzztime propagates"           boundary_526.log     1 1 FuzzBamlfuzzDynamic            empty "" 15x
+# Negative fuzztime is meaningless / invalid -> fail closed (not parsed as +15m).
+run_case "negative fuzztime propagates"            boundary_526.log     1 1 FuzzBamlfuzzDynamic            empty "" -15m
 
 # --- propagate: structural / state violations ------------------------------
 run_case "multiple FAIL lines propagate"           multi_fail.log        1 1 FuzzBamlfuzzDynamic            empty

--- a/scripts/run-bamlfuzz-native.sh
+++ b/scripts/run-bamlfuzz-native.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# run-bamlfuzz-native.sh
+#
+# Run the nightly native `go test -fuzz` invocation for ONE bamlfuzz target,
+# teeing the FULL output to both the job log (so the #450 container-log dump
+# from TestMain and all fuzz progress stay visible) and a file, then hand the
+# result to bamlfuzz-boundary-guard.sh.
+#
+# The guard tolerates ONLY the Go fuzz coordinator's own -fuzztime boundary
+# deadline (issue #526); every other failure shape — reproducible inputs,
+# parity mismatches, real oracle deadlines, hangs — propagates unchanged.
+#
+# This wrapper is ONLY for the native `-fuzz` path. The Static and Streaming
+# cells run their oracle under `-run` (no fuzz coordinator, so no #526 shape)
+# and must keep invoking `go test` directly.
+#
+# Required env: BAMLFUZZ_FUNCTION (the fuzz target), FUZZTIME.
+# Optional env: BAMLFUZZ_FUZZCACHEDIR (default: the in-tree .fuzzcache),
+#               GO_TEST_TIMEOUT (default: 80m).
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${here}/.." && pwd)"
+
+target="${BAMLFUZZ_FUNCTION:?BAMLFUZZ_FUNCTION must be set}"
+fuzztime="${FUZZTIME:?FUZZTIME must be set}"
+go_timeout="${GO_TEST_TIMEOUT:-80m}"
+fuzzcachedir="${BAMLFUZZ_FUZZCACHEDIR:-${repo_root}/adapters/common/codegen/testdata/bamlfuzz/.fuzzcache}"
+artifact_root="${repo_root}/adapters/common/codegen/testdata/bamlfuzz"
+
+logfile="$(mktemp "${TMPDIR:-/tmp}/bamlfuzz-native.XXXXXX")"
+echo "run-bamlfuzz-native: target=${target} fuzztime=${fuzztime} fuzzcachedir=${fuzzcachedir}"
+
+# Tee everything to the job output AND the log the guard inspects. pipefail +
+# PIPESTATUS[0] recovers go test's real exit code through the tee.
+set -x
+go test -tags=integration,subprocess -v -count=1 -p 1 -timeout "${go_timeout}" \
+  -run='^$' \
+  -fuzz="^${target}\$" \
+  -fuzztime="${fuzztime}" \
+  ./integration \
+  -test.fuzzcachedir="${fuzzcachedir}" 2>&1 | tee "${logfile}"
+status="${PIPESTATUS[0]}"
+set +x
+
+echo "run-bamlfuzz-native: go test exited ${status}"
+exec "${here}/bamlfuzz-boundary-guard.sh" "${logfile}" "${status}" "${target}" "${fuzztime}" "${artifact_root}"

--- a/scripts/run-bamlfuzz-native.sh
+++ b/scripts/run-bamlfuzz-native.sh
@@ -32,8 +32,8 @@ artifact_root="${repo_root}/adapters/common/codegen/testdata/bamlfuzz"
 logfile="$(mktemp "${TMPDIR:-/tmp}/bamlfuzz-native.XXXXXX")"
 echo "run-bamlfuzz-native: target=${target} fuzztime=${fuzztime} fuzzcachedir=${fuzzcachedir}"
 
-# Tee everything to the job output AND the log the guard inspects. pipefail +
-# PIPESTATUS[0] recovers go test's real exit code through the tee.
+# Tee everything to the job output AND the log the guard inspects. Capture the
+# FULL pipe status: PIPESTATUS[0] is go test, PIPESTATUS[1] is tee.
 set -x
 go test -tags=integration,subprocess -v -count=1 -p 1 -timeout "${go_timeout}" \
   -run='^$' \
@@ -41,8 +41,22 @@ go test -tags=integration,subprocess -v -count=1 -p 1 -timeout "${go_timeout}" \
   -fuzztime="${fuzztime}" \
   ./integration \
   -test.fuzzcachedir="${fuzzcachedir}" 2>&1 | tee "${logfile}"
-status="${PIPESTATUS[0]}"
+pipe=("${PIPESTATUS[@]}")
 set +x
+go_status="${pipe[0]}"
+tee_status="${pipe[1]}"
 
-echo "run-bamlfuzz-native: go test exited ${status}"
-exec "${here}/bamlfuzz-boundary-guard.sh" "${logfile}" "${status}" "${target}" "${fuzztime}" "${artifact_root}"
+echo "run-bamlfuzz-native: go test exited ${go_status}, tee exited ${tee_status}"
+
+# Fail closed if tee failed: the log the guard inspects may be truncated or
+# missing, so the guard cannot safely decide. Never hand a partial log to the
+# guard — propagate a nonzero exit instead.
+if [ "${tee_status}" -ne 0 ]; then
+  echo "run-bamlfuzz-native: tee failed (status ${tee_status}); the captured log is unreliable — NOT invoking the boundary guard." >&2
+  if [ "${go_status}" -ne 0 ]; then
+    exit "${go_status}"
+  fi
+  exit 1
+fi
+
+exec "${here}/bamlfuzz-boundary-guard.sh" "${logfile}" "${go_status}" "${target}" "${fuzztime}" "${artifact_root}"

--- a/scripts/testdata/bamlfuzz-guard/boundary_15m0s.log
+++ b/scripts/testdata/bamlfuzz-guard/boundary_15m0s.log
@@ -1,0 +1,7 @@
+fuzz: elapsed: 14m58s, execs: 62457 (70/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m0s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (900.04s)
+context deadline exceeded
+FAIL
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	900.18s

--- a/scripts/testdata/bamlfuzz-guard/boundary_526.log
+++ b/scripts/testdata/bamlfuzz-guard/boundary_526.log
@@ -1,0 +1,11 @@
+=== TestMain: integration env up ===
+fuzz: elapsed: 0s, gathering baseline coverage: 0/1124 completed
+fuzz: elapsed: 3s, gathering baseline coverage: 1124/1124 completed, now fuzzing with 4 workers
+fuzz: elapsed: 14m57s, execs: 62400 (70/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (901.06s)
+context deadline exceeded
+FAIL
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/boundary_invalid.log
+++ b/scripts/testdata/bamlfuzz-guard/boundary_invalid.log
@@ -1,0 +1,8 @@
+fuzz: elapsed: 14m58s, execs: 51200 (61/sec), new interesting: 4 (total: 980)
+fuzz: elapsed: 15m0s, execs: 51280 (63/sec), new interesting: 4 (total: 980)
+fuzz: elapsed: 15m1s, execs: 51280 (0/sec), new interesting: 4 (total: 980)
+--- FAIL: FuzzBamlfuzzInvalidJSONCoercion (901.02s)
+context deadline exceeded
+FAIL
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.18s

--- a/scripts/testdata/bamlfuzz-guard/cde_before_budget.log
+++ b/scripts/testdata/bamlfuzz-guard/cde_before_budget.log
@@ -1,0 +1,6 @@
+fuzz: elapsed: 5m0s, execs: 20000 (70/sec), new interesting: 3 (total: 500)
+fuzz: elapsed: 5m1s, execs: 20000 (0/sec), new interesting: 3 (total: 500)
+--- FAIL: FuzzBamlfuzzDynamic (301.04s)
+context deadline exceeded
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	301.231s

--- a/scripts/testdata/bamlfuzz-guard/dynclient_errored.log
+++ b/scripts/testdata/bamlfuzz-guard/dynclient_errored.log
@@ -1,0 +1,7 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (901.06s)
+context deadline exceeded
+    bamlfuzz_dynamic_test.go:464: dynclient errored: context deadline exceeded
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/execs_changed.log
+++ b/scripts/testdata/bamlfuzz-guard/execs_changed.log
@@ -1,0 +1,6 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62999 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (901.06s)
+context deadline exceeded
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/failing_input.log
+++ b/scripts/testdata/bamlfuzz-guard/failing_input.log
@@ -1,0 +1,7 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (901.06s)
+context deadline exceeded
+    Failing input written to testdata/fuzz/FuzzBamlfuzzDynamic/a1b2c3d4e5f6
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/green.log
+++ b/scripts/testdata/bamlfuzz-guard/green.log
@@ -1,0 +1,6 @@
+=== TestMain: integration env up ===
+fuzz: elapsed: 3s, gathering baseline coverage: 1124/1124 completed, now fuzzing with 4 workers
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+PASS
+ok  	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/harness_failure_marker.log
+++ b/scripts/testdata/bamlfuzz-guard/harness_failure_marker.log
@@ -1,0 +1,7 @@
+fuzz: elapsed: 15m0s, execs: 51280 (63/sec), new interesting: 4 (total: 980)
+fuzz: elapsed: 15m1s, execs: 51280 (0/sec), new interesting: 4 (total: 980)
+--- FAIL: FuzzBamlfuzzInvalidDynamic (901.02s)
+context deadline exceeded
+    bamlfuzz_invalid_test.go:381: harness failure: dynclient context (case=fuzz_drop_required mutation=drop_required): context deadline exceeded
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.18s

--- a/scripts/testdata/bamlfuzz-guard/multi_fail.log
+++ b/scripts/testdata/bamlfuzz-guard/multi_fail.log
@@ -1,0 +1,8 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (901.06s)
+context deadline exceeded
+--- FAIL: TestSomethingElse (1.02s)
+    something_test.go:10: boom
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/no_zerosec.log
+++ b/scripts/testdata/bamlfuzz-guard/no_zerosec.log
@@ -1,0 +1,6 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62500 (43/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (901.06s)
+context deadline exceeded
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/progress_after_zerosec.log
+++ b/scripts/testdata/bamlfuzz-guard/progress_after_zerosec.log
@@ -1,0 +1,7 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m4s, execs: 62500 (14/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (904.06s)
+context deadline exceeded
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	904.231s

--- a/scripts/testdata/bamlfuzz-guard/register_scenario.log
+++ b/scripts/testdata/bamlfuzz-guard/register_scenario.log
@@ -1,0 +1,7 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (901.06s)
+context deadline exceeded
+    bamlfuzz_dynamic_test.go:339: register scenario: context deadline exceeded
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/replay.log
+++ b/scripts/testdata/bamlfuzz-guard/replay.log
@@ -1,0 +1,8 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (901.06s)
+context deadline exceeded
+    bamlfuzz_dynamic_test.go:464: expected_vs_rest
+    replay: ../adapters/common/codegen/testdata/bamlfuzz/dynamic/_artifacts/fuzz.json
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/rest_errored.log
+++ b/scripts/testdata/bamlfuzz-guard/rest_errored.log
@@ -1,0 +1,7 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (901.06s)
+context deadline exceeded
+    bamlfuzz_dynamic_test.go:464: REST errored (status 500): internal error
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/semantic_neq.log
+++ b/scripts/testdata/bamlfuzz-guard/semantic_neq.log
@@ -1,0 +1,7 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (901.06s)
+context deadline exceeded
+    bamlfuzz_dynamic_test.go:464: expected ≠ dynclient
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/write_replay.log
+++ b/scripts/testdata/bamlfuzz-guard/write_replay.log
@@ -1,0 +1,7 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzDynamic (901.06s)
+context deadline exceeded
+    bamlfuzz_dynamic_test.go:503: write replay artifact: open _artifacts: permission denied
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s

--- a/scripts/testdata/bamlfuzz-guard/wrong_target.log
+++ b/scripts/testdata/bamlfuzz-guard/wrong_target.log
@@ -1,0 +1,6 @@
+fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
+fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
+--- FAIL: FuzzBamlfuzzInvalidDynamic (901.06s)
+context deadline exceeded
+exit status 1
+FAIL	github.com/invakid404/baml-rest/integration	901.231s


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Problem (issue #526)

The nightly `FuzzBamlfuzzDynamic` cell failed at the 15m budget edge with a bare:

```
fuzz: elapsed: 15m0s, execs: 62457 (72/sec), new interesting: 7 (total: 1124)
fuzz: elapsed: 15m1s, execs: 62457 (0/sec), new interesting: 7 (total: 1124)
--- FAIL: FuzzBamlfuzzDynamic (901.06s)
context deadline exceeded
```

No `Failing input written to`, no replay envelope, no oracle markers. That is **not** the dynamic oracle's 30s/10s contexts and **not** a reproducible input — those write a crasher file and/or a replay envelope. It is Go's fuzz **coordinator** returning its own `-fuzztime` `context.DeadlineExceeded` while blocked on a worker RPC at the budget boundary (`testing/fuzz.go` prints the non-crasher error verbatim). A Go-stdlib fuzzing boundary artifact, not a retryable case — so the fix is **not** a per-exec retry and **not** widening the 30s deadline.

## Fix — a tested CI wrapper at the native-fuzz invocation boundary

CI/test-infra only; no product code touched.

- **`scripts/run-bamlfuzz-native.sh`** — runs the *identical* `go test -fuzz` invocation the nightly used, tees full stdout+stderr to the job log (so the #450 container-log dump from `TestMain` and all fuzz output stay visible) and to a file, then routes the result through the guard. Recovers go test's real exit via `PIPESTATUS`.
- **`scripts/bamlfuzz-boundary-guard.sh`** — reclassifies a nonzero exit to success **only** when the exact #526 shape holds; otherwise propagates the real exit code.
- **`scripts/bamlfuzz-boundary-guard_test.sh`** + `scripts/testdata/bamlfuzz-guard/*.log` — 16 fixture cases, pure bash, runnable in CI without Docker/Go.
- **`.github/workflows/bamlfuzz-nightly.yml`** — the native `-fuzz` step now `run: ./scripts/run-bamlfuzz-native.sh` with `BAMLFUZZ_FUNCTION: ${{ matrix.target }}` added (all other env preserved: `BAML_VERSION`, `UNARY_SERVER`, `FUZZTIME`, `BAMLFUZZ_SEED`, `-tags`, fuzzcachedir, `BAMLFUZZ_KEEP_ARTIFACTS: ""`). Static/Streaming (`-run`) and the rapid-mode cell are unchanged.

## Exact guard conditions (ALL must hold to tolerate; any miss → propagate)

1. go test exited nonzero (a pass is returned as-is).
2. Exactly one `--- FAIL: ` line, and it is `--- FAIL: <target> (` — enforces "at most one boundary error".
3. A **bare** `context deadline exceeded` line (whole-line match) — distinguishes the coordinator's print from an oracle message embedding the same text.
4. Completed-budget boundary shape: a `fuzz: elapsed:` `(0/sec)` line whose elapsed **≥ configured FUZZTIME** (Go-duration → seconds) **and** whose exec count is **unchanged** from the prior progress line.
5. None of these markers anywhere: `Failing input written to`, `repro:`, `replay:`, `write replay artifact:`, `dynclient errored:`, `REST errored`, `register scenario:`, `schema key order mismatch`, `schema order`, ` diff:`, `≠`.
6. No file under any `adapters/common/codegen/testdata/bamlfuzz/*/_artifacts/`.

On tolerate it prints the loud line: `BAMLFUZZ: tolerated Go native fuzz coordinator deadline at fuzztime boundary; no crasher or replay envelope produced; see issue #526.`

### Marker strings verified against code (not assumed)

Both `failAndDump` (`integration/bamlfuzz_dynamic_test.go`) and `failAndDumpInvalid` (`integration/bamlfuzz_invalid_test.go`) **always** emit `repro:` and either `replay:` or `write replay artifact:`, so those three alone catch every oracle-body failure across all three native targets; the rest are defense-in-depth. The actual REST string is `REST errored (status N): ...`, so the marker is the substring `REST errored` (not `REST errored:`).

### Stricter-than-asked choices

- Added `repro:` to the reject list (every `failAndDump`/`failAndDumpInvalid` path prints it) — a universal, target-agnostic catch beyond the diagnosis's listed markers.
- Boundary check requires elapsed **≥ full fuzztime in seconds** (not just a literal `15m0s` string match), so an early `(0/sec)` blip or a mid-run stall can never satisfy it.
- Artifact check globs **all** `*/_artifacts/` dirs (covers `dynamic/`, `invalid_dynamic/`, `invalid_json_coercion/`), so any target's envelope blocks tolerance.

## Why it cannot mask a real failure

- **Reproducible input** → `Failing input written to` rejects.
- **Parity mismatch** → `repro:`/`replay:` + `≠`/`schema order` reject (a fixture proves `expected ≠ dynclient` propagates).
- **Real oracle deadline** → embedded in `dynclient errored:`/`REST errored` (a fixture proves `dynclient errored: context deadline exceeded` propagates).
- **Hang/deadlock** → never reaches the completed-budget boundary shape; `go test -timeout 80m` and the job `timeout-minutes` still fire.

When tolerated, the cell exits 0, so the `if: failure()` replay-artifact upload and sticky-issue comment are skipped (and the guard already verified there is nothing to upload). The `if: always()` corpus upload still runs.

## Validation (local)

- `shellcheck` — clean (all three scripts).
- `actionlint` — clean (`.github/workflows/bamlfuzz-nightly.yml`).
- Fixture suite — **16/16 pass**: green-passthrough; #526 boundary tolerated for both a Dynamic and an Invalid* cell (+ loud line asserted); and propagation for reproducible crasher, `replay:`, `write replay artifact:`, `dynclient errored:`, `REST errored`, `register scenario:`, semantic `≠`, CDE-before-full-budget, missing `(0/sec)`, execs-changed-at-boundary, multiple FAIL lines, wrong-target FAIL, and an on-disk `_artifacts` file.

Fixes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native fuzz CI handling by tolerating only the Go fuzz coordinator “budget deadline” outcome when the expected boundary shape is observed; genuine fuzz failures still surface and preserve replay artifacts.
  * For invalid-oracle harness/transport failures, error details are now captured so the invalid-case replay envelope is consistently generated.
* **New Features**
  * Added a native fuzz CI runner that classifies tolerated vs actionable fuzz outcomes and enforces boundary expectations.
* **Tests**
  * Added fixture-driven coverage for boundary classification, including artifact presence rules and fuzztime parsing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->