### PR TITLE
buildrequest: prefer Request for call-supported fallback chains (#543)

### DIFF
--- a/adapters/common/codegen/codegen_router.go
+++ b/adapters/common/codegen/codegen_router.go
@@ -117,26 +117,70 @@ func (me *methodEmitter) emitRouter() {
 			Op("&&").Len(jen.Id("__resolution").Dot("Chain")).Op(">").Lit(0)
 	}
 
+	// callFallbackDispatch emits the non-streaming Request dispatch for an
+	// already-resolved fallback chain: build the plan with
+	// BuildRequestAPIRequest, copy the top-level RR metadata, and forward to
+	// the call-request impl with the resolver's per-child Chain / Providers /
+	// LegacyChildren / Targets / NestedRoundRobin threaded through. Assumes
+	// retryPolicy and __resolution are already in scope. Shared by the
+	// no-bridge call block (the sole-landing-spot case) and the bridge's
+	// call-supported preference branch (#543); both consume a SINGLE
+	// __resolution, so centralized RR is selected exactly once and never
+	// double-advances the advancer.
+	callFallbackDispatch := func() []jen.Code {
+		return []jen.Code{
+			jen.Id("__planned").Op(":=").Qual(g.pkgs.BuildRequestPkg, "BuildFallbackChainPlanFromResolution").Call(
+				jen.Id("__effective"),
+				jen.Id("__resolution"),
+				jen.Id("retryPolicy"),
+				jen.Qual(g.pkgs.BuildRequestPkg, "BuildRequestAPIRequest"),
+			),
+			jen.Id("__planned").Dot("RoundRobin").Op("=").Id("__rrInfo"),
+			jen.Id("err").Op("=").Id(me.buildCallRequestMethodName).Call(
+				jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
+				jen.Lit(""), jen.Id("retryPolicy"),
+				jen.Id("__resolution").Dot("Chain"),
+				jen.Id("__resolution").Dot("Providers"),
+				jen.Id("__resolution").Dot("LegacyChildren"),
+				jen.Id("__resolution").Dot("Targets"),
+				jen.Id("__resolution").Dot("NestedRoundRobin"),
+				jen.Id("__planned"),
+				jen.Lit(""),
+			),
+			jen.If(jen.Id("err").Op("!=").Nil()).Block(
+				jen.Return(jen.Nil(), jen.Id("err")),
+			),
+			jen.Return(jen.Id("out"), jen.Nil()),
+		}
+	}
+
 	// Non-streaming BuildRequest path for /call and /call-with-raw.
 	// Uses Request (not StreamRequest) to build non-streaming HTTP requests.
 	// Checked before the streaming path since it's more efficient for call modes.
 	//
 	// When the StreamRequest bridge exists (hasBuildRequest=true) the
-	// call block emits only the single-provider arm and the bridge below
-	// owns ALL fallback-chain resolution for call modes. Two reasons:
+	// call block emits only the single-provider arm; the bridge below owns
+	// the SOLE call-mode fallback-chain resolution and, from that one
+	// resolution, dispatches the chain via the non-streaming Request API
+	// when every provider is call-supported, otherwise via the StreamRequest
+	// bridge (#543). Two reasons the single resolver lives in the bridge:
 	//
-	//   1. Single resolver per request. If both blocks called the typed
-	//      resolver, a mixed chain (centralised RR child plus any
-	//      call-legacy sibling) would advance the SharedState advancer
-	//      in the call block and again in the bridge after falling
+	//   1. Single resolver per request. If both the call block and the
+	//      bridge called the typed resolver, a mixed chain (centralised RR
+	//      child plus any call-legacy sibling) would advance the SharedState
+	//      advancer in the call block and again in the bridge after falling
 	//      through — burning two idempotency-cache slots and skewing
-	//      rotation for that request shape.
+	//      rotation for that request shape. Choosing Request vs StreamRequest
+	//      from the already-resolved __resolution (its LegacyChildren +
+	//      Providers) reuses that single resolution — including its
+	//      centralised RR Targets / NestedRoundRobin — so RR is never
+	//      selected a second time.
 	//   2. Stream-side support is a superset of call-side support
-	//      (IsProviderSupported ⊇ IsCallProviderSupported), so the
-	//      bridge's stream-side classification covers every chain the
-	//      call block could have driven directly; the trade-off is SSE
-	//      accumulation overhead vs a unary HTTP attempt, which is
-	//      acceptable next to LLM call latency.
+	//      (IsProviderSupported ⊇ IsCallProviderSupported), so the bridge's
+	//      stream-side resolver accepts every chain the call block could have
+	//      driven directly PLUS call-unsupported chains the Request API must
+	//      decline. The call-supported subset dispatches unary via Request;
+	//      the remainder bridges through StreamRequest with SSE accumulation.
 	//
 	// When no bridge exists (hasBuildRequest=false) the call block is
 	// the sole BuildRequest landing spot for call modes and emits the
@@ -205,29 +249,7 @@ func (me *methodEmitter) emitRouter() {
 					jen.Return(jen.Nil(), jen.Id("__fbErr")),
 				),
 				jen.If(fallbackChainConsumeCond()).Block(
-					resolveRetryPolicy(),
-					jen.Id("__planned").Op(":=").Qual(g.pkgs.BuildRequestPkg, "BuildFallbackChainPlanFromResolution").Call(
-						jen.Id("__effective"),
-						jen.Id("__resolution"),
-						jen.Id("retryPolicy"),
-						jen.Qual(g.pkgs.BuildRequestPkg, "BuildRequestAPIRequest"),
-					),
-					jen.Id("__planned").Dot("RoundRobin").Op("=").Id("__rrInfo"),
-					jen.Id("err").Op("=").Id(me.buildCallRequestMethodName).Call(
-						jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
-						jen.Lit(""), jen.Id("retryPolicy"),
-						jen.Id("__resolution").Dot("Chain"),
-						jen.Id("__resolution").Dot("Providers"),
-						jen.Id("__resolution").Dot("LegacyChildren"),
-						jen.Id("__resolution").Dot("Targets"),
-						jen.Id("__resolution").Dot("NestedRoundRobin"),
-						jen.Id("__planned"),
-						jen.Lit(""),
-					),
-					jen.If(jen.Id("err").Op("!=").Nil()).Block(
-						jen.Return(jen.Nil(), jen.Id("err")),
-					),
-					jen.Return(jen.Id("out"), jen.Nil()),
+					append([]jen.Code{resolveRetryPolicy()}, callFallbackDispatch()...)...,
 				),
 			)
 		}
@@ -335,16 +357,75 @@ func (me *methodEmitter) emitRouter() {
 		)
 	}
 
-	// Bridge: /call and /call-with-raw that the non-streaming block
-	// declined fall through to the streaming BuildRequest path, which
-	// accumulates SSE deltas into a unary response. Triggered when the
-	// non-streaming Request API is unavailable (g.intro.Request==nil
-	// or the call-side support gate rejected the provider/chain) but the
-	// StreamRequest API can drive it. StreamMode is StreamModeCall or
+	// Bridge: /call and /call-with-raw that the single-provider non-
+	// streaming arm declined fall through here. This block also owns the
+	// SOLE call-mode fallback-chain resolution (see the call-block comment
+	// above): it runs one typed resolver, then for fallback chains prefers
+	// the non-streaming Request dispatch when a Request surface exists and
+	// the resolved chain is fully call-supported (#543); otherwise it
+	// accumulates SSE deltas into a unary response via StreamRequest. The
+	// StreamRequest bridge is reached when the non-streaming Request API is
+	// unavailable (g.intro.Request==nil) or the call-side support gate
+	// rejected the provider/chain. StreamMode is StreamModeCall or
 	// StreamModeCallWithRaw, so NeedsPartials is false inside the
-	// orchestrator and no partials ever reach the output channel — the
-	// pool sees the same shape as the non-streaming call path.
+	// orchestrator and no partials ever reach the output channel — the pool
+	// sees the same shape as the non-streaming call path.
 	if hasBuildRequest {
+		// Build the bridge's fallback-chain consume body. resolveRetryPolicy
+		// runs once; then, when a Request surface exists, a fully
+		// call-supported resolved chain dispatches unary via Request (#543)
+		// before the StreamRequest bridge dispatch. Both arms consume the
+		// SAME __resolution above — the choice is read off the resolved
+		// chain, so there is no second resolve and no second RR advance.
+		bridgeFallbackConsume := []jen.Code{resolveRetryPolicy()}
+		if hasCallBuildRequest {
+			// __callChainSupported is true only when the resolved chain has
+			// no legacy children AND every resolved provider is call-
+			// supported. Computed from __resolution (not a second resolve),
+			// and emitted only when a Request surface exists so stream-only
+			// routers never reference IsCallProviderSupported here.
+			bridgeFallbackConsume = append(bridgeFallbackConsume,
+				jen.Id("__callChainSupported").Op(":=").Len(jen.Id("__resolution").Dot("LegacyChildren")).Op("==").Lit(0),
+				jen.If(jen.Id("__callChainSupported")).Block(
+					jen.For(
+						jen.List(jen.Id("_"), jen.Id("__provider")).Op(":=").Range().Id("__resolution").Dot("Providers"),
+					).Block(
+						jen.If(jen.Op("!").Qual(g.pkgs.BuildRequestPkg, "IsCallProviderSupported").Call(jen.Id("__provider"))).Block(
+							jen.Id("__callChainSupported").Op("=").False(),
+							jen.Break(),
+						),
+					),
+				),
+				jen.If(jen.Id("__callChainSupported")).Block(
+					callFallbackDispatch()...,
+				),
+			)
+		}
+		bridgeFallbackConsume = append(bridgeFallbackConsume,
+			jen.Id("__planned").Op(":=").Qual(g.pkgs.BuildRequestPkg, "BuildFallbackChainPlanFromResolution").Call(
+				jen.Id("__effective"),
+				jen.Id("__resolution"),
+				jen.Id("retryPolicy"),
+				jen.Qual(g.pkgs.BuildRequestPkg, "BuildRequestAPIStreamRequest"),
+			),
+			jen.Id("__planned").Dot("RoundRobin").Op("=").Id("__rrInfo"),
+			jen.Id("err").Op("=").Id(me.buildRequestMethodName).Call(
+				jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
+				jen.Lit(""), jen.Id("retryPolicy"),
+				jen.Id("__resolution").Dot("Chain"),
+				jen.Id("__resolution").Dot("Providers"),
+				jen.Id("__resolution").Dot("LegacyChildren"),
+				jen.Id("__resolution").Dot("Targets"),
+				jen.Id("__resolution").Dot("NestedRoundRobin"),
+				jen.Id("__planned"),
+				jen.Lit(""),
+			),
+			jen.If(jen.Id("err").Op("!=").Nil()).Block(
+				jen.Return(jen.Nil(), jen.Id("err")),
+			),
+			jen.Return(jen.Id("out"), jen.Nil()),
+		)
+
 		routerBody = append(routerBody,
 			jen.Comment("Bridge: /call and /call-with-raw via StreamRequest when Request is unavailable"),
 			jen.If(
@@ -381,13 +462,19 @@ func (me *methodEmitter) emitRouter() {
 					),
 					jen.Return(jen.Id("out"), jen.Nil()),
 				),
-				// Fallback chain path (bridge). Uses IsProviderSupported
-				// (stream side) because the whole point of the bridge is
-				// to accept chains that IsCallProviderSupported rejected.
-				// Threads the typed resolver's per-child Targets +
-				// NestedRoundRobin through to orchestrator dispatch so
-				// centralized RR fallback children rotate cross-worker
-				// even on the bridge path.
+				// Fallback chain path — the sole call-mode resolver.
+				// Resolves with IsProviderSupported (stream side, the
+				// superset predicate) so this one resolution covers every
+				// chain: those fully call-supported AND those that need the
+				// bridge. The dispatch API is then chosen off that single
+				// resolution (no second resolve, no second RR advance):
+				// when a Request surface exists and the resolved chain has
+				// no legacy children and every provider is call-supported,
+				// dispatch unary via BuildRequestAPIRequest (#543);
+				// otherwise bridge via BuildRequestAPIStreamRequest. Either
+				// way the typed resolver's per-child Targets +
+				// NestedRoundRobin thread through so centralized RR fallback
+				// children rotate cross-worker.
 				jen.List(jen.Id("__resolution"), jen.Id("__fbErr")).Op(":=").Qual(g.pkgs.BuildRequestPkg, "ResolveFallbackChainPlanForClient").Call(
 					jen.Id("__reg"),
 					jen.Id("__effective"),
@@ -403,29 +490,7 @@ func (me *methodEmitter) emitRouter() {
 					jen.Return(jen.Nil(), jen.Id("__fbErr")),
 				),
 				jen.If(fallbackChainConsumeCond()).Block(
-					resolveRetryPolicy(),
-					jen.Id("__planned").Op(":=").Qual(g.pkgs.BuildRequestPkg, "BuildFallbackChainPlanFromResolution").Call(
-						jen.Id("__effective"),
-						jen.Id("__resolution"),
-						jen.Id("retryPolicy"),
-						jen.Qual(g.pkgs.BuildRequestPkg, "BuildRequestAPIStreamRequest"),
-					),
-					jen.Id("__planned").Dot("RoundRobin").Op("=").Id("__rrInfo"),
-					jen.Id("err").Op("=").Id(me.buildRequestMethodName).Call(
-						jen.Id("adapter"), jen.Id("rawInput"), jen.Id("out"),
-						jen.Lit(""), jen.Id("retryPolicy"),
-						jen.Id("__resolution").Dot("Chain"),
-						jen.Id("__resolution").Dot("Providers"),
-						jen.Id("__resolution").Dot("LegacyChildren"),
-						jen.Id("__resolution").Dot("Targets"),
-						jen.Id("__resolution").Dot("NestedRoundRobin"),
-						jen.Id("__planned"),
-						jen.Lit(""),
-					),
-					jen.If(jen.Id("err").Op("!=").Nil()).Block(
-						jen.Return(jen.Nil(), jen.Id("err")),
-					),
-					jen.Return(jen.Id("out"), jen.Nil()),
+					bridgeFallbackConsume...,
 				),
 			),
 		)

--- a/adapters/common/codegen/codegen_test.go
+++ b/adapters/common/codegen/codegen_test.go
@@ -744,34 +744,40 @@ func TestEmitRouter_RetryResolutionUsesStrategyAwareHelper(t *testing.T) {
 	}
 }
 
-// TestEmitRouter_CallModeFallbackDefersToBridgeWhenAvailable pins the
+// TestEmitRouter_CallModeFallbackPrefersRequestViaSingleResolver pins the
 // single-resolver-per-request invariant for call-mode requests when a
 // StreamRequest bridge is available: the call block emits ONLY the
-// single-provider arm and the bridge owns the sole typed fallback
-// resolution. A regression that emits ResolveFallbackChainPlanForClient
-// in both the call and bridge blocks would double-advance the
-// SharedState advancer on a mixed chain — the call block's old
-// consume gate (no-call-legacy-children) would decline a centralised-
-// RR-plus-call-legacy-sibling chain after the resolver already
-// committed an RR advance, the chain would fall through to the bridge,
-// and the bridge's own ResolveFallbackChainPlanForClient call would
-// advance a second time. One request → two cross-worker RR slots
-// burned, rotation skewed for that shape.
+// single-provider arm and the bridge runs the sole typed fallback
+// resolution. From that ONE resolution the bridge chooses its dispatch API
+// — the non-streaming Request dispatch when the resolved chain is fully
+// call-supported (#543), otherwise the StreamRequest bridge dispatch.
+//
+// A regression that emits ResolveFallbackChainPlanForClient in both the
+// call and bridge blocks would double-advance the SharedState advancer on a
+// mixed chain (the call block resolves + advances, then the chain falls
+// through to the bridge, which resolves + advances again). The fix keeps a
+// single resolver and reads the Request-vs-StreamRequest decision off the
+// already-resolved __resolution (its LegacyChildren + Providers), so RR is
+// selected exactly once. One request → one cross-worker RR slot.
 //
 // When the bridge does not exist (introspected.StreamRequest == nil),
 // the call block IS the sole BuildRequest landing spot for call modes
-// and must emit its own fallback resolver.
+// and must emit its own fallback resolver (still call-side predicate).
 //
-// Counts ResolveFallbackChainPlanForClient occurrences positionally:
+// Asserted shape:
 //
-//   - Request + StreamRequest both non-nil: exactly 2 occurrences,
-//     one in the streaming block (for stream modes) and one in the
-//     bridge block (the sole call-mode resolver).
-//   - Request only: exactly 1 occurrence, inside the call block (call
-//     block is the only landing spot — no bridge, no stream block).
-//   - StreamRequest only: exactly 1 occurrence, inside the streaming
-//     block (no call block, bridge serves call modes alongside).
-func TestEmitRouter_CallModeFallbackDefersToBridgeWhenAvailable(t *testing.T) {
+//   - Request + StreamRequest both non-nil: exactly 2 resolver call sites
+//     (streaming block + bridge block — the sole call-mode resolver). The
+//     bridge emits a Request dispatch (BuildRequestAPIRequest +
+//     buildCallRequest) gated on __callChainSupported, ordered BEFORE the
+//     StreamRequest fallback dispatch.
+//   - Request only: exactly 1 resolver call site, inside the call block,
+//     using the call-side IsCallProviderSupported predicate.
+//   - StreamRequest only: exactly 2 resolver call sites (streaming +
+//     bridge) and ZERO IsCallProviderSupported references — the bridge's
+//     call-support check is gated on a Request surface existing, so a
+//     stream-only router never emits it (no unused-symbol risk).
+func TestEmitRouter_CallModeFallbackPrefersRequestViaSingleResolver(t *testing.T) {
 	// Save + restore the introspected BuildRequest singletons across
 	// sub-tests so each scenario can pin a specific (Request,
 	// StreamRequest) presence combination.
@@ -811,44 +817,70 @@ func TestEmitRouter_CallModeFallbackDefersToBridgeWhenAvailable(t *testing.T) {
 	// alongside the bridge.
 	const resolverFn = "buildrequest.ResolveFallbackChainPlanForClient("
 
-	t.Run("call-bridge-both-available-bridge-owns-fallback", func(t *testing.T) {
-		// Both APIs non-nil — the bridge exists. Call block emits
-		// only the single-provider arm; the bridge owns fallback for
-		// call modes. Total resolver calls in the router: 2 (stream
-		// block + bridge block).
+	t.Run("call-bridge-both-available-single-resolver-prefers-request", func(t *testing.T) {
+		// Both APIs non-nil — the bridge exists. Call block emits only
+		// the single-provider arm; the bridge runs the sole call-mode
+		// fallback resolver and then prefers the Request dispatch when
+		// the resolved chain is fully call-supported. Total resolver
+		// calls in the router: 2 (stream block + bridge block).
 		introspected.Request = struct{}{}
 		introspected.StreamRequest = struct{}{}
 		rendered := renderRouter(t)
 		got := strings.Count(rendered, resolverFn)
 		if got != 2 {
 			t.Errorf("with Request + StreamRequest non-nil, expected exactly 2 ResolveFallbackChainPlanForClient call sites "+
-				"(streaming block + bridge block; the call block must defer to the bridge to avoid double-advance), got %d.\nrendered:\n%s",
+				"(streaming block + bridge block; the call block must defer to the single bridge resolver to avoid double-advance), got %d.\nrendered:\n%s",
 				got, rendered)
 		}
-		// Positional pin: the bridge call site is gated by StreamMode-
-		// Call / StreamModeCallWithRaw. If the call block re-introduced
-		// the fallback resolver, it would also be gated on call modes
-		// — and a second resolver call would appear before the
-		// streaming block's gate. Pin that the FIRST resolver call site
-		// is the streaming block, identified by IsProviderSupported
-		// being the support predicate. The call-block fallback path
-		// uses IsCallProviderSupported, so a regression where the call
-		// block re-emits the resolver would surface IsCallProviderSupp-
-		// orted as the first predicate AND increase the count above 2.
+		// Positional pin: the FIRST resolver call site is the streaming
+		// block, which uses the stream-side predicate. The bridge's
+		// call-support gate (IsCallProviderSupported) is emitted only
+		// AFTER the bridge resolver, never inside the first (streaming)
+		// resolver's argument list. A regression where the call block
+		// re-emits its own fallback resolver first would surface
+		// IsCallProviderSupported as the first predicate AND push the
+		// count above 2.
 		firstIdx := strings.Index(rendered, resolverFn)
 		if firstIdx < 0 {
 			t.Fatalf("expected at least one ResolveFallbackChainPlanForClient call site; rendered:\n%s", rendered)
 		}
 		secondIdx := firstIdx + strings.Index(rendered[firstIdx+1:], resolverFn) + 1
-		// IsCallProviderSupported must not appear inside the first
-		// resolver invocation's argument list — that's the streaming
-		// block's resolver and it uses the stream-side predicate. The
-		// only path that could put IsCallProviderSupported in the
-		// first invocation is a regression where the call block emits
-		// its own fallback resolver first.
 		argsRegion := rendered[firstIdx : secondIdx+len(resolverFn)+200]
 		if strings.Count(argsRegion, "buildrequest.IsCallProviderSupported") > 0 {
 			t.Errorf("first resolver call site contains IsCallProviderSupported, suggesting the call block re-introduced a fallback resolver; rendered region:\n%s", argsRegion)
+		}
+
+		// The bridge resolution is the SECOND resolver call site. Pin the
+		// #543 behaviour by inspecting the region after it: the bridge
+		// must (a) compute the call-support gate from the resolved chain,
+		// (b) dispatch a Request fallback (BuildRequestAPIRequest +
+		// buildCallRequest) BEFORE (c) the StreamRequest fallback dispatch
+		// (BuildRequestAPIStreamRequest + buildRequest).
+		bridgeRegion := rendered[secondIdx:]
+		if !strings.Contains(bridgeRegion, "__callChainSupported := len(__resolution.LegacyChildren) == 0") {
+			t.Errorf("bridge must compute __callChainSupported from the already-resolved chain (no second resolve); bridge region:\n%s", bridgeRegion)
+		}
+		if !strings.Contains(bridgeRegion, "buildrequest.IsCallProviderSupported(__provider)") {
+			t.Errorf("bridge call-support gate must test each resolved provider via IsCallProviderSupported; bridge region:\n%s", bridgeRegion)
+		}
+		callDispatchIdx := strings.Index(bridgeRegion, "greetUser_buildCallRequest(")
+		streamDispatchIdx := strings.Index(bridgeRegion, "greetUser_buildRequest(")
+		if callDispatchIdx < 0 {
+			t.Errorf("bridge must emit a Request fallback dispatch (greetUser_buildCallRequest) for call-supported chains; bridge region:\n%s", bridgeRegion)
+		}
+		if streamDispatchIdx < 0 {
+			t.Errorf("bridge must still emit the StreamRequest fallback dispatch (greetUser_buildRequest); bridge region:\n%s", bridgeRegion)
+		}
+		if callDispatchIdx >= 0 && streamDispatchIdx >= 0 && callDispatchIdx >= streamDispatchIdx {
+			t.Errorf("bridge Request fallback dispatch must be emitted BEFORE the StreamRequest fallback dispatch (preferred when call-supported); callIdx=%d streamIdx=%d\nbridge region:\n%s",
+				callDispatchIdx, streamDispatchIdx, bridgeRegion)
+		}
+		// The Request dispatch must sit behind the __callChainSupported
+		// gate, i.e. the gate is computed before the call dispatch.
+		gateIdx := strings.Index(bridgeRegion, "if __callChainSupported {")
+		if gateIdx < 0 || (callDispatchIdx >= 0 && gateIdx >= callDispatchIdx) {
+			t.Errorf("bridge Request fallback dispatch must be guarded by the __callChainSupported gate; gateIdx=%d callIdx=%d\nbridge region:\n%s",
+				gateIdx, callDispatchIdx, bridgeRegion)
 		}
 	})
 
@@ -888,6 +920,16 @@ func TestEmitRouter_CallModeFallbackDefersToBridgeWhenAvailable(t *testing.T) {
 			t.Errorf("with StreamRequest-only adapter, expected exactly 2 ResolveFallbackChainPlanForClient call sites "+
 				"(streaming block + bridge block), got %d.\nrendered:\n%s",
 				got, rendered)
+		}
+		// A stream-only router has no Request surface, so the bridge's
+		// call-support preference branch is elided entirely. There must
+		// be ZERO IsCallProviderSupported references anywhere in the
+		// generated router — emitting one would reference a call-support
+		// gate the router never needs and (historically, with a
+		// conditional __brCfg declaration) risk an unused symbol.
+		if n := strings.Count(rendered, "buildrequest.IsCallProviderSupported"); n != 0 {
+			t.Errorf("stream-only adapter must not reference IsCallProviderSupported (the bridge call-support gate is gated on a Request surface), got %d references.\nrendered:\n%s",
+				n, rendered)
 		}
 	})
 }

--- a/adapters/common/codegen/codegen_test.go
+++ b/adapters/common/codegen/codegen_test.go
@@ -845,7 +845,15 @@ func TestEmitRouter_CallModeFallbackPrefersRequestViaSingleResolver(t *testing.T
 			t.Fatalf("expected at least one ResolveFallbackChainPlanForClient call site; rendered:\n%s", rendered)
 		}
 		secondIdx := firstIdx + strings.Index(rendered[firstIdx+1:], resolverFn) + 1
-		argsRegion := rendered[firstIdx : secondIdx+len(resolverFn)+200]
+		// Confine the check to the FIRST resolver site only: everything
+		// from the first resolver call up to (but NOT including) the second
+		// (bridge) resolver. Extending past secondIdx would reach the
+		// bridge's call-support gate, whose valid
+		// `buildrequest.IsCallProviderSupported(__provider)` output would
+		// trip this first-resolver assertion. The streaming block between
+		// the two resolvers uses only IsProviderSupported, so this region
+		// must contain zero IsCallProviderSupported references.
+		argsRegion := rendered[firstIdx:secondIdx]
 		if strings.Count(argsRegion, "buildrequest.IsCallProviderSupported") > 0 {
 			t.Errorf("first resolver call site contains IsCallProviderSupported, suggesting the call block re-introduced a fallback resolver; rendered region:\n%s", argsRegion)
 		}
@@ -875,12 +883,24 @@ func TestEmitRouter_CallModeFallbackPrefersRequestViaSingleResolver(t *testing.T
 			t.Errorf("bridge Request fallback dispatch must be emitted BEFORE the StreamRequest fallback dispatch (preferred when call-supported); callIdx=%d streamIdx=%d\nbridge region:\n%s",
 				callDispatchIdx, streamDispatchIdx, bridgeRegion)
 		}
-		// The Request dispatch must sit behind the __callChainSupported
-		// gate, i.e. the gate is computed before the call dispatch.
-		gateIdx := strings.Index(bridgeRegion, "if __callChainSupported {")
-		if gateIdx < 0 || (callDispatchIdx >= 0 && gateIdx >= callDispatchIdx) {
-			t.Errorf("bridge Request fallback dispatch must be guarded by the __callChainSupported gate; gateIdx=%d callIdx=%d\nbridge region:\n%s",
-				gateIdx, callDispatchIdx, bridgeRegion)
+		// The Request dispatch must sit inside ITS OWN __callChainSupported
+		// gate, not merely somewhere after the earlier provider-loop gate.
+		// The generated shape has TWO `if __callChainSupported {` gates: the
+		// provider-loop gate first, then the Request-dispatch gate. A check
+		// that only requires the dispatch to follow *some* gate would pass
+		// even if greetUser_buildCallRequest escaped its block (as long as it
+		// stayed after the provider-loop gate). So locate the gate that most
+		// closely precedes the dispatch and assert no block closes between
+		// that gate's opening brace and the dispatch — i.e. the dispatch's
+		// nearest enclosing gate is the Request-dispatch gate.
+		const gate = "if __callChainSupported {"
+		if callDispatchIdx >= 0 {
+			gateBeforeDispatch := strings.LastIndex(bridgeRegion[:callDispatchIdx], gate)
+			if gateBeforeDispatch < 0 {
+				t.Errorf("bridge Request fallback dispatch must be guarded by an __callChainSupported gate; none precedes greetUser_buildCallRequest\nbridge region:\n%s", bridgeRegion)
+			} else if between := bridgeRegion[gateBeforeDispatch+len(gate) : callDispatchIdx]; strings.Contains(between, "}") {
+				t.Errorf("bridge Request fallback dispatch escaped its __callChainSupported gate: a block closed between the nearest gate and the dispatch.\nbetween:\n%s\nbridge region:\n%s", between, bridgeRegion)
+			}
 		}
 	})
 

--- a/dynclient/internal/generated/adapter.go
+++ b/dynclient/internal/generated/adapter.go
@@ -1080,6 +1080,24 @@ func Baml_Rest_Dynamic(adapter bamlutils.Adapter, rawInput any) (<-chan bamlutil
 		}
 		if __resolution != nil && len(__resolution.Chain) > 0 {
 			retryPolicy := buildrequest.ResolveStrategyAwareRetryPolicy(adapter, __retryClient, __effective, introspected.ClientRetryPolicy[__retryClient], introspected.ClientRetryPolicy[__effective], introspected.RetryPolicies)
+			__callChainSupported := len(__resolution.LegacyChildren) == 0
+			if __callChainSupported {
+				for _, __provider := range __resolution.Providers {
+					if !buildrequest.IsCallProviderSupported(__provider) {
+						__callChainSupported = false
+						break
+					}
+				}
+			}
+			if __callChainSupported {
+				__planned := buildrequest.BuildFallbackChainPlanFromResolution(__effective, __resolution, retryPolicy, buildrequest.BuildRequestAPIRequest)
+				__planned.RoundRobin = __rrInfo
+				err = bamlRestDynamicBuildCallRequest(adapter, rawInput, out, "", retryPolicy, __resolution.Chain, __resolution.Providers, __resolution.LegacyChildren, __resolution.Targets, __resolution.NestedRoundRobin, __planned, "")
+				if err != nil {
+					return nil, err
+				}
+				return out, nil
+			}
 			__planned := buildrequest.BuildFallbackChainPlanFromResolution(__effective, __resolution, retryPolicy, buildrequest.BuildRequestAPIStreamRequest)
 			__planned.RoundRobin = __rrInfo
 			err = bamlRestDynamicBuildRequest(adapter, rawInput, out, "", retryPolicy, __resolution.Chain, __resolution.Providers, __resolution.LegacyChildren, __resolution.Targets, __resolution.NestedRoundRobin, __planned, "")

--- a/integration/composition_test.go
+++ b/integration/composition_test.go
@@ -129,6 +129,21 @@ func TestFallbackRoundRobinComposition_CentralizedAcrossWorkers(t *testing.T) {
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLPathReason, "fallback-roundrobin-child-buildrequest")
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLClient, "TestFallbackRoundRobinPair")
 
+			// #543: the composition fallback[rr[openai,openai], openai] is
+			// fully call-supported — every RR leaf and the fallback sibling
+			// are openai, and the centralized RR child is recorded in the
+			// resolution with its SELECTED-LEAF provider (openai), not
+			// "baml-roundrobin", and is absent from LegacyChildren. So the
+			// bridge's single resolution is fully call-supported and
+			// dispatches via the non-streaming Request API. A "streamrequest"
+			// here would mean this all-call-supported RR-child shape
+			// needlessly bridged through SSE accumulation. The single
+			// resolution is reused for both the Request-preference decision
+			// and the centralized RR dispatch, so rotation still advances
+			// exactly once per REST request (the leaf-balance invariant below
+			// would break on a double-advance).
+			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI, "request")
+
 			// Winner-Client is the served openai leaf, not the RR
 			// wrapper or fallback strategy parent — the centralised
 			// dispatch surfaces the leaf on outcome metadata so the

--- a/integration/composition_test.go
+++ b/integration/composition_test.go
@@ -143,6 +143,11 @@ func TestFallbackRoundRobinComposition_CentralizedAcrossWorkers(t *testing.T) {
 			// exactly once per REST request (the leaf-balance invariant below
 			// would break on a double-advance).
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI, "request")
+			// The non-streaming Request orchestrator never sets BamlCallCount
+			// (it has no BAML-internal FunctionLog call count to surface), and
+			// the header is emitted only when non-nil — so it must be absent on
+			// the Request path, matching the other fallback Request-path tests.
+			testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 
 			// Winner-Client is the served openai leaf, not the RR
 			// wrapper or fallback strategy parent — the centralised

--- a/integration/fallback_test.go
+++ b/integration/fallback_test.go
@@ -183,8 +183,21 @@ func TestFallbackCall(t *testing.T) {
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
 			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
 			if HasBuildRequestSurface() {
+				// #543: a /call fallback chain whose every provider is
+				// call-supported (both children are openai here) dispatches
+				// via the non-streaming Request API, not the StreamRequest
+				// bridge. The bridge resolves the chain once and, because no
+				// child is call-legacy and openai is call-supported, prefers
+				// the Request dispatch — so BuildRequestAPI is "request", the
+				// same value single-provider /call reports. A "streamrequest"
+				// here would mean the chain needlessly bridged through SSE
+				// accumulation (the pre-#543 behaviour).
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI, "request")
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
+				// Legacy path sets no BuildRequestAPI header (omitempty drops
+				// the empty value).
+				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI)
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
 				// Two children walked (primary failed, secondary succeeded);
 				// hit-count assertion above pins this at 2 calls total, so
@@ -260,8 +273,12 @@ func TestFallbackCall(t *testing.T) {
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
 			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
 			if HasBuildRequestSurface() {
+				// #543: all three children are openai (call-supported), so the
+				// chain dispatches via the Request API rather than bridging.
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI, "request")
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
+				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI)
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
 				// Three children walked (primary + secondary failed, tertiary
 				// succeeded); hit-count assertion above pins this at 3 calls
@@ -420,8 +437,12 @@ func TestFallbackCallWithRaw(t *testing.T) {
 			testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLWinnerProvider, "openai")
 			testutil.AssertHeaderPresent(t, resp.Headers, testutil.HeaderBAMLUpstreamDuration)
 			if HasBuildRequestSurface() {
+				// #543: /call-with-raw shares the routing path with /call, so a
+				// fully call-supported chain reports BuildRequestAPI "request".
+				testutil.AssertHeaderEquals(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI, "request")
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBamlCallCount)
 			} else {
+				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLBuildRequestAPI)
 				testutil.AssertHeaderAbsent(t, resp.Headers, testutil.HeaderBAMLRetryCount)
 				// Two children walked (primary failed, secondary succeeded);
 				// hit-count assertion above pins this at 2 calls total, so


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## What

Make the generated `/call` router dispatch fallback chains through the non-streaming **Request** API whenever every provider in the resolved chain is call-supported, instead of always bridging through `StreamRequest`.

## Why

The non-streaming Request fallback-chain arm (`ResolveFallbackChainPlanForClient` + `BuildFallbackChainPlanFromResolution(… BuildRequestAPIRequest)` + `buildCallRequest`) was emitted only inside `if !hasBuildRequest`. So adapters exposing **both** a `Request` and a `StreamRequest` surface skipped the unary Request path for `/call` fallback chains and bridged through `StreamRequest` — accumulating SSE deltas into a unary response — even when every provider was call-supported. Now that BuildRequest is the default (#537/#540/#542), both-surfaces is the common case, so `/call` fallback chains were needlessly going through the stream bridge. Closes #543.

## How — single resolver, no double-advance

The tempting fix (delete the `if !hasBuildRequest` guard so the Request arm always emits) is wrong: it runs fallback resolution **twice** and **double-advances** the in-process round-robin coordinator (standalone has no per-request idempotency).

Instead this keeps **exactly one** call-mode fallback resolver — the bridge's, using `IsProviderSupported` (the superset predicate) — and chooses the dispatch API from that single `__resolution`:

```
__callChainSupported := len(__resolution.LegacyChildren) == 0
if __callChainSupported {
    for _, p := range __resolution.Providers {
        if !buildrequest.IsCallProviderSupported(p) { __callChainSupported = false; break }
    }
}
if __callChainSupported { /* dispatch via BuildRequestAPIRequest + buildCallRequest */ }
// else: existing StreamRequest bridge dispatch, unchanged
```

The decision reads off the already-resolved chain (`LegacyChildren` + `Providers`) and reuses its centralized RR `Targets` / `NestedRoundRobin`, so **round-robin is selected exactly once** and the coordinator is never advanced twice. For a centralized RR child, `Providers` holds the *selected leaf's* provider (not `baml-roundrobin`) and the child is absent from `LegacyChildren`, so a fully-openai `fallback[rr[A,B], C]` composition correctly dispatches via Request too.

The `__callChainSupported` check is emitted **only when a Request surface exists**, so stream-only routers never reference `IsCallProviderSupported` (no unused-symbol risk). Single-provider `/call` and the forced-bridge paths are unchanged. Emitter-only — no runtime/resolver changes.

## Generated code

`dynclient/internal/generated/adapter.go` regenerated via `cmd/regenerate-dynclient`; the diff is exactly the new bridge branch and is idempotent (a second regen produces no further change).

## Tests

- **Codegen unit** (`TestEmitRouter_CallModeFallbackPrefersRequestViaSingleResolver`, rewritten from the old bridge-only invariant): both-surfaces still emits exactly one call-mode resolver but now emits the Request dispatch **before** the StreamRequest fallback dispatch, gated on `__callChainSupported`; Request-only keeps its call-side resolver; stream-only emits zero `IsCallProviderSupported`.
- **Integration**: `X-BAML-Build-Request-API: request` asserted on the `/call` and `/call-with-raw` fallback-chain happy paths (all providers call-supported) and on the centralized `fallback[rr[openai,openai], openai]` composition. The existing forced-bridge tests still assert `streamrequest` — they use the debug-only `BAML_REST_CALL_UNSUPPORTED_PROVIDERS` hook, which the bridge's call-support re-check honors (`BAML_REST_DISABLE_CALL_BUILD_REQUEST` was retired in #539).

`go build ./...`, `go vet ./...`, `GOWORK=off go test ./codegen`, full non-integration `go test ./...`, and `cmd/verify-framework-adapter` (6/6 green) all pass locally. The Docker integration matrix is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fallback routing for call-based requests to prefer the non-streaming Request path when available.
  - Reduced redundant fallback resolution work to make fallback behavior more consistent.
  - Updated routing metadata on fallback flows: the Request path now reports the expected API mode and omits call-count headers.
  - Refined centralized round-robin fallback behavior to keep rotation consistent across worker and retry paths.

- **Tests**
  - Tightened router code-generation and fallback integration assertions around Request-vs-Stream dispatch selection and metadata headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->