### PR TITLE
debaml: native score-free simple unions (P4 M2c)

### DIFF
--- a/adapters/common/codegen/bamlfuzz/envelope_parse.go
+++ b/adapters/common/codegen/bamlfuzz/envelope_parse.go
@@ -32,6 +32,11 @@ type ParseDiffFailureEnvelope struct {
 	PreserveSchemaOrder bool       `json:"preserve_schema_order"`
 	Schema              FuzzSchema `json:"schema"`
 
+	// UnionChoices mirrors the case's union-arm metadata so a replay artifact
+	// carries enough context to reproduce the schema-order check (which fails
+	// closed on a union path without a matching UnionChoice).
+	UnionChoices map[string]UnionChoice `json:"union_choices,omitempty"`
+
 	// Stream is true when the leg was a parse-stream comparison over an
 	// accumulated prefix; false for a final parse.
 	Stream bool `json:"stream"`

--- a/adapters/common/codegen/bamlfuzz/parse_recovery_case.go
+++ b/adapters/common/codegen/bamlfuzz/parse_recovery_case.go
@@ -57,6 +57,14 @@ type ParseRecoveryCase struct {
 	Raw                 string                `json:"raw,omitempty"`
 	Want                ParseExpected         `json:"want,omitempty"`
 	Prefixes            []ParseRecoveryPrefix `json:"prefixes,omitempty"`
+	// UnionChoices mirrors CaseMetadata.UnionChoices: it maps a JSON-path key
+	// (e.g. ".u") to the union arm the recorded `want` exercised. Recovery
+	// schemas historically carried no unions; the M2c score-free-union cases
+	// add union fields, and the schema-order checker FAILS CLOSED on a union
+	// path without a matching UnionChoice, so any union fixture run with
+	// preserve_schema_order must provide one. Carried through DiffParsers and
+	// characterizeFinal's order check.
+	UnionChoices map[string]UnionChoice `json:"union_choices,omitempty"`
 }
 
 // HasFinal reports whether the case carries a final-parse leg (a Want

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/32_literal_union_string_exact.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/32_literal_union_string_exact.json
@@ -1,0 +1,35 @@
+{
+  "name": "literal_union_string_exact",
+  "description": "M2c CLAIMED: homogeneous string-literal union with pairwise BAML-match-disjoint values (\"small\" | \"large\"); input exactly equals one arm. Native claims because disjointness proves BAML cannot fuzzy-match a 2nd arm. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "literal", "literal": {"kind": "string", "string": "small"}},
+                {"kind": "literal", "literal": {"kind": "string", "string": "large"}}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":\"small\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": "small"}
+  },
+  "union_choices": {
+    ".u": {"index": 0, "kind": "literal", "variant_count": 2}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/33_literal_union_bool_exact.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/33_literal_union_bool_exact.json
@@ -1,0 +1,35 @@
+{
+  "name": "literal_union_bool_exact",
+  "description": "M2c CLAIMED: homogeneous bool-literal union (true | false); JSON bool input exactly equals one arm. No two distinct bool literals can equal the same value, so native claims. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "literal", "literal": {"kind": "bool", "bool": true}},
+                {"kind": "literal", "literal": {"kind": "bool", "bool": false}}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":true}",
+  "want": {
+    "status": "success",
+    "json": {"u": true}
+  },
+  "union_choices": {
+    ".u": {"index": 0, "kind": "literal", "variant_count": 2}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/34_literal_union_int_exact.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/34_literal_union_int_exact.json
@@ -1,0 +1,35 @@
+{
+  "name": "literal_union_int_exact",
+  "description": "M2c CLAIMED: homogeneous int-literal union (1 | 2); exact JSON integer token equals one arm. No two distinct int literals can equal the same value, so native claims. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "literal", "literal": {"kind": "int", "int": 1}},
+                {"kind": "literal", "literal": {"kind": "int", "int": 2}}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":2}",
+  "want": {
+    "status": "success",
+    "json": {"u": 2}
+  },
+  "union_choices": {
+    ".u": {"index": 1, "kind": "literal", "variant_count": 2}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/35_class_union_single_shape.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/35_class_union_single_shape.json
@@ -1,0 +1,49 @@
+{
+  "name": "class_union_single_shape",
+  "description": "M2c CLAIMED: flat disjoint-key class union (Book{title,pages} | Car{brand,wheels}); input key set equals exactly one variant's full field set, every field a required flat leaf. Native claims the matched class, emitted in schema order. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "class_ref", "ref": "Book"},
+                {"kind": "class_ref", "ref": "Car"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Book",
+        "properties": [
+          {"name": "title", "type": {"kind": "string"}},
+          {"name": "pages", "type": {"kind": "int"}}
+        ]
+      },
+      {
+        "name": "Car",
+        "properties": [
+          {"name": "brand", "type": {"kind": "string"}},
+          {"name": "wheels", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"title\":\"Go\",\"pages\":300}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"title": "Go", "pages": 300}}
+  },
+  "union_choices": {
+    ".u": {"index": 0, "kind": "class_ref", "ref": "Book", "variant_count": 2}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/36_nullable_multi_union_null.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/36_nullable_multi_union_null.json
@@ -1,0 +1,36 @@
+{
+  "name": "nullable_multi_union_null",
+  "description": "M2c CLAIMED: nullable multi-union (string | int | null) with UNSAFE non-null arms; JSON-null input takes BAML's null fast path. Native claims null even though it would DECLINE any non-null input. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "string"},
+                {"kind": "int"},
+                {"kind": "null"}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":null}",
+  "want": {
+    "status": "success",
+    "json": {"u": null}
+  },
+  "union_choices": {
+    ".u": {"index": 2, "kind": "null", "variant_count": 3}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/37_string_int_union_numeric_string.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/37_string_int_union_numeric_string.json
@@ -1,0 +1,32 @@
+{
+  "name": "string_int_union_numeric_string",
+  "description": "M2c FALLBACK: bare-primitive union (string | int) with a numeric-string input. BAML stringifies/parses across kinds, so a 2nd arm can succeed -> pick_best scoring. Native declines (bare primitive variant). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "string"},
+                {"kind": "int"}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":\"123\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": "123"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/38_int_float_union_number.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/38_int_float_union_number.json
@@ -1,0 +1,32 @@
+{
+  "name": "int_float_union_number",
+  "description": "M2c FALLBACK: bare-primitive union (int | float) with a numeric input both arms can accept -> numeric overlap / pick_best scoring. Native declines (bare primitive variant). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "int"},
+                {"kind": "float"}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":5}",
+  "want": {
+    "status": "success",
+    "json": {"u": 5}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/39_class_union_overlapping_keys.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/39_class_union_overlapping_keys.json
@@ -1,0 +1,46 @@
+{
+  "name": "class_union_overlapping_keys",
+  "description": "M2c FALLBACK: class union whose variants share a field name (A{id,name} | B{id,label}). Shared keys are not match-disjoint, so BAML can partially match either arm -> scoring. Native declines at the gate. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "class_ref", "ref": "A"},
+                {"kind": "class_ref", "ref": "B"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "A",
+        "properties": [
+          {"name": "id", "type": {"kind": "int"}},
+          {"name": "name", "type": {"kind": "string"}}
+        ]
+      },
+      {
+        "name": "B",
+        "properties": [
+          {"name": "id", "type": {"kind": "int"}},
+          {"name": "label", "type": {"kind": "string"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"id\":1,\"name\":\"x\"}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"id": 1, "name": "x"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/40_single_field_class_union_implied_key.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/40_single_field_class_union_implied_key.json
@@ -1,0 +1,44 @@
+{
+  "name": "single_field_class_union_implied_key",
+  "description": "M2c FALLBACK: class union of single-field classes (A{val} | B{num}). A one-field class is implied-key/inferred-object risk: BAML can absorb a scalar or differently-keyed object into the lone field -> a 2nd arm can succeed. Native declines at the gate. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "class_ref", "ref": "A"},
+                {"kind": "class_ref", "ref": "B"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "A",
+        "properties": [
+          {"name": "val", "type": {"kind": "int"}}
+        ]
+      },
+      {
+        "name": "B",
+        "properties": [
+          {"name": "num", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"val\":5}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"val": 5}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/40_single_field_class_union_implied_key.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/40_single_field_class_union_implied_key.json
@@ -1,6 +1,6 @@
 {
   "name": "single_field_class_union_implied_key",
-  "description": "M2c FALLBACK: class union of single-field classes (A{val} | B{num}). A one-field class is implied-key/inferred-object risk: BAML can absorb a scalar or differently-keyed object into the lone field -> a 2nd arm can succeed. Native declines at the gate. want captured from BAML final parse.",
+  "description": "M2c FALLBACK: class union of single-field classes (A{val} | B{num}) with a BARE SCALAR input. A one-field class is implied-key/inferred-object risk: BAML infers an object from the scalar (coerce_class implied-key), so BOTH arms absorb 5 into their lone field and compete -> pick_best scoring. Native declines at the gate (single-field class union variant). want captured from BAML final parse.",
   "preserve_schema_order": false,
   "schema": {
     "classes": [
@@ -36,7 +36,7 @@
     "root_class": "Root",
     "has_union": true
   },
-  "raw": "{\"u\":{\"val\":5}}",
+  "raw": "{\"u\":5}",
   "want": {
     "status": "success",
     "json": {"u": {"val": 5}}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/41_literal_union_fuzzy_string.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/41_literal_union_fuzzy_string.json
@@ -1,0 +1,32 @@
+{
+  "name": "literal_union_fuzzy_string",
+  "description": "M2c FALLBACK: string-literal union whose values are NOT match-disjoint (\"on\" | \"only\"): \"on\" is a substring of \"only\" under the conservative match_string superset, so BAML could fuzzy-match a 2nd arm -> scoring. Native declines at the gate. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "literal", "literal": {"kind": "string", "string": "on"}},
+                {"kind": "literal", "literal": {"kind": "string", "string": "only"}}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":\"on\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": "on"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/42_literal_class_union_object_to_primitive.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/42_literal_class_union_object_to_primitive.json
@@ -1,0 +1,39 @@
+{
+  "name": "literal_class_union_object_to_primitive",
+  "description": "M2c FALLBACK: mixed literal-vs-class union (\"active\" | Status{code,detail}). BAML's object-to-primitive extraction (single-key object) can feed the literal arm, so a 2nd arm can succeed -> scoring. Native declines at the gate (mixed family). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "literal", "literal": {"kind": "string", "string": "active"}},
+                {"kind": "class_ref", "ref": "Status"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Status",
+        "properties": [
+          {"name": "code", "type": {"kind": "int"}},
+          {"name": "detail", "type": {"kind": "string"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":\"active\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": "active"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/42_literal_class_union_object_to_primitive.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/42_literal_class_union_object_to_primitive.json
@@ -1,6 +1,6 @@
 {
   "name": "literal_class_union_object_to_primitive",
-  "description": "M2c FALLBACK: mixed literal-vs-class union (\"active\" | Status{code,detail}). BAML's object-to-primitive extraction (single-key object) can feed the literal arm, so a 2nd arm can succeed -> scoring. Native declines at the gate (mixed family). want captured from BAML final parse.",
+  "description": "M2c FALLBACK: mixed literal-vs-class union (\"active\" | Status{tag}) with a SINGLE-KEY OBJECT input. The literal arm extracts the inner primitive via object-to-primitive (coerce_literal single-key object) and matches \"active\", while the class arm matches Status{tag:\"active\"} directly, so BOTH arms succeed and compete -> pick_best scoring. Native declines at the gate (mixed literal/class family). want captured from BAML final parse.",
   "preserve_schema_order": false,
   "schema": {
     "classes": [
@@ -22,8 +22,7 @@
       {
         "name": "Status",
         "properties": [
-          {"name": "code", "type": {"kind": "int"}},
-          {"name": "detail", "type": {"kind": "string"}}
+          {"name": "tag", "type": {"kind": "string"}}
         ]
       }
     ],
@@ -31,9 +30,9 @@
     "root_class": "Root",
     "has_union": true
   },
-  "raw": "{\"u\":\"active\"}",
+  "raw": "{\"u\":{\"tag\":\"active\"}}",
   "want": {
     "status": "success",
-    "json": {"u": "active"}
+    "json": {"u": {"tag": "active"}}
   }
 }

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/43_enum_class_union_object_to_string.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/43_enum_class_union_object_to_string.json
@@ -1,6 +1,6 @@
 {
   "name": "enum_class_union_object_to_string",
-  "description": "M2c FALLBACK: mixed enum-vs-class union (Color | Detail{a,b}). BAML's enum coercion uses match_string (incl. object-to-string for single-key objects) and the class arm can carry extra/implied flags, so a 2nd arm can succeed -> scoring. Native declines at the gate (mixed family). want captured from BAML final parse.",
+  "description": "M2c FALLBACK: mixed enum-vs-class union (Color | Detail{a,b}) with an object carrying BOTH the class fields AND an enum token. The enum arm matches RED from the stringified object (match_string object-to-string) while the class arm parses a/b and flags the extra \"color\" key, so BOTH arms succeed and compete -> pick_best scoring. Native declines at the gate (mixed enum/class family). want captured from BAML final parse.",
   "preserve_schema_order": false,
   "schema": {
     "classes": [
@@ -33,9 +33,9 @@
     "root_class": "Root",
     "has_union": true
   },
-  "raw": "{\"u\":\"RED\"}",
+  "raw": "{\"u\":{\"a\":1,\"b\":2,\"color\":\"RED\"}}",
   "want": {
     "status": "success",
-    "json": {"u": "RED"}
+    "json": {"u": {"a": 1, "b": 2}}
   }
 }

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/43_enum_class_union_object_to_string.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/43_enum_class_union_object_to_string.json
@@ -1,0 +1,41 @@
+{
+  "name": "enum_class_union_object_to_string",
+  "description": "M2c FALLBACK: mixed enum-vs-class union (Color | Detail{a,b}). BAML's enum coercion uses match_string (incl. object-to-string for single-key objects) and the class arm can carry extra/implied flags, so a 2nd arm can succeed -> scoring. Native declines at the gate (mixed family). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "enum_ref", "ref": "Color"},
+                {"kind": "class_ref", "ref": "Detail"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Detail",
+        "properties": [
+          {"name": "a", "type": {"kind": "int"}},
+          {"name": "b", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": [
+      {"name": "Color", "values": ["RED", "GREEN", "BLUE"]}
+    ],
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":\"RED\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": "RED"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/44_union_list_singleton_ambiguity.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/44_union_list_singleton_ambiguity.json
@@ -1,0 +1,32 @@
+{
+  "name": "union_list_singleton_ambiguity",
+  "description": "M2c FALLBACK: union with a list variant (string | list<string>). BAML's single-to-array coercion wraps a scalar into a one-element list, so both arms can succeed on a singleton -> scoring. Native declines at the gate (list variant). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "string"},
+                {"kind": "list", "inner": {"kind": "string"}}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":\"a\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": "a"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/45_union_map_value_partial.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/45_union_map_value_partial.json
@@ -1,0 +1,32 @@
+{
+  "name": "union_map_value_partial",
+  "description": "M2c FALLBACK: union with a map variant (map<string,int> | string) where a map value is uncoercible. BAML's map coercer records a MapValueParseError and returns a PARTIAL map rather than hard-failing, so a 2nd arm can succeed -> scoring. Native declines at the gate (map variant). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "int"}},
+                {"kind": "string"}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"a\":1,\"b\":\"x\"}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"a": 1}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/46_nested_union.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/46_nested_union.json
@@ -1,0 +1,38 @@
+{
+  "name": "nested_union",
+  "description": "M2c FALLBACK: nested union ((string | int) | bool). BAML flattens it to string|int|bool, a bare-primitive multi-union whose scored pick_best native cannot reproduce; the nested-union metadata/scoring is deferred. Native declines at the gate. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {
+                  "kind": "union",
+                  "variants": [
+                    {"kind": "string"},
+                    {"kind": "int"}
+                  ]
+                },
+                {"kind": "bool"}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":123}",
+  "want": {
+    "status": "success",
+    "json": {"u": 123}
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/valyala/bytebufferpool v1.0.0
 	golang.org/x/mod v0.37.0
+	golang.org/x/text v0.38.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
@@ -181,7 +182,6 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -193,6 +193,33 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"map_bad_value_type":     false,
 	"map_fuzzy_enum_key":     false,
 	"map_partial_incomplete": false,
+	// M2c native SCORE-FREE SIMPLE UNIONS: claimed when native can PROVE BAML
+	// also resolves to exactly one clean zero-score winner.
+	//
+	// Claimed: homogeneous exact-literal unions (string arms proven pairwise
+	// match-disjoint; bool/int by value equality), a flat disjoint-key class
+	// union (input == one variant's full field set), and the nullable
+	// multi-union null fast path.
+	"literal_union_string_exact": true,
+	"literal_union_bool_exact":   true,
+	"literal_union_int_exact":    true,
+	"class_union_single_shape":   true,
+	"nullable_multi_union_null":  true,
+	// Fallback: every union where a 2nd BAML arm could leniently succeed and
+	// invoke scored pick_best — bare primitive variants, numeric overlap,
+	// overlapping/single-field classes, fuzzy (non-disjoint) string literals,
+	// literal/enum-vs-class, list/single-to-array, map partials, nested
+	// unions. Native declines (fallback) rather than risk a scored divergence.
+	"string_int_union_numeric_string":         false,
+	"int_float_union_number":                  false,
+	"class_union_overlapping_keys":            false,
+	"single_field_class_union_implied_key":    false,
+	"literal_union_fuzzy_string":              false,
+	"literal_class_union_object_to_primitive": false,
+	"enum_class_union_object_to_string":       false,
+	"union_list_singleton_ambiguity":          false,
+	"union_map_value_partial":                 false,
+	"nested_union":                            false,
 }
 
 // parseRecoveryStats tallies how many final-parse cases the native parser
@@ -283,9 +310,11 @@ func runParseRecoveryCase(t *testing.T, baml, native bamlfuzz.Parser, c bamlfuzz
 				characterizeFinal(t, c, idx, bamlRes, bamlErr)
 			}
 
-			// Native-vs-BAML differential. choices is nil: recovery
-			// schemas carry no unions, so the order check needs none.
-			res := bamlfuzz.DiffParsers(ctx, baml, native, req, nil)
+			// Native-vs-BAML differential. choices carries the case's
+			// union-arm metadata so the schema-order check can descend into
+			// the exercised arm (it fails closed on a union path otherwise);
+			// it is nil for the union-free majority of cases.
+			res := bamlfuzz.DiffParsers(ctx, baml, native, req, c.UnionChoices)
 			if !res.SkippedNative && len(res.Failures) > 0 {
 				dumpParseDiffAndFail(t, parseRecoveryArtifactDir, parseDiffEnvelope(c, idx, -1, "", c.Raw, false, res), strings.Join(res.Failures, "; "))
 			}
@@ -360,7 +389,8 @@ func characterizeFinal(t *testing.T, c bamlfuzz.ParseRecoveryCase, idx int, res 
 		env := &bamlfuzz.ParseDiffFailureEnvelope{
 			CaseIndex: idx, CaseName: c.Name, OracleMode: bamlfuzz.OracleParseDiff,
 			PreserveSchemaOrder: c.PreserveSchemaOrder, Schema: c.Schema,
-			PrefixIndex: -1, Raw: c.Raw,
+			UnionChoices: c.UnionChoices,
+			PrefixIndex:  -1, Raw: c.Raw,
 			ExpectedStatus: c.Want.Status, Expected: c.Want.JSON,
 			BAML:     outcome,
 			Failures: []string{fmt.Sprintf("status parity: want %q, BAML produced %q", c.Want.Status, observed)},
@@ -382,7 +412,7 @@ func characterizeFinal(t *testing.T, c bamlfuzz.ParseRecoveryCase, idx int, res 
 	}
 	var orderDiff []bamlfuzz.SchemaOrderDiffEntry
 	if c.PreserveSchemaOrder {
-		od, oerr := bamlfuzz.SchemaOrderDiff("want_vs_baml", c.Schema, c.Want.JSON, res.JSON)
+		od, oerr := bamlfuzz.SchemaOrderDiffWithChoices("want_vs_baml", c.Schema, c.Want.JSON, res.JSON, c.UnionChoices)
 		if oerr != nil {
 			failures = append(failures, fmt.Sprintf("schema order: %v", oerr))
 		} else if len(od) > 0 {
@@ -396,7 +426,8 @@ func characterizeFinal(t *testing.T, c bamlfuzz.ParseRecoveryCase, idx int, res 
 	env := &bamlfuzz.ParseDiffFailureEnvelope{
 		CaseIndex: idx, CaseName: c.Name, OracleMode: bamlfuzz.OracleParseDiff,
 		PreserveSchemaOrder: c.PreserveSchemaOrder, Schema: c.Schema,
-		PrefixIndex: -1, Raw: c.Raw,
+		UnionChoices: c.UnionChoices,
+		PrefixIndex:  -1, Raw: c.Raw,
 		ExpectedStatus: c.Want.Status, Expected: c.Want.JSON,
 		BAML:         bamlfuzz.ParseOutcome{Parser: "baml_dynamic", JSON: res.JSON},
 		SemanticDiff: diff,
@@ -518,7 +549,8 @@ func parseDiffEnvelope(c bamlfuzz.ParseRecoveryCase, idx, prefixIdx int, prefixN
 	return &bamlfuzz.ParseDiffFailureEnvelope{
 		CaseIndex: idx, CaseName: c.Name, OracleMode: bamlfuzz.OracleParseDiff,
 		PreserveSchemaOrder: c.PreserveSchemaOrder, Schema: c.Schema,
-		Stream: stream, PrefixIndex: prefixIdx, PrefixName: prefixName, Raw: raw,
+		UnionChoices: c.UnionChoices,
+		Stream:       stream, PrefixIndex: prefixIdx, PrefixName: prefixName, Raw: raw,
 		SkippedNative: res.SkippedNative,
 		BAML:          res.BAML,
 		Native:        res.NativeOutcome(),

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -57,7 +57,7 @@ func coerce(b *schema.Bundle, t schema.Type, input value) (json.RawMessage, erro
 	case schema.TypeMap:
 		return coerceMap(b, t.Key, t.Value, input)
 	case schema.TypeUnion:
-		return coerceUnion(b, t.Union, input)
+		return coerceUnionSafe(b, t.Union, input)
 	default:
 		return nil, fmt.Errorf("debaml: cannot coerce type kind %q", t.Kind)
 	}
@@ -433,25 +433,179 @@ func flattenStringLiterals(t schema.Type) []string {
 	return out
 }
 
-// coerceUnion handles the only union shape M1/M2a supports: an optional —
-// a nullable union with exactly one non-null variant. A JSON null becomes
-// null; anything else coerces against the lone variant. checkSupported has
-// already rejected every other union, so this is reached only for
-// optionals.
-func coerceUnion(b *schema.Bundle, u *schema.UnionType, input value) (json.RawMessage, error) {
+// coerceUnionSafe coerces a value against a union, claiming native JSON ONLY
+// where it can PROVE BAML also resolves to exactly one clean zero-score
+// winner — otherwise it DECLINES (ErrDeBAMLParseUnsupported → fall back). The
+// M2c trap is that native's STRICT per-variant verdicts do not mirror BAML's
+// LENIENT ones: "exactly one native variant matched" does NOT prove "exactly
+// one BAML variant matched", because BAML leniency (fuzzy enum/literal,
+// string<->number, stringification, array-to-singular, implied-key class,
+// defaults) could make a 2nd arm succeed → BAML runs pick_best SCORING →
+// native's single pick may differ from BAML's scored winner. The claim is
+// limited to three cases (see the package M2c notes):
+//
+//  1. JSON-null input + nullable union → null immediately. This is BAML's
+//     null fast path and covers ANY nullable union (incl. multi-variant),
+//     because BAML returns the zero-score null arm before scoring.
+//  2. nullable single-non-null union (the M1 optional shape) → non-null input
+//     coerces through the lone variant; preserved EXACTLY.
+//  3. non-null input + a multi-variant SAFE FAMILY (homogeneous exact-literal
+//     union or flat disjoint-key class union, proven by
+//     checkSupportedUnionShape) where the value-level guard finds exactly one
+//     winner.
+//
+// Everything else declines. checkSupportedType permits a nullable multi-union
+// at the gate purely for case 1; its non-null arms are re-proven here, so a
+// non-null input to a nullable-but-unsafe union still declines.
+func coerceUnionSafe(b *schema.Bundle, u *schema.UnionType, input value) (json.RawMessage, error) {
 	if u == nil {
 		return nil, fmt.Errorf("debaml: union type missing payload")
 	}
+	// Case 1: nullable null fast path (any nullable union).
 	if input.kind == valNull {
 		if !u.Nullable {
 			return nil, typeMismatch("non-nullable union", input)
 		}
 		return json.RawMessage("null"), nil
 	}
-	if len(u.Variants) != 1 {
-		return nil, fmt.Errorf("debaml: general union scoring is unsupported")
+	// Case 2: M1 optional — a single non-null variant. (Non-nullable single
+	// variants collapse to the bare type in simplifyUnion, so this is reached
+	// only for the nullable optional shape; the behavior is unchanged.)
+	if len(u.Variants) == 1 {
+		return coerce(b, u.Variants[0], input)
 	}
-	return coerce(b, u.Variants[0], input)
+	// Case 3: non-null input against a multi-variant union. Re-prove the
+	// non-null arm set is a safe family (this also rejects non-null input to a
+	// nullable-but-unsafe union, which the gate permitted only for case 1).
+	if err := checkSupportedUnionShape(b, u); err != nil {
+		return nil, err
+	}
+	return coerceUnionSafeMulti(b, u.Variants, input)
+}
+
+// coerceUnionSafeMulti dispatches a proven-safe multi-variant union to its
+// family's value-level guard. checkSupportedUnionShape has already proven the
+// variant set is one of the two homogeneous families, so the else branch is
+// the flat class union.
+func coerceUnionSafeMulti(b *schema.Bundle, variants []schema.Type, input value) (json.RawMessage, error) {
+	if allLiteralVariants(variants) {
+		return coerceLiteralUnion(variants, input)
+	}
+	return coerceFlatClassUnion(b, variants, input)
+}
+
+// coerceLiteralUnion claims a homogeneous exact-literal union when EXACTLY
+// one literal exactly matches the input (and the input's JSON kind matches
+// the literal kind). For string literals the variant set was proven pairwise
+// match-disjoint by checkSupportedUnionShape, so an exact match on one arm
+// guarantees BAML cannot fuzzy-match another; for int/bool no two distinct
+// literals can equal the same value. Zero or (impossibly, after dedup) >1
+// exact matches decline. The matched literal is emitted through coerceLiteral
+// so the output form matches the single-literal path exactly.
+func coerceLiteralUnion(variants []schema.Type, input value) (json.RawMessage, error) {
+	matched := -1
+	count := 0
+	for i := range variants {
+		if literalExactMatches(variants[i].Literal, input) {
+			matched = i
+			count++
+		}
+	}
+	if count != 1 {
+		return nil, unsupported(fmt.Sprintf("literal union: %d exact matches for %s input (need exactly 1; BAML may fuzzy/parse-match)", count, input.kind.String()))
+	}
+	return coerceLiteral(variants[matched].Literal, input)
+}
+
+// literalExactMatches reports whether input EXACTLY matches lit by JSON kind
+// and value: a JSON bool equal to a bool literal, an exact JSON integer token
+// equal to an int literal, or a JSON string equal to a string literal. Any
+// leniency (numeric strings, float rounding, fuzzy string match) is BAML's
+// job and is deliberately NOT reproduced here.
+func literalExactMatches(lit *schema.LiteralValue, input value) bool {
+	if lit == nil {
+		return false
+	}
+	switch lit.Kind {
+	case schema.LiteralBool:
+		return input.kind == valBool && input.boolV == lit.Bool
+	case schema.LiteralInt:
+		if input.kind != valNumber {
+			return false
+		}
+		n, err := input.numV.Int64()
+		return err == nil && n == lit.Int
+	case schema.LiteralString:
+		return input.kind == valString && input.strV == lit.String
+	default:
+		return false
+	}
+}
+
+// coerceFlatClassUnion claims a flat disjoint-key class union when the input
+// is an object whose EXACT key set equals exactly one variant class's full
+// rendered field set (no extras, no missing, no duplicate keys) and that
+// class then coerces cleanly through the strict child coercers. The variant
+// classes were proven flat / >=2-required-field / disjoint-key by
+// checkSupportedUnionShape, so a full-key-set match on one arm guarantees
+// BAML cannot fuzzy-match the input keys onto another arm (every other arm is
+// missing >=2 required fields it cannot fill). Any extra/duplicate/missing
+// key, no match, or child coercion error (sentinel OR claimed) declines —
+// BAML may still resolve those via leniency/scoring.
+func coerceFlatClassUnion(b *schema.Bundle, variants []schema.Type, input value) (json.RawMessage, error) {
+	if input.kind != valObject {
+		// BAML can infer a single-field class from a scalar / imply a key;
+		// these classes are multi-field so a non-object is never a clean arm,
+		// but it is not a hard type error either, so decline.
+		return nil, declineCoerce("class union", input)
+	}
+	keySet := make(map[string]struct{}, len(input.objV))
+	for i := range input.objV {
+		k := input.objV[i].key
+		if _, dup := keySet[k]; dup {
+			return nil, unsupported(fmt.Sprintf("class union: duplicate input key %q", k))
+		}
+		keySet[k] = struct{}{}
+	}
+	matched := -1
+	for i := range variants {
+		cls, ok := b.FindClass(variants[i].Name, variants[i].Mode)
+		if !ok {
+			return nil, fmt.Errorf("debaml: unknown class %q", variants[i].Name)
+		}
+		if renderedFieldSetEquals(cls, keySet) {
+			matched = i
+			break // disjoint field sets ⇒ at most one variant can match.
+		}
+	}
+	if matched < 0 {
+		return nil, unsupported("class union: input key set matches no variant's full field set (extras/missing decline)")
+	}
+	out, err := coerceClass(b, variants[matched].Name, variants[matched].Mode, input)
+	if err != nil {
+		// A child sentinel decline OR a claimed child error both decline the
+		// union: BAML may coerce the field leniently (with a flag) and still
+		// resolve to this arm, or score a different one, so native must not
+		// claim a clean object where BAML's result could differ.
+		return nil, unsupported(fmt.Sprintf("class union: winning class %q child coercion not clean: %v", variants[matched].Name, err))
+	}
+	return out, nil
+}
+
+// renderedFieldSetEquals reports whether the rendered field-name set of cls
+// equals keySet exactly (same size, same members). checkSupportedUnionShape
+// has proven cls's rendered names are distinct, so size equality plus
+// membership is a true set equality.
+func renderedFieldSetEquals(cls *schema.ClassDef, keySet map[string]struct{}) bool {
+	if len(cls.Fields) != len(keySet) {
+		return false
+	}
+	for i := range cls.Fields {
+		if _, ok := keySet[cls.Fields[i].Name.RenderedName()]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // lookupField returns the input value for a class field, matched by the

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -153,18 +153,25 @@ func checkSupportedType(b *schema.Bundle, t schema.Type) error {
 			return unsupported("union without payload")
 		}
 		u := t.Union
-		// An optional — a nullable union with exactly one non-null variant —
-		// is the M1 shape: recurse into the lone arm.
-		if len(u.Variants) == 1 {
-			return checkSupportedType(b, u.Variants[0])
-		}
-		// A nullable multi-union is permitted at the gate for the null fast
-		// path: a JSON-null input always coerces to null (coerceUnionSafe),
-		// regardless of the non-null arms. Non-null input is decided at
-		// coerce time — it declines unless the non-null arm set is itself one
-		// of the M2c safe families, so permitting here never over-claims.
+		// A NULLABLE union always passes the gate for the null fast path: a
+		// JSON-null input coerces to null (coerceUnionSafe) regardless of the
+		// non-null arms — this must hold for ANY nullable union, including a
+		// single-arm optional whose lone non-null arm is itself unsupported
+		// (e.g. a nested/general-union arm or an out-of-scope map). Non-null
+		// input is still decided at coerce time and never over-claims: a
+		// single-non-null optional delegates to coerce on the lone arm (which
+		// declines if that arm is unsupported), and a nullable multi-union
+		// re-proves its non-null arm set is an M2c safe family. Checking
+		// Nullable BEFORE the len==1 recursion is what makes the null claim
+		// consistent across single-arm and multi-arm nullable unions.
 		if u.Nullable {
 			return nil
+		}
+		// A NON-nullable single-variant union collapses to its lone arm in
+		// simplifyUnion, so this is effectively unreachable; recurse into the
+		// arm defensively to mirror that collapse.
+		if len(u.Variants) == 1 {
+			return checkSupportedType(b, u.Variants[0])
 		}
 		// A non-nullable multi-union is in scope only when its variants form
 		// one of the M2c safe families (homogeneous exact-literal union or

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -3,6 +3,10 @@ package debaml
 import (
 	"context"
 	"fmt"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
 
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/internal/schema"
@@ -119,7 +123,7 @@ func checkSupported(b *schema.Bundle) error {
 			return unsupported("class constraints")
 		}
 		for j := range c.Fields {
-			if err := checkSupportedType(c.Fields[j].Type); err != nil {
+			if err := checkSupportedType(b, c.Fields[j].Type); err != nil {
 				return err
 			}
 		}
@@ -127,10 +131,12 @@ func checkSupported(b *schema.Bundle) error {
 	return nil
 }
 
-// checkSupportedType walks one type tree, rejecting the kinds M1 does not
-// coerce. Named class/enum references are leaves (their definitions are
-// validated via the bundle's class/enum slices).
-func checkSupportedType(t schema.Type) error {
+// checkSupportedType walks one type tree, rejecting the kinds native does
+// not coerce. Named class/enum references are leaves (their definitions are
+// validated via the bundle's class/enum slices). It needs the bundle so a
+// general union can be checked against the M2c safe-union families (which
+// inspect each class variant's fields).
+func checkSupportedType(b *schema.Bundle, t schema.Type) error {
 	if len(t.Meta.Constraints) > 0 {
 		return unsupported("type constraints")
 	}
@@ -141,18 +147,29 @@ func checkSupportedType(t schema.Type) error {
 		if t.Elem == nil {
 			return unsupported("list without element")
 		}
-		return checkSupportedType(*t.Elem)
+		return checkSupportedType(b, *t.Elem)
 	case schema.TypeUnion:
 		if t.Union == nil {
 			return unsupported("union without payload")
 		}
-		// Only an optional — a nullable union with exactly one non-null
-		// variant — is in scope. Any other union needs variant scoring,
-		// which is out of M1.
-		if !t.Union.Nullable || len(t.Union.Variants) != 1 {
-			return unsupported("general union")
+		u := t.Union
+		// An optional — a nullable union with exactly one non-null variant —
+		// is the M1 shape: recurse into the lone arm.
+		if len(u.Variants) == 1 {
+			return checkSupportedType(b, u.Variants[0])
 		}
-		return checkSupportedType(t.Union.Variants[0])
+		// A nullable multi-union is permitted at the gate for the null fast
+		// path: a JSON-null input always coerces to null (coerceUnionSafe),
+		// regardless of the non-null arms. Non-null input is decided at
+		// coerce time — it declines unless the non-null arm set is itself one
+		// of the M2c safe families, so permitting here never over-claims.
+		if u.Nullable {
+			return nil
+		}
+		// A non-nullable multi-union is in scope only when its variants form
+		// one of the M2c safe families (homogeneous exact-literal union or
+		// flat disjoint-key class union); checkSupportedUnionShape proves it.
+		return checkSupportedUnionShape(b, u)
 	case schema.TypeMap:
 		// M2b CLAIMS clean maps: a JSON-object input coerced under a
 		// map-key-safe key type and a value type that itself passes the
@@ -166,7 +183,7 @@ func checkSupportedType(t schema.Type) error {
 		if err := checkSupportedMapKey(*t.Key); err != nil {
 			return err
 		}
-		return checkSupportedType(*t.Value)
+		return checkSupportedType(b, *t.Value)
 	case schema.TypeRecursiveAlias:
 		return unsupported("recursive alias")
 	default:
@@ -234,6 +251,254 @@ func isStringLiteralUnionType(t schema.Type) bool {
 		}
 	}
 	return true
+}
+
+// checkSupportedUnionShape reports whether the NON-NULL variant set of a
+// multi-variant union (len(Variants) >= 2) is one of the two M2c safe
+// families. It is the structural half of the M2c claim: it proves BAML
+// cannot leniently succeed on a SECOND arm (which would force BAML's scored
+// pick_best, where native's single pick may diverge). The value-level guard
+// in coerceUnionSafe then proves BAML sees exactly one clean winner for the
+// concrete input.
+//
+// The two safe families are:
+//
+//   - HOMOGENEOUS LITERAL-ONLY union: every variant is a literal of the SAME
+//     kind. For string literals the value set must be pairwise disjoint under
+//     a conservative match_string SUPERSET (matchStringMightMatch) — exact
+//     disjointness is not enough because BAML fuzzy-matches string literals.
+//     int/bool literals need no extra check: BAML matches them by value
+//     equality, which (after dedup) no two distinct literals can both satisfy.
+//   - HOMOGENEOUS FLAT CLASS union: every variant is a constraint-free class
+//     ref whose class has >= 2 fields, every field REQUIRED and a FLAT LEAF
+//     (primitive scalar / literal / enum — no union/map/list/optional/
+//     recursive-alias/nested-class), and whose rendered field-name sets are
+//     pairwise disjoint under the same conservative key-match superset.
+//
+// Every other shape — a bare primitive variant, a list/map variant, a nested
+// union, mixed literal kinds, literal-vs-class, enum-vs-anything, overlapping
+// or single-field classes — declines, because BAML could leniently succeed on
+// a second arm there.
+func checkSupportedUnionShape(b *schema.Bundle, u *schema.UnionType) error {
+	vs := u.Variants
+	if len(vs) < 2 {
+		return unsupported("union shape: needs >= 2 non-null variants")
+	}
+	switch {
+	case allLiteralVariants(vs):
+		return checkHomogeneousLiteralUnion(vs)
+	case allClassVariants(vs):
+		return checkFlatClassUnion(b, vs)
+	default:
+		// Bare primitive, list, map, nested union, or a mixed variant family:
+		// BAML's lenient coercers (stringify, string<->number, array-to-
+		// singular, fuzzy enum/literal, implied-key class, defaults) can make
+		// a second arm succeed, so native cannot prove a single winner.
+		return unsupported("union shape: not a homogeneous literal or flat class union")
+	}
+}
+
+// allLiteralVariants reports whether every variant is a constraint-free
+// literal — the precondition for the homogeneous-literal family.
+func allLiteralVariants(vs []schema.Type) bool {
+	for i := range vs {
+		v := &vs[i]
+		if v.Kind != schema.TypeLiteral || v.Literal == nil || len(v.Meta.Constraints) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// allClassVariants reports whether every variant is a constraint-free class
+// ref — the precondition for the flat-class family.
+func allClassVariants(vs []schema.Type) bool {
+	for i := range vs {
+		v := &vs[i]
+		if v.Kind != schema.TypeClass || len(v.Meta.Constraints) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// checkHomogeneousLiteralUnion validates a literal-only variant set: all the
+// same literal kind, and — for string literals — pairwise match-disjoint.
+func checkHomogeneousLiteralUnion(vs []schema.Type) error {
+	kind := vs[0].Literal.Kind
+	for i := range vs {
+		if vs[i].Literal.Kind != kind {
+			return unsupported("literal union: mixed literal kinds (BAML may coerce a 2nd arm)")
+		}
+	}
+	if kind == schema.LiteralString {
+		lits := make([]string, len(vs))
+		for i := range vs {
+			lits[i] = vs[i].Literal.String
+		}
+		if !stringsPairwiseDisjoint(lits) {
+			return unsupported("string-literal union: values not pairwise match-disjoint (BAML may fuzzy-match a 2nd arm)")
+		}
+	}
+	return nil
+}
+
+// checkFlatClassUnion validates a class-only variant set as a flat,
+// disjoint-key discriminated union: every variant class is constraint-free,
+// has >= 2 required FLAT-LEAF fields, has no duplicate rendered field names,
+// and the variants' rendered field-name sets are pairwise disjoint under the
+// conservative key-match superset.
+func checkFlatClassUnion(b *schema.Bundle, vs []schema.Type) error {
+	sets := make([][]string, len(vs))
+	for i := range vs {
+		v := &vs[i]
+		cls, ok := b.FindClass(v.Name, v.Mode)
+		if !ok {
+			return fmt.Errorf("debaml: unknown class %q", v.Name)
+		}
+		if len(cls.Constraints) > 0 {
+			return unsupported("class-union variant class has constraints")
+		}
+		if len(cls.Fields) < 2 {
+			// A single-field class is implied-key/inferred-object risk: BAML
+			// can absorb a scalar or a differently-keyed object into the lone
+			// field, succeeding where native's exact match fails.
+			return unsupported("class-union variant class has < 2 fields (BAML implied-key risk)")
+		}
+		names := make([]string, 0, len(cls.Fields))
+		seen := make(map[string]struct{}, len(cls.Fields))
+		for j := range cls.Fields {
+			f := &cls.Fields[j]
+			if !isFlatLeafField(f.Type) {
+				// Any optional/union/map/list/nested-class/recursive field opens
+				// BAML leniency (defaults, implied keys, partial maps, single-to-
+				// array), so the class is not a clean discriminated arm.
+				return unsupported("class-union variant has a non-flat-leaf or optional field")
+			}
+			rn := f.Name.RenderedName()
+			if _, dup := seen[rn]; dup {
+				return unsupported("class-union variant has duplicate rendered field names")
+			}
+			seen[rn] = struct{}{}
+			names = append(names, rn)
+		}
+		sets[i] = names
+	}
+	if !fieldNameSetsPairwiseDisjoint(sets) {
+		return unsupported("class-union field-name sets not pairwise match-disjoint (BAML may fuzzy-match keys to a 2nd arm)")
+	}
+	return nil
+}
+
+// isFlatLeafField reports whether t is a flat exact leaf field type usable in
+// an M2c class-union variant: a constraint-free primitive scalar (string /
+// int / float / bool), literal, or enum. Everything else — null/media
+// primitives, unions (incl. optionals), maps, lists, nested classes,
+// recursive aliases — is rejected, because each one introduces BAML leniency
+// native cannot prove away inside a union.
+func isFlatLeafField(t schema.Type) bool {
+	if len(t.Meta.Constraints) > 0 {
+		return false
+	}
+	switch t.Kind {
+	case schema.TypePrimitive:
+		switch t.Primitive {
+		case schema.PrimitiveString, schema.PrimitiveInt, schema.PrimitiveFloat, schema.PrimitiveBool:
+			return true
+		default:
+			return false
+		}
+	case schema.TypeLiteral, schema.TypeEnum:
+		return true
+	default:
+		return false
+	}
+}
+
+// stringsPairwiseDisjoint reports whether no two distinct strings in vals
+// could match under the conservative match_string superset.
+func stringsPairwiseDisjoint(vals []string) bool {
+	for i := 0; i < len(vals); i++ {
+		for j := i + 1; j < len(vals); j++ {
+			if matchStringMightMatch(vals[i], vals[j]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// fieldNameSetsPairwiseDisjoint reports whether no field name in any set
+// could match a field name in any OTHER set under the conservative
+// match_string superset — the property that lets native prove BAML cannot
+// fuzzy-match the input keys of one class-union arm onto another arm.
+func fieldNameSetsPairwiseDisjoint(sets [][]string) bool {
+	for i := 0; i < len(sets); i++ {
+		for j := i + 1; j < len(sets); j++ {
+			for _, a := range sets[i] {
+				for _, b := range sets[j] {
+					if matchStringMightMatch(a, b) {
+						return false
+					}
+				}
+			}
+		}
+	}
+	return true
+}
+
+// matchStringMightMatch is a CONSERVATIVE SUPERSET of BAML's match_string: it
+// returns true whenever BAML could possibly match one of a/b against the
+// other, and only "wrongly" returns true in extra cases (which merely cause
+// native to DECLINE — always parity-safe). BAML's match_string normalizes
+// (trim, strip punctuation, fold case, fold accents) and then substring-
+// matches in both directions; this mirrors that and additionally treats any
+// non-ASCII residue conservatively (BAML may transliterate it in ways this
+// folder does not reproduce, e.g. ø->o, ß->ss), so a pair that still carries
+// non-ASCII letters after folding is treated as a possible match.
+func matchStringMightMatch(a, b string) bool {
+	na, asciiA := normalizeForMatchString(a)
+	nb, asciiB := normalizeForMatchString(b)
+	if !asciiA || !asciiB {
+		// Non-ASCII residue after accent folding could still transliterate-
+		// match in BAML; be conservative and treat as a possible match.
+		return true
+	}
+	if na == "" || nb == "" {
+		// An all-punctuation token normalizes empty and is a substring of
+		// everything under BAML's substring matching; treat as a match.
+		return true
+	}
+	if na == nb {
+		return true
+	}
+	return strings.Contains(na, nb) || strings.Contains(nb, na)
+}
+
+// normalizeForMatchString folds a string the way the conservative
+// match_string superset compares: NFD-decompose, drop combining marks (accent
+// fold), lowercase, and keep only letters and digits (trim + punctuation
+// strip). It also reports whether every kept rune is ASCII, so the caller can
+// treat unfoldable non-ASCII residue conservatively.
+func normalizeForMatchString(s string) (string, bool) {
+	d := norm.NFD.String(s)
+	var sb strings.Builder
+	allASCII := true
+	for _, r := range d {
+		if unicode.Is(unicode.Mn, r) {
+			// Combining mark left by NFD decomposition (the accent itself).
+			continue
+		}
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			continue
+		}
+		lr := unicode.ToLower(r)
+		if lr > unicode.MaxASCII {
+			allASCII = false
+		}
+		sb.WriteRune(lr)
+	}
+	return sb.String(), allASCII
 }
 
 // unsupported wraps bamlutils.ErrDeBAMLParseUnsupported with a reason so

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -739,14 +739,20 @@ func TestParse_UnsupportedPrimitiveUnion(t *testing.T) {
 }
 
 func TestParse_UnsupportedNestedUnionVariant(t *testing.T) {
-	// A union containing a list variant (general union with a non-leaf arm)
-	// declines: list/single-to-array leniency is scored.
+	// A genuinely nested union ((string | int) | bool): BAML flattens it to a
+	// bare-primitive multi-union (string|int|bool) whose scored pick_best
+	// native cannot reproduce, so native declines at the gate. (This mirrors
+	// the nested_union parse-recovery fallback fixture.)
 	s := unionSchema(
-		litStr("a"),
-		&bamlutils.DynamicTypeSpec{Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "string"}},
+		&bamlutils.DynamicTypeSpec{Type: "union", OneOf: []*bamlutils.DynamicTypeSpec{
+			{Type: "string"},
+			{Type: "int"},
+		}},
+		&bamlutils.DynamicTypeSpec{Type: "bool"},
 	)
+	requireUnsupported(t, s, `{"u":123}`)
 	requireUnsupported(t, s, `{"u":"a"}`)
-	requireUnsupported(t, s, `{"u":["a","b"]}`)
+	requireUnsupported(t, s, `{"u":true}`)
 }
 
 func TestParse_SingleFieldClassImpliedKeyDeclines(t *testing.T) {

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -727,6 +727,34 @@ func TestParse_NullableMultiUnionNullClaimed(t *testing.T) {
 	requireUnsupported(t, s, `{"u":5}`)
 }
 
+func TestParse_NullableSingleArmUnsupportedArmClaimsNull(t *testing.T) {
+	// A nullable single-arm union T | null where T is UNSUPPORTED (here T is a
+	// map whose value is a general string|int union — out of scope). The null
+	// fast path must CLAIM null regardless of the unsupported arm (mirroring
+	// BAML's null arm), consistently with nullable MULTI unions. A NON-null
+	// input must DECLINE: coerceUnionSafe delegates to coerce on the lone arm,
+	// which falls back because the arm is unsupported.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type: "optional",
+			Inner: &bamlutils.DynamicTypeSpec{
+				Type: "map",
+				Keys: &bamlutils.DynamicTypeSpec{Type: "string"},
+				Values: &bamlutils.DynamicTypeSpec{
+					Type:  "union",
+					OneOf: []*bamlutils.DynamicTypeSpec{{Type: "string"}, {Type: "int"}},
+				},
+			},
+		})),
+	}
+	// JSON null → CLAIM null (null fast path), even though the lone arm is
+	// unsupported. Before the gate fix this DECLINED (the len==1 recursion
+	// rejected the unsupported arm before the nullable check).
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	// Non-null → DECLINE (the lone map arm has a general-union value type).
+	requireUnsupported(t, s, `{"u":{"a":"x"}}`)
+}
+
 func TestParse_UnsupportedPrimitiveUnion(t *testing.T) {
 	// A bare-primitive multi-union (string|int) declines: BAML stringifies /
 	// parses across kinds, so a second arm could succeed → scoring.

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -515,17 +515,238 @@ func TestParse_UnsupportedMapUnionValue(t *testing.T) {
 	requireUnsupported(t, s, `{"m":{"a":"x"}}`)
 }
 
-func TestParse_UnsupportedGeneralUnion(t *testing.T) {
+// unionSchema wraps a single union property `u` with the given variants.
+func unionSchema(variants ...*bamlutils.DynamicTypeSpec) *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type:  "union",
+			OneOf: variants,
+		})),
+	}
+}
+
+func litStr(v string) *bamlutils.DynamicTypeSpec {
+	return &bamlutils.DynamicTypeSpec{Type: "literal_string", Value: v}
+}
+
+func TestParse_LiteralUnionStringExactClaimed(t *testing.T) {
+	// Homogeneous string-literal union with pairwise BAML-match-disjoint
+	// values: native CLAIMS the arm that EXACTLY equals the input, because
+	// disjointness proves BAML cannot fuzzy-match a second arm.
+	s := unionSchema(litStr("small"), litStr("large"))
+	mustParse(t, s, `{"u":"small"}`, `{"u":"small"}`)
+	mustParse(t, s, `{"u":"large"}`, `{"u":"large"}`)
+	// No exact literal match → DECLINE (BAML may fuzzy-match one arm).
+	requireUnsupported(t, s, `{"u":"medium"}`)
+	// Non-string input → DECLINE (BAML may stringify/coerce it).
+	requireUnsupported(t, s, `{"u":5}`)
+}
+
+func TestParse_LiteralUnionFuzzyStringDeclinedAtGate(t *testing.T) {
+	// "on" is a substring of "only" under the conservative match_string
+	// superset, so the set is NOT provably disjoint: BAML could fuzzy-match
+	// the input "on" against the "only" arm too → scoring → native must
+	// never claim. The whole schema is rejected at the gate (fall back).
+	s := unionSchema(litStr("on"), litStr("only"))
+	requireUnsupported(t, s, `{"u":"on"}`)
+	requireUnsupported(t, s, `{"u":"only"}`)
+	// Case/punctuation-only variants are also non-disjoint under the fold.
+	s2 := unionSchema(litStr("Yes"), litStr("yes!"))
+	requireUnsupported(t, s2, `{"u":"Yes"}`)
+}
+
+func TestParse_LiteralUnionBoolExactClaimed(t *testing.T) {
+	s := unionSchema(
+		&bamlutils.DynamicTypeSpec{Type: "literal_bool", Value: true},
+		&bamlutils.DynamicTypeSpec{Type: "literal_bool", Value: false},
+	)
+	mustParse(t, s, `{"u":true}`, `{"u":true}`)
+	mustParse(t, s, `{"u":false}`, `{"u":false}`)
+	// Non-bool input → DECLINE (BAML accepts fuzzy/string bool).
+	requireUnsupported(t, s, `{"u":"true"}`)
+	requireUnsupported(t, s, `{"u":1}`)
+}
+
+func TestParse_LiteralUnionIntExactClaimed(t *testing.T) {
+	s := unionSchema(
+		&bamlutils.DynamicTypeSpec{Type: "literal_int", Value: int64(1)},
+		&bamlutils.DynamicTypeSpec{Type: "literal_int", Value: int64(2)},
+	)
+	mustParse(t, s, `{"u":1}`, `{"u":1}`)
+	mustParse(t, s, `{"u":2}`, `{"u":2}`)
+	// No literal equals the (exact-integer) input → DECLINE.
+	requireUnsupported(t, s, `{"u":3}`)
+	// Non-integer JSON number token → DECLINE (BAML rounds/parses).
+	requireUnsupported(t, s, `{"u":2.0}`)
+	requireUnsupported(t, s, `{"u":1.5}`)
+	// Numeric string → DECLINE (BAML parses "2"→2).
+	requireUnsupported(t, s, `{"u":"2"}`)
+}
+
+func TestParse_LiteralUnionMixedKindDeclinedAtGate(t *testing.T) {
+	// Mixed literal kinds (string vs int): BAML can string-coerce/parse across
+	// kinds, so a second arm could succeed → decline at the gate.
+	s := unionSchema(litStr("1"), &bamlutils.DynamicTypeSpec{Type: "literal_int", Value: int64(1)})
+	requireUnsupported(t, s, `{"u":"1"}`)
+	requireUnsupported(t, s, `{"u":1}`)
+}
+
+// classUnionSchema wraps a single union property `u` over two flat classes
+// Book{title,pages} and Car{brand,wheels} with disjoint field-name sets.
+func classUnionSchema() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type: "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{
+				{Ref: "Book"},
+				{Ref: "Car"},
+			},
+		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Book", &bamlutils.DynamicClass{
+				Properties: props(kv("title", strProp()), kv("pages", intProp())),
+			}),
+			bamlutils.OrderedKV("Car", &bamlutils.DynamicClass{
+				Properties: props(kv("brand", strProp()), kv("wheels", intProp())),
+			}),
+		),
+	}
+}
+
+func TestParse_ClassUnionFlatDisjointClaimed(t *testing.T) {
+	s := classUnionSchema()
+	// Input key set == exactly one variant's full field set → CLAIM, emitted
+	// in that class's schema order.
+	mustParse(t, s, `{"u":{"title":"Go","pages":300}}`, `{"u":{"title":"Go","pages":300}}`)
+	mustParse(t, s, `{"u":{"brand":"Audi","wheels":4}}`, `{"u":{"brand":"Audi","wheels":4}}`)
+	// Class fields re-emitted in SCHEMA order even when input is out of order.
+	mustParse(t, s, `{"u":{"pages":300,"title":"Go"}}`, `{"u":{"title":"Go","pages":300}}`)
+}
+
+func TestParse_ClassUnionDeclines(t *testing.T) {
+	s := classUnionSchema()
+	// Extra key beyond a variant's full field set → DECLINE (BAML ignores
+	// extras and could still match, or fuzzy-match the extra onto the other
+	// arm).
+	requireUnsupported(t, s, `{"u":{"title":"Go","pages":300,"x":1}}`)
+	// Missing a required field → DECLINE (BAML may fuzzy-match/fill).
+	requireUnsupported(t, s, `{"u":{"title":"Go"}}`)
+	// Key set matches no variant → DECLINE.
+	requireUnsupported(t, s, `{"u":{"foo":1,"bar":2}}`)
+	// Winning class's child does not coerce cleanly (pages is a string) →
+	// DECLINE (BAML coerces "300"→300 with a flag and may still resolve here).
+	requireUnsupported(t, s, `{"u":{"title":"Go","pages":"300"}}`)
+	// Non-object input → DECLINE (BAML can infer/imply a class from a scalar).
+	requireUnsupported(t, s, `{"u":5}`)
+	requireUnsupported(t, s, `{"u":"Go"}`)
+}
+
+func TestParse_ClassUnionOverlappingKeysDeclinedAtGate(t *testing.T) {
+	// Two classes sharing a field name (id) are NOT disjoint: BAML could
+	// partially match either arm → scoring → decline the whole schema.
 	s := &bamlutils.DynamicOutputSchema{
 		Properties: props(kv("u", &bamlutils.DynamicProperty{
 			Type: "union",
 			OneOf: []*bamlutils.DynamicTypeSpec{
-				{Type: "string"},
-				{Type: "int"},
+				{Ref: "A"},
+				{Ref: "B"},
 			},
 		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("A", &bamlutils.DynamicClass{
+				Properties: props(kv("id", intProp()), kv("name", strProp())),
+			}),
+			bamlutils.OrderedKV("B", &bamlutils.DynamicClass{
+				Properties: props(kv("id", intProp()), kv("label", strProp())),
+			}),
+		),
 	}
+	requireUnsupported(t, s, `{"u":{"id":1,"name":"x"}}`)
+}
+
+func TestParse_ClassUnionSingleFieldDeclinedAtGate(t *testing.T) {
+	// A single-field class arm is implied-key risk → decline at the gate even
+	// though the field names are disjoint.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type: "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{
+				{Ref: "A"},
+				{Ref: "B"},
+			},
+		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("A", &bamlutils.DynamicClass{
+				Properties: props(kv("only", intProp())),
+			}),
+			bamlutils.OrderedKV("B", &bamlutils.DynamicClass{
+				Properties: props(kv("solo", strProp())),
+			}),
+		),
+	}
+	requireUnsupported(t, s, `{"u":{"only":1}}`)
+}
+
+func TestParse_ClassUnionNonFlatFieldDeclinedAtGate(t *testing.T) {
+	// A class-union arm with a non-flat-leaf field (a list) is out of scope:
+	// BAML's single-to-array leniency could make a second arm succeed.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type: "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{
+				{Ref: "A"},
+				{Ref: "B"},
+			},
+		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("A", &bamlutils.DynamicClass{
+				Properties: props(kv("title", strProp()), kv("tags", &bamlutils.DynamicProperty{
+					Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "string"},
+				})),
+			}),
+			bamlutils.OrderedKV("B", &bamlutils.DynamicClass{
+				Properties: props(kv("brand", strProp()), kv("wheels", intProp())),
+			}),
+		),
+	}
+	requireUnsupported(t, s, `{"u":{"title":"Go","tags":["a"]}}`)
+}
+
+func TestParse_NullableMultiUnionNullClaimed(t *testing.T) {
+	// A nullable multi-union with UNSAFE non-null arms (bare string/int):
+	// native CLAIMS the null fast path for JSON-null input, but DECLINES every
+	// non-null input (the non-null arm set is not a safe family).
+	s := unionSchema(
+		&bamlutils.DynamicTypeSpec{Type: "string"},
+		&bamlutils.DynamicTypeSpec{Type: "int"},
+		&bamlutils.DynamicTypeSpec{Type: "null"},
+	)
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	// Non-null input → DECLINE (string/int arms are lenient/scored).
 	requireUnsupported(t, s, `{"u":"x"}`)
+	requireUnsupported(t, s, `{"u":5}`)
+}
+
+func TestParse_UnsupportedPrimitiveUnion(t *testing.T) {
+	// A bare-primitive multi-union (string|int) declines: BAML stringifies /
+	// parses across kinds, so a second arm could succeed → scoring.
+	s := unionSchema(
+		&bamlutils.DynamicTypeSpec{Type: "string"},
+		&bamlutils.DynamicTypeSpec{Type: "int"},
+	)
+	requireUnsupported(t, s, `{"u":"x"}`)
+	requireUnsupported(t, s, `{"u":5}`)
+}
+
+func TestParse_UnsupportedNestedUnionVariant(t *testing.T) {
+	// A union containing a list variant (general union with a non-leaf arm)
+	// declines: list/single-to-array leniency is scored.
+	s := unionSchema(
+		litStr("a"),
+		&bamlutils.DynamicTypeSpec{Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "string"}},
+	)
+	requireUnsupported(t, s, `{"u":"a"}`)
+	requireUnsupported(t, s, `{"u":["a","b"]}`)
 }
 
 func TestParse_SingleFieldClassImpliedKeyDeclines(t *testing.T) {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

De-BAML P4 Milestone 2c: the bounded native parser now natively handles a tightly-bounded set of **score-free simple unions**, the last milestone of the M2 stack.

## The governing principle (the M2c trap)

de-BAML's bar is PARITY. Native's STRICT per-variant verdicts do **not** mirror BAML's LENIENT ones, so "exactly one native variant matched" does **not** prove "exactly one BAML variant matched": BAML leniency (fuzzy enum/literal via `match_string`, string↔number, stringification, array-to-singular, implied-key class, defaults) could make a 2nd arm succeed → BAML runs `pick_best` SCORING → native's single pick may differ from BAML's scored winner. So native may CLAIM a union **only** when it can PROVE BAML also sees exactly one clean zero-score winner.

## What native CLAIMS

- **Nullable-null fast path** — JSON-null input to *any* nullable union (incl. multi-variant) → `null`, before inspecting non-null arms.
- **M1 optional** — nullable single-non-null union, preserved **exactly** (subsumes the old `coerceUnion`).
- **Homogeneous exact-literal unions** — all variants literals of the same kind. bool/int by value equality (no two distinct literals match one value); string literals **only** when the value set is pairwise disjoint under a conservative `match_string` SUPERSET (NFD accent-fold, case-fold, punctuation strip, bidirectional substring; non-ASCII residue treated conservatively).
- **Flat disjoint-key class unions** — every variant a constraint-free class with ≥2 required FLAT-LEAF fields (primitive scalar / literal / enum), rendered field-name sets pairwise disjoint under the same superset, the input object's exact key set equal to exactly one variant's full field set (no extras/missing/dupes), coerced cleanly through the strict child coercers.

## What native DECLINES (→ M3/Mcoerce)

Everything lenient/ambiguous/scored: bare primitive string/int/float/bool variants, list/map variants (or nested under map), nested unions, mixed literal kinds, literal-vs-class, enum-vs-anything, overlapping or single-field classes, non-disjoint (fuzzy-matchable) string literals, and any winning-class child that needs lenient coercion. Decline = `ErrDeBAMLParseUnsupported` → fall back to BAML.

## Scope

`internal/debaml` (coercer + gate + unit tests) plus the one bamlfuzz harness metadata addition (`UnionChoices` on `ParseRecoveryCase` + the failure envelope) needed to carry union-arm choices through the parse-recovery order check, the integration differential wiring, and the new corpus. No public seam, no codegen/template change, no dynclient regeneration, no adapter embed regeneration. `golang.org/x/text` was promoted from an indirect to a direct dependency (accent folding for the `match_string` superset); `go.sum` is unchanged.

## Verification

- `gofmt`, `go build ./...`, `go vet ./...` (incl. `-tags=integration`), `go run ./cmd/verify-framework-adapter` (6/6 green).
- `GOWORK=off go test ./codegen/...` (adapters/common), `go test ./internal/debaml ./bamlutils ./worker ./dynclient/...` — all green.
- `go test -tags=integration -run TestBamlfuzzParseRecovery ./integration` in **gating mode** (after capturing wants from live BAML): all 15 new union fixtures pass — 5 native-claimed and diff-green vs live BAML (incl. key order via `union_choices`), 10 fell back.

Part of #546.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced union-aware parse-recovery reporting with per–union-arm choice metadata to improve reproducibility.
  * Added more parse-recovery fixtures covering literal, class, nested, nullable, and ambiguity scenarios.
* **Bug Fixes**
  * Made union “native claim” and recovery decisions more conservative, including stricter matching for fuzzy strings and class-shape ambiguity.
* **Tests**
  * Expanded integration and parser tests to validate union-aware diff reporting and gate behavior across many union variants.
* **Chores**
  * Updated Go dependency on `golang.org/x/text`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->