### PR TITLE
debaml: native structural class coercion + defaults (Mcoerce-d PR 2/3)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/125_single_field_class_scalar_inferred.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/125_single_field_class_scalar_inferred.json
@@ -1,0 +1,43 @@
+{
+  "name": "single_field_class_scalar_inferred",
+  "description": "Mcoerce-d PR 2 CLAIMED: single-field class Box{value int} with a BARE SCALAR input 5. BAML's coerce_class inferred-object absorbs the scalar into the lone field (ImpliedKey cost 2 + InferedObject cost 0). Native ports it and claims {value:5}. want live-captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "class_ref",
+              "ref": "Box"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Box",
+        "properties": [
+          {
+            "name": "value",
+            "type": {
+              "kind": "int"
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":5}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": {
+        "value": 5
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/126_single_field_class_object_implied_key.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/126_single_field_class_object_implied_key.json
@@ -1,0 +1,43 @@
+{
+  "name": "single_field_class_object_implied_key",
+  "description": "Mcoerce-d PR 2 CLAIMED: single-field class Box{value string} with an object {foo:5} whose key does NOT match the lone field. BAML's coerce_class implied-key coerces the WHOLE object into the string field (JsonToString Display '{foo: 5}' + ImpliedKey cost 2, no ExtraKey). want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "class_ref",
+              "ref": "Box"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Box",
+        "properties": [
+          {
+            "name": "value",
+            "type": {
+              "kind": "string"
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":{\"foo\":5}}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": {
+        "value": "{foo: 5}"
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/127_class_missing_optional_null.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/127_class_missing_optional_null.json
@@ -1,0 +1,53 @@
+{
+  "name": "class_missing_optional_null",
+  "description": "Mcoerce-d PR 2 CLAIMED: class C{name string, nick string?} with nick ABSENT. BAML fills the missing optional with null (OptionalDefaultFromNoValue cost 1 + Pending); the dynamic pipeline injects the null. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "class_ref",
+              "ref": "C"
+            }
+          }
+        ]
+      },
+      {
+        "name": "C",
+        "properties": [
+          {
+            "name": "name",
+            "type": {
+              "kind": "string"
+            }
+          },
+          {
+            "name": "nick",
+            "type": {
+              "kind": "optional",
+              "inner": {
+                "kind": "string"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":{\"name\":\"Ada\"}}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": {
+        "name": "Ada",
+        "nick": null
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/128_class_required_list_default_from_no_value.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/128_class_required_list_default_from_no_value.json
@@ -1,0 +1,46 @@
+{
+  "name": "class_required_list_default_from_no_value",
+  "description": "Mcoerce-d PR 2 CLAIMED: class C{items int[]} with items ABSENT (empty object). BAML's TypeIR::default_value fills the list default [] (DefaultFromNoValue cost 100 + Pending). want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "class_ref",
+              "ref": "C"
+            }
+          }
+        ]
+      },
+      {
+        "name": "C",
+        "properties": [
+          {
+            "name": "items",
+            "type": {
+              "kind": "list",
+              "inner": {
+                "kind": "int"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":{}}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": {
+        "items": []
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/129_class_required_map_default_from_no_value.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/129_class_required_map_default_from_no_value.json
@@ -1,0 +1,49 @@
+{
+  "name": "class_required_map_default_from_no_value",
+  "description": "Mcoerce-d PR 2 CLAIMED: class C{m map<string,int>} with m ABSENT. BAML fills the map default {} (DefaultFromNoValue cost 100). want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "class_ref",
+              "ref": "C"
+            }
+          }
+        ]
+      },
+      {
+        "name": "C",
+        "properties": [
+          {
+            "name": "m",
+            "type": {
+              "kind": "map",
+              "key": {
+                "kind": "string"
+              },
+              "inner": {
+                "kind": "int"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":{}}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": {
+        "m": {}
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/130_class_required_null_default_from_no_value.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/130_class_required_null_default_from_no_value.json
@@ -1,0 +1,43 @@
+{
+  "name": "class_required_null_default_from_no_value",
+  "description": "Mcoerce-d PR 2 CLAIMED: class C{n null} with n ABSENT. BAML fills the primitive-null default null (DefaultFromNoValue cost 100). want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "class_ref",
+              "ref": "C"
+            }
+          }
+        ]
+      },
+      {
+        "name": "C",
+        "properties": [
+          {
+            "name": "n",
+            "type": {
+              "kind": "null"
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":{}}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": {
+        "n": null
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/131_class_map_field_default_but_had_unparseable_value.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/131_class_map_field_default_but_had_unparseable_value.json
@@ -1,0 +1,49 @@
+{
+  "name": "class_map_field_default_but_had_unparseable_value",
+  "description": "Mcoerce-d PR 2 CLAIMED: class C{m map<string,int>} with m present as a NON-object 'bad'. coerce_map errors on a non-object (error_unexpected_type), so BAML fills the map default {} (DefaultButHadUnparseableValue cost 2). want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "class_ref",
+              "ref": "C"
+            }
+          }
+        ]
+      },
+      {
+        "name": "C",
+        "properties": [
+          {
+            "name": "m",
+            "type": {
+              "kind": "map",
+              "key": {
+                "kind": "string"
+              },
+              "inner": {
+                "kind": "int"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":{\"m\":\"bad\"}}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": {
+        "m": {}
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/132_list_single_field_class_scalar_kept.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/132_list_single_field_class_scalar_kept.json
@@ -1,0 +1,51 @@
+{
+  "name": "list_single_field_class_scalar_kept",
+  "description": "Mcoerce-d PR 2 CLAIMED: list<Box> where Box{value int}, scalar elements. Each element inferred-object-absorbs into its Box (ImpliedKey), so both elements are KEPT (not skipped, not a whole-list decline). want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "list",
+              "inner": {
+                "kind": "class_ref",
+                "ref": "Box"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "Box",
+        "properties": [
+          {
+            "name": "value",
+            "type": {
+              "kind": "int"
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":[5,6]}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": [
+        {
+          "value": 5
+        },
+        {
+          "value": 6
+        }
+      ]
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/133_map_string_single_field_class_scalar_value_kept.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/133_map_string_single_field_class_scalar_value_kept.json
@@ -1,0 +1,54 @@
+{
+  "name": "map_string_single_field_class_scalar_value_kept",
+  "description": "Mcoerce-d PR 2 CLAIMED: map<string,Box> where Box{value int}, scalar values. Each value inferred-object-absorbs into its Box, so both entries are KEPT. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "map",
+              "key": {
+                "kind": "string"
+              },
+              "inner": {
+                "kind": "class_ref",
+                "ref": "Box"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "Box",
+        "properties": [
+          {
+            "name": "value",
+            "type": {
+              "kind": "int"
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":{\"a\":5,\"b\":6}}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": {
+        "a": {
+          "value": 5
+        },
+        "b": {
+          "value": 6
+        }
+      }
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/134_list_class_required_default_value_kept.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/134_list_class_required_default_value_kept.json
@@ -1,0 +1,51 @@
+{
+  "name": "list_class_required_default_value_kept",
+  "description": "Mcoerce-d PR 2 CLAIMED: list<C> where C{items int[]}, an empty-object element. BAML fills C's required list default [], so the element is KEPT as {items:[]}. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "list",
+              "inner": {
+                "kind": "class_ref",
+                "ref": "C"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "C",
+        "properties": [
+          {
+            "name": "items",
+            "type": {
+              "kind": "list",
+              "inner": {
+                "kind": "int"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":[{}]}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": [
+        {
+          "items": []
+        }
+      ]
+    }
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/135_map_string_class_required_default_value_kept.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/135_map_string_class_required_default_value_kept.json
@@ -1,0 +1,54 @@
+{
+  "name": "map_string_class_required_default_value_kept",
+  "description": "Mcoerce-d PR 2 CLAIMED: map<string,C> where C{items int[]}, an empty-object value. BAML fills C's required list default [], so the entry is KEPT as {items:[]}. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "map",
+              "key": {
+                "kind": "string"
+              },
+              "inner": {
+                "kind": "class_ref",
+                "ref": "C"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "C",
+        "properties": [
+          {
+            "name": "items",
+            "type": {
+              "kind": "list",
+              "inner": {
+                "kind": "int"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":{\"k\":{}}}",
+  "want": {
+    "status": "success",
+    "json": {
+      "u": {
+        "k": {
+          "items": []
+        }
+      }
+    }
+  }
+}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -379,6 +379,28 @@ var parseRecoveryNativeClaim = map[string]bool{
 	// Integer stringification still claims (see the CLAIMED entries above).
 	"primitive_string_number_noninteger_stays_fallback": false,
 	"list_string_noninteger_number_stays_fallback":      false,
+
+	// Mcoerce-d PR 2 — STRUCTURAL CLASS DEFAULTS. coerceClass now ports BAML's
+	// coerce_class.rs (non-array subset): single-field OBJECT implied-key and
+	// SCALAR/null inferred-object absorption, missing-optional null fill, and
+	// TypeIR::default_value required-field fills (list→[], map→{}, null→null;
+	// DefaultFromNoValue) plus the present-map-non-object default {}
+	// (DefaultButHadUnparseableValue). These resolve byte-identical to BAML, so the
+	// deterministic non-union class cases are CLAIMED — including the collection
+	// flips (a single-field-class scalar element / class-with-defaults element is
+	// KEPT in a list/map). ARRAY input to a class still DECLINES (M3
+	// array-to-singular). No union-family broadening (PR 3).
+	"single_field_class_scalar_inferred":                true,
+	"single_field_class_object_implied_key":             true,
+	"class_missing_optional_null":                       true,
+	"class_required_list_default_from_no_value":         true,
+	"class_required_map_default_from_no_value":          true,
+	"class_required_null_default_from_no_value":         true,
+	"class_map_field_default_but_had_unparseable_value": true,
+	"list_single_field_class_scalar_kept":               true,
+	"map_string_single_field_class_scalar_value_kept":   true,
+	"list_class_required_default_value_kept":            true,
+	"map_string_class_required_default_value_kept":      true,
 }
 
 // parseRecoveryStats tallies how many final-parse cases the native parser

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -62,6 +62,19 @@ func (f *coerceFlags) isFlagged() bool { return f != nil && f.flagged }
 // isUncertain reports whether a non-ASCII case-fold uncertainty was recorded.
 func (f *coerceFlags) isUncertain() bool { return f != nil && f.uncertain }
 
+// mergeFrom folds a CHILD accumulator's signals into f: a flagged child makes f
+// non-clean (a class/list score is own flags plus child scores), and an uncertain
+// child makes f uncertain. Nil-safe on the receiver (flag / markUncertain are),
+// so untracked callers pay nothing; child is always non-nil at the call sites.
+func (f *coerceFlags) mergeFrom(child *coerceFlags) {
+	if child.isFlagged() {
+		f.flag()
+	}
+	if child.isUncertain() {
+		f.markUncertain()
+	}
+}
+
 // coerce converts an ordered value (decoded strict, or via the
 // conservative fixing pass) into the flattened dynamic output JSON for
 // type t, returning a json.RawMessage. checkSupported has already rejected
@@ -108,27 +121,37 @@ func (f *coerceFlags) isUncertain() bool { return f != nil && f.uncertain }
 // rule holds, and the leaf-level collection classifiers keep the newly-succeeding
 // string/enum/literal children instead of declining the whole collection (a
 // direct string←null child is now a proven ArrayItemParseError/MapValueParseError
-// skip). The remaining leniencies stay STRICT and DECLINE: class STRUCTURAL
-// coercion — single-field implied-key / inferred-object absorption, extra-key
-// tolerance, and default-fill (Mcoerce-d PR 2) — and broadened union families
-// (Mcoerce-d PR 3). Where native's coercion fails but BAML may leniently SUCCEED
-// (or null-default) — or where native cannot determine BAML's exact
-// success/failure — coercion DECLINES (ErrDeBAMLParseUnsupported → fall back to
-// BAML), so native is never "more capable" than BAML.
+// skip). Mcoerce-d PR 2 adds native STRUCTURAL CLASS coercion (coerceClass /
+// coerce_class.rs): input-key→field assignment (first-match, keep-first
+// duplicates, ExtraKey extras), single-field OBJECT implied-key and SCALAR/null
+// inferred-object absorption (ImpliedKey / InferedObject), missing-optional null
+// fill (OptionalDefaultFromNoValue), and required-field DEFAULTS via
+// TypeIR::default_value (defaultValue — list→[], map→{}, null→null, first
+// defaultable union arm; DefaultFromNoValue) plus the present-map-non-object
+// default {} (DefaultButHadUnparseableValue). Each new flag is score-bearing so
+// the nullable-union clean-only rule holds, and a class child that now succeeds
+// through these paths is KEPT in a list/map instead of declining the whole
+// collection. ARRAY input to a class still DECLINES (coerce_array_to_singular /
+// pick_best = M3), as do broadened union families (Mcoerce-d PR 3). Where
+// native's coercion fails but BAML may leniently SUCCEED (or null-default) — or
+// where native cannot determine BAML's exact success/failure — coercion DECLINES
+// (ErrDeBAMLParseUnsupported → fall back to BAML), so native is never "more
+// capable" than BAML.
 //
-// Native CLAIMS a coercion error only where BAML also errors: a non-object
-// where a MULTI-field class is required (coerceClass typeMismatch), or a
-// match_string substring TIE (StrMatchOneFromMany — coerceEnum/coerceLiteral
-// ambiguousMatch). A required field still unmatched after fuzzy key matching
-// DECLINES — BAML may default-fill or hard-fail and native cannot tell which.
-// Union claims count LENIENT per-variant successes and claim only the lone
-// winner; two-plus successes are BAML pick_best (M3) and DECLINE. A consequence
-// is that native still declines some inputs BAML would itself reject or coerce
-// differently (e.g. a required field with no fuzzy key match, an int-LITERAL
-// value mismatch after rounding, a single-key object into a literal) — behavior
-// is identical via fallback, and precise claim-parity for those is deferred to
-// the rest of the Mcoerce milestone (#546). See coercePrimitive / coerceList /
-// coerceEnum / coerceLiteral / coerceClass for the per-kind boundary.
+// Native CLAIMS a coercion error only where BAML also errors: a match_string
+// substring TIE (StrMatchOneFromMany — coerceEnum / coerceLiteral
+// ambiguousMatch). A class missing a required NON-defaultable field DECLINES
+// (BAML errors, but native falls back to stay strictly non-over-claiming), as
+// does ARRAY input to a class (M3 array-to-singular). Union claims count LENIENT
+// per-variant successes and claim only the lone winner; two-plus successes are
+// BAML pick_best (M3) and DECLINE. A consequence is that native still declines
+// some inputs BAML would itself reject or coerce differently (a required field
+// with no key match, a present field native's coercer is stricter on, an
+// implied-key/inferred coercion native declines, an int-LITERAL value mismatch
+// after rounding) — behavior is identical via fallback, and precise claim-parity
+// for those is deferred to the rest of the Mcoerce milestone (#546). See
+// coercePrimitive / coerceList / coerceEnum / coerceLiteral / coerceClass for the
+// per-kind boundary.
 func coerce(b *schema.Bundle, t schema.Type, input value, f *coerceFlags) (json.RawMessage, error) {
 	switch t.Kind {
 	case schema.TypePrimitive:
@@ -902,140 +925,340 @@ func enumMatchCandidates(e *schema.EnumDef) []matchCandidate {
 	return cands
 }
 
-// coerceClass coerces an object value into a class, emitting fields in
-// schema declaration order. Input keys are matched to fields by BAML's
-// actual no-substring match_string (Mcoerce-a, via matchesStringToString),
-// reproducing coerce_class.rs: each input key is assigned to the FIRST field
-// whose rendered name it matches (case-insensitive / punctuation-stripped /
-// accent-folded — but NOT substring); when two input keys match the same
-// field the FIRST keeps it (update_map's "keep first", coerce_class.rs:548);
-// extra/unknown keys are ignored (ExtraKey, not emitted). It CLAIMS when the
-// input is an object and every required field is matched and coerces;
-// otherwise it DECLINES, because BAML's class coercer is leniently broader
-// than native and native cannot tell whether BAML would succeed:
+// coerceClass ports BAML's structural class coercer (coerce_class.rs, the
+// non-array subset) so native reproduces BAML's class value BYTE-for-BYTE.
+// Fields are emitted in SCHEMA declaration order under their CANONICAL names;
+// input keys are matched to fields by BAML's no-substring match_string
+// (matchesStringToString) — each key to the FIRST field whose rendered name it
+// fuzzily matches, first key keeps a field (update_map "keep first"), unmatched
+// keys are extras (ExtraKey, cost 1, not emitted). On top of field assignment it
+// ports (Mcoerce-d):
 //
-//   - A required field still unmatched after fuzzy key matching → DECLINE:
-//     BAML may fill a type default (list/map/null/union) or hard-fail
-//     (coerce_class.rs:342/field_type.rs:288), which native cannot reproduce.
-//   - A SINGLE-field class with a non-object input, or an object NONE of
-//     whose keys match the lone field → DECLINE: BAML absorbs the value into
-//     the one field via implied-key / inferred-object, or fills a default
-//     for an empty object (coerce_class.rs:224/295/313) — all Mcoerce-d.
+//   - SINGLE-field OBJECT implied-key (coerce_class.rs:224): when NO key matched
+//     the lone field and the object is non-empty, the WHOLE object is coerced
+//     into that field (ImpliedKey, cost 2) instead of flagging ExtraKey.
+//   - SINGLE-field SCALAR/null inferred-object (coerce_class.rs:295): a
+//     non-object non-array value is coerced into the lone field (ImpliedKey cost
+//     2 on the child + InferedObject cost 0 on the class).
+//   - Missing OPTIONAL field → null (OptionalDefaultFromNoValue cost 1 + Pending);
+//     native OMITS it (InjectAbsentOptionals re-adds the null downstream) but
+//     flags the score so a nullable-union arm stays non-clean.
+//   - Missing required field → TypeIR::default_value (defaultValue): list→[],
+//     map→{}, primitive-null→null, first-defaultable-union-arm, tuple (all cost
+//     100 DefaultFromNoValue); a non-defaultable missing required field is a
+//     BAML error_missing_required_field.
+//   - Present required MAP field with a NON-object value → the map default {}
+//     (DefaultButHadUnparseableValue cost 2): coerce_map errors on a non-object
+//     (error_unexpected_type), a PROVEN failure whose default is deterministic.
 //
-// A MULTI-field class with a NON-OBJECT input stays CLAIMED (typeMismatch):
-// BAML hard-fails turning a scalar into a multi-field object too, so the
-// differential checks error parity. A claimed child error (e.g. an enum
-// substring tie) propagates so the differential checks error parity; lenient
-// structural coercion (defaults, implied keys) is deferred to Mcoerce-d. Any
-// EXTRA input key (ExtraKey, cost 1) and any flagged child flag cf, so a
-// nullable-union claim can require this class arm to be clean.
+// It CLAIMS a class SUCCESS when every field resolves to a value native can
+// prove equals BAML's, PROPAGATES a claimed child error (an enum/literal
+// substring tie — BAML errors that non-defaultable field and so the class), and
+// DECLINES (fall back) otherwise:
+//
+//   - ARRAY input → DECLINE: BAML runs coerce_array_to_singular / pick_best over
+//     the items (M3); native does not model the scored selection.
+//   - A required NON-defaultable field is absent → DECLINE: BAML errors, but
+//     native falls back to stay strictly non-over-claiming (mirroring the
+//     pre-Mcoerce-d conservative choice).
+//   - A field native's coercer merely DECLINED (native stricter, so BAML may
+//     leniently succeed or null-default) or an implied-key/inferred coercion that
+//     declined → DECLINE: native cannot prove BAML's field value.
+//
+// Every score-bearing flag (ExtraKey / ImpliedKey / OptionalDefaultFromNoValue /
+// DefaultFromNoValue / DefaultButHadUnparseableValue) and any flagged child folds
+// into cf, so a nullable-union claim can require this class arm to be clean.
 func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input value, cf *coerceFlags) (json.RawMessage, error) {
 	cls, ok := b.FindClass(name, mode)
 	if !ok {
 		return nil, fmt.Errorf("debaml: unknown class %q", name)
 	}
-	singleField := len(cls.Fields) == 1
-	if input.kind != valObject {
-		if singleField {
-			return nil, declineCoerce("single-field class (BAML implied-key)", input)
+	// ARRAY input → coerce_array_to_singular / multi-candidate pick_best (M3):
+	// native cannot reproduce the scored selection (nor prove an all-items-fail
+	// error without walking the array), so it DECLINES and lets BAML decide.
+	if input.kind == valArray {
+		return nil, declineCoerce("class (BAML array-to-singular / pick_best, M3)", input)
+	}
+	nF := len(cls.Fields)
+	singleField := nF == 1
+
+	// Per-field resolution: out[i] holds the emitted bytes when filled[i]. A
+	// still-unfilled required NON-defaultable field records missingRequired (a
+	// claimed BAML error); a field native cannot resolve to BAML's exact value
+	// records indeterminate (fall back).
+	out := make([]json.RawMessage, nF)
+	filled := make([]bool, nF)
+	missingRequired := false
+	indeterminate := false
+
+	// resolveMatched coerces a matched/implied/inferred field value into field i,
+	// folding a clean child's flags on success and classifying a failure: a
+	// PROVEN map-non-object failure fills the {} default; every other declinable
+	// failure is INDETERMINATE (native may be stricter than BAML); a hard failure
+	// propagates.
+	resolveMatched := func(i int, v value) error {
+		childF := &coerceFlags{}
+		o, err := coerce(b, cls.Fields[i].Type, v, childF)
+		if err == nil {
+			out[i] = o
+			filled[i] = true
+			cf.mergeFrom(childF)
+			return nil
 		}
-		return nil, typeMismatch("object", input)
+		if !declinableChildError(err) {
+			return err // hard/invariant failure: propagate, never mask.
+		}
+		if isClaimedMismatch(err) {
+			// A CLAIMED field error (enum/literal substring tie StrMatchOneFromMany,
+			// a non-nullable-union null) — BAML PROVABLY errors this field, and only
+			// NON-defaultable field types produce it, so BAML errors the whole class
+			// (no array candidate for non-array input). Propagate so native claims
+			// the same error (the differential checks status parity).
+			return err
+		}
+		if cls.Fields[i].Type.Kind == schema.TypeMap && v.kind != valObject {
+			// coerce_map on a non-object is error_unexpected_type (coerce_map.rs),
+			// so BAML fills the map default {} with DefaultButHadUnparseableValue.
+			out[i] = json.RawMessage("{}")
+			filled[i] = true
+			cf.flag() // DefaultButHadUnparseableValue (cost 2)
+			return nil
+		}
+		if childF.isUncertain() {
+			cf.markUncertain()
+		}
+		indeterminate = true
+		return nil
 	}
 
-	// Assign input keys to fields the way BAML does: iterate input keys in
-	// order, and for each map it to the FIRST field whose rendered name it
-	// fuzzily matches (no substring). When two input keys match the same field,
-	// the FIRST keeps it (update_map "keep first") — later duplicates are
-	// ignored, NOT treated as extras. An input key matching no field is an
-	// extra (ExtraKey). This input-key-first order — rather than scanning
-	// fields for a matching key — is what makes one key resolve to a single
-	// field, avoiding a key being assigned to two fold-equal fields at once.
-	assigned := make([]value, len(cls.Fields))
-	present := make([]bool, len(cls.Fields))
-	foundAny := false
-	hasExtra := false
-	keyUncertain := false
-	for i := range input.objV {
-		key := input.objV[i].key
-		matchedField := -1
-		for j := range cls.Fields {
-			m, unc := matchesStringToString(key, cls.Fields[j].Name.RenderedName())
-			if unc {
-				// This key-vs-field comparison hinged on a non-ASCII case fold
-				// native cannot prove equals BAML's, so the assignment is
-				// untrustworthy.
-				keyUncertain = true
-				cf.markUncertain()
+	// coerceImplied coerces v into the lone field (implied-key / inferred-object),
+	// filling it with ImpliedKey (cost 2) on success. A CLAIMED failure propagates
+	// (the lone non-defaultable field errors → BAML errors the class); an unproven
+	// declinable failure records indeterminate (native cannot prove BAML's
+	// ExtraKey+default/error path).
+	coerceImplied := func(v value) error {
+		childF := &coerceFlags{}
+		o, err := coerce(b, cls.Fields[0].Type, v, childF)
+		if err == nil {
+			out[0] = o
+			filled[0] = true
+			cf.mergeFrom(childF)
+			cf.flag() // ImpliedKey (cost 2); InferedObject is cost 0 (no flag).
+			return nil
+		}
+		if !declinableChildError(err) {
+			return err
+		}
+		if isClaimedMismatch(err) {
+			return err // claimed field error → BAML errors the class; propagate.
+		}
+		if childF.isUncertain() {
+			cf.markUncertain()
+		}
+		indeterminate = true
+		return nil
+	}
+
+	switch input.kind {
+	case valObject:
+		// Assign input keys to fields in INPUT order: each key to the FIRST field
+		// it fuzzily matches (no substring); a key matching an already-filled
+		// field is a duplicate (keep first, ignored, NOT an extra); a key matching
+		// no field is an extra. Input-key-first order (rather than scanning fields
+		// for a matching key) is what resolves one key to a single field.
+		matched := make([]bool, nF)
+		assigned := make([]value, nF)
+		foundAny := false
+		extraCount := 0
+		keyUncertain := false
+		for i := range input.objV {
+			key := input.objV[i].key
+			mf := -1
+			for j := range cls.Fields {
+				m, unc := matchesStringToString(key, cls.Fields[j].Name.RenderedName())
+				if unc {
+					keyUncertain = true
+					cf.markUncertain()
+				}
+				if m {
+					mf = j
+					break
+				}
 			}
-			if m {
-				matchedField = j
-				break
+			switch {
+			case mf < 0:
+				extraCount++
+			case matched[mf]:
+				// Duplicate match for an already-filled field: keep first, ignore.
+			default:
+				assigned[mf] = input.objV[i].val
+				matched[mf] = true
+				foundAny = true
+			}
+		}
+		if keyUncertain {
+			// A field-key match/no-match could diverge from BAML; DECLINE (cf is
+			// already marked so an enclosing union counter declines too).
+			return nil, unsupported(fmt.Sprintf("class %q: non-ASCII case-fold uncertainty in a field key (cannot prove assignment equals BAML)", name))
+		}
+		for j := range cls.Fields {
+			if matched[j] {
+				if err := resolveMatched(j, assigned[j]); err != nil {
+					return nil, err
+				}
 			}
 		}
 		switch {
-		case matchedField < 0:
-			hasExtra = true // unmatched input key -> ExtraKey
-		case present[matchedField]:
-			// Duplicate match for an already-filled field: keep first, ignore.
-		default:
-			assigned[matchedField] = input.objV[i].val
-			present[matchedField] = true
-			foundAny = true
+		case singleField && !foundAny && extraCount > 0:
+			// No key matched the lone field: coerce the whole object into it
+			// (ImpliedKey, no ExtraKey). A declinable failure → indeterminate.
+			if err := coerceImplied(input); err != nil {
+				return nil, err
+			}
+		case extraCount > 0:
+			cf.flag() // ExtraKey (cost 1 each) — not a clean zero-score class.
+		}
+	default:
+		// Scalar / null (non-object, non-array). A single-field class absorbs the
+		// value into its lone field (inferred-object); a multi-field class assigns
+		// nothing (BAML's Some(x) arm is a no-op for >1 field) — every field falls
+		// to the default/missing pass below.
+		if singleField {
+			if err := coerceImplied(input); err != nil {
+				return nil, err
+			}
 		}
 	}
-	if keyUncertain {
-		// A field-key match/no-match could diverge from BAML; DECLINE rather
-		// than claim a (possibly wrong) assignment. cf is already marked so an
-		// enclosing union counter declines the whole union.
-		return nil, unsupported(fmt.Sprintf("class %q: non-ASCII case-fold uncertainty in a field key (cannot prove assignment equals BAML)", name))
+
+	if indeterminate {
+		// A field native could not resolve to BAML's exact value (a non-proven
+		// coercion decline, or an implied-key/inferred decline): fall back so
+		// BAML's lenient success / null-default / scored choice stands.
+		return nil, unsupported(fmt.Sprintf("class %q: a field could not be resolved to BAML's value (deferred lenient success/default/scoring)", name))
 	}
-	if singleField && !foundAny {
-		// No input key matched the lone field: BAML tries implied-key /
-		// inferred-object on the whole object, or fills a default for an empty
-		// object — native cannot reproduce either, so DECLINE (Mcoerce-d).
-		return nil, unsupported(fmt.Sprintf("single-field class %q: lone field unmatched (BAML implied-key/default)", name))
+
+	// Defaults / missing pass for every still-unfilled field (BAML's "check what
+	// we have / what we need").
+	for i := range cls.Fields {
+		if filled[i] {
+			continue
+		}
+		ft := cls.Fields[i].Type
+		if isOptional(ft) {
+			// Absent optional → null (OptionalDefaultFromNoValue + Pending). Native
+			// omits it (InjectAbsentOptionals adds the null downstream, identically
+			// for both legs) but flags the score for nullable-union cleanliness.
+			cf.flag() // OptionalDefaultFromNoValue (cost 1)
+			continue
+		}
+		if d, ok := defaultValue(ft); ok {
+			out[i] = d
+			filled[i] = true
+			cf.flag() // DefaultFromNoValue (cost 100)
+			continue
+		}
+		missingRequired = true
 	}
-	if hasExtra {
-		cf.flag() // ExtraKey (cost 1 each) -> not a clean zero-score class
+
+	if missingRequired {
+		// A required non-defaultable field is absent: BAML has no array candidate
+		// for non-array input, so it errors (error_missing_required_field). Native
+		// DECLINES (falls back) rather than claim the error — mirroring the
+		// pre-Mcoerce-d conservative choice: BAML's fuzzy field-key matching is
+		// reproduced here, but declining keeps native strictly non-over-claiming
+		// (a container/union wrapper that would skip or score the entry falls
+		// back too). The class-with-all-required-flat-leaf SCALAR case that a
+		// list/map element must SKIP is still identified independently by
+		// provenListItemError (classAllRequiredFlatLeaf), so partial collections
+		// stay correct.
+		return nil, unsupported(fmt.Sprintf("class %q: required non-defaultable field missing (BAML errors; native falls back)", name))
 	}
 
 	var buf bytes.Buffer
 	buf.WriteByte('{')
 	first := true
 	for i := range cls.Fields {
-		f := &cls.Fields[i]
-		if !present[i] {
-			if isOptional(f.Type) {
-				// Absent optional: omit it. The downstream
-				// InjectAbsentOptionals pass inserts the null, identically
-				// for the native and BAML paths.
-				continue
-			}
-			// A required field with no key match even after fuzzy matching:
-			// BAML may fill a type default (field_type.rs:288) or hard-fail,
-			// and native cannot tell which, so it DECLINES (fall back to BAML)
-			// rather than claim a missing-required error that would be WRONG
-			// when BAML defaults. Default-filling parity is Mcoerce-d.
-			return nil, unsupported(fmt.Sprintf("class %q: required field %q has no key match (BAML may default/error)", name, f.Name.RenderedName()))
-		}
-		child, err := coerce(b, f.Type, assigned[i], cf)
-		if err != nil {
-			return nil, err
+		if !filled[i] {
+			continue // absent optional (omitted; InjectAbsentOptionals adds null).
 		}
 		if !first {
 			buf.WriteByte(',')
 		}
 		first = false
-		key, err := marshalJSON(f.Name.Name)
+		key, err := marshalJSON(cls.Fields[i].Name.Name)
 		if err != nil {
 			return nil, err
 		}
 		buf.Write(key)
 		buf.WriteByte(':')
-		buf.Write(child)
+		buf.Write(out[i])
 	}
 	buf.WriteByte('}')
 	return buf.Bytes(), nil
+}
+
+// defaultValue ports TypeIR::default_value (field_type.rs:288) for the subset
+// native supports: the value BAML fills for a class field with no usable input.
+// It returns the default's JSON bytes and whether the type is DEFAULTABLE:
+//
+//   - list  → []
+//   - map   → {}
+//   - primitive null → null
+//   - union → the FIRST defaultable arm from iter_include_null (non-null variants
+//     in declaration order, then null appended when the union is optional),
+//     resolved recursively.
+//   - tuple → the list of every element's default, only when ALL elements have
+//     defaults (native rejects tuple at the gate, so this stays unreachable but
+//     faithful).
+//
+// Non-defaultable (ok=false): enum, literal, class, recursive alias, and the
+// primitive scalars string/int/float/bool — a missing required field of those is
+// a BAML error_missing_required_field. BAML only uses a default that passes its
+// asserts; native rejects every constrained type at the gate, so all defaults
+// here are unconditional.
+func defaultValue(t schema.Type) (json.RawMessage, bool) {
+	switch t.Kind {
+	case schema.TypeList:
+		return json.RawMessage("[]"), true
+	case schema.TypeMap:
+		return json.RawMessage("{}"), true
+	case schema.TypePrimitive:
+		if t.Primitive == schema.PrimitiveNull {
+			return json.RawMessage("null"), true
+		}
+		return nil, false
+	case schema.TypeUnion:
+		if t.Union == nil {
+			return nil, false
+		}
+		for i := range t.Union.Variants {
+			if d, ok := defaultValue(t.Union.Variants[i]); ok {
+				return d, true
+			}
+		}
+		if t.Union.Nullable {
+			return json.RawMessage("null"), true // the appended null arm
+		}
+		return nil, false
+	case schema.TypeTuple:
+		var buf bytes.Buffer
+		buf.WriteByte('[')
+		for i := range t.Items {
+			d, ok := defaultValue(t.Items[i])
+			if !ok {
+				return nil, false
+			}
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			buf.Write(d)
+		}
+		buf.WriteByte(']')
+		return buf.Bytes(), true
+	default:
+		// enum, literal, class, recursive_alias, primitive scalar, arrow, top.
+		return nil, false
+	}
 }
 
 // coerceList coerces a value into a list, porting BAML's coerce_array
@@ -1223,11 +1446,16 @@ func provenListItemError(b *schema.Bundle, elem schema.Type, item value) bool {
 		return elem.Literal != nil && elem.Literal.Kind == schema.LiteralString && item.kind == valString
 	case schema.TypeClass:
 		// A multi-field class whose fields are ALL required flat leaves has no
-		// default_value for any field, so a genuine SCALAR input leaves every
-		// required field unfilled → BAML error_missing_required_field. An ARRAY
-		// element defers to coerce_array_to_singular (M3); a single-field class, or
-		// a class with any defaultable (list/map/optional) field, defers to
-		// Mcoerce-d — so those are NOT proven.
+		// default_value for any field and is not single-field, so a genuine SCALAR
+		// input can be neither inferred-object-absorbed nor default-filled — every
+		// required field stays unfilled → BAML error_missing_required_field (a
+		// PROVEN skip, which coerceClass itself now claims via missingRequiredField).
+		// Everything else is NOT proven: a single-field class (Mcoerce-d inferred-
+		// object / implied-key) or a class with any defaultable (list/map/optional/
+		// defaultable-union) field now SUCCEEDS through coerceClass and is KEPT
+		// before reaching here (or DECLINES as indeterminate → whole-list fallback);
+		// a valObject may coerce or default; an ARRAY element defers to
+		// coerce_array_to_singular (pick_best, M3).
 		cls, ok := b.FindClass(elem.Name, elem.Mode)
 		if !ok {
 			return false
@@ -1239,7 +1467,7 @@ func provenListItemError(b *schema.Bundle, elem schema.Type, item value) bool {
 		case valString, valNumber, valBool, valNull:
 			return true
 		default:
-			return false // valObject: coerce succeeds/defers; valArray: M3.
+			return false // valObject: coerce succeeds/defaults/declines; valArray: M3.
 		}
 	default:
 		// map / list / union children: a map non-object, a nested list, or a
@@ -1923,6 +2151,17 @@ func declinableChildError(err error) bool {
 	if errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
 		return true
 	}
+	var me *mismatchError
+	return errors.As(err, &me)
+}
+
+// isClaimedMismatch reports whether err is a CLAIMED value-verdict mismatchError
+// (typeMismatch / ambiguousMatch — an error BAML also produces) as opposed to the
+// ErrDeBAMLParseUnsupported fallback sentinel. coerceClass uses it to distinguish
+// a field failure BAML PROVABLY errors on (propagate as the class error, since
+// such a field type is non-defaultable) from one native merely DECLINED (native
+// stricter than BAML → indeterminate, fall back).
+func isClaimedMismatch(err error) bool {
 	var me *mismatchError
 	return errors.As(err, &me)
 }

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -983,9 +983,9 @@ func coerceClass(b *schema.Bundle, name string, mode schema.StreamingMode, input
 	singleField := nF == 1
 
 	// Per-field resolution: out[i] holds the emitted bytes when filled[i]. A
-	// still-unfilled required NON-defaultable field records missingRequired (a
-	// claimed BAML error); a field native cannot resolve to BAML's exact value
-	// records indeterminate (fall back).
+	// still-unfilled required NON-defaultable field sets missingRequired (BAML
+	// errors; native DECLINES, see below); a field native cannot resolve to
+	// BAML's exact value sets indeterminate (fall back).
 	out := make([]json.RawMessage, nF)
 	filled := make([]bool, nF)
 	missingRequired := false
@@ -1448,10 +1448,12 @@ func provenListItemError(b *schema.Bundle, elem schema.Type, item value) bool {
 		// A multi-field class whose fields are ALL required flat leaves has no
 		// default_value for any field and is not single-field, so a genuine SCALAR
 		// input can be neither inferred-object-absorbed nor default-filled — every
-		// required field stays unfilled → BAML error_missing_required_field (a
-		// PROVEN skip, which coerceClass itself now claims via missingRequiredField).
-		// Everything else is NOT proven: a single-field class (Mcoerce-d inferred-
-		// object / implied-key) or a class with any defaultable (list/map/optional/
+		// required field stays unfilled → BAML error_missing_required_field. That
+		// is the PROVEN skip this whitelist establishes (coerceClass itself only
+		// DECLINES that case — see its missingRequired branch — so the list/map
+		// skip verdict is decided HERE, not by a claimed class error). Everything
+		// else is NOT proven: a single-field class (Mcoerce-d inferred-object /
+		// implied-key) or a class with any defaultable (list/map/optional/
 		// defaultable-union) field now SUCCEEDS through coerceClass and is KEPT
 		// before reaching here (or DECLINES as indeterminate → whole-list fallback);
 		// a valObject may coerce or default; an ARRAY element defers to

--- a/internal/debaml/coerce_class_test.go
+++ b/internal/debaml/coerce_class_test.go
@@ -132,6 +132,24 @@ func TestCoerceClass_SingleFieldScalarInferredObject(t *testing.T) {
 	// A scalar that the lone field cannot coerce -> DECLINE (native cannot prove
 	// BAML's outcome). "hello" -> int is a proven BAML error, but native declines.
 	requireUnsupported(t, intBox, `{"u":"hello"}`)
+
+	// A bare JSON null takes the SAME inferred-object path (non-object non-array):
+	// coerceImplied(null) coerces null into the lone field. For an int/string
+	// field, coerce_int/coerce_string on null is error_unexpected_null (a sentinel
+	// decline, not a proven-map default), so the class is indeterminate and native
+	// DECLINES (BAML errors; native falls back).
+	requireUnsupported(t, intBox, `{"u":null}`)
+	requireUnsupported(t, strBox, `{"u":null}`)
+	// Directly: coerceClass on a bare null declines with the fallback sentinel.
+	bn, cn := classBundle(t, strBox, "Box")
+	if _, err := coerceClass(bn, cn.Name, cn.Mode, nullVal(), nil); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+		t.Errorf("single-field string class <- null: expected ErrDeBAMLParseUnsupported, got %v", err)
+	}
+
+	// When the lone field ACCEPTS null (an optional), the inferred-object path
+	// SUCCEEDS on null: null is absorbed into the field as null (ImpliedKey).
+	optBox := nestedClassSchema("Box", props(kv("value", optProp(&bamlutils.DynamicTypeSpec{Type: "int"}))))
+	mustParse(t, optBox, `{"u":null}`, `{"u":{"value":null}}`)
 }
 
 // TestCoerceClass_MissingOptionalNull pins that an absent optional field is
@@ -268,6 +286,10 @@ func TestDefaultValue(t *testing.T) {
 		{"union-skip-nondefaultable", schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{strT, mapT}}}, "{}"},
 		// Nullable union with no defaultable non-null arm -> the appended null arm.
 		{"union-nullable-null", schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{intT}, Nullable: true}}, "null"},
+		// Tuple: a single-element defaultable tuple (no comma path).
+		{"tuple-single", schema.Type{Kind: schema.TypeTuple, Items: []schema.Type{nullT}}, "[null]"},
+		// Tuple: every element defaultable -> the JOINED element defaults, in order.
+		{"tuple-all-defaultable", schema.Type{Kind: schema.TypeTuple, Items: []schema.Type{listT, mapT}}, "[[],{}]"},
 	}
 	for _, c := range defaultable {
 		got, ok := defaultValue(c.t)
@@ -287,6 +309,9 @@ func TestDefaultValue(t *testing.T) {
 		{"literal", litT},
 		// A non-nullable union of non-defaultable arms (int | string).
 		{"union-all-nondefaultable", schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{intT, strT}}}},
+		// A tuple with ANY non-defaultable element (int[] , string) -> early return,
+		// the whole tuple is non-defaultable.
+		{"tuple-has-nondefaultable", schema.Type{Kind: schema.TypeTuple, Items: []schema.Type{listT, strT}}},
 	}
 	for _, c := range nonDefaultable {
 		if _, ok := defaultValue(c.t); ok {

--- a/internal/debaml/coerce_class_test.go
+++ b/internal/debaml/coerce_class_test.go
@@ -1,0 +1,417 @@
+package debaml
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// classBundle builds an indexed bundle from a DynamicOutputSchema and returns a
+// schema.Type referring to the named class, for direct coerceClass unit tests.
+func classBundle(t *testing.T, s *bamlutils.DynamicOutputSchema, class string) (*schema.Bundle, schema.Type) {
+	t.Helper()
+	b, err := schema.FromDynamicOutputSchema(s, schema.BuildOptions{})
+	if err != nil {
+		t.Fatalf("build bundle: %v", err)
+	}
+	for i := range b.Classes {
+		if b.Classes[i].Name.Name == class {
+			return b, schema.Type{Kind: schema.TypeClass, Name: b.Classes[i].Name.Name, Mode: b.Classes[i].Mode}
+		}
+	}
+	t.Fatalf("class %q not found in bundle", class)
+	return nil, schema.Type{}
+}
+
+// nestedClassSchema builds Root{u: <ref C>} plus the named class C with the
+// given properties, so an end-to-end mustParse of {"u": ...} exercises coerceClass
+// on C.
+func nestedClassSchema(cls string, props bamlutils.OrderedMap[*bamlutils.DynamicProperty]) *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: bamlutils.MustOrderedMap(bamlutils.OrderedKV("u", &bamlutils.DynamicProperty{Ref: cls})),
+		Classes:    bamlutils.MustOrderedMap(bamlutils.OrderedKV(cls, &bamlutils.DynamicClass{Properties: props})),
+	}
+}
+
+func optProp(inner *bamlutils.DynamicTypeSpec) *bamlutils.DynamicProperty {
+	return &bamlutils.DynamicProperty{Type: "optional", Inner: inner}
+}
+func listProp(inner *bamlutils.DynamicTypeSpec) *bamlutils.DynamicProperty {
+	return &bamlutils.DynamicProperty{Type: "list", Items: inner}
+}
+func mapProp(val *bamlutils.DynamicTypeSpec) *bamlutils.DynamicProperty {
+	return &bamlutils.DynamicProperty{Type: "map", Keys: &bamlutils.DynamicTypeSpec{Type: "string"}, Values: val}
+}
+func nullProp() *bamlutils.DynamicProperty { return &bamlutils.DynamicProperty{Type: "null"} }
+
+// TestCoerceClass_FieldAssignment pins BAML's object→class field assignment:
+// input-key order, first-field match, first-key-wins for duplicate matches,
+// unmatched keys omitted (ExtraKey), fields emitted in SCHEMA order.
+func TestCoerceClass_FieldAssignment(t *testing.T) {
+	// Root{a int, b string} with input keys out of schema order + an extra key.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("a", intProp()), kv("b", strProp())),
+	}
+	// Extra key ignored, fields re-emitted in schema order.
+	mustParseExact(t, s, `{"b":"x","a":1,"extra":9}`, `{"a":1,"b":"x"}`)
+	// Duplicate matching key: first value wins.
+	mustParse(t, s, `{"a":1,"a":2,"b":"x"}`, `{"a":1,"b":"x"}`)
+
+	// ExtraKey is score-bearing: a class with an extra key is not clean.
+	b, ct := classBundle(t, s, "Baml_Rest_DynamicOutput")
+	cf := &coerceFlags{}
+	if _, err := coerceClass(b, ct.Name, ct.Mode, objVal(fld("a", numV("1")), fld("b", strVv("x")), fld("extra", numV("9"))), cf); err != nil {
+		t.Fatalf("coerceClass extra: %v", err)
+	}
+	if !cf.isFlagged() {
+		t.Errorf("an extra input key must flag cf (ExtraKey, score-bearing)")
+	}
+	// A clean object (no extras) must NOT flag.
+	cfClean := &coerceFlags{}
+	if _, err := coerceClass(b, ct.Name, ct.Mode, objVal(fld("a", numV("1")), fld("b", strVv("x"))), cfClean); err != nil {
+		t.Fatalf("coerceClass clean: %v", err)
+	}
+	if cfClean.isFlagged() {
+		t.Errorf("a clean all-matched object must NOT flag cf")
+	}
+}
+
+// TestCoerceClass_SingleFieldObjectImpliedKey pins the single-field implied-key
+// path: when no input key matches the lone field, the WHOLE object is coerced
+// into it (ImpliedKey). A string field stringifies the object (JsonToString); an
+// int field with an object implied value FAILS (proven) so the class declines.
+func TestCoerceClass_SingleFieldObjectImpliedKey(t *testing.T) {
+	// Box{value string}: {foo:5} implied-key-coerces the whole object -> "{foo: 5}".
+	strBox := nestedClassSchema("Box", props(kv("value", strProp())))
+	mustParse(t, strBox, `{"u":{"foo":5}}`, `{"u":{"value":"{foo: 5}"}}`)
+
+	// The implied path is score-bearing (ImpliedKey + JsonToString).
+	b, ct := classBundle(t, strBox, "Box")
+	cf := &coerceFlags{}
+	if _, err := coerceClass(b, ct.Name, ct.Mode, objVal(fld("foo", numV("5"))), cf); err != nil {
+		t.Fatalf("implied-key: %v", err)
+	}
+	if !cf.isFlagged() {
+		t.Errorf("single-field implied-key must flag cf (ImpliedKey, score-bearing)")
+	}
+
+	// Box{value int}: {other:5} implied-coerces int<-object which is a proven
+	// BAML error, and BAML then errors (missing required non-defaultable); native
+	// cannot prove that from its own decline, so it DECLINES.
+	intBox := nestedClassSchema("Box", props(kv("value", intProp())))
+	requireUnsupported(t, intBox, `{"u":{"other":5}}`)
+
+	// A matching key takes the normal path (no implied-key).
+	mustParse(t, intBox, `{"u":{"value":5}}`, `{"u":{"value":5}}`)
+}
+
+// TestCoerceClass_SingleFieldScalarInferredObject pins the inferred-object path:
+// a non-object non-array value is absorbed into the lone field (ImpliedKey +
+// InferedObject). An int field takes the scalar directly; a string field
+// stringifies it.
+func TestCoerceClass_SingleFieldScalarInferredObject(t *testing.T) {
+	intBox := nestedClassSchema("Box", props(kv("value", intProp())))
+	mustParse(t, intBox, `{"u":5}`, `{"u":{"value":5}}`)
+
+	strBox := nestedClassSchema("Box", props(kv("value", strProp())))
+	mustParse(t, strBox, `{"u":true}`, `{"u":{"value":"true"}}`)
+	mustParse(t, strBox, `{"u":5}`, `{"u":{"value":"5"}}`)
+
+	// InferedObject is cost 0; the ONLY score-bearing flag is the child ImpliedKey.
+	b, ct := classBundle(t, intBox, "Box")
+	cf := &coerceFlags{}
+	if _, err := coerceClass(b, ct.Name, ct.Mode, numV("5"), cf); err != nil {
+		t.Fatalf("inferred-object: %v", err)
+	}
+	if !cf.isFlagged() {
+		t.Errorf("inferred-object must flag cf (ImpliedKey, score-bearing)")
+	}
+
+	// A scalar that the lone field cannot coerce -> DECLINE (native cannot prove
+	// BAML's outcome). "hello" -> int is a proven BAML error, but native declines.
+	requireUnsupported(t, intBox, `{"u":"hello"}`)
+}
+
+// TestCoerceClass_MissingOptionalNull pins that an absent optional field is
+// omitted (InjectAbsentOptionals adds the null downstream) yet flags cf
+// (OptionalDefaultFromNoValue, score 1) for nullable-union cleanliness.
+func TestCoerceClass_MissingOptionalNull(t *testing.T) {
+	// Root{name string, nick string?} with nick absent.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("name", strProp()), kv("nick", optProp(&bamlutils.DynamicTypeSpec{Type: "string"}))),
+	}
+	// The native coercer omits the absent optional; equality is semantic here.
+	mustParse(t, s, `{"name":"Ada"}`, `{"name":"Ada"}`)
+
+	b, ct := classBundle(t, s, "Baml_Rest_DynamicOutput")
+	cf := &coerceFlags{}
+	out, err := coerceClass(b, ct.Name, ct.Mode, objVal(fld("name", strVv("Ada"))), cf)
+	if err != nil {
+		t.Fatalf("missing optional: %v", err)
+	}
+	if string(out) != `{"name":"Ada"}` {
+		t.Errorf("absent optional must be OMITTED: got %s", out)
+	}
+	if !cf.isFlagged() {
+		t.Errorf("absent optional must flag cf (OptionalDefaultFromNoValue, score-bearing)")
+	}
+}
+
+// TestCoerceClass_RequiredDefaults pins TypeIR::default_value fills for a missing
+// REQUIRED field: list→[], map→{}, primitive-null→null. Each flags cf
+// (DefaultFromNoValue, score 100). A non-defaultable missing required field
+// (int) DECLINES.
+func TestCoerceClass_RequiredDefaults(t *testing.T) {
+	// Required list field absent -> [].
+	listS := nestedClassSchema("C", props(kv("items", listProp(&bamlutils.DynamicTypeSpec{Type: "int"}))))
+	mustParse(t, listS, `{"u":{}}`, `{"u":{"items":[]}}`)
+
+	// Required map field absent -> {}.
+	mapS := nestedClassSchema("C", props(kv("m", mapProp(&bamlutils.DynamicTypeSpec{Type: "int"}))))
+	mustParse(t, mapS, `{"u":{}}`, `{"u":{"m":{}}}`)
+
+	// Required null-primitive field absent -> null.
+	nullS := nestedClassSchema("C", props(kv("n", nullProp())))
+	mustParse(t, nullS, `{"u":{}}`, `{"u":{"n":null}}`)
+
+	// Each default flags cf.
+	b, ct := classBundle(t, listS, "C")
+	cf := &coerceFlags{}
+	if _, err := coerceClass(b, ct.Name, ct.Mode, objVal(), cf); err != nil {
+		t.Fatalf("list default: %v", err)
+	}
+	if !cf.isFlagged() {
+		t.Errorf("DefaultFromNoValue must flag cf (score 100)")
+	}
+
+	// A non-defaultable required field (int) absent -> DECLINE (BAML errors,
+	// native falls back).
+	intS := nestedClassSchema("C", props(kv("x", intProp())))
+	requireUnsupported(t, intS, `{"u":{}}`)
+}
+
+// TestCoerceClass_MapFieldDefaultButUnparseable pins DefaultButHadUnparseableValue:
+// a present REQUIRED map field with a NON-object value is a proven coerce_map
+// error, so BAML fills the map default {} and native CLAIMS it.
+func TestCoerceClass_MapFieldDefaultButUnparseable(t *testing.T) {
+	mapS := nestedClassSchema("C", props(kv("m", mapProp(&bamlutils.DynamicTypeSpec{Type: "int"}))))
+	mustParse(t, mapS, `{"u":{"m":"bad"}}`, `{"u":{"m":{}}}`)
+	mustParse(t, mapS, `{"u":{"m":[1,2]}}`, `{"u":{"m":{}}}`)
+
+	b, ct := classBundle(t, mapS, "C")
+	cf := &coerceFlags{}
+	if _, err := coerceClass(b, ct.Name, ct.Mode, objVal(fld("m", strVv("bad"))), cf); err != nil {
+		t.Fatalf("map default-but-unparseable: %v", err)
+	}
+	if !cf.isFlagged() {
+		t.Errorf("DefaultButHadUnparseableValue must flag cf (score 2)")
+	}
+	// A map field with an OBJECT value coerces normally (partial map, not a default).
+	mustParse(t, mapS, `{"u":{"m":{"a":1}}}`, `{"u":{"m":{"a":1}}}`)
+}
+
+// TestCoerceClass_ScalarMultiFieldAllDefaultable pins that a SCALAR into a
+// multi-field class assigns nothing and fills every field's default (BAML's
+// Some(x) arm is a no-op for >1 field); all-defaultable -> success.
+func TestCoerceClass_ScalarMultiFieldAllDefaultable(t *testing.T) {
+	// C{a int[], b map<string,int>}: a scalar fills both defaults.
+	s := nestedClassSchema("C", props(
+		kv("a", listProp(&bamlutils.DynamicTypeSpec{Type: "int"})),
+		kv("b", mapProp(&bamlutils.DynamicTypeSpec{Type: "int"})),
+	))
+	mustParse(t, s, `{"u":5}`, `{"u":{"a":[],"b":{}}}`)
+	// An empty object behaves the same (no keys -> all defaults).
+	mustParse(t, s, `{"u":{}}`, `{"u":{"a":[],"b":{}}}`)
+}
+
+// TestCoerceClass_ArrayDeclines pins the HARD boundary: an ARRAY into a class is
+// coerce_array_to_singular / pick_best (M3), so native DECLINES regardless of
+// field count (single- and multi-field).
+func TestCoerceClass_ArrayDeclines(t *testing.T) {
+	intBox := nestedClassSchema("Box", props(kv("value", intProp())))
+	requireUnsupported(t, intBox, `{"u":[1,2,3]}`)
+
+	multi := nestedClassSchema("C", props(kv("a", intProp()), kv("b", strProp())))
+	requireUnsupported(t, multi, `{"u":[1,2,3]}`)
+
+	// Direct coerceClass with an array declines with the sentinel.
+	b, ct := classBundle(t, intBox, "Box")
+	if _, err := coerceClass(b, ct.Name, ct.Mode, arrVal(numV("1")), nil); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+		t.Errorf("array->class: expected ErrDeBAMLParseUnsupported, got %v", err)
+	}
+}
+
+// TestDefaultValue pins the defaultValue helper (TypeIR::default_value) per kind.
+func TestDefaultValue(t *testing.T) {
+	listT := schema.Type{Kind: schema.TypeList, Elem: &schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt}}
+	mapT := schema.Type{Kind: schema.TypeMap, Key: &schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveString}, Value: &schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt}}
+	nullT := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveNull}
+	intT := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt}
+	strT := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveString}
+	enumT := schema.Type{Kind: schema.TypeEnum, Name: "E"}
+	classT := schema.Type{Kind: schema.TypeClass, Name: "C"}
+	litT := strLitType("x")
+
+	defaultable := []struct {
+		name string
+		t    schema.Type
+		want string
+	}{
+		{"list", listT, "[]"},
+		{"map", mapT, "{}"},
+		{"null", nullT, "null"},
+		// Union: FIRST defaultable arm (list) wins in declaration order.
+		{"union-list-first", schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{listT, strT}}}, "[]"},
+		// Union: a non-defaultable arm is skipped; the map arm defaults.
+		{"union-skip-nondefaultable", schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{strT, mapT}}}, "{}"},
+		// Nullable union with no defaultable non-null arm -> the appended null arm.
+		{"union-nullable-null", schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{intT}, Nullable: true}}, "null"},
+	}
+	for _, c := range defaultable {
+		got, ok := defaultValue(c.t)
+		if !ok || string(got) != c.want {
+			t.Errorf("defaultValue(%s) = (%s,%v), want (%s,true)", c.name, got, ok, c.want)
+		}
+	}
+
+	nonDefaultable := []struct {
+		name string
+		t    schema.Type
+	}{
+		{"int", intT},
+		{"string", strT},
+		{"enum", enumT},
+		{"class", classT},
+		{"literal", litT},
+		// A non-nullable union of non-defaultable arms (int | string).
+		{"union-all-nondefaultable", schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{intT, strT}}}},
+	}
+	for _, c := range nonDefaultable {
+		if _, ok := defaultValue(c.t); ok {
+			t.Errorf("defaultValue(%s) must be non-defaultable (ok=false)", c.name)
+		}
+	}
+}
+
+// TestCoerceClass_NullableCleanOnly pins the nullable-union clean-only rule for
+// class arms: a class that fills any score-bearing flag (extra key, absent
+// optional, default) inside a nullable single-arm union DECLINES against the
+// scored null arm; only a clean class arm claims.
+func TestCoerceClass_NullableCleanOnly(t *testing.T) {
+	// Root{u: (C)?}, C{name string} — a clean class arm claims.
+	clean := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", optProp(&bamlutils.DynamicTypeSpec{Ref: "C"}))),
+		Classes:    bamlutils.MustOrderedMap(bamlutils.OrderedKV("C", &bamlutils.DynamicClass{Properties: props(kv("name", strProp()))})),
+	}
+	mustParse(t, clean, `{"u":{"name":"x"}}`, `{"u":{"name":"x"}}`)
+	// An EXTRA key makes the class arm non-clean -> declines against null (M3).
+	requireUnsupported(t, clean, `{"u":{"name":"x","extra":1}}`)
+
+	// Root{u: (C)?}, C{name string, nick string?} — an absent optional makes the
+	// arm non-clean (OptionalDefaultFromNoValue) -> declines against null.
+	withOpt := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", optProp(&bamlutils.DynamicTypeSpec{Ref: "C"}))),
+		Classes: bamlutils.MustOrderedMap(bamlutils.OrderedKV("C", &bamlutils.DynamicClass{
+			Properties: props(kv("name", strProp()), kv("nick", optProp(&bamlutils.DynamicTypeSpec{Type: "string"}))),
+		})),
+	}
+	requireUnsupported(t, withOpt, `{"u":{"name":"x"}}`)
+	// Both fields present -> clean -> claims.
+	mustParse(t, withOpt, `{"u":{"name":"x","nick":"y"}}`, `{"u":{"name":"x","nick":"y"}}`)
+
+	// A JSON null still takes the null fast path.
+	mustParse(t, clean, `{"u":null}`, `{"u":null}`)
+}
+
+// TestCoerceClass_Fixture40ShapeStaysFallback is the LOAD-BEARING over-claim
+// guard: a union of SINGLE-field classes (fixture 40 shape) with a scalar input
+// must STAY fallback. It declines at the SCHEMA GATE (checkFlatClassUnion rejects
+// a <2-field class-union variant), and — were the gate lifted — the lenient
+// coerceClass makes BOTH single-field arms succeed via inferred-object, so the
+// flat-class-union counter would see >=2 successes and decline. This must hold
+// after coerceClass became lenient.
+func TestCoerceClass_Fixture40ShapeStaysFallback(t *testing.T) {
+	// Root{u: A | B}, A{val int}, B{num int}, input {"u":5}.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type:  "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{{Ref: "A"}, {Ref: "B"}},
+		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("A", &bamlutils.DynamicClass{Properties: props(kv("val", intProp()))}),
+			bamlutils.OrderedKV("B", &bamlutils.DynamicClass{Properties: props(kv("num", intProp()))}),
+		),
+	}
+	requireUnsupported(t, s, `{"u":5}`)
+
+	// Both single-field classes DO absorb the scalar via inferred-object (which
+	// is exactly why the union must stay fallback): each coerceClass succeeds.
+	bA, aT := classBundle(t, s, "A")
+	if _, err := coerceClass(bA, aT.Name, aT.Mode, numV("5"), nil); err != nil {
+		t.Errorf("A{val int} must absorb scalar 5 via inferred-object: %v", err)
+	}
+	bB, bT := classBundle(t, s, "B")
+	if _, err := coerceClass(bB, bT.Name, bT.Mode, numV("5"), nil); err != nil {
+		t.Errorf("B{num int} must absorb scalar 5 via inferred-object: %v", err)
+	}
+}
+
+// TestCoerceClass_ClaimedChildErrorPropagates pins that a CLAIMED field error (an
+// enum/string-literal substring TIE, StrMatchOneFromMany) is PROPAGATED as the
+// class error — BAML errors that non-defaultable field and thus the whole class,
+// so native claims the same error rather than swallowing it into a fallback
+// (fixture 51 shape as a class field).
+func TestCoerceClass_ClaimedChildErrorPropagates(t *testing.T) {
+	// Root{animal: Animal}, Animal{CAT,DOG}; "cat dog" substring-ties both.
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("animal", &bamlutils.DynamicProperty{Ref: "Animal"})),
+		Enums: bamlutils.MustOrderedMap(bamlutils.OrderedKV("Animal", &bamlutils.DynamicEnum{
+			Values: []*bamlutils.DynamicEnumValue{{Name: "CAT"}, {Name: "DOG"}},
+		})),
+	}
+	requireClaimedError(t, s, `{"animal":"cat dog"}`)
+
+	// The same tie via a single-field implied-key path also propagates: Box{a
+	// enum} with a non-matching object whose Display substring-ties both values.
+	b, ct := classBundle(t, s, "Baml_Rest_DynamicOutput")
+	if _, err := coerceClass(b, ct.Name, ct.Mode, objVal(fld("animal", strVv("cat dog"))), nil); err == nil {
+		t.Errorf("substring-tie field must claim an error, got nil")
+	} else if errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+		t.Errorf("substring-tie field must be a CLAIMED error, got fallback sentinel: %v", err)
+	}
+}
+
+// TestCoerceClass_CollectionChildFlips pins that class children which now succeed
+// through Mcoerce-d structural coercion are KEPT in a list/map (not skipped, not
+// a whole-collection decline).
+func TestCoerceClass_CollectionChildFlips(t *testing.T) {
+	// list<Box> where Box{value int}: scalar elements infer-object into each Box.
+	listBox := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", listProp(&bamlutils.DynamicTypeSpec{Ref: "Box"}))),
+		Classes:    bamlutils.MustOrderedMap(bamlutils.OrderedKV("Box", &bamlutils.DynamicClass{Properties: props(kv("value", intProp()))})),
+	}
+	mustParse(t, listBox, `{"u":[5,6]}`, `{"u":[{"value":5},{"value":6}]}`)
+
+	// map<string, Box>: scalar values infer-object into each Box.
+	mapBox := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", mapProp(&bamlutils.DynamicTypeSpec{Ref: "Box"}))),
+		Classes:    bamlutils.MustOrderedMap(bamlutils.OrderedKV("Box", &bamlutils.DynamicClass{Properties: props(kv("value", intProp()))})),
+	}
+	mustParse(t, mapBox, `{"u":{"a":5,"b":6}}`, `{"u":{"a":{"value":5},"b":{"value":6}}}`)
+
+	// list<C> where C{items int[]}: an empty-object element fills the list default.
+	listDefault := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", listProp(&bamlutils.DynamicTypeSpec{Ref: "C"}))),
+		Classes:    bamlutils.MustOrderedMap(bamlutils.OrderedKV("C", &bamlutils.DynamicClass{Properties: props(kv("items", listProp(&bamlutils.DynamicTypeSpec{Type: "int"})))})),
+	}
+	mustParse(t, listDefault, `{"u":[{}]}`, `{"u":[{"items":[]}]}`)
+
+	// map<string, C> where C{items int[]}: an empty-object value fills the default.
+	mapDefault := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", mapProp(&bamlutils.DynamicTypeSpec{Ref: "C"}))),
+		Classes:    bamlutils.MustOrderedMap(bamlutils.OrderedKV("C", &bamlutils.DynamicClass{Properties: props(kv("items", listProp(&bamlutils.DynamicTypeSpec{Type: "int"})))})),
+	}
+	mustParse(t, mapDefault, `{"u":{"k":{}}}`, `{"u":{"k":{"items":[]}}}`)
+}

--- a/internal/debaml/coerce_map_test.go
+++ b/internal/debaml/coerce_map_test.go
@@ -189,14 +189,17 @@ func TestCoerceMap_DuplicateKeyDeclines(t *testing.T) {
 	requireUnsupported(t, s, `{"scores":{"a":1,"a":"bad"}}`)
 }
 
-// TestCoerceMap_NonObjectDeclines pins the conservative non-object decline
-// (unchanged): a non-object where a map is required is not a hard type error, so
-// native falls back rather than claiming a mismatch BAML would not produce.
-func TestCoerceMap_NonObjectDeclines(t *testing.T) {
+// TestCoerceMap_NonObjectFieldDefaults pins the Mcoerce-d PR 2 flip: a REQUIRED
+// map class field with a NON-object value is a PROVEN coerce_map
+// error_unexpected_type, so BAML fills the map default {} with
+// DefaultButHadUnparseableValue (score 2). Native now reproduces the default and
+// CLAIMS {"scores":{}}. (A standalone/list/nullable map with a non-object still
+// declines — only the class-field-default path is claimed here.)
+func TestCoerceMap_NonObjectFieldDefaults(t *testing.T) {
 	s := mapStringIntSchema()
-	requireUnsupported(t, s, `{"scores":[1,2,3]}`)
-	requireUnsupported(t, s, `{"scores":"x"}`)
-	requireUnsupported(t, s, `{"scores":5}`)
+	mustParse(t, s, `{"scores":[1,2,3]}`, `{"scores":{}}`)
+	mustParse(t, s, `{"scores":"x"}`, `{"scores":{}}`)
+	mustParse(t, s, `{"scores":5}`, `{"scores":{}}`)
 }
 
 // TestCoerceMap_NullableCleanOnlyDeclines pins the union revisit for maps: an

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -324,12 +324,12 @@ func TestParse_MapStringInt(t *testing.T) {
 	mustParseExact(t, mapStringIntSchema(), `{"scores":{}}`, `{"scores":{}}`)
 }
 
-func TestParse_MapNonObjectDeclines(t *testing.T) {
-	// A non-object where a map is required is NOT a hard error: BAML's
-	// object/map coercion + scoring can still produce a (partial) map, so
-	// native declines rather than claiming a mismatch.
-	requireUnsupported(t, mapStringIntSchema(), `{"scores":[1,2,3]}`)
-	requireUnsupported(t, mapStringIntSchema(), `{"scores":"x"}`)
+func TestParse_MapNonObjectFieldDefaults(t *testing.T) {
+	// Mcoerce-d PR 2: a required map class field with a non-object value is a
+	// PROVEN coerce_map error_unexpected_type, so BAML fills the map default {}
+	// (DefaultButHadUnparseableValue) and native now CLAIMS {"scores":{}}.
+	mustParse(t, mapStringIntSchema(), `{"scores":[1,2,3]}`, `{"scores":{}}`)
+	mustParse(t, mapStringIntSchema(), `{"scores":"x"}`, `{"scores":{}}`)
 }
 
 func TestParse_MapBadValuePartialSkip(t *testing.T) {
@@ -925,25 +925,37 @@ func TestParse_UnsupportedNestedUnionVariant(t *testing.T) {
 	requireUnsupported(t, s, `{"u":true}`)
 }
 
-func TestParse_SingleFieldClassImpliedKeyDeclines(t *testing.T) {
-	// A single-field class: BAML absorbs a scalar/non-object — or an object
-	// whose lone field key is absent — directly into the one field via its
-	// implied-key / inferred-object coercion, so it often SUCCEEDS where
-	// native's strict object/key match fails. Native must DECLINE, not claim.
+func TestParse_SingleFieldClassImpliedKeyInferredObject(t *testing.T) {
+	// A single-field class: BAML absorbs a scalar/non-object into the one field
+	// via inferred-object, or an object whose keys miss the lone field via
+	// implied-key. Mcoerce-d PR 2 ports both, so native now CLAIMS them when the
+	// lone-field coercion succeeds and matches BAML byte-for-byte.
 	oneField := &bamlutils.DynamicOutputSchema{
 		Properties: props(kv("value", intProp())),
 	}
-	// Non-object input -> BAML implied-key {value: 42}; native declines.
-	requireUnsupported(t, oneField, `42`)
-	// Object with no matching key -> BAML implied path; native declines.
+	// Scalar input -> inferred-object into the lone int field (ImpliedKey +
+	// InferedObject): claimed {value: 42}.
+	mustParse(t, oneField, `42`, `{"value":42}`)
+	// Object with no matching key, lone field is int -> implied-key coerces the
+	// WHOLE object into the int field, which FAILS (object->int is
+	// error_unexpected_type), so the field is missing + non-defaultable and BAML
+	// errors; native cannot prove that from its own decline, so it DECLINES.
 	requireUnsupported(t, oneField, `{"other":5}`)
 	// The lone field present -> normal claim (no implied-key needed).
 	mustParse(t, oneField, `{"value":5}`, `{"value":5}`)
 
-	// A MULTI-field class with a NON-OBJECT input stays CLAIMED — BAML
-	// hard-fails turning a scalar/array into a multi-field object too, so the
-	// differential checks error parity rather than masking it.
-	requireClaimedError(t, personSchema(), `[1,2,3]`)
+	// A single-field STRING class absorbs a non-matching object via implied-key +
+	// JsonToString: {foo: 5} stringifies to "{foo: 5}" into the lone string field.
+	strBox := &bamlutils.DynamicOutputSchema{Properties: props(kv("value", strProp()))}
+	mustParse(t, strBox, `{"foo":5}`, `{"value":"{foo: 5}"}`)
+	// A scalar into the lone string field: inferred-object + JsonToString.
+	mustParse(t, strBox, `true`, `{"value":"true"}`)
+
+	// A MULTI-field class with a NON-OBJECT input DECLINES: an ARRAY defers to
+	// coerce_array_to_singular (M3) and a scalar leaves every required
+	// non-defaultable field missing (BAML errors, native falls back).
+	requireUnsupported(t, personSchema(), `[1,2,3]`)
+	requireUnsupported(t, personSchema(), `42`)
 }
 
 func TestParse_MultiFieldFuzzyKey(t *testing.T) {
@@ -1111,10 +1123,12 @@ func TestParse_MultipleTopLevelValuesDeclines(t *testing.T) {
 	mustParse(t, personSchema(), `{"name":"Ada","age":36} see "{}".`, `{"name":"Ada","age":36}`)
 }
 
-func TestParse_TopLevelArrayIsClaimedError(t *testing.T) {
-	// The synthetic top-level is always an object; a top-level array fails
-	// to coerce — a claimed error, not a fallback.
-	requireClaimedError(t, personSchema(), `[1,2,3]`)
+func TestParse_TopLevelArrayDeclines(t *testing.T) {
+	// The synthetic top-level is always a class. Mcoerce-d PR 2: an ARRAY into a
+	// class is coerce_array_to_singular / pick_best (M3) — BAML may coerce the
+	// first matching item into the class (e.g. [{name,age}] succeeds) — so native
+	// DECLINES (falls back) rather than claim a scored outcome it cannot model.
+	requireUnsupported(t, personSchema(), `[1,2,3]`)
 }
 
 func TestParse_AliasedFieldMatchesRenderedNameOnly(t *testing.T) {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## Mcoerce-d PR 2/3 — structural class defaults

De-BAML epic #546, slice **Mcoerce-d PR 2 of 3**. This is the deep/riskiest slice: it ports BAML's `coerce_class.rs` (the non-array subset) into `coerceClass`. PR 1 (stringification + literal extraction) is already merged (#562); the union revisit is PR 3.

### What it does

`coerceClass` now reproduces BAML's class value **byte-for-byte** for the deterministic non-union subset, on top of the existing field-matching/first-wins/ExtraKey/nullable-clean-only scaffolding:

- **Object field assignment** — input-key order, first-field match (`matches_string_to_string`, no substring), keep-first duplicates, unmatched keys flagged `ExtraKey` (cost 1) and omitted, fields emitted in schema order under canonical names.
- **Single-field OBJECT implied-key** — when no key matches the lone field, the whole object is coerced into it (`ImpliedKey`, cost 2), no `ExtraKey`.
- **Single-field SCALAR/null inferred-object** — a non-object non-array value is absorbed into the lone field (`ImpliedKey` cost 2 + `InferedObject` cost 0).
- **Missing optional → null** (`OptionalDefaultFromNoValue`, cost 1) — omitted from bytes (InjectAbsentOptionals re-adds it) but score-flagged.
- **Required-field defaults** via `TypeIR::default_value` (`defaultValue`): list→`[]`, map→`{}`, primitive-null→`null`, first-defaultable-union-arm, tuple — `DefaultFromNoValue` (cost 100).
- **Present required-map non-object → `{}`** (`DefaultButHadUnparseableValue`, cost 2): `coerce_map` errors on a non-object (`error_unexpected_type`), a proven failure with a deterministic default.

Every new flag threads into `coerceFlags`, so the nullable-union clean-only rule stays conservative. A class child that now succeeds through these paths is **kept** in a list/map instead of declining the whole collection. A claimed child error (enum/literal substring tie) **propagates** as the class error (status parity).

### Boundaries held (verified)

- **ARRAY input to a class DECLINES** — `coerce_array_to_singular` / multi-candidate `pick_best` is M3. (This also fixes a latent over-claim: the old blanket `typeMismatch` was wrong for `[{...}]` inputs BAML coerces.)
- **Required non-defaultable missing field DECLINES** — BAML errors, but native falls back to stay strictly non-over-claiming.
- **No union-family broadening / no `pick_best`** (PR 3).
- **Fixtures 40 / 42 / 43 stay fallback** — they decline at the *schema gate* (`checkSupportedUnionShape` rejects single-field / mixed class unions), so `coerceClass` becoming lenient cannot flip them. A unit test (`TestCoerceClass_Fixture40ShapeStaysFallback`) pins this and confirms both single-field arms *do* absorb the scalar via inferred-object (exactly why the union must stay fallback).

### Validation

- `internal/debaml` unit tests: new `coerce_class_test.go` covers every structural path (assign / implied-key / inferred-object / optional-null / each default kind / non-defaultable-fails / claimed-error propagation / collection flips / nullable-clean-only / `defaultValue`), plus updated map/class tests.
- **11 live-captured** parse-recovery fixtures (125–135) — all diff-green native-vs-BAML (`88 claimed, 44 fallback`, full suite passes). Wants captured with `BAMLFUZZ_PARSE_CAPTURE=1`, never hand-written.
- Over-claim guard: 1200 random generated schemas run through the native-vs-BAML parse differential — 0 divergence.
- `gofmt` / `go vet ./...` / `go vet -tags=integration` / `go test ./internal/debaml ./bamlutils ./worker ./dynclient/...` / `GOWORK=off go test ./codegen` / `go run ./cmd/verify-framework-adapter` all green.

### Differential dispositions (every flip justified)

Flipped **fallback → claimed** (native now byte-matches BAML):

| fixture | input | BAML/native output | why |
|---|---|---|---|
| 125 `single_field_class_scalar_inferred` | `{"u":5}` | `{"u":{"value":5}}` | inferred-object |
| 126 `single_field_class_object_implied_key` | `{"u":{"foo":5}}` | `{"u":{"value":"{foo: 5}"}}` | implied-key + JsonToString |
| 127 `class_missing_optional_null` | `{"u":{"name":"Ada"}}` | `{"u":{"name":"Ada","nick":null}}` | OptionalDefaultFromNoValue |
| 128 `class_required_list_default_from_no_value` | `{"u":{}}` | `{"u":{"items":[]}}` | list DefaultFromNoValue |
| 129 `class_required_map_default_from_no_value` | `{"u":{}}` | `{"u":{"m":{}}}` | map DefaultFromNoValue |
| 130 `class_required_null_default_from_no_value` | `{"u":{}}` | `{"u":{"n":null}}` | null DefaultFromNoValue |
| 131 `class_map_field_default_but_had_unparseable_value` | `{"u":{"m":"bad"}}` | `{"u":{"m":{}}}` | DefaultButHadUnparseableValue |
| 132 `list_single_field_class_scalar_kept` | `{"u":[5,6]}` | `{"u":[{"value":5},{"value":6}]}` | element inferred-object kept |
| 133 `map_string_single_field_class_scalar_value_kept` | `{"u":{"a":5,"b":6}}` | `{"u":{"a":{"value":5},"b":{"value":6}}}` | value inferred-object kept |
| 134 `list_class_required_default_value_kept` | `{"u":[{}]}` | `{"u":[{"items":[]}]}` | element default kept |
| 135 `map_string_class_required_default_value_kept` | `{"u":{"k":{}}}` | `{"u":{"k":{"items":[]}}}` | value default kept |

Also flipped in unit tests: `TestCoerceMap_NonObjectFieldDefaults` / `TestParse_MapNonObjectFieldDefaults` (`{"scores":"x"|5|[1,2,3]}` → `{"scores":{}}`), single-field-class inferred/implied cases, and top-level/array-to-class now **declines** (was a claimed error — the old claim was buggy for `[{...}]`).

Stayed **fallback** (unchanged): 40, 42, 43, 39, 53 (union scoring, M3), and the required-missing-field / array-to-class declines.

### Note: `class_required_union_first_defaultable_arm` omitted

The union-first-defaultable-arm default (`default_value`'s Union branch) is faithfully implemented and unit-tested (`TestDefaultValue`), but is **not reachable as a claimed fixture**: a *required* non-nullable union must be an M2c safe family (literal/class union — no defaultable arm), and a *nullable* union field is optional, so an absent one takes the `OptionalDefaultFromNoValue` null path, not `default_value`. So no supported schema yields a non-null union default via a class field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded parsing recovery for single-field classes (including inferred values from scalar/object shapes) and stronger missing-field defaulting for required/optional fields.
  * Improved structural default handling for lists, maps, and null values when inputs are incomplete or malformed.
* **Bug Fixes**
  * Non-object values for required map fields now recover by producing empty/default map results instead of failing.
  * Updated fallback vs decline behavior for top-level array inputs to be more consistent.
* **Tests**
  * Added new parse-recovery fuzz fixtures and extended unit/integration coverage for these edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->