### PR TITLE
bamlfuzz: strict diff compares i64-boundary ints with integer precision (#558)

### DIFF
--- a/adapters/common/codegen/bamlfuzz/parse_diff.go
+++ b/adapters/common/codegen/bamlfuzz/parse_diff.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"sort"
 	"strings"
@@ -250,7 +251,17 @@ func strictDecodeAny(b json.RawMessage) (any, error) {
 	if err := dec.Decode(&v); err != nil {
 		return nil, err
 	}
-	if dec.More() {
+	// Require the decoder to be fully drained so trailing content is
+	// rejected exactly as json.Unmarshal rejects it. dec.More() is NOT a
+	// substitute: it reports false before a closing ']' or '}', so tokens
+	// like `1]` or `{}]` would slip through. A second Decode must return
+	// io.EOF; insignificant trailing whitespace is consumed and still
+	// yields io.EOF, while any further value or stray byte surfaces here.
+	var scratch json.RawMessage
+	if err := dec.Decode(&scratch); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return nil, err
+		}
 		return nil, fmt.Errorf("unexpected trailing JSON content after top-level value")
 	}
 	return v, nil

--- a/adapters/common/codegen/bamlfuzz/parse_diff.go
+++ b/adapters/common/codegen/bamlfuzz/parse_diff.go
@@ -1,10 +1,12 @@
 package bamlfuzz
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"sort"
 	"strings"
 )
@@ -211,17 +213,47 @@ func parseOutcome(name string, res ParseResult, err error) ParseOutcome {
 // leaking back into this comparator — the small duplication buys that
 // safety property.
 func SemanticDiffStrict(side string, a, b json.RawMessage) ([]SemanticDiffEntry, error) {
-	av, err := decodeAny(a)
+	av, err := strictDecodeAny(a)
 	if err != nil {
 		return nil, fmt.Errorf("decode a: %w", err)
 	}
-	bv, err := decodeAny(b)
+	bv, err := strictDecodeAny(b)
 	if err != nil {
 		return nil, fmt.Errorf("decode b: %w", err)
 	}
 	var out []SemanticDiffEntry
 	strictDiffAny(&out, side, "$", av, bv)
 	return out, nil
+}
+
+// strictDecodeAny decodes a JSON payload into the generic any-tree the
+// strict comparator walks, preserving every number as a json.Number
+// instead of collapsing it to float64. Keeping the exact integer token
+// lets strictDeepEqual distinguish i64::MAX (9223372036854775807) from
+// 9223372036854775808 — a one-off drift float64 rounds away. UseNumber
+// applies to the whole decode, so numbers nested inside objects and arrays
+// are preserved too.
+//
+// This is intentionally NOT the shared decodeAny from envelope.go: that
+// decoder feeds the lenient comparators, which switch on float64, and the
+// strict native-vs-BAML leg keeps its own recursion (see the note on
+// strictDiffAny / strictDeepEqual). Empty input is a hard decode error and
+// trailing content after the first value is rejected, both mirroring
+// decodeAny's json.Unmarshal contract.
+func strictDecodeAny(b json.RawMessage) (any, error) {
+	if len(b) == 0 {
+		return nil, fmt.Errorf("empty JSON payload")
+	}
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("unexpected trailing JSON content after top-level value")
+	}
+	return v, nil
 }
 
 // strictDiffAny appends path-level disagreements between `a` (reference)
@@ -274,7 +306,10 @@ func strictDiffAny(out *[]SemanticDiffEntry, side, path string, a, b any) {
 
 // strictDeepEqual is structural JSON equality modulo object key ordering
 // only — no null-key tolerance. Two objects are equal iff they carry the
-// identical key set and every value is strictDeepEqual.
+// identical key set and every value is strictDeepEqual. Numbers are
+// compared via numbersEqual: two integer tokens by arbitrary-precision
+// big.Int (so i64-boundary drift is not rounded away) and otherwise by
+// float64 value (so 50 and 50.0 still agree).
 func strictDeepEqual(a, b any) bool {
 	switch av := a.(type) {
 	case map[string]any:
@@ -300,9 +335,9 @@ func strictDeepEqual(a, b any) bool {
 			}
 		}
 		return true
-	case float64:
-		bv, ok := b.(float64)
-		return ok && av == bv
+	case json.Number:
+		bv, ok := b.(json.Number)
+		return ok && numbersEqual(av, bv)
 	case string:
 		bv, ok := b.(string)
 		return ok && av == bv
@@ -314,4 +349,41 @@ func strictDeepEqual(a, b any) bool {
 	default:
 		return false
 	}
+}
+
+// isIntegerToken reports whether a decoded JSON number's source token is an
+// integer literal — no fractional point and no exponent. The decision is
+// made on the token TEXT, never the value: 1e2 is a non-integer token even
+// though it denotes 100, and 9223372036854775808 is an integer token even
+// though float64 cannot represent it exactly.
+func isIntegerToken(n json.Number) bool {
+	return !strings.ContainsAny(string(n), ".eE")
+}
+
+// numbersEqual compares two decoded JSON numbers with integer precision at
+// the i64 boundary. When BOTH tokens are integer literals they are compared
+// as arbitrary-precision big.Int, so 9223372036854775807 (i64::MAX) and
+// 9223372036854775808 correctly differ instead of colliding at float64.
+// When EITHER token is non-integer (carries a '.', 'e', or 'E') the
+// comparison falls back to float64 value equality, preserving intended
+// equalities like 50 vs 50.0 and 100 vs 1e2.
+func numbersEqual(a, b json.Number) bool {
+	if isIntegerToken(a) && isIntegerToken(b) {
+		ai, aok := new(big.Int).SetString(string(a), 10)
+		bi, bok := new(big.Int).SetString(string(b), 10)
+		if aok && bok {
+			return ai.Cmp(bi) == 0
+		}
+		// A token we classified as an integer that big.Int nonetheless
+		// rejects is malformed for base 10; fall through to the float
+		// comparison rather than silently claiming equality.
+	}
+	af, aerr := a.Float64()
+	bf, berr := b.Float64()
+	if aerr != nil || berr != nil {
+		// Neither representation parsed as a float; require exact token
+		// equality so we never equate two values we cannot compare.
+		return string(a) == string(b)
+	}
+	return af == bf
 }

--- a/adapters/common/codegen/bamlfuzz/parse_diff_test.go
+++ b/adapters/common/codegen/bamlfuzz/parse_diff_test.go
@@ -347,3 +347,40 @@ func TestDiffParsersIntBoundaryDrift(t *testing.T) {
 		t.Fatalf("expected diff at $.n, got %q", res.SemanticDiff[0].Path)
 	}
 }
+
+// TestStrictDecodeAnyRejectsTrailingContent guards the full-EOF check: the
+// strict decoder must reject any content after the top-level value, exactly
+// as json.Unmarshal does. A dec.More()-based guard WRONGLY accepts payloads
+// whose next byte is a closing bracket (More() reports false there), so
+// `1]`, `1}`, `{}]`, `[]}` are the regression cases; `1 2`, `{} {}`, and
+// `"a" "b"` (a genuine second value) must reject too.
+func TestStrictDecodeAnyRejectsTrailingContent(t *testing.T) {
+	bad := []string{`1]`, `1}`, `{}]`, `[]}`, `1 2`, `{} {}`, `"a" "b"`}
+	for _, in := range bad {
+		if _, err := strictDecodeAny(json.RawMessage(in)); err == nil {
+			t.Errorf("strictDecodeAny(%q): expected trailing-content error, got nil", in)
+		}
+	}
+}
+
+// TestStrictDecodeAnyAcceptsValidAndTrailingWhitespace confirms the EOF
+// check still admits a single valid value, including one followed only by
+// insignificant leading/trailing whitespace and newlines.
+func TestStrictDecodeAnyAcceptsValidAndTrailingWhitespace(t *testing.T) {
+	good := []string{`1`, `1.5`, `{"a":1}`, `[1,2,3]`, "1\n", "  {\"a\":1}  \n\t", `"x"`}
+	for _, in := range good {
+		if _, err := strictDecodeAny(json.RawMessage(in)); err != nil {
+			t.Errorf("strictDecodeAny(%q): expected success, got %v", in, err)
+		}
+	}
+}
+
+// TestSemanticDiffStrictRejectsTrailingGarbageInput exercises the guard
+// end-to-end: malformed input like `1]` must surface as a decode error
+// rather than being silently accepted and compared as its leading value
+// `1` (the finding's example, which the dec.More() guard let pass equal).
+func TestSemanticDiffStrictRejectsTrailingGarbageInput(t *testing.T) {
+	if _, err := SemanticDiffStrict("x", json.RawMessage(`1]`), json.RawMessage(`1`)); err == nil {
+		t.Fatalf("expected decode error for trailing-garbage side, got nil")
+	}
+}

--- a/adapters/common/codegen/bamlfuzz/parse_diff_test.go
+++ b/adapters/common/codegen/bamlfuzz/parse_diff_test.go
@@ -251,3 +251,99 @@ func TestRegisterNativeParserRoundTrip(t *testing.T) {
 		t.Fatalf("nil registration should install NoopParser, got %T", RegisteredNativeParser())
 	}
 }
+
+// TestSemanticDiffStrictIntBoundaryDiffers pins the fix for #558: i64::MAX
+// and i64::MAX+1 collapse to the same float64, so the old decodeAny path
+// masked the drift. With json.Number + big.Int the strict comparator must
+// flag it. This test FAILS pre-fix (no diff) and PASSES post-fix.
+func TestSemanticDiffStrictIntBoundaryDiffers(t *testing.T) {
+	a := json.RawMessage(`9223372036854775807`)
+	b := json.RawMessage(`9223372036854775808`)
+	diff, err := SemanticDiffStrict("t", a, b)
+	if err != nil {
+		t.Fatalf("unexpected decode error: %v", err)
+	}
+	if len(diff) != 1 {
+		t.Fatalf("expected exactly one boundary-int diff, got %d: %+v", len(diff), diff)
+	}
+	if diff[0].Path != "$" {
+		t.Fatalf("expected diff at top-level path $, got %q", diff[0].Path)
+	}
+}
+
+// TestSemanticDiffStrictLargeIntEqual guards against a false positive: the
+// same out-of-float64-range integer on both sides must still compare equal
+// via big.Int, producing no diff.
+func TestSemanticDiffStrictLargeIntEqual(t *testing.T) {
+	a := json.RawMessage(`9223372036854775807`)
+	b := json.RawMessage(`9223372036854775807`)
+	diff, err := SemanticDiffStrict("t", a, b)
+	if err != nil {
+		t.Fatalf("unexpected decode error: %v", err)
+	}
+	if len(diff) != 0 {
+		t.Fatalf("identical large ints must be equal, got %+v", diff)
+	}
+}
+
+// TestSemanticDiffStrictNumberEquality covers the non-integer fallback: a
+// token carrying '.', 'e', or 'E' keeps float64 value comparison, so 50 vs
+// 50.0 and 100 vs 1e2 stay equal while genuinely different numbers diff.
+func TestSemanticDiffStrictNumberEquality(t *testing.T) {
+	cases := []struct {
+		name   string
+		a, b   string
+		wantEq bool
+	}{
+		{"int_vs_decimal", `50`, `50.0`, true},
+		{"int_vs_exponent", `100`, `1e2`, true},
+		{"decimal_vs_exponent", `100.0`, `1e2`, true},
+		{"distinct_small_ints", `50`, `51`, false},
+		{"decimal_mismatch", `50.5`, `50.6`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diff, err := SemanticDiffStrict("t", json.RawMessage(tc.a), json.RawMessage(tc.b))
+			if err != nil {
+				t.Fatalf("unexpected decode error: %v", err)
+			}
+			gotEq := len(diff) == 0
+			if gotEq != tc.wantEq {
+				t.Fatalf("%s vs %s: wantEqual=%v gotEqual=%v (diff %+v)", tc.a, tc.b, tc.wantEq, gotEq, diff)
+			}
+		})
+	}
+}
+
+// TestSemanticDiffStrictNestedIntBoundaryPath verifies boundary-int drift
+// buried under an object key and an array index is reported at the precise
+// nested path, so path-level diff output stays correct with json.Number.
+func TestSemanticDiffStrictNestedIntBoundaryPath(t *testing.T) {
+	a := json.RawMessage(`{"outer":{"vals":[1,9223372036854775807]}}`)
+	b := json.RawMessage(`{"outer":{"vals":[1,9223372036854775808]}}`)
+	diff, err := SemanticDiffStrict("t", a, b)
+	if err != nil {
+		t.Fatalf("unexpected decode error: %v", err)
+	}
+	if len(diff) != 1 {
+		t.Fatalf("expected one nested boundary diff, got %d: %+v", len(diff), diff)
+	}
+	if diff[0].Path != "$.outer.vals[1]" {
+		t.Fatalf("expected diff path $.outer.vals[1], got %q", diff[0].Path)
+	}
+}
+
+// TestDiffParsersIntBoundaryDrift exercises the fix end-to-end: a
+// boundary-int drift between BAML and native output is now a real semantic
+// failure rather than a masked pass.
+func TestDiffParsersIntBoundaryDrift(t *testing.T) {
+	baml := fakeParser{name: "baml", json: json.RawMessage(`{"n":9223372036854775807}`)}
+	native := fakeParser{name: "native", json: json.RawMessage(`{"n":9223372036854775808}`)}
+	res := DiffParsers(context.Background(), baml, native, ParseRequest{Raw: "x"}, nil)
+	if len(res.SemanticDiff) == 0 || len(res.Failures) == 0 {
+		t.Fatalf("boundary-int drift must fail the differential, got %+v", res)
+	}
+	if res.SemanticDiff[0].Path != "$.n" {
+		t.Fatalf("expected diff at $.n, got %q", res.SemanticDiff[0].Path)
+	}
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Summary

Fixes #558. Test-infra hardening of the bamlfuzz parse-recovery differential comparator (`adapters/common/codegen/bamlfuzz/parse_diff.go`). No de-BAML behavior change.

`SemanticDiffStrict` decoded JSON via `decodeAny` → `json.Unmarshal` into `any`, so JSON numbers became `float64` and `strictDeepEqual` compared them as `float64`. That masked one-off integer drift at the i64 boundary: `9223372036854775807` (i64::MAX) and `9223372036854775808` round to the same `float64` and compared **EQUAL**, so a boundary-size integer divergence between BAML and native output would pass silently.

## Fix

- Add `strictDecodeAny`, a `parse_diff.go`-local decoder using `json.Decoder` with `UseNumber()`, preserving `json.Number` through nested objects/arrays. The shared `decodeAny` in `envelope.go` is **left untouched** so the lenient comparators keep their `float64` semantics (they switch on `float64`), preserving the deliberate strict/lenient recursion split.
- `strictDeepEqual` now compares numbers via `numbersEqual`:
  - **both tokens integer** (text has no `.`/`e`/`E`) → compare as `big.Int`, so `9223372036854775807` ≠ `9223372036854775808`;
  - **either token non-integer** → fall back to `float64` value equality, so `50` vs `50.0` and `100` vs `1e2` stay equal.
  - Integer-ness is decided by the `json.Number` **token text**, never the value.
- Empty-input and trailing-content decode errors mirror the previous `json.Unmarshal` contract; all other comparator semantics (success/error parity, schema-order/path diff output, string/bool/null handling) are unchanged.

## Tests (same package)

- `TestSemanticDiffStrictIntBoundaryDiffers` — `9223372036854775807` vs `...808` now produces a DIFF (previously masked); **fails pre-fix, passes post-fix**.
- `TestSemanticDiffStrictLargeIntEqual` — identical large int both sides stays EQUAL.
- `TestSemanticDiffStrictNumberEquality` — `50` vs `50.0`, `100` vs `1e2`, `100.0` vs `1e2` EQUAL; `50` vs `51`, `50.5` vs `50.6` DIFF.
- `TestSemanticDiffStrictNestedIntBoundaryPath` — boundary drift under `$.outer.vals[1]` reports the precise nested path.
- `TestDiffParsersIntBoundaryDrift` — end-to-end through `DiffParsers`, boundary drift at `$.n` is a real failure.

## Validation

- `gofmt` clean.
- From `adapters/common`: `GOWORK=off go test ./codegen/...` and `GOWORK=off go vet ./codegen/...` pass.
- Broader `go build ./...` passes.
- Only `parse_diff.go` + `parse_diff_test.go` changed — no `internal`/`debaml` or other module touched.

Related: epic #546. Source: #557 review CR-B4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved strict JSON comparison to accurately handle very large integers at 64-bit boundaries without rounding.
  * Tightened strict diff behavior to reject empty inputs and any trailing non-whitespace content.
  * Enhanced numeric matching to treat equivalent numeric formats consistently, while still flagging real value differences.
  * Added more coverage to ensure nested mismatches are correctly detected and reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->