### PR TITLE
buildrequest: make the BuildRequest route unconditional; retire BAML_REST_USE_BUILD_REQUEST

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,20 +24,18 @@ jobs:
       - name: Build version matrix
         id: set-matrix
         run: |
-          # Build the matrix from baml_versions.json with two cross-cutting
-          # exclusions:
+          # Build the matrix from baml_versions.json. The BuildRequest
+          # route is unconditional as of #537 (no use-build-request axis):
+          # it is taken automatically when the BAML version exposes the
+          # Request/StreamRequest surfaces (>= 0.219).
           #
-          #   1. http-client has no effect on the legacy CallStream path
-          #      (BAML_REST_HTTP_CLIENT is only read by the BuildRequest
-          #      path through llmhttp). Pin the !buildrequest cells to
-          #      nethttp only so auto/fasthttp don't duplicate cycles.
-          #
-          #   2. BAML versions below 0.219.0 have no BuildRequest API at
-          #      all — the adapter gate routes those requests through
-          #      CallStream regardless of BAML_REST_USE_BUILD_REQUEST.
-          #      Running their buildrequest=true row would just redo the
-          #      buildrequest=false work three times (once per
-          #      http-client value).
+          # Cross-cutting exclusion: http-client has no effect on the legacy
+          # CallStream path (BAML_REST_HTTP_CLIENT is only read by the
+          # BuildRequest path through llmhttp). BAML versions below 0.219.0
+          # have no BuildRequest API at all, so every request routes through
+          # CallStream — pin those (non-supportsBuildRequest) versions to
+          # nethttp only so auto/fasthttp don't duplicate cycles. Modern
+          # versions keep the full http-client spread.
           #
           # The "auto" value exercises the default dispatch path (ALPN
           # probe on HTTPS, fasthttp short-circuit on plain http). mockllm
@@ -57,12 +55,10 @@ jobs:
             | {
                 "baml-version": $versions,
                 "unary-server": [false, true],
-                "use-build-request": [false, true],
                 "http-client": ["auto", "nethttp", "fasthttp"],
                 "exclude": (
-                  ($versions | map({"baml-version": ., "use-build-request": false, "http-client": "auto"}))
-                  + ($versions | map({"baml-version": ., "use-build-request": false, "http-client": "fasthttp"}))
-                  + ($versions | map(select(supportsBuildRequest | not)) | map({"baml-version": ., "use-build-request": true}))
+                  ($versions | map(select(supportsBuildRequest | not)) | map({"baml-version": ., "http-client": "auto"}))
+                  + ($versions | map(select(supportsBuildRequest | not)) | map({"baml-version": ., "http-client": "fasthttp"}))
                 )
               }
           ' integration/baml_versions.json)
@@ -339,7 +335,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Run Integration Tests (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }}, build-request=${{ matrix.use-build-request }}, http-client=${{ matrix.http-client }})
+      - name: Run Integration Tests (BAML ${{ matrix.baml-version }}, unary=${{ matrix.unary-server }}, http-client=${{ matrix.http-client }})
         # Step timeout (45m) and the watchdog (42m) share the SAME origin
         # (go-test start), so the watchdog provably fires 3m before this
         # step is killed regardless of how long the pre-test steps took.
@@ -349,7 +345,6 @@ jobs:
         env:
           BAML_VERSION: ${{ matrix.baml-version }}
           UNARY_SERVER: ${{ matrix.unary-server }}
-          BAML_REST_USE_BUILD_REQUEST: ${{ matrix.use-build-request }}
           BAML_REST_HTTP_CLIENT: ${{ matrix.http-client }}
           # Step timeout (45m) minus 3m margin.
           BAML_REST_SUITE_WATCHDOG: 42m
@@ -411,11 +406,11 @@ jobs:
       fail-fast: false
       matrix:
         # Bounded in-process matrix: latest BAML only, both unary-server
-        # values and both use-build-request values. http-client stays at
-        # `auto` because the subprocess job already covers the full
-        # http-client spread and in-process does not change request dispatch.
+        # values. The BuildRequest route is unconditional (#537), so there
+        # is no use-build-request axis. http-client stays at `auto` because
+        # the subprocess job already covers the full http-client spread and
+        # in-process does not change request dispatch.
         unary-server: [false, true]
-        use-build-request: [false, true]
 
     steps:
       - name: Checkout Repository
@@ -458,14 +453,13 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Run Integration Tests (in-process, BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }}, build-request=${{ matrix.use-build-request }})
+      - name: Run Integration Tests (in-process, BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }})
         # Step timeout (45m) and watchdog (42m) share the go-test origin;
         # watchdog fires 3m before the step is killed. #420
         timeout-minutes: 45
         env:
           BAML_VERSION: ${{ needs.get-latest-version.outputs.latest }}
           UNARY_SERVER: ${{ matrix.unary-server }}
-          BAML_REST_USE_BUILD_REQUEST: ${{ matrix.use-build-request }}
           BAML_REST_HTTP_CLIENT: auto
           # Step timeout (45m) minus 3m margin.
           BAML_REST_SUITE_WATCHDOG: 42m
@@ -675,18 +669,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The BuildRequest route is unconditional (#537), so there is no
+        # use-build-request axis. BAML-from-source is always a modern
+        # (>= 0.219) BuildRequest-capable runtime, so the full http-client
+        # spread is meaningful and needs no legacy-leg exclusions.
         unary-server: [false, true]
-        use-build-request: [false, true]
         http-client: [auto, nethttp, fasthttp]
-        exclude:
-          # See the matrix comment on the versioned job — http-client has
-          # no effect on the legacy path, so the auto × !buildrequest and
-          # fasthttp × !buildrequest cells would just duplicate the
-          # nethttp × !buildrequest cell.
-          - use-build-request: false
-            http-client: auto
-          - use-build-request: false
-            http-client: fasthttp
 
     steps:
       - name: Checkout Repository
@@ -741,7 +729,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Run Integration Tests (BAML Source, unary=${{ matrix.unary-server }}, build-request=${{ matrix.use-build-request }}, http-client=${{ matrix.http-client }})
+      - name: Run Integration Tests (BAML Source, unary=${{ matrix.unary-server }}, http-client=${{ matrix.http-client }})
         # Step timeout (70m) and the watchdog (67m) share the SAME origin
         # (go-test start), so the watchdog fires 3m before the step is
         # killed regardless of pre-test step duration — the gap the bare
@@ -755,7 +743,6 @@ jobs:
           # instead of running the in-image cargo build (testutil/container.go).
           BAML_PREBUILT_CFFI_DIR: ${{ github.workspace }}/prebuilt-cffi
           UNARY_SERVER: ${{ matrix.unary-server }}
-          BAML_REST_USE_BUILD_REQUEST: ${{ matrix.use-build-request }}
           BAML_REST_HTTP_CLIENT: ${{ matrix.http-client }}
           # Step timeout (70m) minus 3m margin. Larger than the 45m-cap
           # jobs because a healthy baml-source m.Run runs 38-45m and must

--- a/README.md
+++ b/README.md
@@ -86,14 +86,21 @@ env var only; dynclient stays explicit-only and never reads it.
 
 baml-rest reads the following environment variables at startup:
 
-- `BAML_REST_USE_BUILD_REQUEST` — toggle the BuildRequest/StreamRequest code
-  path. `1`/`true`/`yes`/`on` enables it; any other value (including empty)
-  falls back to the legacy CallStream+OnTick path. This is a full rollback:
-  on BAML 0.219+ adapters, baml-rest's centralised round-robin (resolver,
-  in-process coordinator, and worker SharedState broker / RemoteAdvancer)
-  is also disengaged, and BAML's own runtime handles strategy rotation
-  per-worker. Use this flag as an incident-response kill switch when
-  anything in the new request path regresses.
+- BuildRequest is attempted by default whenever supported — the
+  BuildRequest/StreamRequest route is taken automatically when the
+  generated BAML client exposes those surfaces (BAML 0.219+). Older BAML
+  versions without Request/StreamRequest, and unsupported/empty providers,
+  use the legacy CallStream+OnTick path. The retired
+  `BAML_REST_USE_BUILD_REQUEST` env var is ignored; if it is still set,
+  baml-rest logs a one-time startup deprecation warning. There is no
+  full-route rollback flag — use `BAML_REST_DISABLE_CALL_BUILD_REQUEST`
+  (below) for the narrower /call hatch, or roll back the deployment.
+- `BAML_REST_DISABLE_CALL_BUILD_REQUEST` — when truthy, the non-streaming
+  Request API is treated as unsupported for every provider, so
+  `/call{,-with-raw}` fall through to the stream-accumulation bridge (when
+  StreamRequest is available) or legacy. This is a narrower operational
+  hatch for the non-streaming Request API only; it does not disable the
+  broader BuildRequest route.
 - `BAML_REST_BASE_URL_REWRITES` — semicolon-separated URL rewrite rules
   applied to LLM provider base URLs, both at build time and at runtime.
   Format: `from1=to1;from2=to2`. See
@@ -233,10 +240,11 @@ tolerance for losing in-flight requests when the process crashes.
 
 Recommended version: **v0.223.0**
 
-The BuildRequest code path (`BAML_REST_USE_BUILD_REQUEST=true`) requires
-BAML **v0.219.0** or newer. Older BAML versions remain functional via the
-CallStream+OnTick path, but baml-rest logs a warning at startup when no
-BuildRequest API is detected in the generated client.
+The BuildRequest code path requires BAML **v0.219.0** or newer and is taken
+automatically when the generated client exposes the Request/StreamRequest
+surfaces. Older BAML versions remain functional via the CallStream+OnTick
+path, but baml-rest logs a warning at startup when no BuildRequest API is
+detected in the generated client.
 
 - **v0.215.0**: Type builder is fully broken and panics the entire application
   when used ([issue](https://github.com/BoundaryML/baml/issues/2862))

--- a/adapters/common/codegen/codegen_adapter.go
+++ b/adapters/common/codegen/codegen_adapter.go
@@ -159,10 +159,10 @@ func emitFrameworkAdapter(out *jen.File, opts Options) {
 	structFields = append(structFields,
 		jen.Line(),
 		jen.Comment("buildRequestConfig carries the per-handler BuildRequest knobs"),
-		jen.Comment("(UseBuildRequest, DisableCallBuildRequest). The generated"),
-		jen.Comment("router reads this via BuildRequestConfig() instead of the"),
-		jen.Comment("env-cached buildrequest.UseBuildRequest helper so two handlers"),
-		jen.Comment("in the same process can carry distinct configurations."),
+		jen.Comment("(DisableCallBuildRequest). The generated router reads this via"),
+		jen.Comment("BuildRequestConfig() instead of the env-cached buildrequest"),
+		jen.Comment("helper so two handlers in the same process can carry distinct"),
+		jen.Comment("configurations."),
 		jen.Id("buildRequestConfig").Qual(bamlutilsPkg, "BuildRequestConfig"),
 		jen.Line(),
 		jen.Comment("deBAMLConfig carries the per-handler BAML_REST_USE_DEBAML"),
@@ -528,7 +528,7 @@ func emitFrameworkAdapterHTTPClient(out *jen.File, opts Options, llmhttpPkg stri
 
 // emitFrameworkAdapterBuildRequestConfig emits the per-handler
 // BuildRequestConfig setter/getter pair the generated router consults
-// instead of buildrequest.UseBuildRequest() globals.
+// instead of the buildrequest package's env-cached globals.
 func emitFrameworkAdapterBuildRequestConfig(out *jen.File, bamlutilsPkg string) {
 	out.Func().Params(jen.Id("b").Op("*").Id("BamlAdapter")).
 		Id("SetBuildRequestConfig").Params(jen.Id("cfg").Qual(bamlutilsPkg, "BuildRequestConfig")).

--- a/adapters/common/codegen/codegen_router.go
+++ b/adapters/common/codegen/codegen_router.go
@@ -7,8 +7,9 @@ import (
 // emitRouter emits the public per-method router function. The
 // router selects between BuildRequest, the streaming-bridged call
 // path, and the legacy CallStream+OnTick fallthrough based on the
-// adapter's StreamMode and the runtime UseBuildRequest gate; it
-// then forwards to the corresponding generated impl
+// adapter's StreamMode and the available BuildRequest surfaces
+// (the BuildRequest route is unconditional as of #537); it then
+// forwards to the corresponding generated impl
 // (<method>_buildRequest / <method>_buildCallRequest / <method>_noRaw
 // / <method>_full).
 func (me *methodEmitter) emitRouter() {
@@ -22,9 +23,10 @@ func (me *methodEmitter) emitRouter() {
 	// Generate the public router function that dispatches based on StreamMode()
 	// Creates the output channel and passes it to the inner implementation.
 	//
-	// When the BuildRequest path is available and the feature flag is set,
-	// it takes priority for both call and stream modes. Falls back to the
-	// legacy paths for unsupported providers or when the feature flag is off.
+	// When a BuildRequest surface is available it takes priority for both
+	// call and stream modes (the route is unconditional as of #537). Falls
+	// back to the legacy paths for unsupported/empty providers or BAML
+	// versions that expose neither Request nor StreamRequest.
 	routerBody := []jen.Code{
 		jen.Id("out").Op(":=").Make(jen.Chan().Add(streamResultInterface.Clone()), jen.Lit(100)),
 		jen.Var().Id("err").Error(),
@@ -33,10 +35,9 @@ func (me *methodEmitter) emitRouter() {
 	// Seed __retryClient and __effective from ResolvePrimaryClient
 	// and leave __rrInfo nil. This is the legacy-equivalent shape:
 	// primary override applied, no RR unwrap, no coordinator advance,
-	// no RR metadata. supportsWithClient adapters with the flag on
-	// upgrade __effective via ResolveEffectiveClient below; everyone
-	// else (older adapters, or modern adapters with the flag off)
-	// keeps this baseline so BAML's own strategy rotation owns RR.
+	// no RR metadata. supportsWithClient adapters upgrade __effective
+	// via ResolveEffectiveClient below; older adapters keep this
+	// baseline so BAML's own strategy rotation owns RR.
 	//
 	// __retryClient preserves the pre-unwrap client name (the strategy
 	// wrapper itself, or the function's primary-override target).
@@ -54,58 +55,43 @@ func (me *methodEmitter) emitRouter() {
 		jen.Var().Id("__rrInfo").Op("*").Qual(g.pkgs.InterfacesPkg, "RoundRobinInfo"),
 	)
 	if g.supportsWithClient {
-		// Cache UseBuildRequest() once per request so every gate
-		// downstream sees the same value. Without this,
-		// ResolveEffectiveClient ran unconditionally for
-		// supportsWithClient adapters and the BR landing blocks
-		// re-read the env var, which (a) made the flag-off path
-		// keep advancing the RR coordinator and pinning BAML to
-		// the leaf via WithClient, defeating its kill-switch
-		// contract, and (b) created split-decision risk if the
-		// cached value ever drifted within a request.
-		//
-		// Scoped under `if supportsWithClient` because every
-		// __useBuildRequest reference downstream — the upgrade
-		// gate just below, the BR landing-block gates, and the
-		// legacy predicate gate — is itself only emitted when
-		// supportsWithClient is true (those gates check
-		// hasCallBuildRequest / hasBuildRequest, which the
-		// fail-fast invariant in generate ties to
-		// supportsWithClient via panic). Hoisting the declaration
-		// to router entry would emit "declared and not used" on
-		// v0.204 / v0.215 adapters where every consumer is
-		// filtered out.
-		routerBody = append(routerBody,
-			jen.Id("__brCfg").Op(":=").Id("adapter").Dot("BuildRequestConfig").Call(),
-			jen.Id("__useBuildRequest").Op(":=").Id("__brCfg").Dot("UseBuildRequest"),
-		)
+		// Per-handler BuildRequest config. As of #537 the BuildRequest
+		// route is unconditional, so __brCfg no longer carries a route
+		// gate — its only remaining use is DisableCallBuildRequest,
+		// threaded into the call-side support predicate
+		// (IsCallProviderSupportedWithConfig). Emit the declaration only
+		// when a consumer actually exists: the non-streaming call block
+		// (hasCallBuildRequest) or the final legacy call-side predicate
+		// override (emitted only when there is no stream bridge, i.e.
+		// !hasBuildRequest). A streaming-only modern adapter
+		// (StreamRequest set, Request nil) has neither consumer, so
+		// declaring __brCfg there would emit "declared and not used".
+		if hasCallBuildRequest || !hasBuildRequest {
+			routerBody = append(routerBody,
+				jen.Id("__brCfg").Op(":=").Id("adapter").Dot("BuildRequestConfig").Call(),
+			)
+		}
 
 		// Full RR resolution upgrade: apply the runtime primary
-		// override, unwrap baml-roundrobin wrappers, and advance
-		// the coordinator (or the worker-installed RemoteAdvancer)
-		// for the leaf selection. Gated on __useBuildRequest so
-		// that flipping BAML_REST_USE_BUILD_REQUEST off truly
-		// reverts to the legacy CallStream+OnTick semantics —
-		// including BAML's per-worker runtime RR rotation. Without
-		// the runtime gate, the coordinator advances and __rrInfo
-		// gets populated even when the operator has explicitly
-		// disabled the new code path.
+		// override, unwrap baml-roundrobin wrappers, and advance the
+		// coordinator (or the worker-installed RemoteAdvancer) for the
+		// leaf selection. Unconditional on supportsWithClient adapters
+		// — the BuildRequest route is always attempted (#537), so RR
+		// centralization always runs for modern adapters.
 		routerBody = append(routerBody,
-			jen.If(jen.Id("__useBuildRequest")).Block(
-				jen.List(jen.Id("__rrEffective"), jen.Id("__rrInfoUpgrade"), jen.Id("__rrErr")).Op(":=").
-					Qual(g.pkgs.BuildRequestPkg, "ResolveEffectiveClient").Call(
-					jen.Id("adapter"),
-					jen.Qual(g.pkgs.IntrospectedPkg, "FunctionClient").Index(jen.Lit(me.methodName)),
-					jen.Qual(g.pkgs.IntrospectedPkg, "FallbackChains"),
-					jen.Qual(g.pkgs.IntrospectedPkg, "ClientProvider"),
-					jen.Qual(g.pkgs.IntrospectedPkg, "RoundRobinCoordinator"),
-				),
-				jen.If(jen.Id("__rrErr").Op("!=").Nil()).Block(
-					jen.Return(jen.Nil(), jen.Id("__rrErr")),
-				),
-				jen.Id("__effective").Op("=").Id("__rrEffective"),
-				jen.Id("__rrInfo").Op("=").Id("__rrInfoUpgrade"),
+			jen.List(jen.Id("__rrEffective"), jen.Id("__rrInfoUpgrade"), jen.Id("__rrErr")).Op(":=").
+				Qual(g.pkgs.BuildRequestPkg, "ResolveEffectiveClient").Call(
+				jen.Id("adapter"),
+				jen.Qual(g.pkgs.IntrospectedPkg, "FunctionClient").Index(jen.Lit(me.methodName)),
+				jen.Qual(g.pkgs.IntrospectedPkg, "FallbackChains"),
+				jen.Qual(g.pkgs.IntrospectedPkg, "ClientProvider"),
+				jen.Qual(g.pkgs.IntrospectedPkg, "RoundRobinCoordinator"),
 			),
+			jen.If(jen.Id("__rrErr").Op("!=").Nil()).Block(
+				jen.Return(jen.Nil(), jen.Id("__rrErr")),
+			),
+			jen.Id("__effective").Op("=").Id("__rrEffective"),
+			jen.Id("__rrInfo").Op("=").Id("__rrInfoUpgrade"),
 		)
 	}
 	routerBody = append(routerBody,
@@ -267,8 +253,7 @@ func (me *methodEmitter) emitRouter() {
 		routerBody = append(routerBody,
 			jen.Comment("Try non-streaming BuildRequest path for /call and /call-with-raw"),
 			jen.If(
-				jen.Id("__useBuildRequest").
-					Op("&&").Qual(g.pkgs.IntrospectedPkg, "Request").Op("!=").Nil().
+				jen.Qual(g.pkgs.IntrospectedPkg, "Request").Op("!=").Nil().
 					Op("&&").Parens(jen.Id("mode").Op("==").Qual(g.pkgs.InterfacesPkg, "StreamModeCall").
 					Op("||").Id("mode").Op("==").Qual(g.pkgs.InterfacesPkg, "StreamModeCallWithRaw")),
 			).Block(callBlockBody...),
@@ -283,8 +268,7 @@ func (me *methodEmitter) emitRouter() {
 		routerBody = append(routerBody,
 			jen.Comment("Try streaming BuildRequest path for /stream and /stream-with-raw"),
 			jen.If(
-				jen.Id("__useBuildRequest").
-					Op("&&").Qual(g.pkgs.IntrospectedPkg, "StreamRequest").Op("!=").Nil().
+				jen.Qual(g.pkgs.IntrospectedPkg, "StreamRequest").Op("!=").Nil().
 					Op("&&").Parens(jen.Id("mode").Op("==").Qual(g.pkgs.InterfacesPkg, "StreamModeStream").
 					Op("||").Id("mode").Op("==").Qual(g.pkgs.InterfacesPkg, "StreamModeStreamWithRaw")),
 			).Block(
@@ -383,8 +367,7 @@ func (me *methodEmitter) emitRouter() {
 		routerBody = append(routerBody,
 			jen.Comment("Bridge: /call and /call-with-raw via StreamRequest when Request is unavailable"),
 			jen.If(
-				jen.Id("__useBuildRequest").
-					Op("&&").Qual(g.pkgs.IntrospectedPkg, "StreamRequest").Op("!=").Nil().
+				jen.Qual(g.pkgs.IntrospectedPkg, "StreamRequest").Op("!=").Nil().
 					Op("&&").Parens(jen.Id("mode").Op("==").Qual(g.pkgs.InterfacesPkg, "StreamModeCall").
 					Op("||").Id("mode").Op("==").Qual(g.pkgs.InterfacesPkg, "StreamModeCallWithRaw")),
 			).Block(
@@ -474,7 +457,7 @@ func (me *methodEmitter) emitRouter() {
 	// honour them (the policy is used by the legacy BAML runtime, not by
 	// the generator).
 	routerBody = append(routerBody,
-		jen.Comment("Legacy path: CallStream + OnTick (for unsupported providers or when BuildRequest is disabled)"),
+		jen.Comment("Legacy path: CallStream + OnTick (for unsupported/empty providers or BAML versions without a BuildRequest surface)"),
 		// Retry policy resolution mirrors the BuildRequest paths:
 		// wrapper-first (__retryClient — the pre-unwrap strategy /
 		// primary-override target) with leaf-fallback to __effective
@@ -511,38 +494,33 @@ func (me *methodEmitter) emitRouter() {
 		// nil on the non-RR and legacy-only-adapter paths.
 		// Mode-aware predicate selection: the legacy metadata
 		// plan classifies the request's provider against either
-		// the stream support table or the call support table. For
-		// call modes that reach final legacy *without* a stream
-		// bridge having re-resolved them (hasBuildRequest=false)
-		// the metadata reason should reflect the call-side
-		// classification — otherwise
+		// the stream support table or the call support table. The
+		// BuildRequest route is unconditional (#537), so a call
+		// mode reaches final legacy only when no BuildRequest
+		// landing block accepted it.
+		//
+		// When a stream bridge exists (hasBuildRequest=true) every
+		// call-mode fallthrough was already gated on
+		// IsProviderSupported — a provider that is stream-supported
+		// but call-only-unsupported (e.g. under
 		// BAML_REST_DISABLE_CALL_BUILD_REQUEST or the debug
-		// BAML_REST_CALL_UNSUPPORTED_PROVIDERS flag can produce a
-		// too-optimistic PathReason. When a stream bridge exists
-		// every call-mode fallthrough has already been gated on
-		// IsProviderSupported, so the stream predicate is the
-		// correct one. Stream modes always use the stream
-		// predicate.
+		// BAML_REST_CALL_UNSUPPORTED_PROVIDERS hook) bridges and
+		// never reaches here — so the stream predicate is the
+		// correct one and no call-side override is emitted.
 		//
-		// Every BuildRequest landing block is also gated at
-		// runtime on UseBuildRequest(). When BuildRequest is
-		// compiled in but the runtime gate returns false, /call
-		// and /call-with-raw skip both the non-streaming Request
-		// path AND the stream bridge, falling directly to final
-		// legacy. In that path no stream-bridge re-resolution
-		// happened, so the metadata predicate must be the call-
-		// side IsCallProviderSupported.
-		//
-		// Emit a runtime gate inside the hasBuildRequest=true
-		// arm: default to IsProviderSupported (correct when the
-		// stream bridge actually ran), and override to
-		// IsCallProviderSupported only when mode is a call mode
-		// AND UseBuildRequest() returned false. The
-		// no-hasBuildRequest arm keeps its original
-		// compile-time-only override since there is no stream
-		// bridge to re-resolve in any case.
+		// When there is no stream bridge (hasBuildRequest=false) a
+		// call mode the non-streaming Request path declined falls
+		// straight to legacy, so the metadata reason must reflect
+		// the call-side classification; otherwise those flags would
+		// produce a too-optimistic PathReason. Stream modes always
+		// use the stream predicate.
 		jen.Id("__legacyPredicate").Op(":=").Qual(g.pkgs.BuildRequestPkg, "IsProviderSupported"),
 		func() jen.Code {
+			if hasBuildRequest {
+				// Stream bridge present: the stream predicate is
+				// always correct for call-mode fallthroughs.
+				return jen.Null()
+			}
 			callModeCond := jen.Id("mode").Op("==").Qual(g.pkgs.InterfacesPkg, "StreamModeCall").
 				Op("||").Id("mode").Op("==").Qual(g.pkgs.InterfacesPkg, "StreamModeCallWithRaw")
 			// callPredicate names the call-side predicate the legacy
@@ -560,46 +538,25 @@ func (me *methodEmitter) emitRouter() {
 			} else {
 				callPredicate = jen.Qual(g.pkgs.BuildRequestPkg, "IsCallProviderSupported")
 			}
-			if hasBuildRequest {
-				return jen.If(
-					jen.Parens(callModeCond).
-						Op("&&").Op("!").Id("__useBuildRequest"),
-				).Block(
-					jen.Id("__legacyPredicate").Op("=").Add(callPredicate),
-				)
-			}
 			return jen.If(callModeCond).Block(
 				jen.Id("__legacyPredicate").Op("=").Add(callPredicate),
 			)
 		}(),
-		// Use the config-aware sibling on adapters where __brCfg is
-		// in scope (supportsWithClient=true) so legacy plans surface
-		// PathReasonBuildRequestDisabled based on this handler's
-		// BuildRequest config rather than process-wide env state.
-		// Older adapters keep the env-cached entry point.
-		func() jen.Code {
-			if g.supportsWithClient {
-				return jen.Id("__plannedLegacy").Op(":=").Qual(g.pkgs.BuildRequestPkg, "BuildLegacyMetadataPlanForClientWithConfig").Call(
-					jen.Id("__reg"),
-					jen.Id("__effective"),
-					jen.Qual(g.pkgs.IntrospectedPkg, "ClientProvider").Index(jen.Id("__effective")),
-					jen.Qual(g.pkgs.IntrospectedPkg, "FallbackChains"),
-					jen.Qual(g.pkgs.IntrospectedPkg, "ClientProvider"),
-					jen.Id("__legacyPredicate"),
-					jen.Id("__legacyRetryPolicy"),
-					jen.Id("__brCfg"),
-				)
-			}
-			return jen.Id("__plannedLegacy").Op(":=").Qual(g.pkgs.BuildRequestPkg, "BuildLegacyMetadataPlanForClient").Call(
-				jen.Id("__reg"),
-				jen.Id("__effective"),
-				jen.Qual(g.pkgs.IntrospectedPkg, "ClientProvider").Index(jen.Id("__effective")),
-				jen.Qual(g.pkgs.IntrospectedPkg, "FallbackChains"),
-				jen.Qual(g.pkgs.IntrospectedPkg, "ClientProvider"),
-				jen.Id("__legacyPredicate"),
-				jen.Id("__legacyRetryPolicy"),
-			)
-		}(),
+		// BuildLegacyMetadataPlanForClient classifies the legacy
+		// route's PathReason. The BuildRequest route is unconditional
+		// (#537), so there is no longer a buildrequest-disabled reason
+		// to thread per-handler config in for; the call-side
+		// DisableCallBuildRequest knob is already folded into
+		// __legacyPredicate above.
+		jen.Id("__plannedLegacy").Op(":=").Qual(g.pkgs.BuildRequestPkg, "BuildLegacyMetadataPlanForClient").Call(
+			jen.Id("__reg"),
+			jen.Id("__effective"),
+			jen.Qual(g.pkgs.IntrospectedPkg, "ClientProvider").Index(jen.Id("__effective")),
+			jen.Qual(g.pkgs.IntrospectedPkg, "FallbackChains"),
+			jen.Qual(g.pkgs.IntrospectedPkg, "ClientProvider"),
+			jen.Id("__legacyPredicate"),
+			jen.Id("__legacyRetryPolicy"),
+		),
 		jen.Id("__plannedLegacy").Dot("RoundRobin").Op("=").Id("__rrInfo"),
 		// __legacyClientOverride is always __effective. On 0.219+
 		// the legacy dispatcher uses it both for WithClient

--- a/bamlutils/buildrequest/call_support_debug.go
+++ b/bamlutils/buildrequest/call_support_debug.go
@@ -13,8 +13,8 @@ import (
 )
 
 // callUnsupportedProvidersOnce caches the parsed set so
-// debugFilterCallSupported stays hot on the request path. Same rationale
-// as useBuildRequestOnce — os.Getenv takes a lock each call.
+// debugFilterCallSupported stays hot on the request path — os.Getenv
+// takes a lock each call.
 var callUnsupportedProvidersOnce sync.Once
 var callUnsupportedProvidersCached map[string]bool
 

--- a/bamlutils/buildrequest/config_test.go
+++ b/bamlutils/buildrequest/config_test.go
@@ -36,21 +36,17 @@ func TestIsCallProviderSupportedWithConfig_DisableIsPerCall(t *testing.T) {
 	}
 }
 
-// TestBuildLegacyMetadataPlanForClientWithConfig_UseBuildRequestFalse
-// pins the load-bearing classification: a legacy-path plan built with
-// UseBuildRequest=false MUST surface PathReasonBuildRequestDisabled
-// regardless of process-level env. The plan-builder's tail-rule reads
-// cfg.UseBuildRequest directly; if it ever reverts to the env-cached
-// helper, the per-handler classification would silently follow the
-// env instead of this handler's config.
-func TestBuildLegacyMetadataPlanForClientWithConfig_UseBuildRequestFalse(t *testing.T) {
+// TestBuildLegacyMetadataPlanForClient_SupportedSingleProviderNoRetiredReason
+// pins that the BuildRequest route gate is gone (#537): a legacy-path
+// plan for a supported single provider with no other classification
+// reason MUST leave PathReason empty and never synthesize the retired
+// PathReasonBuildRequestDisabled. A regression that re-introduced the
+// route gate would surface here as a stray "buildrequest-disabled"
+// reason on a perfectly valid handler.
+func TestBuildLegacyMetadataPlanForClient_SupportedSingleProviderNoRetiredReason(t *testing.T) {
 	t.Parallel()
 
-	cfg := bamlutils.BuildRequestConfig{UseBuildRequest: false}
-	// Supported provider on the legacy path with no other reason to
-	// classify — the only thing left for PathReason is the
-	// BuildRequest-disabled tail.
-	plan := BuildLegacyMetadataPlanForClientWithConfig(
+	plan := BuildLegacyMetadataPlanForClient(
 		nil,        // no runtime registry
 		"MyClient", // effective client name
 		"openai",   // introspected provider (call-supported)
@@ -58,50 +54,27 @@ func TestBuildLegacyMetadataPlanForClientWithConfig_UseBuildRequestFalse(t *test
 		nil,        // no introspected providers
 		IsProviderSupported,
 		nil, // no retry policy
-		cfg,
-	)
-	if plan == nil {
-		t.Fatal("expected plan")
-	}
-	if plan.PathReason != PathReasonBuildRequestDisabled {
-		t.Errorf("expected PathReason=%q, got %q", PathReasonBuildRequestDisabled, plan.PathReason)
-	}
-}
-
-// TestBuildLegacyMetadataPlanForClientWithConfig_UseBuildRequestTrue
-// is the inverse pin: when the handler's config has UseBuildRequest
-// set, the tail rule must leave PathReason empty for a legacy-path
-// plan that has no other classification reason. A regression that
-// inverted the conditional would surface here as a stray
-// "buildrequest-disabled" reason on a perfectly valid handler.
-func TestBuildLegacyMetadataPlanForClientWithConfig_UseBuildRequestTrue(t *testing.T) {
-	t.Parallel()
-
-	cfg := bamlutils.BuildRequestConfig{UseBuildRequest: true}
-	plan := BuildLegacyMetadataPlanForClientWithConfig(
-		nil, "MyClient", "openai", nil, nil, IsProviderSupported, nil, cfg,
 	)
 	if plan == nil {
 		t.Fatal("expected plan")
 	}
 	if plan.PathReason != "" {
-		t.Errorf("expected empty PathReason on UseBuildRequest=true with no other reason, got %q", plan.PathReason)
+		t.Errorf("expected empty PathReason for a supported single provider, got %q", plan.PathReason)
+	}
+	if plan.PathReason == PathReasonBuildRequestDisabled {
+		t.Errorf("retired PathReasonBuildRequestDisabled must never be emitted")
 	}
 }
 
-// TestEnvConfigMatchesEnvHelpers proves the convenience wrapper
-// preserves the same env contract every existing caller already
-// depends on. A regression that diverged the two paths would silently
-// drift server behaviour between the env-cached helper and the new
-// per-instance plumbing.
-func TestEnvConfigMatchesEnvHelpers(t *testing.T) {
+// TestEnvConfig_OnlyDisableCallBuildRequestIsEnvDriven proves EnvConfig
+// reads only the surviving env-driven field. After #537 the
+// BuildRequest route gate is retired, so EnvConfig carries just
+// DisableCallBuildRequest, sourced from the same env-cached helper every
+// caller depends on.
+func TestEnvConfig_OnlyDisableCallBuildRequestIsEnvDriven(t *testing.T) {
 	t.Parallel()
 
 	got := EnvConfig()
-	if got.UseBuildRequest != UseBuildRequest() {
-		t.Errorf("EnvConfig.UseBuildRequest = %v, UseBuildRequest() = %v",
-			got.UseBuildRequest, UseBuildRequest())
-	}
 	if got.DisableCallBuildRequest != disableCallBuildRequest() {
 		t.Errorf("EnvConfig.DisableCallBuildRequest = %v, disableCallBuildRequest() = %v",
 			got.DisableCallBuildRequest, disableCallBuildRequest())

--- a/bamlutils/buildrequest/metadata.go
+++ b/bamlutils/buildrequest/metadata.go
@@ -52,15 +52,14 @@ const (
 	// the request reached the legacy metadata-plan builder unresolved.
 	// In modern adapters (BAML >= 0.219.0 with SupportsWithClient) top-
 	// level RR is normally unwrapped by ResolveEffectiveClient before
-	// dispatch. This reason fires on three paths:
+	// dispatch (the codegen gate invokes ResolveEffectiveClient whenever
+	// supportsWithClient is true — the BuildRequest route is unconditional
+	// as of #537). This reason fires on two paths:
 	//
-	//   - Older adapters that lack the WithClient CallOption.
-	//   - BAML_REST_USE_BUILD_REQUEST=false: the codegen gate (in
-	//     adapters/common/codegen/codegen.go) only invokes
-	//     ResolveEffectiveClient when supportsWithClient &&
-	//     __useBuildRequest, so flipping the flag off leaves a
-	//     top-level RR client unresolved even on a SupportsWithClient
-	//     adapter, and the legacy plan surfaces this reason.
+	//   - Older adapters that lack the WithClient CallOption (no
+	//     SupportsWithClient), where the codegen gate skips
+	//     ResolveEffectiveClient and the top-level RR client reaches the
+	//     legacy plan builder unresolved.
 	//   - Defensive path when RR resolution failed (cycle / empty
 	//     chain) and the caller fell through with the unresolved
 	//     client name.
@@ -94,8 +93,11 @@ const (
 	// callback (deferred shapes, unsupported leaves, invalid
 	// `options.strategy` / `options.start` overrides).
 	PathReasonFallbackRoundRobinChildBuildRequest = "fallback-roundrobin-child-buildrequest"
-	// PathReasonBuildRequestDisabled: BAML_REST_USE_BUILD_REQUEST is off.
-	// Deliberate configuration — no operator alert.
+	// PathReasonBuildRequestDisabled: historical. Reported when the
+	// retired BAML_REST_USE_BUILD_REQUEST route gate was off. As of #537
+	// the BuildRequest route is unconditional and this reason is never
+	// emitted; the constant is retained only for backward compatibility
+	// with metrics/dashboards that key off the string.
 	PathReasonBuildRequestDisabled = "buildrequest-disabled"
 	// PathReasonInvalidStrategyOverride: a runtime client_registry entry
 	// supplied an `options.strategy` value that ParseStrategyOption could
@@ -519,19 +521,15 @@ func BuildFallbackChainPlanForClient(
 //
 // The plan's Path is always "legacy" (this helper is only invoked on the
 // legacy side). PathReason reflects whichever of the following applied:
-//   - feature-flag off (PathReasonBuildRequestDisabled)
 //   - unsupported or empty provider
 //   - fallback strategy not routable (empty chain, empty child provider,
 //     or all-legacy chain)
 //   - fallback chain contains a baml-roundrobin child whose rotation is
 //     left to BAML's per-worker runtime (PathReasonFallbackRoundRobinChildLegacy)
 //   - an unresolved baml-roundrobin top-level client — fires on
-//     older adapters without SupportsWithClient, when
-//     BAML_REST_USE_BUILD_REQUEST=false (the codegen ResolveEffective-
-//     Client gate is `supportsWithClient && __useBuildRequest`, so the
-//     flag-off path leaves top-level RR unresolved even on modern
-//     adapters), or defensively if RR resolution reached this builder
-//     without being unwrapped upstream (PathReasonRoundRobin)
+//     older adapters without SupportsWithClient, or defensively if RR
+//     resolution reached this builder without being unwrapped upstream
+//     (PathReasonRoundRobin)
 //
 // The plan includes retry policy information when a policy resolves, and
 // chain/legacyChildren information for strategy clients.
@@ -543,32 +541,6 @@ func BuildLegacyMetadataPlan(
 	clientProviders map[string]string,
 	isProviderSupported func(string) bool,
 	retryPolicy *retry.Policy,
-) *bamlutils.Metadata {
-	return BuildLegacyMetadataPlanWithConfig(
-		adapter, defaultClientName, introspectedProvider,
-		fallbackChains, clientProviders, isProviderSupported, retryPolicy,
-		EnvConfig(),
-	)
-}
-
-// BuildLegacyMetadataPlanWithConfig is the config-aware sibling of
-// BuildLegacyMetadataPlan. cfg.UseBuildRequest drives the
-// PathReasonBuildRequestDisabled classification at the bottom of the
-// plan-building flow — when false (and no earlier reason fired) the
-// plan reports the kill-switch as the legacy-path reason.
-//
-// Generated routers pass the per-handler config so per-request
-// metadata reflects this handler's settings rather than process-wide
-// env state.
-func BuildLegacyMetadataPlanWithConfig(
-	adapter bamlutils.Adapter,
-	defaultClientName string,
-	introspectedProvider string,
-	fallbackChains map[string][]string,
-	clientProviders map[string]string,
-	isProviderSupported func(string) bool,
-	retryPolicy *retry.Policy,
-	cfg bamlutils.BuildRequestConfig,
 ) *bamlutils.Metadata {
 	resolution := ResolveProviderWithReason(adapter, defaultClientName, introspectedProvider, isProviderSupported)
 
@@ -631,13 +603,6 @@ func BuildLegacyMetadataPlanWithConfig(
 		}
 	}
 
-	// BAML_REST_USE_BUILD_REQUEST being off is never surfaced by the per-
-	// request resolution helpers; encode it here since a legacy-path
-	// execution with a supported single provider otherwise looks empty.
-	if plan.PathReason == "" && !cfg.UseBuildRequest {
-		plan.PathReason = PathReasonBuildRequestDisabled
-	}
-
 	return plan
 }
 
@@ -658,27 +623,6 @@ func BuildLegacyMetadataPlanForClient(
 	clientProviders map[string]string,
 	isProviderSupported func(string) bool,
 	retryPolicy *retry.Policy,
-) *bamlutils.Metadata {
-	return BuildLegacyMetadataPlanForClientWithConfig(
-		reg, clientName, introspectedProvider,
-		fallbackChains, clientProviders, isProviderSupported, retryPolicy,
-		EnvConfig(),
-	)
-}
-
-// BuildLegacyMetadataPlanForClientWithConfig is the config-aware
-// sibling of BuildLegacyMetadataPlanForClient. cfg.UseBuildRequest
-// drives the PathReasonBuildRequestDisabled classification — see
-// BuildLegacyMetadataPlanWithConfig for the broader contract.
-func BuildLegacyMetadataPlanForClientWithConfig(
-	reg *bamlutils.ClientRegistry,
-	clientName string,
-	introspectedProvider string,
-	fallbackChains map[string][]string,
-	clientProviders map[string]string,
-	isProviderSupported func(string) bool,
-	retryPolicy *retry.Policy,
-	cfg bamlutils.BuildRequestConfig,
 ) *bamlutils.Metadata {
 	provider := ResolveClientProvider(reg, clientName, clientProviders)
 	// ResolveClientProvider returns "" both for "no provider configured"
@@ -756,10 +700,6 @@ func BuildLegacyMetadataPlanForClientWithConfig(
 		//     gate skips ResolveEffectiveClient entirely; the
 		//     unresolved RR client lands here and surfaces
 		//     PathReasonRoundRobin.
-		//   - BAML_REST_USE_BUILD_REQUEST=false: the codegen gate is
-		//     `supportsWithClient && __useBuildRequest`, so flipping
-		//     the flag off also skips the unwrap on a modern adapter.
-		//     PathReasonRoundRobin surfaces here too.
 		plan.Strategy = "baml-roundrobin"
 		if _, present, valid := roundrobin.InspectStrategyOverride(reg, clientName); present && !valid {
 			plan.PathReason = PathReasonInvalidStrategyOverride
@@ -782,10 +722,6 @@ func BuildLegacyMetadataPlanForClientWithConfig(
 		if isProviderSupported != nil && !isProviderSupported(provider) {
 			plan.PathReason = PathReasonUnsupportedProvider
 		}
-	}
-
-	if plan.PathReason == "" && !cfg.UseBuildRequest {
-		plan.PathReason = PathReasonBuildRequestDisabled
 	}
 
 	return plan

--- a/bamlutils/buildrequest/metadata_bugfix_test.go
+++ b/bamlutils/buildrequest/metadata_bugfix_test.go
@@ -2,44 +2,20 @@ package buildrequest
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/invakid404/baml-rest/bamlutils"
 )
 
-// setBuildRequestForTest forces UseBuildRequest() to return a fixed value for
-// the duration of the test. The production cache is a sync.Once + bool pair;
-// we replace the Once with a fresh one and pre-fire it so the cached bool is
-// authoritative without re-running parseBuildRequestEnv. Cleanup resets the
-// Once to a fresh one (never copies a used Once — sync.Once's contract
-// forbids that) so neighbouring tests re-run parseBuildRequestEnv on first
-// UseBuildRequest() call.
-//
-// Tests that call this helper must NOT use t.Parallel — they share the
-// process-global cache.
-func setBuildRequestForTest(t *testing.T, v bool) {
-	t.Helper()
-	prevCached := useBuildRequestCached
-	useBuildRequestOnce = sync.Once{}
-	useBuildRequestCached = v
-	useBuildRequestOnce.Do(func() {})
-	t.Cleanup(func() {
-		// Reset to a fresh Once so the next UseBuildRequest() call
-		// re-reads the env var. Do NOT assign back a copy of a prior
-		// Once — sync.Once must not be copied after first use.
-		useBuildRequestOnce = sync.Once{}
-		useBuildRequestCached = prevCached
-	})
-}
-
-// TestBuildLegacyMetadataPlan_ValidChainBuildRequestDisabled exercises Bug 1.
-// When the request goes legacy because BuildRequest is disabled (not because
-// the chain is malformed), PathReason must NOT be PathReasonFallbackEmptyChain.
-// That value is a placeholder seeded by ResolveProviderWithReason and should
-// be overwritten by the real classification.
-func TestBuildLegacyMetadataPlan_ValidChainBuildRequestDisabled(t *testing.T) {
-	setBuildRequestForTest(t, false)
+// TestBuildLegacyMetadataPlan_ValidChainNotMisclassifiedAsEmpty exercises
+// Bug 1: when BuildLegacyMetadataPlan classifies a request with a valid,
+// fully-enumerable fallback chain, PathReason must NOT be
+// PathReasonFallbackEmptyChain. That value is a placeholder seeded by
+// ResolveProviderWithReason and must be overwritten by the real
+// classification. It must also never be the retired
+// PathReasonBuildRequestDisabled (the route gate was removed in #537).
+func TestBuildLegacyMetadataPlan_ValidChainNotMisclassifiedAsEmpty(t *testing.T) {
+	t.Parallel()
 
 	adapter := &mockAdapter{Context: context.Background()}
 	chains := map[string][]string{
@@ -54,10 +30,10 @@ func TestBuildLegacyMetadataPlan_ValidChainBuildRequestDisabled(t *testing.T) {
 	plan := BuildLegacyMetadataPlan(adapter, "Strategy", "baml-fallback", chains, providers, IsProviderSupported, nil)
 
 	if plan.PathReason == PathReasonFallbackEmptyChain {
-		t.Fatalf("BUG 1: valid chain with BuildRequest disabled reports fallback-empty-chain; want buildrequest-disabled. plan=%+v", plan)
+		t.Fatalf("BUG 1: valid chain reports fallback-empty-chain. plan=%+v", plan)
 	}
-	if plan.PathReason != PathReasonBuildRequestDisabled {
-		t.Errorf("PathReason: got %q, want %q", plan.PathReason, PathReasonBuildRequestDisabled)
+	if plan.PathReason == PathReasonBuildRequestDisabled {
+		t.Errorf("retired PathReasonBuildRequestDisabled must never be emitted; plan=%+v", plan)
 	}
 	// The chain should still be enumerated for observability.
 	if got, want := plan.Chain, []string{"Primary", "Backup"}; !equalStringSlice(got, want) {

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -26,54 +26,6 @@ import (
 	"github.com/invakid404/baml-rest/bamlutils/sseclient"
 )
 
-// parseBuildRequestEnv reads BAML_REST_USE_BUILD_REQUEST and returns its
-// boolean interpretation. Extracted so the test can verify parsing logic
-// independently of the cache.
-func parseBuildRequestEnv() bool {
-	return bamlutils.IsTruthyEnvValue(os.Getenv("BAML_REST_USE_BUILD_REQUEST"))
-}
-
-// useBuildRequestOnce caches the result of parseBuildRequestEnv. The env var
-// is read once on first call and the result is reused for all subsequent
-// calls. This avoids repeated os.Getenv (which acquires a lock) on every
-// request dispatch — the generated router reads the cached value once at
-// router entry and threads it into every gate (BuildRequest landing,
-// legacy predicate, and the supportsWithClient ResolveEffectiveClient
-// upgrade) so the same boolean drives every decision in a request.
-var useBuildRequestOnce sync.Once
-var useBuildRequestCached bool
-
-// UseBuildRequest returns true if the BuildRequest/StreamRequest paths are enabled.
-// Controlled by the BAML_REST_USE_BUILD_REQUEST environment variable.
-//
-// When false, the flag is a full rollback to the legacy CallStream+OnTick
-// path: the BuildRequest transport is skipped, baml-rest's RR resolver
-// and coordinator are NOT engaged on supportsWithClient adapters, and
-// BAML's own runtime owns strategy rotation per-worker. This is the
-// kill-switch contract — flipping the flag off should remove every new
-// failure surface this PR added (RemoteAdvancer, SharedState broker,
-// in-process coordinator) from the request path so operators can revert
-// to legacy semantics during incident response.
-//
-// Scope: the flag is read by both the request-path gates (codegen
-// upgrade in adapters/common/codegen, ResolveEffectiveClient consumers)
-// and the host startup wiring in cmd/serve. cmd/serve only seeds
-// SharedStateSeeds when the flag is on; with it off, the host doesn't
-// host a SharedStateStore, the plugin map ships without
-// SharedStateImpl, no reverse broker is accepted, and the worker's
-// AttachSharedState handshake never runs. That keeps the kill-switch
-// rollback genuinely surface-free: the broker, store, and remote
-// advancer are all skipped end-to-end rather than constructed and
-// merely unused.
-//
-// The environment variable is read once and cached for the process lifetime.
-func UseBuildRequest() bool {
-	useBuildRequestOnce.Do(func() {
-		useBuildRequestCached = parseBuildRequestEnv()
-	})
-	return useBuildRequestCached
-}
-
 // parseDisableCallBuildRequestEnv reads BAML_REST_DISABLE_CALL_BUILD_REQUEST
 // and returns its boolean interpretation. Extracted so the test can verify
 // parsing logic independently of the cache.
@@ -82,7 +34,7 @@ func parseDisableCallBuildRequestEnv() bool {
 }
 
 // disableCallBuildRequestOnce caches the result of the env lookup so
-// IsCallProviderSupported stays hot. Same rationale as useBuildRequestOnce.
+// IsCallProviderSupported stays hot — os.Getenv takes a lock each call.
 var disableCallBuildRequestOnce sync.Once
 var disableCallBuildRequestCached bool
 
@@ -206,16 +158,19 @@ func IsCallProviderSupported(provider string) bool {
 }
 
 // EnvConfig returns the BuildRequestConfig parsed from the process env.
-// The values are read through the same sync.Once-backed caches as the
-// legacy helpers (UseBuildRequest / disableCallBuildRequest) so this
-// helper costs the same as the older form on the hot path.
+// The values are read through the sync.Once-backed disableCallBuildRequest
+// cache so this helper costs the same as a direct env read on the hot path.
+//
+// BuildRequest is always attempted whenever the generated BAML client
+// exposes Request/StreamRequest surfaces — the legacy BAML_REST_USE_BUILD_REQUEST
+// route gate was retired in #537, so only DisableCallBuildRequest (the
+// narrower /call Request-API hatch) is env-driven here.
 //
 // Used by cmd/worker and cmd/serve at startup to populate per-handler
 // worker.Config.BuildRequest; programmatic callers can supply a literal
 // bamlutils.BuildRequestConfig instead.
 func EnvConfig() bamlutils.BuildRequestConfig {
 	return bamlutils.BuildRequestConfig{
-		UseBuildRequest:         UseBuildRequest(),
 		DisableCallBuildRequest: disableCallBuildRequest(),
 	}
 }

--- a/bamlutils/buildrequest/orchestrator_test.go
+++ b/bamlutils/buildrequest/orchestrator_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -426,35 +425,6 @@ func TestRunStreamOrchestration_ContextCancellation(t *testing.T) {
 	}
 	if count == 0 {
 		t.Error("expected at least some results before context cancellation")
-	}
-}
-
-func TestParseBuildRequestEnv(t *testing.T) {
-	tests := []struct {
-		env      string
-		expected bool
-	}{
-		{"", false},
-		{"0", false},
-		{"false", false},
-		{"no", false},
-		{"1", true},
-		{"true", true},
-		{"yes", true},
-		{"on", true},
-		{"TRUE", true},
-		{"True", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.env, func(t *testing.T) {
-			os.Setenv("BAML_REST_USE_BUILD_REQUEST", tt.env)
-			defer os.Unsetenv("BAML_REST_USE_BUILD_REQUEST")
-
-			if got := parseBuildRequestEnv(); got != tt.expected {
-				t.Errorf("parseBuildRequestEnv() with env=%q: got %v, want %v", tt.env, got, tt.expected)
-			}
-		})
 	}
 }
 

--- a/bamlutils/clientdefaults/clientdefaults.go
+++ b/bamlutils/clientdefaults/clientdefaults.go
@@ -56,8 +56,8 @@
 // re-run those tests to confirm the current runtime still preserves
 // message-level metadata through BuildRequest. The worker emits a
 // startup advisory when BAML_REST_CLIENT_DEFAULTS sets
-// allowed_role_metadata and BAML_REST_USE_BUILD_REQUEST=true so
-// operators have a pointer to those tests.
+// allowed_role_metadata (the BuildRequest route is on by default as of
+// #537) so operators have a pointer to those tests.
 package clientdefaults
 
 import (

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -968,23 +968,23 @@ type RoundRobinAdvancer interface {
 	Advance(clientName string, childCount int) (int, error)
 }
 
-// BuildRequestConfig carries the per-handler settings that drove the
+// BuildRequestConfig carries the per-handler settings that drive the
 // codegen-emitted BuildRequest gates. Adapters expose the typed shape
-// so generated routers can read `adapter.BuildRequestConfig().UseBuildRequest`
-// instead of reaching into the buildrequest package's env-cached
-// globals — every handler in a single process can carry a distinct
-// configuration without leaking through process-wide state.
+// so generated routers can read `adapter.BuildRequestConfig()` instead
+// of reaching into the buildrequest package's env-cached globals — every
+// handler in a single process can carry a distinct configuration without
+// leaking through process-wide state.
+//
+// As of #537 the BuildRequest route is unconditional: it is attempted
+// whenever the generated BAML client exposes Request/StreamRequest
+// surfaces. The retired BAML_REST_USE_BUILD_REQUEST route gate no longer
+// has a field here; only the narrower DisableCallBuildRequest hatch
+// remains.
 //
 // Operators running the standard cmd/serve binaries see no behaviour
-// change: cmd/worker and cmd/serve resolve the env vars once at
-// startup and populate this struct identically across every handler
-// in the pool.
+// change: cmd/worker and cmd/serve resolve the env var once at startup
+// and populate this struct identically across every handler in the pool.
 type BuildRequestConfig struct {
-	// UseBuildRequest mirrors BAML_REST_USE_BUILD_REQUEST. When false,
-	// every BuildRequest landing gate in the generated router declines
-	// and dispatch falls through to the legacy CallStream+OnTick path.
-	UseBuildRequest bool
-
 	// DisableCallBuildRequest mirrors BAML_REST_DISABLE_CALL_BUILD_REQUEST.
 	// When true, the non-streaming Request API is treated as unsupported
 	// for every provider on this handler — /call{,-with-raw} fall through
@@ -1025,9 +1025,9 @@ type DeBAMLConfig struct {
 type DeBAMLRenderFunc func(schema *DynamicOutputSchema) (string, error)
 
 // EnvUseDeBAML is the umbrella env var that enables native de-BAML
-// behaviour. Distinct from BAML_REST_USE_BUILD_REQUEST: that selects the
-// transport route, this selects whether native de-BAML paths run on
-// routes that expose a native seam.
+// behaviour. It selects whether native de-BAML paths run on routes that
+// expose a native seam — independent of transport-route selection (the
+// BuildRequest route is unconditional as of #537).
 const EnvUseDeBAML = "BAML_REST_USE_DEBAML"
 
 // DeBAMLConfigFromEnv resolves BAML_REST_USE_DEBAML into a DeBAMLConfig.
@@ -1040,11 +1040,11 @@ func DeBAMLConfigFromEnv() DeBAMLConfig {
 }
 
 // IsTruthyEnvValue is the single truthy-env contract shared across
-// baml-rest's boolean env vars (BAML_REST_USE_BUILD_REQUEST,
-// BAML_REST_DISABLE_CALL_BUILD_REQUEST, BAML_REST_USE_DEBAML, and the
-// serve-host preserve-order default). Exactly 1/true/yes/on
-// (case-insensitive) are true; every other value — including the empty
-// string and whitespace-padded variants (no trimming) — is false.
+// baml-rest's boolean env vars (BAML_REST_DISABLE_CALL_BUILD_REQUEST,
+// BAML_REST_USE_DEBAML, and the serve-host preserve-order default).
+// Exactly 1/true/yes/on (case-insensitive) are true; every other value —
+// including the empty string and whitespace-padded variants (no
+// trimming) — is false.
 func IsTruthyEnvValue(v string) bool {
 	switch strings.ToLower(v) {
 	case "1", "true", "yes", "on":
@@ -1106,12 +1106,12 @@ type Adapter interface {
 	SetHTTPClient(*llmhttp.Client)
 	// SetBuildRequestConfig stores the per-handler BuildRequestConfig.
 	// The generated router consults BuildRequestConfig() for the
-	// per-request UseBuildRequest / DisableCallBuildRequest decision
-	// rather than the buildrequest package's env-cached helpers.
+	// per-request DisableCallBuildRequest decision rather than the
+	// buildrequest package's env-cached helper.
 	SetBuildRequestConfig(BuildRequestConfig)
 	// BuildRequestConfig returns the per-handler BuildRequestConfig
 	// installed via SetBuildRequestConfig. Zero value when unset —
-	// the codegen-emitted router treats both fields as false.
+	// the codegen-emitted router treats DisableCallBuildRequest as false.
 	BuildRequestConfig() BuildRequestConfig
 	// SetDeBAMLConfig stores the per-handler DeBAMLConfig (the
 	// BAML_REST_USE_DEBAML umbrella switch). cmd/serve and cmd/worker

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -981,9 +981,9 @@ type RoundRobinAdvancer interface {
 // has a field here; only the narrower DisableCallBuildRequest hatch
 // remains.
 //
-// Operators running the standard cmd/serve binaries see no behaviour
-// change: cmd/worker and cmd/serve resolve the env var once at startup
-// and populate this struct identically across every handler in the pool.
+// The remaining DisableCallBuildRequest value is still resolved once at
+// startup (by cmd/serve and cmd/worker) and installed uniformly across
+// every handler in the pool.
 type BuildRequestConfig struct {
 	// DisableCallBuildRequest mirrors BAML_REST_DISABLE_CALL_BUILD_REQUEST.
 	// When true, the non-streaming Request API is treated as unsupported

--- a/cmd/serve/config.go
+++ b/cmd/serve/config.go
@@ -13,17 +13,17 @@ import (
 const envPreserveSchemaOrderDefault = "BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT"
 
 // preserveSchemaOrderDefaultFromEnv resolves BAML_REST_PRESERVE_SCHEMA_ORDER_DEFAULT
-// at server startup. Truthy parsing intentionally matches the
-// parseBuildRequestEnv contract over in bamlutils/buildrequest so the
-// two env vars behave identically — 1/true/yes/on (case-insensitive)
-// enable the default; every other value disables it.
+// at server startup. Truthy parsing intentionally matches the shared
+// bamlutils.IsTruthyEnvValue contract so baml-rest's boolean env vars
+// behave identically — 1/true/yes/on (case-insensitive) enable the
+// default; every other value disables it.
 func preserveSchemaOrderDefaultFromEnv() bool {
 	return parseTruthyEnvBool(os.Getenv(envPreserveSchemaOrderDefault))
 }
 
-// parseTruthyEnvBool mirrors parseBuildRequestEnv: 1/true/yes/on after
-// lowercasing count as truthy, anything else (including empty string,
-// whitespace-padded variants, and unrecognized tokens) is falsy.
+// parseTruthyEnvBool mirrors bamlutils.IsTruthyEnvValue: 1/true/yes/on
+// after lowercasing count as truthy, anything else (including empty
+// string, whitespace-padded variants, and unrecognized tokens) is falsy.
 func parseTruthyEnvBool(v string) bool {
 	switch strings.ToLower(v) {
 	case "1", "true", "yes", "on":

--- a/cmd/serve/config_test.go
+++ b/cmd/serve/config_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 // TestParseTruthyEnvBool pins the env-parser contract: 1/true/yes/on
-// (case-insensitive) are the only truthy tokens. Mirrors the
-// parseBuildRequestEnv accept list in bamlutils/buildrequest so the two
-// server env flags share a single truthiness convention — diverging
-// would surprise operators who set both vars together.
+// (case-insensitive) are the only truthy tokens. Mirrors the shared
+// bamlutils.IsTruthyEnvValue accept list so baml-rest's server env flags
+// share a single truthiness convention — diverging would surprise
+// operators who set multiple vars together.
 func TestParseTruthyEnvBool(t *testing.T) {
 	t.Parallel()
 
@@ -30,7 +30,7 @@ func TestParseTruthyEnvBool(t *testing.T) {
 		{"false", false},
 		{"off", false},
 		{"no", false},
-		{" true ", false}, // no whitespace trimming — mirrors parseBuildRequestEnv
+		{" true ", false}, // no whitespace trimming — mirrors IsTruthyEnvValue
 		{"truthy", false},
 		{"2", false},
 	}

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -242,7 +242,9 @@ var serveCmd = &cobra.Command{
 		// BAML_REST_USE_BUILD_REQUEST was retired in #537: the BuildRequest
 		// route is now unconditional. Warn (do not error) if a stale
 		// deployment still sets it so operators get a clean migration
-		// signal without an outage.
+		// signal without an outage. This host startup path runs in both
+		// subprocess and in-process modes, so it is the single emission
+		// point — the worker subprocess deliberately does not repeat it.
 		if _, present := os.LookupEnv("BAML_REST_USE_BUILD_REQUEST"); present {
 			logger.Warn().Msg("BAML_REST_USE_BUILD_REQUEST is retired and ignored: the BuildRequest route is attempted whenever the generated BAML client exposes Request or StreamRequest. Remove the variable from your configuration.")
 		}

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -239,6 +239,13 @@ var serveCmd = &cobra.Command{
 		// configuration the subprocess build's cmd/worker would
 		// produce on its own at process startup.
 		buildRequestConfig := buildrequest.EnvConfig()
+		// BAML_REST_USE_BUILD_REQUEST was retired in #537: the BuildRequest
+		// route is now unconditional. Warn (do not error) if a stale
+		// deployment still sets it so operators get a clean migration
+		// signal without an outage.
+		if _, present := os.LookupEnv("BAML_REST_USE_BUILD_REQUEST"); present {
+			logger.Warn().Msg("BAML_REST_USE_BUILD_REQUEST is retired and ignored: the BuildRequest route is attempted whenever the generated BAML client exposes Request or StreamRequest. Remove the variable from your configuration.")
+		}
 		deBAMLConfig := bamlutils.DeBAMLConfigFromEnv()
 		preserveSchemaOrderDefault := preserveSchemaOrderDefaultFromEnv()
 		baseURLRewrites := urlrewrite.LoadDefaultRules()
@@ -280,19 +287,12 @@ var serveCmd = &cobra.Command{
 		// `start N` values; unseeded clients get a random offset on first
 		// touch, matching the legacy single-process Coordinator behaviour.
 		//
-		// Gated on UseBuildRequest: with the kill-switch off, baml-rest's
-		// RR resolver isn't engaged on the request path (the codegen
-		// upgrade gate at adapters/common/codegen/codegen.go skips
-		// ResolveEffectiveClient and the worker's per-request
-		// SetRoundRobinAdvancer feeds an unread advancer), so the broker
-		// channel and the AttachSharedState handshake would be pure dead
-		// weight. Skipping seeds collapses the kill-switch contract
-		// end-to-end: no host-side store, no SharedStateImpl in the
-		// plugin map, no reverse-broker dial, and BAML's per-worker
-		// runtime owns rotation exactly as it did pre-PR.
-		// Gate on BuildRequest enabled AND at least one BuildRequest
-		// surface (Request or StreamRequest) actually exposed by the
-		// generated codegen. Streaming-only BAML emits
+		// Gate on at least one BuildRequest surface (Request or
+		// StreamRequest) actually exposed by the generated codegen. The
+		// BuildRequest route is unconditional as of #537, so baml-rest's
+		// RR resolver is always engaged on the request path for modern
+		// adapters — the only remaining reason to skip seeding is a BAML
+		// version that exposes neither surface. Streaming-only BAML emits
 		// `var Request any` / `var StreamRequest any` for the absent
 		// surface (cmd/introspect/main.go); the codegen distinguishes
 		// the two surfaces (codegen.go non-stream vs stream emission)
@@ -300,7 +300,7 @@ var serveCmd = &cobra.Command{
 		// Request is nil. Only when neither surface exists does the
 		// BuildRequest path become unexercisable — wiring SharedState
 		// in that case would be pure dead weight.
-		if buildRequestConfig.UseBuildRequest && (introspected.Request != nil || introspected.StreamRequest != nil) {
+		if introspected.Request != nil || introspected.StreamRequest != nil {
 			poolConfig.SharedStateSeeds = introspected.RoundRobinStart
 		}
 

--- a/cmd/serve/worker_mode.go
+++ b/cmd/serve/worker_mode.go
@@ -24,9 +24,11 @@ type workerModeRuntimeConfig struct {
 	// internal/rootruntime.Runtime{}.
 	Runtime worker.Runtime
 
-	// BuildRequest mirrors the BAML_REST_USE_BUILD_REQUEST /
-	// BAML_REST_DISABLE_CALL_BUILD_REQUEST envs as a typed config the
-	// generated router reads through adapter.BuildRequestConfig().
+	// BuildRequest mirrors the BAML_REST_DISABLE_CALL_BUILD_REQUEST env
+	// as a typed config the generated router reads through
+	// adapter.BuildRequestConfig(). The BuildRequest route itself is
+	// unconditional as of #537; only the narrower call-side hatch
+	// remains env-driven.
 	BuildRequest bamlutils.BuildRequestConfig
 
 	// DeBAML mirrors BAML_REST_USE_DEBAML — the umbrella switch the

--- a/cmd/serve/worker_mode_inprocess.go
+++ b/cmd/serve/worker_mode_inprocess.go
@@ -38,11 +38,19 @@ func configureWorkerMode(logger zerolog.Logger, cfg *pool.Config, runtimeCfg wor
 	if err != nil {
 		return fmt.Errorf("invalid BAML_REST_CLIENT_DEFAULTS: %w", err)
 	}
-	// Gate on BuildRequest surface availability: the advisory only applies
-	// when traffic actually takes the BuildRequest route. On BAML versions
-	// that expose neither Request nor StreamRequest, all traffic is legacy
-	// and the BuildRequest serializer caveat is irrelevant.
-	if clientDefaults.HasKey("allowed_role_metadata") && (introspected.Request != nil || introspected.StreamRequest != nil) {
+	// Gate on the effective BuildRequest route: the advisory only applies
+	// when a BuildRequest serializer is actually in the request path.
+	// StreamRequest is always BuildRequest (streaming, plus the /call
+	// bridge, which ignores DisableCallBuildRequest); the non-streaming
+	// Request path is taken only when Request exists AND
+	// DisableCallBuildRequest is off. When neither holds, all traffic is
+	// legacy and the serializer caveat is irrelevant. Note this is NOT
+	// `(Request|StreamRequest) && !DisableCallBuildRequest`: that would
+	// wrongly suppress the advisory when StreamRequest still routes
+	// streaming + bridged-/call traffic through BuildRequest.
+	buildRequestInUse := introspected.StreamRequest != nil ||
+		(introspected.Request != nil && !runtimeCfg.BuildRequest.DisableCallBuildRequest)
+	if clientDefaults.HasKey("allowed_role_metadata") && buildRequestInUse {
 		logger.Warn().Msg(
 			"BAML_REST_CLIENT_DEFAULTS sets allowed_role_metadata and the " +
 				"BuildRequest route is on by default; older BAML BuildRequest " +

--- a/cmd/serve/worker_mode_inprocess.go
+++ b/cmd/serve/worker_mode_inprocess.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/invakid404/baml-rest/introspected"
 	"github.com/invakid404/baml-rest/pool"
 	"github.com/invakid404/baml-rest/worker"
 	"github.com/invakid404/baml-rest/workerplugin"
@@ -37,7 +38,11 @@ func configureWorkerMode(logger zerolog.Logger, cfg *pool.Config, runtimeCfg wor
 	if err != nil {
 		return fmt.Errorf("invalid BAML_REST_CLIENT_DEFAULTS: %w", err)
 	}
-	if clientDefaults.HasKey("allowed_role_metadata") {
+	// Gate on BuildRequest surface availability: the advisory only applies
+	// when traffic actually takes the BuildRequest route. On BAML versions
+	// that expose neither Request nor StreamRequest, all traffic is legacy
+	// and the BuildRequest serializer caveat is irrelevant.
+	if clientDefaults.HasKey("allowed_role_metadata") && (introspected.Request != nil || introspected.StreamRequest != nil) {
 		logger.Warn().Msg(
 			"BAML_REST_CLIENT_DEFAULTS sets allowed_role_metadata and the " +
 				"BuildRequest route is on by default; older BAML BuildRequest " +

--- a/cmd/serve/worker_mode_inprocess.go
+++ b/cmd/serve/worker_mode_inprocess.go
@@ -37,10 +37,10 @@ func configureWorkerMode(logger zerolog.Logger, cfg *pool.Config, runtimeCfg wor
 	if err != nil {
 		return fmt.Errorf("invalid BAML_REST_CLIENT_DEFAULTS: %w", err)
 	}
-	if clientDefaults.HasKey("allowed_role_metadata") && runtimeCfg.BuildRequest.UseBuildRequest {
+	if clientDefaults.HasKey("allowed_role_metadata") {
 		logger.Warn().Msg(
-			"BAML_REST_CLIENT_DEFAULTS sets allowed_role_metadata and " +
-				"BAML_REST_USE_BUILD_REQUEST=true; older BAML BuildRequest " +
+			"BAML_REST_CLIENT_DEFAULTS sets allowed_role_metadata and the " +
+				"BuildRequest route is on by default; older BAML BuildRequest " +
 				"serializers may drop message-level metadata (e.g. cache_control). " +
 				"Keep this covered by integration tests when changing supported " +
 				"BAML versions.")

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -73,11 +73,19 @@ func main() {
 		logger.Error("invalid BAML_REST_CLIENT_DEFAULTS", "err", err.Error())
 		os.Exit(1)
 	}
-	// Gate on BuildRequest surface availability: the advisory only applies
-	// when traffic actually takes the BuildRequest route. On BAML versions
-	// that expose neither Request nor StreamRequest, all traffic is legacy
-	// and the BuildRequest serializer caveat is irrelevant.
-	if clientDefaults.HasKey("allowed_role_metadata") && (introspected.Request != nil || introspected.StreamRequest != nil) {
+	// Gate on the effective BuildRequest route: the advisory only applies
+	// when a BuildRequest serializer is actually in the request path.
+	// StreamRequest is always BuildRequest (streaming, plus the /call
+	// bridge, which ignores DisableCallBuildRequest); the non-streaming
+	// Request path is taken only when Request exists AND
+	// DisableCallBuildRequest is off. When neither holds, all traffic is
+	// legacy and the serializer caveat is irrelevant. Note this is NOT
+	// `(Request|StreamRequest) && !DisableCallBuildRequest`: that would
+	// wrongly suppress the advisory when StreamRequest still routes
+	// streaming + bridged-/call traffic through BuildRequest.
+	buildRequestInUse := introspected.StreamRequest != nil ||
+		(introspected.Request != nil && !buildRequestConfig.DisableCallBuildRequest)
+	if clientDefaults.HasKey("allowed_role_metadata") && buildRequestInUse {
 		logger.Warn(
 			"BAML_REST_CLIENT_DEFAULTS sets allowed_role_metadata and the " +
 				"BuildRequest route is on by default; older BAML BuildRequest " +

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -44,13 +44,11 @@ func main() {
 	// boundary; library-mode callers wire their own config inside the
 	// host process instead.
 	buildRequestConfig := buildrequest.EnvConfig()
-	// BAML_REST_USE_BUILD_REQUEST was retired in #537: the BuildRequest
-	// route is now unconditional. Warn (do not error) if a stale
-	// deployment still sets it so operators get a clean migration signal
-	// without an outage.
-	if _, present := os.LookupEnv("BAML_REST_USE_BUILD_REQUEST"); present {
-		logger.Warn("BAML_REST_USE_BUILD_REQUEST is retired and ignored: the BuildRequest route is attempted whenever the generated BAML client exposes Request or StreamRequest. Remove the variable from your configuration.")
-	}
+	// Note: the retired-BAML_REST_USE_BUILD_REQUEST deprecation warning is
+	// emitted once by the host (cmd/serve), which runs at startup in both
+	// subprocess and in-process modes. Emitting it here too would duplicate
+	// the message once per pooled worker subprocess, so the worker stays
+	// silent on it.
 	deBAMLConfig := bamlutils.DeBAMLConfigFromEnv()
 	baseURLRewrites := urlrewrite.LoadDefaultRules()
 	streamIdleTimeout := llmhttp.StreamIdleTimeoutFromEnv()

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -43,6 +43,13 @@ func main() {
 	// boundary; library-mode callers wire their own config inside the
 	// host process instead.
 	buildRequestConfig := buildrequest.EnvConfig()
+	// BAML_REST_USE_BUILD_REQUEST was retired in #537: the BuildRequest
+	// route is now unconditional. Warn (do not error) if a stale
+	// deployment still sets it so operators get a clean migration signal
+	// without an outage.
+	if _, present := os.LookupEnv("BAML_REST_USE_BUILD_REQUEST"); present {
+		logger.Warn("BAML_REST_USE_BUILD_REQUEST is retired and ignored: the BuildRequest route is attempted whenever the generated BAML client exposes Request or StreamRequest. Remove the variable from your configuration.")
+	}
 	deBAMLConfig := bamlutils.DeBAMLConfigFromEnv()
 	baseURLRewrites := urlrewrite.LoadDefaultRules()
 	streamIdleTimeout := llmhttp.StreamIdleTimeoutFromEnv()
@@ -67,10 +74,10 @@ func main() {
 		logger.Error("invalid BAML_REST_CLIENT_DEFAULTS", "err", err.Error())
 		os.Exit(1)
 	}
-	if clientDefaults.HasKey("allowed_role_metadata") && buildRequestConfig.UseBuildRequest {
+	if clientDefaults.HasKey("allowed_role_metadata") {
 		logger.Warn(
-			"BAML_REST_CLIENT_DEFAULTS sets allowed_role_metadata and " +
-				"BAML_REST_USE_BUILD_REQUEST=true; older BAML BuildRequest " +
+			"BAML_REST_CLIENT_DEFAULTS sets allowed_role_metadata and the " +
+				"BuildRequest route is on by default; older BAML BuildRequest " +
 				"serializers may drop message-level metadata (e.g. cache_control). " +
 				"Keep this covered by integration tests when changing supported " +
 				"BAML versions.")

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/invakid404/baml-rest/internal/debaml"
 	"github.com/invakid404/baml-rest/internal/memlimit"
 	"github.com/invakid404/baml-rest/internal/rootruntime"
+	"github.com/invakid404/baml-rest/introspected"
 	"github.com/invakid404/baml-rest/worker"
 	"github.com/invakid404/baml-rest/workerplugin"
 	pb "github.com/invakid404/baml-rest/workerplugin/proto"
@@ -74,7 +75,11 @@ func main() {
 		logger.Error("invalid BAML_REST_CLIENT_DEFAULTS", "err", err.Error())
 		os.Exit(1)
 	}
-	if clientDefaults.HasKey("allowed_role_metadata") {
+	// Gate on BuildRequest surface availability: the advisory only applies
+	// when traffic actually takes the BuildRequest route. On BAML versions
+	// that expose neither Request nor StreamRequest, all traffic is legacy
+	// and the BuildRequest serializer caveat is irrelevant.
+	if clientDefaults.HasKey("allowed_role_metadata") && (introspected.Request != nil || introspected.StreamRequest != nil) {
 		logger.Warn(
 			"BAML_REST_CLIENT_DEFAULTS sets allowed_role_metadata and the " +
 				"BuildRequest route is on by default; older BAML BuildRequest " +

--- a/dynclient/client_test.go
+++ b/dynclient/client_test.go
@@ -226,7 +226,6 @@ func TestNewAppliesOptions(t *testing.T) {
 	t.Cleanup(store.Close)
 
 	c := newClient(t, rt,
-		WithUseBuildRequest(true),
 		WithDisableCallBuildRequest(true),
 		WithDeBAML(true),
 		WithDeBAMLRenderer(func(*bamlutils.DynamicOutputSchema) (string, error) { return "block", nil }),
@@ -253,8 +252,8 @@ func TestNewAppliesOptions(t *testing.T) {
 	if captured == nil {
 		t.Fatal("expected adapter to be captured")
 	}
-	if got := captured.BuildRequestConfig(); got.UseBuildRequest != true || got.DisableCallBuildRequest != true {
-		t.Errorf("BuildRequestConfig = %#v, want both flags true", got)
+	if got := captured.BuildRequestConfig(); got.DisableCallBuildRequest != true {
+		t.Errorf("BuildRequestConfig = %#v, want DisableCallBuildRequest=true", got)
 	}
 	if !captured.DeBAMLConfig().Enabled {
 		t.Errorf("DeBAMLConfig = %#v, want Enabled=true (WithDeBAML wiring)", captured.DeBAMLConfig())

--- a/dynclient/internal/generated/adapter.go
+++ b/dynclient/internal/generated/adapter.go
@@ -1014,18 +1014,15 @@ func Baml_Rest_Dynamic(adapter bamlutils.Adapter, rawInput any) (<-chan bamlutil
 	__effective := __retryClient
 	var __rrInfo *bamlutils.RoundRobinInfo
 	__brCfg := adapter.BuildRequestConfig()
-	__useBuildRequest := __brCfg.UseBuildRequest
-	if __useBuildRequest {
-		__rrEffective, __rrInfoUpgrade, __rrErr := buildrequest.ResolveEffectiveClient(adapter, introspected.FunctionClient["Baml_Rest_Dynamic"], introspected.FallbackChains, introspected.ClientProvider, introspected.RoundRobinCoordinator)
-		if __rrErr != nil {
-			return nil, __rrErr
-		}
-		__effective = __rrEffective
-		__rrInfo = __rrInfoUpgrade
+	__rrEffective, __rrInfoUpgrade, __rrErr := buildrequest.ResolveEffectiveClient(adapter, introspected.FunctionClient["Baml_Rest_Dynamic"], introspected.FallbackChains, introspected.ClientProvider, introspected.RoundRobinCoordinator)
+	if __rrErr != nil {
+		return nil, __rrErr
 	}
+	__effective = __rrEffective
+	__rrInfo = __rrInfoUpgrade
 	__reg := adapter.OriginalClientRegistry()
 	// Try non-streaming BuildRequest path for /call and /call-with-raw
-	if __useBuildRequest && introspected.Request != nil && (mode == bamlutils.StreamModeCall || mode == bamlutils.StreamModeCallWithRaw) {
+	if introspected.Request != nil && (mode == bamlutils.StreamModeCall || mode == bamlutils.StreamModeCallWithRaw) {
 		provider := buildrequest.ResolveClientProvider(__reg, __effective, introspected.ClientProvider)
 		if provider != "" && buildrequest.IsCallProviderSupportedWithConfig(provider, __brCfg) {
 			retryPolicy := buildrequest.ResolveStrategyAwareRetryPolicy(adapter, __retryClient, __effective, introspected.ClientRetryPolicy[__retryClient], introspected.ClientRetryPolicy[__effective], introspected.RetryPolicies)
@@ -1039,7 +1036,7 @@ func Baml_Rest_Dynamic(adapter bamlutils.Adapter, rawInput any) (<-chan bamlutil
 		}
 	}
 	// Try streaming BuildRequest path for /stream and /stream-with-raw
-	if __useBuildRequest && introspected.StreamRequest != nil && (mode == bamlutils.StreamModeStream || mode == bamlutils.StreamModeStreamWithRaw) {
+	if introspected.StreamRequest != nil && (mode == bamlutils.StreamModeStream || mode == bamlutils.StreamModeStreamWithRaw) {
 		provider := buildrequest.ResolveClientProvider(__reg, __effective, introspected.ClientProvider)
 		if provider != "" && buildrequest.IsProviderSupported(provider) {
 			retryPolicy := buildrequest.ResolveStrategyAwareRetryPolicy(adapter, __retryClient, __effective, introspected.ClientRetryPolicy[__retryClient], introspected.ClientRetryPolicy[__effective], introspected.RetryPolicies)
@@ -1067,7 +1064,7 @@ func Baml_Rest_Dynamic(adapter bamlutils.Adapter, rawInput any) (<-chan bamlutil
 		}
 	}
 	// Bridge: /call and /call-with-raw via StreamRequest when Request is unavailable
-	if __useBuildRequest && introspected.StreamRequest != nil && (mode == bamlutils.StreamModeCall || mode == bamlutils.StreamModeCallWithRaw) {
+	if introspected.StreamRequest != nil && (mode == bamlutils.StreamModeCall || mode == bamlutils.StreamModeCallWithRaw) {
 		provider := buildrequest.ResolveClientProvider(__reg, __effective, introspected.ClientProvider)
 		if provider != "" && buildrequest.IsProviderSupported(provider) {
 			retryPolicy := buildrequest.ResolveStrategyAwareRetryPolicy(adapter, __retryClient, __effective, introspected.ClientRetryPolicy[__retryClient], introspected.ClientRetryPolicy[__effective], introspected.RetryPolicies)
@@ -1094,15 +1091,10 @@ func Baml_Rest_Dynamic(adapter bamlutils.Adapter, rawInput any) (<-chan bamlutil
 			return out, nil
 		}
 	}
-	// Legacy path: CallStream + OnTick (for unsupported providers or when BuildRequest is disabled)
+	// Legacy path: CallStream + OnTick (for unsupported/empty providers or BAML versions without a BuildRequest surface)
 	__legacyRetryPolicy := buildrequest.ResolveStrategyAwareRetryPolicy(adapter, __retryClient, __effective, introspected.ClientRetryPolicy[__retryClient], introspected.ClientRetryPolicy[__effective], introspected.RetryPolicies)
 	__legacyPredicate := buildrequest.IsProviderSupported
-	if (mode == bamlutils.StreamModeCall || mode == bamlutils.StreamModeCallWithRaw) && !__useBuildRequest {
-		__legacyPredicate = func(p string) bool {
-			return buildrequest.IsCallProviderSupportedWithConfig(p, __brCfg)
-		}
-	}
-	__plannedLegacy := buildrequest.BuildLegacyMetadataPlanForClientWithConfig(__reg, __effective, introspected.ClientProvider[__effective], introspected.FallbackChains, introspected.ClientProvider, __legacyPredicate, __legacyRetryPolicy, __brCfg)
+	__plannedLegacy := buildrequest.BuildLegacyMetadataPlanForClient(__reg, __effective, introspected.ClientProvider[__effective], introspected.FallbackChains, introspected.ClientProvider, __legacyPredicate, __legacyRetryPolicy)
 	__plannedLegacy.RoundRobin = __rrInfo
 	__legacyClientOverride := __effective
 	buildrequest.LogLegacyClassification(adapter, "Baml_Rest_Dynamic", __plannedLegacy)

--- a/dynclient/internal/generated/adapter/adapter.go
+++ b/dynclient/internal/generated/adapter/adapter.go
@@ -61,10 +61,10 @@ type BamlAdapter struct {
 	httpClient *llmhttp.Client
 
 	// buildRequestConfig carries the per-handler BuildRequest knobs
-	// (UseBuildRequest, DisableCallBuildRequest). The generated
-	// router reads this via BuildRequestConfig() instead of the
-	// env-cached buildrequest.UseBuildRequest helper so two handlers
-	// in the same process can carry distinct configurations.
+	// (DisableCallBuildRequest). The generated router reads this via
+	// BuildRequestConfig() instead of the env-cached buildrequest
+	// helper so two handlers in the same process can carry distinct
+	// configurations.
 	buildRequestConfig bamlutils.BuildRequestConfig
 
 	// deBAMLConfig carries the per-handler BAML_REST_USE_DEBAML

--- a/dynclient/internal/generated/runtime_test.go
+++ b/dynclient/internal/generated/runtime_test.go
@@ -45,7 +45,6 @@ func TestRuntimeMakeAdapter(t *testing.T) {
 	}
 
 	wantBR := bamlutils.BuildRequestConfig{
-		UseBuildRequest:         true,
 		DisableCallBuildRequest: true,
 	}
 	adapter.SetBuildRequestConfig(wantBR)

--- a/dynclient/options.go
+++ b/dynclient/options.go
@@ -58,16 +58,6 @@ type config struct {
 	preserveSchemaOrderDefault bool
 }
 
-// WithUseBuildRequest mirrors the BAML_REST_USE_BUILD_REQUEST gate for a
-// single client. When enabled, the BuildRequest path drives dispatch for
-// supported providers.
-func WithUseBuildRequest(enabled bool) Option {
-	return func(c *config) error {
-		c.buildRequest.UseBuildRequest = enabled
-		return nil
-	}
-}
-
 // WithDisableCallBuildRequest mirrors BAML_REST_DISABLE_CALL_BUILD_REQUEST.
 // When true, the non-streaming Request API is treated as unsupported and
 // /call{,-with-raw} fall through to the stream-accumulation bridge or
@@ -83,11 +73,10 @@ func WithDisableCallBuildRequest(disabled bool) Option {
 // single client. When enabled, native de-BAML behaviour runs on routes
 // that expose a native seam — today, the native ctx.output_format
 // renderer on the dynamic BuildRequest route. dynclient never reads the
-// env var; callers opt in explicitly here. Distinct from
-// WithUseBuildRequest: the native output_format seam only exists on the
-// BuildRequest route, so enabling de-BAML without
-// WithUseBuildRequest leaves the request on the legacy BAML path for
-// this cut (route coupling tracked in #537).
+// env var; callers opt in explicitly here. The native output_format seam
+// lives on the BuildRequest route, which is unconditional as of #537, so
+// de-BAML reaches the native seam on capable BAML versions without any
+// route opt-in.
 func WithDeBAML(enabled bool) Option {
 	return func(c *config) error {
 		c.deBAML.Enabled = enabled
@@ -100,8 +89,8 @@ func WithDeBAML(enabled bool) Option {
 // root internal/schema + outputformat packages, so a caller in the root
 // module supplies the renderer (e.g. internal/debaml.Render). Without it,
 // WithDeBAML has no renderer wired and the dynamic path stays
-// BAML-as-today. Pairs with WithDeBAML (the enable switch) and
-// WithUseBuildRequest (the native seam only exists on that route, #537).
+// BAML-as-today. Pairs with WithDeBAML (the enable switch); the native
+// seam lives on the BuildRequest route, which is unconditional as of #537.
 func WithDeBAMLRenderer(render bamlutils.DeBAMLRenderFunc) Option {
 	return func(c *config) error {
 		c.deBAMLRender = render

--- a/dynclient/types.go
+++ b/dynclient/types.go
@@ -112,9 +112,9 @@ type MetadataPhase = bamlutils.MetadataPhase
 type RoundRobinInfo = bamlutils.RoundRobinInfo
 
 // BuildRequestConfig carries the per-client BuildRequest toggles. Public
-// callers configure these through WithUseBuildRequest /
-// WithDisableCallBuildRequest rather than constructing this struct
-// directly.
+// callers configure these through WithDisableCallBuildRequest rather than
+// constructing this struct directly. The BuildRequest route itself is
+// unconditional as of #537.
 type BuildRequestConfig = bamlutils.BuildRequestConfig
 
 // Logger is the minimal logger interface accepted by WithLogger; the

--- a/integration/bridge_test.go
+++ b/integration/bridge_test.go
@@ -32,7 +32,7 @@ import (
 // The bridge only makes sense with BuildRequest on, so the test skips on the
 // legacy leg where the flag would no-op.
 func TestCallBridge_ForcesStreamRequest(t *testing.T) {
-	if !ActuallyBuildRequest() {
+	if !HasBuildRequestSurface() {
 		t.Skip("bridge requires BuildRequest path; skipping on legacy or pre-0.219 runtimes")
 	}
 
@@ -260,7 +260,7 @@ func TestCallBridge_ForcesStreamRequest(t *testing.T) {
 // Requires the debug build tag (see cmd/build/build.sh), which the
 // integration testcontainer already enables.
 func TestCallBridge_MixedChainFallsThrough(t *testing.T) {
-	if !ActuallyBuildRequest() {
+	if !HasBuildRequestSurface() {
 		t.Skip("bridge requires BuildRequest path; skipping on legacy or pre-0.219 runtimes")
 	}
 

--- a/integration/bridge_test.go
+++ b/integration/bridge_test.go
@@ -37,7 +37,6 @@ func TestCallBridge_ForcesStreamRequest(t *testing.T) {
 	}
 
 	opts := matrixSetupOptions()
-	opts.UseBuildRequest = true
 	opts.RuntimeEnv = map[string]string{
 		// Forces IsCallProviderSupported to return false for every
 		// provider, routing /call{,-with-raw} through the stream-
@@ -266,7 +265,6 @@ func TestCallBridge_MixedChainFallsThrough(t *testing.T) {
 	}
 
 	opts := matrixSetupOptions()
-	opts.UseBuildRequest = true
 	opts.RuntimeEnv = map[string]string{
 		// Mark openai-generic as call-unsupported (but still stream-
 		// supported). Debug-tag only — no effect on release builds.

--- a/integration/cache_control_test.go
+++ b/integration/cache_control_test.go
@@ -149,11 +149,9 @@ func TestDynclientCacheControlMessageMetadataRoundTrip(t *testing.T) {
 				},
 			}
 
-			// Pin the BuildRequest path — the issue reporter ran into
-			// the bug with WithUseBuildRequest(true) explicitly. Don't
-			// rely on the global ActuallyBuildRequest() flag for this
-			// regression.
-			client := newDynclient(t, dynclient.WithUseBuildRequest(true))
+			// The BuildRequest route is unconditional (#537), so a plain
+			// dynclient drives this regression on capable BAML versions.
+			client := newDynclient(t)
 
 			resp, err := client.DynamicCall(ctx, libReq)
 			if err != nil {

--- a/integration/call_test.go
+++ b/integration/call_test.go
@@ -49,7 +49,7 @@ func TestCallEndpoint(t *testing.T) {
 			// retries, which the legacy path does not perform.
 			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLPath)
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestClient")
-			if ActuallyBuildRequest() {
+			if HasBuildRequestSurface() {
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
 				// Non-streaming /call on a BuildRequest-capable provider
 				// uses the Request API (block 1 wins before the stream-bridge
@@ -402,7 +402,7 @@ func TestCallWithRawEndpoint(t *testing.T) {
 			// shares the same header-emission path.
 			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLPath)
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestClient")
-			if ActuallyBuildRequest() {
+			if HasBuildRequestSurface() {
 				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "buildrequest")
 				// /call-with-raw on a BuildRequest-capable provider uses the
 				// Request API; the stream-bridge would report "streamrequest".

--- a/integration/client_defaults_test.go
+++ b/integration/client_defaults_test.go
@@ -36,12 +36,12 @@ func TestClientDefaults_AllowedRoleMetadata(t *testing.T) {
 		// Older BAML BuildRequest serializers dropped message-level
 		// metadata for some providers. BAML v0.222 preserves
 		// cache_control for the dynamic template shape used here after
-		// the class-free literal alias-bypass landed for #304, so this
-		// leg runs against both runtime paths. If a future supported
-		// BAML version regresses, narrow the skip to that version
-		// rather than reinstating a blanket UseBuildRequest skip — the
-		// blanket form would mask the openai-generic BuildRequest path
-		// the user originally reported on.
+		// the class-free literal alias-bypass landed for #304. The
+		// BuildRequest route is unconditional (#537), so this runs on the
+		// BuildRequest path whenever the BAML version exposes it. If a
+		// future supported BAML version regresses, narrow the skip to
+		// that version — the openai-generic BuildRequest path the user
+		// originally reported on must stay covered.
 
 		opts := matrixSetupOptions()
 		opts.RuntimeEnv = map[string]string{

--- a/integration/dynamic_debaml_oracle_a_test.go
+++ b/integration/dynamic_debaml_oracle_a_test.go
@@ -28,9 +28,8 @@ import (
 // is the output_format text, which for these fixtures must not.
 
 // debamlGate restricts the de-BAML wiring tests to a BAML version whose
-// BuildRequest API exposes the native seam. The dynclient clients below
-// force WithUseBuildRequest(true) regardless of the suite's container
-// mode, so this gates on the BAML version only.
+// BuildRequest API exposes the native seam. The BuildRequest route is
+// unconditional as of #537, so this gates on the BAML version only.
 func debamlGate(t *testing.T) {
 	t.Helper()
 	dynclientCallGate(t)
@@ -40,15 +39,15 @@ func debamlGate(t *testing.T) {
 }
 
 // newDeBAMLClients returns two in-process dynclients on the BuildRequest
-// route: one with de-BAML off (BAML-as-today) and one with de-BAML on. The
-// ON client is wired with the real native renderer (internal/debaml.Render)
-// via WithDeBAMLRenderer — dynclient is a separate module and cannot import
-// the renderer itself, so a root-module caller supplies it.
+// route (unconditional as of #537): one with de-BAML off (BAML-as-today)
+// and one with de-BAML on. The ON client is wired with the real native
+// renderer (internal/debaml.Render) via WithDeBAMLRenderer — dynclient is a
+// separate module and cannot import the renderer itself, so a root-module
+// caller supplies it.
 func newDeBAMLClients(t *testing.T) (off, on *dynclient.Client) {
 	t.Helper()
-	off = newDynclient(t, dynclient.WithUseBuildRequest(true))
+	off = newDynclient(t)
 	on = newDynclient(t,
-		dynclient.WithUseBuildRequest(true),
 		dynclient.WithDeBAML(true),
 		dynclient.WithDeBAMLRenderer(debaml.Render),
 	)
@@ -237,41 +236,40 @@ func TestDeBAMLOracleA_Streaming(t *testing.T) {
 	}
 }
 
-// TestDeBAMLOracleA_BuildRequestFlagSeparation pins the accepted route
-// coupling (#537): with BAML_REST_USE_BUILD_REQUEST off, the request stays
-// on the legacy BAML path and the de-BAML flag is a no-op, so flag-ON ==
-// flag-OFF even for a metadata-bearing schema (the seam is never reached).
-// This also proves the two flags are independent: WithDeBAML does not
-// implicitly enable BuildRequest.
-func TestDeBAMLOracleA_BuildRequestFlagSeparation(t *testing.T) {
+// TestDeBAMLOracleA_DeBAMLReachesSeamWithoutRouteOpt pins the post-#537
+// behaviour: the BuildRequest route is unconditional, so WithDeBAML(true)
+// reaches the native output_format seam WITHOUT any route opt-in. For a
+// metadata-bearing schema the native renderer surfaces metadata the
+// BAML-dynamic path drops, so flag-ON must DIFFER from flag-OFF even though
+// neither client passes a route option. This is the inverse of the
+// pre-#537 flag-separation contract, which expected a no-op because the
+// legacy route had no seam.
+func TestDeBAMLOracleA_DeBAMLReachesSeamWithoutRouteOpt(t *testing.T) {
 	debamlGate(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	scenarioID := "test-debaml-a-flagsep"
-	opts := setupNonStreamingScenario(t, scenarioID, oracleAMock)
+	opts := setupNonStreamingScenario(t, scenarioID, oracleBMock)
 	reg := dynRegistry(opts.ClientRegistry)
 
-	// Both clients leave BuildRequest OFF (the dynclient default); one
-	// still asks for de-BAML. The legacy route has no native seam, so the
-	// bodies must match even though the schema carries divergent metadata.
-	// The ON client has de-BAML fully enabled AND the renderer wired, so
-	// the no-op is attributable to the route (BuildRequest off), not a
-	// missing renderer.
-	legacyOff := newDynclient(t)
-	legacyOnButNoBuildRequest := newDynclient(t, dynclient.WithDeBAML(true), dynclient.WithDeBAMLRenderer(debaml.Render))
+	// Neither client passes any route option — the BuildRequest route is
+	// on by default (#537). Only the de-BAML flag differs, so a divergence
+	// proves WithDeBAML reaches the native seam on the unconditional route.
+	off := newDynclient(t)
+	on := newDynclient(t, dynclient.WithDeBAML(true), dynclient.WithDeBAMLRenderer(debaml.Render))
 
-	offBody := captureCallBody(t, ctx, legacyOff, scenarioID, dynclient.Request{
+	offBody := captureCallBody(t, ctx, off, scenarioID, dynclient.Request{
 		Messages:       []dynclient.Message{{Role: "system", PartsContent: []dynclient.ContentPart{{Type: "output_format"}}}, {Role: "user", TextContent: strPtr("Go.")}},
 		ClientRegistry: reg, OutputSchema: oracleBSchema(),
 	})
-	onBody := captureCallBody(t, ctx, legacyOnButNoBuildRequest, scenarioID, dynclient.Request{
+	onBody := captureCallBody(t, ctx, on, scenarioID, dynclient.Request{
 		Messages:       []dynclient.Message{{Role: "system", PartsContent: []dynclient.ContentPart{{Type: "output_format"}}}, {Role: "user", TextContent: strPtr("Go.")}},
 		ClientRegistry: reg, OutputSchema: oracleBSchema(),
 	})
 
-	if !bytes.Equal(offBody, onBody) {
-		t.Errorf("de-BAML must be a no-op off the BuildRequest route (accepted #537 coupling), but bodies differed\n--- OFF ---\n%s\n--- ON ---\n%s", offBody, onBody)
+	if bytes.Equal(offBody, onBody) {
+		t.Errorf("WithDeBAML must reach the native seam on the unconditional BuildRequest route (#537), but flag-ON == flag-OFF\n--- OFF ---\n%s\n--- ON ---\n%s", offBody, onBody)
 	}
 }

--- a/integration/dynamic_debaml_rest_test.go
+++ b/integration/dynamic_debaml_rest_test.go
@@ -18,13 +18,15 @@ import (
 //
 // Oracle B proves native metadata appears for the in-process dynclient.
 // This test proves the SAME on the REST production path: a dedicated
-// baml-rest container started with BOTH BAML_REST_USE_BUILD_REQUEST=true
-// AND BAML_REST_USE_DEBAML=true must emit the native ctx.output_format
-// block (with the metadata BAML's dynamic TypeBuilder drops) into the
-// provider request — and the shared, flag-OFF TestEnv must not. This
-// guards the gap where the production generated adapter never actually
-// emitted the de-BAML injection (codegen only wired it for dynclient),
-// so BAML_REST_USE_DEBAML was inert for REST traffic.
+// baml-rest container started with BAML_REST_USE_DEBAML=true must emit the
+// native ctx.output_format block (with the metadata BAML's dynamic
+// TypeBuilder drops) into the provider request — and the shared,
+// de-BAML-OFF TestEnv must not. The BuildRequest route is unconditional as
+// of #537, so both containers share the same route and the differential
+// isolates exactly BAML_REST_USE_DEBAML. This guards the gap where the
+// production generated adapter never actually emitted the de-BAML injection
+// (codegen only wired it for dynclient), so BAML_REST_USE_DEBAML was inert
+// for REST traffic.
 
 // restMetadataSchema mirrors oracleBSchema in the HTTP/testutil shape:
 // field description + alias, class description (+ a class alias that must
@@ -69,19 +71,19 @@ func restOutputFormatFirstMessage() []testutil.DynamicMessage {
 const restDeBAMLMock = `{"title":"t","addr":{"street":"s","city":"c"},"status":"ACTIVE"}`
 
 // TestDeBAMLRest_MetadataAppearsOnProductionPath spins a dedicated
-// container with both flags on, sends a metadata-bearing dynamic request,
-// and asserts the native metadata is in the captured provider body — the
+// container with de-BAML on, sends a metadata-bearing dynamic request, and
+// asserts the native metadata is in the captured provider body — the
 // REST-production proof that BAML_REST_USE_DEBAML is live. The shared
-// flag-OFF TestEnv provides the negative leg.
+// de-BAML-OFF TestEnv provides the negative leg.
 func TestDeBAMLRest_MetadataAppearsOnProductionPath(t *testing.T) {
-	// The native seam exists only on the BuildRequest route (BAML >= 0.219).
+	// The native seam exists only on the BuildRequest route (BAML >= 0.219),
+	// which is unconditional as of #537.
 	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") {
 		t.Skip("Skipping: de-BAML REST seam requires the BuildRequest route (BAML >= 0.219.0)")
 	}
 
-	// --- flag-ON: dedicated container with both flags ---
+	// --- de-BAML ON: dedicated container with the de-BAML flag ---
 	opts := matrixSetupOptions()
-	opts.UseBuildRequest = true // → container BAML_REST_USE_BUILD_REQUEST=true
 	opts.RuntimeEnv = map[string]string{
 		"BAML_REST_USE_DEBAML": "true",
 	}
@@ -136,18 +138,11 @@ func TestDeBAMLRest_MetadataAppearsOnProductionPath(t *testing.T) {
 		t.Errorf("flag-ON REST block unexpectedly contains class alias %q (canonical names only)\n--- ON ---\n%s", "PostalAddress", onBlock)
 	}
 
-	// flag-OFF differential — only run when the shared TestEnv is on the
-	// SAME BuildRequest route as the dedicated ON container, so the
-	// comparison isolates exactly BAML_REST_USE_DEBAML and never the
-	// route. On the legacy matrix leg the shared env uses a different
-	// route, so skip it there (the route-independent ON assertions above
-	// already prove de-BAML is active). The ON container forces
-	// UseBuildRequest=true; ActuallyBuildRequest() reports whether the
-	// shared env does too.
-	if !ActuallyBuildRequest() {
-		t.Log("flag-OFF differential skipped: shared TestEnv is on the legacy route this leg; ON-only assertions cover the production proof")
-		return
-	}
+	// de-BAML-OFF differential — the BuildRequest route is unconditional
+	// (#537), so the shared TestEnv runs the SAME route as the dedicated ON
+	// container on BAML >= 0.219 (already guaranteed by the skip above).
+	// The comparison therefore isolates exactly BAML_REST_USE_DEBAML and
+	// never the route.
 	offScenario := "test-debaml-rest-off"
 	registerDeBAMLRestScenario(t, MockClient, offScenario)
 	offBlock := restCaptureBlock(t, BAMLClient, MockClient, TestEnv.MockLLMInternal, offScenario)

--- a/integration/dynclient_test.go
+++ b/integration/dynclient_test.go
@@ -445,11 +445,14 @@ func TestDynclientNestedDynamicTypesUnwrapped(t *testing.T) {
 	}
 }
 
-// TestDynclientBuildRequestOptionsSmoke verifies that the WithUseBuildRequest
-// option threads through to the worker handler — the call must succeed
-// against the mock LLM with the option enabled. The HTTP path's
-// equivalent is gated on env, so this test only validates that the
-// option doesn't break the happy path.
+// TestDynclientBuildRequestOptionsSmoke verifies that the surviving
+// WithDisableCallBuildRequest option threads through to the worker handler
+// — the call must succeed against the mock LLM with the option enabled
+// (the /call request bridges through StreamRequest instead of the
+// non-streaming Request API). The BuildRequest route itself is
+// unconditional as of #537, so there is no route-selection option to
+// exercise; this only validates that the surviving option doesn't break
+// the happy path.
 func TestDynclientBuildRequestOptionsSmoke(t *testing.T) {
 	dynclientCallGate(t)
 
@@ -467,11 +470,11 @@ func TestDynclientBuildRequestOptionsSmoke(t *testing.T) {
 	}
 
 	client := newDynclient(t,
-		dynclient.WithUseBuildRequest(ActuallyBuildRequest()),
+		dynclient.WithDisableCallBuildRequest(true),
 	)
 	libResp, err := client.DynamicCall(ctx, libReq)
 	if err != nil {
-		t.Fatalf("Library DynamicCall with build-request option: %v", err)
+		t.Fatalf("Library DynamicCall with disable-call-build-request option: %v", err)
 	}
 	var decoded map[string]any
 	if err := sonic.Unmarshal(libResp.Data, &decoded); err != nil {

--- a/integration/error_taxonomy_test.go
+++ b/integration/error_taxonomy_test.go
@@ -406,8 +406,8 @@ func TestBuildRequestClassification_ParseErrorFromProseStreamWithRaw(t *testing.
 	// `{"error":..., "code":..., "details":...}` (see
 	// SSEStreamWriterPublisher.PublishError / NDJSONEvent).
 	var payload struct {
-		Error   string          `json:"error"`
-		Code    string          `json:"code"`
+		Error   string             `json:"error"`
+		Code    string             `json:"code"`
 		Details stdjson.RawMessage `json:"details"`
 	}
 	if err := sonic.Unmarshal(errEvent.Data, &payload); err != nil {

--- a/integration/error_taxonomy_test.go
+++ b/integration/error_taxonomy_test.go
@@ -35,7 +35,7 @@ import (
 // is only exercised on no-surface (pre-0.219) BAML versions.
 func requireLegacyMode(t *testing.T) {
 	t.Helper()
-	if ActuallyBuildRequest() {
+	if HasBuildRequestSurface() {
 		t.Skip("legacy classifier test; requires a BAML version with no BuildRequest surface (pre-0.219)")
 	}
 }
@@ -281,7 +281,7 @@ func TestLegacyClassification_ParseEndpointGarbage(t *testing.T) {
 // modern matrix cell.
 func requireBuildRequestMode(t *testing.T) {
 	t.Helper()
-	if !ActuallyBuildRequest() {
+	if !HasBuildRequestSurface() {
 		t.Skip("BuildRequest classifier test; requires a BuildRequest surface (BAML >= 0.219)")
 	}
 }

--- a/integration/error_taxonomy_test.go
+++ b/integration/error_taxonomy_test.go
@@ -19,24 +19,24 @@ import (
 // These tests pin the legacy CallStream+OnTick path's conservative
 // string-prefix classifier end-to-end. The classifier itself is a
 // fall-through inside cmd/worker.classifyBAMLError that only fires
-// when no typed BuildRequest surface matched — so on the
-// BuildRequest-mode CI leg these tests would silently validate PR 2's
-// typed branch instead of the new prefix arms. forcing legacy mode via
-// BAML_REST_USE_BUILD_REQUEST=false (consumed by TestMain into the
-// shared TestEnv) is the only way to actually exercise the new code.
+// when no typed BuildRequest surface matched. The BuildRequest route is
+// unconditional as of #537, so the legacy classifier is only reachable on
+// BAML versions that expose no Request/StreamRequest surface (pre-0.219) —
+// those are the cells where these tests exercise the new prefix arms.
 //
 // The unit tests in cmd/worker/error_classify_test.go cover the prefix
 // matrix in isolation; these integration tests verify the wiring from
 // BAML's FFI string through the worker bridge to the HTTP envelope's
 // code / details fields.
 
-// requireLegacyMode skips the calling test when the shared TestEnv is
-// running BuildRequest. Mirrors the existing TestLegacyMode_* pattern
-// in roundrobin_overrides_test.go.
+// requireLegacyMode skips the calling test on BAML versions that DO expose
+// a BuildRequest surface — there the route is taken unconditionally (#537)
+// and the legacy classifier is unreachable. The legacy prefix classifier
+// is only exercised on no-surface (pre-0.219) BAML versions.
 func requireLegacyMode(t *testing.T) {
 	t.Helper()
 	if ActuallyBuildRequest() {
-		t.Skip("legacy classifier test; requires BAML_REST_USE_BUILD_REQUEST=false")
+		t.Skip("legacy classifier test; requires a BAML version with no BuildRequest surface (pre-0.219)")
 	}
 }
 
@@ -272,15 +272,17 @@ func TestLegacyClassification_ParseEndpointGarbage(t *testing.T) {
 	})
 }
 
-// requireBuildRequestMode skips the calling test when the shared
-// TestEnv is NOT running BuildRequest. Inverse of requireLegacyMode —
-// pairs the legacy classifier coverage above with BuildRequest-path
-// coverage so the details.raw contract (#256) has end-to-end pinning
-// on both orchestrators.
+// requireBuildRequestMode skips the calling test on BAML versions that
+// expose no BuildRequest surface (pre-0.219), where dispatch falls through
+// to legacy. Inverse of requireLegacyMode — pairs the legacy classifier
+// coverage above with BuildRequest-path coverage so the details.raw
+// contract (#256) has end-to-end pinning on both orchestrators. The
+// BuildRequest route is unconditional as of #537, so this runs in every
+// modern matrix cell.
 func requireBuildRequestMode(t *testing.T) {
 	t.Helper()
 	if !ActuallyBuildRequest() {
-		t.Skip("BuildRequest classifier test; requires BAML_REST_USE_BUILD_REQUEST=true on BAML >= 0.219")
+		t.Skip("BuildRequest classifier test; requires a BuildRequest surface (BAML >= 0.219)")
 	}
 }
 

--- a/integration/fallback_test.go
+++ b/integration/fallback_test.go
@@ -182,7 +182,7 @@ func TestFallbackCall(t *testing.T) {
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackSecondary")
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
 			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
-			if ActuallyBuildRequest() {
+			if HasBuildRequestSurface() {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
@@ -259,7 +259,7 @@ func TestFallbackCall(t *testing.T) {
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackTertiary")
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
 			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
-			if ActuallyBuildRequest() {
+			if HasBuildRequestSurface() {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
@@ -419,7 +419,7 @@ func TestFallbackCallWithRaw(t *testing.T) {
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerClient, "FallbackSecondary")
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
 			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
-			if ActuallyBuildRequest() {
+			if HasBuildRequestSurface() {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
@@ -488,7 +488,7 @@ func TestFallbackStream(t *testing.T) {
 		// not share that behavior, so only assert the exact streaming hit counts
 		// on versions that use the BuildRequest fallback orchestrator (the
 		// BuildRequest route is unconditional as of #537).
-		if ActuallyBuildRequest() {
+		if HasBuildRequestSurface() {
 			assertHitCounts(t, map[string]int{"fallback-primary": 1, "fallback-secondary": 0})
 		}
 	})
@@ -567,7 +567,7 @@ func TestFallbackStream(t *testing.T) {
 			t.Errorf("planned.RetryMax: got %v, want 3", tracker.planned.RetryMax)
 		}
 		wantChain := []string{"FallbackPrimary", "FallbackSecondary"}
-		if ActuallyBuildRequest() {
+		if HasBuildRequestSurface() {
 			if !equalSliceStrings(tracker.planned.Chain, wantChain) {
 				t.Errorf("planned.Chain: got %v, want %v", tracker.planned.Chain, wantChain)
 			}

--- a/integration/fallback_test.go
+++ b/integration/fallback_test.go
@@ -486,8 +486,9 @@ func TestFallbackStream(t *testing.T) {
 		// BAML < 0.219.0 uses the legacy streaming fallback path, which may
 		// contact the secondary child even when the primary succeeds. Unary does
 		// not share that behavior, so only assert the exact streaming hit counts
-		// on versions that use the BuildRequest fallback orchestrator.
-		if bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0") && UseBuildRequest {
+		// on versions that use the BuildRequest fallback orchestrator (the
+		// BuildRequest route is unconditional as of #537).
+		if ActuallyBuildRequest() {
 			assertHitCounts(t, map[string]int{"fallback-primary": 1, "fallback-secondary": 0})
 		}
 	})

--- a/integration/http_client_alpn_test.go
+++ b/integration/http_client_alpn_test.go
@@ -35,7 +35,7 @@ import (
 // trust the mock's self-signed cert). The versioned matrix only runs the
 // auto/fasthttp arms on BuildRequest cells anyway.
 func TestHTTPClientALPNSelection(t *testing.T) {
-	if !ActuallyBuildRequest() {
+	if !HasBuildRequestSurface() {
 		t.Skip("http-client selection only applies to the BuildRequest path (llmhttp); skipping on legacy CallStream")
 	}
 	if TestEnv.MockLLMInternalTLS == "" {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -75,13 +75,14 @@ func matrixSetupOptions() testutil.SetupOptions {
 	}
 }
 
-// ActuallyBuildRequest reports whether a request is genuinely routed through
-// the BuildRequest orchestrator. The BuildRequest route is unconditional as
-// of #537, so the only remaining gate is BAML runtime capability: the
-// Request / StreamRequest APIs the route depends on first exist in BAML
-// 0.219.0. Older runtimes expose no BuildRequest surface and fall through to
-// the legacy path.
-func ActuallyBuildRequest() bool {
+// HasBuildRequestSurface reports whether the BAML runtime exposes the
+// BuildRequest surface — i.e. the Request / StreamRequest APIs the route
+// depends on, which first exist in BAML 0.219.0. This is a runtime
+// capability check, not a routing decision: the BuildRequest route is
+// unconditional as of #537, so on a runtime that exposes the surface every
+// supported request takes it; older runtimes expose no surface and fall
+// through to the legacy path.
+func HasBuildRequestSurface() bool {
 	return bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0")
 }
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -46,10 +46,6 @@ var BAMLSourcePath string
 // local runs, which keep building the cffi lib from source.
 var PrebuiltCffiDir string
 
-// UseBuildRequest is true when the test container runs the BuildRequest path.
-// Set in TestMain from the BAML_REST_USE_BUILD_REQUEST env var.
-var UseBuildRequest bool
-
 // Matrix-derived setup inputs populated by TestMain before m.Run. Dedicated
 // tests read these via matrixSetupOptions so a new axis added to TestMain
 // propagates without each callsite needing to be updated.
@@ -75,18 +71,18 @@ func matrixSetupOptions() testutil.SetupOptions {
 		BAMLSource:      BAMLSourcePath,
 		PrebuiltCffiDir: PrebuiltCffiDir,
 		UnaryServer:     unaryServer,
-		UseBuildRequest: UseBuildRequest,
 		InProcess:       inProcessBuild,
 	}
 }
 
 // ActuallyBuildRequest reports whether a request is genuinely routed through
-// the BuildRequest orchestrator given both the runtime env gate and the BAML
-// runtime version. BuildRequest requires the Request / StreamRequest APIs
-// which only exist from BAML 0.219.0; older runtimes fall through to the
-// legacy path even when BAML_REST_USE_BUILD_REQUEST=true.
+// the BuildRequest orchestrator. The BuildRequest route is unconditional as
+// of #537, so the only remaining gate is BAML runtime capability: the
+// Request / StreamRequest APIs the route depends on first exist in BAML
+// 0.219.0. Older runtimes expose no BuildRequest surface and fall through to
+// the legacy path.
 func ActuallyBuildRequest() bool {
-	return UseBuildRequest && bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0")
+	return bamlutils.IsVersionAtLeast(BAMLVersion, "0.219.0")
 }
 
 // skipIfInProcess short-circuits a test that depends on subprocess-only
@@ -98,18 +94,6 @@ func skipIfInProcess(t *testing.T, reason string) {
 	t.Helper()
 	if inProcessBuild {
 		t.Skipf("in-process build: %s", reason)
-	}
-}
-
-// parseBoolEnv parses a boolean environment variable using the same accepted
-// literals as the server's UseBuildRequest parser: 1/true/yes/on → true,
-// everything else (including empty) → false.
-func parseBoolEnv(value string) bool {
-	switch strings.ToLower(value) {
-	case "1", "true", "yes", "on":
-		return true
-	default:
-		return false
 	}
 }
 
@@ -474,8 +458,6 @@ func TestMain(m *testing.M) {
 			os.Exit(1)
 		}
 	}
-	UseBuildRequest = parseBoolEnv(os.Getenv("BAML_REST_USE_BUILD_REQUEST"))
-
 	// The overall setup budget is mode-aware and centralized in testutil
 	// (#424): baml-source builds the Rust cffi stage and need the larger
 	// budget, the light jobs a smaller one. This ctx is NOT covered by
@@ -496,7 +478,6 @@ func TestMain(m *testing.M) {
 	println("  Mock LLM Internal URL:", TestEnv.MockLLMInternal)
 	println("  BAML REST URL:", TestEnv.BAMLRestURL)
 	println("  Unary URL:", TestEnv.BAMLRestUnaryURL)
-	println("  UseBuildRequest:", strconv.FormatBool(UseBuildRequest))
 	println("  InProcess:", strconv.FormatBool(inProcessBuild))
 
 	// Create clients

--- a/integration/roundrobin_overrides_test.go
+++ b/integration/roundrobin_overrides_test.go
@@ -479,7 +479,7 @@ func TestInvalidRuntimeRoundRobinStartReturnsLegacyError(t *testing.T) {
 // is only reachable on no-surface (pre-0.219) BAML versions — this test
 // runs there.
 func TestLegacyModeHonorsRuntimeFallbackStrategyOverride(t *testing.T) {
-	if ActuallyBuildRequest() {
+	if HasBuildRequestSurface() {
 		t.Skip("legacy-mode regression test; requires a BAML version with no BuildRequest surface (pre-0.219)")
 	}
 	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
@@ -581,7 +581,7 @@ func TestLegacyModeHonorsRuntimeFallbackStrategyOverride(t *testing.T) {
 // is only reachable on no-surface (pre-0.219) BAML versions — this test
 // runs there.
 func TestLegacyModeSupportsDynamicFallbackPrimary(t *testing.T) {
-	if ActuallyBuildRequest() {
+	if HasBuildRequestSurface() {
 		t.Skip("legacy-mode regression test; requires a BAML version with no BuildRequest surface (pre-0.219)")
 	}
 	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {

--- a/integration/roundrobin_overrides_test.go
+++ b/integration/roundrobin_overrides_test.go
@@ -466,20 +466,21 @@ func TestInvalidRuntimeRoundRobinStartReturnsLegacyError(t *testing.T) {
 }
 
 // TestLegacyModeHonorsRuntimeFallbackStrategyOverride pins that when
-// a request falls through to legacy (UseBuildRequest=false, or BR-
-// unsupported children), the legacy registry view preserves explicit
-// fallback-parent overrides. BAML must execute the runtime chain and
-// the static children are NEVER hit. We swap the parent's strategy
-// to point at a fully-dynamic child (RuntimePrimary, defined here in
-// the registry only) pointing at the tertiary mock scenario, so a
-// hit on tertiary proves the runtime override was honoured end-to-end.
+// a request falls through to legacy (a BAML version with no BuildRequest
+// surface, or BR-unsupported children), the legacy registry view
+// preserves explicit fallback-parent overrides. BAML must execute the
+// runtime chain and the static children are NEVER hit. We swap the
+// parent's strategy to point at a fully-dynamic child (RuntimePrimary,
+// defined here in the registry only) pointing at the tertiary mock
+// scenario, so a hit on tertiary proves the runtime override was honoured
+// end-to-end.
 //
-// Skipped on the BuildRequest-mode CI leg because this test
-// specifically exercises legacy dispatch — it relies on the existing
-// TestEnv being legacy-mode.
+// The BuildRequest route is unconditional as of #537, so legacy dispatch
+// is only reachable on no-surface (pre-0.219) BAML versions — this test
+// runs there.
 func TestLegacyModeHonorsRuntimeFallbackStrategyOverride(t *testing.T) {
 	if ActuallyBuildRequest() {
-		t.Skip("legacy-mode regression test; relies on TestEnv being UseBuildRequest=false")
+		t.Skip("legacy-mode regression test; requires a BAML version with no BuildRequest surface (pre-0.219)")
 	}
 	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
 		waitForHealthy(t, 30*time.Second)
@@ -576,10 +577,12 @@ func TestLegacyModeHonorsRuntimeFallbackStrategyOverride(t *testing.T) {
 // pointing at FallbackPrimary, with Primary set to the parent name —
 // BAML resolves the primary, walks the chain, hits FallbackPrimary.
 //
-// Skipped on the BuildRequest-mode CI leg.
+// The BuildRequest route is unconditional as of #537, so legacy dispatch
+// is only reachable on no-surface (pre-0.219) BAML versions — this test
+// runs there.
 func TestLegacyModeSupportsDynamicFallbackPrimary(t *testing.T) {
 	if ActuallyBuildRequest() {
-		t.Skip("legacy-mode regression test; relies on TestEnv being UseBuildRequest=false")
+		t.Skip("legacy-mode regression test; requires a BAML version with no BuildRequest surface (pre-0.219)")
 	}
 	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
 		waitForHealthy(t, 30*time.Second)
@@ -634,58 +637,12 @@ func TestLegacyModeSupportsDynamicFallbackPrimary(t *testing.T) {
 	})
 }
 
-// TestLegacyMode_RR_NoCentralization pins that with
-// BAML_REST_USE_BUILD_REQUEST=false on a 0.219+ adapter, the flag
-// is a full kill switch — baml-rest's centralised RR (resolver,
-// in-process coordinator, RemoteAdvancer) must NOT engage, and
-// BAML's per-worker runtime rotation owns the strategy. The
-// observable contract: the request still succeeds, but the
-// X-BAML-RoundRobin-* headers are absent because no baml-rest RR
-// resolution happened. ResolveEffectiveClient is gated on
-// `supportsWithClient && __useBuildRequest`, so with the flag off
-// __rrInfo never gets populated and no RR headers leak.
-//
-// Skipped on the BuildRequest-mode CI leg — this tests the
-// flag-off semantics specifically.
-func TestLegacyMode_RR_NoCentralization(t *testing.T) {
-	if ActuallyBuildRequest() {
-		t.Skip("legacy-mode regression test; relies on TestEnv being UseBuildRequest=false")
-	}
-	forEachUnaryClient(t, func(t *testing.T, client *testutil.BAMLRestClient) {
-		waitForHealthy(t, 30*time.Second)
-		clearRoundRobinScenarios(t)
-		registerAllGreetingScenarios(t, []string{"fallback-primary", "fallback-secondary"})
-
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		resp, err := client.Call(ctx, testutil.CallRequest{
-			Method: "GetGreetingRoundRobinPair",
-			Input:  map[string]any{"name": "World"},
-		})
-		if err != nil {
-			t.Fatalf("Call failed: %v", err)
-		}
-		if resp.StatusCode != 200 {
-			t.Fatalf("expected 200 (BAML's per-worker RR should still serve the request); got %d body=%s err=%s", resp.StatusCode, string(resp.Body), resp.Error)
-		}
-		// The smoking-gun assertion: when the flag is off, baml-rest
-		// must NOT have populated __rrInfo, so the X-BAML-RoundRobin-*
-		// header set is absent. BAML's runtime rotation on each
-		// worker handled the request, but its rotation is per-worker
-		// and not surfaced through baml-rest's planned metadata.
-		for _, name := range []string{
-			testutil.HeaderBAMLRoundRobinName,
-			testutil.HeaderBAMLRoundRobinSelected,
-			testutil.HeaderBAMLRoundRobinIndex,
-		} {
-			if got := resp.Headers.Get(name); got != "" {
-				t.Errorf("flag-off path leaked %s=%q — baml-rest RR engaged when it should be reverted to BAML runtime", name, got)
-			}
-		}
-		testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPath, "legacy")
-	})
-}
+// Note: the former TestLegacyMode_RR_NoCentralization was removed in #537.
+// It pinned the retired BAML_REST_USE_BUILD_REQUEST=false kill switch
+// (centralised RR must not engage on a 0.219+ adapter when the flag was
+// off). The BuildRequest route is now unconditional, so that operator-
+// facing behaviour intentionally no longer exists and there is nothing to
+// assert.
 
 // TestNestedStrategyOverrides_ValidRRChildHonoured pins the runtime-
 // override path end-to-end for a fallback whose nested RR child has a

--- a/integration/roundrobin_test.go
+++ b/integration/roundrobin_test.go
@@ -120,7 +120,7 @@ func assertBalanced(t *testing.T, ids []string, total int) {
 // tests stay DRY.
 func skipIfNoBuildRequest(t *testing.T) {
 	t.Helper()
-	if !ActuallyBuildRequest() {
+	if !HasBuildRequestSurface() {
 		t.Skip("Skipping: baml-roundrobin BuildRequest-path tests require a BuildRequest surface (BAML >= 0.219.0)")
 	}
 }

--- a/integration/roundrobin_test.go
+++ b/integration/roundrobin_test.go
@@ -108,17 +108,20 @@ func assertBalanced(t *testing.T, ids []string, total int) {
 	}
 }
 
-// skipIfNoBuildRequest skips the calling test when the container is
-// running the legacy dispatch path. The centralised round-robin wiring
-// (SharedState, RemoteAdvancer, pool-level request_id) only matters on
-// the BuildRequest path; the legacy path delegates rotation to BAML's
-// runtime and doesn't guarantee the planned-metadata headers or per-
-// child hit counts these tests assert. Hoisted out of the per-test
-// inline Skip so the four RR tests stay DRY.
+// skipIfNoBuildRequest skips the calling test on BAML versions that expose
+// no BuildRequest surface (pre-0.219), where dispatch falls through to the
+// legacy path. The centralised round-robin wiring (SharedState,
+// RemoteAdvancer, pool-level request_id) only matters on the BuildRequest
+// path; the legacy path delegates rotation to BAML's runtime and doesn't
+// guarantee the planned-metadata headers or per-child hit counts these
+// tests assert. The BuildRequest route itself is unconditional as of #537,
+// so this now gates purely on BAML capability and runs in every modern
+// matrix cell. Hoisted out of the per-test inline Skip so the four RR
+// tests stay DRY.
 func skipIfNoBuildRequest(t *testing.T) {
 	t.Helper()
 	if !ActuallyBuildRequest() {
-		t.Skip("Skipping: baml-roundrobin BuildRequest-path tests require BAML >= 0.219.0 AND BAML_REST_USE_BUILD_REQUEST=true")
+		t.Skip("Skipping: baml-roundrobin BuildRequest-path tests require a BuildRequest surface (BAML >= 0.219.0)")
 	}
 }
 

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -98,7 +98,7 @@ func TestStreamEndpoint(t *testing.T) {
 		// derivation, RetryCount vs BamlCallCount, etc.) are checked by
 		// the appropriate tracker assertion below.
 		assertFirstSemanticEventIsMetadata(t, firstSemanticEvent)
-		if ActuallyBuildRequest() {
+		if HasBuildRequestSurface() {
 			tracker.assertBuildRequestInvariants()
 		} else {
 			tracker.assertLegacyInvariants()
@@ -289,7 +289,7 @@ func TestStreamMidStreamFailure(t *testing.T) {
 		// own Rust loop on the legacy path), so the server-side assertion is
 		// skipped there and the legacy client-bounded shape is exercised
 		// instead.
-		serverSideIdle := inProcessBuild && ActuallyBuildRequest()
+		serverSideIdle := inProcessBuild && HasBuildRequestSurface()
 
 		// Generous client ctx so that, when serverSideIdle is true, the
 		// SERVER-side idle timeout — not the client deadline — is what ends
@@ -1056,7 +1056,7 @@ func TestStreamNDJSONEndpoint(t *testing.T) {
 
 		// NDJSON metadata parity with the SSE path.
 		assertFirstSemanticEventIsMetadata(t, firstSemanticEvent)
-		if ActuallyBuildRequest() {
+		if HasBuildRequestSurface() {
 			tracker.assertBuildRequestInvariants()
 		} else {
 			tracker.assertLegacyInvariants()
@@ -1390,7 +1390,7 @@ func TestStreamWithRawNDJSONEndpoint(t *testing.T) {
 		// with the correct ordering, and planned must arrive BEFORE any
 		// raw/data event so clients see routing info first.
 		assertFirstSemanticEventIsMetadata(t, firstSemanticEvent)
-		if ActuallyBuildRequest() {
+		if HasBuildRequestSurface() {
 			tracker.assertBuildRequestInvariants()
 		} else {
 			tracker.assertLegacyInvariants()
@@ -1834,7 +1834,7 @@ func TestStreamWithRawEndpoint(t *testing.T) {
 		// with the correct ordering, and planned must arrive BEFORE any
 		// raw/data event so clients see routing info first.
 		assertFirstSemanticEventIsMetadata(t, firstSemanticEvent)
-		if ActuallyBuildRequest() {
+		if HasBuildRequestSurface() {
 			tracker.assertBuildRequestInvariants()
 		} else {
 			tracker.assertLegacyInvariants()

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
-	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -122,12 +121,6 @@ type SetupOptions struct {
 
 	// UnaryServer enables the opt-in chi/net-http unary server on port 8081.
 	UnaryServer bool
-
-	// UseBuildRequest enables the BuildRequest/StreamRequest path inside
-	// the container. When false the container uses the legacy
-	// CallStream+OnTick path. This must be forwarded from the host env
-	// so that the CI matrix leg actually toggles the code path under test.
-	UseBuildRequest bool
 
 	// InProcess builds the baml-rest binary without the `subprocess`
 	// build tag so the server and worker handler share one OS process.
@@ -665,7 +658,8 @@ const HTTPClientSelectorEnvVar = "BAML_REST_HTTP_CLIENT"
 
 // buildContainerEnv returns the env map passed to the baml-rest container.
 // Entries in opts.RuntimeEnv take precedence over the shared defaults, so a
-// test can override BAML_LOG or BAML_REST_USE_BUILD_REQUEST if it needs to.
+// test can override BAML_LOG or BAML_REST_DISABLE_CALL_BUILD_REQUEST if it
+// needs to.
 //
 // This is the single chokepoint where every baml-rest container's env is
 // built — matrix and dedicated tests alike — so the host BAML_REST_HTTP_CLIENT
@@ -676,10 +670,13 @@ const HTTPClientSelectorEnvVar = "BAML_REST_HTTP_CLIENT"
 // preserving precedence: an explicit opts.RuntimeEnv[BAML_REST_HTTP_CLIENT]
 // pin is applied last and wins, so a test that deliberately pins a backend is
 // never overridden by the host env.
+//
+// Note: the BuildRequest route is unconditional as of #537, so there is no
+// BAML_REST_USE_BUILD_REQUEST forwarding here — the route is always attempted
+// when the BAML version exposes a Request/StreamRequest surface.
 func buildContainerEnv(opts SetupOptions) map[string]string {
 	env := map[string]string{
-		"BAML_LOG":                    "debug",
-		"BAML_REST_USE_BUILD_REQUEST": strconv.FormatBool(opts.UseBuildRequest),
+		"BAML_LOG": "debug",
 	}
 	// Forward the host http-client selector when set (non-empty). Set before
 	// the RuntimeEnv loop so an explicit RuntimeEnv pin overrides it; left

--- a/worker/handler.go
+++ b/worker/handler.go
@@ -32,8 +32,9 @@ import (
 //   - SharedState nil: the handler logs the existing once-per-process
 //     warning the first time a request tries to use round-robin shared
 //     state, then falls back to the in-process Coordinator.
-//   - BuildRequest: zero value disables the BuildRequest path on this
-//     handler and propagates to the generated router via the adapter's
+//   - BuildRequest: zero value leaves the BuildRequest route on (it is
+//     unconditional as of #537) with DisableCallBuildRequest off. The
+//     config propagates to the generated router via the adapter's
 //     BuildRequestConfig() accessor.
 //   - BaseURLRewrites nil: no per-handler URL rewrites — the worker
 //     skips the rewrite pass before SetClientRegistry; the per-handler

--- a/worker/runtime_test.go
+++ b/worker/runtime_test.go
@@ -133,14 +133,15 @@ func TestHandlerParseMissingMethod(t *testing.T) {
 // the same runtime but different BuildRequest configs install the
 // matching value on their adapters — no leakage through a shared
 // global. This is the load-bearing assertion for the dynclient seam:
-// generated routers read `adapter.BuildRequestConfig().UseBuildRequest`,
+// generated routers read `adapter.BuildRequestConfig().DisableCallBuildRequest`,
 // and that value MUST be the per-handler choice rather than a process-
-// wide env cache.
+// wide env cache. (The BuildRequest route itself is unconditional as of
+// #537 — DisableCallBuildRequest is the only remaining per-handler knob.)
 func TestHandlerPerInstanceBuildRequestConfig(t *testing.T) {
 	t.Parallel()
 
-	cfgA := bamlutils.BuildRequestConfig{UseBuildRequest: true, DisableCallBuildRequest: false}
-	cfgB := bamlutils.BuildRequestConfig{UseBuildRequest: false, DisableCallBuildRequest: true}
+	cfgA := bamlutils.BuildRequestConfig{DisableCallBuildRequest: false}
+	cfgB := bamlutils.BuildRequestConfig{DisableCallBuildRequest: true}
 
 	makeMethod := func(captured **fakeAdapter) bamlutils.StreamingMethod {
 		return bamlutils.StreamingMethod{


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

Closes #537. Makes the BuildRequest route **always-on** and retires the `BAML_REST_USE_BUILD_REQUEST` gate.

## What changes

The BuildRequest/StreamRequest route is now attempted **unconditionally** whenever the generated BAML client exposes a `Request` or `StreamRequest` surface (BAML >= 0.219). The legacy `CallStream+OnTick` route remains reachable only for unsupported/empty providers and BAML versions with no BuildRequest surface. Today, unset env meant the server/worker defaulted to legacy; after this PR, all BuildRequest-capable supported traffic uses BuildRequest by default.

### Generated router + generator
- Stop emitting/reading `__useBuildRequest`; the Request / StreamRequest / call-bridge landing blocks always attempt for capable adapters.
- Run `ResolveEffectiveClient` unconditionally on `supportsWithClient` adapters.
- Keep `__brCfg` only for `DisableCallBuildRequest` (declared only when a consumer exists, so a streaming-only adapter doesn't emit an unused variable).
- Stop synthesizing `PathReasonBuildRequestDisabled` — the constant is kept for metrics/dashboard compatibility but is never emitted.
- Regenerated `dynclient/internal/generated/adapter.go` + `adapter/adapter.go` via `genadapter` (byte-identical / idempotent).

### Env + config
- Retire `BAML_REST_USE_BUILD_REQUEST` parsing. `cmd/serve` and `cmd/worker` log a **one-time startup deprecation warning** if it is still set (warn, never error). `EnvConfig` now carries only `DisableCallBuildRequest`.
- `cmd/serve` `SharedStateSeeds` gating moved to BuildRequest **surface availability** rather than the removed route gate.

### API break (per approved adjustment)
- **Removed** `dynclient.WithUseBuildRequest` and `BuildRequestConfig.UseBuildRequest` entirely — clean break, no deprecated no-op, no inverse/replacement toggle.

### Kept
- `BAML_REST_DISABLE_CALL_BUILD_REQUEST` (the narrower /call Request-API hatch) and the debug-only test hooks, unchanged.
- The final legacy route code (now reachable only for no-surface / unsupported / empty-provider cases).
- In-BuildRequest legacy fallback children (`legacyStreamChildFn` / `legacyCallChildFn` / `LegacyChildren`, tracked by #538) — untouched.

## Tests + CI
- Dropped the `use-build-request` matrix axis and env forwarding across all three integration jobs; kept the `http-client` axis (legacy-leg exclusions now key on no-surface BAML versions).
- `ActuallyBuildRequest()` now means "the BAML version exposes a BuildRequest surface".
- Legacy-route integration tests restricted to no-surface (pre-0.219) versions; `TestLegacyMode_RR_NoCentralization` (retired kill-switch) removed; `TestDeBAMLOracleA` flag-separation **inverted** to assert `WithDeBAML` reaches the native seam without any route opt-in.
- Unit tests reconciled (`config_test`, `metadata_bugfix_test`, `orchestrator_test`, `runtime_test`, `client_test`, `worker/runtime_test`).

## Verification
- `gofmt`, `go build ./...`, `GOWORK=off go build/test ./...` in `dynclient/`, `go test` across all modules, codegen tests, `go vet ./...`, and `go vet -tags integration ./integration/...` all pass.
- `genadapter` re-run is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BuildRequest routing is now attempted by default whenever supported, with automatic fallback for older/unsupported setups.
  * Added/clarified support for narrowing behavior via `DisableCallBuildRequest` (non-streaming `/call` only).

* **Bug Fixes**
  * Removed retired BuildRequest gating logic from runtime and integration test harnesses; routing classification/path-reason behavior updated accordingly.

* **Documentation**
  * Updated README and in-app/warning text: `BAML_REST_USE_BUILD_REQUEST` is now ignored with a deprecation warning, and “full rollback” guidance was removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
