### PR TITLE
debaml: native list collection coercion + partials (Mcoerce-c, lists)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/100_union_list_partial_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/100_union_list_partial_stays_fallback.json
@@ -1,0 +1,32 @@
+{
+  "name": "union_list_partial_stays_fallback",
+  "description": "Mcoerce-c FALLBACK: union (int | list<int>) with a partial array [1, 'bad', 2]. The list arm now leniently succeeds ([1,2] after an ArrayItemParseError skip), but the int arm can also succeed via coerce_array_to_singular, so BAML runs scored pick_best (M3). A union with a list arm is not an M2c safe family, so native declines at the gate and never over-claims the partial list. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "int"},
+                {"kind": "list", "inner": {"kind": "int"}}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":[1,\"bad\",2]}",
+  "want": {
+    "status": "success",
+    "json": {"u": [1, 2]}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/92_list_singleton_int_success.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/92_list_singleton_int_success.json
@@ -1,0 +1,22 @@
+{
+  "name": "list_singleton_int_success",
+  "description": "Mcoerce-c CLAIMED: list<int> field, non-array numeric-string input '123'. BAML wraps it as a single implied element (SingleToArray) and coerces it to 123 -> [123]. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "list", "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"123\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": [123]}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/93_list_singleton_bad_int_empty.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/93_list_singleton_bad_int_empty.json
@@ -1,0 +1,22 @@
+{
+  "name": "list_singleton_bad_int_empty",
+  "description": "Mcoerce-c CLAIMED: list<int> field, non-array unparseable string 'bad'. BAML wraps it (SingleToArray), the inner int coercion errors (ArrayItemParseError(0)), and the list still SUCCEEDS as the EMPTY list []. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "list", "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"bad\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": []}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/94_list_array_partial_bad_int.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/94_list_array_partial_bad_int.json
@@ -1,0 +1,22 @@
+{
+  "name": "list_array_partial_bad_int",
+  "description": "Mcoerce-c CLAIMED: list<int> field, array with good values around one unparseable value ['1', 2, 'bad', 4]. BAML drops 'bad' (ArrayItemParseError) and keeps the rest in accepted order -> [1, 2, 4]. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "list", "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":[\"1\",2,\"bad\",4]}",
+  "want": {
+    "status": "success",
+    "json": {"u": [1, 2, 4]}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/95_list_array_lenient_elements_kept.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/95_list_array_lenient_elements_kept.json
@@ -1,0 +1,22 @@
+{
+  "name": "list_array_lenient_elements_kept",
+  "description": "Mcoerce-c CLAIMED: list<int> field with Mcoerce-b lenient elements ['1', 2.6, '3/2'] — numeric string, float->int round (half-away), and a fraction — all KEPT inside the list -> [1, 3, 2]. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "list", "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":[\"1\",2.6,\"3/2\"]}",
+  "want": {
+    "status": "success",
+    "json": {"u": [1, 3, 2]}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/96_list_string_non_string_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/96_list_string_non_string_stays_fallback.json
@@ -1,0 +1,22 @@
+{
+  "name": "list_string_non_string_stays_fallback",
+  "description": "Mcoerce-c FALLBACK: list<string> with a numeric element ['a', 2]. BAML stringifies 2 -> '2' (JsonToString), which is Mcoerce-d, so native cannot PROVE the element is a parse error and declines the whole list rather than skip an item BAML keeps. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "list", "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":[\"a\",2]}",
+  "want": {
+    "status": "success",
+    "json": {"u": ["a", "2"]}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/97_list_class_non_object_partial.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/97_list_class_non_object_partial.json
@@ -1,0 +1,28 @@
+{
+  "name": "list_class_non_object_partial",
+  "description": "Mcoerce-c CLAIMED: list<Pair> where Pair is a multi-field all-required-flat-leaf class and one array item is a scalar [5, {a,b}]. A scalar cannot fill Pair's required fields (no default_value), so BAML errors (error_missing_required_field) and drops it (ArrayItemParseError), keeping the valid object -> [{a,b}]. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "items", "type": {"kind": "list", "inner": {"kind": "class_ref", "ref": "Pair"}}}
+        ]
+      },
+      {
+        "name": "Pair",
+        "properties": [
+          {"name": "a", "type": {"kind": "string"}},
+          {"name": "b", "type": {"kind": "string"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"items\":[5,{\"a\":\"x\",\"b\":\"y\"}]}",
+  "want": {
+    "status": "success",
+    "json": {"items": [{"a": "x", "b": "y"}]}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/98_nullable_optional_list_singleton_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/98_nullable_optional_list_singleton_stays_fallback.json
@@ -1,0 +1,22 @@
+{
+  "name": "nullable_optional_list_singleton_stays_fallback",
+  "description": "Mcoerce-c FALLBACK: optional list<int> (list<int> | null) with a non-array singleton '123'. The non-null list arm succeeds via SingleToArray, which is SCORE-BEARING (score 1), so BAML scores it against the null arm (DefaultButHadValue=110). Native's nullable clean-only rule declines a flagged non-null arm (scoring is M3). want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "optional", "inner": {"kind": "list", "inner": {"kind": "int"}}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":\"123\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": [123]}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/99_nullable_optional_list_clean_array_claim.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/99_nullable_optional_list_clean_array_claim.json
@@ -1,0 +1,22 @@
+{
+  "name": "nullable_optional_list_clean_array_claim",
+  "description": "Mcoerce-c CLAIMED: optional list<int> (list<int> | null) with a CLEAN array input [1, 2]. The non-null list arm is a clean zero-score success, which trivially beats the null arm (DefaultButHadValue=110), so native claims it under the nullable clean-only rule -> [1, 2]. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "optional", "inner": {"kind": "list", "inner": {"kind": "int"}}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":[1,2]}",
+  "want": {
+    "status": "success",
+    "json": {"u": [1, 2]}
+  }
+}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -297,6 +297,27 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"float_nan_fraction_stays_fallback":       false,
 	"int_inf_stays_fallback":                  false,
 	"int_nan_stays_fallback":                  false,
+	// Mcoerce-c native LISTS (coerceList / coerce_array.rs): non-array
+	// SingleToArray wrapping, PARTIAL array skips of PROVEN-parse-error items,
+	// and empty-list-on-singleton-failure resolve byte-identical to BAML, so the
+	// deterministic collection claims are CLAIMED. A child native merely DECLINED
+	// (could be a DEFERRED Mcoerce-d success — JsonToString, etc.) is NOT skipped;
+	// native declines the whole list. The union revisit counts a list arm as a
+	// lenient success and, for nullable lists, keeps the clean-only rule: a
+	// SingleToArray/partial-skip/flagged-child list arm declines against the
+	// scored null arm.
+	"list_singleton_int_success":               true,
+	"list_singleton_bad_int_empty":             true,
+	"list_array_partial_bad_int":               true,
+	"list_array_lenient_elements_kept":         true,
+	"list_class_non_object_partial":            true,
+	"nullable_optional_list_clean_array_claim": true,
+	// Mcoerce-c LIST fallback set: a list<string> non-string element defers to
+	// JsonToString (Mcoerce-d); a nullable list arm flagged by SingleToArray is
+	// score-bearing (M3 vs null); a union with a list arm can force pick_best.
+	"list_string_non_string_stays_fallback":           false,
+	"nullable_optional_list_singleton_stays_fallback": false,
+	"union_list_partial_stays_fallback":               false,
 }
 
 // parseRecoveryStats tallies how many final-parse cases the native parser

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -79,12 +79,16 @@ func (f *coerceFlags) isUncertain() bool { return f != nil && f.uncertain }
 // match_string), and non-null→null defaulting — plus int/bool LITERALS by
 // primitive-coerce-then-compare. Each score-bearing conversion (FloatToInt,
 // StringToFloat, StringToBool, DefaultButHadValue) flags the coerceFlags
-// accumulator so the nullable-union clean-only rule holds. The remaining
-// leniencies stay STRICT and DECLINE: non-string stringification (ObjectToString
-// / JsonToString), single-key-object ObjectToPrimitive literal extraction,
-// single-to-array wrapping, single-field implied-key / inferred-object
-// absorption, partial list/map skips, and class default-fill — all deferred to
-// Mcoerce-c/d. Where native's coercion fails but BAML may leniently SUCCEED (or
+// accumulator so the nullable-union clean-only rule holds. Mcoerce-c adds native
+// LIST parity (coerceList / coerceArray.rs): non-array SINGLE-TO-ARRAY wrapping,
+// PARTIAL array skips of PROVEN-parse-error items, and empty-list-on-singleton-
+// failure — each score-bearing (SingleToArray, ArrayItemParseError, child flags)
+// so the nullable-union clean-only rule still holds. The remaining leniencies stay
+// STRICT and DECLINE: non-string stringification (ObjectToString / JsonToString),
+// single-key-object ObjectToPrimitive literal extraction, single-field implied-key
+// / inferred-object absorption, PARTIAL MAP skips, and class default-fill — all
+// deferred to Mcoerce-c(maps)/d. Where native's coercion fails but BAML may
+// leniently SUCCEED (or
 // null-default) — or where native cannot determine BAML's exact success/failure
 // — coercion DECLINES (ErrDeBAMLParseUnsupported → fall back to BAML), so native
 // is never "more capable" than BAML.
@@ -814,41 +818,314 @@ func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input
 	return buf.Bytes(), nil
 }
 
+// coerceList coerces a value into a list, porting BAML's coerce_array
+// (coerce_array.rs) so native reproduces BAML's PARTIAL-list result byte-for-byte.
+// A list coercion always SUCCEEDS: child failures fold into list-level flags, not
+// a list error.
+//
+//   - ARRAY input: each element is coerced in input order. A KEPT child's coerced
+//     output is appended in accepted order; a child that is a PROVEN BAML parse
+//     error (provenListItemError) is DROPPED — BAML records ArrayItemParseError(i)
+//     and continues — so an all-bad array becomes [] and [good,bad,good] becomes
+//     [good,good].
+//   - NON-ARRAY input: BAML wraps the value as a single implied element
+//     (SingleToArray). A successful inner coercion yields [child]; a PROVEN inner
+//     parse error yields an EMPTY list (SingleToArray + ArrayItemParseError(0)),
+//     NOT a parse failure.
+//
+// THE CRUX (over-claim guard): a child failure is SKIPPED only when it is a
+// PROVEN BAML parse error for that exact child target+input. A child native
+// merely DECLINED (an ErrDeBAMLParseUnsupported that is NOT a proven error) may be
+// a DEFERRED Mcoerce-d SUCCESS (e.g. list<string> with a number → JsonToString),
+// so native DECLINES THE WHOLE LIST there rather than skip an item BAML would
+// keep. A case-fold-uncertain child likewise declines the whole list. A
+// HARD/invariant child error propagates unchanged. See coerceListChild /
+// provenListItemError for the exact safe-skip vs must-decline split.
+//
+// Score-bearing flags (SingleToArray, each ArrayItemParseError skip, and a kept
+// child's own flags) are threaded into cf so the nullable-union clean-only rule
+// (coerceUnionSafe) sees a flagged list arm and declines it against the scored
+// null arm — Mcoerce-c does not score collection arms against null.
 func coerceList(b *schema.Bundle, elem *schema.Type, input value, cf *coerceFlags) (json.RawMessage, error) {
 	if elem == nil {
 		return nil, fmt.Errorf("debaml: list type missing element")
 	}
-	if input.kind != valArray {
-		// BAML wraps a non-array value into a one-element array; native is
-		// stricter, so decline rather than claim a mismatch BAML would not
-		// produce.
-		return nil, declineCoerce("list target", input)
-	}
 	var buf bytes.Buffer
 	buf.WriteByte('[')
-	for i := range input.arrV {
-		// A clean array adds no list-level flag; element flags (e.g. a
-		// substring enum) propagate through cf so a nullable list arm can
-		// require all elements clean.
-		child, err := coerce(b, *elem, input.arrV[i], cf)
+
+	if input.kind != valArray {
+		// Non-array → BAML wraps it as one implied element (SingleToArray, score 1).
+		cf.flag()
+		out, keep, err := coerceListChild(b, *elem, input, cf)
 		if err != nil {
-			if !declinableChildError(err) {
-				return nil, err // hard/invariant failure: propagate, never mask.
-			}
-			// A bad element (decline sentinel or value-verdict mismatch): BAML
-			// records ArrayItemParseError and SKIPS it, returning a partial list
-			// that still succeeds — native cannot reproduce that partial result,
-			// so it DECLINES the whole list rather than claim a list error where
-			// BAML would just drop the element. Partial-list parity is Mcoerce-c.
-			return nil, unsupported(fmt.Sprintf("list element %d: %v (BAML skips bad items via ArrayItemParseError)", i, err))
+			return nil, err
 		}
-		if i > 0 {
+		if keep {
+			buf.Write(out)
+		} else {
+			// The implied element is a proven parse error → ArrayItemParseError(0):
+			// the list is the EMPTY list, which still SUCCEEDS.
+			cf.flag()
+		}
+		buf.WriteByte(']')
+		return buf.Bytes(), nil
+	}
+
+	first := true
+	for i := range input.arrV {
+		out, keep, err := coerceListChild(b, *elem, input.arrV[i], cf)
+		if err != nil {
+			return nil, err
+		}
+		if !keep {
+			// Proven BAML parse error → ArrayItemParseError(i) (score 1+i): SKIP.
+			cf.flag()
+			continue
+		}
+		if !first {
 			buf.WriteByte(',')
 		}
-		buf.Write(child)
+		first = false
+		buf.Write(out)
 	}
 	buf.WriteByte(']')
 	return buf.Bytes(), nil
+}
+
+// coerceListChild coerces one list element (array item or implied singleton).
+// It returns exactly one of:
+//
+//   - (out, true, nil):  the child coerced; append out (its flags merged into cf).
+//   - (nil, false, nil): the child is a PROVEN BAML parse error; the caller SKIPS
+//     it (BAML records ArrayItemParseError and the list still succeeds).
+//   - (nil, false, err): the whole list must FAIL — err is either a HARD/invariant
+//     error to propagate, or an ErrDeBAMLParseUnsupported DECLINE because the
+//     child could be a DEFERRED Mcoerce-d success or its match verdict was
+//     case-fold-uncertain, so native falls back rather than skip an item BAML
+//     might keep.
+func coerceListChild(b *schema.Bundle, elem schema.Type, item value, cf *coerceFlags) (json.RawMessage, bool, error) {
+	childF := &coerceFlags{}
+	out, err := coerce(b, elem, item, childF)
+	if err == nil {
+		// Kept: the child value's own flags count toward the list arm's score
+		// (types.rs List score = own flags + sum of child scores), so propagate
+		// them so an enclosing nullable optional sees a non-clean list arm.
+		if childF.isFlagged() {
+			cf.flag()
+		}
+		if childF.isUncertain() {
+			cf.markUncertain()
+		}
+		return out, true, nil
+	}
+	if !declinableChildError(err) {
+		return nil, false, err // hard/invariant failure: propagate, never mask.
+	}
+	if childF.isUncertain() {
+		// The child's match verdict hinged on a non-ASCII case fold native cannot
+		// prove equals BAML — it might MATCH (BAML keeps) or MISS (BAML skips), and
+		// native cannot tell which, so DECLINE the whole list.
+		cf.markUncertain()
+		return nil, false, unsupported(fmt.Sprintf("list element %s→%s: non-ASCII case-fold uncertainty (cannot prove skip vs keep)", item.kind, elem.Kind))
+	}
+	if provenListItemError(b, elem, item) {
+		return nil, false, nil // PROVEN parse error → BAML skips via ArrayItemParseError.
+	}
+	// A declinable error that is NOT a proven parse error: BAML may still SUCCEED
+	// via a deferred Mcoerce-d path (JsonToString / ObjectToString /
+	// ObjectToPrimitive / implied-key / default-fill / array-to-singular / union
+	// scoring), so native cannot skip it — DECLINE the whole list (fall back).
+	return nil, false, unsupported(fmt.Sprintf("list element %s→%s: child declined but not a proven BAML parse error (deferred Mcoerce-d success possible): %v", item.kind, elem.Kind, err))
+}
+
+// provenListItemError reports whether BAML PROVABLY errors coercing item to the
+// list element type elem — the ONLY case where BAML records ArrayItemParseError
+// and drops the item, so native may skip it. It is a WHITELIST called ONLY after
+// native's own coercion FAILED with a declinable error AND was not case-fold-
+// uncertain, so for match_string-based targets (bool/enum/string-literal from a
+// STRING) a native failure already equals a BAML failure. For NUMERIC targets
+// native is STRICTER than BAML (inf/overflow/hex/underscore), so a string is
+// proven only when BAML's own parse strategies are re-checked
+// (bamlStringNumberFails); an input kind BAML rejects with error_unexpected_type
+// is proven; an ARRAY defers to coerce_array_to_singular (pick_best, M3) and a
+// class/map/union child (or object into a numeric/literal target) defers to
+// Mcoerce-d, so those are NOT proven and DECLINE the whole list.
+func provenListItemError(b *schema.Bundle, elem schema.Type, item value) bool {
+	switch elem.Kind {
+	case schema.TypePrimitive:
+		switch elem.Primitive {
+		case schema.PrimitiveInt, schema.PrimitiveFloat:
+			switch item.kind {
+			case valString:
+				return bamlStringNumberFails(item.strV)
+			case valObject, valBool, valNull:
+				return true // BAML coerce_int/coerce_float: error_unexpected_type.
+			default:
+				// valNumber: BAML always coerces a number; valArray:
+				// coerce_array_to_singular (pick_best, M3) — both DEFERRED.
+				return false
+			}
+		case schema.PrimitiveBool:
+			switch item.kind {
+			case valString:
+				// Reached only after a native bool coercion FAILED and was NOT
+				// case-fold-uncertain: a certain casefold + match_string miss/tie,
+				// which BAML's coerce_bool turns into error_unexpected_type.
+				return true
+			case valObject, valNumber, valNull:
+				return true // error_unexpected_type (BAML never coerces number→bool).
+			default:
+				return false // valBool: success; valArray: array-to-singular (M3).
+			}
+		default:
+			// string / null targets: a native failure is a DEFERRED BAML SUCCESS
+			// (JsonToString for string; null defaults for any value), never proven.
+			return false
+		}
+	case schema.TypeEnum:
+		// A non-string enum input stringifies (ObjectToString, Mcoerce-d). A
+		// STRING native rejected (non-uncertain) is a certain match_string
+		// miss/tie, which coerce_enum turns into an error in a required
+		// list-element position.
+		return item.kind == valString
+	case schema.TypeLiteral:
+		// Only a STRING literal from a STRING is a proven match_string failure;
+		// int/bool literals (value mismatch / exhausted parse) and object/scalar
+		// extraction defer to Mcoerce-d.
+		return elem.Literal != nil && elem.Literal.Kind == schema.LiteralString && item.kind == valString
+	case schema.TypeClass:
+		// A multi-field class whose fields are ALL required flat leaves has no
+		// default_value for any field, so a genuine SCALAR input leaves every
+		// required field unfilled → BAML error_missing_required_field. An ARRAY
+		// element defers to coerce_array_to_singular (M3); a single-field class, or
+		// a class with any defaultable (list/map/optional) field, defers to
+		// Mcoerce-d — so those are NOT proven.
+		cls, ok := b.FindClass(elem.Name, elem.Mode)
+		if !ok {
+			return false
+		}
+		if !classAllRequiredFlatLeaf(cls) {
+			return false
+		}
+		switch item.kind {
+		case valString, valNumber, valBool, valNull:
+			return true
+		default:
+			return false // valObject: coerce succeeds/defers; valArray: M3.
+		}
+	default:
+		// map / list / union children: a map non-object, a nested list, or a
+		// union needing scoring are all DEFERRED, never proven parse errors.
+		return false
+	}
+}
+
+// classAllRequiredFlatLeaf reports whether cls is a multi-field class every field
+// of which is a REQUIRED flat leaf (primitive scalar / literal / enum — the
+// isFlatLeafField set, which excludes optionals, lists, maps, unions and nested
+// classes). Such a class has no field with a BAML default_value, so a genuine
+// SCALAR input can be neither absorbed (single-field implied-key needs len==1)
+// nor default-filled, guaranteeing a missing-required-field error — the only
+// class shape safe to treat as a proven list-item skip.
+func classAllRequiredFlatLeaf(cls *schema.ClassDef) bool {
+	if len(cls.Fields) < 2 {
+		return false
+	}
+	for i := range cls.Fields {
+		if !isFlatLeafField(cls.Fields[i].Type) {
+			return false
+		}
+	}
+	return true
+}
+
+// bamlStringNumberFails reports whether BAML's coerce_int / coerce_float STRING
+// path (coerce_primitive.rs) would DEFINITELY error on s — i.e. NONE of Rust's
+// strategies yields a number: i64, u64, f64 (INCLUDING inf/nan/overflow, which
+// Rust parses to a non-finite f64 BAML then saturates), a single fraction, or a
+// single extracted comma/currency number. Native's own numeric coercers are
+// STRICTER (they reject non-finite/overflow/underscore/hex), so a native failure
+// does NOT prove a BAML failure; only this Rust-faithful re-check does, and only
+// a TRUE result makes a bad numeric string a skippable list item. (A single-i64/
+// -u64 string is always f64-parseable, so rustF64Parseable subsumes all three.)
+func bamlStringNumberFails(s string) bool {
+	t := trimNumericString(s) // BAML: s.trim().trim_end_matches(',')
+	if rustF64Parseable(t) {
+		return false
+	}
+	if bamlFractionParses(t) {
+		return false
+	}
+	if bamlCommaNumberParses(t) {
+		return false
+	}
+	return true
+}
+
+// rustF64Parseable reports whether Rust's <str>::parse::<f64>() would return Ok
+// for s — the predicate BAML's numeric coercers use. It mirrors parseF64Rust's
+// REJECTIONS (digit-group underscores and hex-float syntax, which Go's ParseFloat
+// accepts but Rust does not) but, UNLIKE parseF64Rust, treats an OVERFLOW as a
+// parse SUCCESS: Rust returns Ok(±inf) for "1e400" while Go returns ErrRange, and
+// "inf"/"nan" parse to non-finite values both accept. Native's own coercers
+// DECLINE those non-finite results, but for classifying a list item native needs
+// BAML's verdict — and BAML SUCCEEDS (saturating) — so they must NOT count as
+// proven parse errors.
+func rustF64Parseable(s string) bool {
+	if s == "" {
+		return false
+	}
+	if strings.IndexByte(s, '_') >= 0 {
+		return false // Rust f64 parse rejects digit-group underscores.
+	}
+	t := s
+	if t[0] == '+' || t[0] == '-' {
+		t = t[1:]
+	}
+	if strings.HasPrefix(t, "0x") || strings.HasPrefix(t, "0X") {
+		return false // Rust f64 parse rejects hex-float syntax.
+	}
+	if _, err := strconv.ParseFloat(s, 64); err == nil {
+		return true
+	} else if errors.Is(err, strconv.ErrRange) {
+		return true // overflow → Rust yields Ok(±inf).
+	}
+	return false
+}
+
+// bamlFractionParses mirrors float_from_maybe_fraction (coerce_primitive.rs):
+// split on the FIRST '/', both trimmed sides parse as Rust f64, denominator
+// non-zero. (BAML then divides; the exact quotient is irrelevant here — a success
+// means BAML coerces the string, so it is NOT a proven error.)
+func bamlFractionParses(s string) bool {
+	i := strings.IndexByte(s, '/')
+	if i < 0 {
+		return false
+	}
+	num := strings.TrimSpace(s[:i])
+	den := strings.TrimSpace(s[i+1:])
+	if !rustF64Parseable(num) || !rustF64Parseable(den) {
+		return false
+	}
+	// denominator != 0.0 (BAML's guard). A den that overflows to ±inf is != 0.
+	d, err := strconv.ParseFloat(den, 64)
+	if err != nil && !errors.Is(err, strconv.ErrRange) {
+		return false
+	}
+	return d != 0.0
+}
+
+// bamlCommaNumberParses mirrors float_from_comma_separated (coerce_primitive.rs):
+// require EXACTLY one extracted-number regex match, strip its commas and Unicode
+// currency symbols, then parse the remainder as Rust f64.
+func bamlCommaNumberParses(s string) bool {
+	ms := extractedNumberRe.FindAllString(s, -1)
+	if len(ms) != 1 {
+		return false
+	}
+	withoutCommas := strings.ReplaceAll(ms[0], ",", "")
+	withoutCurrency := currencySymbolRe.ReplaceAllString(withoutCommas, "")
+	return rustF64Parseable(withoutCurrency)
 }
 
 // coerceMap coerces a JSON object into a map, emitting entries in INPUT key

--- a/internal/debaml/coerce_list_test.go
+++ b/internal/debaml/coerce_list_test.go
@@ -1,0 +1,271 @@
+package debaml
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// listIntSchema is a root class with one required list<int> field u.
+func listIntSchema() *bamlutils.DynamicOutputSchema {
+	return oneField(&bamlutils.DynamicProperty{
+		Type:  "list",
+		Items: &bamlutils.DynamicTypeSpec{Type: "int"},
+	})
+}
+
+// listStrSchema is a root class with one required list<string> field u.
+func listStrSchema() *bamlutils.DynamicOutputSchema {
+	return oneField(&bamlutils.DynamicProperty{
+		Type:  "list",
+		Items: &bamlutils.DynamicTypeSpec{Type: "string"},
+	})
+}
+
+// optionalListIntSchema is a root class with one optional list<int> field u
+// (a nullable single-arm union over list<int>).
+func optionalListIntSchema() *bamlutils.DynamicOutputSchema {
+	return oneField(&bamlutils.DynamicProperty{
+		Type:  "optional",
+		Inner: &bamlutils.DynamicTypeSpec{Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "int"}},
+	})
+}
+
+// listOfPairSchema is Root{ items: Pair[] }, Pair{ a: string, b: string } — a
+// multi-field, all-required-flat-leaf class, so a SCALAR element is a proven
+// missing-required-field error.
+func listOfPairSchema() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("items", &bamlutils.DynamicProperty{
+			Type:  "list",
+			Items: &bamlutils.DynamicTypeSpec{Ref: "Pair"},
+		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Pair", &bamlutils.DynamicClass{
+				Properties: props(kv("a", strProp()), kv("b", strProp())),
+			}),
+		),
+	}
+}
+
+// TestCoerceList_ArrayPartialSkip pins BAML coerce_array's partial-list result:
+// a PROVEN-parse-error element is dropped (ArrayItemParseError) while the list
+// still succeeds, keeping accepted items in accepted input order.
+func TestCoerceList_ArrayPartialSkip(t *testing.T) {
+	s := listIntSchema()
+	// "1"->1, 2.6->3 (round half-away), "bad" skipped, 4->4.
+	mustParse(t, s, `{"u":["1",2.6,"bad",4]}`, `{"u":[1,3,4]}`)
+	// All-bad array -> [].
+	mustParse(t, s, `{"u":["bad","nope",""]}`, `{"u":[]}`)
+	// Proven non-string item kinds BAML rejects with error_unexpected_type are
+	// also skipped: null, bool, object.
+	mustParse(t, s, `{"u":[1,null,2,true,3,{"x":1}]}`, `{"u":[1,2,3]}`)
+}
+
+// TestCoerceList_LenientElementsKept pins that Mcoerce-a/b leaf coercions run
+// inside a list and KEEP the item (numeric-string, float->int round, fraction,
+// extracted currency).
+func TestCoerceList_LenientElementsKept(t *testing.T) {
+	s := listIntSchema()
+	mustParse(t, s, `{"u":["1",2.6,"3/2","$1,234"]}`, `{"u":[1,3,2,1234]}`)
+}
+
+// TestCoerceList_SingletonWrap pins SingleToArray: a non-array input becomes a
+// one-element list on inner success, and an EMPTY list (not a parse failure) on
+// a proven inner parse error.
+func TestCoerceList_SingletonWrap(t *testing.T) {
+	s := listIntSchema()
+	mustParse(t, s, `{"u":"123"}`, `{"u":[123]}`) // inner success -> [123]
+	mustParse(t, s, `{"u":2.6}`, `{"u":[3]}`)     // number singleton rounds
+	mustParse(t, s, `{"u":"bad"}`, `{"u":[]}`)    // proven inner parse error -> []
+	mustParse(t, s, `{"u":true}`, `{"u":[]}`)     // bool->int proven error -> []
+}
+
+// TestCoerceList_StringElementDeferredDeclines pins the CRUX must-decline: a
+// list<string> child that native declines is a DEFERRED Mcoerce-d success
+// (JsonToString), NOT a proven parse error, so native declines the whole list.
+func TestCoerceList_StringElementDeferredDeclines(t *testing.T) {
+	s := listStrSchema()
+	mustParse(t, s, `{"u":["a","b"]}`, `{"u":["a","b"]}`) // clean claim
+	// Number element -> BAML JsonToString keeps it; native can't prove a parse
+	// error, so it declines the whole list rather than skip an item BAML keeps.
+	requireUnsupported(t, s, `{"u":["a",2]}`)
+	// Number singleton -> SingleToArray then JsonToString (Mcoerce-d) -> decline.
+	requireUnsupported(t, s, `{"u":5}`)
+	// String singleton coerces cleanly -> claim.
+	mustParse(t, s, `{"u":"x"}`, `{"u":["x"]}`)
+}
+
+// TestCoerceList_ClassScalarSkips pins that a multi-field flat class element
+// that is a genuine SCALAR is a proven missing-required-field error (skipped),
+// while an object element is kept, and an ARRAY element (coerce_array_to_singular
+// = pick_best, M3) makes native decline the whole list.
+func TestCoerceList_ClassScalarSkips(t *testing.T) {
+	s := listOfPairSchema()
+	// Scalar 5 skipped; the object is kept in schema order.
+	mustParse(t, s, `{"items":[5,{"a":"x","b":"y"}]}`, `{"items":[{"a":"x","b":"y"}]}`)
+	// Scalar-only -> [].
+	mustParse(t, s, `{"items":[5]}`, `{"items":[]}`)
+	// An ARRAY element defers to coerce_array_to_singular (M3) -> decline whole list.
+	requireUnsupported(t, s, `{"items":[["x","y"]]}`)
+}
+
+// TestCoerceList_NullableOptionalCleanOnly pins the union revisit for lists:
+// a list arm carrying score-bearing flags (SingleToArray / ArrayItemParseError /
+// child flags) declines against the scored null arm, while a CLEAN array claims.
+func TestCoerceList_NullableOptionalCleanOnly(t *testing.T) {
+	s := optionalListIntSchema()
+	// Clean array -> clean list arm (score 0) beats null (110) -> claim.
+	mustParse(t, s, `{"u":[1,2]}`, `{"u":[1,2]}`)
+	// JSON null -> the null fast path claims null.
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	// Singleton -> SingleToArray (score-bearing) -> decline (M3 scoring vs null).
+	requireUnsupported(t, s, `{"u":"123"}`)
+	// A kept-but-flagged element (2.6 -> FloatToInt) makes the arm non-clean -> decline.
+	requireUnsupported(t, s, `{"u":[2.6]}`)
+	// A partial skip (ArrayItemParseError) makes the arm non-clean -> decline.
+	requireUnsupported(t, s, `{"u":[1,"bad"]}`)
+}
+
+// TestProvenListItemError_Primitives pins the child-error classifier for
+// primitive element targets — the load-bearing safe-skip vs must-decline split.
+// The bundle is unused for non-class targets, so it is nil here.
+func TestProvenListItemError_Primitives(t *testing.T) {
+	intT := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt}
+	floatT := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveFloat}
+	boolT := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveBool}
+	strT := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveString}
+	enumT := schema.Type{Kind: schema.TypeEnum, Name: "E"}
+	litStrT := schema.Type{Kind: schema.TypeLiteral, Literal: &schema.LiteralValue{Kind: schema.LiteralString, String: "A"}}
+	litIntT := schema.Type{Kind: schema.TypeLiteral, Literal: &schema.LiteralValue{Kind: schema.LiteralInt, Int: 1}}
+
+	str := func(s string) value { return value{kind: valString, strV: s} }
+	num := func(s string) value { return value{kind: valNumber, numV: json.Number(s)} }
+	obj := value{kind: valObject}
+	arr := value{kind: valArray}
+	null := value{kind: valNull}
+	boolV := value{kind: valBool, boolV: true}
+
+	cases := []struct {
+		name string
+		elem schema.Type
+		item value
+		want bool
+	}{
+		// int/float + unparseable string -> proven.
+		{"int-bad-string", intT, str("bad"), true},
+		{"int-empty-string", intT, str(""), true},
+		{"float-bad-string", floatT, str("nope"), true},
+		// int/float + string BAML coerces (inf/overflow/fraction/comma) -> NOT proven.
+		{"int-inf-string", intT, str("inf"), false},
+		{"int-overflow-string", intT, str("1e400"), false},
+		{"int-fraction-string", intT, str("3/2"), false},
+		{"int-currency-string", intT, str("$1,234"), false},
+		{"float-hex-string-proven", floatT, str("0x1p4"), true}, // Rust rejects hex; no number extracted
+		// int/float + kinds BAML rejects with error_unexpected_type -> proven.
+		{"int-object", intT, obj, true},
+		{"int-bool", intT, boolV, true},
+		{"int-null", intT, null, true},
+		// int + array -> coerce_array_to_singular (M3) -> NOT proven.
+		{"int-array", intT, arr, false},
+		// int + number -> BAML always coerces -> NOT proven.
+		{"int-number", intT, num("5"), false},
+		// bool: a string is reached only after a certain match miss -> proven;
+		// object/number/null error_unexpected_type -> proven; array M3 -> not.
+		{"bool-string", boolT, str("nope"), true},
+		{"bool-number", boolT, num("1"), true},
+		{"bool-null", boolT, null, true},
+		{"bool-array", boolT, arr, false},
+		// string target: never proven (JsonToString / clean string success).
+		{"string-number", strT, num("5"), false},
+		{"string-object", strT, obj, false},
+		// enum: only a string is a proven match miss; non-string stringifies.
+		{"enum-string", enumT, str("zzz"), true},
+		{"enum-object", enumT, obj, false},
+		// literal: only a string literal from a string is proven.
+		{"litstr-string", litStrT, str("zzz"), true},
+		{"litstr-number", litStrT, num("5"), false},
+		{"litint-string", litIntT, str("bad"), false}, // int literal defers to Mcoerce-d
+	}
+	for _, c := range cases {
+		if got := provenListItemError(nil, c.elem, c.item); got != c.want {
+			t.Errorf("%s: provenListItemError = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestProvenListItemError_Class pins the class branch: a genuine scalar into a
+// multi-field flat class is proven, an object/array element is not (object may
+// coerce/defer, array is coerce_array_to_singular = M3).
+func TestProvenListItemError_Class(t *testing.T) {
+	b, err := schema.FromDynamicOutputSchema(listOfPairSchema(), schema.BuildOptions{})
+	if err != nil {
+		t.Fatalf("build bundle: %v", err)
+	}
+	var pair schema.Type
+	for i := range b.Classes {
+		if len(b.Classes[i].Fields) == 2 { // Pair (Root's "items" field is len 1)
+			pair = schema.Type{Kind: schema.TypeClass, Name: b.Classes[i].Name.Name, Mode: b.Classes[i].Mode}
+		}
+	}
+	if pair.Name == "" {
+		t.Fatal("Pair class not found in bundle")
+	}
+	cases := []struct {
+		name string
+		item value
+		want bool
+	}{
+		{"scalar-number", value{kind: valNumber, numV: json.Number("5")}, true},
+		{"scalar-string", value{kind: valString, strV: "x"}, true},
+		{"scalar-bool", value{kind: valBool, boolV: true}, true},
+		{"scalar-null", value{kind: valNull}, true},
+		{"object", value{kind: valObject}, false}, // object coerces/defers, not proven here
+		{"array", value{kind: valArray}, false},   // coerce_array_to_singular (M3)
+	}
+	for _, c := range cases {
+		if got := provenListItemError(b, pair, c.item); got != c.want {
+			t.Errorf("%s: provenListItemError(class) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestBamlStringNumberFails pins the Rust-faithful numeric-string re-check: it is
+// TRUE only when BAML's coerce_int/coerce_float string path would DEFINITELY
+// error (no i64/u64/f64 incl. inf/nan/overflow, no fraction, no single extracted
+// number), so a bad numeric string can be skipped without over-claiming the
+// inf/overflow/hex cases BAML coerces.
+func TestBamlStringNumberFails(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		// Genuine failures.
+		{"bad", true},
+		{"", true},
+		{"   ", true},
+		{"abc def", true},
+		{"0x1p4", true},   // hex: Rust rejects f64; regex splits into 3 numbers
+		{"1_000", true},   // underscore: Rust rejects f64; regex splits into 2 numbers
+		{"3/0", true},     // fraction denom 0; regex 2 numbers
+		{"1 and 2", true}, // 2 extracted numbers
+		// BAML coerces these -> NOT a failure.
+		{"123", false},
+		{" 123, ", false}, // trim + trailing-comma trim
+		{"inf", false},    // Rust f64 inf
+		{"nan", false},    // Rust f64 nan
+		{"1e400", false},  // overflow -> Rust Ok(inf)
+		{"3/2", false},    // fraction
+		{"$1,234", false}, // extracted currency
+		{"50%", false},    // single extracted number
+		{"The answer is 10,000", false},
+		{"12,111,123,", false},
+	}
+	for _, c := range cases {
+		if got := bamlStringNumberFails(c.in); got != c.want {
+			t.Errorf("bamlStringNumberFails(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/debaml/coerce_test.go
+++ b/internal/debaml/coerce_test.go
@@ -179,17 +179,21 @@ func TestMatchMapKeyUncertaintyMarksFlags(t *testing.T) {
 	}
 }
 
-// TestWrapperDeclinesValueVerdict confirms the no-regression side of CR1: a
-// VALUE-verdict child error (here typeMismatch — a scalar where a multi-field
-// class is required) still makes the wrapper DECLINE (fall back), so BAML's
-// partial-list behavior is deferred, not claimed.
+// TestWrapperDeclinesValueVerdict confirms the no-regression side of CR1 for the
+// wrapper that STILL declines on a value-verdict child: coerceMap (partial maps
+// are deferred to the Mcoerce-c maps follow-up). A non-object map VALUE where a
+// multi-field class is required makes coerceClass return typeMismatch
+// (value-verdict), and coerceMap declines the whole map rather than skip the
+// entry. (coerceList, by contrast, now SKIPS such a proven parse error — see
+// coerce_list_test.go's TestCoerceList_ClassScalarSkips.)
 func TestWrapperDeclinesValueVerdict(t *testing.T) {
-	// Root{ items: Pair[] }, Pair{ a, b }. A non-object list element makes
-	// coerceClass return typeMismatch (value-verdict) -> coerceList declines.
+	// Root{ items: map<string, Pair> }, Pair{ a, b }. A non-object map value
+	// makes coerceClass return typeMismatch (value-verdict) -> coerceMap declines.
 	s := &bamlutils.DynamicOutputSchema{
 		Properties: props(kv("items", &bamlutils.DynamicProperty{
-			Type:  "list",
-			Items: &bamlutils.DynamicTypeSpec{Ref: "Pair"},
+			Type:   "map",
+			Keys:   &bamlutils.DynamicTypeSpec{Type: "string"},
+			Values: &bamlutils.DynamicTypeSpec{Ref: "Pair"},
 		})),
 		Classes: bamlutils.MustOrderedMap(
 			bamlutils.OrderedKV("Pair", &bamlutils.DynamicClass{
@@ -197,5 +201,5 @@ func TestWrapperDeclinesValueVerdict(t *testing.T) {
 			}),
 		),
 	}
-	requireUnsupported(t, s, `{"items":[5]}`)
+	requireUnsupported(t, s, `{"items":{"k":5}}`)
 }

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -181,12 +181,17 @@ func TestParse_List(t *testing.T) {
 		})),
 	}
 	mustParse(t, s, `{"tags":["x","y","z"]}`, `{"tags":["x","y","z"]}`)
-	// Wrong element type DECLINES: BAML stringifies 2->"2" in a string list,
-	// so native (strict) declines rather than claiming a mismatch.
+	// Wrong element type DECLINES: BAML stringifies 2->"2" in a string list
+	// (JsonToString is Mcoerce-d), so native can't PROVE the element is a parse
+	// error and declines the whole list rather than skip an item BAML would keep.
 	requireUnsupported(t, s, `{"tags":["x",2]}`)
-	// A non-array where a list is required DECLINES: BAML wraps a singleton
-	// into a one-element array, so native declines rather than claiming.
-	requireUnsupported(t, s, `{"tags":"x"}`)
+	// Mcoerce-c: a non-array STRING where list<string> is required is wrapped as
+	// a single implied element (SingleToArray) and coerces cleanly -> claimed.
+	mustParse(t, s, `{"tags":"x"}`, `{"tags":["x"]}`)
+	// A non-array NUMBER singleton still DECLINES: BAML stringifies it
+	// (JsonToString, Mcoerce-d), so the singleton element is not a proven parse
+	// error and native falls back rather than emit an empty/wrong list.
+	requireUnsupported(t, s, `{"tags":5}`)
 }
 
 func TestParse_OptionalPresentAndAbsent(t *testing.T) {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Mcoerce-c — LISTS (maps to follow)

Ports BAML's `coerce_array` (`coerce_array.rs`) into native de-BAML for deterministic, non-union `list<T>` targets. Maps are intentionally **not** touched here — `coerceMap` is unchanged and is a separate Mcoerce-c follow-up PR (per the approved split).

### What lists now do (byte-exact with BAML)
A list coercion always **succeeds**; child failures fold into list-level flags instead of failing the list.

- **Array input** — each element coerced in input order. A **proven** BAML parse-error child is dropped (`ArrayItemParseError`) while the list still succeeds: all-bad → `[]`, `[good,bad,good]` → `[good,good]`, accepted items in accepted order.
- **Non-array input** — `SingleToArray` wrapping: inner success → `[child]`, proven inner parse error → **empty list** `[]` (not a parse failure).

### The load-bearing crux — child-error classifier
A child is **skipped only when it is a PROVEN BAML parse error** for that exact child target + input (`provenListItemError`, a whitelist):
- int/float ← unparseable string (`bamlStringNumberFails`, re-derived **Rust-faithfully** so inf/nan/overflow/hex/underscore — which BAML coerces or errors differently than the strict native coercers — never produce an over-claimed skip), or an input kind BAML rejects with `error_unexpected_type` (object/bool/null → numeric).
- bool/enum/string-literal ← a certain (non-uncertain) `match_string` miss.
- multi-field **all-required-flat-leaf** class ← a genuine scalar (no `default_value` → guaranteed missing-required-field error). An **array** element defers to `coerce_array_to_singular` (pick_best, M3) → **not** skipped.

A child native merely **declined** (an `ErrDeBAMLParseUnsupported` that is *not* proven — e.g. `list<string>` with a number → `JsonToString`, Mcoerce-d) may be a deferred BAML **success**, so native **declines the whole list** rather than skip an item BAML would keep. A case-fold-uncertain child likewise declines the whole list. Hard/invariant child errors propagate unchanged.

### Union revisit (lists)
Score-bearing flags (`SingleToArray`, each `ArrayItemParseError`, kept-child flags) thread into `coerceFlags`, so the nullable clean-only rule holds: a flagged list arm declines against the scored null arm (M3). A multi-variant union with a list arm is not an M2c safe family → declines at the gate, never over-claiming a partial list. No `pick_best`, no array-to-singular.

### Scope / non-goals
`internal/debaml/{coerce,*_test}.go` + `integration/bamlfuzz_parse_recovery_test.go` + 9 corpus JSON only. **No** `coerceMap` change, no seam/regen/embed/`go.mod`. Runtime gate stays `BAML_REST_USE_DEBAML`.

### Corpus + differential
9 new parse-recovery fixtures, **all `want`s captured live** (`BAMLFUZZ_PARSE_CAPTURE=1`), each pinned in `parseRecoveryNativeClaim`:

| Fixture | Disposition |
|---|---|
| `list_singleton_int_success` (`"123"`→`[123]`) | claimed |
| `list_singleton_bad_int_empty` (`"bad"`→`[]`) | claimed |
| `list_array_partial_bad_int` (`["1",2,"bad",4]`→`[1,2,4]`) | claimed |
| `list_array_lenient_elements_kept` (`["1",2.6,"3/2"]`→`[1,3,2]`) | claimed |
| `list_class_non_object_partial` (`[5,{a,b}]`→`[{a,b}]`) | claimed |
| `nullable_optional_list_clean_array_claim` (`[1,2]`→`[1,2]`) | claimed |
| `list_string_non_string_stays_fallback` (`["a",2]`, JsonToString=Mcoerce-d) | fallback |
| `nullable_optional_list_singleton_stays_fallback` (SingleToArray score-bearing=M3) | fallback |
| `union_list_partial_stays_fallback` (union w/ list arm → pick_best) | fallback |

`union_list_singleton_ambiguity` stays fallback (unchanged).

### Validation
- `gofmt` clean; `go build ./...`; `go vet ./...` + `go vet -tags=integration ./...` clean
- `go test ./internal/debaml ./bamlutils ./worker ./dynclient/...` — pass
- `GOWORK=off go test ./codegen` (from `adapters/common`) — pass
- `go run ./cmd/verify-framework-adapter` — 6/6 green
- **parse-recovery differential (Docker) — PASS**: native dispositions **57 claimed / 40 fell back** (+6 claimed, +3 fallback); claimed native output matches BAML byte-for-byte, fallback cases decline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved list parsing recovery for common inputs, including wrapping single values into one-item lists and preserving valid items in partially bad arrays.
  * Expanded support for flexible parsing of mixed list content, including string conversion and cleaner handling of optional list values.

* **Bug Fixes**
  * Fixed several cases where list parsing could fail unnecessarily when only some elements were invalid.
  * Updated parsing behavior for nested and union-based list cases so successful values are retained more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->