### PR TITLE
debaml: native map coercion (P4 M2b)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/24_strict_map_string_int.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/24_strict_map_string_int.json
@@ -1,0 +1,21 @@
+{
+  "name": "strict_map_string_int",
+  "description": "Clean map<string,int>: object input, string keys, in-scope int values. M2b-native-claimed. Map output MUST preserve INPUT key order (keys here are out of lexical order). want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "scores", "type": {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"scores\":{\"z\":1,\"a\":2,\"m\":3}}",
+  "want": {
+    "status": "success",
+    "json": {"scores": {"z": 1, "a": 2, "m": 3}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/25_map_enum_keys.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/25_map_enum_keys.json
@@ -1,0 +1,24 @@
+{
+  "name": "map_enum_keys",
+  "description": "map<Key,string> with enum keys matched EXACTLY by rendered name. The emitted map key is the ORIGINAL input string (here identical to the canonical name), in input key order. M2b-native-claimed. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "labels", "type": {"kind": "map", "key": {"kind": "enum_ref", "ref": "Key"}, "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "enums": [
+      {"name": "Key", "values": ["A", "B"]}
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"labels\":{\"A\":\"one\",\"B\":\"two\"}}",
+  "want": {
+    "status": "success",
+    "json": {"labels": {"A": "one", "B": "two"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/26_map_string_class_values.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/26_map_string_class_values.json
@@ -1,0 +1,28 @@
+{
+  "name": "map_string_class_values",
+  "description": "map<string, Item> with map keys out of lexical order AND each Item value's fields out of schema order. The two ordering policies coexist: map keys stay INPUT-ordered while Item fields are re-emitted in SCHEMA order. M2b-native-claimed. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "by_id", "type": {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "class_ref", "ref": "Item"}}}
+        ]
+      },
+      {
+        "name": "Item",
+        "properties": [
+          {"name": "id", "type": {"kind": "string"}},
+          {"name": "label", "type": {"kind": "string"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"by_id\":{\"z\":{\"label\":\"zed\",\"id\":\"3\"},\"a\":{\"label\":\"ay\",\"id\":\"1\"}}}",
+  "want": {
+    "status": "success",
+    "json": {"by_id": {"z": {"id": "3", "label": "zed"}, "a": {"id": "1", "label": "ay"}}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/27_map_literal_union_keys_exact.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/27_map_literal_union_keys_exact.json
@@ -1,0 +1,24 @@
+{
+  "name": "map_literal_union_keys_exact",
+  "description": "map<\"A\"|\"B\", string>: a non-nullable union of string literals as the map key, matched EXACTLY (exactly one flattened literal equal to the input key). Emitted keys are the original input strings, in input order. M2b-native-claimed. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "m", "type": {"kind": "map", "key": {"kind": "union", "variants": [
+            {"kind": "literal", "literal": {"kind": "string", "string": "A"}},
+            {"kind": "literal", "literal": {"kind": "string", "string": "B"}}
+          ]}, "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"m\":{\"A\":\"x\",\"B\":\"y\"}}",
+  "want": {
+    "status": "success",
+    "json": {"m": {"A": "x", "B": "y"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/28_map_bad_enum_key.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/28_map_bad_enum_key.json
@@ -1,0 +1,24 @@
+{
+  "name": "map_bad_enum_key",
+  "description": "map<Key,string> where one key (\"C\") is not in enum Key {A,B}. BAML records MapKeyParseError and SKIPS that entry, returning a partial map {\"A\":\"one\"}. Native cannot reproduce a partial map, so it DECLINES (pinned native disposition: fallback). want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "labels", "type": {"kind": "map", "key": {"kind": "enum_ref", "ref": "Key"}, "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "enums": [
+      {"name": "Key", "values": ["A", "B"]}
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"labels\":{\"A\":\"one\",\"C\":\"two\"}}",
+  "want": {
+    "status": "success",
+    "json": {"labels": {"A": "one"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/28_map_bad_enum_key.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/28_map_bad_enum_key.json
@@ -1,6 +1,6 @@
 {
   "name": "map_bad_enum_key",
-  "description": "map<Key,string> where one key (\"C\") is not in enum Key {A,B}. BAML records MapKeyParseError and SKIPS that entry, returning a partial map {\"A\":\"one\"}. Native cannot reproduce a partial map, so it DECLINES (pinned native disposition: fallback). want captured from BAML final parse.",
+  "description": "map<Key,string> mixing an exact enum key (\"A\") with a non-member key (\"C\") for enum Key {A,B}. BAML's (dynamic) enum-key coercion is lenient: it accepts the non-exact key and inserts the ORIGINAL key string, so the result is the FULL map {\"A\":\"one\",\"C\":\"two\"}, NOT a partial one. Native requires an EXACT rendered-name match for every key and so DECLINES the whole map when any key is non-exact (pinned native disposition: fallback). want captured from live BAML final parse.",
   "preserve_schema_order": true,
   "schema": {
     "classes": [
@@ -19,6 +19,6 @@
   "raw": "{\"labels\":{\"A\":\"one\",\"C\":\"two\"}}",
   "want": {
     "status": "success",
-    "json": {"labels": {"A": "one"}}
+    "json": {"labels": {"A": "one", "C": "two"}}
   }
 }

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/29_map_bad_value_type.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/29_map_bad_value_type.json
@@ -1,0 +1,21 @@
+{
+  "name": "map_bad_value_type",
+  "description": "map<string,int> where one value (\"b\") is an object, which cannot coerce to int. BAML records MapValueParseError and SKIPS that entry, returning a partial map {\"a\":1}. Native declines the WHOLE map (a child value error means BAML returned a partial result native cannot claim) — pinned native disposition: fallback. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "scores", "type": {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"scores\":{\"a\":1,\"b\":{\"x\":1}}}",
+  "want": {
+    "status": "success",
+    "json": {"scores": {"a": 1}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/30_map_fuzzy_enum_key.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/30_map_fuzzy_enum_key.json
@@ -1,0 +1,24 @@
+{
+  "name": "map_fuzzy_enum_key",
+  "description": "map<Key,string> with a case-variant key (\"a\" for enum value A). BAML's enum key coercion fuzzy-matches via match_string and SUCCEEDS, inserting the ORIGINAL key string \"a\". Native exact match misses, so it DECLINES (fuzzy keys are Mcoerce) — pinned native disposition: fallback. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "labels", "type": {"kind": "map", "key": {"kind": "enum_ref", "ref": "Key"}, "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "enums": [
+      {"name": "Key", "values": ["A", "B"]}
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"labels\":{\"a\":\"one\"}}",
+  "want": {
+    "status": "success",
+    "json": {"labels": {"a": "one"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/31_map_partial_incomplete.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/31_map_partial_incomplete.json
@@ -1,6 +1,6 @@
 {
   "name": "map_partial_incomplete",
-  "description": "Unterminated map<string,int>: the object is cut off with no closing braces, but both entries have complete values. BAML's JSONish parser closes the open collections at EOF and recovers the partial map. Native finds no balanced span and DECLINES (M2a defers unterminated structures) — pinned native disposition: fallback. want captured from BAML final parse.",
+  "description": "Unterminated map<string,int>: the object is cut off with no closing braces. BAML's JSONish parser recovers the incomplete map as an EMPTY map (the incomplete entries are dropped), yielding {\"scores\":{}}. Native finds no balanced span and DECLINES (M2a defers unterminated structures) — pinned native disposition: fallback. want captured from live BAML final parse.",
   "preserve_schema_order": true,
   "schema": {
     "classes": [
@@ -16,6 +16,6 @@
   "raw": "{\"scores\":{\"a\":1,\"b\":2",
   "want": {
     "status": "success",
-    "json": {"scores": {"a": 1, "b": 2}}
+    "json": {"scores": {}}
   }
 }

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/31_map_partial_incomplete.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/31_map_partial_incomplete.json
@@ -1,0 +1,21 @@
+{
+  "name": "map_partial_incomplete",
+  "description": "Unterminated map<string,int>: the object is cut off with no closing braces, but both entries have complete values. BAML's JSONish parser closes the open collections at EOF and recovers the partial map. Native finds no balanced span and DECLINES (M2a defers unterminated structures) — pinned native disposition: fallback. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "scores", "type": {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"scores\":{\"a\":1,\"b\":2",
+  "want": {
+    "status": "success",
+    "json": {"scores": {"a": 1, "b": 2}}
+  }
+}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -177,6 +177,22 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"array_stray_commas":     true,
 	// Deferred repair (comments) — pinned fallback until claimed.
 	"comments_fallback": false,
+	// M2b native MAPS: clean maps are claimed and diff-green vs BAML —
+	// object input, exact key match (string / enum / string-literal /
+	// string-literal-union), in-scope values, emitted in INPUT key order.
+	"strict_map_string_int":        true,
+	"map_enum_keys":                true,
+	"map_string_class_values":      true,
+	"map_literal_union_keys_exact": true,
+	// M2b decline set: every map BAML would return as partial/scored — a
+	// skipped bad key/value (MapKeyParseError / MapValueParseError), a fuzzy
+	// match_string key (Mcoerce), or an unterminated/incomplete map (M2a
+	// defers). Native declines (fallback) rather than claim a clean result
+	// where BAML carries flags or skips entries.
+	"map_bad_enum_key":       false,
+	"map_bad_value_type":     false,
+	"map_fuzzy_enum_key":     false,
+	"map_partial_incomplete": false,
 }
 
 // parseRecoveryStats tallies how many final-parse cases the native parser

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -54,6 +54,8 @@ func coerce(b *schema.Bundle, t schema.Type, input value) (json.RawMessage, erro
 		return coerceClass(b, t.Name, t.Mode, input)
 	case schema.TypeList:
 		return coerceList(b, t.Elem, input)
+	case schema.TypeMap:
+		return coerceMap(b, t.Key, t.Value, input)
 	case schema.TypeUnion:
 		return coerceUnion(b, t.Union, input)
 	default:
@@ -275,6 +277,160 @@ func coerceList(b *schema.Bundle, elem *schema.Type, input value) (json.RawMessa
 	}
 	buf.WriteByte(']')
 	return buf.Bytes(), nil
+}
+
+// coerceMap coerces a JSON object into a map, emitting entries in INPUT key
+// order (the opposite of coerceClass's schema order: a map's keys are data,
+// a class's fields are the schema). It CLAIMS only the clean-map subset and
+// DECLINES everything BAML would represent as a partial/scored map — because
+// BAML's map coercer does NOT hard-fail on a bad entry: it records a
+// score-bearing MapKeyParseError / MapValueParseError and SKIPS that entry,
+// returning a partial map. Native cannot reproduce that partial result, and
+// must never claim a clean map where BAML would return a flagged/partial
+// one, so any uncertainty DECLINES (ErrDeBAMLParseUnsupported → fall back):
+//
+//   - Non-object input → DECLINE: BAML has object/map coercion + scoring
+//     outside this clean subset (it is not a hard type error).
+//   - A key with no EXACT match (matchMapKey) → DECLINE: BAML's enum/literal
+//     key coercion is fuzzy (match_string), and a no-match key is skipped
+//     with a flag rather than failing the map. Fuzzy key matching is Mcoerce.
+//   - ANY value coercion error (sentinel OR claimed) → DECLINE the WHOLE
+//     map: BAML attaches MapValueParseError and skips just that entry, so a
+//     native hard-claim here would diverge from BAML's partial success.
+//   - A duplicate output key → DECLINE: BAML's IndexMap insert/overwrite
+//     ordering for duplicates is unproven, so native does not claim it.
+//
+// Accepted entries are keyed by the ORIGINAL input key string (never the
+// canonical enum/literal form, matching coerce_map.rs:165-174), and an empty
+// object is a clean empty map. A class value is emitted by coerceClass in
+// schema order, nested inside the input-ordered map.
+func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value) (json.RawMessage, error) {
+	if keyT == nil || valT == nil {
+		return nil, fmt.Errorf("debaml: map type missing key or value")
+	}
+	if input.kind != valObject {
+		// Not a hard type error: BAML's object/map coercion + scoring can
+		// still produce a (partial/flagged) map from a non-object, so decline
+		// rather than claim a mismatch BAML would not produce.
+		return nil, declineCoerce("map target", input)
+	}
+
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	seen := make(map[string]struct{}, len(input.objV))
+	first := true
+	for i := range input.objV {
+		f := &input.objV[i]
+		if err := matchMapKey(b, *keyT, f.key); err != nil {
+			return nil, err
+		}
+		if _, dup := seen[f.key]; dup {
+			return nil, unsupported(fmt.Sprintf("map duplicate key %q (BAML duplicate insert/overwrite ordering unproven)", f.key))
+		}
+		seen[f.key] = struct{}{}
+
+		child, err := coerce(b, *valT, f.val)
+		if err != nil {
+			// A bad value: BAML records MapValueParseError and SKIPS this
+			// entry, returning a partial map — native cannot reproduce that, so
+			// decline the whole map (regardless of whether the child error was
+			// a sentinel decline or a claimed mismatch).
+			return nil, unsupported(fmt.Sprintf("map value for key %q: %v (BAML skips bad entries via MapValueParseError)", f.key, err))
+		}
+
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		key, err := marshalJSON(f.key)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(key)
+		buf.WriteByte(':')
+		buf.Write(child)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// matchMapKey validates an input object key string against the declared map
+// key type by EXACT match only, returning nil on a clean accept and a
+// DECLINE sentinel otherwise. checkSupportedMapKey has already restricted
+// the key type to the four legal shapes, so the default arm is defensive.
+//
+//   - string primitive: accept any key verbatim.
+//   - enum: require an EXACT rendered-name/alias match (the same exact path
+//     coerceEnum uses); BAML's full enum key coercion is fuzzy (match_string)
+//     so a non-exact key is Mcoerce, not a native claim.
+//   - string literal: require exact string equality.
+//   - union of string literals: require EXACTLY ONE flattened literal equal
+//     to the key (no match, or a duplicate-literal ambiguity, declines).
+//
+// The accepted key is NOT rewritten — coerceMap emits the original input key
+// string, matching BAML's insertion of the raw object key.
+func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
+	switch keyT.Kind {
+	case schema.TypePrimitive:
+		if keyT.Primitive == schema.PrimitiveString {
+			return nil
+		}
+		return unsupported(fmt.Sprintf("map key primitive %q", keyT.Primitive))
+	case schema.TypeEnum:
+		e, ok := b.FindEnum(keyT.Name)
+		if !ok {
+			return fmt.Errorf("debaml: unknown enum %q", keyT.Name)
+		}
+		if _, ok := e.ValueByRenderedName(key); !ok {
+			return unsupported(fmt.Sprintf("map key %q: no exact enum %q match (BAML fuzzy-matches)", key, keyT.Name))
+		}
+		return nil
+	case schema.TypeLiteral:
+		if keyT.Literal == nil || keyT.Literal.Kind != schema.LiteralString {
+			return unsupported("map key literal must be a string literal")
+		}
+		if key != keyT.Literal.String {
+			return unsupported(fmt.Sprintf("map key %q: no exact literal %q match (BAML fuzzy-matches)", key, keyT.Literal.String))
+		}
+		return nil
+	case schema.TypeUnion:
+		matches := 0
+		for _, lit := range flattenStringLiterals(keyT) {
+			if lit == key {
+				matches++
+			}
+		}
+		if matches != 1 {
+			return unsupported(fmt.Sprintf("map key %q: %d exact string-literal-union matches (need exactly 1; BAML fuzzy-matches)", key, matches))
+		}
+		return nil
+	default:
+		return unsupported(fmt.Sprintf("map key kind %q", keyT.Kind))
+	}
+}
+
+// flattenStringLiterals collects, in declaration order, every string-literal
+// value reachable from a (recursively nested) union — the candidate set a
+// union-of-string-literals map key is matched against. checkSupportedMapKey
+// has already proven t is a string-literal union, so non-literal/non-union
+// members are not expected and are skipped defensively.
+func flattenStringLiterals(t schema.Type) []string {
+	if t.Union == nil {
+		return nil
+	}
+	var out []string
+	for i := range t.Union.Variants {
+		v := &t.Union.Variants[i]
+		switch v.Kind {
+		case schema.TypeLiteral:
+			if v.Literal != nil && v.Literal.Kind == schema.LiteralString {
+				out = append(out, v.Literal.String)
+			}
+		case schema.TypeUnion:
+			out = append(out, flattenStringLiterals(*v)...)
+		}
+	}
+	return out
 }
 
 // coerceUnion handles the only union shape M1/M2a supports: an optional —

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -20,8 +20,11 @@ import (
 // caller falls back to BAML for that final parse:
 //
 //   - Stream parses (req.Stream==true) — native stream semantics are M4.
-//   - Schemas that cannot be lowered/validated, or that use maps, general
-//     (multi-variant) unions, constraints, or recursive aliases.
+//   - Schemas that cannot be lowered/validated, or that use general
+//     (multi-variant) unions, constraints, recursive aliases, or a map
+//     whose key/value falls outside the clean M2b map subset (see
+//     checkSupportedMapKey and coerceMap). Clean maps — object input,
+//     exact key match, in-scope value — are claimed in input key order.
 //   - Raw text whose JSON-looking candidate needs a repair outside the
 //     conservative M2a fixing subset — comments, escapes, missing commas,
 //     unterminated structures, multiple top-level values, … — which stays
@@ -151,12 +154,86 @@ func checkSupportedType(t schema.Type) error {
 		}
 		return checkSupportedType(t.Union.Variants[0])
 	case schema.TypeMap:
-		return unsupported("map")
+		// M2b CLAIMS clean maps: a JSON-object input coerced under a
+		// map-key-safe key type and a value type that itself passes the
+		// cut-line. The key must be checked SPECIALLY — not via the general
+		// checkSupportedType, which rejects every union — because a
+		// non-nullable union of string literals is a legal map key while
+		// being an out-of-scope union everywhere else.
+		if t.Key == nil || t.Value == nil {
+			return unsupported("map without key or value")
+		}
+		if err := checkSupportedMapKey(*t.Key); err != nil {
+			return err
+		}
+		return checkSupportedType(*t.Value)
 	case schema.TypeRecursiveAlias:
 		return unsupported("recursive alias")
 	default:
 		return unsupported(fmt.Sprintf("type kind %q", t.Kind))
 	}
+}
+
+// checkSupportedMapKey reports whether t is a map key shape M2b coerces by
+// EXACT match: a string primitive, an enum, a string literal, or a
+// non-nullable union whose recursively-flattened members are all string
+// literals. This mirrors BAML's allowed map-key set (coerce_map.rs) and the
+// repo's own isValidMapKey schema gate, kept separate from
+// checkSupportedType so the legal union-of-string-literals key is not
+// caught by the general-union rejection. A constrained key is out of scope.
+func checkSupportedMapKey(t schema.Type) error {
+	if len(t.Meta.Constraints) > 0 {
+		return unsupported("map key constraints")
+	}
+	switch t.Kind {
+	case schema.TypePrimitive:
+		if t.Primitive == schema.PrimitiveString {
+			return nil
+		}
+		return unsupported(fmt.Sprintf("map key primitive %q (only string)", t.Primitive))
+	case schema.TypeEnum:
+		return nil
+	case schema.TypeLiteral:
+		if t.Literal != nil && t.Literal.Kind == schema.LiteralString {
+			return nil
+		}
+		return unsupported("map key literal must be a string literal")
+	case schema.TypeUnion:
+		if isStringLiteralUnionType(t) {
+			return nil
+		}
+		return unsupported("map key union must be a non-nullable union of string literals")
+	default:
+		return unsupported(fmt.Sprintf("map key kind %q", t.Kind))
+	}
+}
+
+// isStringLiteralUnionType reports whether t is a non-nullable union every
+// member of which is a string literal or a nested non-nullable union of
+// string literals — the only union shape BAML (and M2b) accept as a map
+// key. It mirrors schema.isStringLiteralUnion: the non-nullable requirement
+// reproduces jsonish rejecting the null iter_include_null() appends for an
+// optional union.
+func isStringLiteralUnionType(t schema.Type) bool {
+	if t.Union == nil || t.Union.Nullable || len(t.Union.Variants) == 0 {
+		return false
+	}
+	for i := range t.Union.Variants {
+		v := &t.Union.Variants[i]
+		switch v.Kind {
+		case schema.TypeLiteral:
+			if v.Literal == nil || v.Literal.Kind != schema.LiteralString {
+				return false
+			}
+		case schema.TypeUnion:
+			if !isStringLiteralUnionType(*v) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // unsupported wraps bamlutils.ErrDeBAMLParseUnsupported with a reason so

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -297,15 +297,222 @@ func TestParse_UnsupportedNilSchema(t *testing.T) {
 	}
 }
 
-func TestParse_UnsupportedMap(t *testing.T) {
-	s := &bamlutils.DynamicOutputSchema{
-		Properties: props(kv("m", &bamlutils.DynamicProperty{
+// mapStringIntSchema is a root class with one map<string,int> field.
+func mapStringIntSchema() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("scores", &bamlutils.DynamicProperty{
 			Type:   "map",
 			Keys:   &bamlutils.DynamicTypeSpec{Type: "string"},
 			Values: &bamlutils.DynamicTypeSpec{Type: "int"},
 		})),
 	}
-	requireUnsupported(t, s, `{"m":{"a":1}}`)
+}
+
+func TestParse_MapStringInt(t *testing.T) {
+	// Clean map<string,int>: object input, string keys, in-scope int values.
+	// Byte-exact on purpose — map output MUST preserve INPUT key order (the
+	// keys here are deliberately out of lexical order), the M2b contract.
+	mustParseExact(t, mapStringIntSchema(),
+		`{"scores":{"z":1,"a":2,"m":3}}`,
+		`{"scores":{"z":1,"a":2,"m":3}}`)
+	// Empty object is a clean empty map.
+	mustParseExact(t, mapStringIntSchema(), `{"scores":{}}`, `{"scores":{}}`)
+}
+
+func TestParse_MapNonObjectDeclines(t *testing.T) {
+	// A non-object where a map is required is NOT a hard error: BAML's
+	// object/map coercion + scoring can still produce a (partial) map, so
+	// native declines rather than claiming a mismatch.
+	requireUnsupported(t, mapStringIntSchema(), `{"scores":[1,2,3]}`)
+	requireUnsupported(t, mapStringIntSchema(), `{"scores":"x"}`)
+}
+
+func TestParse_MapBadValueDeclines(t *testing.T) {
+	// A value that fails native clean coercion DECLINES the WHOLE map: BAML
+	// records MapValueParseError and SKIPS just that entry, returning a
+	// partial map — native cannot claim a different/partial result.
+	// String where int required (BAML parses "x"->skip or number-extracts).
+	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":"x"}}`)
+	// Float where int required (BAML rounds; native is exact -> child declines).
+	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":2.5}}`)
+}
+
+func TestParse_MapDuplicateKeyDeclines(t *testing.T) {
+	// A duplicate input key would collapse to one output key; BAML's
+	// duplicate insert/overwrite ordering is unproven here, so native
+	// declines rather than claim it.
+	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"a":2}}`)
+}
+
+// mapEnumKeySchema is a root class with one map<Key,string> field where Key
+// is an enum {A,B}.
+func mapEnumKeySchema() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("labels", &bamlutils.DynamicProperty{
+			Type:   "map",
+			Keys:   &bamlutils.DynamicTypeSpec{Ref: "Key"},
+			Values: &bamlutils.DynamicTypeSpec{Type: "string"},
+		})),
+		Enums: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Key", &bamlutils.DynamicEnum{
+				Values: []*bamlutils.DynamicEnumValue{{Name: "A"}, {Name: "B"}},
+			}),
+		),
+	}
+}
+
+func TestParse_MapEnumKeysExact(t *testing.T) {
+	// Enum keys matched EXACTLY by rendered name; the emitted key is the
+	// ORIGINAL input string (here identical to the canonical name), in input
+	// key order.
+	mustParseExact(t, mapEnumKeySchema(),
+		`{"labels":{"A":"one","B":"two"}}`,
+		`{"labels":{"A":"one","B":"two"}}`)
+}
+
+func TestParse_MapBadEnumKeyDeclines(t *testing.T) {
+	// A key not exactly in the enum: BAML records MapKeyParseError and skips
+	// it (partial map). Native declines the whole map.
+	requireUnsupported(t, mapEnumKeySchema(), `{"labels":{"A":"one","C":"two"}}`)
+}
+
+func TestParse_MapFuzzyEnumKeyDeclines(t *testing.T) {
+	// A case/fuzzy variant ("a" for enum value A): BAML's enum key coercion
+	// fuzzy-matches via match_string and SUCCEEDS (emitting the original key
+	// "a"); native's exact match misses, so it declines (fuzzy keys are
+	// Mcoerce). Native must NOT claim a missing/clean result.
+	requireUnsupported(t, mapEnumKeySchema(), `{"labels":{"a":"one"}}`)
+}
+
+func TestParse_MapEnumKeyAlias(t *testing.T) {
+	// The model is shown the alias; an exact alias match is accepted and the
+	// emitted key is the ORIGINAL input string (the alias), NOT the canonical
+	// enum name — maps insert the raw object key.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("labels", &bamlutils.DynamicProperty{
+			Type:   "map",
+			Keys:   &bamlutils.DynamicTypeSpec{Ref: "Key"},
+			Values: &bamlutils.DynamicTypeSpec{Type: "string"},
+		})),
+		Enums: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Key", &bamlutils.DynamicEnum{
+				Values: []*bamlutils.DynamicEnumValue{{Name: "GREEN", Alias: "Verde"}},
+			}),
+		),
+	}
+	mustParseExact(t, s, `{"labels":{"Verde":"x"}}`, `{"labels":{"Verde":"x"}}`)
+}
+
+func TestParse_MapLiteralUnionKeysExact(t *testing.T) {
+	// map<"A"|"B", string>: a non-nullable union of string literals as the
+	// key, matched EXACTLY (exactly one flattened literal equal to the key).
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("m", &bamlutils.DynamicProperty{
+			Type: "map",
+			Keys: &bamlutils.DynamicTypeSpec{
+				Type: "union",
+				OneOf: []*bamlutils.DynamicTypeSpec{
+					{Type: "literal_string", Value: "A"},
+					{Type: "literal_string", Value: "B"},
+				},
+			},
+			Values: &bamlutils.DynamicTypeSpec{Type: "string"},
+		})),
+	}
+	mustParseExact(t, s, `{"m":{"A":"x","B":"y"}}`, `{"m":{"A":"x","B":"y"}}`)
+	// A key not among the literals declines (BAML fuzzy-matches/skips).
+	requireUnsupported(t, s, `{"m":{"A":"x","C":"z"}}`)
+}
+
+// mapStringItemSchema is a root class with one map<string, Item> field; Item
+// has fields {id, label} in that schema order.
+func mapStringItemSchema() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("by_id", &bamlutils.DynamicProperty{
+			Type:   "map",
+			Keys:   &bamlutils.DynamicTypeSpec{Type: "string"},
+			Values: &bamlutils.DynamicTypeSpec{Ref: "Item"},
+		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Item", &bamlutils.DynamicClass{
+				Properties: props(kv("id", strProp()), kv("label", strProp())),
+			}),
+		),
+	}
+}
+
+func TestParse_MapStringClassValues(t *testing.T) {
+	// Map keys are out of lexical order AND each Item value has its fields out
+	// of schema order in the input. The two ordering policies must coexist:
+	// map keys stay in INPUT order while class fields are re-emitted in SCHEMA
+	// order. Byte-exact on purpose — this is the dual-ordering contract.
+	mustParseExact(t, mapStringItemSchema(),
+		`{"by_id":{"z":{"label":"zed","id":"3"},"a":{"label":"ay","id":"1"}}}`,
+		`{"by_id":{"z":{"id":"3","label":"zed"},"a":{"id":"1","label":"ay"}}}`)
+	// A map-to-class entry missing a required field DECLINES the whole map:
+	// BAML skips the bad entry (MapValueParseError), native cannot claim it.
+	requireUnsupported(t, mapStringItemSchema(),
+		`{"by_id":{"a":{"id":"1","label":"ay"},"b":{"id":"2"}}}`)
+}
+
+func TestParse_MapNestedMap(t *testing.T) {
+	// map<string, map<string,int>>: nested maps under the same M2b rules,
+	// both levels preserving input key order.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("grid", &bamlutils.DynamicProperty{
+			Type: "map",
+			Keys: &bamlutils.DynamicTypeSpec{Type: "string"},
+			Values: &bamlutils.DynamicTypeSpec{
+				Type:   "map",
+				Keys:   &bamlutils.DynamicTypeSpec{Type: "string"},
+				Values: &bamlutils.DynamicTypeSpec{Type: "int"},
+			},
+		})),
+	}
+	mustParseExact(t, s,
+		`{"grid":{"r2":{"c1":1,"c0":2},"r1":{"c9":3}}}`,
+		`{"grid":{"r2":{"c1":1,"c0":2},"r1":{"c9":3}}}`)
+}
+
+func TestParse_MapIncompleteDeclines(t *testing.T) {
+	// An unterminated map has no balanced span; native finds no
+	// cleanly-claimable candidate and DECLINES (BAML closes/recovers at EOF,
+	// which M2a defers) — never a claimed error.
+	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":`)
+	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":2`)
+}
+
+func TestParse_UnsupportedMapIntKey(t *testing.T) {
+	// A map key outside the legal set (int) is rejected upstream by schema
+	// validation; the parser falls back rather than claiming.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("m", &bamlutils.DynamicProperty{
+			Type:   "map",
+			Keys:   &bamlutils.DynamicTypeSpec{Type: "int"},
+			Values: &bamlutils.DynamicTypeSpec{Type: "int"},
+		})),
+	}
+	requireUnsupported(t, s, `{"m":{"1":1}}`)
+}
+
+func TestParse_UnsupportedMapUnionValue(t *testing.T) {
+	// A map value that is a general (multi-variant) union is out of scope:
+	// checkSupportedType rejects it via the value recursion, so the parser
+	// falls back.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("m", &bamlutils.DynamicProperty{
+			Type: "map",
+			Keys: &bamlutils.DynamicTypeSpec{Type: "string"},
+			Values: &bamlutils.DynamicTypeSpec{
+				Type: "union",
+				OneOf: []*bamlutils.DynamicTypeSpec{
+					{Type: "string"},
+					{Type: "int"},
+				},
+			},
+		})),
+	}
+	requireUnsupported(t, s, `{"m":{"a":"x"}}`)
 }
 
 func TestParse_UnsupportedGeneralUnion(t *testing.T) {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

De-BAML P4 Milestone 2b: native **map** coercion in `internal/debaml`, gated solely by `BAML_REST_USE_DEBAML`. No seam, codegen, dynclient-regen, or embed changes. Part of #546 (reference only — does not close the epic).

## What M2b CLAIMS (must match BAML exactly)

A map target whose input is a JSON **object**, in the clean-map subset:

- **Key type** ∈ { string primitive, enum, string literal, non-nullable union of string literals }, matched **EXACTLY**: string primitive accepts any key; enum requires an exact rendered-name/alias match; string literal requires exact string equality; a union-of-string-literals requires exactly one flattened literal equal to the key.
- The **original input key string** is inserted (never the canonical enum/literal form), preserving **input key order** (iterating the ordered value's `objV`, never a `map[string]any`).
- Values coerce through the existing M1+M2a `coerce()`. **Class values stay schema-ordered** while **map keys stay input-ordered** — the two policies coexist (verified byte-exact).
- Empty complete map is OK. Nested maps follow the same rules.

## What M2b DECLINES (→ `ErrDeBAMLParseUnsupported`, fall back to BAML)

The governing rule is stricter inside maps because BAML's map coercer never hard-fails a bad entry — it records a score-bearing `MapKeyParseError` / `MapValueParseError` and **skips** that entry, returning a *partial* map. Native cannot reproduce a partial/flagged map, so it declines on:

- Non-object input for a map (a decline, not a claimed type error — BAML has object/map coercion + scoring outside this subset).
- Any **bad or fuzzy key** (case-insensitive / punctuation-stripped / accent / substring `match_string` is the **Mcoerce** milestone).
- Any **value coercion error** → decline the whole map.
- Duplicate output keys (BAML's insert/overwrite ordering unproven here).
- Any key type outside the allowed set, or a nested map whose key/value is unsupported.
- Incomplete / unterminated maps (M2a already declines unterminated structures).

`ObjectToMap` (BAML's inherent per-map flag) is **not** a decline trigger — only map-local key/value-parse flags, the incomplete flag, fuzzy-key flags, or skipped entries are.

## Tests

- `internal/debaml/parse_test.go`: replaces `TestParse_UnsupportedMap` with the M2b suite — byte-exact clean-map claims (string/int, empty, enum keys incl. alias, literal-union keys, nested maps, and the dual map-key-order vs class-field-schema-order contract) plus fallback assertions for non-object/bad-key/fuzzy-key/bad-value/duplicate/incomplete/unsupported-key/union-value.
- `integration/bamlfuzz_parse_recovery_test.go` + `testdata/bamlfuzz/parse_recovery/*.json`: four native-claimed clean-map fixtures and four pinned-fallback fixtures, dispositions wired into `parseRecoveryNativeClaim`. The native-vs-BAML differential is the CI gate.

### Native-claimed (diff-green vs BAML)
`strict_map_string_int`, `map_enum_keys`, `map_string_class_values`, `map_literal_union_keys_exact`

### Pinned-fallback (native declines → BAML)
`map_bad_enum_key`, `map_bad_value_type`, `map_fuzzy_enum_key`, `map_partial_incomplete`

The fallback fixtures' `want` (BAML's observed output) is reasoned from BAML source (`coerce_map.rs`) since live BAML can't run locally; the CI live differential is the final gate for those values.

## Verification (local)

`go build ./...`, `go vet ./...` (incl. `-tags=integration ./integration`), `gofmt`, `go run ./cmd/verify-framework-adapter` (6/6), `GOWORK=off go test ./codegen/...` (adapters/common), `go test ./internal/debaml ./internal/schema ./bamlutils ./worker ./dynclient/...` — all green. The in-process differential (`-tags=integration ./integration`) needs Docker, which the live CI differential runs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced map parsing for “clean” JSON objects, including preserved key order for maps and nested maps.
  * Support added for exact enum and string-literal keys, plus strict handling for unsupported key/value shapes.
  * Expanded parse-recovery behavior for partially invalid map inputs.

* **Bug Fixes**
  * Fixed map parsing outcomes for duplicate keys, incorrect value types, incomplete/unterminated inputs, and fuzzy/invalid map keys.
  * Stabilized output ordering for complex object values within maps.

* **Tests**
  * Added broader map-focused coverage and fuzz recovery cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->