### PR TITLE
debaml: union revisit — claim one-success safe-family unions (Mcoerce-d PR 3/3)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/136_literal_union_object_to_primitive_one_success_claimed.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/136_literal_union_object_to_primitive_one_success_claimed.json
@@ -1,0 +1,32 @@
+{
+  "name": "literal_union_object_to_primitive_one_success_claimed",
+  "description": "Mcoerce-d PR 3 CLAIMED (union revisit): homogeneous int-literal union (1 | 2), single-key object {\"value\":1}. coerce_literal's single-key-object ObjectToPrimitive prelude extracts the inner 1, which matches ONLY arm 1 (int literals match by value equality, so at most one arm), giving EXACTLY one lenient success -> claim. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "literal", "literal": {"kind": "int", "int": 1}},
+                {"kind": "literal", "literal": {"kind": "int", "int": 2}}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"value\":1}}",
+  "want": {
+    "status": "success",
+    "json": {"u": 1}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/137_literal_union_object_to_string_one_success_claimed.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/137_literal_union_object_to_string_one_success_claimed.json
@@ -1,0 +1,32 @@
+{
+  "name": "literal_union_object_to_string_one_success_claimed",
+  "description": "Mcoerce-d PR 3 CLAIMED (union revisit): homogeneous string-literal union (\"5\" | \"6\"), NON-string input 5. match_string's ObjectToString prelude stringifies 5 via jsonish Value Display to \"5\", which matches ONLY the \"5\" arm (the values are pairwise match-disjoint), giving EXACTLY one lenient success -> claim. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "literal", "literal": {"kind": "string", "string": "5"}},
+                {"kind": "literal", "literal": {"kind": "string", "string": "6"}}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":5}",
+  "want": {
+    "status": "success",
+    "json": {"u": "5"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/138_class_union_stringification_one_success_claimed.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/138_class_union_stringification_one_success_claimed.json
@@ -1,0 +1,46 @@
+{
+  "name": "class_union_stringification_one_success_claimed",
+  "description": "Mcoerce-d PR 3 CLAIMED (union revisit): flat disjoint class union Book{title,pages} | Car{brand,wheels}, input carries only Book's fields with title=5 (a NON-string). coerce_string stringifies 5 via jsonish Value Display to \"5\" (JsonToString) so Book succeeds leniently; Car misses its required brand,wheels. EXACTLY one lenient success -> claim Book (non-nullable). want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "class_ref", "ref": "Book"},
+                {"kind": "class_ref", "ref": "Car"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Book",
+        "properties": [
+          {"name": "title", "type": {"kind": "string"}},
+          {"name": "pages", "type": {"kind": "int"}}
+        ]
+      },
+      {
+        "name": "Car",
+        "properties": [
+          {"name": "brand", "type": {"kind": "string"}},
+          {"name": "wheels", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"title\":5,\"pages\":300}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"pages": 300, "title": "5"}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/139_class_union_stringification_two_successes_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/139_class_union_stringification_two_successes_stays_fallback.json
@@ -1,0 +1,46 @@
+{
+  "name": "class_union_stringification_two_successes_stays_fallback",
+  "description": "Mcoerce-d PR 3 FALLBACK (over-claim guard): flat disjoint class union Book{title,pages} | Car{brand,wheels}, input carries ALL FOUR fields with title=5 (a NON-string). Book succeeds (title=5 stringified via JsonToString; brand,wheels are extras) AND Car succeeds (brand,wheels exact; title,pages are extras), so TWO lenient successes -> BAML pick_best scored selection (M3). Native declines the WHOLE union and must NEVER emit either arm. want live-captured (BAML's scored winner).",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "class_ref", "ref": "Book"},
+                {"kind": "class_ref", "ref": "Car"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Book",
+        "properties": [
+          {"name": "title", "type": {"kind": "string"}},
+          {"name": "pages", "type": {"kind": "int"}}
+        ]
+      },
+      {
+        "name": "Car",
+        "properties": [
+          {"name": "brand", "type": {"kind": "string"}},
+          {"name": "wheels", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"title\":5,\"pages\":300,\"brand\":\"Audi\",\"wheels\":4}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"brand": "Audi", "wheels": 4}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/140_nullable_optional_string_json_to_string_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/140_nullable_optional_string_json_to_string_stays_fallback.json
@@ -1,0 +1,22 @@
+{
+  "name": "nullable_optional_string_json_to_string_stays_fallback",
+  "description": "Mcoerce-d PR 3 FALLBACK (nullable clean-only rule): optional string (string | null), NON-string input 5. The non-null arm coerces 5 -> \"5\" but carries JsonToString (score-bearing), so it is not a clean zero-score arm. BAML scores it against the null arm (DefaultButHadValue=110); native does not score, so a FLAGGED non-null arm declines even though its score (2) is < 110. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "u", "type": {"kind": "optional", "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":5}",
+  "want": {
+    "status": "success",
+    "json": {"u": "5"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/141_nullable_optional_class_default_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/141_nullable_optional_class_default_stays_fallback.json
@@ -1,0 +1,34 @@
+{
+  "name": "nullable_optional_class_default_stays_fallback",
+  "description": "Mcoerce-d PR 3 FALLBACK (nullable clean-only rule): optional class (C{items int[]} | null), input {} (items absent). The non-null arm fills the required list default [] (DefaultFromNoValue cost 100), score-bearing, so it is not clean. BAML scores it against the null arm (DefaultButHadValue=110) and the class wins (100 < 110); native does not score, so a FLAGGED non-null arm declines. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {"kind": "optional", "inner": {"kind": "class_ref", "ref": "C"}}
+          }
+        ]
+      },
+      {
+        "name": "C",
+        "properties": [
+          {
+            "name": "items",
+            "type": {"kind": "list", "inner": {"kind": "int"}}
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root"
+  },
+  "raw": "{\"u\":{}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"items": []}}
+  }
+}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -401,6 +401,24 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"map_string_single_field_class_scalar_value_kept":   true,
 	"list_class_required_default_value_kept":            true,
 	"map_string_class_required_default_value_kept":      true,
+
+	// Mcoerce-d PR 3 — UNION REVISIT. The safe-family union counters
+	// (coerceLiteralUnion / coerceFlatClassUnion) count LENIENT successes through
+	// the PR 1/PR 2 leaf + structural coercers, so a union that becomes
+	// deterministic via ObjectToPrimitive / ObjectToString / class-field
+	// JsonToString now CLAIMS when EXACTLY one non-null arm succeeds and DECLINES
+	// on two-plus (BAML pick_best = M3). The nullable clean-only rule still holds:
+	// a FLAGGED non-null winner (JsonToString / ObjectToString / ObjectToPrimitive
+	// / DefaultFromNoValue) declines against the scored null arm. No broadening
+	// beyond the two existing safe families — every mixed / primitive-overlap /
+	// overlapping-key-class / fuzzy-literal / list-map-variant / nested union
+	// stays fallback (see the M2c block above: 37/38/39/41/44/45/46, 40/42/43).
+	"literal_union_object_to_primitive_one_success_claimed":    true,
+	"literal_union_object_to_string_one_success_claimed":       true,
+	"class_union_stringification_one_success_claimed":          true,
+	"class_union_stringification_two_successes_stays_fallback": false,
+	"nullable_optional_string_json_to_string_stays_fallback":   false,
+	"nullable_optional_class_default_stays_fallback":           false,
 }
 
 // parseRecoveryStats tallies how many final-parse cases the native parser

--- a/internal/debaml/coerce_union_revisit_test.go
+++ b/internal/debaml/coerce_union_revisit_test.go
@@ -1,0 +1,118 @@
+package debaml
+
+import (
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// Mcoerce-d PR 3 — UNION REVISIT. The leaf/structural coercers (coerceLiteral,
+// coerceClass) became lenient in PR 1/PR 2 (ObjectToPrimitive / ObjectToString /
+// JsonToString / class defaults), and the safe-family union counters
+// (coerceLiteralUnion / coerceFlatClassUnion) already COUNT successes through
+// them. These tests pin that the counters now CLAIM the newly-deterministic
+// one-success cases while keeping the no-over-claim guard (count != 1 declines)
+// and the nullable clean-only rule (a flagged non-null winner declines vs the
+// scored null arm). No pick_best, no broadening beyond the two safe families.
+
+// TestLiteralUnion_ObjectToPrimitive_OneSuccess pins that a homogeneous
+// int-literal union claims when a single-key-object extraction (ObjectToPrimitive)
+// makes EXACTLY one arm coerce to its value: 1|2 with {"value":1} -> 1.
+func TestLiteralUnion_ObjectToPrimitive_OneSuccess(t *testing.T) {
+	s := litIntUnion(1, 2)
+	mustParse(t, s, `{"u":{"value":1}}`, `{"u":1}`) // extract 1 -> matches arm 1 only
+	mustParse(t, s, `{"u":{"any":2}}`, `{"u":2}`)   // key ignored, extract 2 -> arm 2 only
+	// Extracted inner value matches NO arm -> decline (BAML errors/pick_best neither).
+	requireUnsupported(t, s, `{"u":{"value":7}}`)
+}
+
+// TestLiteralUnion_ObjectToString_OneSuccess pins that a homogeneous
+// string-literal union claims when stringification (ObjectToString) makes
+// EXACTLY one arm match: "5"|"6" with 5 -> "5".
+func TestLiteralUnion_ObjectToString_OneSuccess(t *testing.T) {
+	s := unionSchema(litStr("5"), litStr("6"))
+	mustParse(t, s, `{"u":5}`, `{"u":"5"}`) // Display "5" matches literal "5" only
+	mustParse(t, s, `{"u":6}`, `{"u":"6"}`)
+	// Display matches neither literal -> decline.
+	requireUnsupported(t, s, `{"u":7}`)
+}
+
+// TestLiteralUnion_TwoSuccesses_Decline pins the over-claim guard: a stringified
+// value that substring-matches BOTH disjoint literal arms is two lenient
+// successes -> BAML pick_best (M3) -> decline (native must never pick one).
+func TestLiteralUnion_TwoSuccesses_Decline(t *testing.T) {
+	s := unionSchema(litStr("foo"), litStr("bar"))
+	// Array Display "[foo, bar]" substring-matches both "foo" and "bar" arms.
+	requireUnsupported(t, s, `{"u":["foo","bar"]}`)
+}
+
+// TestLiteralUnion_NullableFlaggedArm_Declines pins the nullable clean-only rule
+// for both literal families: a non-null arm won only via ObjectToPrimitive /
+// ObjectToString is FLAGGED, so it declines against the scored null arm (M3),
+// while the JSON-null fast path still claims null.
+func TestLiteralUnion_NullableFlaggedArm_Declines(t *testing.T) {
+	sInt := oneField(&bamlutils.DynamicProperty{
+		Type: "union",
+		OneOf: []*bamlutils.DynamicTypeSpec{
+			{Type: "literal_int", Value: int64(1)},
+			{Type: "literal_int", Value: int64(2)},
+			{Type: "null"},
+		},
+	})
+	mustParse(t, sInt, `{"u":null}`, `{"u":null}`)   // null fast path
+	requireUnsupported(t, sInt, `{"u":{"value":1}}`) // ObjectToPrimitive flag -> decline
+
+	sStr := unionSchema(litStr("5"), litStr("6"), &bamlutils.DynamicTypeSpec{Type: "null"})
+	mustParse(t, sStr, `{"u":null}`, `{"u":null}`)
+	mustParse(t, sStr, `{"u":"5"}`, `{"u":"5"}`) // clean exact string still claims
+	requireUnsupported(t, sStr, `{"u":5}`)       // ObjectToString flag -> decline
+}
+
+// TestClassUnion_Stringification_OneSuccess pins that a flat disjoint-key class
+// union claims when field stringification (JsonToString) inside EXACTLY one arm
+// makes it succeed: Book{title,pages}|Car{brand,wheels}, title <- 5 -> "5".
+func TestClassUnion_Stringification_OneSuccess(t *testing.T) {
+	s := classUnionSchema()
+	mustParse(t, s, `{"u":{"title":5,"pages":300}}`, `{"u":{"title":"5","pages":300}}`)
+}
+
+// TestClassUnion_Stringification_TwoSuccesses_Decline pins the over-claim guard:
+// an input carrying BOTH arms' full field sets makes both succeed -> BAML
+// pick_best (M3) -> decline (native must never emit either arm).
+func TestClassUnion_Stringification_TwoSuccesses_Decline(t *testing.T) {
+	s := classUnionSchema()
+	requireUnsupported(t, s, `{"u":{"title":5,"pages":300,"brand":"Audi","wheels":4}}`)
+}
+
+// TestClassUnion_NullableStringified_Declines pins the nullable clean-only rule:
+// a JsonToString-flagged winning class arm declines against the scored null arm,
+// while the JSON-null fast path still claims null.
+func TestClassUnion_NullableStringified_Declines(t *testing.T) {
+	s := nullableClassUnionSchema()
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	requireUnsupported(t, s, `{"u":{"title":5,"pages":300}}`) // JsonToString flag -> decline
+}
+
+// TestNullableOptionalString_JsonToString_Declines pins that an optional string
+// with a NON-string input coerces via JsonToString (flagged) and so declines
+// under the nullable clean-only rule, while a clean string passthrough claims.
+func TestNullableOptionalString_JsonToString_Declines(t *testing.T) {
+	s := oneField(&bamlutils.DynamicProperty{Type: "optional", Inner: &bamlutils.DynamicTypeSpec{Type: "string"}})
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	mustParse(t, s, `{"u":"hi"}`, `{"u":"hi"}`) // clean passthrough -> claim
+	requireUnsupported(t, s, `{"u":5}`)         // JsonToString -> decline
+}
+
+// TestNullableOptionalClassDefault_Declines pins that an optional class whose
+// lone arm fills a required-field DEFAULT (DefaultFromNoValue) is flagged, so it
+// declines under the nullable clean-only rule (C{items int[]} with {} -> []).
+func TestNullableOptionalClassDefault_Declines(t *testing.T) {
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", optProp(&bamlutils.DynamicTypeSpec{Ref: "C"}))),
+		Classes: bamlutils.MustOrderedMap(bamlutils.OrderedKV("C", &bamlutils.DynamicClass{
+			Properties: props(kv("items", listProp(&bamlutils.DynamicTypeSpec{Type: "int"}))),
+		})),
+	}
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	requireUnsupported(t, s, `{"u":{}}`) // DefaultFromNoValue -> decline
+}


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->

## Mcoerce-d PR 3 of 3 — UNION REVISIT (de-BAML epic #546, final Mcoerce slice)

Recompute the **safe-family** union claims so that unions which became
deterministic through the PR 1/PR 2 leniency (`ObjectToPrimitive` /
`ObjectToString` / class-field `JsonToString` / class defaults) now CLAIM
their single lenient success — while keeping the no-over-claim guard.

### What changed
The safe-family union counters (`coerceLiteralUnion` / `coerceFlatClassUnion`)
already count LENIENT per-arm successes through the now-lenient
`coerceLiteral` / `coerceClass` (wired in PR 2). So the union revisit needed
**no production-code change** — this PR proves and pins the behavior:

- **`internal/debaml/coerce_union_revisit_test.go`** (new): one-success-claim,
  two-success-decline, and nullable-flagged-decline for each safe family:
  - homogeneous literal union via `ObjectToPrimitive` (`1|2` + `{"value":1}` → `1`)
    and `ObjectToString` (`"5"|"6"` + `5` → `"5"`);
  - flat disjoint class union via field stringification (`Book|Car`, `title:5` → `"5"`);
  - nullable optional string `JsonToString` and optional class default declines.
- **6 corpus fixtures (136–141)** — wants **live-captured** via
  `BAMLFUZZ_PARSE_CAPTURE=1`, pinned in `parseRecoveryNativeClaim`:
  - claimed: `literal_union_object_to_primitive_one_success_claimed`,
    `literal_union_object_to_string_one_success_claimed`,
    `class_union_stringification_one_success_claimed`;
  - fallback: `class_union_stringification_two_successes_stays_fallback`,
    `nullable_optional_string_json_to_string_stays_fallback`,
    `nullable_optional_class_default_stays_fallback`.

### Boundaries held (over-claim guard)
The M2c gate (`checkSupportedUnionShape`) is **unchanged** — no broadening
beyond the two existing safe families. Confirmed still fallback via the full
differential: `37/38/39/41/44/45/46`, `40/42/43`, nullable `53/77/78/98/108`,
plus the 3 new fallback fixtures. No `pick_best`, no mixed/nested/variant unions.

Scope: `internal/debaml/*_test.go` + `integration/bamlfuzz_parse_recovery_test.go`
+ corpus JSON only. No seam / regen / embed / go.mod / production coercer changes.

### Validation
- `gofmt` clean; `go build ./...`; `go vet ./...` + `-tags=integration`.
- `go test ./internal/debaml ./bamlutils ./worker ./dynclient/...` green;
  `GOWORK=off go test ./codegen/...` green; `go run ./cmd/verify-framework-adapter` 6/6.
- **bamlfuzz differential green: 91 claimed, 47 fallback, 0 failures**; all 6
  new wants match live BAML exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved union coercion and parse-recovery outcomes, refining when unions are claimed versus when the system correctly falls back to a safer selection.
  * Fixed edge cases for object-to-primitive/string coercion, null vs non-null behavior, and defaulting for optional class fields.

* **Tests**
  * Added new BAMLFuzz parse-recovery fixtures covering literal unions, class unions, and nullable/optional coercion scenarios.
  * Updated integration expectations and added dedicated regression tests for the “UNION REVISIT” coercion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->