### PR TITLE
debaml: lenient primitive/literal numerics/bools/nulls (Mcoerce-b)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/54_primitive_int_json_float_round.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/54_primitive_int_json_float_round.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_int_json_float_round",
+  "description": "Mcoerce-b CLAIMED: int target, JSON float 1.6 -> round-half-away-from-zero to 2 (FloatToInt). A required (non-nullable) int field claims regardless of the score-bearing flag. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":1.6}",
+  "want": {
+    "status": "success",
+    "json": {"u": 2}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/55_primitive_int_numeric_string_trim_comma.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/55_primitive_int_numeric_string_trim_comma.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_int_numeric_string_trim_comma",
+  "description": "Mcoerce-b CLAIMED: int target, numeric string ' 123, ' -> trim() then trim_end_matches(',') -> '123' -> 123 via a CLEAN direct i64 parse (no flag). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\" 123, \"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 123}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/56_primitive_int_u64_wrap.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/56_primitive_int_u64_wrap.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_int_u64_wrap",
+  "description": "Mcoerce-b CLAIMED: int target, JSON integer above i64::MAX (u64::MAX). as_i64 misses, as_u64 hits, and Rust's `n as i64` two's-complement wrap yields -1. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":18446744073709551615}",
+  "want": {
+    "status": "success",
+    "json": {"u": -1}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/57_primitive_int_fraction_string.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/57_primitive_int_fraction_string.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_int_fraction_string",
+  "description": "Mcoerce-b CLAIMED: int target, fraction string '3/2' -> 1.5 -> round-half-away 2 (FloatToInt). Required int field claims. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"3/2\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 2}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/58_primitive_int_extracted_currency.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/58_primitive_int_extracted_currency.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_int_extracted_currency",
+  "description": "Mcoerce-b CLAIMED: int target, currency/comma string '$1,234' -> exactly one extracted-number match -> commas stripped, \\p{Sc} '$' removed -> 1234.0 -> 1234 (FloatToInt). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"$1,234\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 1234}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/59_primitive_float_numeric_string.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/59_primitive_float_numeric_string.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_float_numeric_string",
+  "description": "Mcoerce-b CLAIMED: float target, direct numeric string '3.14' -> 3.14 via a CLEAN f64 parse (no flag). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "float"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"3.14\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 3.14}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/60_primitive_float_fraction_string.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/60_primitive_float_fraction_string.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_float_fraction_string",
+  "description": "Mcoerce-b CLAIMED: float target, fraction string '3/2' -> 1.5 (fraction path is CLEAN for float, no flag). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "float"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"3/2\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 1.5}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/61_primitive_float_percent_not_ratio.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/61_primitive_float_percent_not_ratio.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_float_percent_not_ratio",
+  "description": "Mcoerce-b CLAIMED: float target, '50%' -> the extracted-number regex matches '50' (percent is NOT part of the match and is NOT divided), so the value is 50.0, NOT 0.5 or 5050 (StringToFloat). want captured LIVE from BAML final parse to pin the exposed JSON byte form.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "float"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"50%\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 50}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/62_primitive_float_extracted_sentence.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/62_primitive_float_extracted_sentence.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_float_extracted_sentence",
+  "description": "Mcoerce-b CLAIMED: float target, sentence with exactly one number 'Save up to 20% on your purchase' -> 20.0 (StringToFloat). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "float"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"Save up to 20% on your purchase\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 20}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/63_primitive_bool_casefold.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/63_primitive_bool_casefold.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_bool_casefold",
+  "description": "Mcoerce-b CLAIMED: bool target, 'TRUE' -> to_lowercase 'true' -> true (StringToBool). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "bool"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"TRUE\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": true}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/64_primitive_bool_match_string_substring.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/64_primitive_bool_match_string_substring.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_bool_match_string_substring",
+  "description": "Mcoerce-b CLAIMED: bool target, 'it is true.' -> casefold misses, match_string finds 'true' uniquely by substring -> true. The match_string SubstringMatch flag is DROPPED; only StringToBool (score 1) is added. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "bool"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"it is true.\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": true}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/65_primitive_null_non_null_default.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/65_primitive_null_non_null_default.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_null_non_null_default",
+  "description": "Mcoerce-b CLAIMED: null target, non-null value 5 -> null with DefaultButHadValue (score 110). A standalone primitive-null target always resolves to null. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "null"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":5}",
+  "want": {
+    "status": "success",
+    "json": {"u": null}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/66_literal_int_float_round_match.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/66_literal_int_float_round_match.json
@@ -1,0 +1,22 @@
+{
+  "name": "literal_int_float_round_match",
+  "description": "Mcoerce-b CLAIMED: literal int 2, JSON float 1.6 -> coerce_int rounds to 2 == literal (FloatToInt preserved). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "literal", "literal": {"kind": "int", "int": 2}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":1.6}",
+  "want": {
+    "status": "success",
+    "json": {"u": 2}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/67_literal_int_numeric_string_match.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/67_literal_int_numeric_string_match.json
@@ -1,0 +1,22 @@
+{
+  "name": "literal_int_numeric_string_match",
+  "description": "Mcoerce-b CLAIMED: literal int 2, numeric string '2' -> coerce_int '2' == 2 == literal (clean). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "literal", "literal": {"kind": "int", "int": 2}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"2\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 2}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/68_literal_int_numeric_string_mismatch.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/68_literal_int_numeric_string_mismatch.json
@@ -1,0 +1,21 @@
+{
+  "name": "literal_int_numeric_string_mismatch",
+  "description": "Mcoerce-b FALLBACK: literal int 2, numeric string '5' -> coerce_int '5' == 5 != 2. BAML ERRORS (Expected 2, got String(5)) on the required field. Native does NOT claim BAML's error/default choice on a literal value mismatch (conservative), so it declines (fallback). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "literal", "literal": {"kind": "int", "int": 2}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"5\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/69_literal_bool_string_match.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/69_literal_bool_string_match.json
@@ -1,0 +1,22 @@
+{
+  "name": "literal_bool_string_match",
+  "description": "Mcoerce-b CLAIMED: literal bool true, string 'true' -> coerce_bool casefold -> true == literal (StringToBool preserved). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "literal", "literal": {"kind": "bool", "bool": true}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"true\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": true}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/70_literal_bool_string_mismatch.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/70_literal_bool_string_mismatch.json
@@ -1,0 +1,21 @@
+{
+  "name": "literal_bool_string_mismatch",
+  "description": "Mcoerce-b FALLBACK: literal bool true, string 'false' -> coerce_bool -> false != true. BAML ERRORS (Expected true, got String(false)) on the required field. Native does NOT claim BAML's error/default choice on a literal value mismatch (conservative), so it declines (fallback). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "literal", "literal": {"kind": "bool", "bool": true}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"false\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/71_literal_int_single_key_object_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/71_literal_int_single_key_object_stays_fallback.json
@@ -1,0 +1,22 @@
+{
+  "name": "literal_int_single_key_object_stays_fallback",
+  "description": "Mcoerce-b FALLBACK: literal int 1, single-key object {\"value\":\"1\"}. BAML extracts the inner primitive and adds ObjectToPrimitive (score 2), which is Mcoerce-d, so native does NOT copy that prelude and declines the object input. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "literal", "literal": {"kind": "int", "int": 1}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":{\"value\":\"1\"}}",
+  "want": {
+    "status": "success",
+    "json": {"u": 1}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/72_primitive_string_non_string_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/72_primitive_string_non_string_stays_fallback.json
@@ -1,0 +1,22 @@
+{
+  "name": "primitive_string_non_string_stays_fallback",
+  "description": "Mcoerce-b FALLBACK: string target, JSON number 5. BAML stringifies non-string input via JsonToString (score 2), which is Mcoerce-d; native primitive STRING stays strict and declines. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "string"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":5}",
+  "want": {
+    "status": "success",
+    "json": {"u": "5"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/73_union_literal_int_string_one_lenient_success.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/73_union_literal_int_string_one_lenient_success.json
@@ -1,0 +1,32 @@
+{
+  "name": "union_literal_int_string_one_lenient_success",
+  "description": "Mcoerce-b CLAIMED (M2c revisit): homogeneous int-literal union (1 | 2), numeric string '2'. coerce_int '2' == 2 matches only arm 2 (a coerced int equals at most one literal), so EXACTLY one lenient success -> claim. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "literal", "literal": {"kind": "int", "int": 1}},
+                {"kind": "literal", "literal": {"kind": "int", "int": 2}}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":\"2\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 2}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/74_class_union_lenient_leaf_one_success.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/74_class_union_lenient_leaf_one_success.json
@@ -1,0 +1,46 @@
+{
+  "name": "class_union_lenient_leaf_one_success",
+  "description": "Mcoerce-b CLAIMED (M2c revisit): flat disjoint class union A{a int,b string} | B{c int,d string}, input carries only A's fields with a='5' a numeric string. A succeeds leniently (a='5'->5 clean); B misses its required c,d. EXACTLY one success -> claim A (non-nullable). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "class_ref", "ref": "A"},
+                {"kind": "class_ref", "ref": "B"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "A",
+        "properties": [
+          {"name": "a", "type": {"kind": "int"}},
+          {"name": "b", "type": {"kind": "string"}}
+        ]
+      },
+      {
+        "name": "B",
+        "properties": [
+          {"name": "c", "type": {"kind": "int"}},
+          {"name": "d", "type": {"kind": "string"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"a\":\"5\",\"b\":\"x\"}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"a": 5, "b": "x"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/75_class_union_strict_plus_lenient_two_successes_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/75_class_union_strict_plus_lenient_two_successes_stays_fallback.json
@@ -1,0 +1,46 @@
+{
+  "name": "class_union_strict_plus_lenient_two_successes_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (over-claim guard): flat disjoint class union A{a int,b string} | B{c int,d string}, input carries ALL four fields with c='5' a numeric string. A succeeds strictly (a,b; c,d extras); B NEWLY succeeds leniently (c='5'->5; a,b extras). TWO lenient successes force BAML pick_best (M3), so native declines the WHOLE union and must NEVER emit the old strict A arm. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "class_ref", "ref": "A"},
+                {"kind": "class_ref", "ref": "B"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "A",
+        "properties": [
+          {"name": "a", "type": {"kind": "int"}},
+          {"name": "b", "type": {"kind": "string"}}
+        ]
+      },
+      {
+        "name": "B",
+        "properties": [
+          {"name": "c", "type": {"kind": "int"}},
+          {"name": "d", "type": {"kind": "string"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"a\":1,\"b\":\"x\",\"c\":\"5\",\"d\":\"y\"}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"a": 1, "b": "x"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/75_class_union_strict_plus_lenient_two_successes_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/75_class_union_strict_plus_lenient_two_successes_stays_fallback.json
@@ -1,6 +1,6 @@
 {
   "name": "class_union_strict_plus_lenient_two_successes_stays_fallback",
-  "description": "Mcoerce-b FALLBACK (over-claim guard): flat disjoint class union A{a int,b string} | B{c int,d string}, input carries ALL four fields with c='5' a numeric string. A succeeds strictly (a,b; c,d extras); B NEWLY succeeds leniently (c='5'->5; a,b extras). TWO lenient successes force BAML pick_best (M3), so native declines the WHOLE union and must NEVER emit the old strict A arm. want captured from BAML final parse.",
+  "description": "Mcoerce-b FALLBACK (over-claim guard): flat disjoint class union A{a int,b string} | B{c int,d string}, input carries ALL four fields with c=\"5\" a numeric string. A succeeds strictly on its own fields (c,d are extras); B newly succeeds through lenient numeric-string int coercion (c=\"5\"->5; a,b are extras). This is one strict success plus one lenient success, so native declines the WHOLE union for BAML pick_best (M3) and must NEVER emit the old strict A arm. want captured from BAML final parse.",
   "preserve_schema_order": false,
   "schema": {
     "classes": [

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/76_nullable_optional_int_clean_string_claim.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/76_nullable_optional_int_clean_string_claim.json
@@ -1,0 +1,22 @@
+{
+  "name": "nullable_optional_int_clean_string_claim",
+  "description": "Mcoerce-b CLAIMED: optional int (int | null), string '123' -> CLEAN direct i64 parse (no flag). A clean non-null arm trivially beats the null arm (DefaultButHadValue=110), so native claims. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "optional", "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"123\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 123}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/77_nullable_optional_int_float_round_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/77_nullable_optional_int_float_round_stays_fallback.json
@@ -1,0 +1,22 @@
+{
+  "name": "nullable_optional_int_float_round_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (nullable clean-only rule): optional int (int | null), JSON float 1.6 -> the non-null arm coerces to 2 but carries FloatToInt (score-bearing). A flagged non-null arm declines even though its score (1) is < 110, because scoring the arm against the null arm is M3. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "optional", "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":1.6}",
+  "want": {
+    "status": "success",
+    "json": {"u": 2}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/78_nullable_optional_bool_string_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/78_nullable_optional_bool_string_stays_fallback.json
@@ -1,0 +1,22 @@
+{
+  "name": "nullable_optional_bool_string_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (nullable clean-only rule): optional bool (bool | null), string 'true' -> the non-null arm coerces to true but carries StringToBool (score-bearing). A flagged non-null arm declines (scored win vs null is M3). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "optional", "inner": {"kind": "bool"}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"true\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": true}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/79_float_hex_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/79_float_hex_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "float_hex_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1): float target, hex-float string '0x1p4'. Go's ParseFloat would parse it to 16, but Rust's str::parse::<f64>() REJECTS hex floats, so native rejects it too (no over-claim) and declines. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "float"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"0x1p4\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/80_float_signed_hex_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/80_float_signed_hex_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "float_signed_hex_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1): float target, signed hex-float string '+0x1p4'. parseF64Rust strips one leading sign then rejects the '0x' prefix (Rust rejects hex floats), so native declines. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "float"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"+0x1p4\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/81_float_underscore_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/81_float_underscore_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "float_underscore_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1): float target, underscore-grouped string '1_000'. Go's ParseFloat parses it to 1000, but Rust's f64 parse REJECTS digit-group underscores, so native rejects it too and declines. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "float"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"1_000\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/82_float_hex_fraction_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/82_float_hex_fraction_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "float_hex_fraction_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1): float target, fraction '0x1p4/2' whose numerator is a hex float. The fraction path parses each side with the Rust-compatible f64 parse, which rejects '0x1p4', so native declines. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "float"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"0x1p4/2\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/83_int_hex_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/83_int_hex_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "int_hex_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1): int target, hex-float string '0x1p4'. i64/u64 parse reject it, the Rust-compatible f64 parse rejects hex floats, and the extracted-number regex finds multiple digit runs (0,1,4) so it declines too. Native never claims 16. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"0x1p4\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/84_int_underscore_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/84_int_underscore_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "int_underscore_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1): int target, underscore-grouped string '1_000'. i64/u64/f64 parse all reject underscores (Rust parity), and the extracted-number regex sees two digit runs (1, 000) so it declines. Native never claims 1000. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"1_000\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/85_int_hex_fraction_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/85_int_hex_fraction_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "int_hex_fraction_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1): int target, fraction '0x1p4/2' whose numerator is a hex float. The fraction path rejects the hex numerator (Rust parity) and the extracted-number regex sees multiple digit runs, so native declines. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"0x1p4/2\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/86_literal_int_hex_spelling_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/86_literal_int_hex_spelling_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "literal_int_hex_spelling_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1): literal int 16, hex-float string '0x1p4' (which Go would parse to 16 == the literal). The literal path inherits the primitive int coercer's Rust-parity reject of hex floats, so native declines and never claims 16. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "literal", "literal": {"kind": "int", "int": 16}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"0x1p4\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/87_float_nan_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/87_float_nan_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "float_nan_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1): float target, 'NaN'. Rust (and Go) parse it to a NaN float, but NaN has no valid JSON number spelling, so native declines rather than emit an invalid token. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "float"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"NaN\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/88_float_inf_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/88_float_inf_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "float_inf_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1): float target, 'inf'. Parses to +Inf, which has no valid JSON number spelling, so native declines rather than emit an invalid token. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "float"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"inf\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/89_float_nan_fraction_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/89_float_nan_fraction_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "float_nan_fraction_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1): float target, fraction 'NaN/2' whose numerator is NaN -> the fraction result is NaN, which has no valid JSON number spelling, so native declines. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "float"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"NaN/2\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/90_int_inf_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/90_int_inf_stays_fallback.json
@@ -1,0 +1,22 @@
+{
+  "name": "int_inf_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1, documented divergence): int target, 'inf'. BAML's int coercer saturates via round() as i64 -> i64::MAX, but native conservatively DECLINES non-finite rather than claim against the dynamic bridge's handling (parity-safe under-claim). want captured LIVE from BAML final parse to pin BAML's saturated output.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"inf\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 9223372036854775807}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/91_int_nan_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/91_int_nan_stays_fallback.json
@@ -1,0 +1,22 @@
+{
+  "name": "int_nan_stays_fallback",
+  "description": "Mcoerce-b FALLBACK (CR-B1, documented divergence): int target, 'nan'. BAML's int coercer casts round(nan) as i64 -> 0, but native conservatively DECLINES non-finite rather than claim against the dynamic bridge's handling (parity-safe under-claim). want captured LIVE from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"nan\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": 0}
+  }
+}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -237,6 +237,46 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"union_list_singleton_ambiguity":          false,
 	"union_map_value_partial":                 false,
 	"nested_union":                            false,
+	// Mcoerce-b native LENIENT PRIMITIVE + LITERAL numeric/bool/null coercion:
+	// numeric-string parsing (trim + trailing-comma trim, i64 / u64-wrap / f64 /
+	// fraction / extracted-number regex), float→int rounding (half-away,
+	// saturating cast), string→bool (casefold + match_string), and non-null→null
+	// defaulting — plus int/bool literals by primitive-coerce-then-compare. These
+	// resolve byte-identical to BAML, so the in-scope conversions are CLAIMED.
+	"primitive_int_json_float_round":          true,
+	"primitive_int_numeric_string_trim_comma": true,
+	"primitive_int_u64_wrap":                  true,
+	"primitive_int_fraction_string":           true,
+	"primitive_int_extracted_currency":        true,
+	"primitive_float_numeric_string":          true,
+	"primitive_float_fraction_string":         true,
+	"primitive_float_percent_not_ratio":       true,
+	"primitive_float_extracted_sentence":      true,
+	"primitive_bool_casefold":                 true,
+	"primitive_bool_match_string_substring":   true,
+	"primitive_null_non_null_default":         true,
+	"literal_int_float_round_match":           true,
+	"literal_int_numeric_string_match":        true,
+	"literal_bool_string_match":               true,
+	// M2c union revisit: exactly one lenient success claims.
+	"union_literal_int_string_one_lenient_success": true,
+	"class_union_lenient_leaf_one_success":         true,
+	// Nullable clean-only rule: a CLEAN non-null arm (direct string→int parse)
+	// beats the scored null arm, so it claims.
+	"nullable_optional_int_clean_string_claim": true,
+	// Mcoerce-b FALLBACK set: a literal VALUE mismatch after a successful
+	// primitive coercion (native declines BAML's error/default choice), the
+	// single-key-object ObjectToPrimitive and non-string JsonToString paths
+	// (Mcoerce-d), the over-claim guard where a lenient leaf makes a 2nd union
+	// arm succeed (BAML pick_best = M3), and the nullable clean-only rule where a
+	// score-bearing non-null arm loses claimability against the scored null arm.
+	"literal_int_numeric_string_mismatch":                          false,
+	"literal_bool_string_mismatch":                                 false,
+	"literal_int_single_key_object_stays_fallback":                 false,
+	"primitive_string_non_string_stays_fallback":                   false,
+	"class_union_strict_plus_lenient_two_successes_stays_fallback": false,
+	"nullable_optional_int_float_round_stays_fallback":             false,
+	"nullable_optional_bool_string_stays_fallback":                 false,
 }
 
 // parseRecoveryStats tallies how many final-parse cases the native parser

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -277,6 +277,26 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"class_union_strict_plus_lenient_two_successes_stays_fallback": false,
 	"nullable_optional_int_float_round_stays_fallback":             false,
 	"nullable_optional_bool_string_stays_fallback":                 false,
+	// CR-B1 FALLBACK set: float spellings Go's ParseFloat accepts but Rust's
+	// str::parse::<f64>() rejects (hex floats, digit-group underscores) must NOT
+	// be claimed — parseF64Rust rejects them so native declines exactly where
+	// BAML declines. Non-finite results (NaN / ±Inf) have no valid JSON number
+	// form, so the float paths decline; the int path also declines non-finite
+	// (a parity-safe under-claim: BAML saturates inf->i64::MAX / nan->0, but
+	// native falls back rather than claim against the dynamic bridge).
+	"float_hex_stays_fallback":                false,
+	"float_signed_hex_stays_fallback":         false,
+	"float_underscore_stays_fallback":         false,
+	"float_hex_fraction_stays_fallback":       false,
+	"int_hex_stays_fallback":                  false,
+	"int_underscore_stays_fallback":           false,
+	"int_hex_fraction_stays_fallback":         false,
+	"literal_int_hex_spelling_stays_fallback": false,
+	"float_nan_stays_fallback":                false,
+	"float_inf_stays_fallback":                false,
+	"float_nan_fraction_stays_fallback":       false,
+	"int_inf_stays_fallback":                  false,
+	"int_nan_stays_fallback":                  false,
 }
 
 // parseRecoveryStats tallies how many final-parse cases the native parser

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -235,10 +235,18 @@ func coerceIntValue(input value) (n int64, flagged bool, err error) {
 			return v, fl, nil
 		}
 		if v, ok := floatFromMaybeFraction(t); ok {
-			return i64FromF64Round(v), true, nil // FloatToInt
+			n, fin := i64FromF64RoundOk(v)
+			if !fin {
+				return 0, false, declineCoerce("int target (non-finite fraction)", input)
+			}
+			return n, true, nil // FloatToInt
 		}
 		if v, ok := floatFromCommaSeparated(t); ok {
-			return i64FromF64Round(v), true, nil // FloatToInt
+			n, fin := i64FromF64RoundOk(v)
+			if !fin {
+				return 0, false, declineCoerce("int target (non-finite extracted)", input)
+			}
+			return n, true, nil // FloatToInt
 		}
 		return 0, false, declineCoerce("int target", input)
 	default:
@@ -261,7 +269,11 @@ func intFromNumeric(s string, input value) (int64, bool, error) {
 		return int64(v), false, nil // Rust u64 as i64 (two's-complement wrap)
 	}
 	if v, ok := parseF64Rust(s); ok {
-		return i64FromF64Round(v), true, nil // FloatToInt
+		n, fin := i64FromF64RoundOk(v)
+		if !fin {
+			return 0, false, declineCoerce("int target (non-finite)", input)
+		}
+		return n, true, nil // FloatToInt
 	}
 	return 0, false, declineCoerce("int target", input)
 }
@@ -281,19 +293,19 @@ func coerceFloatValue(input value) (json.RawMessage, bool, error) {
 	case valString:
 		t := trimNumericString(input.strV)
 		if v, ok := parseF64Rust(t); ok {
-			return floatRaw(v), false, nil
+			return emitFloat(v, false, input) // non-finite ("inf"/"nan") declines
 		}
 		if v, ok := parseI64Rust(t); ok {
-			return floatRaw(float64(v)), false, nil
+			return emitFloat(float64(v), false, input)
 		}
 		if v, ok := parseU64Rust(t); ok {
-			return floatRaw(float64(v)), false, nil
+			return emitFloat(float64(v), false, input)
 		}
 		if v, ok := floatFromMaybeFraction(t); ok {
-			return floatRaw(v), false, nil
+			return emitFloat(v, false, input)
 		}
 		if v, ok := floatFromCommaSeparated(t); ok {
-			return floatRaw(v), true, nil // StringToFloat
+			return emitFloat(v, true, input) // StringToFloat
 		}
 		return nil, false, declineCoerce("float target", input)
 	default:
@@ -354,12 +366,29 @@ func boolRaw(b bool) json.RawMessage {
 	return json.RawMessage("false")
 }
 
-// floatRaw emits f as a JSON number using the shortest round-trip form. The
-// differential compares numeric VALUE (both sides decode to float64), so the
-// byte spelling (50 vs 50.0 vs scientific) never affects parity — only the
-// decoded value must equal BAML's coerced float.
-func floatRaw(f float64) json.RawMessage {
-	return json.RawMessage(strconv.FormatFloat(f, 'g', -1, 64))
+// floatRaw emits f as a JSON number using the shortest round-trip form, or
+// reports ok=false for a NON-FINITE value (NaN, +Inf, -Inf) — which has no
+// valid JSON number spelling, so the caller must DECLINE rather than emit an
+// invalid token like "NaN"/"+Inf". The differential compares numeric VALUE
+// (both sides decode to float64), so the byte spelling (50 vs 50.0 vs
+// scientific) never affects parity — only the decoded value must equal BAML's.
+func floatRaw(f float64) (json.RawMessage, bool) {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return nil, false
+	}
+	return json.RawMessage(strconv.FormatFloat(f, 'g', -1, 64)), true
+}
+
+// emitFloat wraps floatRaw for coerceFloatValue's string paths: a finite value
+// emits (carrying the given StringToFloat flag), while a NON-FINITE value
+// DECLINES — BAML's Float(NaN/±Inf) has no valid JSON number form, so native
+// falls back rather than claim invalid output.
+func emitFloat(v float64, flagged bool, input value) (json.RawMessage, bool, error) {
+	out, ok := floatRaw(v)
+	if !ok {
+		return nil, false, declineCoerce("float target (non-finite)", input)
+	}
+	return out, flagged, nil
 }
 
 // trimNumericString mirrors BAML's shared numeric-string preprocessing:
@@ -387,12 +416,38 @@ func parseU64Rust(s string) (uint64, bool) {
 	return n, err == nil
 }
 
-// parseF64Rust mirrors s.parse::<f64>() for the corpus (decimal / exponent /
-// inf / nan forms). Go ParseFloat additionally accepts hex-float syntax Rust
-// rejects, but no such token appears in the numeric-string corpus.
+// parseF64Rust mirrors s.parse::<f64>() (Rust's FromStr for f64): decimal /
+// exponent / leading-dot / signed forms, plus the case-insensitive "inf" /
+// "infinity" / "nan" special values. Go's strconv.ParseFloat is a SUPERSET —
+// it also accepts two spellings Rust REJECTS: digit-group underscores
+// ("1_000") and hex floats ("0x1p4"). Both are rejected here BEFORE
+// ParseFloat, so native never CLAIMS a numeric string BAML's coerce_int /
+// coerce_float would decline (a parity over-claim). A ParseFloat range error
+// (overflow, e.g. "1e400") also declines — Rust yields Ok(inf) there, but
+// native conservatively falls back rather than guess the dynamic bridge's
+// handling of a non-finite value.
+//
+// NOTE: a valid "inf" / "nan" spelling returns the non-finite value with
+// ok=true — the caller then rejects it: the int path via i64FromF64RoundOk and
+// every FLOAT-emitting path via floatRaw both DECLINE non-finite (a NaN / ±Inf
+// has no valid JSON number form, and native does not claim BAML's saturation
+// against the dynamic bridge).
 func parseF64Rust(s string) (float64, bool) {
+	if strings.IndexByte(s, '_') >= 0 {
+		return 0, false // Rust f64 parse rejects digit-group underscores.
+	}
+	t := s
+	if len(t) > 0 && (t[0] == '+' || t[0] == '-') {
+		t = t[1:]
+	}
+	if strings.HasPrefix(t, "0x") || strings.HasPrefix(t, "0X") {
+		return 0, false // Rust f64 parse rejects hex-float syntax.
+	}
 	f, err := strconv.ParseFloat(s, 64)
-	return f, err == nil
+	if err != nil {
+		return 0, false
+	}
+	return f, true
 }
 
 // i64FromF64Round rounds f half-away-from-zero (Rust f64::round) then applies
@@ -412,6 +467,20 @@ func i64FromF64Round(f float64) int64 {
 	default:
 		return int64(r)
 	}
+}
+
+// i64FromF64RoundOk applies i64FromF64Round but reports ok=false for a
+// NON-FINITE input (NaN / ±Inf). BAML would saturate it via `round() as i64`
+// (inf→i64::MAX, nan→0), but native conservatively DECLINES the whole int
+// coercion rather than claim against the dynamic bridge's non-finite handling
+// — a parity-safe under-claim (fall back to BAML) captured in the corpus. A
+// FINITE value out of i64 range (e.g. 1e19) still saturates and returns
+// ok=true, matching BAML exactly.
+func i64FromF64RoundOk(f float64) (int64, bool) {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, false
+	}
+	return i64FromF64Round(f), true
 }
 
 // floatFromMaybeFraction ports float_from_maybe_fraction: split on the FIRST

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/invakid404/baml-rest/bamlutils"
@@ -66,18 +69,25 @@ func (f *coerceFlags) isUncertain() bool { return f != nil && f.uncertain }
 // pipeline keys on. Class fields are emitted in schema declaration order so
 // that order pass remains the authority.
 //
-// Coercion cut-line (Mcoerce-a): native now matches enum values, string
-// literals, class field keys, and map keys through BAML's actual match_string
-// (trim / accent+ligature fold / punctuation strip / case-insensitive /
-// substring — see match_string.go), so fuzzy matches BAML accepts are CLAIMED
-// byte-exact. The remaining leniencies stay STRICT and DECLINE: numeric/bool
-// string parsing, float→int rounding, non-string stringification (ObjectToString
-// / JsonToString), single-to-array wrapping, single-field implied-key /
-// inferred-object absorption, partial list/map skips, and class default-fill —
-// all deferred to Mcoerce-b/c/d. Where native's match fails but BAML may
-// leniently SUCCEED (or null-default) — or where native cannot determine BAML's
-// exact success/failure — coercion DECLINES (ErrDeBAMLParseUnsupported → fall
-// back to BAML), so native is never "more capable" than BAML.
+// Coercion cut-line (Mcoerce-b): on top of Mcoerce-a's match_string parity
+// (enum values, string literals, class field keys, map keys via trim /
+// accent+ligature fold / punctuation strip / case-insensitive / substring —
+// see match_string.go), native now ports BAML's lenient PRIMITIVE and LITERAL
+// numeric/bool/null coercers: numeric-string parsing (trim + trailing-comma
+// trim, i64 / u64-wrap / f64 / fraction / extracted-number regex), float→int
+// rounding (half-away-from-zero, saturating cast), string→bool (casefold +
+// match_string), and non-null→null defaulting — plus int/bool LITERALS by
+// primitive-coerce-then-compare. Each score-bearing conversion (FloatToInt,
+// StringToFloat, StringToBool, DefaultButHadValue) flags the coerceFlags
+// accumulator so the nullable-union clean-only rule holds. The remaining
+// leniencies stay STRICT and DECLINE: non-string stringification (ObjectToString
+// / JsonToString), single-key-object ObjectToPrimitive literal extraction,
+// single-to-array wrapping, single-field implied-key / inferred-object
+// absorption, partial list/map skips, and class default-fill — all deferred to
+// Mcoerce-c/d. Where native's coercion fails but BAML may leniently SUCCEED (or
+// null-default) — or where native cannot determine BAML's exact success/failure
+// — coercion DECLINES (ErrDeBAMLParseUnsupported → fall back to BAML), so native
+// is never "more capable" than BAML.
 //
 // Native CLAIMS a coercion error only where BAML also errors: a non-object
 // where a MULTI-field class is required (coerceClass typeMismatch), or a
@@ -86,18 +96,20 @@ func (f *coerceFlags) isUncertain() bool { return f != nil && f.uncertain }
 // DECLINES — BAML may default-fill or hard-fail and native cannot tell which.
 // Union claims count LENIENT per-variant successes and claim only the lone
 // winner; two-plus successes are BAML pick_best (M3) and DECLINE. A consequence
-// is that native still declines some inputs BAML would itself reject (e.g. a
-// required field with no fuzzy key match, {version:3} for literal 2, a
-// non-integer for an int) — behavior is identical via fallback, and precise
-// claim-parity for those is deferred to the rest of the Mcoerce milestone
-// (#546). See coercePrimitive / coerceList / coerceEnum / coerceLiteral /
-// coerceClass for the per-kind boundary.
+// is that native still declines some inputs BAML would itself reject or coerce
+// differently (e.g. a required field with no fuzzy key match, an int-LITERAL
+// value mismatch after rounding, a single-key object into a literal) — behavior
+// is identical via fallback, and precise claim-parity for those is deferred to
+// the rest of the Mcoerce milestone (#546). See coercePrimitive / coerceList /
+// coerceEnum / coerceLiteral / coerceClass for the per-kind boundary.
 func coerce(b *schema.Bundle, t schema.Type, input value, f *coerceFlags) (json.RawMessage, error) {
 	switch t.Kind {
 	case schema.TypePrimitive:
-		// Primitives match strictly in Mcoerce-a (exact JSON type), so they
-		// never add a score-bearing flag — no need to thread f.
-		return coercePrimitive(t.Primitive, input)
+		// Primitives are lenient in Mcoerce-b (numeric-string parse, float→int
+		// rounding, string→bool, non-null→null default), each of which adds a
+		// score-bearing flag, so f is threaded through for the nullable-union
+		// clean-only rule.
+		return coercePrimitive(t.Primitive, input, f)
 	case schema.TypeLiteral:
 		return coerceLiteral(t.Literal, input, f)
 	case schema.TypeEnum:
@@ -115,64 +127,348 @@ func coerce(b *schema.Bundle, t schema.Type, input value, f *coerceFlags) (json.
 	}
 }
 
-// coercePrimitive coerces a value to a primitive target. Native primitive
-// matching is intentionally STRICT (exact JSON type, integer-exact ints),
-// whereas BAML's primitive coercers are lenient: they stringify non-string
-// JSON, parse numeric strings, round float→int, and so on. A strict native
-// failure is therefore exactly where BAML would still succeed, so every
-// mismatch / non-exact value DECLINES (ErrDeBAMLParseUnsupported → fall
-// back to BAML) rather than claiming a hard error BAML would not produce.
-// Porting BAML's full lenient numeric/string coercer is a later milestone;
-// declining keeps parity in the meantime (BAML yields the correct coerced
-// value via fallback).
-func coercePrimitive(p schema.PrimitiveKind, input value) (json.RawMessage, error) {
+// coercePrimitive coerces a value to a primitive target. Mcoerce-b ports
+// BAML's lenient numeric/bool/null coercers (coerce_primitive.rs) so native
+// claims the same conversions BAML would:
+//
+//   - int:   JSON number (i64 / u64-wrap / float→int round) and string
+//     (trim+comma-trim then i64 / u64-wrap / float→int / fraction / extracted
+//     number). Float/fraction/extracted paths add FloatToInt (score 1).
+//   - float: JSON number and string (f64 / i64 / u64 / fraction / extracted).
+//     The extracted-number path adds StringToFloat (score 1).
+//   - bool:  JSON bool, casefold "true"/"false", or a match_string true/false
+//     substring hit — the string paths add StringToBool (score 1).
+//   - null:  JSON null is clean; any non-null value defaults to null with
+//     DefaultButHadValue (score 110).
+//
+// Primitive STRING stays STRICT (only a JSON string coerces): non-string→string
+// via JsonToString (score 2) is Mcoerce-d, so a non-string DECLINES. Every
+// score-bearing conversion marks f (nil-safe) so the nullable-union clean-only
+// rule can require the winning non-null arm to be clean.
+func coercePrimitive(p schema.PrimitiveKind, input value, f *coerceFlags) (json.RawMessage, error) {
 	switch p {
 	case schema.PrimitiveString:
 		if input.kind != valString {
+			// Non-string → string is JsonToString (score 2), Mcoerce-d.
 			return nil, declineCoerce("string target", input)
 		}
 		return marshalJSON(input.strV)
 	case schema.PrimitiveInt:
-		if input.kind != valNumber {
-			return nil, declineCoerce("int target", input)
-		}
-		if _, err := input.numV.Int64(); err != nil {
-			// Fractional, out-of-range, or exponent forms BAML rounds/parses.
-			return nil, unsupported(fmt.Sprintf("int target: %s not an exact integer", input.numV.String()))
-		}
-		return json.RawMessage(input.numV.String()), nil
+		return coercePrimitiveInt(input, f)
 	case schema.PrimitiveFloat:
-		if input.kind != valNumber {
-			return nil, declineCoerce("float target", input)
-		}
-		if _, err := input.numV.Float64(); err != nil {
-			return nil, unsupported(fmt.Sprintf("float target: %s not representable", input.numV.String()))
-		}
-		return json.RawMessage(input.numV.String()), nil
+		return coercePrimitiveFloat(input, f)
 	case schema.PrimitiveBool:
-		if input.kind != valBool {
-			return nil, declineCoerce("bool target", input)
-		}
-		return marshalJSON(input.boolV)
+		return coercePrimitiveBool(input, f)
 	case schema.PrimitiveNull:
-		if input.kind != valNull {
-			return nil, declineCoerce("null target", input)
-		}
-		return json.RawMessage("null"), nil
+		return coercePrimitiveNull(input, f)
 	default:
 		return nil, fmt.Errorf("debaml: unsupported primitive %q", p)
 	}
+}
+
+// coercePrimitiveInt emits the coerced integer as a JSON number, marking f
+// when the value came from a float/fraction/extracted path (FloatToInt).
+func coercePrimitiveInt(input value, f *coerceFlags) (json.RawMessage, error) {
+	n, flagged, err := coerceIntValue(input)
+	if err != nil {
+		return nil, err
+	}
+	if flagged {
+		f.flag() // FloatToInt (score 1)
+	}
+	return json.RawMessage(strconv.FormatInt(n, 10)), nil
+}
+
+// coercePrimitiveFloat emits the coerced float as a JSON number, marking f
+// when the value came from the extracted-number path (StringToFloat).
+func coercePrimitiveFloat(input value, f *coerceFlags) (json.RawMessage, error) {
+	out, flagged, err := coerceFloatValue(input)
+	if err != nil {
+		return nil, err
+	}
+	if flagged {
+		f.flag() // StringToFloat (score 1)
+	}
+	return out, nil
+}
+
+// coercePrimitiveBool emits the coerced bool, marking f when it came from a
+// string (StringToBool). A non-ASCII case-fold uncertainty in the match_string
+// fallback marks f and DECLINES (native cannot prove the verdict equals BAML).
+func coercePrimitiveBool(input value, f *coerceFlags) (json.RawMessage, error) {
+	b, flagged, uncertain, err := coerceBoolValue(input)
+	if uncertain {
+		f.markUncertain()
+	}
+	if err != nil {
+		return nil, err
+	}
+	if flagged {
+		f.flag() // StringToBool (score 1)
+	}
+	return boolRaw(b), nil
+}
+
+// coercePrimitiveNull emits JSON null. A non-null input defaults to null with
+// DefaultButHadValue (score 110), marking f. In a nullable-union scoring
+// decision the implicit null arm is handled by coerceUnionSafe, not here — this
+// is the standalone primitive-null target BAML always resolves to null.
+func coercePrimitiveNull(input value, f *coerceFlags) (json.RawMessage, error) {
+	if input.kind != valNull {
+		f.flag() // DefaultButHadValue (score 110)
+	}
+	return json.RawMessage("null"), nil
+}
+
+// coerceIntValue ports coerce_int (coerce_primitive.rs). It returns the coerced
+// i64, whether a FloatToInt-class conversion happened (score-bearing), and an
+// error. A JSON number tries i64, then u64 (Rust wrap cast), then f64 (round
+// half-away-from-zero, saturating cast). A string is trimmed then comma-trimmed
+// and tried as i64, u64, f64, fraction, and finally the extracted-number regex.
+func coerceIntValue(input value) (n int64, flagged bool, err error) {
+	switch input.kind {
+	case valNumber:
+		return intFromNumeric(input.numV.String(), input)
+	case valString:
+		t := trimNumericString(input.strV)
+		if v, fl, e := intFromNumeric(t, input); e == nil {
+			return v, fl, nil
+		}
+		if v, ok := floatFromMaybeFraction(t); ok {
+			return i64FromF64Round(v), true, nil // FloatToInt
+		}
+		if v, ok := floatFromCommaSeparated(t); ok {
+			return i64FromF64Round(v), true, nil // FloatToInt
+		}
+		return 0, false, declineCoerce("int target", input)
+	default:
+		// Array→singular (coerce_array_to_singular) is Mcoerce-c; every other
+		// kind is a BAML error_unexpected_type but native declines conservatively.
+		return 0, false, declineCoerce("int target", input)
+	}
+}
+
+// intFromNumeric parses a numeric token (a JSON number's text, or a
+// trimmed/comma-trimmed string) as int the way BAML's number arm does: i64,
+// then u64 wrapped to i64, then f64 rounded (FloatToInt). It returns a non-nil
+// error only when none of the three parse — the string arm then falls through
+// to the fraction / extracted-number strategies.
+func intFromNumeric(s string, input value) (int64, bool, error) {
+	if v, ok := parseI64Rust(s); ok {
+		return v, false, nil
+	}
+	if v, ok := parseU64Rust(s); ok {
+		return int64(v), false, nil // Rust u64 as i64 (two's-complement wrap)
+	}
+	if v, ok := parseF64Rust(s); ok {
+		return i64FromF64Round(v), true, nil // FloatToInt
+	}
+	return 0, false, declineCoerce("int target", input)
+}
+
+// coerceFloatValue ports coerce_float (coerce_primitive.rs), returning the
+// emitted JSON number, whether the extracted-number path (StringToFloat) was
+// used, and an error. A JSON number emits its exact token (as_f64 always
+// succeeds for a valid number). A string is trimmed then comma-trimmed and
+// tried as f64, i64, u64, fraction (all clean), then extracted (StringToFloat).
+func coerceFloatValue(input value) (json.RawMessage, bool, error) {
+	switch input.kind {
+	case valNumber:
+		if _, ok := parseF64Rust(input.numV.String()); ok {
+			return json.RawMessage(input.numV.String()), false, nil
+		}
+		return nil, false, declineCoerce("float target", input)
+	case valString:
+		t := trimNumericString(input.strV)
+		if v, ok := parseF64Rust(t); ok {
+			return floatRaw(v), false, nil
+		}
+		if v, ok := parseI64Rust(t); ok {
+			return floatRaw(float64(v)), false, nil
+		}
+		if v, ok := parseU64Rust(t); ok {
+			return floatRaw(float64(v)), false, nil
+		}
+		if v, ok := floatFromMaybeFraction(t); ok {
+			return floatRaw(v), false, nil
+		}
+		if v, ok := floatFromCommaSeparated(t); ok {
+			return floatRaw(v), true, nil // StringToFloat
+		}
+		return nil, false, declineCoerce("float target", input)
+	default:
+		return nil, false, declineCoerce("float target", input)
+	}
+}
+
+// boolMatchCandidates is the true/false candidate set coerce_bool passes to
+// match_string (coerce_primitive.rs:366) when the casefold check misses.
+var boolMatchCandidates = []matchCandidate{
+	{name: "true", validValues: []string{"true", "True", "TRUE"}},
+	{name: "false", validValues: []string{"false", "False", "FALSE"}},
+}
+
+// coerceBoolValue ports coerce_bool (coerce_primitive.rs). It returns the bool,
+// whether a StringToBool conversion happened, whether a non-ASCII case-fold
+// uncertainty was hit in the match_string fallback, and an error. A JSON bool
+// is clean; a string is first tested casefold-exact against "true"/"false",
+// then via match_string (substring enabled) — whose own flags (SubstringMatch)
+// are DROPPED: a substring hit still adds only StringToBool (score 1).
+func coerceBoolValue(input value) (b bool, flagged bool, uncertain bool, err error) {
+	switch input.kind {
+	case valBool:
+		return input.boolV, false, false, nil
+	case valString:
+		switch strings.ToLower(input.strV) {
+		case "true":
+			return true, true, false, nil // StringToBool
+		case "false":
+			return false, true, false, nil // StringToBool
+		}
+		matched, outcome, _, unc := matchString(input.strV, boolMatchCandidates, true)
+		if unc {
+			return false, false, true, unsupported("bool target: non-ASCII case-fold uncertainty in match_string")
+		}
+		if outcome == matchOne {
+			switch matched {
+			case "true":
+				return true, true, false, nil // StringToBool (NOT SubstringMatch)
+			case "false":
+				return false, true, false, nil
+			}
+		}
+		// match_string no-match or substring TIE (StrMatchOneFromMany): BAML's
+		// coerce_bool errors; for a required bool it errors, for an optional one
+		// it null-defaults, and native cannot tell which without scoring — decline.
+		return false, false, false, declineCoerce("bool target", input)
+	default:
+		return false, false, false, declineCoerce("bool target", input)
+	}
+}
+
+// boolRaw emits a bool as its JSON literal.
+func boolRaw(b bool) json.RawMessage {
+	if b {
+		return json.RawMessage("true")
+	}
+	return json.RawMessage("false")
+}
+
+// floatRaw emits f as a JSON number using the shortest round-trip form. The
+// differential compares numeric VALUE (both sides decode to float64), so the
+// byte spelling (50 vs 50.0 vs scientific) never affects parity — only the
+// decoded value must equal BAML's coerced float.
+func floatRaw(f float64) json.RawMessage {
+	return json.RawMessage(strconv.FormatFloat(f, 'g', -1, 64))
+}
+
+// trimNumericString mirrors BAML's shared numeric-string preprocessing:
+// s.trim() then s.trim_end_matches(',') — whitespace-trim, THEN strip every
+// trailing comma (no second whitespace trim).
+func trimNumericString(s string) string {
+	return strings.TrimRight(strings.TrimSpace(s), ",")
+}
+
+// parseI64Rust mirrors s.parse::<i64>(): base-10, optional leading sign, no
+// underscores (Go ParseInt base 10 rejects them, matching Rust).
+func parseI64Rust(s string) (int64, bool) {
+	n, err := strconv.ParseInt(s, 10, 64)
+	return n, err == nil
+}
+
+// parseU64Rust mirrors s.parse::<u64>(): base-10 digits with an optional
+// leading '+' (Rust unsigned FromStr accepts '+', Go ParseUint does not, so a
+// single leading '+' is stripped first).
+func parseU64Rust(s string) (uint64, bool) {
+	if strings.HasPrefix(s, "+") {
+		s = s[1:]
+	}
+	n, err := strconv.ParseUint(s, 10, 64)
+	return n, err == nil
+}
+
+// parseF64Rust mirrors s.parse::<f64>() for the corpus (decimal / exponent /
+// inf / nan forms). Go ParseFloat additionally accepts hex-float syntax Rust
+// rejects, but no such token appears in the numeric-string corpus.
+func parseF64Rust(s string) (float64, bool) {
+	f, err := strconv.ParseFloat(s, 64)
+	return f, err == nil
+}
+
+// i64FromF64Round rounds f half-away-from-zero (Rust f64::round) then applies
+// Rust's saturating float→int cast: NaN→0, values ≥ 2^63 saturate to
+// math.MaxInt64, values < -2^63 saturate to math.MinInt64. (Go's own
+// float→int conversion is implementation-defined out of range, so the bounds
+// are checked explicitly.)
+func i64FromF64Round(f float64) int64 {
+	r := math.Round(f) // ties away from zero, matching Rust f64::round
+	switch {
+	case math.IsNaN(r):
+		return 0
+	case r >= 9223372036854775808.0: // 2^63 (i64::MAX + 1)
+		return math.MaxInt64
+	case r < -9223372036854775808.0: // -2^63 (i64::MIN, exactly representable)
+		return math.MinInt64
+	default:
+		return int64(r)
+	}
+}
+
+// floatFromMaybeFraction ports float_from_maybe_fraction: split on the FIRST
+// '/', parse each side (trimmed) as f64, and divide when the denominator is
+// non-zero.
+func floatFromMaybeFraction(s string) (float64, bool) {
+	i := strings.IndexByte(s, '/')
+	if i < 0 {
+		return 0, false
+	}
+	num, ok1 := parseF64Rust(strings.TrimSpace(s[:i]))
+	den, ok2 := parseF64Rust(strings.TrimSpace(s[i+1:]))
+	if !ok1 || !ok2 || den == 0.0 {
+		return 0, false
+	}
+	return num / den, true
+}
+
+// extractedNumberRe ports float_from_comma_separated's number regex verbatim:
+// unanchored, an optional sign and currency prefix, then a comma-grouped /
+// decimal / plain / leading-dot mantissa with an optional exponent. It is
+// deliberately case-sensitive on 'e' (matching the Rust literal).
+var extractedNumberRe = regexp.MustCompile(`([-+]?)\$?(?:\d+(?:,\d+)*(?:\.\d+)?|\d+\.\d+|\d+|\.\d+)(?:e[-+]?\d+)?`)
+
+// currencySymbolRe matches any Unicode currency symbol (\p{Sc}), removed from
+// the extracted number before parsing.
+var currencySymbolRe = regexp.MustCompile(`\p{Sc}`)
+
+// floatFromCommaSeparated ports float_from_comma_separated: require EXACTLY one
+// regex match in the whole string, strip its commas, then strip Unicode
+// currency symbols, and parse the remainder as f64. Percent signs are never
+// part of the match (so "50%" → 50.0, not 0.5) and multiple numbers yield no
+// result.
+func floatFromCommaSeparated(s string) (float64, bool) {
+	ms := extractedNumberRe.FindAllString(s, -1)
+	if len(ms) != 1 {
+		return 0, false
+	}
+	withoutCommas := strings.ReplaceAll(ms[0], ",", "")
+	withoutCurrency := currencySymbolRe.ReplaceAllString(withoutCommas, "")
+	return parseF64Rust(withoutCurrency)
 }
 
 // coerceLiteral coerces a value to a literal target. String literals route
 // through BAML's actual match_string (Mcoerce-a) — trim / fold / strip /
 // case-insensitive / substring — emitting the canonical literal (not the
 // fuzzy raw input); a substring tie is a CLAIMED error and a no-match
-// DECLINES. Int and bool literals still match EXACTLY: BAML rounds/parses
-// them (string→int, float→int), which is Mcoerce-b, so a non-exact int/bool
-// DECLINES rather than claiming a mismatch BAML would not produce. A
-// non-string input to a string literal also DECLINES (BAML's single-key
-// object ObjectToPrimitive extraction is Mcoerce-d).
+// DECLINES. Int and bool literals are LENIENT in Mcoerce-b: they run the
+// primitive int/bool coercer and compare the coerced value to the literal
+// (coerce_literal.rs:110-135), so string→int, float→int, and string→bool all
+// resolve exactly as BAML would. On a value MISMATCH after a successful
+// primitive coercion native DECLINES (falls back) rather than claiming BAML's
+// error-vs-default choice, keeping the conservative Mcoerce boundary.
+//
+// BAML's coerce_literal runs a single-key-object ObjectToPrimitive extraction
+// BEFORE every literal kind; that prelude is Mcoerce-d, so native does NOT copy
+// it — an OBJECT input to an int/bool (or string) literal DECLINES here.
 func coerceLiteral(lit *schema.LiteralValue, input value, f *coerceFlags) (json.RawMessage, error) {
 	if lit == nil {
 		return nil, fmt.Errorf("debaml: literal type missing value")
@@ -200,19 +496,48 @@ func coerceLiteral(lit *schema.LiteralValue, input value, f *coerceFlags) (json.
 			return nil, unsupported(fmt.Sprintf("literal string %q: %q matches no value (BAML errors or null-defaults)", lit.String, input.strV))
 		}
 	case schema.LiteralInt:
-		if input.kind != valNumber {
-			return nil, declineCoerce("literal int", input)
+		if input.kind == valObject {
+			// Single-key-object ObjectToPrimitive extraction is Mcoerce-d.
+			return nil, declineCoerce("literal int (BAML single-key object extraction)", input)
 		}
-		n, err := input.numV.Int64()
-		if err != nil || n != lit.Int {
-			return nil, unsupported(fmt.Sprintf("literal int %d: no exact match (BAML rounds/parses)", lit.Int))
+		n, flagged, err := coerceIntValue(input)
+		if err != nil {
+			if !declinableChildError(err) {
+				return nil, err // hard/invariant failure: propagate.
+			}
+			return nil, unsupported(fmt.Sprintf("literal int %d: primitive int coercion declined: %v", lit.Int, err))
 		}
-		return json.RawMessage(input.numV.String()), nil
+		if n != lit.Int {
+			// BAML errors here (required) or null-defaults (optional); native
+			// cannot tell which without scoring, so decline (fall back).
+			return nil, unsupported(fmt.Sprintf("literal int %d: coerced to %d (value mismatch → BAML error/default)", lit.Int, n))
+		}
+		if flagged {
+			f.flag() // FloatToInt (score 1) — preserved from the primitive coercer.
+		}
+		return json.RawMessage(strconv.FormatInt(n, 10)), nil
 	case schema.LiteralBool:
-		if input.kind != valBool || input.boolV != lit.Bool {
-			return nil, unsupported(fmt.Sprintf("literal bool %v: no exact match", lit.Bool))
+		if input.kind == valObject {
+			return nil, declineCoerce("literal bool (BAML single-key object extraction)", input)
 		}
-		return marshalJSON(input.boolV)
+		b, flagged, uncertain, err := coerceBoolValue(input)
+		if uncertain {
+			f.markUncertain()
+			return nil, unsupported(fmt.Sprintf("literal bool %v: non-ASCII case-fold uncertainty (cannot prove verdict equals BAML)", lit.Bool))
+		}
+		if err != nil {
+			if !declinableChildError(err) {
+				return nil, err // hard/invariant failure: propagate.
+			}
+			return nil, unsupported(fmt.Sprintf("literal bool %v: primitive bool coercion declined: %v", lit.Bool, err))
+		}
+		if b != lit.Bool {
+			return nil, unsupported(fmt.Sprintf("literal bool %v: coerced to %v (value mismatch → BAML error/default)", lit.Bool, b))
+		}
+		if flagged {
+			f.flag() // StringToBool (score 1) — preserved from the primitive coercer.
+		}
+		return boolRaw(b), nil
 	default:
 		return nil, fmt.Errorf("debaml: unknown literal kind %q", lit.Kind)
 	}
@@ -699,8 +1024,11 @@ func flattenStringLiterals(t schema.Type) []string {
 //     score < 110; if it carries ≥110 worth of flags BAML returns NULL. Native
 //     does not score, so in a nullable context it claims the non-null arm ONLY
 //     when that arm is CLEAN (zero score-bearing flags) — which trivially beats
-//     null's 110. A flagged arm (extra keys, substring match, object→map, …)
-//     DECLINES (it might be an M3 scored win for null or another arm).
+//     null's 110. A flagged arm (extra keys, substring match, object→map, or an
+//     Mcoerce-b FloatToInt / StringToFloat / StringToBool / DefaultButHadValue
+//     conversion) DECLINES (it might be an M3 scored win for null or another
+//     arm) — so optional int|null with "123" claims (clean direct parse) while
+//     the same with 1.6 declines (FloatToInt).
 //
 // The claim is limited to:
 //
@@ -788,11 +1116,14 @@ func resolveArmFlags(requireClean bool, arm, cf *coerceFlags) error {
 }
 
 // coerceLiteralUnion claims a homogeneous literal union when EXACTLY one
-// variant leniently coerces (Mcoerce-a's no-over-claim rule). It counts
-// per-variant successes through coerceLiteral itself — so string literals
-// are evaluated with the actual match_string (a fuzzy/substring hit counts),
-// while int/bool literals stay exact (their lenient numeric coercion is
-// Mcoerce-b). Two-plus lenient successes mean BAML would run scored pick_best
+// variant leniently coerces (the no-over-claim rule). It counts per-variant
+// successes through coerceLiteral itself — so string literals are evaluated
+// with the actual match_string (a fuzzy/substring hit counts), and int/bool
+// literals now count their Mcoerce-b lenient coercion too (a numeric string or
+// rounded float that equals the literal, a casefold/substring bool). This is
+// the M2c union revisit: once int/bool leaves are lenient, a union that had one
+// STRICT success can gain a second LENIENT one, so counting through the lenient
+// coerceLiteral is load-bearing. Two-plus lenient successes mean BAML would run scored pick_best
 // — e.g. input "foobar" substring-matching both "foo" and "bar" arms even
 // though the literal VALUES were proven match-disjoint at the gate — so
 // native DECLINES (M3). Zero successes decline too. When requireClean (nullable

--- a/internal/debaml/coerce_lenient_test.go
+++ b/internal/debaml/coerce_lenient_test.go
@@ -68,6 +68,31 @@ func TestCoercePrimitiveString_StaysStrict(t *testing.T) {
 	requireUnsupported(t, s, `{"u":true}`)
 }
 
+// TestCoercePrimitive_GoOnlyFloatSpellingsDecline pins the CR-B1 fix
+// end-to-end: float spellings Go's ParseFloat accepts but Rust rejects
+// (underscores, hex floats) and non-finite results DECLINE for int, float, and
+// int-literal targets, so native never claims a value BAML would decline nor
+// emits an invalid JSON token.
+func TestCoercePrimitive_GoOnlyFloatSpellingsDecline(t *testing.T) {
+	ints := oneField(intProp())
+	requireUnsupported(t, ints, `{"u":"0x1p4"}`)
+	requireUnsupported(t, ints, `{"u":"1_000"}`)
+	requireUnsupported(t, ints, `{"u":"0x1p4/2"}`)
+	requireUnsupported(t, ints, `{"u":"inf"}`) // non-finite -> decline
+	requireUnsupported(t, ints, `{"u":"nan"}`)
+
+	floats := oneField(&bamlutils.DynamicProperty{Type: "float"})
+	requireUnsupported(t, floats, `{"u":"0x1p4"}`)
+	requireUnsupported(t, floats, `{"u":"1_000"}`)
+	requireUnsupported(t, floats, `{"u":"NaN"}`) // non-finite -> no valid JSON
+	requireUnsupported(t, floats, `{"u":"inf"}`)
+	requireUnsupported(t, floats, `{"u":"NaN/2"}`)
+
+	// Literal int inherits the primitive int reject: "0x1p4" would be 16 in Go
+	// (== the literal) but Rust rejects it, so native declines (never claims 16).
+	requireUnsupported(t, litIntField(16), `{"u":"0x1p4"}`)
+}
+
 // litIntField / litBoolField build a single literal-typed field.
 func litIntField(v int64) *bamlutils.DynamicOutputSchema {
 	return oneField(&bamlutils.DynamicProperty{Type: "literal_int", Value: v})

--- a/internal/debaml/coerce_lenient_test.go
+++ b/internal/debaml/coerce_lenient_test.go
@@ -1,0 +1,178 @@
+package debaml
+
+import (
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// oneField builds a Root schema with a single field u of the given property.
+func oneField(p *bamlutils.DynamicProperty) *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{Properties: props(kv("u", p))}
+}
+
+// TestCoercePrimitiveInt_Lenient pins the end-to-end lenient int coercions a
+// non-union int field claims: JSON float rounding, u64 wrap, numeric string,
+// fraction, and extracted currency/sentence numbers.
+func TestCoercePrimitiveInt_Lenient(t *testing.T) {
+	s := oneField(intProp())
+	mustParse(t, s, `{"u":1.6}`, `{"u":2}`)
+	mustParse(t, s, `{"u":5.0}`, `{"u":5}`)
+	mustParse(t, s, `{"u":18446744073709551615}`, `{"u":-1}`) // u64 wrap
+	mustParse(t, s, `{"u":"123"}`, `{"u":123}`)
+	mustParse(t, s, `{"u":" 123, "}`, `{"u":123}`)
+	mustParse(t, s, `{"u":"3/2"}`, `{"u":2}`) // round(1.5)=2
+	mustParse(t, s, `{"u":"$1,234"}`, `{"u":1234}`)
+	mustParse(t, s, `{"u":"The answer is 10,000"}`, `{"u":10000}`)
+	// Non-numeric string: BAML coerce_int errors / null-defaults; native declines.
+	requireUnsupported(t, s, `{"u":"hello"}`)
+}
+
+// TestCoercePrimitiveFloat_Lenient pins lenient float coercions: numeric
+// string, fraction, percent (50%→50.0, not 0.5), and extracted sentence number.
+func TestCoercePrimitiveFloat_Lenient(t *testing.T) {
+	s := oneField(&bamlutils.DynamicProperty{Type: "float"})
+	mustParse(t, s, `{"u":5}`, `{"u":5}`)
+	mustParse(t, s, `{"u":"3.14"}`, `{"u":3.14}`)
+	mustParse(t, s, `{"u":"3/2"}`, `{"u":1.5}`)
+	mustParse(t, s, `{"u":"50%"}`, `{"u":50.0}`)
+	mustParse(t, s, `{"u":"1,234.56"}`, `{"u":1234.56}`)
+	requireUnsupported(t, s, `{"u":"nope"}`)
+}
+
+// TestCoercePrimitiveBool_Lenient pins lenient bool coercions: casefold and
+// match_string substring.
+func TestCoercePrimitiveBool_Lenient(t *testing.T) {
+	s := oneField(boolProp())
+	mustParse(t, s, `{"u":"TRUE"}`, `{"u":true}`)
+	mustParse(t, s, `{"u":"False"}`, `{"u":false}`)
+	mustParse(t, s, `{"u":"it is true."}`, `{"u":true}`)
+	requireUnsupported(t, s, `{"u":"maybe"}`)
+}
+
+// TestCoercePrimitiveNull_EndToEnd pins that a non-union null field claims null
+// for any non-null value (DefaultButHadValue), and for JSON null.
+func TestCoercePrimitiveNull_EndToEnd(t *testing.T) {
+	s := oneField(&bamlutils.DynamicProperty{Type: "null"})
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	mustParse(t, s, `{"u":5}`, `{"u":null}`)
+	mustParse(t, s, `{"u":"anything"}`, `{"u":null}`)
+}
+
+// TestCoercePrimitiveString_StaysStrict pins the b/d boundary: a non-string
+// into a string field is JsonToString (Mcoerce-d), so native declines.
+func TestCoercePrimitiveString_StaysStrict(t *testing.T) {
+	s := oneField(strProp())
+	mustParse(t, s, `{"u":"hi"}`, `{"u":"hi"}`)
+	requireUnsupported(t, s, `{"u":5}`)
+	requireUnsupported(t, s, `{"u":true}`)
+}
+
+// litIntField / litBoolField build a single literal-typed field.
+func litIntField(v int64) *bamlutils.DynamicOutputSchema {
+	return oneField(&bamlutils.DynamicProperty{Type: "literal_int", Value: v})
+}
+func litBoolField(v bool) *bamlutils.DynamicOutputSchema {
+	return oneField(&bamlutils.DynamicProperty{Type: "literal_bool", Value: v})
+}
+
+// TestCoerceLiteralInt_Lenient pins int-literal coercion by primitive-coerce
+// then value-compare, and the conservative fallback on mismatch / object input.
+func TestCoerceLiteralInt_Lenient(t *testing.T) {
+	s := litIntField(2)
+	mustParse(t, s, `{"u":2}`, `{"u":2}`)
+	mustParse(t, s, `{"u":"2"}`, `{"u":2}`)         // string→int match
+	mustParse(t, s, `{"u":1.6}`, `{"u":2}`)         // round(1.6)=2 == literal
+	requireUnsupported(t, s, `{"u":"5"}`)           // coerces to 5 != 2 -> fallback
+	requireUnsupported(t, s, `{"u":3}`)             // 3 != 2 -> fallback
+	requireUnsupported(t, s, `{"u":{"value":"2"}}`) // single-key object = Mcoerce-d
+}
+
+// TestCoerceLiteralBool_Lenient pins bool-literal coercion by primitive-coerce
+// then value-compare, and the conservative fallback on mismatch / object input.
+func TestCoerceLiteralBool_Lenient(t *testing.T) {
+	s := litBoolField(true)
+	mustParse(t, s, `{"u":true}`, `{"u":true}`)
+	mustParse(t, s, `{"u":"true"}`, `{"u":true}`) // casefold match
+	mustParse(t, s, `{"u":"TRUE"}`, `{"u":true}`)
+	requireUnsupported(t, s, `{"u":"false"}`)          // coerces to false != true
+	requireUnsupported(t, s, `{"u":false}`)            // false != true
+	requireUnsupported(t, s, `{"u":{"value":"true"}}`) // single-key object = Mcoerce-d
+}
+
+// litIntUnion builds Root{u: v0 | v1} of int literals.
+func litIntUnion(v0, v1 int64) *bamlutils.DynamicOutputSchema {
+	return oneField(&bamlutils.DynamicProperty{
+		Type: "union",
+		OneOf: []*bamlutils.DynamicTypeSpec{
+			{Type: "literal_int", Value: v0},
+			{Type: "literal_int", Value: v1},
+		},
+	})
+}
+
+// TestLiteralIntUnion_OneLenientSuccess pins the M2c revisit: a homogeneous
+// int-literal union claims when EXACTLY one arm leniently coerces to its value.
+func TestLiteralIntUnion_OneLenientSuccess(t *testing.T) {
+	s := litIntUnion(1, 2)
+	mustParse(t, s, `{"u":2}`, `{"u":2}`)
+	mustParse(t, s, `{"u":"2"}`, `{"u":2}`) // "2"→2 matches only arm 2
+	mustParse(t, s, `{"u":1.6}`, `{"u":2}`) // round→2 matches only arm 2
+	// A value matching NO arm declines (BAML errors / null-defaults).
+	requireUnsupported(t, s, `{"u":"7"}`)
+}
+
+// TestClassUnion_LenientLeaf_OneSuccess pins that the flat disjoint Book|Car
+// class union claims when a numeric-string leaf lets exactly ONE arm succeed
+// (Car's wheels="4"→4 is a clean direct string parse; Book misses its fields).
+func TestClassUnion_LenientLeaf_OneSuccess(t *testing.T) {
+	s := classUnionSchema() // Book{title,pages} | Car{brand,wheels}
+	mustParse(t, s, `{"u":{"brand":"Audi","wheels":"4"}}`, `{"u":{"brand":"Audi","wheels":4}}`)
+}
+
+// TestClassUnion_TwoLenientSuccesses_Fallback pins the over-claim guard: a
+// numeric-string field (wheels="4") makes the SECOND arm (Car) newly succeed
+// on an input that also strictly satisfies Book, so native declines the whole
+// union (BAML pick_best = M3) rather than emitting the old strict Book arm.
+func TestClassUnion_TwoLenientSuccesses_Fallback(t *testing.T) {
+	s := classUnionSchema()
+	// title,pages satisfy Book (brand,wheels extras); brand + wheels="4" satisfy
+	// Car (title,pages extras) -> TWO lenient successes -> decline. Before
+	// Mcoerce-b wheels="4" declined, so only Book succeeded (the over-claim).
+	requireUnsupported(t, s, `{"u":{"title":"Go","pages":300,"brand":"Audi","wheels":"4"}}`)
+}
+
+// TestNullableOptionalInt_CleanOnly pins the nullable clean-only rule for an
+// optional int: a clean direct string parse claims, but a FloatToInt round
+// declines (the null arm competes by scoring → M3).
+func TestNullableOptionalInt_CleanOnly(t *testing.T) {
+	s := oneField(&bamlutils.DynamicProperty{Type: "optional", Inner: &bamlutils.DynamicTypeSpec{Type: "int"}})
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	mustParse(t, s, `{"u":"123"}`, `{"u":123}`) // clean direct parse -> claim
+	requireUnsupported(t, s, `{"u":1.6}`)       // FloatToInt -> decline
+}
+
+// TestNullableOptionalBool_StringDeclines pins that an optional bool with a
+// string bool (StringToBool) declines under the clean-only rule.
+func TestNullableOptionalBool_StringDeclines(t *testing.T) {
+	s := oneField(&bamlutils.DynamicProperty{Type: "optional", Inner: &bamlutils.DynamicTypeSpec{Type: "bool"}})
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	mustParse(t, s, `{"u":true}`, `{"u":true}`) // clean JSON bool -> claim
+	requireUnsupported(t, s, `{"u":"true"}`)    // StringToBool -> decline
+}
+
+// TestNullableLiteralIntUnion_CleanOnly pins the clean-only rule inside a
+// nullable homogeneous int-literal union.
+func TestNullableLiteralIntUnion_CleanOnly(t *testing.T) {
+	s := oneField(&bamlutils.DynamicProperty{
+		Type: "union",
+		OneOf: []*bamlutils.DynamicTypeSpec{
+			{Type: "literal_int", Value: int64(1)},
+			{Type: "literal_int", Value: int64(2)},
+			{Type: "null"},
+		},
+	})
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	mustParse(t, s, `{"u":"2"}`, `{"u":2}`) // clean string→int, arm 2 -> claim
+	requireUnsupported(t, s, `{"u":1.6}`)   // arm 2 via FloatToInt -> decline
+}

--- a/internal/debaml/coerce_numeric_test.go
+++ b/internal/debaml/coerce_numeric_test.go
@@ -114,7 +114,8 @@ func TestParseF64Rust_RejectsGoOnlySpellings(t *testing.T) {
 		}
 	}
 	// Rust also accepts "inf"/"nan" spellings; parseF64Rust returns them
-	// non-finite with ok=true (the caller decides — int saturates, float declines).
+	// non-finite with ok=true. Callers then decline them: int via
+	// i64FromF64RoundOk, float via floatRaw/emitFloat.
 	for _, s := range []string{"inf", "+inf", "-inf", "Infinity", "nan", "NaN"} {
 		if _, ok := parseF64Rust(s); !ok {
 			t.Errorf("parseF64Rust(%q) rejected, want accept (non-finite, ok=true)", s)

--- a/internal/debaml/coerce_numeric_test.go
+++ b/internal/debaml/coerce_numeric_test.go
@@ -89,6 +89,54 @@ func TestFloatFromCommaSeparated(t *testing.T) {
 	}
 }
 
+// TestParseF64Rust_RejectsGoOnlySpellings pins the CR-B1 fix: parseF64Rust
+// rejects the float spellings Go's strconv.ParseFloat accepts but Rust's
+// str::parse::<f64>() does NOT (underscores, hex floats), and reports a
+// ParseFloat range error (overflow) as a decline — while still accepting every
+// valid Rust decimal/exponent/leading-dot/signed form and the "inf"/"nan"
+// special values (as non-finite, ok=true).
+func TestParseF64Rust_RejectsGoOnlySpellings(t *testing.T) {
+	reject := []string{"1_000", "0x1p4", "+0x1p4", "0X1p4", "-0x1.8p+2", "1_0.5", "1e400"}
+	for _, s := range reject {
+		if v, ok := parseF64Rust(s); ok {
+			t.Errorf("parseF64Rust(%q) accepted (=%v), want reject (Go-only/overflow)", s, v)
+		}
+	}
+	// Valid Rust forms accepted (finite).
+	accept := map[string]float64{
+		"1": 1, "+1": 1, "-1": -1, "1.5": 1.5, ".5": 0.5, "1.": 1, "+.5": 0.5,
+		"1e5": 1e5, "1E5": 1e5, "-2.5e-1": -0.25,
+	}
+	for s, want := range accept {
+		v, ok := parseF64Rust(s)
+		if !ok || v != want {
+			t.Errorf("parseF64Rust(%q) = (%v,%v), want (%v,true)", s, v, ok, want)
+		}
+	}
+	// Rust also accepts "inf"/"nan" spellings; parseF64Rust returns them
+	// non-finite with ok=true (the caller decides — int saturates, float declines).
+	for _, s := range []string{"inf", "+inf", "-inf", "Infinity", "nan", "NaN"} {
+		if _, ok := parseF64Rust(s); !ok {
+			t.Errorf("parseF64Rust(%q) rejected, want accept (non-finite, ok=true)", s)
+		}
+	}
+}
+
+// TestFloatRaw_NonFinite pins that floatRaw refuses to emit a non-finite float
+// (which has no valid JSON number form), reporting ok=false so the caller
+// declines instead of emitting an invalid token.
+func TestFloatRaw_NonFinite(t *testing.T) {
+	for _, f := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		if _, ok := floatRaw(f); ok {
+			t.Errorf("floatRaw(%v) ok=true, want false (invalid JSON)", f)
+		}
+	}
+	out, ok := floatRaw(50)
+	if !ok || string(out) != "50" {
+		t.Errorf("floatRaw(50) = (%q,%v), want (\"50\",true)", string(out), ok)
+	}
+}
+
 // TestI64FromF64Round pins Rust's f64::round (ties away from zero) followed by
 // the saturating float→int cast (NaN→0, out-of-range→i64 bound).
 func TestI64FromF64Round(t *testing.T) {
@@ -179,6 +227,16 @@ func TestCoerceIntValue(t *testing.T) {
 		{"str-garbage", strVv("hello"), 0, false, false},
 		{"str-multi-number", strVv("1 and 2"), 0, false, false},
 		{"bool-input", value{kind: valBool, boolV: true}, 0, false, false},
+		// CR-B1: Go-only float spellings Rust rejects must DECLINE (no over-claim).
+		{"str-hex-float-reject", strVv("0x1p4"), 0, false, false},
+		{"str-underscore-reject", strVv("1_000"), 0, false, false},
+		{"str-hex-fraction-reject", strVv("0x1p4/2"), 0, false, false},
+		// CR-B1: non-finite ("inf"/"nan"/fraction) DECLINES (parity-safe under-claim).
+		{"str-inf-declines", strVv("inf"), 0, false, false},
+		{"str-nan-declines", strVv("nan"), 0, false, false},
+		{"str-inf-fraction-declines", strVv("inf/2"), 0, false, false},
+		// A FINITE out-of-range value still saturates and CLAIMS (matches BAML).
+		{"str-finite-overflow-saturates", strVv("1e19"), math.MaxInt64, true, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -222,6 +280,14 @@ func TestCoerceFloatValue(t *testing.T) {
 		{"str-sentence", strVv("Save up to 20% on your purchase"), 20.0, true, true},
 		{"str-garbage", strVv("hello"), 0, false, false},
 		{"str-multi", strVv("1 and 2"), 0, false, false},
+		// CR-B1: Go-only float spellings Rust rejects must DECLINE (no over-claim).
+		{"str-hex-reject", strVv("0x1p4"), 0, false, false},
+		{"str-underscore-reject", strVv("1_000"), 0, false, false},
+		{"str-hex-fraction-reject", strVv("0x1p4/2"), 0, false, false},
+		// CR-B1: non-finite has no valid JSON number form -> DECLINE (never emit).
+		{"str-nan-declines", strVv("NaN"), 0, false, false},
+		{"str-inf-declines", strVv("inf"), 0, false, false},
+		{"str-nan-fraction-declines", strVv("NaN/2"), 0, false, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/debaml/coerce_numeric_test.go
+++ b/internal/debaml/coerce_numeric_test.go
@@ -1,0 +1,318 @@
+package debaml
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// numV builds a JSON-number value from a literal token.
+func numV(tok string) value { return value{kind: valNumber, numV: json.Number(tok)} }
+
+// strV builds a JSON-string value.
+func strVv(s string) value { return value{kind: valString, strV: s} }
+
+// TestFloatFromCommaSeparated ports BAML's own test_float_from_comma_separated
+// table (coerce_primitive.rs) VERBATIM, pinning the extracted-number regex,
+// comma stripping, \p{Sc} currency removal, and the "exactly one match"
+// requirement byte-for-byte against Rust. The key semantic anchors: "50%" is
+// 50.0 (percent is NOT part of the match and NOT divided), a currency symbol
+// before OR after a number is stripped, US thousands-commas collapse, European
+// decimal-commas and multi-number strings yield no match.
+func TestFloatFromCommaSeparated(t *testing.T) {
+	type tc struct {
+		in   string
+		want float64
+		ok   bool
+	}
+	cases := []tc{
+		// European formats (deliberately unsupported where noted in BAML).
+		{"3,14", 314.0, true},
+		{"1.234,56", 0, false},
+		{"1.234.567,89", 0, false},
+		{"€1.234,56", 0, false},
+		{"-€1.234,56", 0, false},
+		{"€1.234", 1.234, true}, // TODO in BAML - technically incorrect
+		{"1.234€", 1.234, true}, // TODO in BAML - technically incorrect
+		{"€1,234.56", 1234.56, true},
+		// US formats.
+		{"3,000", 3000.0, true},
+		{"3,100.00", 3100.00, true},
+		{"1,234.56", 1234.56, true},
+		{"1,234,567.89", 1234567.89, true},
+		{"$1,234.56", 1234.56, true},
+		{"-$1,234.56", -1234.56, true},
+		{"$1,234", 1234.0, true},
+		{"1,234$", 1234.0, true},
+		{"+$1,234.56", 1234.56, true},
+		{"$9,999,999,999", 9999999999.0, true},
+		{"$1.23.456", 0, false},
+		{"$1.234.567.890", 0, false},
+		{"$314", 314.0, true},
+		// Indian format.
+		{"$1,23,456", 123456.0, true},
+		// Percentages.
+		{"50%", 50.0, true},
+		{"3.15%", 3.15, true},
+		{".009%", 0.009, true},
+		{"1.234,56%", 0, false},
+		{"$1,234.56%", 1234.56, true},
+		// Strings containing numbers.
+		{"The answer is 10,000", 10000.0, true},
+		{"The total is €1.234,56 today", 0, false},
+		{"You owe $3,000 for the service", 3000.0, true},
+		{"Save up to 20% on your purchase", 20.0, true},
+		{"Revenue grew by 1,234.56 this quarter", 1234.56, true},
+		{"Profit is -€1.234,56 in the last month", 0, false},
+		// Multiple numbers -> no single match.
+		{"The answer is 10,000 and $3,000", 0, false},
+		{"We earned €1.234,56 and $2,345.67 this year", 0, false},
+		{"Increase of 5% and a profit of $1,000", 0, false},
+		{"Loss of -€500 and a gain of 1,200.50", 0, false},
+		{"Targets: 2,000 units and €3.000,75 revenue", 0, false},
+		// Trailing periods and commas.
+		{"12,111,123.", 12111123.0, true},
+		{"12,111,123,", 12111123.0, true},
+	}
+	for _, c := range cases {
+		got, ok := floatFromCommaSeparated(c.in)
+		if ok != c.ok {
+			t.Errorf("floatFromCommaSeparated(%q) ok=%v, want %v (got %v)", c.in, ok, c.ok, got)
+			continue
+		}
+		if ok && got != c.want {
+			t.Errorf("floatFromCommaSeparated(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// TestI64FromF64Round pins Rust's f64::round (ties away from zero) followed by
+// the saturating float→int cast (NaN→0, out-of-range→i64 bound).
+func TestI64FromF64Round(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want int64
+	}{
+		{1.6, 2}, {1.4, 1}, {-1.6, -2}, {-1.4, -1},
+		{0.5, 1}, {-0.5, -1}, {2.5, 3}, {-2.5, -3}, // ties away from zero
+		{0.0, 0}, {-0.0, 0},
+		{1.5e19, math.MaxInt64},  // > 2^63 saturates high
+		{-1.5e19, math.MinInt64}, // < -2^63 saturates low
+	}
+	for _, c := range cases {
+		if got := i64FromF64Round(c.in); got != c.want {
+			t.Errorf("i64FromF64Round(%v) = %d, want %d", c.in, got, c.want)
+		}
+	}
+	if got := i64FromF64Round(math.NaN()); got != 0 {
+		t.Errorf("i64FromF64Round(NaN) = %d, want 0", got)
+	}
+	if got := i64FromF64Round(math.Inf(1)); got != math.MaxInt64 {
+		t.Errorf("i64FromF64Round(+Inf) = %d, want MaxInt64", got)
+	}
+	if got := i64FromF64Round(math.Inf(-1)); got != math.MinInt64 {
+		t.Errorf("i64FromF64Round(-Inf) = %d, want MinInt64", got)
+	}
+}
+
+// TestParseU64Rust pins the u64 parse (leading '+' allowed) and the u64→i64
+// two's-complement wrap that BAML's `n as i64` performs for values above
+// i64::MAX (e.g. u64::MAX → -1).
+func TestParseU64Rust(t *testing.T) {
+	if v, ok := parseU64Rust("18446744073709551615"); !ok || int64(v) != -1 {
+		t.Errorf("parseU64Rust(u64::MAX) = (%d,%v); int64 wrap = %d, want -1", v, ok, int64(v))
+	}
+	if v, ok := parseU64Rust("+9223372036854775808"); !ok || int64(v) != math.MinInt64 {
+		t.Errorf("parseU64Rust(+2^63) = (%d,%v); int64 wrap = %d, want MinInt64", v, ok, int64(v))
+	}
+	if _, ok := parseU64Rust("-5"); ok {
+		t.Errorf("parseU64Rust(-5) accepted, want reject")
+	}
+	if _, ok := parseU64Rust("abc"); ok {
+		t.Errorf("parseU64Rust(abc) accepted, want reject")
+	}
+}
+
+// TestTrimNumericString pins the shared preprocessing: trim() THEN
+// trim_end_matches(',') with no second whitespace trim.
+func TestTrimNumericString(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{" 123, ", "123"},
+		{"123, ,", "123, "}, // comma-trim stops at the space
+		{"  42  ", "42"},
+		{"7,,,", "7"},
+	}
+	for _, c := range cases {
+		if got := trimNumericString(c.in); got != c.want {
+			t.Errorf("trimNumericString(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestCoerceIntValue pins coerce_int across JSON-number and string inputs and
+// the FloatToInt flag (score-bearing) on the float/fraction/extracted paths.
+func TestCoerceIntValue(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      value
+		want    int64
+		flagged bool
+		ok      bool
+	}{
+		{"json-int", numV("5"), 5, false, true},
+		{"json-neg", numV("-7"), -7, false, true},
+		{"json-u64-wrap", numV("18446744073709551615"), -1, false, true},
+		{"json-float-round", numV("1.6"), 2, true, true},
+		{"json-float-exact", numV("5.0"), 5, true, true}, // 5.0 is f64 -> FloatToInt
+		{"str-int", strVv("123"), 123, false, true},
+		{"str-int-trim-comma", strVv(" 123, "), 123, false, true},
+		{"str-u64-wrap", strVv("18446744073709551615"), -1, false, true},
+		{"str-float-round", strVv("1.6"), 2, true, true},
+		{"str-fraction", strVv("3/2"), 2, true, true},       // round(1.5)=2
+		{"str-fraction-neg", strVv("-7/2"), -4, true, true}, // round(-3.5)=-4
+		{"str-extracted-currency", strVv("$1,234"), 1234, true, true},
+		{"str-extracted-sentence", strVv("The answer is 10,000"), 10000, true, true},
+		{"str-comma-grouped", strVv("1,234"), 1234, true, true}, // i64 parse fails on comma -> extracted
+		{"str-garbage", strVv("hello"), 0, false, false},
+		{"str-multi-number", strVv("1 and 2"), 0, false, false},
+		{"bool-input", value{kind: valBool, boolV: true}, 0, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, flagged, err := coerceIntValue(c.in)
+			if c.ok {
+				if err != nil {
+					t.Fatalf("coerceIntValue(%+v) unexpected error: %v", c.in, err)
+				}
+				if got != c.want {
+					t.Errorf("value = %d, want %d", got, c.want)
+				}
+				if flagged != c.flagged {
+					t.Errorf("flagged = %v, want %v", flagged, c.flagged)
+				}
+			} else {
+				if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+					t.Fatalf("want ErrDeBAMLParseUnsupported, got err=%v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestCoerceFloatValue pins coerce_float across JSON-number and string inputs
+// and the StringToFloat flag on the extracted-number path only.
+func TestCoerceFloatValue(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      value
+		want    float64
+		flagged bool
+		ok      bool
+	}{
+		{"json-int", numV("5"), 5, false, true},
+		{"json-float", numV("3.14"), 3.14, false, true},
+		{"str-float", strVv("3.14"), 3.14, false, true},
+		{"str-int", strVv("42"), 42, false, true},
+		{"str-fraction", strVv("3/2"), 1.5, false, true}, // fraction: no flag
+		{"str-percent", strVv("50%"), 50.0, true, true},  // extracted: StringToFloat
+		{"str-currency", strVv("$1,234.56"), 1234.56, true, true},
+		{"str-sentence", strVv("Save up to 20% on your purchase"), 20.0, true, true},
+		{"str-garbage", strVv("hello"), 0, false, false},
+		{"str-multi", strVv("1 and 2"), 0, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, flagged, err := coerceFloatValue(c.in)
+			if c.ok {
+				if err != nil {
+					t.Fatalf("coerceFloatValue(%+v) unexpected error: %v", c.in, err)
+				}
+				var got float64
+				if e := json.Unmarshal(out, &got); e != nil {
+					t.Fatalf("emitted %q is not a JSON number: %v", string(out), e)
+				}
+				if got != c.want {
+					t.Errorf("value = %v, want %v", got, c.want)
+				}
+				if flagged != c.flagged {
+					t.Errorf("flagged = %v, want %v", flagged, c.flagged)
+				}
+			} else {
+				if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+					t.Fatalf("want ErrDeBAMLParseUnsupported, got err=%v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestCoerceBoolValue pins coerce_bool: JSON bool (clean), casefold
+// "true"/"false" (StringToBool), match_string substring (StringToBool, NOT
+// SubstringMatch), and no-match / ambiguous-tie declines.
+func TestCoerceBoolValue(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      value
+		want    bool
+		flagged bool
+		ok      bool
+	}{
+		{"json-true", value{kind: valBool, boolV: true}, true, false, true},
+		{"json-false", value{kind: valBool, boolV: false}, false, false, true},
+		{"casefold-true", strVv("TRUE"), true, true, true},
+		{"casefold-mixed", strVv("TrUe"), true, true, true},
+		{"casefold-false", strVv("False"), false, true, true},
+		{"substring-true", strVv("it is true."), true, true, true},
+		{"substring-false", strVv("definitely false"), false, true, true},
+		{"no-match", strVv("maybe"), false, false, false},
+		{"ambiguous-tie", strVv("true or false"), false, false, false},
+		{"number-input", numV("1"), false, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, flagged, uncertain, err := coerceBoolValue(c.in)
+			if uncertain {
+				t.Fatalf("unexpected uncertain for ASCII input")
+			}
+			if c.ok {
+				if err != nil {
+					t.Fatalf("coerceBoolValue(%+v) unexpected error: %v", c.in, err)
+				}
+				if got != c.want {
+					t.Errorf("value = %v, want %v", got, c.want)
+				}
+				if flagged != c.flagged {
+					t.Errorf("flagged = %v, want %v", flagged, c.flagged)
+				}
+			} else {
+				if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+					t.Fatalf("want ErrDeBAMLParseUnsupported, got err=%v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestCoercePrimitiveNull pins coerce_null: JSON null is clean; any non-null
+// value defaults to null and flags DefaultButHadValue (score 110).
+func TestCoercePrimitiveNull(t *testing.T) {
+	cf := &coerceFlags{}
+	out, err := coercePrimitiveNull(value{kind: valNull}, cf)
+	if err != nil || string(out) != "null" {
+		t.Fatalf("null input: out=%q err=%v, want null/nil", string(out), err)
+	}
+	if cf.isFlagged() {
+		t.Errorf("null input should be clean, cf flagged")
+	}
+	cf2 := &coerceFlags{}
+	out, err = coercePrimitiveNull(numV("5"), cf2)
+	if err != nil || string(out) != "null" {
+		t.Fatalf("non-null input: out=%q err=%v, want null/nil", string(out), err)
+	}
+	if !cf2.isFlagged() {
+		t.Errorf("non-null input should flag DefaultButHadValue")
+	}
+}

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -524,9 +524,11 @@ func normalizeForMatchString(s string) (string, bool) {
 // separate file so the de-BAML embed source list stays unchanged.
 //
 // Null handling and non-string stringification (ObjectToString) are the
-// CALLER's job: matchString operates on an already-string input. Mcoerce-a only
-// coerces string inputs; non-string enum/literal inputs decline upstream (their
-// jsonish::Value Display reproduction is Mcoerce-b/d).
+// CALLER's job: matchString operates on an already-string input. Mcoerce-b adds
+// lenient numeric/bool/null PRIMITIVE + int/bool LITERAL coercion (see
+// coerce.go), but enum/string-literal matching still coerces string inputs
+// only; non-string enum/literal inputs decline upstream (their jsonish::Value
+// Display reproduction — ObjectToString / JsonToString — is Mcoerce-d).
 
 // matchOutcome is the verdict of a matchString evaluation.
 type matchOutcome int

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -153,23 +153,22 @@ func TestParse_PrimitivesAndBool(t *testing.T) {
 	mustParse(t, s, `{"s":"x","i":7,"f":1.5,"b":true}`, `{"s":"x","i":7,"f":1.5,"b":true}`)
 }
 
-func TestParse_ConservativeTypeMatchDeclines(t *testing.T) {
-	// Native primitive matching is strict, but BAML's primitive coercers are
-	// lenient (parse numeric strings, round float->int). A strict native
-	// failure is exactly where BAML would still succeed, so these DECLINE
-	// (fall back to BAML) rather than claim an error BAML would not produce.
+func TestParse_LenientPrimitiveCoercion(t *testing.T) {
+	// Mcoerce-b: native now ports BAML's lenient int/bool/float/null coercers,
+	// so numeric-string and float→int inputs to an int field CLAIM the coerced
+	// value (byte-identical to BAML) instead of declining.
 	//
-	// String where an int is required: BAML parses "36"->36.
-	requireUnsupported(t, personSchema(), `{"name":"Ada","age":"36"}`)
-	// Float where an int is required (strict JSON): BAML rounds 36.5->37.
-	// (Latent M1 case — was a claimed error, must be a fallback.)
-	requireUnsupported(t, personSchema(), `{"name":"Ada","age":36.5}`)
-	// Same via the fixing parser (single-quoted name forces the fix path),
-	// the new M2a exposure: native now CLAIMS the fix, so the non-integer
-	// coercion must DECLINE, not propagate a claimed error.
-	requireUnsupported(t, personSchema(), `{name:'Ada', age:36.5}`)
-	requireUnsupported(t, personSchema(), `{name:'Ada', age:'36'}`)
-	// Number where a string is required: BAML stringifies 36->"36".
+	// String where an int is required: BAML parses "36"->36 (clean).
+	mustParse(t, personSchema(), `{"name":"Ada","age":"36"}`, `{"name":"Ada","age":36}`)
+	// Float where an int is required: BAML rounds 36.5->37 (FloatToInt). A
+	// required (non-nullable) field claims regardless of the flag.
+	mustParse(t, personSchema(), `{"name":"Ada","age":36.5}`, `{"name":"Ada","age":37}`)
+	// Same via the fixing parser (single-quoted name forces the fix path): the
+	// fix is CLAIMED and the lenient coercion now CLAIMS too.
+	mustParse(t, personSchema(), `{name:'Ada', age:36.5}`, `{"name":"Ada","age":37}`)
+	mustParse(t, personSchema(), `{name:'Ada', age:'36'}`, `{"name":"Ada","age":36}`)
+	// Number where a string is required stays STRICT: non-string→string is
+	// JsonToString (Mcoerce-d), so native DECLINES (BAML stringifies 36->"36").
 	s := &bamlutils.DynamicOutputSchema{Properties: props(kv("v", strProp()))}
 	requireUnsupported(t, s, `{"v":36}`)
 }
@@ -332,13 +331,25 @@ func TestParse_MapNonObjectDeclines(t *testing.T) {
 }
 
 func TestParse_MapBadValueDeclines(t *testing.T) {
-	// A value that fails native clean coercion DECLINES the WHOLE map: BAML
-	// records MapValueParseError and SKIPS just that entry, returning a
-	// partial map — native cannot claim a different/partial result.
-	// String where int required (BAML parses "x"->skip or number-extracts).
+	// A value that fails native coercion (even with Mcoerce-b leniency) DECLINES
+	// the WHOLE map: BAML records MapValueParseError and SKIPS just that entry,
+	// returning a partial map — native cannot claim a different/partial result.
+	// "x" is not a number in any form (no i64/u64/f64/fraction/extracted match),
+	// so coerce_int errors and BAML skips the entry.
 	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":"x"}}`)
-	// Float where int required (BAML rounds; native is exact -> child declines).
-	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":2.5}}`)
+	// A float map value is NO LONGER "bad": Mcoerce-b rounds 2.5->3 (FloatToInt,
+	// a successful coercion BAML keeps), so this now CLAIMS — see
+	// TestParse_MapLenientValueClaimed.
+}
+
+// TestParse_MapLenientValueClaimed pins the Mcoerce-b map-value flip: a float
+// or numeric-string value coerces to int (a successful, entry-KEEPING coercion,
+// not a MapValueParseError), so the whole clean map is CLAIMED byte-identical
+// to BAML. The map's own score ignores the value's FloatToInt flag (score.rs),
+// so this stays a claimable clean map.
+func TestParse_MapLenientValueClaimed(t *testing.T) {
+	mustParse(t, mapStringIntSchema(), `{"scores":{"a":1,"b":2.5}}`, `{"scores":{"a":1,"b":3}}`)
+	mustParse(t, mapStringIntSchema(), `{"scores":{"a":1,"b":"7"}}`, `{"scores":{"a":1,"b":7}}`)
 }
 
 func TestParse_MapDuplicateKeyDeclines(t *testing.T) {
@@ -565,8 +576,13 @@ func TestParse_LiteralUnionBoolExactClaimed(t *testing.T) {
 	)
 	mustParse(t, s, `{"u":true}`, `{"u":true}`)
 	mustParse(t, s, `{"u":false}`, `{"u":false}`)
-	// Non-bool input → DECLINE (BAML accepts fuzzy/string bool).
-	requireUnsupported(t, s, `{"u":"true"}`)
+	// Mcoerce-b: a string bool coerces (StringToBool) and matches exactly one
+	// arm, so the union CLAIMS (a coerced bool equals at most one literal, so
+	// the family stays safe). "true"→true.
+	mustParse(t, s, `{"u":"true"}`, `{"u":true}`)
+	mustParse(t, s, `{"u":"False"}`, `{"u":false}`)
+	// A number is not a bool in any form (coerce_bool errors on a number), so
+	// neither arm coerces → DECLINE.
 	requireUnsupported(t, s, `{"u":1}`)
 }
 
@@ -577,13 +593,13 @@ func TestParse_LiteralUnionIntExactClaimed(t *testing.T) {
 	)
 	mustParse(t, s, `{"u":1}`, `{"u":1}`)
 	mustParse(t, s, `{"u":2}`, `{"u":2}`)
-	// No literal equals the (exact-integer) input → DECLINE.
+	// No literal equals the coerced integer → DECLINE (3 matches neither arm).
 	requireUnsupported(t, s, `{"u":3}`)
-	// Non-integer JSON number token → DECLINE (BAML rounds/parses).
-	requireUnsupported(t, s, `{"u":2.0}`)
-	requireUnsupported(t, s, `{"u":1.5}`)
-	// Numeric string → DECLINE (BAML parses "2"→2).
-	requireUnsupported(t, s, `{"u":"2"}`)
+	// Mcoerce-b: a JSON float rounds and a numeric string parses; the coerced
+	// int equals at most one literal, so the union CLAIMS the lone match.
+	mustParse(t, s, `{"u":2.0}`, `{"u":2}`) // 2.0→2 matches literal 2
+	mustParse(t, s, `{"u":1.5}`, `{"u":2}`) // round(1.5)=2 matches literal 2
+	mustParse(t, s, `{"u":"2"}`, `{"u":2}`) // "2"→2 matches literal 2
 }
 
 func TestParse_LiteralUnionMixedKindDeclinedAtGate(t *testing.T) {
@@ -628,6 +644,10 @@ func TestParse_ClassUnionFlatDisjointClaimed(t *testing.T) {
 	// (ExtraKey) and the arm still wins — exactly one variant succeeds, so it
 	// is CLAIMED (the extra "x" does not fuzzy-match Car's disjoint fields).
 	mustParse(t, s, `{"u":{"title":"Go","pages":300,"x":1}}`, `{"u":{"title":"Go","pages":300}}`)
+	// Mcoerce-b: pages="300" now coerces via a CLEAN direct string→int parse
+	// (BAML's s.parse::<i64>() adds no flag), so Book is still the lone clean
+	// winner and is CLAIMED. (Before Mcoerce-b native declined this.)
+	mustParse(t, s, `{"u":{"title":"Go","pages":"300"}}`, `{"u":{"title":"Go","pages":300}}`)
 }
 
 func TestParse_ClassUnionDeclines(t *testing.T) {
@@ -636,9 +656,6 @@ func TestParse_ClassUnionDeclines(t *testing.T) {
 	requireUnsupported(t, s, `{"u":{"title":"Go"}}`)
 	// Key set matches no variant → DECLINE.
 	requireUnsupported(t, s, `{"u":{"foo":1,"bar":2}}`)
-	// Winning class's child does not coerce cleanly (pages is a string) →
-	// DECLINE (BAML coerces "300"→300 with a flag and may still resolve here).
-	requireUnsupported(t, s, `{"u":{"title":"Go","pages":"300"}}`)
 	// Non-object input → DECLINE (BAML can infer/imply a class from a scalar).
 	requireUnsupported(t, s, `{"u":5}`)
 	requireUnsupported(t, s, `{"u":"Go"}`)


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Mcoerce-b: lenient primitive & literal numerics/bools/nulls (de-BAML #546)

Ports BAML's lenient **primitive** and **literal** numeric/bool/null coercers (`coerce_primitive.rs` / `coerce_literal.rs`, BAML v0.223.0) into native de-BAML, so native **claims** the conversions BAML would while preserving the no-over-claim union rule. Behavior stays gated behind the existing `BAML_REST_USE_DEBAML` path; the bamlfuzz differential drives `internal/debaml.Parse` directly as today.

### What's ported (all in `internal/debaml/coerce.go`)
- **Primitive int / float** — numeric-string preprocessing (`trim()` then `trim_end_matches(',')`, in that order), then `i64` / `u64`-wrap / `f64` / fraction / extracted-number regex, with **Rust-exact** casts:
  - `u64 → i64` two's-complement wrap (`u64::MAX → -1`)
  - `f64::round` half-away-from-zero, then **saturating** `float→i64` (NaN→0, out-of-range→`i64` bound)
  - the extracted-number regex **verbatim**: unanchored, exactly one match required, strip commas then `\p{Sc}` currency, percent **not** part of the match → `"50%" == 50.0` (not `0.5`, not `5050`)
- **Primitive bool** — casefold `"true"`/`"false"`, else `match_string` (substring); the matcher's own `SubstringMatch` flag is **dropped**, only `StringToBool` is added.
- **Primitive null** — any non-null value → `null` with `DefaultButHadValue`.
- **Literal int / bool** — primitive-coerce **then value-compare**; a value **mismatch** conservatively **falls back** (does not claim BAML's error/default choice). The single-key-object `ObjectToPrimitive` prelude is **not** copied (Mcoerce-d).
- **Primitive string stays strict** — non-string→string (`JsonToString`) remains Mcoerce-d and declines.

Every score-bearing conversion (`FloatToInt`, `StringToFloat`, `StringToBool`, `DefaultButHadValue`) flags the `coerceFlags` accumulator.

### M2c union revisit (ships here — load-bearing)
`coerceLiteralUnion` / `coerceFlatClassUnion` now count **lenient** successes through the updated coercers and **decline any union with ≥2 successes** (no `pick_best`), never emitting the old strict-chosen arm. The **nullable clean-only** rule declines a non-null arm carrying any Mcoerce-b flag (a scored win vs the null arm is M3): optional `int|null` claims `"123"` (clean direct parse) but falls back on `1.6` (`FloatToInt`) and on a string bool (`StringToBool`). A new over-claim guard fixture (disjoint class union where a numeric-string field makes a 2nd arm newly succeed) is pinned **fallback**.

### Tests
- Unit (`internal/debaml/*_test.go`): the full Rust `float_from_comma_separated` table, cast tests (u64 wrap / round-half-away / saturation), primitive/literal/union/nullable coercer tests. A handful of existing tests that asserted the old strict declines were updated to the new (BAML-parity) claims.
- Corpus: **25** new `parse_recovery` fixtures (17 claimed, 8 fallback), each pinned in `parseRecoveryNativeClaim`. **All `want` blocks captured live** via `BAMLFUZZ_PARSE_CAPTURE=1` — the two literal-mismatch fixtures captured as BAML **errors**, `"50%"`/`"20%"` captured as `50`/`20`.

### Differential result
`51 claimed / 24 fell back to BAML`, **0 failures, no cut-line drift**.

### Guarantees
- **Union revisit** ships in this PR (native never over-claims a multi-success union).
- **Nullable clean-only** rule enforced (flagged non-null arm declines).
- **No** seam / codegen-regen / embed-list / `go.mod` / `go.sum` changes. Scope: `internal/debaml/{coerce.go, parse.go (comments), *_test.go}`, `integration/bamlfuzz_parse_recovery_test.go`, and the corpus JSON only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded lenient parsing and recovery for primitive values, including numeric strings (trimming and trailing comma handling), fractions, currency-formatted numbers, and additional float spellings.
  * Improved boolean parsing with case-insensitive and substring-based matching, plus stronger nullable/optional “clean-only” behavior.

* **Bug Fixes**
  * Corrected literal/union/class-union/map claim vs fallback decisions to accept true matches and safely fall back on mismatches or over-claim cases.
  * Tightened rejection for unsupported “Go-only” float spellings and prevented invalid non-finite JSON-number outputs (e.g., hex/underscore/NaN/±Inf handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->