### PR TITLE
debaml: native map collection coercion + value partials (Mcoerce-c, maps)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/101_map_value_partial_bad_int.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/101_map_value_partial_bad_int.json
@@ -1,0 +1,21 @@
+{
+  "name": "map_value_partial_bad_int",
+  "description": "Mcoerce-c CLAIMED: map<string,int> where one value (\"bad\") is an unparseable string. BAML's coerce_int errors on it, so the map records MapValueParseError and SKIPS just that entry, returning a PARTIAL map with the accepted entries in INPUT key order. Native reproduces the proven-parse-error skip byte-exact. want captured from live BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "scores", "type": {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"scores\":{\"a\":1,\"bad\":\"nope\",\"c\":\"7\"}}",
+  "want": {
+    "status": "success",
+    "json": {"scores": {"a": 1, "c": 7}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/102_map_value_lenient_kept.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/102_map_value_lenient_kept.json
@@ -1,0 +1,21 @@
+{
+  "name": "map_value_lenient_kept",
+  "description": "Mcoerce-c CLAIMED: map<string,int> with Mcoerce-b lenient VALUES — a numeric string (\"7\") and a float (2.5, rounded half-away to 3). Both are successful, entry-KEEPING coercions (not MapValueParseError), so the whole map is claimed byte-identical to BAML, in INPUT key order. The map's own score ignores the value FloatToInt flag (score.rs). want captured from live BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "scores", "type": {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"scores\":{\"a\":\"7\",\"b\":2.5}}",
+  "want": {
+    "status": "success",
+    "json": {"scores": {"a": 7, "b": 3}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/103_map_literal_key_partial_bad_key.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/103_map_literal_key_partial_bad_key.json
@@ -1,0 +1,24 @@
+{
+  "name": "map_literal_key_partial_bad_key",
+  "description": "Mcoerce-c FALLBACK (live probe): map<\"A\"|\"B\", string> with a KEY (\"C\") matching NO string-literal-union arm. The DYNAMIC bridge's literal-union key coercion is LENIENT — it accepts the non-matching key and inserts the ORIGINAL string, so the result is the FULL map {\"A\":\"x\",\"C\":\"z\",\"B\":\"y\"}, NOT a partial one. A missed literal key is therefore a DEFERRED Mcoerce-d keep, not a provable MapKeyParseError skip, so native declines the WHOLE map rather than skip an entry BAML keeps (pinned native disposition: fallback). want captured from live BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "m", "type": {"kind": "map", "key": {"kind": "union", "variants": [
+            {"kind": "literal", "literal": {"kind": "string", "string": "A"}},
+            {"kind": "literal", "literal": {"kind": "string", "string": "B"}}
+          ]}, "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"m\":{\"A\":\"x\",\"C\":\"z\",\"B\":\"y\"}}",
+  "want": {
+    "status": "success",
+    "json": {"m": {"A": "x", "C": "z", "B": "y"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/104_map_bad_key_original_order.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/104_map_bad_key_original_order.json
@@ -1,0 +1,24 @@
+{
+  "name": "map_bad_key_original_order",
+  "description": "Mcoerce-c FALLBACK (live probe): map<\"A\"|\"B\", string> with a non-matching key (\"C\") between two matching keys that are OUT of lexical order (\"B\" before \"A\"). Confirms the dynamic bridge keeps ALL keys (incl. the non-matching \"C\") under their ORIGINAL strings in INPUT order — a FULL map, not a partial one — so native declines the WHOLE map (a missed literal-union key is a DEFERRED Mcoerce-d keep, not a skip). Pinned native disposition: fallback. want captured from live BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "m", "type": {"kind": "map", "key": {"kind": "union", "variants": [
+            {"kind": "literal", "literal": {"kind": "string", "string": "A"}},
+            {"kind": "literal", "literal": {"kind": "string", "string": "B"}}
+          ]}, "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"m\":{\"B\":\"y\",\"C\":\"z\",\"A\":\"x\"}}",
+  "want": {
+    "status": "success",
+    "json": {"m": {"B": "y", "C": "z", "A": "x"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/105_map_enum_key_nonmember_live_probe.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/105_map_enum_key_nonmember_live_probe.json
@@ -1,0 +1,24 @@
+{
+  "name": "map_enum_key_nonmember_live_probe",
+  "description": "Mcoerce-c FALLBACK (live probe): map<Key,string> over enum Key{A,B} with a NON-MEMBER key (\"C\"). The dynamic bridge's enum-key coercion is LENIENT: it accepts the non-member key and inserts the ORIGINAL string, so the result is the FULL map (like map_bad_enum_key), NOT a partial one. A missed enum key is therefore NOT a proven MapKeyParseError, so native declines the WHOLE map rather than skip an entry BAML keeps (pinned native disposition: fallback). want captured from live BAML final parse.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "labels", "type": {"kind": "map", "key": {"kind": "enum_ref", "ref": "Key"}, "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "enums": [
+      {"name": "Key", "values": ["A", "B"]}
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"labels\":{\"A\":\"one\",\"C\":\"two\"}}",
+  "want": {
+    "status": "success",
+    "json": {"labels": {"A": "one", "C": "two"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/106_map_duplicate_key_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/106_map_duplicate_key_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "map_duplicate_key_stays_fallback",
+  "description": "Mcoerce-c FALLBACK: map<string,int> with a DUPLICATE original input key (\"a\" twice). BAML's IndexMap insert/overwrite ordering for duplicates is unproven, so native declines the WHOLE map before claiming output — even if one occurrence would otherwise be accepted (pinned native disposition: fallback). want captured from live BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "scores", "type": {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"scores\":{\"a\":1,\"a\":2}}",
+  "want": {
+    "status": "success",
+    "json": {"scores": {"a": 2}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/107_map_string_string_non_string_value_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/107_map_string_string_non_string_value_stays_fallback.json
@@ -1,0 +1,21 @@
+{
+  "name": "map_string_string_non_string_value_stays_fallback",
+  "description": "Mcoerce-c FALLBACK: map<string,string> with a NUMBER value (5). BAML stringifies it via JsonToString (an entry-KEEPING lenient success, Mcoerce-d), so the value is NOT a proven MapValueParseError. Native cannot prove keep-vs-skip and declines the WHOLE map rather than skip an entry BAML would keep (pinned native disposition: fallback). want captured from live BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "m", "type": {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "raw": "{\"m\":{\"a\":\"x\",\"b\":5}}",
+  "want": {
+    "status": "success",
+    "json": {"m": {"a": "x", "b": "5"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/108_nullable_optional_map_object_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/108_nullable_optional_map_object_stays_fallback.json
@@ -1,0 +1,22 @@
+{
+  "name": "nullable_optional_map_object_stays_fallback",
+  "description": "Mcoerce-c FALLBACK: optional map<string,int> (map | null) with OBJECT input. The non-null map arm succeeds but ALWAYS carries ObjectToMap (score-bearing, cost 1), so BAML scores it against the null arm (DefaultButHadValue=110). Native's nullable clean-only rule declines a flagged non-null arm (scoring is M3), even for a clean fully-accepted map (pinned native disposition: fallback). want captured from live BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "optional", "inner": {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "int"}}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":{\"a\":1,\"b\":2}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"a": 1, "b": 2}}
+  }
+}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -189,8 +189,11 @@ var parseRecoveryNativeClaim = map[string]bool{
 	// unterminated/incomplete map (M2a defers). Native declines (fallback)
 	// rather than claim a clean result where BAML carries flags or skips
 	// entries. (map_fuzzy_enum_key flipped to claimed in Mcoerce-a.)
-	"map_bad_enum_key":       false,
-	"map_bad_value_type":     false,
+	"map_bad_enum_key": false,
+	// Mcoerce-c native MAPS flip: an OBJECT map value can't coerce to int
+	// (error_unexpected_type), a PROVEN MapValueParseError, so BAML skips just
+	// that entry and native now reproduces the partial map {"a":1} — CLAIMED.
+	"map_bad_value_type":     true,
 	"map_partial_incomplete": false,
 	// Mcoerce-a native match_string parity: enum / string-literal / class
 	// field-key / map-key fuzzy matching (case / accent+ligature fold /
@@ -318,6 +321,26 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"list_string_non_string_stays_fallback":           false,
 	"nullable_optional_list_singleton_stays_fallback": false,
 	"union_list_partial_stays_fallback":               false,
+	// Mcoerce-c native MAPS (coerceMap / coerce_map.rs): object→map ObjectToMap
+	// flagging, VALUE-then-KEY coercion, and PARTIAL entry skips of PROVEN map
+	// VALUE parse errors (MapValueParseError) resolve byte-identical to BAML, so
+	// the deterministic partial-map claims are CLAIMED — accepted entries in INPUT
+	// key order under their ORIGINAL key strings.
+	"map_value_partial_bad_int": true,
+	"map_value_lenient_kept":    true,
+	// Mcoerce-c MAP fallback set. KEY misses are NOT native skips: the dynamic
+	// bridge keeps non-matching enum / string-literal / literal-union keys
+	// leniently (live-captured FULL maps, not partial), so a key miss is a
+	// DEFERRED Mcoerce-d keep and native declines the WHOLE map. Also fallback: a
+	// duplicate original key (unproven insert order), a map<string,string>
+	// non-string value (JsonToString, Mcoerce-d), and a nullable map arm flagged
+	// by ObjectToMap (score-bearing, M3 vs null).
+	"map_literal_key_partial_bad_key":                   false,
+	"map_bad_key_original_order":                        false,
+	"map_enum_key_nonmember_live_probe":                 false,
+	"map_duplicate_key_stays_fallback":                  false,
+	"map_string_string_non_string_value_stays_fallback": false,
+	"nullable_optional_map_object_stays_fallback":       false,
 }
 
 // parseRecoveryStats tallies how many final-parse cases the native parser

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -83,12 +83,16 @@ func (f *coerceFlags) isUncertain() bool { return f != nil && f.uncertain }
 // LIST parity (coerceList / coerceArray.rs): non-array SINGLE-TO-ARRAY wrapping,
 // PARTIAL array skips of PROVEN-parse-error items, and empty-list-on-singleton-
 // failure — each score-bearing (SingleToArray, ArrayItemParseError, child flags)
-// so the nullable-union clean-only rule still holds. The remaining leniencies stay
+// so the nullable-union clean-only rule still holds. Mcoerce-c also adds native
+// MAP parity (coerceMap / coerce_map.rs): object→map ObjectToMap flagging, VALUE-
+// then-KEY coercion, PARTIAL entry skips of PROVEN value/key parse errors
+// (MapValueParseError / MapKeyParseError), and ORIGINAL input key strings in
+// input order — each score-bearing (ObjectToMap, the partial errors) so the
+// nullable-union clean-only rule still holds. The remaining leniencies stay
 // STRICT and DECLINE: non-string stringification (ObjectToString / JsonToString),
 // single-key-object ObjectToPrimitive literal extraction, single-field implied-key
-// / inferred-object absorption, PARTIAL MAP skips, and class default-fill — all
-// deferred to Mcoerce-c(maps)/d. Where native's coercion fails but BAML may
-// leniently SUCCEED (or
+// / inferred-object absorption, and class default-fill — all deferred to
+// Mcoerce-d. Where native's coercion fails but BAML may leniently SUCCEED (or
 // null-default) — or where native cannot determine BAML's exact success/failure
 // — coercion DECLINES (ErrDeBAMLParseUnsupported → fall back to BAML), so native
 // is never "more capable" than BAML.
@@ -1128,31 +1132,48 @@ func bamlCommaNumberParses(s string) bool {
 	return rustF64Parseable(withoutCurrency)
 }
 
-// coerceMap coerces a JSON object into a map, emitting entries in INPUT key
-// order (the opposite of coerceClass's schema order: a map's keys are data,
-// a class's fields are the schema). It CLAIMS only the clean-map subset and
-// DECLINES everything BAML would represent as a partial/scored map — because
-// BAML's map coercer does NOT hard-fail on a bad entry: it records a
-// score-bearing MapKeyParseError / MapValueParseError and SKIPS that entry,
-// returning a partial map. Native cannot reproduce that partial result, and
-// must never claim a clean map where BAML would return a flagged/partial
-// one, so any uncertainty DECLINES (ErrDeBAMLParseUnsupported → fall back):
+// coerceMap coerces a JSON object into a map, porting BAML's coerce_map
+// (coerce_map.rs) so native reproduces BAML's PARTIAL-map result byte-for-byte.
+// A map coercion of an OBJECT always SUCCEEDS: a bad VALUE folds into a
+// score-bearing MapValueParseError and the ENTRY is SKIPPED, not a map error.
+// Entries are emitted in INPUT key order (the opposite of coerceClass's schema
+// order: a map's keys are data, a class's fields are the schema), keyed by the
+// ORIGINAL input key string (never the canonical enum/literal form, matching
+// coerce_map.rs:165-174) — so an all-bad-value map becomes {} and
+// {"b":good,"bad":bad,"a":good} becomes {"b":...,"a":...}.
 //
-//   - Non-object input → DECLINE: BAML has object/map coercion + scoring
-//     outside this clean subset (it is not a hard type error).
-//   - A key with no EXACT match (matchMapKey) → DECLINE: BAML's enum/literal
-//     key coercion is fuzzy (match_string), and a no-match key is skipped
-//     with a flag rather than failing the map. Fuzzy key matching is Mcoerce.
-//   - ANY value coercion error (sentinel OR claimed) → DECLINE the WHOLE
-//     map: BAML attaches MapValueParseError and skips just that entry, so a
-//     native hard-claim here would diverge from BAML's partial success.
-//   - A duplicate output key → DECLINE: BAML's IndexMap insert/overwrite
-//     ordering for duplicates is unproven, so native does not claim it.
+// Per BAML each entry coerces the VALUE first, then the KEY:
 //
-// Accepted entries are keyed by the ORIGINAL input key string (never the
-// canonical enum/literal form, matching coerce_map.rs:165-174), and an empty
-// object is a clean empty map. A class value is emitted by coerceClass in
-// schema order, nested inside the input-ordered map.
+//   - value coercion PROVEN-errors → MapValueParseError: SKIP the whole entry
+//     WITHOUT coercing the key (coerceMapValueChild / provenMapValueError).
+//   - value succeeds but the KEY does not cleanly coerce → DECLINE the whole map
+//     (coerceMapKey). Unlike a value, a KEY never yields a native partial skip:
+//     the DYNAMIC bridge's enum/literal/literal-union key coercion is LENIENT —
+//     it accepts a NON-MATCHING key and KEEPS the ORIGINAL string (live-captured:
+//     {"A":x,"C":z} over enum {A,B} or over "A"|"B" → the FULL map, not a partial
+//     one), so a key miss is a DEFERRED Mcoerce-d keep, not a provable skip.
+//   - both succeed → insert (original key string, coerced value).
+//
+// THE CRUX (over-claim guard, mirroring coerceList): an entry's VALUE is SKIPPED
+// only when its failure is a PROVEN BAML parse error for that exact value
+// target+input. A value native merely DECLINED (an ErrDeBAMLParseUnsupported that
+// is NOT a proven error) may be a DEFERRED Mcoerce-d SUCCESS (e.g.
+// map<string,string> with a NUMBER value → JsonToString), so native DECLINES THE
+// WHOLE MAP there rather than skip an entry BAML would keep. A case-fold-
+// uncertain value or key likewise declines the whole map.
+//
+// Native still DECLINES (ErrDeBAMLParseUnsupported → fall back) on:
+//   - Non-object input: BAML has object/map coercion + scoring outside this
+//     subset (it is not a hard type error).
+//   - A DUPLICATE original input key: BAML's IndexMap insert/overwrite ordering
+//     for duplicates is unproven, and a skipped duplicate must not be reasoned
+//     safe, so ANY duplicate declines the whole map before emitting.
+//
+// Every object→map carries ObjectToMap (cost 1), and BAML scores a map by its
+// OWN flags only — the value scores do NOT propagate (score.rs:21) — so a map is
+// NEVER a zero-score "clean" arm: cf is flagged, so a nullable optional map arm
+// declines against the scored null arm (the clean-only rule), and Mcoerce-c does
+// not score collection arms against null.
 func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value, cf *coerceFlags) (json.RawMessage, error) {
 	if keyT == nil || valT == nil {
 		return nil, fmt.Errorf("debaml: map type missing key or value")
@@ -1163,38 +1184,44 @@ func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value, cf *coerc
 		// rather than claim a mismatch BAML would not produce.
 		return nil, declineCoerce("map target", input)
 	}
-	// Every object→map carries ObjectToMap (cost 1), and BAML scores a map by
-	// its OWN flags only — the value scores do NOT propagate (score.rs:21). So
-	// a map is NEVER a zero-score "clean" arm: flag cf, and coerce values with
-	// no accumulator since their flags don't affect the map's score.
+	// Any DUPLICATE original input key declines the WHOLE map up-front (BAML's
+	// duplicate insert/overwrite ordering is unproven). Scanning ALL keys before
+	// emitting means a duplicate whose entry would otherwise SKIP still declines
+	// — native never reasons that a skipped duplicate leaves the rest safe.
+	seen := make(map[string]struct{}, len(input.objV))
+	for i := range input.objV {
+		k := input.objV[i].key
+		if _, dup := seen[k]; dup {
+			return nil, unsupported(fmt.Sprintf("map duplicate key %q (BAML duplicate insert/overwrite ordering unproven)", k))
+		}
+		seen[k] = struct{}{}
+	}
+
+	// Every object→map carries ObjectToMap (cost 1); flag before iterating.
 	cf.flag()
 
 	var buf bytes.Buffer
 	buf.WriteByte('{')
-	seen := make(map[string]struct{}, len(input.objV))
 	first := true
 	for i := range input.objV {
 		f := &input.objV[i]
-		if err := matchMapKey(b, *keyT, f.key, cf); err != nil {
+		// VALUE first (BAML coerce_map order): a proven value error skips the
+		// entry WITHOUT coercing the key.
+		child, keepVal, err := coerceMapValueChild(b, *valT, f.val, cf)
+		if err != nil {
+			return nil, err // hard/invariant error, or decline-the-whole-map.
+		}
+		if !keepVal {
+			cf.flag() // MapValueParseError (cost 1) → skip entry.
+			continue
+		}
+		// KEY second: the original key string coerced against the key type. A key
+		// that does not cleanly coerce DECLINES the whole map (the dynamic bridge
+		// keeps non-matching keys leniently — a miss is Mcoerce-d, never a skip).
+		if err := coerceMapKey(b, *keyT, f.key, cf); err != nil {
 			return nil, err
 		}
-		if _, dup := seen[f.key]; dup {
-			return nil, unsupported(fmt.Sprintf("map duplicate key %q (BAML duplicate insert/overwrite ordering unproven)", f.key))
-		}
-		seen[f.key] = struct{}{}
-
-		child, err := coerce(b, *valT, f.val, nil)
-		if err != nil {
-			if !declinableChildError(err) {
-				return nil, err // hard/invariant failure: propagate, never mask.
-			}
-			// A bad value (decline sentinel or value-verdict mismatch): BAML
-			// records MapValueParseError and SKIPS this entry, returning a
-			// partial map — native cannot reproduce that, so decline the whole
-			// map. Partial-map parity is Mcoerce-c.
-			return nil, unsupported(fmt.Sprintf("map value for key %q: %v (BAML skips bad entries via MapValueParseError)", f.key, err))
-		}
-
+		// Both succeeded: insert the ORIGINAL input key string + coerced value.
 		if !first {
 			buf.WriteByte(',')
 		}
@@ -1211,36 +1238,93 @@ func coerceMap(b *schema.Bundle, keyT, valT *schema.Type, input value, cf *coerc
 	return buf.Bytes(), nil
 }
 
-// matchMapKey validates an input object key string against the declared map
-// key type via BAML's actual match_string (Mcoerce-a), returning nil on a
-// clean accept and a DECLINE sentinel otherwise. checkSupportedMapKey has
-// already restricted the key type to the four legal shapes, so the default
-// arm is defensive. BAML coerces the key with the key type's coercer
-// (coerce_map.rs:163) and, on success, inserts the entry under the ORIGINAL
-// input key string — so the accepted key is never rewritten, and the only
-// thing that matters here is whether the key coercion SUCCEEDS:
+// coerceMapValueChild coerces one map VALUE. Like coerceListChild it returns
+// exactly one of:
 //
-//   - string primitive: accept any key verbatim.
-//   - enum: accept on a clean match_string match (substring enabled); a
-//     no-match or substring TIE declines (BAML skips the entry via
-//     MapKeyParseError, returning a partial map — Mcoerce-c).
-//   - string literal: accept on a clean match_string match (substring enabled).
-//   - union of string literals: accept when AT LEAST ONE arm matches. The
-//     map output is the original key regardless of which arm BAML's union
-//     pick_best selects, so multiple matches do not need scoring here.
+//   - (out, true, nil):  the value coerced; insert the entry with out.
+//   - (nil, false, nil): the value is a PROVEN BAML parse error; the caller SKIPS
+//     the entry (BAML records MapValueParseError and the map still succeeds).
+//   - (nil, false, err): the whole map must FAIL — a HARD/invariant error, or an
+//     ErrDeBAMLParseUnsupported DECLINE because the value could be a DEFERRED
+//     Mcoerce-d success or its verdict was case-fold-uncertain, so native falls
+//     back rather than skip an entry BAML might keep.
 //
-// Any non-clean key DECLINES the whole map, because BAML would skip just that
-// entry and return a partial map, which native does not yet reproduce
-// (Mcoerce-c). The accepted key is NOT rewritten — coerceMap emits the
-// original input key string, matching BAML's insertion of the raw object key.
+// A map scores by its OWN flags only (score.rs) — a kept value's own flags do
+// NOT propagate to the map score — so, unlike coerceListChild, a flagged value
+// does NOT flag cf here (the map is already non-clean via ObjectToMap). The
+// child's case-fold uncertainty is still propagated defensively.
+func coerceMapValueChild(b *schema.Bundle, valT schema.Type, val value, cf *coerceFlags) (json.RawMessage, bool, error) {
+	childF := &coerceFlags{}
+	out, err := coerce(b, valT, val, childF)
+	if err == nil {
+		if childF.isUncertain() {
+			cf.markUncertain()
+		}
+		return out, true, nil
+	}
+	if !declinableChildError(err) {
+		return nil, false, err // hard/invariant failure: propagate, never mask.
+	}
+	if childF.isUncertain() {
+		// The value's match verdict hinged on a non-ASCII case fold native cannot
+		// prove equals BAML — it might MATCH (BAML keeps) or MISS (BAML skips), so
+		// DECLINE the whole map.
+		cf.markUncertain()
+		return nil, false, unsupported(fmt.Sprintf("map value %s→%s: non-ASCII case-fold uncertainty (cannot prove skip vs keep)", val.kind, valT.Kind))
+	}
+	if provenMapValueError(b, valT, val) {
+		return nil, false, nil // PROVEN parse error → BAML skips via MapValueParseError.
+	}
+	// A declinable error that is NOT a proven parse error: BAML may still SUCCEED
+	// via a deferred Mcoerce-d path (JsonToString / ObjectToString /
+	// ObjectToPrimitive / implied-key / default-fill / array-to-singular / union
+	// scoring), so native cannot skip it — DECLINE the whole map (fall back).
+	return nil, false, unsupported(fmt.Sprintf("map value %s→%s: child declined but not a proven BAML parse error (deferred Mcoerce-d success possible): %v", val.kind, valT.Kind, err))
+}
+
+// provenMapValueError reports whether BAML PROVABLY errors coercing a map VALUE
+// child — the ONLY case native may SKIP the entry (MapValueParseError). A map
+// value is coerced on the raw child with a fresh scope exactly like a list
+// ELEMENT (both invoke the value type's coercer on the child, and both wrap a
+// failure in a *ParseError flag and skip), so the proven-parse-error whitelist
+// is IDENTICAL: it delegates to provenListItemError. See that function for the
+// per-kind safe-skip vs must-decline split (numeric-string re-derivation via
+// bamlStringNumberFails, error_unexpected_type kinds, certain match_string miss,
+// multi-field all-required-flat-leaf class ← scalar; object/array/union/nested-
+// collection values DEFER and decline the whole map instead of skipping).
+func provenMapValueError(b *schema.Bundle, valT schema.Type, val value) bool {
+	return provenListItemError(b, valT, val)
+}
+
+// coerceMapKey coerces one map KEY: the ORIGINAL input key STRING wrapped as a
+// JSONish string and coerced against the key type (BAML coerce_map.rs:163). It
+// returns nil on a clean ACCEPT (the entry is inserted under the ORIGINAL key
+// string, never the canonical enum/literal form) and a DECLINE sentinel
+// otherwise. checkSupportedMapKey has already restricted the key type to the
+// four legal shapes (string primitive / enum / string literal / non-nullable
+// union of string literals), so the default arm is defensive.
 //
-// A non-ASCII case-fold uncertainty on a key declines the map AND marks cf
-// (nil-safe), so that — should a map ever become reachable as a union arm —
-// the enclosing union counter makes the same conservative whole-union decline
-// rather than treating the rejected key as an ordinary non-match. Today no
-// claimable union admits a map arm (parse.go's safe families are literal/class
-// only), so this is purely defensive signal propagation, never an over-claim.
-func matchMapKey(b *schema.Bundle, keyT schema.Type, key string, cf *coerceFlags) error {
+// Unlike a map VALUE, a KEY has NO native partial-skip path: a key that does not
+// cleanly match DECLINES THE WHOLE MAP (Mcoerce-d), never a per-entry skip. The
+// live-captured DYNAMIC behavior is that enum / string-literal / literal-union
+// map keys are LENIENT — a NON-MATCHING key is ACCEPTED and inserted under its
+// ORIGINAL string, so {"A":x,"C":z} over enum {A,B} (map_bad_enum_key) or over
+// "A"|"B" (map_literal_key_partial_bad_key) yields the FULL map, not a partial
+// one. Native cannot SKIP a missed key (BAML keeps it) nor reproduce that lenient
+// keep (that is Mcoerce-d structural leniency), so it declines the whole map on
+// ANY non-clean key. Per key type:
+//
+//   - string primitive: any key coerces → ACCEPT.
+//   - enum / string literal / string-literal union: a clean match_string match
+//     (any arm, for a union) → ACCEPT; a case-fold-UNCERTAIN verdict marks cf and
+//     declines; a certain MISS declines the whole map (dynamic lenient keep).
+//
+// A non-ASCII case-fold uncertainty marks cf (nil-safe) so that — should a map
+// ever become reachable as a union arm — the enclosing union counter makes the
+// same conservative whole-union decline. Today no claimable union admits a map
+// arm (parse.go's safe families are literal/class only), so this is purely
+// defensive signal propagation, never an over-claim.
+func coerceMapKey(b *schema.Bundle, keyT schema.Type, key string, cf *coerceFlags) error {
 	switch keyT.Kind {
 	case schema.TypePrimitive:
 		if keyT.Primitive == schema.PrimitiveString {
@@ -1252,11 +1336,8 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string, cf *coerceFlags
 		if !ok {
 			return fmt.Errorf("debaml: unknown enum %q", keyT.Name)
 		}
-		// The key's own match flags do not propagate to the map score (BAML
-		// discards the coerced key, inserting the original string), so ignore
-		// the substring bit — only success/failure matters. But a non-ASCII
-		// case-fold uncertainty means the key inclusion could diverge, so
-		// DECLINE the whole map (Mcoerce stays conservative on uncertainty).
+		// Only success/failure matters (BAML discards the coerced key, inserting
+		// the original string), so ignore the substring bit.
 		_, outcome, _, uncertain := matchString(key, enumMatchCandidates(e), true)
 		if uncertain {
 			cf.markUncertain()
@@ -1265,7 +1346,9 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string, cf *coerceFlags
 		if outcome == matchOne {
 			return nil
 		}
-		return unsupported(fmt.Sprintf("map key %q: no clean enum %q match (BAML skips via MapKeyParseError)", key, keyT.Name))
+		// A missed enum key is a DEFERRED lenient keep (dynamic enum keys accept
+		// non-members → full map), not a skip, so decline the whole map.
+		return unsupported(fmt.Sprintf("map key %q: no clean enum %q match (dynamic keeps non-members → Mcoerce-d decline)", key, keyT.Name))
 	case schema.TypeLiteral:
 		if keyT.Literal == nil || keyT.Literal.Kind != schema.LiteralString {
 			return unsupported("map key literal must be a string literal")
@@ -1278,13 +1361,14 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string, cf *coerceFlags
 		if outcome == matchOne {
 			return nil
 		}
-		return unsupported(fmt.Sprintf("map key %q: no clean literal %q match (BAML skips via MapKeyParseError)", key, keyT.Literal.String))
+		// A missed literal key is a DEFERRED lenient keep, not a skip → decline.
+		return unsupported(fmt.Sprintf("map key %q: no clean literal %q match (dynamic keeps non-matches → Mcoerce-d decline)", key, keyT.Literal.String))
 	case schema.TypeUnion:
 		// Only a non-nullable union of string literals is a legal map key
 		// (the same invariant the parse gate proves via isStringLiteralUnionType
 		// / checkSupportedMapKey). flattenStringLiterals is intentionally lossy —
 		// it silently drops any non-literal arm — so assert the invariant here
-		// too, defensively, since matchMapKey is unit/future-callable without the
+		// too, defensively, since coerceMapKey is unit/future-callable without the
 		// gate: a mixed union must NOT be treated as its string-literal subset.
 		if !isStringLiteralUnionType(keyT) {
 			return unsupported("map key union must be a non-nullable union of string literals")
@@ -1325,7 +1409,9 @@ func matchMapKey(b *schema.Bundle, keyT schema.Type, key string, cf *coerceFlags
 			cf.markUncertain()
 			return unsupported(fmt.Sprintf("map key %q: non-ASCII case-fold uncertainty against string-literal-union arms", key))
 		}
-		return unsupported(fmt.Sprintf("map key %q: matches no string-literal-union arm (BAML skips via MapKeyParseError)", key))
+		// No arm matched: a DEFERRED lenient keep (dynamic keeps non-matching
+		// literal-union keys → full map), not a skip → decline the whole map.
+		return unsupported(fmt.Sprintf("map key %q: matches no string-literal-union arm (dynamic keeps non-matches → Mcoerce-d decline)", key))
 	default:
 		return unsupported(fmt.Sprintf("map key kind %q", keyT.Kind))
 	}

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -84,11 +84,14 @@ func (f *coerceFlags) isUncertain() bool { return f != nil && f.uncertain }
 // PARTIAL array skips of PROVEN-parse-error items, and empty-list-on-singleton-
 // failure — each score-bearing (SingleToArray, ArrayItemParseError, child flags)
 // so the nullable-union clean-only rule still holds. Mcoerce-c also adds native
-// MAP parity (coerceMap / coerce_map.rs): object→map ObjectToMap flagging, VALUE-
-// then-KEY coercion, PARTIAL entry skips of PROVEN value/key parse errors
-// (MapValueParseError / MapKeyParseError), and ORIGINAL input key strings in
-// input order — each score-bearing (ObjectToMap, the partial errors) so the
-// nullable-union clean-only rule still holds. The remaining leniencies stay
+// MAP parity (coerceMap / coerce_map.rs): object→map ObjectToMap flagging,
+// VALUE-then-KEY coercion, VALUE partial entry skips of PROVEN value parse
+// errors (MapValueParseError), and ORIGINAL input key strings in input order.
+// KEYS do not partial-skip in native: any non-clean enum/literal/literal-union
+// key verdict declines the WHOLE map (no MapKeyParseError skip), because the
+// dynamic bridge keeps non-matching keys leniently. ObjectToMap and value
+// partial skips are score-bearing, so the nullable-union clean-only rule still
+// holds. The remaining leniencies stay
 // STRICT and DECLINE: non-string stringification (ObjectToString / JsonToString),
 // single-key-object ObjectToPrimitive literal extraction, single-field implied-key
 // / inferred-object absorption, and class default-fill — all deferred to

--- a/internal/debaml/coerce_map_test.go
+++ b/internal/debaml/coerce_map_test.go
@@ -149,14 +149,18 @@ func TestCoerceMap_ValueThenKeyOrder(t *testing.T) {
 	mustParseExact(t, s, `{"u":{"É":"zzz"}}`, `{"u":{}}`)
 }
 
-// TestCoerceMap_DeferredValuePreemptsKeySkip pins the other side of value-first:
-// a value that is a DEFERRED Mcoerce-d success (JsonToString) declines the WHOLE
-// map even when the key would otherwise be a proven skip — native must not emit
-// a partial map that drops an entry BAML would keep via a lenient value path.
+// TestCoerceMap_DeferredValuePreemptsKeySkip pins value-first ordering: a value
+// that is a DEFERRED Mcoerce-d success (JsonToString) declines the WHOLE map
+// before the key is even coerced — native must not emit a partial map that drops
+// an entry BAML would keep via a lenient value path.
 func TestCoerceMap_DeferredValuePreemptsKeySkip(t *testing.T) {
-	// map<"A"|"B", string> with {"C": 5}: key "C" would be a proven MapKeyParseError
-	// skip, but the value 5 -> string is JsonToString (Mcoerce-d, NOT proven), so
-	// the whole map declines rather than skipping the entry.
+	// map<"A"|"B", string> with {"C": 5}: the value 5 -> string is JsonToString
+	// (Mcoerce-d, NOT a proven parse error), so the map declines on the VALUE
+	// first — the key "C" is never reached. And even if it were, a non-matching
+	// key is NOT a skip: coerceMapKey is decline-only (the dynamic bridge keeps
+	// non-matching literal-union keys leniently -> a whole-map decline, not a
+	// partial MapKeyParseError skip; see TestCoerceMap_KeyMissDeclines). Either
+	// way the whole map declines rather than dropping an entry.
 	requireUnsupported(t, mapLitUnionStrSchema(), `{"u":{"C":5}}`)
 }
 

--- a/internal/debaml/coerce_map_test.go
+++ b/internal/debaml/coerce_map_test.go
@@ -1,0 +1,238 @@
+package debaml
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// mapStrStrSchema is Root{ m: map<string,string> }.
+func mapStrStrSchema() *bamlutils.DynamicOutputSchema {
+	return oneField(&bamlutils.DynamicProperty{
+		Type:   "map",
+		Keys:   &bamlutils.DynamicTypeSpec{Type: "string"},
+		Values: &bamlutils.DynamicTypeSpec{Type: "string"},
+	})
+}
+
+// optionalMapStrIntSchema is Root{ u: (map<string,int>)? } — an optional map,
+// i.e. a nullable single-arm union over map<string,int>.
+func optionalMapStrIntSchema() *bamlutils.DynamicOutputSchema {
+	return oneField(&bamlutils.DynamicProperty{
+		Type: "optional",
+		Inner: &bamlutils.DynamicTypeSpec{
+			Type:   "map",
+			Keys:   &bamlutils.DynamicTypeSpec{Type: "string"},
+			Values: &bamlutils.DynamicTypeSpec{Type: "int"},
+		},
+	})
+}
+
+// mapLitUnionStrSchema is Root{ m: map<"A"|"B", string> } — a string-literal
+// union key with string values.
+func mapLitUnionStrSchema() *bamlutils.DynamicOutputSchema {
+	return oneField(&bamlutils.DynamicProperty{
+		Type: "map",
+		Keys: &bamlutils.DynamicTypeSpec{
+			Type: "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{
+				{Type: "literal_string", Value: "A"},
+				{Type: "literal_string", Value: "B"},
+			},
+		},
+		Values: &bamlutils.DynamicTypeSpec{Type: "string"},
+	})
+}
+
+// mapStrPairSchema is Root{ items: map<string, Pair> }, Pair{ a: string,
+// b: string } — a multi-field, all-required-flat-leaf value class, so a SCALAR
+// value is a proven missing-required-field error (a skippable entry).
+func mapStrPairSchema() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("items", &bamlutils.DynamicProperty{
+			Type:   "map",
+			Keys:   &bamlutils.DynamicTypeSpec{Type: "string"},
+			Values: &bamlutils.DynamicTypeSpec{Ref: "Pair"},
+		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Pair", &bamlutils.DynamicClass{
+				Properties: props(kv("a", strProp()), kv("b", strProp())),
+			}),
+		),
+	}
+}
+
+// TestCoerceMap_ValuePartialSkip pins BAML coerce_map's partial-map result: a
+// PROVEN-parse-error VALUE is dropped (MapValueParseError) while the map still
+// succeeds, keeping accepted entries in accepted INPUT key order.
+func TestCoerceMap_ValuePartialSkip(t *testing.T) {
+	s := mapStringIntSchema()
+	// "a":1 kept, "b":"bad" skipped (proven int parse error), "c":"7" kept (7).
+	mustParseExact(t, s, `{"scores":{"a":1,"bad":"nope","c":"7"}}`, `{"scores":{"a":1,"c":7}}`)
+	// All-bad values -> {}.
+	mustParseExact(t, s, `{"scores":{"a":"x","b":"y"}}`, `{"scores":{}}`)
+	// Proven non-string value kinds BAML rejects with error_unexpected_type are
+	// also skipped: object, bool, null (a number is always coerced, kept).
+	mustParseExact(t, s, `{"scores":{"a":1,"b":{"x":1},"c":true,"d":null,"e":2}}`, `{"scores":{"a":1,"e":2}}`)
+}
+
+// TestCoerceMap_LenientValuesKept pins that Mcoerce-a/b leaf coercions run
+// inside a map VALUE and KEEP the entry (numeric-string, float->int round,
+// fraction, extracted currency), in input key order.
+func TestCoerceMap_LenientValuesKept(t *testing.T) {
+	s := mapStringIntSchema()
+	mustParseExact(t, s, `{"scores":{"a":"1","b":2.6,"c":"3/2","d":"$1,234"}}`, `{"scores":{"a":1,"b":3,"c":2,"d":1234}}`)
+}
+
+// TestCoerceMap_ClassValueScalarSkips pins that a multi-field flat class VALUE
+// that is a genuine SCALAR is a proven missing-required-field error (skipped),
+// while an object value is kept in schema order; an object MISSING a required
+// field is a DEFERRED case (BAML may default/error) and declines the whole map.
+func TestCoerceMap_ClassValueScalarSkips(t *testing.T) {
+	s := mapStrPairSchema()
+	// Scalar 5 skipped; the object value kept, its fields in SCHEMA order.
+	mustParseExact(t, s, `{"items":{"k":5,"p":{"b":"y","a":"x"}}}`, `{"items":{"p":{"a":"x","b":"y"}}}`)
+	// Scalar-only -> {}.
+	mustParseExact(t, s, `{"items":{"k":5}}`, `{"items":{}}`)
+	// An object value missing a required field is NOT a proven skip (BAML may
+	// default-fill) -> decline the WHOLE map.
+	requireUnsupported(t, s, `{"items":{"a":{"a":"x","b":"y"},"b":{"a":"x"}}}`)
+}
+
+// TestCoerceMap_KeyMissDeclines pins that a KEY matching NO string-literal-union
+// arm is NOT a native partial skip: the dynamic bridge keeps non-matching keys
+// leniently (a live-captured FULL map), so native declines the WHOLE map rather
+// than skip an entry BAML would keep. A fully-matching map (incl. a fuzzy
+// case-variant kept under its ORIGINAL string) still claims.
+func TestCoerceMap_KeyMissDeclines(t *testing.T) {
+	s := mapLitUnionStrSchema()
+	// All keys match -> claim, keeping ORIGINAL strings in INPUT order.
+	mustParseExact(t, s, `{"u":{"B":"y","A":"x"}}`, `{"u":{"B":"y","A":"x"}}`)
+	// A fuzzy (case-variant) key still matches via match_string and is KEPT under
+	// its ORIGINAL string, not the canonical literal.
+	mustParseExact(t, s, `{"u":{"a":"x"}}`, `{"u":{"a":"x"}}`)
+	// A key matching no arm -> decline the whole map (dynamic keeps it -> Mcoerce-d).
+	requireUnsupported(t, s, `{"u":{"B":"y","C":"z","A":"x"}}`)
+}
+
+// TestCoerceMap_EnumKeyMissDeclines pins that a MISSED enum key is NOT a partial
+// skip: the dynamic bridge keeps non-member enum keys (map_bad_enum_key -> full
+// map), so native declines the whole map rather than skip an entry BAML keeps.
+func TestCoerceMap_EnumKeyMissDeclines(t *testing.T) {
+	s := mapEnumKeySchema()
+	// All keys match -> claim; a missed key -> decline (not a partial skip).
+	mustParseExact(t, s, `{"labels":{"A":"one","B":"two"}}`, `{"labels":{"A":"one","B":"two"}}`)
+	requireUnsupported(t, s, `{"labels":{"A":"one","C":"two"}}`)
+}
+
+// TestCoerceMap_ValueThenKeyOrder pins BAML's VALUE-first order: an entry with a
+// PROVEN-bad VALUE is SKIPPED without ever coercing the KEY, so a would-be
+// case-fold-UNCERTAIN key (which, if evaluated, would decline the whole map)
+// never fires — the entry is simply dropped and the map succeeds.
+func TestCoerceMap_ValueThenKeyOrder(t *testing.T) {
+	// map<"é"|"x", int>: key "É" vs literal "é" is case-fold UNCERTAIN (would
+	// decline the map if the key were coerced), but the value "zzz" is a PROVEN
+	// int parse error coerced FIRST, so the entry skips and the map is {}.
+	s := oneField(&bamlutils.DynamicProperty{
+		Type: "map",
+		Keys: &bamlutils.DynamicTypeSpec{
+			Type: "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{
+				{Type: "literal_string", Value: "é"},
+				{Type: "literal_string", Value: "x"},
+			},
+		},
+		Values: &bamlutils.DynamicTypeSpec{Type: "int"},
+	})
+	mustParseExact(t, s, `{"u":{"É":"zzz"}}`, `{"u":{}}`)
+}
+
+// TestCoerceMap_DeferredValuePreemptsKeySkip pins the other side of value-first:
+// a value that is a DEFERRED Mcoerce-d success (JsonToString) declines the WHOLE
+// map even when the key would otherwise be a proven skip — native must not emit
+// a partial map that drops an entry BAML would keep via a lenient value path.
+func TestCoerceMap_DeferredValuePreemptsKeySkip(t *testing.T) {
+	// map<"A"|"B", string> with {"C": 5}: key "C" would be a proven MapKeyParseError
+	// skip, but the value 5 -> string is JsonToString (Mcoerce-d, NOT proven), so
+	// the whole map declines rather than skipping the entry.
+	requireUnsupported(t, mapLitUnionStrSchema(), `{"u":{"C":5}}`)
+}
+
+// TestCoerceMap_StringStringNonStringValueDeclines pins the must-decline value
+// path: map<string,string> with a NUMBER value is BAML JsonToString (Mcoerce-d),
+// NOT a proven parse error, so native declines the whole map (never skips or
+// stringifies).
+func TestCoerceMap_StringStringNonStringValueDeclines(t *testing.T) {
+	s := mapStrStrSchema()
+	mustParseExact(t, s, `{"u":{"a":"x","b":"y"}}`, `{"u":{"a":"x","b":"y"}}`) // clean claim
+	requireUnsupported(t, s, `{"u":{"a":"x","b":5}}`)
+	requireUnsupported(t, s, `{"u":{"a":true}}`)
+}
+
+// TestCoerceMap_DuplicateKeyDeclines pins that ANY duplicate original input key
+// declines the whole map — even when the duplicate entry would itself SKIP (a
+// skipped duplicate must not be reasoned to leave the rest safe).
+func TestCoerceMap_DuplicateKeyDeclines(t *testing.T) {
+	s := mapStringIntSchema()
+	requireUnsupported(t, s, `{"scores":{"a":1,"a":2}}`)
+	// Duplicate whose second entry has a (proven-bad) value still declines.
+	requireUnsupported(t, s, `{"scores":{"a":1,"a":"bad"}}`)
+}
+
+// TestCoerceMap_NonObjectDeclines pins the conservative non-object decline
+// (unchanged): a non-object where a map is required is not a hard type error, so
+// native falls back rather than claiming a mismatch BAML would not produce.
+func TestCoerceMap_NonObjectDeclines(t *testing.T) {
+	s := mapStringIntSchema()
+	requireUnsupported(t, s, `{"scores":[1,2,3]}`)
+	requireUnsupported(t, s, `{"scores":"x"}`)
+	requireUnsupported(t, s, `{"scores":5}`)
+}
+
+// TestCoerceMap_NullableCleanOnlyDeclines pins the union revisit for maps: an
+// object-input map arm ALWAYS carries ObjectToMap (score-bearing), so a nullable
+// optional map declines against the scored null arm — while a JSON null claims
+// the null fast path.
+func TestCoerceMap_NullableCleanOnlyDeclines(t *testing.T) {
+	s := optionalMapStrIntSchema()
+	// JSON null -> the null fast path claims null.
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	// Object input -> ObjectToMap (score-bearing) -> decline (M3 scoring vs null),
+	// even for a clean, fully-accepted map.
+	requireUnsupported(t, s, `{"u":{"a":1}}`)
+	requireUnsupported(t, s, `{"u":{}}`)
+}
+
+// TestProvenMapValueError pins the map-VALUE child classifier delegates to the
+// shared provenListItemError whitelist (map values coerce exactly like list
+// items): a proven int parse error / error_unexpected_type kind skips, while a
+// deferred (string-target / object-class / array / number) value does not.
+func TestProvenMapValueError(t *testing.T) {
+	intT := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt}
+	strT := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveString}
+	str := func(s string) value { return value{kind: valString, strV: s} }
+	num := func(s string) value { return value{kind: valNumber, numV: json.Number(s)} }
+
+	cases := []struct {
+		name string
+		valT schema.Type
+		val  value
+		want bool
+	}{
+		{"int-bad-string", intT, str("bad"), true},
+		{"int-object", intT, value{kind: valObject}, true},
+		{"int-bool", intT, value{kind: valBool, boolV: true}, true},
+		{"int-null", intT, value{kind: valNull}, true},
+		{"int-number", intT, num("5"), false},            // BAML always coerces a number
+		{"int-fraction-string", intT, str("3/2"), false}, // BAML coerces
+		{"string-number", strT, num("5"), false},         // JsonToString (Mcoerce-d)
+		{"string-object", strT, value{kind: valObject}, false},
+	}
+	for _, c := range cases {
+		if got := provenMapValueError(nil, c.valT, c.val); got != c.want {
+			t.Errorf("%s: provenMapValueError = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/debaml/coerce_test.go
+++ b/internal/debaml/coerce_test.go
@@ -101,17 +101,22 @@ func litUnionType(lits ...string) schema.Type {
 	return schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: vs}}
 }
 
-// TestMatchMapKeyUncertaintyMarksFlags covers every matchMapKey uncertainty and
-// acceptance branch (string-literal, string-literal-union, enum), pinning:
-//   - CR-MAPKEY: an uncertain key DECLINES and marks cf.uncertain, nil-safely.
-//   - the string-literal-union ACCEPT-ANY-ARM fix: a clean arm accepts the key
-//     even if an EARLIER arm was uncertain (no over-decline, no spurious mark).
-//   - the mixed-union guard: a union with a non-string-literal arm declines
-//     (never treated as its string-literal subset).
+// TestCoerceMapKey covers every coerceMapKey branch (string primitive,
+// string-literal, string-literal-union, enum), pinning the TWO-way outcome:
 //
-// The runes are 'é'(U+00E9, IsLower -> certain) and 'É'(U+00C9, not IsLower ->
-// uncertain once it reaches the case-fold attempt).
-func TestMatchMapKeyUncertaintyMarksFlags(t *testing.T) {
+//   - ACCEPT: err=nil — a clean match_string match (any arm, for a union), or any
+//     string-primitive key.
+//   - DECLINE the whole map: err=ErrDeBAMLParseUnsupported — a case-fold-UNCERTAIN
+//     verdict (marks cf.uncertain, nil-safely), the mixed-union guard, or a
+//     certain MISS. A KEY never yields a partial skip: the dynamic bridge keeps
+//     non-matching enum/literal/literal-union keys leniently (full map), so a
+//     miss is a DEFERRED Mcoerce-d keep and native declines the whole map.
+//
+// It also pins the string-literal-union ACCEPT-ANY-ARM rule (a clean arm accepts
+// even if an EARLIER arm was uncertain). The runes are 'é'(U+00E9, IsLower ->
+// certain) and 'É'(U+00C9, not IsLower -> uncertain once it reaches the case-fold
+// attempt).
+func TestCoerceMapKey(t *testing.T) {
 	// An indexed bundle with an (ASCII) enum key type — enum uncertainty is
 	// driven by the non-ASCII INPUT key, so the enum values stay ASCII.
 	enumB, err := schema.FromDynamicOutputSchema(mapEnumKeySchema(), schema.BuildOptions{})
@@ -119,6 +124,7 @@ func TestMatchMapKeyUncertaintyMarksFlags(t *testing.T) {
 		t.Fatalf("build enum bundle: %v", err)
 	}
 	enumKey := schema.Type{Kind: schema.TypeEnum, Name: enumB.Enums[0].Name.Name}
+	strKey := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveString}
 
 	mixedUnion := schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{
 		strLitType("é"),
@@ -130,42 +136,47 @@ func TestMatchMapKeyUncertaintyMarksFlags(t *testing.T) {
 		b             *schema.Bundle
 		keyT          schema.Type
 		key           string
-		wantAccept    bool // true = nil (accepted), false = unsupported decline
+		wantAccept    bool // true = nil (accepted), false = whole-map decline (err)
 		wantUncertain bool
 	}{
-		{"literal-uncertain", nil, strLitType("é"), "É", false, true},
+		// String primitive: any key coerces -> ACCEPT.
+		{"string-any", nil, strKey, "whatever", true, false},
+		// String literal: exact -> ACCEPT; certain miss -> DECLINE (dynamic keeps);
+		// uncertain case fold -> DECLINE + mark.
 		{"literal-exact", nil, strLitType("é"), "é", true, false},
+		{"literal-certain-miss-decline", nil, strLitType("abc"), "xyz", false, false},
+		{"literal-uncertain-decline", nil, strLitType("é"), "É", false, true},
+		// String-literal union.
+		{"union-normal-accept", nil, litUnionType("é", "beta"), "beta", true, false},
+		{"union-certain-miss-decline", nil, litUnionType("abc", "def"), "xyz", false, false},
 		// UNCERTAIN-ONLY match: key "É" matches literal "é" only via the case-fold
-		// pass (matchString returns matchOne AND uncertain) -> must DECLINE and
-		// mark uncertain, NOT accept. (This case was wrongly accepted before the
-		// accepted = matchOne && !uncertain fix.)
+		// pass (matchString returns matchOne AND uncertain) -> DECLINE + mark, NOT
+		// accept.
 		{"union-uncertain-only-match", nil, litUnionType("é"), "É", false, true},
-		// No arm cleanly matches, but an arm's verdict was uncertain -> mark.
+		// No arm cleanly matches, but an arm's verdict was uncertain -> DECLINE.
 		{"union-uncertain-no-clean", nil, litUnionType("abc", "def"), "É", false, true},
 		// ACCEPT-ANY-ARM rescue: arm "abc" is uncertain for "É", but arm "É"
 		// matches EXACTLY (before the case-fold attempt, so certain) -> accept,
 		// and DON'T mark uncertain.
 		{"union-accept-any-arm", nil, litUnionType("abc", "É"), "É", true, false},
-		// A later arm matches exactly with no uncertainty anywhere.
-		{"union-normal-accept", nil, litUnionType("é", "beta"), "beta", true, false},
 		// Mixed union (string literal | int): declined by the guard, no scan.
 		{"mixed-union-guard", nil, mixedUnion, "É", false, false},
-		// Enum: the non-ASCII input key drives the uncertainty (values are ASCII).
-		{"enum-uncertain", enumB, enumKey, "É", false, true},
+		// Enum: exact -> ACCEPT; a MISS (dynamic keeps non-members) -> DECLINE the
+		// whole map; uncertain -> DECLINE + mark.
 		{"enum-exact", enumB, enumKey, "A", true, false},
+		{"enum-miss-decline", enumB, enumKey, "ZZZ", false, false},
+		{"enum-uncertain-decline", enumB, enumKey, "É", false, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			cf := &coerceFlags{}
-			err := matchMapKey(c.b, c.keyT, c.key, cf)
+			err := coerceMapKey(c.b, c.keyT, c.key, cf)
 			if c.wantAccept {
 				if err != nil {
 					t.Fatalf("want accept (nil), got %v", err)
 				}
-			} else {
-				if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
-					t.Fatalf("want ErrDeBAMLParseUnsupported decline, got %v", err)
-				}
+			} else if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Fatalf("want ErrDeBAMLParseUnsupported decline, got %v", err)
 			}
 			if cf.isUncertain() != c.wantUncertain {
 				t.Errorf("cf.uncertain = %v, want %v", cf.isUncertain(), c.wantUncertain)
@@ -174,32 +185,7 @@ func TestMatchMapKeyUncertaintyMarksFlags(t *testing.T) {
 	}
 
 	// Nil-safe: an uncertain key with a nil accumulator must not panic.
-	if err := matchMapKey(nil, strLitType("é"), "É", nil); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+	if err := coerceMapKey(nil, strLitType("é"), "É", nil); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
 		t.Fatalf("nil cf: want ErrDeBAMLParseUnsupported, got %v", err)
 	}
-}
-
-// TestWrapperDeclinesValueVerdict confirms the no-regression side of CR1 for the
-// wrapper that STILL declines on a value-verdict child: coerceMap (partial maps
-// are deferred to the Mcoerce-c maps follow-up). A non-object map VALUE where a
-// multi-field class is required makes coerceClass return typeMismatch
-// (value-verdict), and coerceMap declines the whole map rather than skip the
-// entry. (coerceList, by contrast, now SKIPS such a proven parse error — see
-// coerce_list_test.go's TestCoerceList_ClassScalarSkips.)
-func TestWrapperDeclinesValueVerdict(t *testing.T) {
-	// Root{ items: map<string, Pair> }, Pair{ a, b }. A non-object map value
-	// makes coerceClass return typeMismatch (value-verdict) -> coerceMap declines.
-	s := &bamlutils.DynamicOutputSchema{
-		Properties: props(kv("items", &bamlutils.DynamicProperty{
-			Type:   "map",
-			Keys:   &bamlutils.DynamicTypeSpec{Type: "string"},
-			Values: &bamlutils.DynamicTypeSpec{Ref: "Pair"},
-		})),
-		Classes: bamlutils.MustOrderedMap(
-			bamlutils.OrderedKV("Pair", &bamlutils.DynamicClass{
-				Properties: props(kv("a", strProp()), kv("b", strProp())),
-			}),
-		),
-	}
-	requireUnsupported(t, s, `{"items":{"k":5}}`)
 }

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -335,16 +335,17 @@ func TestParse_MapNonObjectDeclines(t *testing.T) {
 	requireUnsupported(t, mapStringIntSchema(), `{"scores":"x"}`)
 }
 
-func TestParse_MapBadValueDeclines(t *testing.T) {
-	// A value that fails native coercion (even with Mcoerce-b leniency) DECLINES
-	// the WHOLE map: BAML records MapValueParseError and SKIPS just that entry,
-	// returning a partial map — native cannot claim a different/partial result.
-	// "x" is not a number in any form (no i64/u64/f64/fraction/extracted match),
-	// so coerce_int errors and BAML skips the entry.
-	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":"x"}}`)
-	// A float map value is NO LONGER "bad": Mcoerce-b rounds 2.5->3 (FloatToInt,
-	// a successful coercion BAML keeps), so this now CLAIMS — see
-	// TestParse_MapLenientValueClaimed.
+func TestParse_MapBadValuePartialSkip(t *testing.T) {
+	// Mcoerce-c: a value that is a PROVEN BAML int parse error is SKIPPED as a
+	// partial map entry (MapValueParseError), not a whole-map decline. "x" is not
+	// a number in any form (no i64/u64/f64/fraction/extracted match), so
+	// coerce_int errors and BAML skips just that entry, keeping the rest in input
+	// order.
+	mustParseExact(t, mapStringIntSchema(), `{"scores":{"a":1,"b":"x"}}`, `{"scores":{"a":1}}`)
+	// All values bad -> {} (still a successful, empty map).
+	mustParseExact(t, mapStringIntSchema(), `{"scores":{"a":"x","b":"y"}}`, `{"scores":{}}`)
+	// A float map value is NOT "bad": Mcoerce-b rounds 2.5->3 (FloatToInt, a
+	// successful coercion BAML keeps) — see TestParse_MapLenientValueClaimed.
 }
 
 // TestParse_MapLenientValueClaimed pins the Mcoerce-b map-value flip: a float
@@ -439,7 +440,9 @@ func TestParse_MapLiteralUnionKeysExact(t *testing.T) {
 		})),
 	}
 	mustParseExact(t, s, `{"m":{"A":"x","B":"y"}}`, `{"m":{"A":"x","B":"y"}}`)
-	// A key not among the literals declines (BAML fuzzy-matches/skips).
+	// A key matching NO string-literal-union arm is NOT a native partial skip: the
+	// dynamic bridge KEEPS the non-matching key (live-captured full map), so
+	// native declines the WHOLE map rather than skip an entry BAML keeps.
 	requireUnsupported(t, s, `{"m":{"A":"x","C":"z"}}`)
 }
 


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Mcoerce-c MAPS (de-BAML epic #546)

Ports BAML's `coerce_map` partial-map behavior into native de-BAML for deterministic, non-union map targets. This is the **maps** slice of Mcoerce-c; the **lists** slice already shipped in #560. `coerceList` and its helpers are **untouched** — maps only.

### coerceMap (`internal/debaml/coerce.go`)
- **Object → map is always object-to-map:** `ObjectToMap` (score-bearing) is flagged before iterating, so a map is never a zero-score "clean" arm.
- **VALUE first, then KEY** (BAML `coerce_map.rs` order): a proven-parse-error **value** folds into `MapValueParseError` and the entry is **skipped** (partial map), keeping accepted entries in **INPUT key order** under their **ORIGINAL key strings**; a bad **key** declines the whole map.
- **Value child-classifier** (`coerceMapValueChild` / `provenMapValueError`) **reuses the LISTS `provenListItemError` whitelist verbatim** — a map value coerces on the raw child exactly like a list item — so only a **proven** BAML parse error is skipped. A value native merely *declined* (a deferred Mcoerce-d success, e.g. `map<string,string>` with a **number** → `JsonToString`) declines the **whole map** rather than skip an entry BAML would keep.
- **KEY child-classifier** (`coerceMapKey`): unchanged from M2b — a key that does not cleanly match declines the whole map. **Live capture proved the dynamic bridge keeps non-matching enum / string-literal / literal-union keys leniently (full map, not partial)**, so a key miss is a deferred Mcoerce-d keep, never a native skip.
- **Decline preserved:** duplicate original keys (unproven insert/overwrite order) and non-object input.
- **Nullable clean-only:** map score is OWN flags only (`score.rs`) — a kept value's flags don't propagate — so a nullable optional map arm declines against the scored null arm. Mcoerce-c does not score collection arms vs null.

### Map child-classifier design (values + keys)
| child | proven-error → **SKIP entry** | deferred/uncertain → **DECLINE whole map** |
|---|---|---|
| **value** | numeric-string re-derivation (`bamlStringNumberFails`), `error_unexpected_type` kinds (object/bool/null → int; number/object/null → bool), certain match_string miss, multi-field all-required-flat-leaf class ← scalar | non-string → string/enum/literal (`JsonToString`/`ObjectToString`), object → literal (`ObjectToPrimitive`), object-missing-required class (default-fill), array (array-to-singular/M3), union scoring, case-fold uncertain |
| **key** | *(none — dynamic bridge keeps non-matching keys leniently)* | any non-clean match_string verdict: enum / string-literal / literal-union miss (full-map keep = Mcoerce-d), or case-fold uncertain |

### Corpus differential dispositions (all wants live-captured; gating diff green)
**Flipped to CLAIMED**
- `map_value_partial_bad_int` — `{"a":1,"bad":"nope","c":"7"}` → `{"a":1,"c":7}` (proven int-parse-error value skipped).
- `map_value_lenient_kept` — `{"a":"7","b":2.5}` → `{"a":7,"b":3}` (Mcoerce-b lenient values kept; map score ignores FloatToInt).
- `map_bad_value_type` (existing, false→**true**) — `{"a":1,"b":{"x":1}}` → `{"a":1}` (object value → int is a proven `error_unexpected_type` skip).

**Stay / pinned FALLBACK** (native declines; each justified)
- `map_literal_key_partial_bad_key`, `map_bad_key_original_order` — **live capture showed FULL maps**: the dynamic bridge keeps a non-matching `"A"|"B"` literal-union key, so a key miss is Mcoerce-d, not a skip.
- `map_enum_key_nonmember_live_probe` — non-member enum key kept (full map), same lenient-keep finding as `map_bad_enum_key`.
- `map_duplicate_key_stays_fallback` — duplicate original key (BAML insert/overwrite order unproven).
- `map_string_string_non_string_value_stays_fallback` — number value → `JsonToString` (Mcoerce-d).
- `nullable_optional_map_object_stays_fallback` — `ObjectToMap` is score-bearing (M3 vs null).
- `union_map_value_partial` — existing over-claim guard (partial map arm + string arm → pick_best).

### Validation
`gofmt` · `go build ./...` · `go vet ./...` + `-tags=integration` · `go test ./internal/debaml ./bamlutils ./worker ./dynclient/...` · `GOWORK=off go test ./codegen` (from `adapters/common`) · `go run ./cmd/verify-framework-adapter` (6/6) — all green. **bamlfuzz parse-recovery differential ran locally** (Docker + cached BAML v0.223.0 CFFI): native-vs-BAML diff green, every fixture's disposition matches its pin (60 claimed / 45 fallback).

Scope: `internal/debaml/{coerce,*_test}.go` + `integration/bamlfuzz_parse_recovery_test.go` + corpus JSON only. Runtime gate stays `BAML_REST_USE_DEBAML`; no seam/regen/embed/go.mod changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced map parse-recovery now returns partial results when only specific map entries fail to coerce.
  * Preserves original input key order in recovered map outputs.
  * Improves lenient map value coercion (e.g., numeric strings and float-to-int rounding where applicable).

* **Bug Fixes**
  * Duplicate-key map inputs now reliably decline the entire map.
  * Non-clean map-key misses now decline the whole map, while proven value errors can be skipped without discarding valid entries.

* **Tests**
  * Expanded parse-recovery fixtures and added broader map coercion test coverage for edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->