### PR TITLE
debaml: native match_string coercion parity (Mcoerce-a)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/30_map_fuzzy_enum_key.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/30_map_fuzzy_enum_key.json
@@ -1,6 +1,6 @@
 {
   "name": "map_fuzzy_enum_key",
-  "description": "map<Key,string> with a case-variant key (\"a\" for enum value A). BAML's enum key coercion fuzzy-matches via match_string and SUCCEEDS, inserting the ORIGINAL key string \"a\". Native exact match misses, so it DECLINES (fuzzy keys are Mcoerce) — pinned native disposition: fallback. want captured from BAML final parse.",
+  "description": "Mcoerce-a: map<Key,string> with a case-variant key (\"a\" for enum value A). BAML's enum key coercion fuzzy-matches via match_string and SUCCEEDS, inserting the ORIGINAL key string \"a\" (not the canonical enum name). Native now reproduces match_string and CLAIMS this byte-exact — pinned native disposition: claimed. want captured from BAML final parse.",
   "preserve_schema_order": true,
   "schema": {
     "classes": [

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/47_enum_fuzzy_case_punct_accent.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/47_enum_fuzzy_case_punct_accent.json
@@ -1,0 +1,24 @@
+{
+  "name": "enum_fuzzy_case_punct_accent",
+  "description": "Mcoerce-a: a non-union enum value matched fuzzily via match_string (case-fold + accent/ligature fold: \"Résumé\" -> RESUME). The canonical enum value name is emitted, not the raw input. Native-claimed and diff-green vs BAML. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "status", "type": {"kind": "enum_ref", "ref": "Action"}}
+        ]
+      }
+    ],
+    "enums": [
+      {"name": "Action", "values": ["RESUME", "ARCHIVE"]}
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"status\":\"Résumé\"}",
+  "want": {
+    "status": "success",
+    "json": {"status": "RESUME"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/48_literal_fuzzy_string_non_union.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/48_literal_fuzzy_string_non_union.json
@@ -1,0 +1,21 @@
+{
+  "name": "literal_fuzzy_string_non_union",
+  "description": "Mcoerce-a: a NON-union string literal matched fuzzily via match_string with substring enabled (\"status is active\" contains \"active\"). The canonical literal is emitted, not the raw input. Non-union so there is no scoring risk. Native-claimed and diff-green vs BAML. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "kind", "type": {"kind": "literal", "literal": {"kind": "string", "string": "active"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"kind\":\"status is active\"}",
+  "want": {
+    "status": "success",
+    "json": {"kind": "active"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/49_class_fuzzy_field_key.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/49_class_fuzzy_field_key.json
@@ -1,0 +1,22 @@
+{
+  "name": "class_fuzzy_field_key",
+  "description": "Mcoerce-a: class object field keys matched fuzzily via matches_string_to_string (NO substring): case-variant keys \"Name\"/\"Age\" match `name`/`age`. Output keys are the CANONICAL field names in schema order. Native-claimed and diff-green vs BAML. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "age", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"Name\":\"Ada\",\"Age\":36}",
+  "want": {
+    "status": "success",
+    "json": {"name": "Ada", "age": 36}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/50_map_fuzzy_literal_key.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/50_map_fuzzy_literal_key.json
@@ -1,0 +1,24 @@
+{
+  "name": "map_fuzzy_literal_key",
+  "description": "Mcoerce-a: map<\"alpha\"|\"beta\", string> with a case-variant key (\"ALPHA\" for literal \"alpha\"). The string-literal-union key coercion fuzzy-matches via match_string and SUCCEEDS; the entry is inserted under the ORIGINAL input key \"ALPHA\", not the canonical literal. Native-claimed and diff-green vs BAML. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "m", "type": {"kind": "map", "key": {"kind": "union", "variants": [
+            {"kind": "literal", "literal": {"kind": "string", "string": "alpha"}},
+            {"kind": "literal", "literal": {"kind": "string", "string": "beta"}}
+          ]}, "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"m\":{\"ALPHA\":\"x\"}}",
+  "want": {
+    "status": "success",
+    "json": {"m": {"ALPHA": "x"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/51_match_string_ambiguous_substring_error.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/51_match_string_ambiguous_substring_error.json
@@ -1,0 +1,23 @@
+{
+  "name": "match_string_ambiguous_substring_error",
+  "description": "Mcoerce-a: a NON-union enum whose input substring-matches TWO variants with equal counts (\"cat dog\" -> CAT and DOG once each). BAML's match_string errors via StrMatchOneFromMany (try_match_only_once) before emitting, so the required field cannot resolve and the parse ERRORS. Native must CLAIM the same error, not arbitrarily pick a tied variant. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "animal", "type": {"kind": "enum_ref", "ref": "Animal"}}
+        ]
+      }
+    ],
+    "enums": [
+      {"name": "Animal", "values": ["CAT", "DOG"]}
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"animal\":\"cat dog\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/52_nullable_class_union_clean_claimed.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/52_nullable_class_union_clean_claimed.json
@@ -1,0 +1,88 @@
+{
+  "name": "nullable_class_union_clean_claimed",
+  "description": "Mcoerce-a F1: nullable flat class union (Book | Car | null). A CLEAN non-null arm (exact keys, no extras, exact children) scores 0, beating BAML's null arm (DefaultButHadValue=110), so BAML and native both resolve to Book. Native-claimed and diff-green vs BAML. want captured from BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {
+                  "kind": "class_ref",
+                  "ref": "Book"
+                },
+                {
+                  "kind": "class_ref",
+                  "ref": "Car"
+                },
+                {
+                  "kind": "null"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Book",
+        "properties": [
+          {
+            "name": "title",
+            "type": {
+              "kind": "string"
+            }
+          },
+          {
+            "name": "pages",
+            "type": {
+              "kind": "int"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Car",
+        "properties": [
+          {
+            "name": "brand",
+            "type": {
+              "kind": "string"
+            }
+          },
+          {
+            "name": "wheels",
+            "type": {
+              "kind": "int"
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"title\":\"Go\",\"pages\":300}}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": {
+        "title": "Go",
+        "pages": 300
+      }
+    }
+  },
+  "union_choices": {
+    ".u": {
+      "index": 0,
+      "kind": "class_ref",
+      "ref": "Book",
+      "variant_count": 3
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/53_nullable_class_union_extra_keys_null.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/53_nullable_class_union_extra_keys_null.json
@@ -1,0 +1,77 @@
+{
+  "name": "nullable_class_union_extra_keys_null",
+  "description": "Mcoerce-a F1 (cold-review probe): nullable flat class union (Book | Car | null) where the Book arm carries 115 EXTRA input keys (ExtraKey cost 1 each => score 115) which OUTSCORES BAML's null arm (DefaultButHadValue=110), so BAML returns NULL, not Book. Native does not score and cannot tell the null arm wins, so it DECLINES (fallback) rather than claim Book \u2014 pinned disposition: fallback. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {
+                  "kind": "class_ref",
+                  "ref": "Book"
+                },
+                {
+                  "kind": "class_ref",
+                  "ref": "Car"
+                },
+                {
+                  "kind": "null"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Book",
+        "properties": [
+          {
+            "name": "title",
+            "type": {
+              "kind": "string"
+            }
+          },
+          {
+            "name": "pages",
+            "type": {
+              "kind": "int"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Car",
+        "properties": [
+          {
+            "name": "brand",
+            "type": {
+              "kind": "string"
+            }
+          },
+          {
+            "name": "wheels",
+            "type": {
+              "kind": "int"
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"title\":\"Go\",\"pages\":300,\"e0\":1,\"e1\":1,\"e2\":1,\"e3\":1,\"e4\":1,\"e5\":1,\"e6\":1,\"e7\":1,\"e8\":1,\"e9\":1,\"e10\":1,\"e11\":1,\"e12\":1,\"e13\":1,\"e14\":1,\"e15\":1,\"e16\":1,\"e17\":1,\"e18\":1,\"e19\":1,\"e20\":1,\"e21\":1,\"e22\":1,\"e23\":1,\"e24\":1,\"e25\":1,\"e26\":1,\"e27\":1,\"e28\":1,\"e29\":1,\"e30\":1,\"e31\":1,\"e32\":1,\"e33\":1,\"e34\":1,\"e35\":1,\"e36\":1,\"e37\":1,\"e38\":1,\"e39\":1,\"e40\":1,\"e41\":1,\"e42\":1,\"e43\":1,\"e44\":1,\"e45\":1,\"e46\":1,\"e47\":1,\"e48\":1,\"e49\":1,\"e50\":1,\"e51\":1,\"e52\":1,\"e53\":1,\"e54\":1,\"e55\":1,\"e56\":1,\"e57\":1,\"e58\":1,\"e59\":1,\"e60\":1,\"e61\":1,\"e62\":1,\"e63\":1,\"e64\":1,\"e65\":1,\"e66\":1,\"e67\":1,\"e68\":1,\"e69\":1,\"e70\":1,\"e71\":1,\"e72\":1,\"e73\":1,\"e74\":1,\"e75\":1,\"e76\":1,\"e77\":1,\"e78\":1,\"e79\":1,\"e80\":1,\"e81\":1,\"e82\":1,\"e83\":1,\"e84\":1,\"e85\":1,\"e86\":1,\"e87\":1,\"e88\":1,\"e89\":1,\"e90\":1,\"e91\":1,\"e92\":1,\"e93\":1,\"e94\":1,\"e95\":1,\"e96\":1,\"e97\":1,\"e98\":1,\"e99\":1,\"e100\":1,\"e101\":1,\"e102\":1,\"e103\":1,\"e104\":1,\"e105\":1,\"e106\":1,\"e107\":1,\"e108\":1,\"e109\":1,\"e110\":1,\"e111\":1,\"e112\":1,\"e113\":1,\"e114\":1}}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": null
+    }
+  }
+}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -185,14 +185,25 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"map_string_class_values":      true,
 	"map_literal_union_keys_exact": true,
 	// M2b decline set: every map BAML would return as partial/scored — a
-	// skipped bad key/value (MapKeyParseError / MapValueParseError), a fuzzy
-	// match_string key (Mcoerce), or an unterminated/incomplete map (M2a
-	// defers). Native declines (fallback) rather than claim a clean result
-	// where BAML carries flags or skips entries.
+	// skipped bad key/value (MapKeyParseError / MapValueParseError) or an
+	// unterminated/incomplete map (M2a defers). Native declines (fallback)
+	// rather than claim a clean result where BAML carries flags or skips
+	// entries. (map_fuzzy_enum_key flipped to claimed in Mcoerce-a.)
 	"map_bad_enum_key":       false,
 	"map_bad_value_type":     false,
-	"map_fuzzy_enum_key":     false,
 	"map_partial_incomplete": false,
+	// Mcoerce-a native match_string parity: enum / string-literal / class
+	// field-key / map-key fuzzy matching (case / accent+ligature fold /
+	// punctuation strip / case-insensitive / substring) is reproduced
+	// byte-exact, so fuzzy matches BAML accepts are now CLAIMED. A non-union
+	// substring TIE is a CLAIMED error (StrMatchOneFromMany). Multi-success
+	// unions stay deferred to M3.
+	"map_fuzzy_enum_key":                     true,
+	"enum_fuzzy_case_punct_accent":           true,
+	"literal_fuzzy_string_non_union":         true,
+	"class_fuzzy_field_key":                  true,
+	"map_fuzzy_literal_key":                  true,
+	"match_string_ambiguous_substring_error": true,
 	// M2c native SCORE-FREE SIMPLE UNIONS: claimed when native can PROVE BAML
 	// also resolves to exactly one clean zero-score winner.
 	//

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -204,6 +204,12 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"class_fuzzy_field_key":                  true,
 	"map_fuzzy_literal_key":                  true,
 	"match_string_ambiguous_substring_error": true,
+	// Mcoerce-a F1: a NULLABLE flat class union scores its null arm
+	// (DefaultButHadValue=110) for non-null input, so native claims the
+	// non-null arm only when it is a CLEAN zero-score success. A clean arm
+	// claims; an arm carrying enough ExtraKey flags to lose to null declines.
+	"nullable_class_union_clean_claimed":   true,
+	"nullable_class_union_extra_keys_null": false,
 	// M2c native SCORE-FREE SIMPLE UNIONS: claimed when native can PROVE BAML
 	// also resolves to exactly one clean zero-score winner.
 	//

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -609,22 +609,42 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string, cf *coerceFlags
 		}
 		return unsupported(fmt.Sprintf("map key %q: no clean literal %q match (BAML skips via MapKeyParseError)", key, keyT.Literal.String))
 	case schema.TypeUnion:
-		// A union-of-string-literals key coerces through the union coercer,
-		// which succeeds when ANY literal arm matches; the map then inserts the
-		// original key, so the winning arm is irrelevant.
+		// Only a non-nullable union of string literals is a legal map key
+		// (the same invariant the parse gate proves via isStringLiteralUnionType
+		// / checkSupportedMapKey). flattenStringLiterals is intentionally lossy —
+		// it silently drops any non-literal arm — so assert the invariant here
+		// too, defensively, since matchMapKey is unit/future-callable without the
+		// gate: a mixed union must NOT be treated as its string-literal subset.
+		if !isStringLiteralUnionType(keyT) {
+			return unsupported("map key union must be a non-nullable union of string literals")
+		}
+		// A union-of-string-literals key coerces through BAML's union coercer,
+		// which accepts when ANY arm matches; the map then inserts the ORIGINAL
+		// key, so the winning arm is irrelevant. Scan ALL arms: a certain match
+		// on any arm accepts the key, so uncertainty on an EARLIER arm must not
+		// short-circuit a later clean acceptance (that would over-decline).
 		accepted := false
+		sawUncertain := false
 		for _, lit := range flattenStringLiterals(keyT) {
 			_, outcome, _, uncertain := matchString(key, []matchCandidate{{name: lit, validValues: []string{lit}}}, true)
 			if uncertain {
-				cf.markUncertain()
-				return unsupported(fmt.Sprintf("map key %q: non-ASCII case-fold uncertainty against string-literal-union arm %q", key, lit))
+				sawUncertain = true
 			}
 			if outcome == matchOne {
 				accepted = true
 			}
 		}
 		if accepted {
+			// A clean arm matched; the key is valid regardless of any uncertain
+			// arm, and the map inserts the original key — no uncertainty to mark.
 			return nil
+		}
+		if sawUncertain {
+			// No clean arm, but an arm's verdict hinged on a non-ASCII case fold
+			// native cannot prove equals BAML — decline the map AND propagate the
+			// uncertainty (so any enclosing union counter declines conservatively).
+			cf.markUncertain()
+			return unsupported(fmt.Sprintf("map key %q: non-ASCII case-fold uncertainty against string-literal-union arms", key))
 		}
 		return unsupported(fmt.Sprintf("map key %q: matches no string-literal-union arm (BAML skips via MapKeyParseError)", key))
 	default:

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -3,9 +3,11 @@ package debaml
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/internal/schema"
 )
 
@@ -391,13 +393,14 @@ func coerceList(b *schema.Bundle, elem *schema.Type, input value, cf *coerceFlag
 		// require all elements clean.
 		child, err := coerce(b, *elem, input.arrV[i], cf)
 		if err != nil {
-			// A bad element: BAML records ArrayItemParseError and SKIPS it,
-			// returning a partial list that still succeeds — native cannot
-			// reproduce that partial result, so it DECLINES the whole list
-			// rather than propagate the element's verdict (a CLAIMED child
-			// error such as an enum substring tie must NOT become a claimed
-			// list error where BAML would just drop the element). Partial-list
-			// parity is Mcoerce-c.
+			if !declinableChildError(err) {
+				return nil, err // hard/invariant failure: propagate, never mask.
+			}
+			// A bad element (decline sentinel or value-verdict mismatch): BAML
+			// records ArrayItemParseError and SKIPS it, returning a partial list
+			// that still succeeds — native cannot reproduce that partial result,
+			// so it DECLINES the whole list rather than claim a list error where
+			// BAML would just drop the element. Partial-list parity is Mcoerce-c.
 			return nil, unsupported(fmt.Sprintf("list element %d: %v (BAML skips bad items via ArrayItemParseError)", i, err))
 		}
 		if i > 0 {
@@ -466,10 +469,13 @@ func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value, cf *coerc
 
 		child, err := coerce(b, *valT, f.val, nil)
 		if err != nil {
-			// A bad value: BAML records MapValueParseError and SKIPS this
-			// entry, returning a partial map — native cannot reproduce that, so
-			// decline the whole map (regardless of whether the child error was
-			// a sentinel decline or a claimed mismatch).
+			if !declinableChildError(err) {
+				return nil, err // hard/invariant failure: propagate, never mask.
+			}
+			// A bad value (decline sentinel or value-verdict mismatch): BAML
+			// records MapValueParseError and SKIPS this entry, returning a
+			// partial map — native cannot reproduce that, so decline the whole
+			// map. Partial-map parity is Mcoerce-c.
 			return nil, unsupported(fmt.Sprintf("map value for key %q: %v (BAML skips bad entries via MapValueParseError)", f.key, err))
 		}
 
@@ -627,6 +633,9 @@ func coerceUnionSafe(b *schema.Bundle, u *schema.UnionType, input value, cf *coe
 		arm := &coerceFlags{}
 		out, err := coerce(b, u.Variants[0], input, arm)
 		if err != nil {
+			if !declinableChildError(err) {
+				return nil, err // hard/invariant failure: propagate, never mask.
+			}
 			return nil, unsupported(fmt.Sprintf("optional single-arm union: non-null arm did not cleanly succeed (BAML may null-default): %v", err))
 		}
 		if arm.isFlagged() {
@@ -687,10 +696,15 @@ func coerceLiteralUnion(variants []schema.Type, input value, requireClean bool, 
 	matched := -1
 	count := 0
 	for i := range variants {
-		if _, err := coerceLiteral(variants[i].Literal, input, nil); err == nil {
+		_, err := coerceLiteral(variants[i].Literal, input, nil)
+		switch {
+		case err == nil:
 			matched = i
 			count++
+		case !declinableChildError(err):
+			return nil, err // hard/invariant failure in an arm: propagate.
 		}
+		// A declinable error just means this arm did not match; keep counting.
 	}
 	if count != 1 {
 		return nil, unsupported(fmt.Sprintf("literal union: %d lenient matches for %s input (need exactly 1; 2+ is BAML pick_best = M3)", count, input.kind.String()))
@@ -731,10 +745,15 @@ func coerceFlatClassUnion(b *schema.Bundle, variants []schema.Type, input value,
 	matched := -1
 	count := 0
 	for i := range variants {
-		if _, err := coerceClass(b, variants[i].Name, variants[i].Mode, input, nil); err == nil {
+		_, err := coerceClass(b, variants[i].Name, variants[i].Mode, input, nil)
+		switch {
+		case err == nil:
 			matched = i
 			count++
+		case !declinableChildError(err):
+			return nil, err // hard/invariant failure in an arm: propagate.
 		}
+		// A declinable error just means this arm did not match; keep counting.
 	}
 	if count != 1 {
 		return nil, unsupported(fmt.Sprintf("class union: %d variant classes coerce cleanly (need exactly 1; 2+ is BAML pick_best = M3)", count))
@@ -769,12 +788,43 @@ func marshalJSON(v any) (json.RawMessage, error) {
 	return json.RawMessage(bytes.TrimRight(buf.Bytes(), "\n")), nil
 }
 
+// mismatchError marks a CLAIMED value-level coercion verdict — a hard JSON-type
+// mismatch (typeMismatch) or a match_string substring tie (ambiguousMatch) —
+// for which BAML produces a comparable error on the SAME value. At the top
+// level it propagates as a claimed parse failure (the differential checks BAML
+// also errors); but inside a container/union child-wrapper it is DECLINABLE,
+// because BAML would skip the entry (partial list/map) or score it (union),
+// which native does not reproduce, so the wrapper falls back instead. It is
+// deliberately NOT the ErrDeBAMLParseUnsupported sentinel, so it stays a claim
+// at the seam (declinableChildError identifies it for the wrappers).
+type mismatchError struct{ msg string }
+
+func (e *mismatchError) Error() string { return e.msg }
+
+// declinableChildError reports whether a child coercion error should make a
+// container/union wrapper DECLINE (fall back) rather than propagate. Only two
+// classes decline: the ErrDeBAMLParseUnsupported fallback sentinel (native
+// stricter than BAML, so BAML may still succeed/skip/score), and a value-verdict
+// mismatchError (BAML skips the entry or scores the value). EVERY OTHER error is
+// a HARD failure — an unknown enum/class ref, a missing type payload, a marshal
+// failure, an unexpected kind: a native bug or schema-invariant violation that
+// must PROPAGATE so the native-vs-BAML differential surfaces it (per the seam
+// contract: anything but ErrDeBAMLParseUnsupported is a claimed error), rather
+// than being silently masked as a BAML fallback.
+func declinableChildError(err error) bool {
+	if errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+		return true
+	}
+	var me *mismatchError
+	return errors.As(err, &me)
+}
+
 // typeMismatch reports a conservative JSON-type mismatch as a CLAIMED
 // coercion error. Used where BAML would also fail (e.g. a scalar/array
 // where a class object is required), so the differential checks error
 // parity rather than masking it behind a fallback.
 func typeMismatch(want string, input value) error {
-	return fmt.Errorf("debaml: expected %s, got %s", want, input.kind.String())
+	return &mismatchError{msg: fmt.Sprintf("debaml: expected %s, got %s", want, input.kind.String())}
 }
 
 // ambiguousMatch reports a match_string substring TIE (StrMatchOneFromMany)
@@ -785,7 +835,7 @@ func typeMismatch(want string, input value) error {
 // Safe to claim only outside an optional arm; coerceUnionSafe's case 2
 // converts it to a DECLINE where BAML would null-default instead.
 func ambiguousMatch(target, input string) error {
-	return fmt.Errorf("debaml: %s: %q ambiguously substring-matches multiple candidates (BAML StrMatchOneFromMany)", target, input)
+	return &mismatchError{msg: fmt.Sprintf("debaml: %s: %q ambiguously substring-matches multiple candidates (BAML StrMatchOneFromMany)", target, input)}
 }
 
 // declineCoerce reports a coercion mismatch as a DECLINE

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -504,7 +504,7 @@ func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value, cf *coerc
 	first := true
 	for i := range input.objV {
 		f := &input.objV[i]
-		if err := matchMapKey(b, *keyT, f.key); err != nil {
+		if err := matchMapKey(b, *keyT, f.key, cf); err != nil {
 			return nil, err
 		}
 		if _, dup := seen[f.key]; dup {
@@ -562,7 +562,14 @@ func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value, cf *coerc
 // entry and return a partial map, which native does not yet reproduce
 // (Mcoerce-c). The accepted key is NOT rewritten — coerceMap emits the
 // original input key string, matching BAML's insertion of the raw object key.
-func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
+//
+// A non-ASCII case-fold uncertainty on a key declines the map AND marks cf
+// (nil-safe), so that — should a map ever become reachable as a union arm —
+// the enclosing union counter makes the same conservative whole-union decline
+// rather than treating the rejected key as an ordinary non-match. Today no
+// claimable union admits a map arm (parse.go's safe families are literal/class
+// only), so this is purely defensive signal propagation, never an over-claim.
+func matchMapKey(b *schema.Bundle, keyT schema.Type, key string, cf *coerceFlags) error {
 	switch keyT.Kind {
 	case schema.TypePrimitive:
 		if keyT.Primitive == schema.PrimitiveString {
@@ -581,6 +588,7 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
 		// DECLINE the whole map (Mcoerce stays conservative on uncertainty).
 		_, outcome, _, uncertain := matchString(key, enumMatchCandidates(e), true)
 		if uncertain {
+			cf.markUncertain()
 			return unsupported(fmt.Sprintf("map key %q: non-ASCII case-fold uncertainty against enum %q", key, keyT.Name))
 		}
 		if outcome == matchOne {
@@ -593,6 +601,7 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
 		}
 		_, outcome, _, uncertain := matchString(key, []matchCandidate{{name: keyT.Literal.String, validValues: []string{keyT.Literal.String}}}, true)
 		if uncertain {
+			cf.markUncertain()
 			return unsupported(fmt.Sprintf("map key %q: non-ASCII case-fold uncertainty against literal %q", key, keyT.Literal.String))
 		}
 		if outcome == matchOne {
@@ -607,6 +616,7 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
 		for _, lit := range flattenStringLiterals(keyT) {
 			_, outcome, _, uncertain := matchString(key, []matchCandidate{{name: lit, validValues: []string{lit}}}, true)
 			if uncertain {
+				cf.markUncertain()
 				return unsupported(fmt.Sprintf("map key %q: non-ASCII case-fold uncertainty against string-literal-union arm %q", key, lit))
 			}
 			if outcome == matchOne {

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -11,17 +11,26 @@ import (
 	"github.com/invakid404/baml-rest/internal/schema"
 )
 
-// coerceFlags accumulates whether a coercion produced ANY BAML score-bearing
-// condition native CLAIMS (and is therefore NOT a zero-score "clean" success):
-// a SubstringMatch (enum/literal/map-key substring, cost 2), an ExtraKey
-// (unmatched class input key, cost 1 each), or an ObjectToMap (every object→map,
-// cost 1). It is threaded only where cleanliness matters — the NULLABLE-union
-// claim, where BAML's null arm competes by scoring (DefaultButHadValue, cost
-// 110): only a clean (score-0) non-null arm provably beats null without native
-// having to compute scores. A nil receiver means "don't track" (the top-level
-// and non-nullable paths), so threading it adds no overhead there.
+// coerceFlags accumulates two signals a union claim needs:
+//
+//   - flagged: a BAML score-bearing condition native CLAIMS (and is therefore
+//     NOT a zero-score "clean" success): a SubstringMatch (enum/literal/map-key
+//     substring, cost 2), an ExtraKey (unmatched class input key, cost 1 each),
+//     or an ObjectToMap (every object→map, cost 1). Used by the NULLABLE-union
+//     claim, where BAML's null arm competes by scoring (DefaultButHadValue,
+//     cost 110): only a clean (score-0) non-null arm provably beats null
+//     without native computing scores.
+//   - uncertain: the match verdict depended on a non-ASCII case fold native
+//     cannot prove equals Rust's str::to_lowercase (caseFoldUncertain). Used by
+//     EVERY union claim: if any arm's verdict was uncertain, native cannot
+//     trust its per-arm count (a false-rejected leaf would let it claim the
+//     wrong arm), so it declines.
+//
+// A nil receiver means "don't track" (top-level / non-nullable / standalone),
+// so threading it is free there.
 type coerceFlags struct {
-	flagged bool
+	flagged   bool
+	uncertain bool
 }
 
 // flag marks the coercion as non-clean. Nil-safe so untracked paths are free.
@@ -31,8 +40,18 @@ func (f *coerceFlags) flag() {
 	}
 }
 
+// markUncertain records a non-ASCII case-fold native cannot prove matches BAML.
+func (f *coerceFlags) markUncertain() {
+	if f != nil {
+		f.uncertain = true
+	}
+}
+
 // isFlagged reports whether any score-bearing condition was recorded.
 func (f *coerceFlags) isFlagged() bool { return f != nil && f.flagged }
+
+// isUncertain reports whether a non-ASCII case-fold uncertainty was recorded.
+func (f *coerceFlags) isUncertain() bool { return f != nil && f.uncertain }
 
 // coerce converts an ordered value (decoded strict, or via the
 // conservative fixing pass) into the flattened dynamic output JSON for
@@ -163,7 +182,11 @@ func coerceLiteral(lit *schema.LiteralValue, input value, f *coerceFlags) (json.
 		if input.kind != valString {
 			return nil, declineCoerce("literal string", input)
 		}
-		matched, outcome, viaSub := matchString(input.strV, []matchCandidate{{name: lit.String, validValues: []string{lit.String}}}, true)
+		matched, outcome, viaSub, uncertain := matchString(input.strV, []matchCandidate{{name: lit.String, validValues: []string{lit.String}}}, true)
+		if uncertain {
+			f.markUncertain()
+			return nil, unsupported(fmt.Sprintf("literal string %q: non-ASCII case-fold uncertainty for %q (cannot prove match equals BAML)", lit.String, input.strV))
+		}
 		switch outcome {
 		case matchOne:
 			if viaSub {
@@ -215,7 +238,14 @@ func coerceEnum(b *schema.Bundle, name string, input value, f *coerceFlags) (jso
 	if !ok {
 		return nil, fmt.Errorf("debaml: unknown enum %q", name)
 	}
-	matched, outcome, viaSub := matchString(input.strV, enumMatchCandidates(e), true)
+	matched, outcome, viaSub, uncertain := matchString(input.strV, enumMatchCandidates(e), true)
+	if uncertain {
+		// The verdict hinged on a non-ASCII case fold native cannot prove
+		// equals BAML's. Mark it (so a union counter declines the whole union)
+		// and DECLINE rather than claim a match/no-match that might diverge.
+		f.markUncertain()
+		return nil, unsupported(fmt.Sprintf("enum %q: non-ASCII case-fold uncertainty for %q (cannot prove match equals BAML)", name, input.strV))
+	}
 	switch outcome {
 	case matchOne:
 		if viaSub {
@@ -306,11 +336,20 @@ func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input
 	present := make([]bool, len(cls.Fields))
 	foundAny := false
 	hasExtra := false
+	keyUncertain := false
 	for i := range input.objV {
 		key := input.objV[i].key
 		matchedField := -1
 		for j := range cls.Fields {
-			if matchesStringToString(key, cls.Fields[j].Name.RenderedName()) {
+			m, unc := matchesStringToString(key, cls.Fields[j].Name.RenderedName())
+			if unc {
+				// This key-vs-field comparison hinged on a non-ASCII case fold
+				// native cannot prove equals BAML's, so the assignment is
+				// untrustworthy.
+				keyUncertain = true
+				cf.markUncertain()
+			}
+			if m {
 				matchedField = j
 				break
 			}
@@ -325,6 +364,12 @@ func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input
 			present[matchedField] = true
 			foundAny = true
 		}
+	}
+	if keyUncertain {
+		// A field-key match/no-match could diverge from BAML; DECLINE rather
+		// than claim a (possibly wrong) assignment. cf is already marked so an
+		// enclosing union counter declines the whole union.
+		return nil, unsupported(fmt.Sprintf("class %q: non-ASCII case-fold uncertainty in a field key (cannot prove assignment equals BAML)", name))
 	}
 	if singleField && !foundAny {
 		// No input key matched the lone field: BAML tries implied-key /
@@ -531,8 +576,14 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
 		}
 		// The key's own match flags do not propagate to the map score (BAML
 		// discards the coerced key, inserting the original string), so ignore
-		// the substring bit — only success/failure matters.
-		if _, outcome, _ := matchString(key, enumMatchCandidates(e), true); outcome == matchOne {
+		// the substring bit — only success/failure matters. But a non-ASCII
+		// case-fold uncertainty means the key inclusion could diverge, so
+		// DECLINE the whole map (Mcoerce stays conservative on uncertainty).
+		_, outcome, _, uncertain := matchString(key, enumMatchCandidates(e), true)
+		if uncertain {
+			return unsupported(fmt.Sprintf("map key %q: non-ASCII case-fold uncertainty against enum %q", key, keyT.Name))
+		}
+		if outcome == matchOne {
 			return nil
 		}
 		return unsupported(fmt.Sprintf("map key %q: no clean enum %q match (BAML skips via MapKeyParseError)", key, keyT.Name))
@@ -540,7 +591,11 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
 		if keyT.Literal == nil || keyT.Literal.Kind != schema.LiteralString {
 			return unsupported("map key literal must be a string literal")
 		}
-		if _, outcome, _ := matchString(key, []matchCandidate{{name: keyT.Literal.String, validValues: []string{keyT.Literal.String}}}, true); outcome == matchOne {
+		_, outcome, _, uncertain := matchString(key, []matchCandidate{{name: keyT.Literal.String, validValues: []string{keyT.Literal.String}}}, true)
+		if uncertain {
+			return unsupported(fmt.Sprintf("map key %q: non-ASCII case-fold uncertainty against literal %q", key, keyT.Literal.String))
+		}
+		if outcome == matchOne {
 			return nil
 		}
 		return unsupported(fmt.Sprintf("map key %q: no clean literal %q match (BAML skips via MapKeyParseError)", key, keyT.Literal.String))
@@ -548,10 +603,18 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
 		// A union-of-string-literals key coerces through the union coercer,
 		// which succeeds when ANY literal arm matches; the map then inserts the
 		// original key, so the winning arm is irrelevant.
+		accepted := false
 		for _, lit := range flattenStringLiterals(keyT) {
-			if _, outcome, _ := matchString(key, []matchCandidate{{name: lit, validValues: []string{lit}}}, true); outcome == matchOne {
-				return nil
+			_, outcome, _, uncertain := matchString(key, []matchCandidate{{name: lit, validValues: []string{lit}}}, true)
+			if uncertain {
+				return unsupported(fmt.Sprintf("map key %q: non-ASCII case-fold uncertainty against string-literal-union arm %q", key, lit))
 			}
+			if outcome == matchOne {
+				accepted = true
+			}
+		}
+		if accepted {
+			return nil
 		}
 		return unsupported(fmt.Sprintf("map key %q: matches no string-literal-union arm (BAML skips via MapKeyParseError)", key))
 	default:
@@ -638,6 +701,12 @@ func coerceUnionSafe(b *schema.Bundle, u *schema.UnionType, input value, cf *coe
 			}
 			return nil, unsupported(fmt.Sprintf("optional single-arm union: non-null arm did not cleanly succeed (BAML may null-default): %v", err))
 		}
+		if arm.isUncertain() {
+			// The arm matched, but its verdict hinged on a non-ASCII case fold
+			// native cannot prove equals BAML — decline rather than risk a
+			// claim BAML would resolve differently (to the arm, or to null).
+			return nil, unsupported("optional single-arm union: non-ASCII case-fold uncertainty in the non-null arm")
+		}
 		if arm.isFlagged() {
 			return nil, unsupported("optional single-arm union: non-null arm is not a clean zero-score match (null arm competes by scoring → M3)")
 		}
@@ -695,8 +764,9 @@ func resolveArmFlags(requireClean bool, arm, cf *coerceFlags) error {
 func coerceLiteralUnion(variants []schema.Type, input value, requireClean bool, cf *coerceFlags) (json.RawMessage, error) {
 	matched := -1
 	count := 0
+	unc := &coerceFlags{}
 	for i := range variants {
-		_, err := coerceLiteral(variants[i].Literal, input, nil)
+		_, err := coerceLiteral(variants[i].Literal, input, unc)
 		switch {
 		case err == nil:
 			matched = i
@@ -705,6 +775,12 @@ func coerceLiteralUnion(variants []schema.Type, input value, requireClean bool, 
 			return nil, err // hard/invariant failure in an arm: propagate.
 		}
 		// A declinable error just means this arm did not match; keep counting.
+	}
+	if unc.isUncertain() {
+		// Some arm's match verdict hinged on a non-ASCII case fold native
+		// cannot prove equals BAML; a false-rejected arm would let native claim
+		// the wrong lone winner, so DECLINE the whole union.
+		return nil, unsupported("literal union: non-ASCII case-fold uncertainty in an arm (cannot prove verdict equals BAML)")
 	}
 	if count != 1 {
 		return nil, unsupported(fmt.Sprintf("literal union: %d lenient matches for %s input (need exactly 1; 2+ is BAML pick_best = M3)", count, input.kind.String()))
@@ -744,8 +820,9 @@ func coerceFlatClassUnion(b *schema.Bundle, variants []schema.Type, input value,
 	}
 	matched := -1
 	count := 0
+	unc := &coerceFlags{}
 	for i := range variants {
-		_, err := coerceClass(b, variants[i].Name, variants[i].Mode, input, nil)
+		_, err := coerceClass(b, variants[i].Name, variants[i].Mode, input, unc)
 		switch {
 		case err == nil:
 			matched = i
@@ -754,6 +831,12 @@ func coerceFlatClassUnion(b *schema.Bundle, variants []schema.Type, input value,
 			return nil, err // hard/invariant failure in an arm: propagate.
 		}
 		// A declinable error just means this arm did not match; keep counting.
+	}
+	if unc.isUncertain() {
+		// Some arm's field-key or leaf match hinged on a non-ASCII case fold
+		// native cannot prove equals BAML; a false-rejected arm would let native
+		// claim the wrong lone winner, so DECLINE the whole union.
+		return nil, unsupported("class union: non-ASCII case-fold uncertainty in an arm (cannot prove verdict equals BAML)")
 	}
 	if count != 1 {
 		return nil, unsupported(fmt.Sprintf("class union: %d variant classes coerce cleanly (need exactly 1; 2+ is BAML pick_best = M3)", count))

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -620,15 +620,23 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string, cf *coerceFlags
 		}
 		// A union-of-string-literals key coerces through BAML's union coercer,
 		// which accepts when ANY arm matches; the map then inserts the ORIGINAL
-		// key, so the winning arm is irrelevant. Scan ALL arms: a certain match
-		// on any arm accepts the key, so uncertainty on an EARLIER arm must not
-		// short-circuit a later clean acceptance (that would over-decline).
+		// key, so the winning arm is irrelevant. Scan ALL arms: only a CERTAIN
+		// match accepts the key. An uncertain-only match (matchString can return
+		// matchOne together with uncertain when the match is achieved solely in
+		// the non-ASCII case-fold pass, e.g. key "É" vs literal "é") must NOT
+		// accept — that verdict hinges on a lowercasing native cannot prove
+		// equals BAML — so it only records sawUncertain. A later CERTAIN arm
+		// still rescues an earlier uncertain one (its match returns before the
+		// case-fold attempt, so uncertain is false), which is why scanning all
+		// arms — rather than short-circuiting on the first uncertain arm —
+		// avoids over-declining.
 		accepted := false
 		sawUncertain := false
 		for _, lit := range flattenStringLiterals(keyT) {
 			_, outcome, _, uncertain := matchString(key, []matchCandidate{{name: lit, validValues: []string{lit}}}, true)
 			if uncertain {
 				sawUncertain = true
+				continue
 			}
 			if outcome == matchOne {
 				accepted = true

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -9,6 +9,29 @@ import (
 	"github.com/invakid404/baml-rest/internal/schema"
 )
 
+// coerceFlags accumulates whether a coercion produced ANY BAML score-bearing
+// condition native CLAIMS (and is therefore NOT a zero-score "clean" success):
+// a SubstringMatch (enum/literal/map-key substring, cost 2), an ExtraKey
+// (unmatched class input key, cost 1 each), or an ObjectToMap (every object→map,
+// cost 1). It is threaded only where cleanliness matters — the NULLABLE-union
+// claim, where BAML's null arm competes by scoring (DefaultButHadValue, cost
+// 110): only a clean (score-0) non-null arm provably beats null without native
+// having to compute scores. A nil receiver means "don't track" (the top-level
+// and non-nullable paths), so threading it adds no overhead there.
+type coerceFlags struct {
+	flagged bool
+}
+
+// flag marks the coercion as non-clean. Nil-safe so untracked paths are free.
+func (f *coerceFlags) flag() {
+	if f != nil {
+		f.flagged = true
+	}
+}
+
+// isFlagged reports whether any score-bearing condition was recorded.
+func (f *coerceFlags) isFlagged() bool { return f != nil && f.flagged }
+
 // coerce converts an ordered value (decoded strict, or via the
 // conservative fixing pass) into the flattened dynamic output JSON for
 // type t, returning a json.RawMessage. checkSupported has already rejected
@@ -48,22 +71,24 @@ import (
 // claim-parity for those is deferred to the rest of the Mcoerce milestone
 // (#546). See coercePrimitive / coerceList / coerceEnum / coerceLiteral /
 // coerceClass for the per-kind boundary.
-func coerce(b *schema.Bundle, t schema.Type, input value) (json.RawMessage, error) {
+func coerce(b *schema.Bundle, t schema.Type, input value, f *coerceFlags) (json.RawMessage, error) {
 	switch t.Kind {
 	case schema.TypePrimitive:
+		// Primitives match strictly in Mcoerce-a (exact JSON type), so they
+		// never add a score-bearing flag — no need to thread f.
 		return coercePrimitive(t.Primitive, input)
 	case schema.TypeLiteral:
-		return coerceLiteral(t.Literal, input)
+		return coerceLiteral(t.Literal, input, f)
 	case schema.TypeEnum:
-		return coerceEnum(b, t.Name, input)
+		return coerceEnum(b, t.Name, input, f)
 	case schema.TypeClass:
-		return coerceClass(b, t.Name, t.Mode, input)
+		return coerceClass(b, t.Name, t.Mode, input, f)
 	case schema.TypeList:
-		return coerceList(b, t.Elem, input)
+		return coerceList(b, t.Elem, input, f)
 	case schema.TypeMap:
-		return coerceMap(b, t.Key, t.Value, input)
+		return coerceMap(b, t.Key, t.Value, input, f)
 	case schema.TypeUnion:
-		return coerceUnionSafe(b, t.Union, input)
+		return coerceUnionSafe(b, t.Union, input, f)
 	default:
 		return nil, fmt.Errorf("debaml: cannot coerce type kind %q", t.Kind)
 	}
@@ -127,7 +152,7 @@ func coercePrimitive(p schema.PrimitiveKind, input value) (json.RawMessage, erro
 // DECLINES rather than claiming a mismatch BAML would not produce. A
 // non-string input to a string literal also DECLINES (BAML's single-key
 // object ObjectToPrimitive extraction is Mcoerce-d).
-func coerceLiteral(lit *schema.LiteralValue, input value) (json.RawMessage, error) {
+func coerceLiteral(lit *schema.LiteralValue, input value, f *coerceFlags) (json.RawMessage, error) {
 	if lit == nil {
 		return nil, fmt.Errorf("debaml: literal type missing value")
 	}
@@ -136,9 +161,12 @@ func coerceLiteral(lit *schema.LiteralValue, input value) (json.RawMessage, erro
 		if input.kind != valString {
 			return nil, declineCoerce("literal string", input)
 		}
-		matched, outcome := matchString(input.strV, []matchCandidate{{name: lit.String, validValues: []string{lit.String}}}, true)
+		matched, outcome, viaSub := matchString(input.strV, []matchCandidate{{name: lit.String, validValues: []string{lit.String}}}, true)
 		switch outcome {
 		case matchOne:
+			if viaSub {
+				f.flag() // SubstringMatch (cost 2)
+			}
 			return marshalJSON(matched)
 		case matchAmbiguous:
 			// A single candidate cannot tie; defensive.
@@ -177,7 +205,7 @@ func coerceLiteral(lit *schema.LiteralValue, input value) (json.RawMessage, erro
 // stringifies it via jsonish Value Display (ObjectToString), whose exact
 // reproduction is Mcoerce-b/d. An enum absent from the lowered bundle is a
 // broken schema, kept as a claimed error.
-func coerceEnum(b *schema.Bundle, name string, input value) (json.RawMessage, error) {
+func coerceEnum(b *schema.Bundle, name string, input value, f *coerceFlags) (json.RawMessage, error) {
 	if input.kind != valString {
 		return nil, declineCoerce("enum target", input)
 	}
@@ -185,9 +213,12 @@ func coerceEnum(b *schema.Bundle, name string, input value) (json.RawMessage, er
 	if !ok {
 		return nil, fmt.Errorf("debaml: unknown enum %q", name)
 	}
-	matched, outcome := matchString(input.strV, enumMatchCandidates(e), true)
+	matched, outcome, viaSub := matchString(input.strV, enumMatchCandidates(e), true)
 	switch outcome {
 	case matchOne:
+		if viaSub {
+			f.flag() // SubstringMatch (cost 2)
+		}
 		// matched is the candidate name = the value's canonical real name.
 		return marshalJSON(matched)
 	case matchAmbiguous:
@@ -226,7 +257,8 @@ func enumMatchCandidates(e *schema.EnumDef) []matchCandidate {
 // actual no-substring match_string (Mcoerce-a, via matchesStringToString),
 // reproducing coerce_class.rs: each input key is assigned to the FIRST field
 // whose rendered name it matches (case-insensitive / punctuation-stripped /
-// accent-folded — but NOT substring); duplicate matches resolve last-wins,
+// accent-folded — but NOT substring); when two input keys match the same
+// field the FIRST keeps it (update_map's "keep first", coerce_class.rs:548);
 // extra/unknown keys are ignored (ExtraKey, not emitted). It CLAIMS when the
 // input is an object and every required field is matched and coerces;
 // otherwise it DECLINES, because BAML's class coercer is leniently broader
@@ -244,8 +276,10 @@ func enumMatchCandidates(e *schema.EnumDef) []matchCandidate {
 // BAML hard-fails turning a scalar into a multi-field object too, so the
 // differential checks error parity. A claimed child error (e.g. an enum
 // substring tie) propagates so the differential checks error parity; lenient
-// structural coercion (defaults, implied keys) is deferred to Mcoerce-d.
-func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input value) (json.RawMessage, error) {
+// structural coercion (defaults, implied keys) is deferred to Mcoerce-d. Any
+// EXTRA input key (ExtraKey, cost 1) and any flagged child flag cf, so a
+// nullable-union claim can require this class arm to be clean.
+func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input value, cf *coerceFlags) (json.RawMessage, error) {
 	cls, ok := b.FindClass(name, mode)
 	if !ok {
 		return nil, fmt.Errorf("debaml: unknown class %q", name)
@@ -260,23 +294,34 @@ func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input
 
 	// Assign input keys to fields the way BAML does: iterate input keys in
 	// order, and for each map it to the FIRST field whose rendered name it
-	// fuzzily matches (no substring). Later matches overwrite earlier ones for
-	// the same field (last-wins, matching update_map). Unmatched input keys are
-	// extras (ignored). This input-key-first order — rather than scanning
+	// fuzzily matches (no substring). When two input keys match the same field,
+	// the FIRST keeps it (update_map "keep first") — later duplicates are
+	// ignored, NOT treated as extras. An input key matching no field is an
+	// extra (ExtraKey). This input-key-first order — rather than scanning
 	// fields for a matching key — is what makes one key resolve to a single
 	// field, avoiding a key being assigned to two fold-equal fields at once.
 	assigned := make([]value, len(cls.Fields))
 	present := make([]bool, len(cls.Fields))
 	foundAny := false
+	hasExtra := false
 	for i := range input.objV {
 		key := input.objV[i].key
+		matchedField := -1
 		for j := range cls.Fields {
 			if matchesStringToString(key, cls.Fields[j].Name.RenderedName()) {
-				assigned[j] = input.objV[i].val
-				present[j] = true
-				foundAny = true
+				matchedField = j
 				break
 			}
+		}
+		switch {
+		case matchedField < 0:
+			hasExtra = true // unmatched input key -> ExtraKey
+		case present[matchedField]:
+			// Duplicate match for an already-filled field: keep first, ignore.
+		default:
+			assigned[matchedField] = input.objV[i].val
+			present[matchedField] = true
+			foundAny = true
 		}
 	}
 	if singleField && !foundAny {
@@ -284,6 +329,9 @@ func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input
 		// inferred-object on the whole object, or fills a default for an empty
 		// object — native cannot reproduce either, so DECLINE (Mcoerce-d).
 		return nil, unsupported(fmt.Sprintf("single-field class %q: lone field unmatched (BAML implied-key/default)", name))
+	}
+	if hasExtra {
+		cf.flag() // ExtraKey (cost 1 each) -> not a clean zero-score class
 	}
 
 	var buf bytes.Buffer
@@ -305,7 +353,7 @@ func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input
 			// when BAML defaults. Default-filling parity is Mcoerce-d.
 			return nil, unsupported(fmt.Sprintf("class %q: required field %q has no key match (BAML may default/error)", name, f.Name.RenderedName()))
 		}
-		child, err := coerce(b, f.Type, assigned[i])
+		child, err := coerce(b, f.Type, assigned[i], cf)
 		if err != nil {
 			return nil, err
 		}
@@ -325,7 +373,7 @@ func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input
 	return buf.Bytes(), nil
 }
 
-func coerceList(b *schema.Bundle, elem *schema.Type, input value) (json.RawMessage, error) {
+func coerceList(b *schema.Bundle, elem *schema.Type, input value, cf *coerceFlags) (json.RawMessage, error) {
 	if elem == nil {
 		return nil, fmt.Errorf("debaml: list type missing element")
 	}
@@ -338,7 +386,10 @@ func coerceList(b *schema.Bundle, elem *schema.Type, input value) (json.RawMessa
 	var buf bytes.Buffer
 	buf.WriteByte('[')
 	for i := range input.arrV {
-		child, err := coerce(b, *elem, input.arrV[i])
+		// A clean array adds no list-level flag; element flags (e.g. a
+		// substring enum) propagate through cf so a nullable list arm can
+		// require all elements clean.
+		child, err := coerce(b, *elem, input.arrV[i], cf)
 		if err != nil {
 			// A bad element: BAML records ArrayItemParseError and SKIPS it,
 			// returning a partial list that still succeeds — native cannot
@@ -383,7 +434,7 @@ func coerceList(b *schema.Bundle, elem *schema.Type, input value) (json.RawMessa
 // canonical enum/literal form, matching coerce_map.rs:165-174), and an empty
 // object is a clean empty map. A class value is emitted by coerceClass in
 // schema order, nested inside the input-ordered map.
-func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value) (json.RawMessage, error) {
+func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value, cf *coerceFlags) (json.RawMessage, error) {
 	if keyT == nil || valT == nil {
 		return nil, fmt.Errorf("debaml: map type missing key or value")
 	}
@@ -393,6 +444,11 @@ func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value) (json.Raw
 		// rather than claim a mismatch BAML would not produce.
 		return nil, declineCoerce("map target", input)
 	}
+	// Every object→map carries ObjectToMap (cost 1), and BAML scores a map by
+	// its OWN flags only — the value scores do NOT propagate (score.rs:21). So
+	// a map is NEVER a zero-score "clean" arm: flag cf, and coerce values with
+	// no accumulator since their flags don't affect the map's score.
+	cf.flag()
 
 	var buf bytes.Buffer
 	buf.WriteByte('{')
@@ -408,7 +464,7 @@ func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value) (json.Raw
 		}
 		seen[f.key] = struct{}{}
 
-		child, err := coerce(b, *valT, f.val)
+		child, err := coerce(b, *valT, f.val, nil)
 		if err != nil {
 			// A bad value: BAML records MapValueParseError and SKIPS this
 			// entry, returning a partial map — native cannot reproduce that, so
@@ -467,7 +523,10 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
 		if !ok {
 			return fmt.Errorf("debaml: unknown enum %q", keyT.Name)
 		}
-		if _, outcome := matchString(key, enumMatchCandidates(e), true); outcome == matchOne {
+		// The key's own match flags do not propagate to the map score (BAML
+		// discards the coerced key, inserting the original string), so ignore
+		// the substring bit — only success/failure matters.
+		if _, outcome, _ := matchString(key, enumMatchCandidates(e), true); outcome == matchOne {
 			return nil
 		}
 		return unsupported(fmt.Sprintf("map key %q: no clean enum %q match (BAML skips via MapKeyParseError)", key, keyT.Name))
@@ -475,7 +534,7 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
 		if keyT.Literal == nil || keyT.Literal.Kind != schema.LiteralString {
 			return unsupported("map key literal must be a string literal")
 		}
-		if _, outcome := matchString(key, []matchCandidate{{name: keyT.Literal.String, validValues: []string{keyT.Literal.String}}}, true); outcome == matchOne {
+		if _, outcome, _ := matchString(key, []matchCandidate{{name: keyT.Literal.String, validValues: []string{keyT.Literal.String}}}, true); outcome == matchOne {
 			return nil
 		}
 		return unsupported(fmt.Sprintf("map key %q: no clean literal %q match (BAML skips via MapKeyParseError)", key, keyT.Literal.String))
@@ -484,7 +543,7 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
 		// which succeeds when ANY literal arm matches; the map then inserts the
 		// original key, so the winning arm is irrelevant.
 		for _, lit := range flattenStringLiterals(keyT) {
-			if _, outcome := matchString(key, []matchCandidate{{name: lit, validValues: []string{lit}}}, true); outcome == matchOne {
+			if _, outcome, _ := matchString(key, []matchCandidate{{name: lit, validValues: []string{lit}}}, true); outcome == matchOne {
 				return nil
 			}
 		}
@@ -520,29 +579,34 @@ func flattenStringLiterals(t schema.Type) []string {
 
 // coerceUnionSafe coerces a value against a union, claiming native JSON ONLY
 // where it can PROVE BAML also resolves to exactly one clean zero-score
-// winner — otherwise it DECLINES (ErrDeBAMLParseUnsupported → fall back). The
-// M2c trap is that native's STRICT per-variant verdicts do not mirror BAML's
-// LENIENT ones: "exactly one native variant matched" does NOT prove "exactly
-// one BAML variant matched", because BAML leniency (fuzzy enum/literal,
-// string<->number, stringification, array-to-singular, implied-key class,
-// defaults) could make a 2nd arm succeed → BAML runs pick_best SCORING →
-// native's single pick may differ from BAML's scored winner. The claim is
-// limited to three cases (see the package M2c notes):
+// winner — otherwise it DECLINES (ErrDeBAMLParseUnsupported → fall back). Two
+// traps shape the claim:
 //
-//  1. JSON-null input + nullable union → null immediately. This is BAML's
-//     null fast path and covers ANY nullable union (incl. multi-variant),
-//     because BAML returns the zero-score null arm before scoring.
-//  2. nullable single-non-null union (the M1 optional shape) → non-null input
-//     coerces through the lone variant; preserved EXACTLY.
-//  3. non-null input + a multi-variant SAFE FAMILY (homogeneous exact-literal
-//     union or flat disjoint-key class union, proven by
-//     checkSupportedUnionShape) where the value-level guard finds exactly one
-//     winner.
+//   - LENIENCY (M2c): native's per-variant verdicts must mirror BAML's lenient
+//     ones, and exactly one variant must succeed; two-plus is BAML pick_best
+//     SCORING (M3) and declines.
+//   - THE NULL ARM SCORES (F1): for a NULLABLE union with NON-null input, BAML
+//     includes the null arm in scoring — any non-null value coerces to null
+//     with DefaultButHadValue cost 110 (coerce_union.rs:129,
+//     coerce_primitive.rs:116). So the chosen non-null arm wins only if its
+//     score < 110; if it carries ≥110 worth of flags BAML returns NULL. Native
+//     does not score, so in a nullable context it claims the non-null arm ONLY
+//     when that arm is CLEAN (zero score-bearing flags) — which trivially beats
+//     null's 110. A flagged arm (extra keys, substring match, object→map, …)
+//     DECLINES (it might be an M3 scored win for null or another arm).
 //
-// Everything else declines. checkSupportedType permits a nullable multi-union
-// at the gate purely for case 1; its non-null arms are re-proven here, so a
-// non-null input to a nullable-but-unsafe union still declines.
-func coerceUnionSafe(b *schema.Bundle, u *schema.UnionType, input value) (json.RawMessage, error) {
+// The claim is limited to:
+//
+//  1. JSON-null input + nullable union → null immediately (BAML's null fast path).
+//  2. nullable single-non-null union (the optional shape) → non-null input
+//     coerces through the lone variant ONLY when that coercion is clean.
+//  3. non-null input + a multi-variant SAFE FAMILY (homogeneous literal union or
+//     flat disjoint-key class union) where exactly one variant succeeds — and,
+//     when the union is nullable, that winner is clean.
+//
+// cf carries the winner's cleanliness up to an OUTER nullable context (a flagged
+// arm makes an enclosing optional non-clean too).
+func coerceUnionSafe(b *schema.Bundle, u *schema.UnionType, input value, cf *coerceFlags) (json.RawMessage, error) {
 	if u == nil {
 		return nil, fmt.Errorf("debaml: union type missing payload")
 	}
@@ -553,19 +617,20 @@ func coerceUnionSafe(b *schema.Bundle, u *schema.UnionType, input value) (json.R
 		}
 		return json.RawMessage("null"), nil
 	}
-	// Case 2: optional — a single non-null variant. (Non-nullable single
-	// variants collapse to the bare type in simplifyUnion, so this is reached
-	// only for the nullable optional shape.) A non-null input coerces through
-	// the lone arm; but once coercion is lenient (Mcoerce-a), the arm FAILING
-	// no longer means the union fails — BAML falls back to the null arm
-	// (coerce_primitive null → DefaultButHadValue, a non-zero score) and
-	// returns null. Native cannot reproduce that scored null default, so any
-	// arm failure (a DECLINE, or a CLAIMED error such as an enum substring
-	// tie) becomes a union DECLINE rather than propagating the arm's verdict.
+	// Case 2: optional — a single non-null variant (always the nullable shape,
+	// since a non-nullable single variant collapses to the bare type in
+	// simplifyUnion). Coerce the lone arm into a LOCAL accumulator: an arm
+	// FAILURE means BAML null-defaults (cost 110) — native can't reproduce that
+	// — and a FLAGGED arm might also lose to null by score, so claim ONLY a
+	// clean success.
 	if len(u.Variants) == 1 {
-		out, err := coerce(b, u.Variants[0], input)
+		arm := &coerceFlags{}
+		out, err := coerce(b, u.Variants[0], input, arm)
 		if err != nil {
 			return nil, unsupported(fmt.Sprintf("optional single-arm union: non-null arm did not cleanly succeed (BAML may null-default): %v", err))
+		}
+		if arm.isFlagged() {
+			return nil, unsupported("optional single-arm union: non-null arm is not a clean zero-score match (null arm competes by scoring → M3)")
 		}
 		return out, nil
 	}
@@ -575,18 +640,35 @@ func coerceUnionSafe(b *schema.Bundle, u *schema.UnionType, input value) (json.R
 	if err := checkSupportedUnionShape(b, u); err != nil {
 		return nil, err
 	}
-	return coerceUnionSafeMulti(b, u.Variants, input)
+	return coerceUnionSafeMulti(b, u.Variants, input, u.Nullable, cf)
 }
 
 // coerceUnionSafeMulti dispatches a proven-safe multi-variant union to its
-// family's value-level guard. checkSupportedUnionShape has already proven the
-// variant set is one of the two homogeneous families, so the else branch is
-// the flat class union.
-func coerceUnionSafeMulti(b *schema.Bundle, variants []schema.Type, input value) (json.RawMessage, error) {
+// family's value-level guard. requireClean is the union's Nullable flag: when
+// true the lone winner must be a clean zero-score success (the null arm
+// competes by scoring). checkSupportedUnionShape has already proven the variant
+// set is one of the two homogeneous families, so the else branch is the flat
+// class union.
+func coerceUnionSafeMulti(b *schema.Bundle, variants []schema.Type, input value, requireClean bool, cf *coerceFlags) (json.RawMessage, error) {
 	if allLiteralVariants(variants) {
-		return coerceLiteralUnion(variants, input)
+		return coerceLiteralUnion(variants, input, requireClean, cf)
 	}
-	return coerceFlatClassUnion(b, variants, input)
+	return coerceFlatClassUnion(b, variants, input, requireClean, cf)
+}
+
+// resolveArmFlags applies the lone winner's local flags. When requireClean (a
+// nullable union, where BAML's 110-cost null arm competes), a flagged winner
+// DECLINES. Otherwise a flagged winner is still claimed but its flags propagate
+// to the caller's accumulator, so an enclosing nullable context sees it.
+func resolveArmFlags(requireClean bool, arm, cf *coerceFlags) error {
+	if !arm.isFlagged() {
+		return nil
+	}
+	if requireClean {
+		return unsupported("nullable union: lone non-null arm is not a clean zero-score match (null arm competes by scoring → M3)")
+	}
+	cf.flag()
+	return nil
 }
 
 // coerceLiteralUnion claims a homogeneous literal union when EXACTLY one
@@ -597,14 +679,15 @@ func coerceUnionSafeMulti(b *schema.Bundle, variants []schema.Type, input value)
 // Mcoerce-b). Two-plus lenient successes mean BAML would run scored pick_best
 // — e.g. input "foobar" substring-matching both "foo" and "bar" arms even
 // though the literal VALUES were proven match-disjoint at the gate — so
-// native DECLINES (M3). Zero successes decline too. The single winner is
-// re-coerced through coerceLiteral so the emitted form matches the
-// single-literal path exactly.
-func coerceLiteralUnion(variants []schema.Type, input value) (json.RawMessage, error) {
+// native DECLINES (M3). Zero successes decline too. When requireClean (nullable
+// union), a winner that only substring-matched (SubstringMatch flag) declines —
+// the null arm could score lower. The single winner is re-coerced through
+// coerceLiteral so the emitted form matches the single-literal path exactly.
+func coerceLiteralUnion(variants []schema.Type, input value, requireClean bool, cf *coerceFlags) (json.RawMessage, error) {
 	matched := -1
 	count := 0
 	for i := range variants {
-		if _, err := coerceLiteral(variants[i].Literal, input); err == nil {
+		if _, err := coerceLiteral(variants[i].Literal, input, nil); err == nil {
 			matched = i
 			count++
 		}
@@ -612,7 +695,15 @@ func coerceLiteralUnion(variants []schema.Type, input value) (json.RawMessage, e
 	if count != 1 {
 		return nil, unsupported(fmt.Sprintf("literal union: %d lenient matches for %s input (need exactly 1; 2+ is BAML pick_best = M3)", count, input.kind.String()))
 	}
-	return coerceLiteral(variants[matched].Literal, input)
+	arm := &coerceFlags{}
+	out, err := coerceLiteral(variants[matched].Literal, input, arm)
+	if err != nil {
+		return nil, err
+	}
+	if err := resolveArmFlags(requireClean, arm, cf); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // coerceFlatClassUnion claims a flat disjoint-key class union when EXACTLY
@@ -625,10 +716,12 @@ func coerceLiteralUnion(variants []schema.Type, input value) (json.RawMessage, e
 // cannot satisfy another (every other arm is missing >=2 disjoint required
 // fields it cannot fill) — unless the input ALSO carries a second arm's full
 // field set, which makes BOTH succeed and forces BAML's scored pick_best, so
-// native DECLINES (M3). Zero successes decline too. A child coercion error
-// (sentinel OR claimed) just means that variant did not succeed and is
-// swallowed by the count; only the lone clean winner is emitted.
-func coerceFlatClassUnion(b *schema.Bundle, variants []schema.Type, input value) (json.RawMessage, error) {
+// native DECLINES (M3). Zero successes decline too. When requireClean (nullable
+// union), a winner carrying ExtraKey flags (extra input keys) or any flagged
+// child DECLINES — BAML's null arm (110) could outscore it. A child coercion
+// error (sentinel OR claimed) just means that variant did not succeed and is
+// swallowed by the count; only the lone winner is emitted.
+func coerceFlatClassUnion(b *schema.Bundle, variants []schema.Type, input value, requireClean bool, cf *coerceFlags) (json.RawMessage, error) {
 	if input.kind != valObject {
 		// BAML can infer a single-field class from a scalar / imply a key;
 		// these classes are multi-field so a non-object is never a clean arm,
@@ -638,7 +731,7 @@ func coerceFlatClassUnion(b *schema.Bundle, variants []schema.Type, input value)
 	matched := -1
 	count := 0
 	for i := range variants {
-		if _, err := coerceClass(b, variants[i].Name, variants[i].Mode, input); err == nil {
+		if _, err := coerceClass(b, variants[i].Name, variants[i].Mode, input, nil); err == nil {
 			matched = i
 			count++
 		}
@@ -646,7 +739,15 @@ func coerceFlatClassUnion(b *schema.Bundle, variants []schema.Type, input value)
 	if count != 1 {
 		return nil, unsupported(fmt.Sprintf("class union: %d variant classes coerce cleanly (need exactly 1; 2+ is BAML pick_best = M3)", count))
 	}
-	return coerceClass(b, variants[matched].Name, variants[matched].Mode, input)
+	arm := &coerceFlags{}
+	out, err := coerceClass(b, variants[matched].Name, variants[matched].Mode, input, arm)
+	if err != nil {
+		return nil, err
+	}
+	if err := resolveArmFlags(requireClean, arm, cf); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // isOptional reports whether t is an optional (a nullable union), the only

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/invakid404/baml-rest/internal/schema"
 )
@@ -21,27 +22,32 @@ import (
 // pipeline keys on. Class fields are emitted in schema declaration order so
 // that order pass remains the authority.
 //
-// Coercion cut-line (DELIBERATE, M2a): native matches types STRICTLY, while
-// BAML's coercers are lenient (parse numeric strings, round float→int,
-// stringify non-strings, fuzzy-match enums/literals via match_string, wrap
-// singletons into arrays, absorb a scalar into a single-field class). Where
-// native's strict match fails but BAML may leniently SUCCEED — or where
-// native cannot determine BAML's exact success/failure — coercion DECLINES
-// (ErrDeBAMLParseUnsupported → fall back to BAML), so native is never "more
-// capable" than BAML. Native CLAIMS a coercion error only for the mismatch
-// BAML also hard-rejects: a non-object where a MULTI-field class is required
-// (coerceClass). A required field with no EXACT key match instead DECLINES —
-// BAML may fuzzy-match the key via match_string or hard-fail, and native
-// cannot tell which apart (deferred to Mcoerce) — while a class whose every
-// required field is exact-matched is claimed. A consequence is that native
-// also declines some inputs BAML would itself reject (e.g. {color:"MAUVE"}
-// with no enum match, {version:3} for literal 2, a non-integer for an int,
-// or a genuinely-absent required field) — behavior is
-// identical via fallback, and precise claim-parity for those (porting BAML's
-// match_string for keys/enums/literals + lenient numeric/structural coercion)
-// is deferred to the Mcoerce milestone (#546). See coercePrimitive /
-// coerceList / coerceEnum / coerceLiteral / coerceClass for the per-kind
-// boundary.
+// Coercion cut-line (Mcoerce-a): native now matches enum values, string
+// literals, class field keys, and map keys through BAML's actual match_string
+// (trim / accent+ligature fold / punctuation strip / case-insensitive /
+// substring — see match_string.go), so fuzzy matches BAML accepts are CLAIMED
+// byte-exact. The remaining leniencies stay STRICT and DECLINE: numeric/bool
+// string parsing, float→int rounding, non-string stringification (ObjectToString
+// / JsonToString), single-to-array wrapping, single-field implied-key /
+// inferred-object absorption, partial list/map skips, and class default-fill —
+// all deferred to Mcoerce-b/c/d. Where native's match fails but BAML may
+// leniently SUCCEED (or null-default) — or where native cannot determine BAML's
+// exact success/failure — coercion DECLINES (ErrDeBAMLParseUnsupported → fall
+// back to BAML), so native is never "more capable" than BAML.
+//
+// Native CLAIMS a coercion error only where BAML also errors: a non-object
+// where a MULTI-field class is required (coerceClass typeMismatch), or a
+// match_string substring TIE (StrMatchOneFromMany — coerceEnum/coerceLiteral
+// ambiguousMatch). A required field still unmatched after fuzzy key matching
+// DECLINES — BAML may default-fill or hard-fail and native cannot tell which.
+// Union claims count LENIENT per-variant successes and claim only the lone
+// winner; two-plus successes are BAML pick_best (M3) and DECLINE. A consequence
+// is that native still declines some inputs BAML would itself reject (e.g. a
+// required field with no fuzzy key match, {version:3} for literal 2, a
+// non-integer for an int) — behavior is identical via fallback, and precise
+// claim-parity for those is deferred to the rest of the Mcoerce milestone
+// (#546). See coercePrimitive / coerceList / coerceEnum / coerceLiteral /
+// coerceClass for the per-kind boundary.
 func coerce(b *schema.Bundle, t schema.Type, input value) (json.RawMessage, error) {
 	switch t.Kind {
 	case schema.TypePrimitive:
@@ -112,23 +118,34 @@ func coercePrimitive(p schema.PrimitiveKind, input value) (json.RawMessage, erro
 	}
 }
 
-// coerceLiteral coerces a value to a literal target. Native matching is
-// EXACT, whereas BAML's literal coercion routes string literals through the
-// fuzzy match_string helper (trim / strip-punctuation / case-insensitive /
-// substring) and rounds/parses for int and bool literals. A non-exact
-// native match is therefore where BAML's lenient matcher would still
-// succeed, so any mismatch DECLINES (fall back to BAML) rather than
-// claiming an error BAML would not produce.
+// coerceLiteral coerces a value to a literal target. String literals route
+// through BAML's actual match_string (Mcoerce-a) — trim / fold / strip /
+// case-insensitive / substring — emitting the canonical literal (not the
+// fuzzy raw input); a substring tie is a CLAIMED error and a no-match
+// DECLINES. Int and bool literals still match EXACTLY: BAML rounds/parses
+// them (string→int, float→int), which is Mcoerce-b, so a non-exact int/bool
+// DECLINES rather than claiming a mismatch BAML would not produce. A
+// non-string input to a string literal also DECLINES (BAML's single-key
+// object ObjectToPrimitive extraction is Mcoerce-d).
 func coerceLiteral(lit *schema.LiteralValue, input value) (json.RawMessage, error) {
 	if lit == nil {
 		return nil, fmt.Errorf("debaml: literal type missing value")
 	}
 	switch lit.Kind {
 	case schema.LiteralString:
-		if input.kind != valString || input.strV != lit.String {
-			return nil, unsupported(fmt.Sprintf("literal string %q: no exact match (BAML fuzzy-matches)", lit.String))
+		if input.kind != valString {
+			return nil, declineCoerce("literal string", input)
 		}
-		return marshalJSON(input.strV)
+		matched, outcome := matchString(input.strV, []matchCandidate{{name: lit.String, validValues: []string{lit.String}}}, true)
+		switch outcome {
+		case matchOne:
+			return marshalJSON(matched)
+		case matchAmbiguous:
+			// A single candidate cannot tie; defensive.
+			return nil, ambiguousMatch(fmt.Sprintf("literal string %q", lit.String), input.strV)
+		default:
+			return nil, unsupported(fmt.Sprintf("literal string %q: %q matches no value (BAML errors or null-defaults)", lit.String, input.strV))
+		}
 	case schema.LiteralInt:
 		if input.kind != valNumber {
 			return nil, declineCoerce("literal int", input)
@@ -148,14 +165,18 @@ func coerceLiteral(lit *schema.LiteralValue, input value) (json.RawMessage, erro
 	}
 }
 
-// coerceEnum coerces a value to an enum target by EXACT rendered-name (or
-// alias) match. BAML's enum coercion routes through the fuzzy match_string
-// helper (trim / strip-punctuation / case-insensitive / accent-removal /
-// substring), so a value with no exact native match may still match in
-// BAML. To avoid claiming a mismatch BAML would not produce, a non-string
-// input or a no-exact-match value DECLINES (fall back to BAML). An enum
-// referenced but absent from the lowered bundle is a broken schema, kept as
-// a claimed error.
+// coerceEnum coerces a string value to an enum target via BAML's actual
+// match_string (Mcoerce-a): trim / accent+ligature fold / punctuation strip
+// / case-insensitive / substring, against each value's rendered name,
+// description, and "rendered: description" form (enumMatchCandidates). The
+// canonical real name of the matched value is emitted. A substring TIE is a
+// CLAIMED error (StrMatchOneFromMany — BAML errors before emitting), while a
+// no-match DECLINES: BAML errors in a required position but null-defaults in
+// an optional one (DefaultButHadValue), and native cannot tell which apart
+// without scoring, so it falls back. A non-string input also DECLINES — BAML
+// stringifies it via jsonish Value Display (ObjectToString), whose exact
+// reproduction is Mcoerce-b/d. An enum absent from the lowered bundle is a
+// broken schema, kept as a claimed error.
 func coerceEnum(b *schema.Bundle, name string, input value) (json.RawMessage, error) {
 	if input.kind != valString {
 		return nil, declineCoerce("enum target", input)
@@ -164,33 +185,66 @@ func coerceEnum(b *schema.Bundle, name string, input value) (json.RawMessage, er
 	if !ok {
 		return nil, fmt.Errorf("debaml: unknown enum %q", name)
 	}
-	v, ok := e.ValueByRenderedName(input.strV)
-	if !ok {
-		return nil, unsupported(fmt.Sprintf("enum %q: %q not an exact value (BAML fuzzy-matches)", name, input.strV))
+	matched, outcome := matchString(input.strV, enumMatchCandidates(e), true)
+	switch outcome {
+	case matchOne:
+		// matched is the candidate name = the value's canonical real name.
+		return marshalJSON(matched)
+	case matchAmbiguous:
+		return nil, ambiguousMatch(fmt.Sprintf("enum %q", name), input.strV)
+	default:
+		return nil, unsupported(fmt.Sprintf("enum %q: %q matches no value (BAML errors or null-defaults)", name, input.strV))
 	}
-	// Emit the canonical enum value name, matching BAML's enum coercion.
-	return marshalJSON(v.Name.Name)
+}
+
+// enumMatchCandidates builds the (real_name, valid_values) candidate set
+// BAML's enum coercer matches against (coerce_enum.rs:14): each value's
+// rendered name, plus — when it has a non-empty trimmed description — that
+// description and the "rendered: description" form. The candidate NAME is
+// the canonical real name, which match_string returns and coerceEnum emits.
+func enumMatchCandidates(e *schema.EnumDef) []matchCandidate {
+	cands := make([]matchCandidate, 0, len(e.Values))
+	for i := range e.Values {
+		v := &e.Values[i]
+		rendered := v.Name.RenderedName()
+		var vals []string
+		if v.Description != nil {
+			if d := strings.TrimSpace(*v.Description); d != "" {
+				vals = []string{rendered, d, rendered + ": " + d}
+			}
+		}
+		if vals == nil {
+			vals = []string{rendered}
+		}
+		cands = append(cands, matchCandidate{name: v.Name.Name, validValues: vals})
+	}
+	return cands
 }
 
 // coerceClass coerces an object value into a class, emitting fields in
-// schema declaration order. It CLAIMS only when native is confident it
-// matches BAML's structure: the input is an object and every required field
-// is matched by an EXACT key. Otherwise it DECLINES, because BAML's class
-// coercer is leniently broader than native's strict matching and native
-// cannot tell whether BAML would succeed:
+// schema declaration order. Input keys are matched to fields by BAML's
+// actual no-substring match_string (Mcoerce-a, via matchesStringToString),
+// reproducing coerce_class.rs: each input key is assigned to the FIRST field
+// whose rendered name it matches (case-insensitive / punctuation-stripped /
+// accent-folded — but NOT substring); duplicate matches resolve last-wins,
+// extra/unknown keys are ignored (ExtraKey, not emitted). It CLAIMS when the
+// input is an object and every required field is matched and coerces;
+// otherwise it DECLINES, because BAML's class coercer is leniently broader
+// than native and native cannot tell whether BAML would succeed:
 //
-//   - A required field with no EXACT key match → DECLINE: BAML matches field
-//     keys fuzzily (coerce_class.rs → match_string: case-insensitive /
-//     punctuation-stripped / substring), so {"Name":...} may match `name`.
-//   - A SINGLE-field class with a non-object input, or an object whose lone
-//     field key is absent → DECLINE: BAML absorbs the value into the one
-//     field via implied-key / inferred-object (coerce_class.rs:224/295/300).
+//   - A required field still unmatched after fuzzy key matching → DECLINE:
+//     BAML may fill a type default (list/map/null/union) or hard-fail
+//     (coerce_class.rs:342/field_type.rs:288), which native cannot reproduce.
+//   - A SINGLE-field class with a non-object input, or an object NONE of
+//     whose keys match the lone field → DECLINE: BAML absorbs the value into
+//     the one field via implied-key / inferred-object, or fills a default
+//     for an empty object (coerce_class.rs:224/295/313) — all Mcoerce-d.
 //
 // A MULTI-field class with a NON-OBJECT input stays CLAIMED (typeMismatch):
 // BAML hard-fails turning a scalar into a multi-field object too, so the
-// differential checks error parity. Extra/unknown input keys are ignored on
-// both sides (native iterates only schema fields). Precise key-matching and
-// lenient structural coercion are deferred to the Mcoerce milestone (#546).
+// differential checks error parity. A claimed child error (e.g. an enum
+// substring tie) propagates so the differential checks error parity; lenient
+// structural coercion (defaults, implied keys) is deferred to Mcoerce-d.
 func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input value) (json.RawMessage, error) {
 	cls, ok := b.FindClass(name, mode)
 	if !ok {
@@ -203,10 +257,33 @@ func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input
 		}
 		return nil, typeMismatch("object", input)
 	}
-	if singleField {
-		if _, present := lookupField(input.objV, cls.Fields[0].Name); !present {
-			return nil, unsupported(fmt.Sprintf("debaml: single-field class %q: lone field absent (BAML implied-key may coerce the object)", name))
+
+	// Assign input keys to fields the way BAML does: iterate input keys in
+	// order, and for each map it to the FIRST field whose rendered name it
+	// fuzzily matches (no substring). Later matches overwrite earlier ones for
+	// the same field (last-wins, matching update_map). Unmatched input keys are
+	// extras (ignored). This input-key-first order — rather than scanning
+	// fields for a matching key — is what makes one key resolve to a single
+	// field, avoiding a key being assigned to two fold-equal fields at once.
+	assigned := make([]value, len(cls.Fields))
+	present := make([]bool, len(cls.Fields))
+	foundAny := false
+	for i := range input.objV {
+		key := input.objV[i].key
+		for j := range cls.Fields {
+			if matchesStringToString(key, cls.Fields[j].Name.RenderedName()) {
+				assigned[j] = input.objV[i].val
+				present[j] = true
+				foundAny = true
+				break
+			}
 		}
+	}
+	if singleField && !foundAny {
+		// No input key matched the lone field: BAML tries implied-key /
+		// inferred-object on the whole object, or fills a default for an empty
+		// object — native cannot reproduce either, so DECLINE (Mcoerce-d).
+		return nil, unsupported(fmt.Sprintf("single-field class %q: lone field unmatched (BAML implied-key/default)", name))
 	}
 
 	var buf bytes.Buffer
@@ -214,26 +291,21 @@ func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input
 	first := true
 	for i := range cls.Fields {
 		f := &cls.Fields[i]
-		val, present := lookupField(input.objV, f.Name)
-		if !present {
+		if !present[i] {
 			if isOptional(f.Type) {
 				// Absent optional: omit it. The downstream
 				// InjectAbsentOptionals pass inserts the null, identically
 				// for the native and BAML paths.
 				continue
 			}
-			// A required field with no EXACT key match: BAML matches field
-			// keys fuzzily (coerce_class.rs → match_string: case-insensitive
-			// / punctuation-stripped / substring), so it may coerce a
-			// differently-cased or near key that native's exact lookup misses
-			// (e.g. {"Name":...} → name) — or it may truly hard-fail. Native
-			// cannot tell which without match_string, so it DECLINES (fall
-			// back to BAML) rather than claim a missing-required error that
-			// would be WRONG when BAML fuzzy-matches. Precise key-matching
-			// parity is deferred to the Mcoerce milestone (#546).
-			return nil, unsupported(fmt.Sprintf("class %q: required field %q has no exact key match (BAML may fuzzy-match keys)", name, f.Name.RenderedName()))
+			// A required field with no key match even after fuzzy matching:
+			// BAML may fill a type default (field_type.rs:288) or hard-fail,
+			// and native cannot tell which, so it DECLINES (fall back to BAML)
+			// rather than claim a missing-required error that would be WRONG
+			// when BAML defaults. Default-filling parity is Mcoerce-d.
+			return nil, unsupported(fmt.Sprintf("class %q: required field %q has no key match (BAML may default/error)", name, f.Name.RenderedName()))
 		}
-		child, err := coerce(b, f.Type, val)
+		child, err := coerce(b, f.Type, assigned[i])
 		if err != nil {
 			return nil, err
 		}
@@ -268,7 +340,14 @@ func coerceList(b *schema.Bundle, elem *schema.Type, input value) (json.RawMessa
 	for i := range input.arrV {
 		child, err := coerce(b, *elem, input.arrV[i])
 		if err != nil {
-			return nil, err
+			// A bad element: BAML records ArrayItemParseError and SKIPS it,
+			// returning a partial list that still succeeds — native cannot
+			// reproduce that partial result, so it DECLINES the whole list
+			// rather than propagate the element's verdict (a CLAIMED child
+			// error such as an enum substring tie must NOT become a claimed
+			// list error where BAML would just drop the element). Partial-list
+			// parity is Mcoerce-c.
+			return nil, unsupported(fmt.Sprintf("list element %d: %v (BAML skips bad items via ArrayItemParseError)", i, err))
 		}
 		if i > 0 {
 			buf.WriteByte(',')
@@ -355,20 +434,27 @@ func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value) (json.Raw
 }
 
 // matchMapKey validates an input object key string against the declared map
-// key type by EXACT match only, returning nil on a clean accept and a
-// DECLINE sentinel otherwise. checkSupportedMapKey has already restricted
-// the key type to the four legal shapes, so the default arm is defensive.
+// key type via BAML's actual match_string (Mcoerce-a), returning nil on a
+// clean accept and a DECLINE sentinel otherwise. checkSupportedMapKey has
+// already restricted the key type to the four legal shapes, so the default
+// arm is defensive. BAML coerces the key with the key type's coercer
+// (coerce_map.rs:163) and, on success, inserts the entry under the ORIGINAL
+// input key string — so the accepted key is never rewritten, and the only
+// thing that matters here is whether the key coercion SUCCEEDS:
 //
 //   - string primitive: accept any key verbatim.
-//   - enum: require an EXACT rendered-name/alias match (the same exact path
-//     coerceEnum uses); BAML's full enum key coercion is fuzzy (match_string)
-//     so a non-exact key is Mcoerce, not a native claim.
-//   - string literal: require exact string equality.
-//   - union of string literals: require EXACTLY ONE flattened literal equal
-//     to the key (no match, or a duplicate-literal ambiguity, declines).
+//   - enum: accept on a clean match_string match (substring enabled); a
+//     no-match or substring TIE declines (BAML skips the entry via
+//     MapKeyParseError, returning a partial map — Mcoerce-c).
+//   - string literal: accept on a clean match_string match (substring enabled).
+//   - union of string literals: accept when AT LEAST ONE arm matches. The
+//     map output is the original key regardless of which arm BAML's union
+//     pick_best selects, so multiple matches do not need scoring here.
 //
-// The accepted key is NOT rewritten — coerceMap emits the original input key
-// string, matching BAML's insertion of the raw object key.
+// Any non-clean key DECLINES the whole map, because BAML would skip just that
+// entry and return a partial map, which native does not yet reproduce
+// (Mcoerce-c). The accepted key is NOT rewritten — coerceMap emits the
+// original input key string, matching BAML's insertion of the raw object key.
 func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
 	switch keyT.Kind {
 	case schema.TypePrimitive:
@@ -381,29 +467,28 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string) error {
 		if !ok {
 			return fmt.Errorf("debaml: unknown enum %q", keyT.Name)
 		}
-		if _, ok := e.ValueByRenderedName(key); !ok {
-			return unsupported(fmt.Sprintf("map key %q: no exact enum %q match (BAML fuzzy-matches)", key, keyT.Name))
+		if _, outcome := matchString(key, enumMatchCandidates(e), true); outcome == matchOne {
+			return nil
 		}
-		return nil
+		return unsupported(fmt.Sprintf("map key %q: no clean enum %q match (BAML skips via MapKeyParseError)", key, keyT.Name))
 	case schema.TypeLiteral:
 		if keyT.Literal == nil || keyT.Literal.Kind != schema.LiteralString {
 			return unsupported("map key literal must be a string literal")
 		}
-		if key != keyT.Literal.String {
-			return unsupported(fmt.Sprintf("map key %q: no exact literal %q match (BAML fuzzy-matches)", key, keyT.Literal.String))
+		if _, outcome := matchString(key, []matchCandidate{{name: keyT.Literal.String, validValues: []string{keyT.Literal.String}}}, true); outcome == matchOne {
+			return nil
 		}
-		return nil
+		return unsupported(fmt.Sprintf("map key %q: no clean literal %q match (BAML skips via MapKeyParseError)", key, keyT.Literal.String))
 	case schema.TypeUnion:
-		matches := 0
+		// A union-of-string-literals key coerces through the union coercer,
+		// which succeeds when ANY literal arm matches; the map then inserts the
+		// original key, so the winning arm is irrelevant.
 		for _, lit := range flattenStringLiterals(keyT) {
-			if lit == key {
-				matches++
+			if _, outcome := matchString(key, []matchCandidate{{name: lit, validValues: []string{lit}}}, true); outcome == matchOne {
+				return nil
 			}
 		}
-		if matches != 1 {
-			return unsupported(fmt.Sprintf("map key %q: %d exact string-literal-union matches (need exactly 1; BAML fuzzy-matches)", key, matches))
-		}
-		return nil
+		return unsupported(fmt.Sprintf("map key %q: matches no string-literal-union arm (BAML skips via MapKeyParseError)", key))
 	default:
 		return unsupported(fmt.Sprintf("map key kind %q", keyT.Kind))
 	}
@@ -468,11 +553,21 @@ func coerceUnionSafe(b *schema.Bundle, u *schema.UnionType, input value) (json.R
 		}
 		return json.RawMessage("null"), nil
 	}
-	// Case 2: M1 optional — a single non-null variant. (Non-nullable single
+	// Case 2: optional — a single non-null variant. (Non-nullable single
 	// variants collapse to the bare type in simplifyUnion, so this is reached
-	// only for the nullable optional shape; the behavior is unchanged.)
+	// only for the nullable optional shape.) A non-null input coerces through
+	// the lone arm; but once coercion is lenient (Mcoerce-a), the arm FAILING
+	// no longer means the union fails — BAML falls back to the null arm
+	// (coerce_primitive null → DefaultButHadValue, a non-zero score) and
+	// returns null. Native cannot reproduce that scored null default, so any
+	// arm failure (a DECLINE, or a CLAIMED error such as an enum substring
+	// tie) becomes a union DECLINE rather than propagating the arm's verdict.
 	if len(u.Variants) == 1 {
-		return coerce(b, u.Variants[0], input)
+		out, err := coerce(b, u.Variants[0], input)
+		if err != nil {
+			return nil, unsupported(fmt.Sprintf("optional single-arm union: non-null arm did not cleanly succeed (BAML may null-default): %v", err))
+		}
+		return out, nil
 	}
 	// Case 3: non-null input against a multi-variant union. Re-prove the
 	// non-null arm set is a safe family (this also rejects non-null input to a
@@ -494,64 +589,45 @@ func coerceUnionSafeMulti(b *schema.Bundle, variants []schema.Type, input value)
 	return coerceFlatClassUnion(b, variants, input)
 }
 
-// coerceLiteralUnion claims a homogeneous exact-literal union when EXACTLY
-// one literal exactly matches the input (and the input's JSON kind matches
-// the literal kind). For string literals the variant set was proven pairwise
-// match-disjoint by checkSupportedUnionShape, so an exact match on one arm
-// guarantees BAML cannot fuzzy-match another; for int/bool no two distinct
-// literals can equal the same value. Zero or (impossibly, after dedup) >1
-// exact matches decline. The matched literal is emitted through coerceLiteral
-// so the output form matches the single-literal path exactly.
+// coerceLiteralUnion claims a homogeneous literal union when EXACTLY one
+// variant leniently coerces (Mcoerce-a's no-over-claim rule). It counts
+// per-variant successes through coerceLiteral itself — so string literals
+// are evaluated with the actual match_string (a fuzzy/substring hit counts),
+// while int/bool literals stay exact (their lenient numeric coercion is
+// Mcoerce-b). Two-plus lenient successes mean BAML would run scored pick_best
+// — e.g. input "foobar" substring-matching both "foo" and "bar" arms even
+// though the literal VALUES were proven match-disjoint at the gate — so
+// native DECLINES (M3). Zero successes decline too. The single winner is
+// re-coerced through coerceLiteral so the emitted form matches the
+// single-literal path exactly.
 func coerceLiteralUnion(variants []schema.Type, input value) (json.RawMessage, error) {
 	matched := -1
 	count := 0
 	for i := range variants {
-		if literalExactMatches(variants[i].Literal, input) {
+		if _, err := coerceLiteral(variants[i].Literal, input); err == nil {
 			matched = i
 			count++
 		}
 	}
 	if count != 1 {
-		return nil, unsupported(fmt.Sprintf("literal union: %d exact matches for %s input (need exactly 1; BAML may fuzzy/parse-match)", count, input.kind.String()))
+		return nil, unsupported(fmt.Sprintf("literal union: %d lenient matches for %s input (need exactly 1; 2+ is BAML pick_best = M3)", count, input.kind.String()))
 	}
 	return coerceLiteral(variants[matched].Literal, input)
 }
 
-// literalExactMatches reports whether input EXACTLY matches lit by JSON kind
-// and value: a JSON bool equal to a bool literal, an exact JSON integer token
-// equal to an int literal, or a JSON string equal to a string literal. Any
-// leniency (numeric strings, float rounding, fuzzy string match) is BAML's
-// job and is deliberately NOT reproduced here.
-func literalExactMatches(lit *schema.LiteralValue, input value) bool {
-	if lit == nil {
-		return false
-	}
-	switch lit.Kind {
-	case schema.LiteralBool:
-		return input.kind == valBool && input.boolV == lit.Bool
-	case schema.LiteralInt:
-		if input.kind != valNumber {
-			return false
-		}
-		n, err := input.numV.Int64()
-		return err == nil && n == lit.Int
-	case schema.LiteralString:
-		return input.kind == valString && input.strV == lit.String
-	default:
-		return false
-	}
-}
-
-// coerceFlatClassUnion claims a flat disjoint-key class union when the input
-// is an object whose EXACT key set equals exactly one variant class's full
-// rendered field set (no extras, no missing, no duplicate keys) and that
-// class then coerces cleanly through the strict child coercers. The variant
-// classes were proven flat / >=2-required-field / disjoint-key by
-// checkSupportedUnionShape, so a full-key-set match on one arm guarantees
-// BAML cannot fuzzy-match the input keys onto another arm (every other arm is
-// missing >=2 required fields it cannot fill). Any extra/duplicate/missing
-// key, no match, or child coercion error (sentinel OR claimed) declines —
-// BAML may still resolve those via leniency/scoring.
+// coerceFlatClassUnion claims a flat disjoint-key class union when EXACTLY
+// one variant class leniently coerces (Mcoerce-a's no-over-claim rule). It
+// counts per-variant successes through coerceClass itself — which now matches
+// field keys fuzzily and ignores extra keys — so a class succeeds when all
+// its required fields are matched and coerce, regardless of extras. The
+// variant classes were proven flat / >=2-required-field / disjoint-key by
+// checkSupportedUnionShape, so an input carrying one class's full field set
+// cannot satisfy another (every other arm is missing >=2 disjoint required
+// fields it cannot fill) — unless the input ALSO carries a second arm's full
+// field set, which makes BOTH succeed and forces BAML's scored pick_best, so
+// native DECLINES (M3). Zero successes decline too. A child coercion error
+// (sentinel OR claimed) just means that variant did not succeed and is
+// swallowed by the count; only the lone clean winner is emitted.
 func coerceFlatClassUnion(b *schema.Bundle, variants []schema.Type, input value) (json.RawMessage, error) {
 	if input.kind != valObject {
 		// BAML can infer a single-field class from a scalar / imply a key;
@@ -559,76 +635,18 @@ func coerceFlatClassUnion(b *schema.Bundle, variants []schema.Type, input value)
 		// but it is not a hard type error either, so decline.
 		return nil, declineCoerce("class union", input)
 	}
-	keySet := make(map[string]struct{}, len(input.objV))
-	for i := range input.objV {
-		k := input.objV[i].key
-		if _, dup := keySet[k]; dup {
-			return nil, unsupported(fmt.Sprintf("class union: duplicate input key %q", k))
-		}
-		keySet[k] = struct{}{}
-	}
 	matched := -1
+	count := 0
 	for i := range variants {
-		cls, ok := b.FindClass(variants[i].Name, variants[i].Mode)
-		if !ok {
-			return nil, fmt.Errorf("debaml: unknown class %q", variants[i].Name)
-		}
-		if renderedFieldSetEquals(cls, keySet) {
+		if _, err := coerceClass(b, variants[i].Name, variants[i].Mode, input); err == nil {
 			matched = i
-			break // disjoint field sets ⇒ at most one variant can match.
+			count++
 		}
 	}
-	if matched < 0 {
-		return nil, unsupported("class union: input key set matches no variant's full field set (extras/missing decline)")
+	if count != 1 {
+		return nil, unsupported(fmt.Sprintf("class union: %d variant classes coerce cleanly (need exactly 1; 2+ is BAML pick_best = M3)", count))
 	}
-	out, err := coerceClass(b, variants[matched].Name, variants[matched].Mode, input)
-	if err != nil {
-		// A child sentinel decline OR a claimed child error both decline the
-		// union: BAML may coerce the field leniently (with a flag) and still
-		// resolve to this arm, or score a different one, so native must not
-		// claim a clean object where BAML's result could differ.
-		return nil, unsupported(fmt.Sprintf("class union: winning class %q child coercion not clean: %v", variants[matched].Name, err))
-	}
-	return out, nil
-}
-
-// renderedFieldSetEquals reports whether the rendered field-name set of cls
-// equals keySet exactly (same size, same members). checkSupportedUnionShape
-// has proven cls's rendered names are distinct, so size equality plus
-// membership is a true set equality.
-func renderedFieldSetEquals(cls *schema.ClassDef, keySet map[string]struct{}) bool {
-	if len(cls.Fields) != len(keySet) {
-		return false
-	}
-	for i := range cls.Fields {
-		if _, ok := keySet[cls.Fields[i].Name.RenderedName()]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
-// lookupField returns the input value for a class field, matched by the
-// rendered name ONLY (the alias when present, else the canonical name) —
-// the same key BAML's jsonish class coercer matches against
-// (name.rendered_name()). An aliased field is therefore NOT matched by its
-// canonical name: BAML treats the canonical key as an extra field and the
-// rendered key as missing, and the native path must agree to stay
-// drift-free. For a field with no alias, RenderedName()==Name, so this is
-// unchanged. Duplicate input keys resolve last-wins, matching the
-// encoding/json map decode the M1 path used. The comma-ok form
-// distinguishes an absent key from a present null value.
-func lookupField(obj []field, name schema.Name) (value, bool) {
-	rendered := name.RenderedName()
-	var found value
-	ok := false
-	for i := range obj {
-		if obj[i].key == rendered {
-			found = obj[i].val
-			ok = true
-		}
-	}
-	return found, ok
+	return coerceClass(b, variants[matched].Name, variants[matched].Mode, input)
 }
 
 // isOptional reports whether t is an optional (a nullable union), the only
@@ -656,6 +674,17 @@ func marshalJSON(v any) (json.RawMessage, error) {
 // parity rather than masking it behind a fallback.
 func typeMismatch(want string, input value) error {
 	return fmt.Errorf("debaml: expected %s, got %s", want, input.kind.String())
+}
+
+// ambiguousMatch reports a match_string substring TIE (StrMatchOneFromMany)
+// as a CLAIMED coercion error: BAML's matcher errors before emitting any of
+// the tied variants, so native claims the same error rather than arbitrarily
+// picking one. Distinct from declineCoerce — the differential checks BAML
+// also errors here (error parity), so this must NOT be the fallback sentinel.
+// Safe to claim only outside an optional arm; coerceUnionSafe's case 2
+// converts it to a DECLINE where BAML would null-default instead.
+func ambiguousMatch(target, input string) error {
+	return fmt.Errorf("debaml: %s: %q ambiguously substring-matches multiple candidates (BAML StrMatchOneFromMany)", target, input)
 }
 
 // declineCoerce reports a coercion mismatch as a DECLINE

--- a/internal/debaml/coerce_test.go
+++ b/internal/debaml/coerce_test.go
@@ -87,6 +87,42 @@ func TestWrappersPropagateHardErrors(t *testing.T) {
 	})
 }
 
+// TestMatchMapKeyUncertaintyMarksFlags pins the CR-MAPKEY signal-propagation
+// fix: a non-ASCII case-fold-uncertain map key DECLINES the map AND marks
+// cf.uncertain (so a future union counter that admits a map arm would decline
+// the whole union), and the *coerceFlags parameter is nil-safe.
+func TestMatchMapKeyUncertaintyMarksFlags(t *testing.T) {
+	// String-literal map key "é"(U+00E9): the input key "É"(U+00C9) only matches
+	// via the uncertain case fold (NFKD leaves the accent, so it is not
+	// accent-fold-connected), and 'É' is non-ASCII and not IsLower -> uncertain.
+	litKey := schema.Type{
+		Kind:    schema.TypeLiteral,
+		Literal: &schema.LiteralValue{Kind: schema.LiteralString, String: "é"},
+	}
+
+	cf := &coerceFlags{}
+	if err := matchMapKey(nil, litKey, "É", cf); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+		t.Fatalf("uncertain map key: want ErrDeBAMLParseUnsupported, got %v", err)
+	}
+	if !cf.isUncertain() {
+		t.Error("uncertain map key did not mark cf.uncertain")
+	}
+
+	// Nil-safe: the same uncertain key with a nil accumulator must not panic.
+	if err := matchMapKey(nil, litKey, "É", nil); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+		t.Fatalf("nil cf: want ErrDeBAMLParseUnsupported, got %v", err)
+	}
+
+	// A CERTAIN (exact) key accepts and leaves cf.uncertain unset.
+	clean := &coerceFlags{}
+	if err := matchMapKey(nil, litKey, "é", clean); err != nil {
+		t.Fatalf("exact key: want accept (nil), got %v", err)
+	}
+	if clean.isUncertain() {
+		t.Error("exact key wrongly marked cf.uncertain")
+	}
+}
+
 // TestWrapperDeclinesValueVerdict confirms the no-regression side of CR1: a
 // VALUE-verdict child error (here typeMismatch — a scalar where a multi-field
 // class is required) still makes the wrapper DECLINE (fall back), so BAML's

--- a/internal/debaml/coerce_test.go
+++ b/internal/debaml/coerce_test.go
@@ -135,10 +135,16 @@ func TestMatchMapKeyUncertaintyMarksFlags(t *testing.T) {
 	}{
 		{"literal-uncertain", nil, strLitType("é"), "É", false, true},
 		{"literal-exact", nil, strLitType("é"), "é", true, false},
+		// UNCERTAIN-ONLY match: key "É" matches literal "é" only via the case-fold
+		// pass (matchString returns matchOne AND uncertain) -> must DECLINE and
+		// mark uncertain, NOT accept. (This case was wrongly accepted before the
+		// accepted = matchOne && !uncertain fix.)
+		{"union-uncertain-only-match", nil, litUnionType("é"), "É", false, true},
 		// No arm cleanly matches, but an arm's verdict was uncertain -> mark.
 		{"union-uncertain-no-clean", nil, litUnionType("abc", "def"), "É", false, true},
-		// ACCEPT-ANY-ARM: arm "abc" is uncertain for "É", but arm "É" matches
-		// exactly -> accept, and DON'T mark uncertain (the fix's key case).
+		// ACCEPT-ANY-ARM rescue: arm "abc" is uncertain for "É", but arm "É"
+		// matches EXACTLY (before the case-fold attempt, so certain) -> accept,
+		// and DON'T mark uncertain.
 		{"union-accept-any-arm", nil, litUnionType("abc", "É"), "É", true, false},
 		// A later arm matches exactly with no uncertainty anywhere.
 		{"union-normal-accept", nil, litUnionType("é", "beta"), "beta", true, false},

--- a/internal/debaml/coerce_test.go
+++ b/internal/debaml/coerce_test.go
@@ -1,0 +1,109 @@
+package debaml
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// TestDeclinableChildError pins the seam-contract classification: only the
+// ErrDeBAMLParseUnsupported fallback sentinel and a value-verdict mismatchError
+// are DECLINABLE; every other error is a HARD failure that must propagate.
+func TestDeclinableChildError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"sentinel-unsupported", unsupported("x"), true},
+		{"sentinel-declineCoerce", declineCoerce("enum target", value{kind: valNumber}), true},
+		{"sentinel-wrapped", fmt.Errorf("outer: %w", unsupported("inner")), true},
+		{"verdict-typeMismatch", typeMismatch("object", value{kind: valString}), true},
+		{"verdict-ambiguous", ambiguousMatch("enum X", "cat dog"), true},
+		{"verdict-wrapped", fmt.Errorf("outer: %w", typeMismatch("object", value{kind: valString})), true},
+		{"hard-unknown-enum", fmt.Errorf("debaml: unknown enum %q", "Ghost"), false},
+		{"hard-plain", errors.New("boom"), false},
+	}
+	for _, c := range cases {
+		if got := declinableChildError(c.err); got != c.want {
+			t.Errorf("%s: declinableChildError(%v) = %v, want %v", c.name, c.err, got, c.want)
+		}
+	}
+}
+
+// TestWrappersPropagateHardErrors proves CR1: a HARD/invariant child error (an
+// unknown enum/class ref, a missing literal payload — none reachable through a
+// VALIDATED schema, hence exercised directly) PROPAGATES through every
+// container/union child-wrapper instead of being masked as the
+// ErrDeBAMLParseUnsupported fallback sentinel.
+func TestWrappersPropagateHardErrors(t *testing.T) {
+	// An empty bundle: FindEnum/FindClass always miss -> coerceEnum/coerceClass
+	// return their "unknown ..." hard errors.
+	b := &schema.Bundle{}
+	strKey := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveString}
+	ghostEnum := schema.Type{Kind: schema.TypeEnum, Name: "Ghost"}
+	ghostClass := schema.Type{Kind: schema.TypeClass, Name: "Ghost"}
+	obj := value{kind: valObject, objV: []field{{key: "k", val: value{kind: valString, strV: "v"}}}}
+	arr := value{kind: valArray, arrV: []value{{kind: valString, strV: "x"}}}
+
+	run := func(name, wantSubstr string, fn func() (interface{}, error)) {
+		_, err := fn()
+		if err == nil {
+			t.Errorf("%s: expected propagated hard error, got nil", name)
+			return
+		}
+		if errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			t.Errorf("%s: hard error MASKED as fallback sentinel: %v", name, err)
+			return
+		}
+		if !strings.Contains(err.Error(), wantSubstr) {
+			t.Errorf("%s: expected propagated %q, got %v", name, wantSubstr, err)
+		}
+	}
+
+	run("coerceList", "unknown enum", func() (interface{}, error) {
+		return coerceList(b, &ghostEnum, arr, nil)
+	})
+	run("coerceMap-value", "unknown enum", func() (interface{}, error) {
+		return coerceMap(b, &strKey, &ghostEnum, obj, nil)
+	})
+	run("coerceUnionSafe-optional-arm", "unknown enum", func() (interface{}, error) {
+		u := &schema.UnionType{Variants: []schema.Type{ghostEnum}, Nullable: true}
+		return coerceUnionSafe(b, u, value{kind: valString, strV: "x"}, nil)
+	})
+	run("coerceFlatClassUnion-counting", "unknown class", func() (interface{}, error) {
+		// Bypasses checkSupportedUnionShape (a unit-level wrapper probe): the
+		// counting loop hits FindClass and must propagate the hard error.
+		return coerceFlatClassUnion(b, []schema.Type{ghostClass, ghostClass}, obj, false, nil)
+	})
+	run("coerceLiteralUnion-counting", "literal type missing value", func() (interface{}, error) {
+		// A literal variant with a nil payload is a hard invariant failure.
+		bad := schema.Type{Kind: schema.TypeLiteral, Literal: nil}
+		return coerceLiteralUnion([]schema.Type{bad, bad}, value{kind: valString, strV: "x"}, false, nil)
+	})
+}
+
+// TestWrapperDeclinesValueVerdict confirms the no-regression side of CR1: a
+// VALUE-verdict child error (here typeMismatch — a scalar where a multi-field
+// class is required) still makes the wrapper DECLINE (fall back), so BAML's
+// partial-list behavior is deferred, not claimed.
+func TestWrapperDeclinesValueVerdict(t *testing.T) {
+	// Root{ items: Pair[] }, Pair{ a, b }. A non-object list element makes
+	// coerceClass return typeMismatch (value-verdict) -> coerceList declines.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("items", &bamlutils.DynamicProperty{
+			Type:  "list",
+			Items: &bamlutils.DynamicTypeSpec{Ref: "Pair"},
+		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Pair", &bamlutils.DynamicClass{
+				Properties: props(kv("a", strProp()), kv("b", strProp())),
+			}),
+		),
+	}
+	requireUnsupported(t, s, `{"items":[5]}`)
+}

--- a/internal/debaml/coerce_test.go
+++ b/internal/debaml/coerce_test.go
@@ -87,39 +87,89 @@ func TestWrappersPropagateHardErrors(t *testing.T) {
 	})
 }
 
-// TestMatchMapKeyUncertaintyMarksFlags pins the CR-MAPKEY signal-propagation
-// fix: a non-ASCII case-fold-uncertain map key DECLINES the map AND marks
-// cf.uncertain (so a future union counter that admits a map arm would decline
-// the whole union), and the *coerceFlags parameter is nil-safe.
+// strLitType builds a string-literal schema type.
+func strLitType(s string) schema.Type {
+	return schema.Type{Kind: schema.TypeLiteral, Literal: &schema.LiteralValue{Kind: schema.LiteralString, String: s}}
+}
+
+// litUnionType builds a non-nullable union of the given string literals.
+func litUnionType(lits ...string) schema.Type {
+	vs := make([]schema.Type, len(lits))
+	for i, l := range lits {
+		vs[i] = strLitType(l)
+	}
+	return schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: vs}}
+}
+
+// TestMatchMapKeyUncertaintyMarksFlags covers every matchMapKey uncertainty and
+// acceptance branch (string-literal, string-literal-union, enum), pinning:
+//   - CR-MAPKEY: an uncertain key DECLINES and marks cf.uncertain, nil-safely.
+//   - the string-literal-union ACCEPT-ANY-ARM fix: a clean arm accepts the key
+//     even if an EARLIER arm was uncertain (no over-decline, no spurious mark).
+//   - the mixed-union guard: a union with a non-string-literal arm declines
+//     (never treated as its string-literal subset).
+//
+// The runes are 'é'(U+00E9, IsLower -> certain) and 'É'(U+00C9, not IsLower ->
+// uncertain once it reaches the case-fold attempt).
 func TestMatchMapKeyUncertaintyMarksFlags(t *testing.T) {
-	// String-literal map key "é"(U+00E9): the input key "É"(U+00C9) only matches
-	// via the uncertain case fold (NFKD leaves the accent, so it is not
-	// accent-fold-connected), and 'É' is non-ASCII and not IsLower -> uncertain.
-	litKey := schema.Type{
-		Kind:    schema.TypeLiteral,
-		Literal: &schema.LiteralValue{Kind: schema.LiteralString, String: "é"},
+	// An indexed bundle with an (ASCII) enum key type — enum uncertainty is
+	// driven by the non-ASCII INPUT key, so the enum values stay ASCII.
+	enumB, err := schema.FromDynamicOutputSchema(mapEnumKeySchema(), schema.BuildOptions{})
+	if err != nil {
+		t.Fatalf("build enum bundle: %v", err)
+	}
+	enumKey := schema.Type{Kind: schema.TypeEnum, Name: enumB.Enums[0].Name.Name}
+
+	mixedUnion := schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{
+		strLitType("é"),
+		{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt},
+	}}}
+
+	cases := []struct {
+		name          string
+		b             *schema.Bundle
+		keyT          schema.Type
+		key           string
+		wantAccept    bool // true = nil (accepted), false = unsupported decline
+		wantUncertain bool
+	}{
+		{"literal-uncertain", nil, strLitType("é"), "É", false, true},
+		{"literal-exact", nil, strLitType("é"), "é", true, false},
+		// No arm cleanly matches, but an arm's verdict was uncertain -> mark.
+		{"union-uncertain-no-clean", nil, litUnionType("abc", "def"), "É", false, true},
+		// ACCEPT-ANY-ARM: arm "abc" is uncertain for "É", but arm "É" matches
+		// exactly -> accept, and DON'T mark uncertain (the fix's key case).
+		{"union-accept-any-arm", nil, litUnionType("abc", "É"), "É", true, false},
+		// A later arm matches exactly with no uncertainty anywhere.
+		{"union-normal-accept", nil, litUnionType("é", "beta"), "beta", true, false},
+		// Mixed union (string literal | int): declined by the guard, no scan.
+		{"mixed-union-guard", nil, mixedUnion, "É", false, false},
+		// Enum: the non-ASCII input key drives the uncertainty (values are ASCII).
+		{"enum-uncertain", enumB, enumKey, "É", false, true},
+		{"enum-exact", enumB, enumKey, "A", true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cf := &coerceFlags{}
+			err := matchMapKey(c.b, c.keyT, c.key, cf)
+			if c.wantAccept {
+				if err != nil {
+					t.Fatalf("want accept (nil), got %v", err)
+				}
+			} else {
+				if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+					t.Fatalf("want ErrDeBAMLParseUnsupported decline, got %v", err)
+				}
+			}
+			if cf.isUncertain() != c.wantUncertain {
+				t.Errorf("cf.uncertain = %v, want %v", cf.isUncertain(), c.wantUncertain)
+			}
+		})
 	}
 
-	cf := &coerceFlags{}
-	if err := matchMapKey(nil, litKey, "É", cf); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
-		t.Fatalf("uncertain map key: want ErrDeBAMLParseUnsupported, got %v", err)
-	}
-	if !cf.isUncertain() {
-		t.Error("uncertain map key did not mark cf.uncertain")
-	}
-
-	// Nil-safe: the same uncertain key with a nil accumulator must not panic.
-	if err := matchMapKey(nil, litKey, "É", nil); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+	// Nil-safe: an uncertain key with a nil accumulator must not panic.
+	if err := matchMapKey(nil, strLitType("é"), "É", nil); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
 		t.Fatalf("nil cf: want ErrDeBAMLParseUnsupported, got %v", err)
-	}
-
-	// A CERTAIN (exact) key accepts and leaves cf.uncertain unset.
-	clean := &coerceFlags{}
-	if err := matchMapKey(nil, litKey, "é", clean); err != nil {
-		t.Fatalf("exact key: want accept (nil), got %v", err)
-	}
-	if clean.isUncertain() {
-		t.Error("exact key wrongly marked cf.uncertain")
 	}
 }
 

--- a/internal/debaml/match_string_test.go
+++ b/internal/debaml/match_string_test.go
@@ -38,6 +38,44 @@ func TestRemoveAccents(t *testing.T) {
 	}
 }
 
+// TestUndLowerCaser pins that native's case fold follows Rust's full-Unicode
+// str::to_lowercase, not Go's simple strings.ToLower: İ (U+0130) lowercases to
+// "i" + U+0307 (combining dot above), which Go's strings.ToLower flattens to a
+// bare "i". (Both fold to "i" after the inner accent removal, but the
+// intermediate must match Rust.)
+func TestUndLowerCaser(t *testing.T) {
+	// İ (U+0130) -> "i" + U+0307 (combining dot above) under full Unicode
+	// lowercasing (Rust / cases.Lower), vs a bare "i" under strings.ToLower.
+	if got := undLowerCaser().String("İ"); got != "i̇" {
+		t.Errorf("undLowerCaser().String(U+0130) = %q, want %q", got, "i̇")
+	}
+	if got := strings.ToLower("İ"); got != "i" {
+		t.Errorf("strings.ToLower(U+0130) = %q, want %q (sanity: it differs from Rust)", got, "i")
+	}
+}
+
+// TestCaseFoldUncertain pins the conservative non-ASCII case-fold uncertainty
+// test: genuinely lowercase non-ASCII letters are CERTAIN (so accented inputs
+// still match), while anything Go can't prove is lowercase-stable is uncertain.
+func TestCaseFoldUncertain(t *testing.T) {
+	// ASCII, plus non-ASCII letters Go reports IsLower (é, ß, ü, ƛ U+019B).
+	certain := []string{"", "name", "RESUME", "résumé", "straße", "grün", "ƛ"}
+	for _, s := range certain {
+		if caseFoldUncertain(s) {
+			t.Errorf("caseFoldUncertain(%q) = true, want false", s)
+		}
+	}
+	// U+A7DC 'Ƛ' (x/text leaves it unchanged but Rust lowercases it to U+019B),
+	// accented uppercase 'É' (U+00C9), and 'İ' (U+0130): all non-ASCII and not
+	// IsLower -> uncertain.
+	uncertain := []string{"Ƛ", "ÉTAT", "İD"}
+	for _, s := range uncertain {
+		if !caseFoldUncertain(s) {
+			t.Errorf("caseFoldUncertain(%q) = false, want true", s)
+		}
+	}
+}
+
 // TestMatchStringOutcomes exercises each match_string strategy and the
 // substring tie path, with both substring-enabled (enum/literal/map-key) and
 // substring-disabled (class field key) candidate sets.
@@ -118,7 +156,7 @@ func TestMatchStringOutcomes(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		name, outcome, viaSub := matchString(c.input, c.candidates, c.allowSubstring)
+		name, outcome, viaSub, uncertain := matchString(c.input, c.candidates, c.allowSubstring)
 		if outcome != c.wantOutcome || (outcome == matchOne && name != c.wantName) {
 			t.Errorf("%s: matchString(%q) = (%q, %v), want (%q, %v)",
 				c.name, c.input, name, outcome, c.wantName, c.wantOutcome)
@@ -128,6 +166,11 @@ func TestMatchStringOutcomes(t *testing.T) {
 		wantSub := strings.HasPrefix(c.name, "substring") && c.wantOutcome != matchNone
 		if viaSub != wantSub {
 			t.Errorf("%s: matchString(%q) viaSubstring = %v, want %v", c.name, c.input, viaSub, wantSub)
+		}
+		// All these cases are ASCII (or fold before the case-fold attempt), so
+		// none should be flagged non-ASCII-case-fold-uncertain.
+		if uncertain {
+			t.Errorf("%s: matchString(%q) unexpectedly uncertain", c.name, c.input)
 		}
 	}
 }
@@ -150,8 +193,12 @@ func TestMatchesStringToString(t *testing.T) {
 		{"color", "shade", false},
 	}
 	for _, c := range cases {
-		if got := matchesStringToString(c.input, c.target); got != c.want {
+		got, uncertain := matchesStringToString(c.input, c.target)
+		if got != c.want {
 			t.Errorf("matchesStringToString(%q, %q) = %v, want %v", c.input, c.target, got, c.want)
+		}
+		if uncertain {
+			t.Errorf("matchesStringToString(%q, %q) unexpectedly uncertain (all ASCII)", c.input, c.target)
 		}
 	}
 }

--- a/internal/debaml/match_string_test.go
+++ b/internal/debaml/match_string_test.go
@@ -1,0 +1,144 @@
+package debaml
+
+import "testing"
+
+// TestRemoveAccents mirrors match_string.rs's remove_accents unit tests
+// verbatim, locking the native fold to BAML's NFKD + ligature behavior.
+func TestRemoveAccents(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"étude", "etude"},
+		{"français", "francais"},
+		{"Español", "Espanol"},
+		{"português", "portugues"},
+		{"médium", "medium"},
+		{"Grün", "Grun"},
+		{"Über", "Uber"},
+		{"Straße", "Strasse"},
+		{"Stadt", "Stadt"},
+		{"æ", "ae"},
+		{"Æ", "AE"},
+		{"ø", "o"},
+		{"Ø", "O"},
+		{"œ", "oe"},
+		{"Œ", "OE"},
+		{"København", "Kobenhavn"},
+		{"cœur", "coeur"},
+		{"œuvre", "oeuvre"},
+		{"Straße ældre øl œuvre", "Strasse aeldre ol oeuvre"},
+		// Leaves non-alphanumeric ASCII and other scripts alone; folds ligatures.
+		{"ß, æ, ø, œ, こんにちは, 🦄", "ss, ae, o, oe, こんにちは, 🦄"},
+	}
+	for _, c := range cases {
+		if got := removeAccents(c.in); got != c.want {
+			t.Errorf("removeAccents(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestMatchStringOutcomes exercises each match_string strategy and the
+// substring tie path, with both substring-enabled (enum/literal/map-key) and
+// substring-disabled (class field key) candidate sets.
+func TestMatchStringOutcomes(t *testing.T) {
+	enumLike := []matchCandidate{
+		{name: "RED", validValues: []string{"RED"}},
+		{name: "GREEN", validValues: []string{"GREEN"}},
+		{name: "BLUE", validValues: []string{"BLUE"}},
+	}
+	cases := []struct {
+		name           string
+		input          string
+		candidates     []matchCandidate
+		allowSubstring bool
+		wantName       string
+		wantOutcome    matchOutcome
+	}{
+		{"exact", "GREEN", enumLike, true, "GREEN", matchOne},
+		{"trim", "  GREEN  ", enumLike, true, "GREEN", matchOne},
+		{"case-insensitive", "green", enumLike, true, "GREEN", matchOne},
+		// '.' and '(' ')' are stripped (only '-'/'_' are kept), so "(GREEN)."
+		// folds to "GREEN".
+		{"punctuation", "(GREEN).", enumLike, true, "GREEN", matchOne},
+		{"no-match", "MAUVE", enumLike, true, "", matchNone},
+		{
+			"accent-fold",
+			"Grün",
+			[]matchCandidate{{name: "GRUN", validValues: []string{"Grun"}}},
+			true,
+			"GRUN",
+			matchOne,
+		},
+		{
+			"substring-single",
+			"the color is green today",
+			enumLike,
+			true,
+			"GREEN",
+			matchOne,
+		},
+		{
+			// "catdog" contains both CAT and DOG non-overlapping -> tie.
+			"substring-tie",
+			"cat dog",
+			[]matchCandidate{
+				{name: "CAT", validValues: []string{"CAT"}},
+				{name: "DOG", validValues: []string{"DOG"}},
+			},
+			true,
+			"",
+			matchAmbiguous,
+		},
+		{
+			// Same candidates, but substring disabled (class field key path):
+			// no exact/fold match -> none, never a tie.
+			"substring-disabled-no-match",
+			"cat dog",
+			[]matchCandidate{
+				{name: "CAT", validValues: []string{"CAT"}},
+				{name: "DOG", validValues: []string{"DOG"}},
+			},
+			false,
+			"",
+			matchNone,
+		},
+		{
+			// Description candidate value matches (enum_match_candidates form).
+			"description-match",
+			"a primary color",
+			[]matchCandidate{{name: "RED", validValues: []string{"RED", "a primary color", "RED: a primary color"}}},
+			true,
+			"RED",
+			matchOne,
+		},
+	}
+	for _, c := range cases {
+		name, outcome := matchString(c.input, c.candidates, c.allowSubstring)
+		if outcome != c.wantOutcome || (outcome == matchOne && name != c.wantName) {
+			t.Errorf("%s: matchString(%q) = (%q, %v), want (%q, %v)",
+				c.name, c.input, name, outcome, c.wantName, c.wantOutcome)
+		}
+	}
+}
+
+// TestMatchesStringToString covers the no-substring field-key matcher: it
+// folds case/punctuation/accents but never substring-matches.
+func TestMatchesStringToString(t *testing.T) {
+	cases := []struct {
+		input, target string
+		want          bool
+	}{
+		{"name", "name", true},
+		{"Name", "name", true},
+		{"  NAME  ", "name", true},
+		{"full name", "fullname", true},  // space stripped to "fullname"
+		{"Grün", "grun", true},           // accent fold + case
+		{"act", "active", false},         // substring NOT allowed for field keys
+		{"full_name", "fullname", false}, // '_' is KEPT, so no match
+		{"names", "name", false},
+		{"color", "shade", false},
+	}
+	for _, c := range cases {
+		if got := matchesStringToString(c.input, c.target); got != c.want {
+			t.Errorf("matchesStringToString(%q, %q) = %v, want %v", c.input, c.target, got, c.want)
+		}
+	}
+}

--- a/internal/debaml/match_string_test.go
+++ b/internal/debaml/match_string_test.go
@@ -1,6 +1,9 @@
 package debaml
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestRemoveAccents mirrors match_string.rs's remove_accents unit tests
 // verbatim, locking the native fold to BAML's NFKD + ligature behavior.
@@ -56,8 +59,12 @@ func TestMatchStringOutcomes(t *testing.T) {
 		{"trim", "  GREEN  ", enumLike, true, "GREEN", matchOne},
 		{"case-insensitive", "green", enumLike, true, "GREEN", matchOne},
 		// '.' and '(' ')' are stripped (only '-'/'_' are kept), so "(GREEN)."
-		// folds to "GREEN".
-		{"punctuation", "(GREEN).", enumLike, true, "GREEN", matchOne},
+		// folds to "GREEN" via the strip-exact path (substring DISABLED here, so
+		// it's a clean score-0 match, not a SubstringMatch).
+		{"punctuation", "(GREEN).", enumLike, false, "GREEN", matchOne},
+		// With substring ENABLED the same input matches "GREEN" as a substring
+		// (SubstringMatch, cost 2) before the strip pass runs.
+		{"substring-punct", "(GREEN).", enumLike, true, "GREEN", matchOne},
 		{"no-match", "MAUVE", enumLike, true, "", matchNone},
 		{
 			"accent-fold",
@@ -111,10 +118,16 @@ func TestMatchStringOutcomes(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		name, outcome := matchString(c.input, c.candidates, c.allowSubstring)
+		name, outcome, viaSub := matchString(c.input, c.candidates, c.allowSubstring)
 		if outcome != c.wantOutcome || (outcome == matchOne && name != c.wantName) {
 			t.Errorf("%s: matchString(%q) = (%q, %v), want (%q, %v)",
 				c.name, c.input, name, outcome, c.wantName, c.wantOutcome)
+		}
+		// Only the substring-* cases should report a substring match (the
+		// SubstringMatch flag, cost 2); exact/fold matches are score 0.
+		wantSub := strings.HasPrefix(c.name, "substring") && c.wantOutcome != matchNone
+		if viaSub != wantSub {
+			t.Errorf("%s: matchString(%q) viaSubstring = %v, want %v", c.name, c.input, viaSub, wantSub)
 		}
 	}
 }

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -78,7 +78,9 @@ func Parse(ctx context.Context, req bamlutils.DeBAMLParseRequest) (bamlutils.DeB
 		return bamlutils.DeBAMLParseResult{}, unsupported("no cleanly-claimable JSON candidate")
 	}
 
-	out, err := coerce(bundle, bundle.Target, parsed)
+	// Top-level coercion needs no cleanliness tracking (nil accumulator): a
+	// nullable target's own null/clean decision is made inside coerceUnionSafe.
+	out, err := coerce(bundle, bundle.Target, parsed, nil)
 	if err != nil {
 		// A candidate was decoded but does not coerce against the schema.
 		// coerce returns ErrDeBAMLParseUnsupported where the failure is only
@@ -550,16 +552,18 @@ type matchCandidate struct {
 // matchString ports match_string.rs::match_string. It trims the input, then
 // runs the case-sensitive / accent-folded / punctuation-stripped /
 // case-insensitive / substring strategies in BAML's exact order, returning the
-// matched candidate name and an outcome. allowSubstring mirrors match_string's
+// matched candidate name, an outcome, and whether the match came from the
+// SUBSTRING strategy (BAML's SubstringMatch flag, cost 2 — the exact/fold
+// strategies are score 0). allowSubstring mirrors match_string's
 // allow_substring_match: class field keys pass false (via
 // matchesStringToString); enum / string-literal / map-key coercion pass true.
-func matchString(input string, candidates []matchCandidate, allowSubstring bool) (string, matchOutcome) {
+func matchString(input string, candidates []matchCandidate, allowSubstring bool) (string, matchOutcome, bool) {
 	// Trim whitespace (no flag, score 0).
 	matchContext := strings.TrimSpace(input)
 
 	// Attempt 1: original (trimmed) candidates.
-	if name, outcome, found := stringMatchStrategy(matchContext, candidates, allowSubstring); found {
-		return name, outcome
+	if name, outcome, sub, found := stringMatchStrategy(matchContext, candidates, allowSubstring); found {
+		return name, outcome, sub
 	}
 
 	// Strip punctuation from input and from every candidate value, then retry
@@ -577,8 +581,8 @@ func matchString(input string, candidates []matchCandidate, allowSubstring bool)
 	// Attempt 2: punctuation-stripped. (BAML's third attempt is a verbatim
 	// repeat of this one over the SAME match_context/candidates — it can only
 	// return the same result — so it is intentionally omitted here.)
-	if name, outcome, found := stringMatchStrategy(matchContext, stripped, allowSubstring); found {
-		return name, outcome
+	if name, outcome, sub, found := stringMatchStrategy(matchContext, stripped, allowSubstring); found {
+		return name, outcome, sub
 	}
 
 	// Attempt 4: case-insensitive over the stripped forms (no flag, score 0).
@@ -591,32 +595,35 @@ func matchString(input string, candidates []matchCandidate, allowSubstring bool)
 		}
 		lowered[i] = matchCandidate{name: stripped[i].name, validValues: vals}
 	}
-	if name, outcome, found := stringMatchStrategy(matchContext, lowered, allowSubstring); found {
-		return name, outcome
+	if name, outcome, sub, found := stringMatchStrategy(matchContext, lowered, allowSubstring); found {
+		return name, outcome, sub
 	}
 
-	return "", matchNone
+	return "", matchNone, false
 }
 
 // matchesStringToString ports match_string.rs::matches_string_to_string: a
 // single-candidate, NO-substring match used for class object field keys
-// (coerce_class.rs:209). Returns whether input matches target.
+// (coerce_class.rs:209). Returns whether input matches target. (The key match
+// adds no class flag in BAML, so its substring bit is irrelevant — substring
+// is disabled here anyway.)
 func matchesStringToString(input, target string) bool {
-	_, outcome := matchString(input, []matchCandidate{{name: target, validValues: []string{target}}}, false)
+	_, outcome, _ := matchString(input, []matchCandidate{{name: target, validValues: []string{target}}}, false)
 	return outcome == matchOne
 }
 
 // stringMatchStrategy ports match_string.rs::string_match_strategy for one
 // already-transformed pass: exact case-sensitive, then accent-folded
 // case-sensitive, then (if allowSubstring) non-overlapping substring counting.
-// found is true when this pass produced a verdict (matchOne or matchAmbiguous).
-func stringMatchStrategy(valueStr string, candidates []matchCandidate, allowSubstring bool) (string, matchOutcome, bool) {
+// found is true when this pass produced a verdict (matchOne or matchAmbiguous);
+// viaSubstring is true only when the verdict came from the substring section.
+func stringMatchStrategy(valueStr string, candidates []matchCandidate, allowSubstring bool) (string, matchOutcome, bool, bool) {
 	// Strategy 1: exact case-sensitive match. First candidate (in order) with
 	// any exactly-equal valid value wins.
 	for i := range candidates {
 		for _, v := range candidates[i].validValues {
 			if v == valueStr {
-				return candidates[i].name, matchOne, true
+				return candidates[i].name, matchOne, false, true
 			}
 		}
 	}
@@ -626,13 +633,13 @@ func stringMatchStrategy(valueStr string, candidates []matchCandidate, allowSubs
 	for i := range candidates {
 		for _, v := range candidates[i].validValues {
 			if removeAccents(v) == unaccentedValue {
-				return candidates[i].name, matchOne, true
+				return candidates[i].name, matchOne, false, true
 			}
 		}
 	}
 
 	if !allowSubstring {
-		return "", matchNone, false
+		return "", matchNone, false, false
 	}
 
 	// Substring matching: gather every occurrence of each candidate value
@@ -664,7 +671,7 @@ func stringMatchStrategy(valueStr string, candidates []matchCandidate, allowSubs
 	}
 
 	if len(all) == 0 {
-		return "", matchNone, false
+		return "", matchNone, false, false
 	}
 
 	// Sort by start ascending, then by end descending (longer first).
@@ -712,9 +719,9 @@ func stringMatchStrategy(valueStr string, candidates []matchCandidate, allowSubs
 	}
 	if atMax > 1 {
 		// Tie across variants -> StrMatchOneFromMany -> BAML errors.
-		return "", matchAmbiguous, true
+		return "", matchAmbiguous, true, true
 	}
-	return best, matchOne, true
+	return best, matchOne, true, true
 }
 
 // matchIndices returns the byte offsets of every non-overlapping occurrence

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -3,6 +3,7 @@ package debaml
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -506,6 +507,278 @@ func normalizeForMatchString(s string) (string, bool) {
 		sb.WriteRune(lr)
 	}
 	return sb.String(), allASCII
+}
+
+// The production matcher below ports BAML's deserializer/coercer/match_string.rs
+// — the fuzzy matcher enum, string-literal, class-field-key, and map-key
+// coercion route through (Mcoerce-a). It is deliberately distinct from the
+// conservative matchStringMightMatch SUPERSET above: that one only gates
+// union-shape disjointness (over-declining there is parity-safe), while this
+// one is the PRODUCTION matcher whose accept/reject/ambiguous verdict and
+// matched candidate native must reproduce BAML byte-exact (a fuzzy match
+// changes the emitted value). It lives here, beside the gate, rather than in a
+// separate file so the de-BAML embed source list stays unchanged.
+//
+// Null handling and non-string stringification (ObjectToString) are the
+// CALLER's job: matchString operates on an already-string input. Mcoerce-a only
+// coerces string inputs; non-string enum/literal inputs decline upstream (their
+// jsonish::Value Display reproduction is Mcoerce-b/d).
+
+// matchOutcome is the verdict of a matchString evaluation.
+type matchOutcome int
+
+const (
+	// matchNone: no candidate matched (BAML error_unexpected_type).
+	matchNone matchOutcome = iota
+	// matchOne: exactly one best candidate — a clean match.
+	matchOne
+	// matchAmbiguous: a substring tie across variants — BAML errors via
+	// StrMatchOneFromMany (try_match_only_once) BEFORE emitting, so native
+	// must never pick one of the tied variants.
+	matchAmbiguous
+)
+
+// matchCandidate is one (name, valid_values) tuple. name is the value
+// emitted on a match (enum real name, literal string, field rendered name);
+// validValues are the strings the input is matched against (the rendered
+// name, plus enum description forms).
+type matchCandidate struct {
+	name        string
+	validValues []string
+}
+
+// matchString ports match_string.rs::match_string. It trims the input, then
+// runs the case-sensitive / accent-folded / punctuation-stripped /
+// case-insensitive / substring strategies in BAML's exact order, returning the
+// matched candidate name and an outcome. allowSubstring mirrors match_string's
+// allow_substring_match: class field keys pass false (via
+// matchesStringToString); enum / string-literal / map-key coercion pass true.
+func matchString(input string, candidates []matchCandidate, allowSubstring bool) (string, matchOutcome) {
+	// Trim whitespace (no flag, score 0).
+	matchContext := strings.TrimSpace(input)
+
+	// Attempt 1: original (trimmed) candidates.
+	if name, outcome, found := stringMatchStrategy(matchContext, candidates, allowSubstring); found {
+		return name, outcome
+	}
+
+	// Strip punctuation from input and from every candidate value, then retry
+	// (no flag — BAML never adds StrippedNonAlphaNumeric despite the unused flag).
+	matchContext = stripPunctuation(matchContext)
+	stripped := make([]matchCandidate, len(candidates))
+	for i := range candidates {
+		vals := make([]string, len(candidates[i].validValues))
+		for j, v := range candidates[i].validValues {
+			vals[j] = stripPunctuation(v)
+		}
+		stripped[i] = matchCandidate{name: candidates[i].name, validValues: vals}
+	}
+
+	// Attempt 2: punctuation-stripped. (BAML's third attempt is a verbatim
+	// repeat of this one over the SAME match_context/candidates — it can only
+	// return the same result — so it is intentionally omitted here.)
+	if name, outcome, found := stringMatchStrategy(matchContext, stripped, allowSubstring); found {
+		return name, outcome
+	}
+
+	// Attempt 4: case-insensitive over the stripped forms (no flag, score 0).
+	matchContext = strings.ToLower(matchContext)
+	lowered := make([]matchCandidate, len(stripped))
+	for i := range stripped {
+		vals := make([]string, len(stripped[i].validValues))
+		for j, v := range stripped[i].validValues {
+			vals[j] = strings.ToLower(v)
+		}
+		lowered[i] = matchCandidate{name: stripped[i].name, validValues: vals}
+	}
+	if name, outcome, found := stringMatchStrategy(matchContext, lowered, allowSubstring); found {
+		return name, outcome
+	}
+
+	return "", matchNone
+}
+
+// matchesStringToString ports match_string.rs::matches_string_to_string: a
+// single-candidate, NO-substring match used for class object field keys
+// (coerce_class.rs:209). Returns whether input matches target.
+func matchesStringToString(input, target string) bool {
+	_, outcome := matchString(input, []matchCandidate{{name: target, validValues: []string{target}}}, false)
+	return outcome == matchOne
+}
+
+// stringMatchStrategy ports match_string.rs::string_match_strategy for one
+// already-transformed pass: exact case-sensitive, then accent-folded
+// case-sensitive, then (if allowSubstring) non-overlapping substring counting.
+// found is true when this pass produced a verdict (matchOne or matchAmbiguous).
+func stringMatchStrategy(valueStr string, candidates []matchCandidate, allowSubstring bool) (string, matchOutcome, bool) {
+	// Strategy 1: exact case-sensitive match. First candidate (in order) with
+	// any exactly-equal valid value wins.
+	for i := range candidates {
+		for _, v := range candidates[i].validValues {
+			if v == valueStr {
+				return candidates[i].name, matchOne, true
+			}
+		}
+	}
+
+	// Strategy 2: accent/ligature-folded case-sensitive match.
+	unaccentedValue := removeAccents(valueStr)
+	for i := range candidates {
+		for _, v := range candidates[i].validValues {
+			if removeAccents(v) == unaccentedValue {
+				return candidates[i].name, matchOne, true
+			}
+		}
+	}
+
+	if !allowSubstring {
+		return "", matchNone, false
+	}
+
+	// Substring matching: gather every occurrence of each candidate value
+	// within valueStr (variant = candidate name).
+	type span struct {
+		start, end int
+		variant    string
+	}
+	var all []span
+	for i := range candidates {
+		for _, valid := range candidates[i].validValues {
+			for _, start := range matchIndices(valueStr, valid) {
+				all = append(all, span{start: start, end: start + len(valid), variant: candidates[i].name})
+			}
+		}
+	}
+
+	// If nothing matched directly, retry against the accent-folded forms.
+	// BAML deliberately keeps end_idx = start + len(ORIGINAL valid_name).
+	if len(all) == 0 {
+		for i := range candidates {
+			for _, valid := range candidates[i].validValues {
+				unaccentedValid := removeAccents(valid)
+				for _, start := range matchIndices(unaccentedValue, unaccentedValid) {
+					all = append(all, span{start: start, end: start + len(valid), variant: candidates[i].name})
+				}
+			}
+		}
+	}
+
+	if len(all) == 0 {
+		return "", matchNone, false
+	}
+
+	// Sort by start ascending, then by end descending (longer first).
+	sort.SliceStable(all, func(a, b int) bool {
+		if all[a].start != all[b].start {
+			return all[a].start < all[b].start
+		}
+		return all[a].end > all[b].end
+	})
+
+	// Drop overlapping matches, keeping the earliest/longest at each position.
+	var filtered []span
+	lastEnd := 0
+	for _, s := range all {
+		if s.start >= lastEnd {
+			lastEnd = s.end
+			filtered = append(filtered, s)
+		}
+	}
+
+	// Count non-overlapping occurrences per variant, preserving first-seen
+	// order so the winner is deterministic on a unique max.
+	counts := make(map[string]int, len(filtered))
+	var order []string
+	for _, s := range filtered {
+		if _, seen := counts[s.variant]; !seen {
+			order = append(order, s.variant)
+		}
+		counts[s.variant]++
+	}
+
+	best := ""
+	max := 0
+	atMax := 0
+	for _, v := range order {
+		c := counts[v]
+		switch {
+		case c > max:
+			max = c
+			best = v
+			atMax = 1
+		case c == max:
+			atMax++
+		}
+	}
+	if atMax > 1 {
+		// Tie across variants -> StrMatchOneFromMany -> BAML errors.
+		return "", matchAmbiguous, true
+	}
+	return best, matchOne, true
+}
+
+// matchIndices returns the byte offsets of every non-overlapping occurrence
+// of needle in haystack, matching Rust's str::match_indices (left-to-right,
+// the next search resumes after a match). An empty needle matches at every
+// char boundary plus the end, reproducing Rust's empty-pattern behavior.
+func matchIndices(haystack, needle string) []int {
+	if needle == "" {
+		idx := make([]int, 0, len(haystack)+1)
+		for i := range haystack {
+			idx = append(idx, i)
+		}
+		return append(idx, len(haystack))
+	}
+	var idx []int
+	for start := 0; start <= len(haystack); {
+		rel := strings.Index(haystack[start:], needle)
+		if rel < 0 {
+			break
+		}
+		pos := start + rel
+		idx = append(idx, pos)
+		start = pos + len(needle)
+	}
+	return idx
+}
+
+// stripPunctuation ports match_string.rs::strip_punctuation: keep
+// alphanumeric runes plus '-' and '_', drop everything else.
+func stripPunctuation(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r == '-' || r == '_' || unicode.IsLetter(r) || unicode.IsNumber(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// ligatureFolder reproduces match_string.rs::remove_accents's pre-NFKD
+// ligature substitutions (ß/æ/Æ/ø/Ø/œ/Œ); the targets share no source rune,
+// so a single non-overlapping pass equals BAML's sequential .replace() calls.
+var ligatureFolder = strings.NewReplacer(
+	"ß", "ss",
+	"æ", "ae", "Æ", "AE",
+	"ø", "o", "Ø", "O",
+	"œ", "oe", "Œ", "OE",
+)
+
+// removeAccents ports match_string.rs::remove_accents: fold the ligatures
+// above, NFKD-decompose, then drop combining marks (General_Category=Mark).
+func removeAccents(s string) string {
+	s = ligatureFolder.Replace(s)
+	decomposed := norm.NFKD.String(s)
+	var b strings.Builder
+	b.Grow(len(decomposed))
+	for _, r := range decomposed {
+		if unicode.In(r, unicode.Mn, unicode.Mc, unicode.Me) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // unsupported wraps bamlutils.ErrDeBAMLParseUnsupported with a reason so

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"unicode"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"golang.org/x/text/unicode/norm"
 
 	"github.com/invakid404/baml-rest/bamlutils"
@@ -549,21 +551,51 @@ type matchCandidate struct {
 	validValues []string
 }
 
+// undLowerCaser builds a fresh full-Unicode lowercaser. BAML's match_string
+// case-fold uses Rust str::to_lowercase (full SpecialCasing — e.g. İ ->
+// i+U+0307), which Go's strings.ToLower (simple per-rune mapping) does NOT
+// reproduce; golang.org/x/text/cases.Lower(language.Und) does. A cases.Caser is
+// NOT safe for concurrent use, so callers build a local one per matchString
+// call (only when the case-fold attempt is actually reached).
+func undLowerCaser() cases.Caser { return cases.Lower(language.Und) }
+
+// caseFoldUncertain reports whether lowercasing s could DIVERGE from Rust's
+// str::to_lowercase. cases.Lower is not byte-identical to Rust for every rune
+// (e.g. x/text v0.38 leaves U+A7DC 'Ƛ' unchanged while Rust lowercases it to
+// 'ƛ'; Go's own case tables don't even classify U+A7DC as uppercase). The
+// robust, conservative test that native CAN prove: a rune is lowercase-stable
+// iff it is ASCII or Go reports it IsLower (a genuinely lowercase letter, whose
+// lowercasing is the identity on both Go and Rust — this keeps 'é'/'ß'/'ü'
+// certain so accented inputs like "Résumé" still match). Any OTHER non-ASCII
+// rune (uppercase, titlecase, or a cased letter Go's tables don't recognize)
+// is treated as uncertain. The corpus is ASCII, so this never fires there.
+func caseFoldUncertain(s string) bool {
+	for _, r := range s {
+		if r > unicode.MaxASCII && !unicode.IsLower(r) {
+			return true
+		}
+	}
+	return false
+}
+
 // matchString ports match_string.rs::match_string. It trims the input, then
 // runs the case-sensitive / accent-folded / punctuation-stripped /
 // case-insensitive / substring strategies in BAML's exact order, returning the
-// matched candidate name, an outcome, and whether the match came from the
-// SUBSTRING strategy (BAML's SubstringMatch flag, cost 2 — the exact/fold
-// strategies are score 0). allowSubstring mirrors match_string's
-// allow_substring_match: class field keys pass false (via
-// matchesStringToString); enum / string-literal / map-key coercion pass true.
-func matchString(input string, candidates []matchCandidate, allowSubstring bool) (string, matchOutcome, bool) {
+// matched candidate name, an outcome, whether the match came from the SUBSTRING
+// strategy (BAML's SubstringMatch flag, cost 2 — the exact/fold strategies are
+// score 0), and whether the case-fold attempt involved a non-ASCII rune whose
+// lowercasing native cannot prove equals Rust's (uncertain — see
+// caseFoldUncertain). uncertain is false whenever a match is found before the
+// case-fold attempt. allowSubstring mirrors match_string's allow_substring_match:
+// class field keys pass false (via matchesStringToString); enum / string-literal
+// / map-key coercion pass true.
+func matchString(input string, candidates []matchCandidate, allowSubstring bool) (string, matchOutcome, bool, bool) {
 	// Trim whitespace (no flag, score 0).
 	matchContext := strings.TrimSpace(input)
 
 	// Attempt 1: original (trimmed) candidates.
 	if name, outcome, sub, found := stringMatchStrategy(matchContext, candidates, allowSubstring); found {
-		return name, outcome, sub
+		return name, outcome, sub, false
 	}
 
 	// Strip punctuation from input and from every candidate value, then retry
@@ -582,34 +614,50 @@ func matchString(input string, candidates []matchCandidate, allowSubstring bool)
 	// repeat of this one over the SAME match_context/candidates — it can only
 	// return the same result — so it is intentionally omitted here.)
 	if name, outcome, sub, found := stringMatchStrategy(matchContext, stripped, allowSubstring); found {
-		return name, outcome, sub
+		return name, outcome, sub, false
 	}
 
-	// Attempt 4: case-insensitive over the stripped forms (no flag, score 0).
-	matchContext = strings.ToLower(matchContext)
+	// The case-fold attempt is now reached. Determine whether lowercasing any of
+	// the forms about to be lowered could diverge from Rust (uncertain).
+	uncertain := caseFoldUncertain(matchContext)
+	if !uncertain {
+		for i := range stripped {
+			for _, v := range stripped[i].validValues {
+				if caseFoldUncertain(v) {
+					uncertain = true
+				}
+			}
+		}
+	}
+
+	// Attempt 4: case-insensitive over the stripped forms (no flag, score 0),
+	// using full-Unicode lowercasing to match Rust's str::to_lowercase.
+	caser := undLowerCaser()
+	matchContext = caser.String(matchContext)
 	lowered := make([]matchCandidate, len(stripped))
 	for i := range stripped {
 		vals := make([]string, len(stripped[i].validValues))
 		for j, v := range stripped[i].validValues {
-			vals[j] = strings.ToLower(v)
+			vals[j] = caser.String(v)
 		}
 		lowered[i] = matchCandidate{name: stripped[i].name, validValues: vals}
 	}
 	if name, outcome, sub, found := stringMatchStrategy(matchContext, lowered, allowSubstring); found {
-		return name, outcome, sub
+		return name, outcome, sub, uncertain
 	}
 
-	return "", matchNone, false
+	return "", matchNone, false, uncertain
 }
 
 // matchesStringToString ports match_string.rs::matches_string_to_string: a
 // single-candidate, NO-substring match used for class object field keys
-// (coerce_class.rs:209). Returns whether input matches target. (The key match
-// adds no class flag in BAML, so its substring bit is irrelevant — substring
-// is disabled here anyway.)
-func matchesStringToString(input, target string) bool {
-	_, outcome, _ := matchString(input, []matchCandidate{{name: target, validValues: []string{target}}}, false)
-	return outcome == matchOne
+// (coerce_class.rs:209). Returns whether input matches target, plus whether the
+// verdict depended on a non-ASCII case fold native cannot prove equals BAML
+// (uncertain — caller declines on it). (The key match adds no class flag in
+// BAML, so the substring bit is irrelevant — substring is disabled here anyway.)
+func matchesStringToString(input, target string) (matched, uncertain bool) {
+	_, outcome, _, unc := matchString(input, []matchCandidate{{name: target, validValues: []string{target}}}, false)
+	return outcome == matchOne, unc
 }
 
 // stringMatchStrategy ports match_string.rs::string_match_strategy for one

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -644,6 +644,68 @@ func TestParse_ClassUnionDeclines(t *testing.T) {
 	requireUnsupported(t, s, `{"u":"Go"}`)
 }
 
+// nullableClassUnionSchema is classUnionSchema's nullable sibling: Book | Car |
+// null. The null arm competes by scoring for non-null input (F1).
+func nullableClassUnionSchema() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type: "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{
+				{Ref: "Book"},
+				{Ref: "Car"},
+				{Type: "null"},
+			},
+		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Book", &bamlutils.DynamicClass{
+				Properties: props(kv("title", strProp()), kv("pages", intProp())),
+			}),
+			bamlutils.OrderedKV("Car", &bamlutils.DynamicClass{
+				Properties: props(kv("brand", strProp()), kv("wheels", intProp())),
+			}),
+		),
+	}
+}
+
+func TestParse_NullableClassUnionRequiresCleanArm(t *testing.T) {
+	// F1: for a NULLABLE union with non-null input, BAML scores the null arm
+	// too (any non-null value -> null with DefaultButHadValue cost 110). Native
+	// does not score, so it claims the non-null arm ONLY when that arm is a
+	// clean zero-score success (which trivially beats null's 110).
+	s := nullableClassUnionSchema()
+	// Null input -> null fast path.
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	// CLEAN winning arm (exact keys, no extras, exact children) -> CLAIM.
+	mustParse(t, s, `{"u":{"title":"Go","pages":300}}`, `{"u":{"title":"Go","pages":300}}`)
+	// FLAGGED winning arm: even ONE extra key adds an ExtraKey flag, so the
+	// null arm could outscore it (the cold-review probe used 111 extras to make
+	// BAML actually return null). Native cannot tell, so it DECLINES — whereas
+	// the SAME input on the NON-nullable Book|Car union is still claimed
+	// (TestParse_ClassUnionFlatDisjointClaimed), since no null arm competes.
+	requireUnsupported(t, s, `{"u":{"title":"Go","pages":300,"x":1}}`)
+}
+
+func TestParse_OptionalArmRequiresCleanArm(t *testing.T) {
+	// F1 on the single-arm optional path: c is Color? (Color enum | null).
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("c", &bamlutils.DynamicProperty{
+			Type:  "optional",
+			Inner: &bamlutils.DynamicTypeSpec{Ref: "Color"},
+		})),
+		Enums: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Color", &bamlutils.DynamicEnum{
+				Values: []*bamlutils.DynamicEnumValue{{Name: "RED"}, {Name: "GREEN"}},
+			}),
+		),
+	}
+	// Exact and case-fold enum matches are score 0 (clean) -> CLAIM.
+	mustParse(t, s, `{"c":"GREEN"}`, `{"c":"GREEN"}`)
+	mustParse(t, s, `{"c":"green"}`, `{"c":"GREEN"}`)
+	// A SUBSTRING match adds SubstringMatch (cost 2): the null arm competes, so
+	// native DECLINES (over-declines vs BAML, which would still pick the enum).
+	requireUnsupported(t, s, `{"c":"the color green please"}`)
+}
+
 func TestParse_ClassUnionOverlappingKeysDeclinedAtGate(t *testing.T) {
 	// Two classes sharing a field name (id) are NOT disjoint: BAML could
 	// partially match either arm → scoring → decline the whole schema.
@@ -817,6 +879,16 @@ func TestParse_MultiFieldFuzzyKey(t *testing.T) {
 	// Extra/unknown keys are ignored on both sides when all required fields
 	// are present -> still CLAIM.
 	mustParse(t, personSchema(), `{"name":"Ada","age":36,"extra":true}`, `{"name":"Ada","age":36}`)
+}
+
+func TestParse_ClassFuzzyKeyFirstWins(t *testing.T) {
+	// F2: when two input keys fuzzy-match the SAME field, BAML's update_map
+	// keeps the FIRST matched value and ignores later duplicates
+	// (coerce_class.rs:548 "DO NOTHING (keep first value)"). "name" and "Name"
+	// both match field `name`; the FIRST ("Ada") wins, not the last.
+	mustParse(t, personSchema(), `{"name":"Ada","Name":"Grace","age":36}`, `{"name":"Ada","age":36}`)
+	// The first occurrence wins regardless of which case appears first.
+	mustParse(t, personSchema(), `{"Name":"Grace","name":"Ada","age":36}`, `{"name":"Grace","age":36}`)
 }
 
 func TestParse_FixingTrailingCommas(t *testing.T) {

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -685,6 +685,61 @@ func TestParse_NullableClassUnionRequiresCleanArm(t *testing.T) {
 	requireUnsupported(t, s, `{"u":{"title":"Go","pages":300,"x":1}}`)
 }
 
+func TestParse_NonASCIICaseFoldUnionDeclines(t *testing.T) {
+	// P2: native's case fold (cases.Lower) is not byte-identical to Rust's
+	// str::to_lowercase for every rune, so any match whose verdict hinges on
+	// lowercasing a non-ASCII rune Go can't prove is lowercase-stable is
+	// UNCERTAIN. A|B with A{a: literal "é"(U+00E9), aa, aaa} | B{b, bb}: arm A's
+	// literal only matches the input "É"(U+00C9) via the case-fold attempt
+	// (NFKD leaves the accent so it is not connected at the accent-fold stage),
+	// and 'É' is non-ASCII and not IsLower → uncertain. Native must DECLINE THE
+	// UNION rather than false-reject A and claim B as the lone winner.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type:  "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{{Ref: "A"}, {Ref: "B"}},
+		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("A", &bamlutils.DynamicClass{
+				Properties: props(
+					kv("a", &bamlutils.DynamicProperty{Type: "literal_string", Value: "é"}),
+					kv("aa", intProp()),
+					kv("aaa", intProp()),
+				),
+			}),
+			bamlutils.OrderedKV("B", &bamlutils.DynamicClass{
+				Properties: props(kv("b", strProp()), kv("bb", intProp())),
+			}),
+		),
+	}
+	requireUnsupported(t, s, "{\"u\":{\"a\":\"É\",\"aa\":1,\"aaa\":1,\"b\":\"x\",\"bb\":2}}")
+}
+
+func TestParse_NonASCIICaseFoldStandaloneFallsBack(t *testing.T) {
+	// Standalone (non-union) literal/enum under the same uncertainty: native
+	// falls back rather than risk a claim that diverges from BAML.
+	lit := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("k", &bamlutils.DynamicProperty{Type: "literal_string", Value: "é"})),
+	}
+	// "É"(U+00C9) only matches "é" via the uncertain case fold -> decline.
+	requireUnsupported(t, lit, "{\"k\":\"É\"}")
+	// Exact "é" needs no case fold -> certain -> claimed (the canonical literal).
+	mustParse(t, lit, "{\"k\":\"é\"}", "{\"k\":\"é\"}")
+
+	enum := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("c", &bamlutils.DynamicProperty{Ref: "Acc"})),
+		Enums: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Acc", &bamlutils.DynamicEnum{
+				Values: []*bamlutils.DynamicEnumValue{{Name: "É"}},
+			}),
+		),
+	}
+	requireUnsupported(t, enum, "{\"c\":\"é\"}")
+
+	// ASCII case folding is UNAFFECTED — it stays certain and is claimed.
+	mustParse(t, personSchema(), `{"Name":"Ada","age":36}`, `{"name":"Ada","age":36}`)
+}
+
 func TestParse_OptionalArmRequiresCleanArm(t *testing.T) {
 	// F1 on the single-arm optional path: c is Color? (Color enum | null).
 	s := &bamlutils.DynamicOutputSchema{

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -239,11 +239,15 @@ func TestParse_Literals(t *testing.T) {
 		),
 	}
 	mustParse(t, s, `{"status":"active","version":2,"ok":true}`, `{"status":"active","version":2,"ok":true}`)
-	// A non-exact literal value DECLINES: BAML's literal coercion is fuzzy
-	// (case/punctuation/substring for strings, rounds/parses for ints), so
-	// native (exact) declines rather than claiming a mismatch BAML might
-	// still match.
-	requireUnsupported(t, s, `{"status":"inactive","version":2,"ok":true}`)
+	// Mcoerce-a: a string literal now matches fuzzily via match_string. A
+	// case variant matches and the CANONICAL literal is emitted (not the raw
+	// input).
+	mustParse(t, s, `{"status":"ACTIVE","version":2,"ok":true}`, `{"status":"active","version":2,"ok":true}`)
+	// A string with no fuzzy match still DECLINES (no exact/fold/substring
+	// hit): BAML errors in this required position, but native falls back.
+	requireUnsupported(t, s, `{"status":"paused","version":2,"ok":true}`)
+	// An int literal stays EXACT: BAML rounds/parses (string→int, float→int),
+	// which is Mcoerce-b, so a non-equal int value DECLINES.
 	requireUnsupported(t, s, `{"status":"active","version":3,"ok":true}`)
 }
 
@@ -376,12 +380,11 @@ func TestParse_MapBadEnumKeyDeclines(t *testing.T) {
 	requireUnsupported(t, mapEnumKeySchema(), `{"labels":{"A":"one","C":"two"}}`)
 }
 
-func TestParse_MapFuzzyEnumKeyDeclines(t *testing.T) {
-	// A case/fuzzy variant ("a" for enum value A): BAML's enum key coercion
-	// fuzzy-matches via match_string and SUCCEEDS (emitting the original key
-	// "a"); native's exact match misses, so it declines (fuzzy keys are
-	// Mcoerce). Native must NOT claim a missing/clean result.
-	requireUnsupported(t, mapEnumKeySchema(), `{"labels":{"a":"one"}}`)
+func TestParse_MapFuzzyEnumKeyClaimed(t *testing.T) {
+	// Mcoerce-a: a case/fuzzy variant ("a" for enum value A) now fuzzy-matches
+	// via match_string and is CLAIMED. The emitted key is the ORIGINAL input
+	// string "a" (maps insert the raw object key), not the canonical enum name.
+	mustParseExact(t, mapEnumKeySchema(), `{"labels":{"a":"one"}}`, `{"labels":{"a":"one"}}`)
 }
 
 func TestParse_MapEnumKeyAlias(t *testing.T) {
@@ -621,14 +624,14 @@ func TestParse_ClassUnionFlatDisjointClaimed(t *testing.T) {
 	mustParse(t, s, `{"u":{"brand":"Audi","wheels":4}}`, `{"u":{"brand":"Audi","wheels":4}}`)
 	// Class fields re-emitted in SCHEMA order even when input is out of order.
 	mustParse(t, s, `{"u":{"pages":300,"title":"Go"}}`, `{"u":{"title":"Go","pages":300}}`)
+	// Mcoerce-a: an EXTRA key beyond a variant's full field set is ignored
+	// (ExtraKey) and the arm still wins — exactly one variant succeeds, so it
+	// is CLAIMED (the extra "x" does not fuzzy-match Car's disjoint fields).
+	mustParse(t, s, `{"u":{"title":"Go","pages":300,"x":1}}`, `{"u":{"title":"Go","pages":300}}`)
 }
 
 func TestParse_ClassUnionDeclines(t *testing.T) {
 	s := classUnionSchema()
-	// Extra key beyond a variant's full field set → DECLINE (BAML ignores
-	// extras and could still match, or fuzzy-match the extra onto the other
-	// arm).
-	requireUnsupported(t, s, `{"u":{"title":"Go","pages":300,"x":1}}`)
 	// Missing a required field → DECLINE (BAML may fuzzy-match/fill).
 	requireUnsupported(t, s, `{"u":{"title":"Go"}}`)
 	// Key set matches no variant → DECLINE.
@@ -804,17 +807,15 @@ func TestParse_SingleFieldClassImpliedKeyDeclines(t *testing.T) {
 	requireClaimedError(t, personSchema(), `[1,2,3]`)
 }
 
-func TestParse_MultiFieldFuzzyKeyDeclines(t *testing.T) {
-	// A required field with no EXACT key match DECLINES: BAML matches field
-	// keys fuzzily (match_string), so a differently-cased key like "Name"
-	// matches `name` in BAML and SUCCEEDS — native must not claim a wrong
-	// missing-required error. Native declines and falls back.
-	requireUnsupported(t, personSchema(), `{"Name":"Ada","age":36}`)
-	// All required fields matched by EXACT key -> native is confident it
-	// matches BAML's structure -> CLAIM.
+func TestParse_MultiFieldFuzzyKey(t *testing.T) {
+	// Mcoerce-a: a required field key now matches fuzzily via match_string
+	// (no substring). A differently-cased key "Name" matches `name`, so the
+	// class is CLAIMED with the CANONICAL field name emitted.
+	mustParse(t, personSchema(), `{"Name":"Ada","age":36}`, `{"name":"Ada","age":36}`)
+	// All required fields matched by EXACT key -> CLAIM.
 	mustParse(t, personSchema(), `{"name":"Ada","age":36}`, `{"name":"Ada","age":36}`)
 	// Extra/unknown keys are ignored on both sides when all required fields
-	// are present by exact key -> still CLAIM.
+	// are present -> still CLAIM.
 	mustParse(t, personSchema(), `{"name":"Ada","age":36,"extra":true}`, `{"name":"Ada","age":36}`)
 }
 

--- a/internal/debaml/value.go
+++ b/internal/debaml/value.go
@@ -63,8 +63,9 @@ type value struct {
 
 // field is one ordered object entry. Duplicate keys are allowed (the
 // strict decoder and fixing parser both preserve them in input order);
-// lookupField resolves duplicates last-wins to match encoding/json's
-// map-decode semantics the M1 path relied on.
+// coerceClass's input-key-first field assignment resolves duplicates
+// last-wins, matching BAML's update_map overwrite (and the encoding/json
+// map-decode semantics the M1 path relied on).
 type field struct {
 	key string
 	val value

--- a/internal/debaml/value.go
+++ b/internal/debaml/value.go
@@ -63,9 +63,8 @@ type value struct {
 
 // field is one ordered object entry. Duplicate keys are allowed (the
 // strict decoder and fixing parser both preserve them in input order);
-// coerceClass's input-key-first field assignment resolves duplicates
-// last-wins, matching BAML's update_map overwrite (and the encoding/json
-// map-decode semantics the M1 path relied on).
+// coerceClass's input-key-first field assignment resolves duplicate matches
+// FIRST-wins, matching BAML's update_map "keep first" (coerce_class.rs:548).
 type field struct {
 	key string
 	val value


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

First PR of the Mcoerce stack for #546. Replaces native's strict
enum / string-literal / class-field-key / map-key matching with BAML's
**actual** `match_string`, so fuzzy matches BAML accepts become native
CLAIMS that reproduce BAML byte-exact. Gated solely by `BAML_REST_USE_DEBAML`;
`internal/debaml` + tests/testdata only — **no seam / codegen / regen / embed**
changes.

## What native now claims

The matcher (ported from `deserializer/coercer/match_string.rs` into
`parse.go`, beside the conservative `matchStringMightMatch` gate) reproduces
BAML's exact strategy order: trim → exact → accent+ligature fold (NFKD +
`ß/æ/ø/œ`, drop combining marks) → punctuation strip (keep alphanumerics +
`-` `_`) → case-insensitive → non-overlapping substring counting.

- **enum / string-literal** (substring enabled): a fuzzy match emits the
  canonical target (real name / literal). `"Résumé"` → `RESUME`,
  `"status is active"` → `"active"`.
- **class field keys** (no substring, via `matches_string_to_string`):
  `{"Name":..,"Age":..}` → `{"name":..,"age":..}`, canonical names in schema
  order.
- **map keys**: a clean enum/literal match (or ≥1 matching string-literal-union
  arm) is accepted under the **original** input key, e.g. `{"a":"one"}` stays
  `{"a":"one"}`.
- **substring tie** (`StrMatchOneFromMany`): `"cat dog"` against `CAT|DOG` is a
  CLAIMED error — native claims the same error, never picks a tied variant.

## The M2c-union no-over-claim revisit

Making enum/literal/field-key matching lenient means a union that had *one
strict success* can now have *two lenient successes* (e.g. an input that
substring-matches two disjoint literal arms, or an object carrying two arms'
full field sets). `coerceLiteralUnion` / `coerceFlatClassUnion` now **count
lenient per-variant successes** and claim only the lone winner; two-plus →
BAML `pick_best` (M3) → DECLINE. Every existing M2c union fallback fixture
(`string_int_union_numeric_string`, `single_field_class_union_implied_key`,
`literal_class_union_object_to_primitive`, `enum_class_union_object_to_string`,
`literal_union_fuzzy_string`, `union_list_singleton_ambiguity`, …) still
declines — verified in the gating differential.

Optional/partial contexts stay safe: the single-arm optional union and
`coerceList` convert any child error (decline **or** claimed) into a DECLINE,
because BAML would null-default the arm (`DefaultButHadValue`) or skip the list
item (`ArrayItemParseError`) rather than fail.

## Deferred (not this PR)

- Multi-success unions → `pick_best` scoring = **M3**.
- Lenient numerics/bools/nulls (numeric strings, float→int, string bools) =
  **Mcoerce-b**.
- Partial list/map skips = **Mcoerce-c**.
- Object/non-string stringification (`ObjectToString` / `JsonToString` `Value`
  Display), single-key `ObjectToPrimitive`, implied-key / inferred-object,
  default-fill = **Mcoerce-d**.

## Verification

`gofmt` / `go build ./...` / `go vet -tags=integration ./...` clean;
`verify-framework-adapter` 6/6; `GOWORK=off go test ./codegen`;
`go test ./internal/debaml ./bamlutils ./worker ./dynclient/...`; and the
gating differential `go test -tags=integration ./integration -run
TestBamlfuzzParseRecovery` green (dispositions 32 claimed, 16 fell back). All
new corpus `want` values captured from live BAML 0.223.0.

Part of #546


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded native fuzzy matching semantics across enums, string literals, class field keys, and map keys, including punctuation and accent/ligature folding plus Unicode case-fold handling.
* **Bug Fixes**
  * Aligned parse-recovery and native claim-vs-decline decisions with clean vs ambiguous matches, including substring tie handling and non-ASCII uncertainty.
  * Tightened nullable/optional union “clean arm” scoring and improved “first-wins” behavior for duplicate object keys.
* **Tests**
  * Added new BAMLFuzz parse-recovery fixtures and Unicode-focused matcher/coercion unit tests; updated parse differential assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->