### PR TITLE
debaml: scalar/literal/enum + nested-scalar union scoring (M3 slice b)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/149_int_string_union_reversal.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/149_int_string_union_reversal.json
@@ -1,0 +1,32 @@
+{
+  "name": "int_string_union_reversal",
+  "description": "M3b CLAIMED: scalar-leaf union (int | string) — the ORDER-REVERSAL of fixture 37. BAML's try_cast pass tries the int arm first, but try_cast(int) REJECTS a JSON string (it needs a number), so the string arm's try_cast wins and the numeric string '123' stays a STRING — exactly as in fixture 37 (string | int). Native reproduces the try_cast-first selection: a numeric string never gets stolen by an int arm regardless of order. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "int"},
+                {"kind": "string"}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":\"123\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": "123"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/150_float_int_union_reversal.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/150_float_int_union_reversal.json
@@ -1,0 +1,32 @@
+{
+  "name": "float_int_union_reversal",
+  "description": "M3b CLAIMED: scalar-leaf union (float | int) — the ORDER-REVERSAL of fixture 38. The float arm (index 0) accepts the JSON integer 5 as a clean f64 cast (score 0), so BAML's early first-score-0 rule returns the float arm before the int arm is scored. The emitted value is numerically 5 (differential compares numbers by value). want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "float"},
+                {"kind": "int"}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":5}",
+  "want": {
+    "status": "success",
+    "json": {"u": 5}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/151_bool_string_union_string_wins.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/151_bool_string_union_string_wins.json
@@ -1,0 +1,32 @@
+{
+  "name": "bool_string_union_string_wins",
+  "description": "M3b CLAIMED: scalar-leaf union (bool | string) with a bool-looking STRING 'true'. The bool arm coerces via StringToBool (score 1, not early); the string arm is clean (score 0), so pick_best / early first-winner keeps it a STRING. Pins that a clean arm beats a flagged arm regardless of declaration order. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "bool"},
+                {"kind": "string"}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":\"true\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": "true"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/152_enum_string_union_exact.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/152_enum_string_union_exact.json
@@ -1,0 +1,34 @@
+{
+  "name": "enum_string_union_exact",
+  "description": "M3b CLAIMED: scalar-leaf union (Color enum | string) with an exact enum token 'GREEN'. The enum arm (index 0) matches exactly via match_string (score 0), so BAML's early first-score-0 rule returns the enum arm's canonical name before the string arm competes. Pins an enum arm winning inside a scored union. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "enum_ref", "ref": "Color"},
+                {"kind": "string"}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": [
+      {"name": "Color", "values": ["RED", "GREEN", "BLUE"]}
+    ],
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":\"GREEN\"}",
+  "want": {
+    "status": "success",
+    "json": {"u": "GREEN"}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/153_scalar_union_no_match_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/153_scalar_union_no_match_fallback.json
@@ -1,0 +1,31 @@
+{
+  "name": "scalar_union_no_match_fallback",
+  "description": "M3b FALLBACK: scalar-leaf union (int | bool), non-nullable, with a non-numeric non-bool string 'hello'. Both arms fail coercion (coerce_int / coerce_bool errors) and there is no null arm, so BAML merges the errors and the parse fails. Native declines (int arm is native-can't-prove for a plain string -> whole union declines), so it falls back. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "int"},
+                {"kind": "bool"}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":\"hello\"}",
+  "want": {
+    "status": "error"
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/154_scalar_union_array_input_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/154_scalar_union_array_input_fallback.json
@@ -1,0 +1,32 @@
+{
+  "name": "scalar_union_array_input_fallback",
+  "description": "M3b FALLBACK: scalar-leaf union (string | int) with ARRAY input [1,2]. BAML's int arm runs coerce_array_to_singular (pick_best over items + FirstMatch) while the string arm stringifies the array (JsonToString); the scored winner is array-to-singular, which native does not model until M3d. Native's int arm declines ARRAY input -> whole union declines -> fall back. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "string"},
+                {"kind": "int"}
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":[1,2]}",
+  "want": {
+    "status": "success",
+    "json": {"u": 1}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/155_list_scalar_union_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/155_list_scalar_union_stays_fallback.json
@@ -1,0 +1,37 @@
+{
+  "name": "list_scalar_union_stays_fallback",
+  "description": "M3b FALLBACK: a MULTI-ARM union as a LIST ELEMENT (list<Color enum | string>). BAML threads the previous element's winning arm into the next element as ctx.union_variant_hint (coerce_array.rs, the only hint setter) and tries that arm FIRST in both the try_cast and lenient phases; native coerces each element independently with no hint, so per-element arm selection can diverge (the reviewer's list<Color|string> ['other','Verde'] case — the alias 'Verde' is not expressible in the FuzzEnum IR, so this uses canonical tokens). Native DECLINES list-element unions in M3b (array union_variant_hint is M3d); the map<_,union> and top-level union claims are unaffected. want live-captured.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "list",
+              "inner": {
+                "kind": "union",
+                "variants": [
+                  {"kind": "enum_ref", "ref": "Color"},
+                  {"kind": "string"}
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "enums": [
+      {"name": "Color", "values": ["RED", "GREEN", "BLUE"]}
+    ],
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":[\"other\",\"GREEN\"]}",
+  "want": {
+    "status": "success",
+    "json": {"u": ["other", "GREEN"]}
+  }
+}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -225,21 +225,40 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"literal_union_int_exact":    true,
 	"class_union_single_shape":   true,
 	"nullable_multi_union_null":  true,
-	// Fallback: every union where a 2nd BAML arm could leniently succeed and
-	// invoke scored pick_best — bare primitive variants, numeric overlap,
-	// overlapping/single-field classes, fuzzy (non-disjoint) string literals,
-	// literal/enum-vs-class, list/single-to-array, map partials, nested
-	// unions. Native declines (fallback) rather than risk a scored divergence.
-	"string_int_union_numeric_string":         false,
-	"int_float_union_number":                  false,
+	// M3b SCALAR-LEAF unions: checkSupportedUnionShape now admits any union whose
+	// arms are all fully-modeled non-composite leaves (primitive int/float/bool/
+	// string, literal, enum, + hoisted null), and coerceScalarLeafUnion scores
+	// each arm through the same per-kind coercer BAML uses, applying the early
+	// first-score-0 rule + pick_best. Bare-primitive, mixed-scalar, non-disjoint
+	// string-literal, and (post-flatten) nested-scalar unions are now CLAIMED —
+	// their scored winner is reproduced exactly; a value-equal int/float, an
+	// order-reversal, and an enum arm are all pinned.
+	"string_int_union_numeric_string": true,
+	"int_float_union_number":          true,
+	"literal_union_fuzzy_string":      true,
+	"nested_union":                    true,
+	"int_string_union_reversal":       true,
+	"float_int_union_reversal":        true,
+	"bool_string_union_string_wins":   true,
+	"enum_string_union_exact":         true,
+	// Fallback: unions where a 2nd BAML arm invokes COMPOSITE scored pick_best or
+	// array-to-singular native does not yet model — mixed scalar+class, overlapping/
+	// single-field classes, literal/enum-vs-class, list/single-to-array, map
+	// partials (M3c/M3d) — plus scalar unions where no arm proves a winner (all
+	// arms error) or the winner is array-to-singular. Native declines (fallback)
+	// rather than risk a scored divergence.
 	"class_union_overlapping_keys":            false,
 	"single_field_class_union_implied_key":    false,
-	"literal_union_fuzzy_string":              false,
 	"literal_class_union_object_to_primitive": false,
 	"enum_class_union_object_to_string":       false,
 	"union_list_singleton_ambiguity":          false,
 	"union_map_value_partial":                 false,
-	"nested_union":                            false,
+	"scalar_union_no_match_fallback":          false,
+	"scalar_union_array_input_fallback":       false,
+	// A multi-arm union as a LIST ELEMENT declines: BAML threads the previous
+	// element's arm as ctx.union_variant_hint (coerce_array.rs) but native has no
+	// hint, so per-element arm selection can diverge. Array union hints are M3d.
+	"list_scalar_union_stays_fallback": false,
 	// Mcoerce-b native LENIENT PRIMITIVE + LITERAL numeric/bool/null coercion:
 	// numeric-string parsing (trim + trailing-comma trim, i64 / u64-wrap / f64 /
 	// fraction / extracted-number regex), float→int rounding (half-away,

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -2374,8 +2374,8 @@ func setWinnerCf(cf *coerceFlags, w candidate) {
 // rule with a faithful port of the BAML SCORE MODEL: each arm is coerced and
 // scored (types.rs inherent BamlValueWithFlags::score()), the first score-0 arm
 // wins immediately, and otherwise array_helper::pick_best chooses the lowest
-// (special-ordering, score, index). The claim stays inside the EXISTING safe
-// families (checkSupportedUnionShape is unchanged — no gate broadening):
+// (special-ordering, score, index). The claim stays inside the supported union
+// families proven by checkSupportedUnionShape:
 //
 //  1. JSON-null input + nullable union → null immediately (BAML's null fast path).
 //  2. nullable single-non-null union (the optional shape) → the lone arm is
@@ -2383,14 +2383,16 @@ func setWinnerCf(cf *coerceFlags, w candidate) {
 //     when its score < 110 (e.g. optional int with 1.6 → 2, FloatToInt score 1),
 //     null wins when the arm scores > 110 (e.g. an extra-key-heavy class), and a
 //     score-110 tie goes to the arm (lower index).
-//  3. non-null input + a multi-variant SAFE FAMILY (homogeneous literal union or
-//     flat disjoint-key class union), scored via selectUnionArms — including two
-//     lenient successes (BAML pick_best) and, when nullable, the null arm.
+//  3. non-null input + a multi-variant SUPPORTED FAMILY — a scalar/literal/enum
+//     leaf union (M3b) or a flat disjoint-key class union — scored via
+//     selectUnionArms, including two lenient successes (BAML pick_best) and, when
+//     nullable, the null arm.
 //
 // Over-claim guards: any arm native cannot prove (an ErrDeBAMLParseUnsupported
 // that is not a proven BAML error) or any uncertain arm DECLINES THE WHOLE UNION;
-// there is no array-to-singular here. cf carries the winner's score/kind up to an
-// outer scored context (a union that is itself a class field / list element).
+// there is no array-to-singular here (an int/float/bool arm declines ARRAY input,
+// declining the union). cf carries the winner's score/kind up to an outer scored
+// context (a union that is itself a class field / list element).
 func coerceUnionSafe(b *schema.Bundle, u *schema.UnionType, input value, cf *coerceFlags) (json.RawMessage, error) {
 	if u == nil {
 		return nil, fmt.Errorf("debaml: union type missing payload")
@@ -2430,29 +2432,67 @@ func coerceUnionSafe(b *schema.Bundle, u *schema.UnionType, input value, cf *coe
 // family's scored coercer. nullable is the union's Nullable flag, threaded so
 // selectUnionArms adds the null arm as a scored candidate.
 // checkSupportedUnionShape has already proven the variant set is one of the two
-// homogeneous families, so the else branch is the flat class union.
+// families, so an all-class set is the flat class union and everything else is
+// the scalar/literal/enum leaf family.
 func coerceUnionSafeMulti(b *schema.Bundle, variants []schema.Type, input value, nullable bool, cf *coerceFlags) (json.RawMessage, error) {
-	if allLiteralVariants(variants) {
-		return coerceLiteralUnion(variants, input, nullable, cf)
+	if allClassVariants(variants) {
+		return coerceFlatClassUnion(b, variants, input, nullable, cf)
 	}
-	return coerceFlatClassUnion(b, variants, input, nullable, cf)
+	return coerceScalarLeafUnion(b, variants, input, nullable, cf)
 }
 
-// coerceLiteralUnion scores a homogeneous literal union (coerce_union.rs over
-// literal arms). Each arm is coerced through coerceLiteral (the actual
-// match_string, ObjectToPrimitive extraction, and int/bool lenient coercion), so
-// a fuzzy/substring hit or a stringified value scores as BAML would. The first
-// score-0 arm wins immediately; otherwise pickBest chooses the lowest score
-// (index tiebreak) — so two arms that both substring-match, e.g. "foo"|"bar"
-// against a value containing both, resolve to the lower-index arm instead of
-// declining. A non-matching arm is a PROVEN BAML error (excluded); an int/bool
-// arm native's stricter primitive coercer merely DECLINED (hex/overflow) is
-// native-can't-prove and declines the whole union. When nullable, the null arm
-// (score 110) competes. The winner's own coercion output is emitted directly.
-func coerceLiteralUnion(variants []schema.Type, input value, nullable bool, cf *coerceFlags) (json.RawMessage, error) {
+// coerceScalarLeafUnion resolves a union whose every arm is a fully-modeled
+// non-composite LEAF — a primitive scalar (int/float/bool/string), a literal
+// (any kind), or an enum (checkSupportedUnionShape's M3b scalar-leaf family) —
+// reproducing BAML's TWO-PHASE union coercion exactly:
+//
+//  1. try_cast pass (tryCastScalarUnion): the FIRST non-null arm whose STRICT
+//     native-JSON-type cast succeeds wins at score 0, BEFORE any lenient
+//     conversion. This is BAML's field_type.rs "try_cast is basically a way to
+//     exit early" over try_cast_union, and is why `int | string` keeps a numeric
+//     string as a STRING and a JSON number picks the int/float arm regardless of
+//     declaration order (the string arm's try_cast rejects a number, the int
+//     arm's rejects a string).
+//  2. lenient coerce pass (only when no arm try_casts): each arm is coerced
+//     through coerce(), which dispatches to the SAME per-kind coercer BAML uses
+//     (coercePrimitive / coerceLiteral / coerceEnum), so a lenient conversion
+//     (numeric-string parse, float→int round, string→bool, stringify+match,
+//     substring/fuzzy hit, single-key extraction) scores exactly as BAML would.
+//     selectUnionArms applies the early first-score-0 rule and otherwise runs
+//     array_helper::pick_best over the successes (plus the null arm, score 110,
+//     when nullable). Every arm being a leaf, pick_best collapses to (score,
+//     index) — no list/class/scalar-vs-composite case fires — so the winner is
+//     exact.
+//
+// In the lenient pass a non-matching or value-mismatched arm is a PROVEN BAML
+// error (excluded from ranking); an arm native's stricter coercer merely DECLINED
+// (native-can't-prove — a non-numeric string to an int arm, or ARRAY input to an
+// int/float/bool arm whose array-to-singular is M3d) or a case-fold-UNCERTAIN arm
+// declines the WHOLE union, because BAML might succeed it via a deferred path and
+// change the winner. The winner's own output is emitted directly.
+//
+// It SUBSUMES the pre-M3b homogeneous-literal path (a literal arm try_casts on an
+// exact match and otherwise coerces identically), which is why the old
+// string-literal disjointness gate is gone: two lenient successes are resolved by
+// pick_best rather than declined.
+func coerceScalarLeafUnion(b *schema.Bundle, variants []schema.Type, input value, nullable bool, cf *coerceFlags) (json.RawMessage, error) {
+	// Phase 1: try_cast pass (coerce_union.rs try_cast_union, run by field_type.rs
+	// BEFORE the lenient coerce). The FIRST non-null arm whose STRICT native-type
+	// cast succeeds is BAML's winner at score 0 — before any numeric parse,
+	// stringify, fuzzy match, or extraction. This is why `int | string` keeps a
+	// numeric STRING as a string and a JSON number picks the int/float arm.
+	if w, ok, err := tryCastScalarUnion(b, variants, input); err != nil {
+		return nil, err
+	} else if ok {
+		setWinnerCf(cf, w)
+		return w.output, nil
+	}
+	// Phase 2: lenient coerce pass (coerce_union.rs standard path) — early
+	// first-score-0, else array_helper::pick_best, with the null arm (score 110)
+	// when nullable.
 	w, err := selectUnionArms(len(variants), nullable, func(i int) (json.RawMessage, *coerceFlags, error) {
 		armF := &coerceFlags{}
-		out, e := coerceLiteral(variants[i].Literal, input, armF)
+		out, e := coerce(b, variants[i], input, armF)
 		return out, armF, e
 	})
 	if err != nil {
@@ -2460,6 +2500,118 @@ func coerceLiteralUnion(variants []schema.Type, input value, nullable bool, cf *
 	}
 	setWinnerCf(cf, w)
 	return w.output, nil
+}
+
+// tryCastScalarUnion ports BAML's try_cast_union (coerce_union.rs) for the
+// scalar-leaf family. field_type.rs runs self.try_cast BEFORE the lenient coerce
+// for EVERY value ("try_cast is basically a way to exit early"); for a union that
+// is try_cast_union over iter_skip_null (the non-null arms in order). A scalar /
+// literal / enum arm's try_cast succeeds ONLY when the input's native JSON type
+// already matches the arm — no numeric parse, stringify, fuzzy/substring match,
+// or single-key extraction — and it always scores 0. So the FIRST arm that
+// try_casts is BAML's immediate winner (UnionMatch), returned before the lenient
+// coerce pass. The null arm is excluded here (the JSON-null input fast path is in
+// coerceUnionSafe; a non-null input never try_casts to null).
+//
+// Returns (winner, true, nil) on a hit; (_, false, nil) when no arm try_casts
+// (caller runs the lenient pass); (_, false, err) only for a value native cannot
+// emit (a JSON number that parses to a non-finite float), which declines the
+// whole union rather than risk emitting an invalid token.
+func tryCastScalarUnion(b *schema.Bundle, variants []schema.Type, input value) (candidate, bool, error) {
+	for i := range variants {
+		out, kind, matched, err := tryCastScalarArm(b, variants[i], input)
+		if err != nil {
+			return candidate{}, false, err
+		}
+		if matched {
+			return candidate{output: out, originIndex: i, kind: kind, score: 0, hasUnionMatch: true}, true, nil
+		}
+	}
+	return candidate{}, false, nil
+}
+
+// tryCastScalarArm ports the per-kind try_cast for the scalar-leaf family
+// (coerce_primitive.rs / coerce_literal.rs / coerce_enum.rs try_cast): a STRICT
+// native-type match that adds no score-bearing flag. It returns the emitted JSON,
+// the BAML value kind (for pick_best/setWinnerCf), and whether the arm matched.
+//
+//   - string:  a JSON string (verbatim).
+//   - int:     a JSON number whose token is an i64-range integer (as_i64 Some) —
+//     a float-valued or u64-overflow number does NOT try_cast (it falls to the
+//     lenient FloatToInt / u64-wrap coerce pass).
+//   - float:   any JSON number (as_f64); a non-finite result (huge exponent) has
+//     no JSON spelling, so the arm declines the whole union.
+//   - bool:    a JSON boolean.
+//   - literal: a JSON value whose native type EQUALS the literal (string by exact
+//     ==, int by as_i64 ==, bool by ==) — no stringify/parse/fuzzy.
+//   - enum:    a JSON string EXACTLY equal to a value's rendered name (no
+//     description forms, no case fold, no substring); emits the canonical name.
+func tryCastScalarArm(b *schema.Bundle, t schema.Type, input value) (json.RawMessage, candKind, bool, error) {
+	switch t.Kind {
+	case schema.TypePrimitive:
+		switch t.Primitive {
+		case schema.PrimitiveString:
+			if input.kind == valString {
+				out, err := marshalJSON(input.strV)
+				return out, candScalar, err == nil, err
+			}
+		case schema.PrimitiveInt:
+			if input.kind == valNumber {
+				if v, ok := parseI64Rust(input.numV.String()); ok {
+					return json.RawMessage(strconv.FormatInt(v, 10)), candScalar, true, nil
+				}
+			}
+		case schema.PrimitiveFloat:
+			if input.kind == valNumber {
+				if v, ok := parseF64Rust(input.numV.String()); ok {
+					out, fin := floatRaw(v)
+					if !fin {
+						return nil, 0, false, unsupported("union try_cast: JSON number parses to a non-finite float (no JSON spelling)")
+					}
+					return out, candScalar, true, nil
+				}
+			}
+		case schema.PrimitiveBool:
+			if input.kind == valBool {
+				return boolRaw(input.boolV), candScalar, true, nil
+			}
+		}
+	case schema.TypeLiteral:
+		if t.Literal == nil {
+			return nil, 0, false, fmt.Errorf("debaml: literal type missing value")
+		}
+		switch t.Literal.Kind {
+		case schema.LiteralString:
+			if input.kind == valString && input.strV == t.Literal.String {
+				out, err := marshalJSON(input.strV)
+				return out, candScalar, err == nil, err
+			}
+		case schema.LiteralInt:
+			if input.kind == valNumber {
+				if v, ok := parseI64Rust(input.numV.String()); ok && v == t.Literal.Int {
+					return json.RawMessage(strconv.FormatInt(v, 10)), candScalar, true, nil
+				}
+			}
+		case schema.LiteralBool:
+			if input.kind == valBool && input.boolV == t.Literal.Bool {
+				return boolRaw(input.boolV), candScalar, true, nil
+			}
+		}
+	case schema.TypeEnum:
+		if input.kind == valString {
+			e, ok := b.FindEnum(t.Name)
+			if !ok {
+				return nil, 0, false, fmt.Errorf("debaml: unknown enum %q", t.Name)
+			}
+			for i := range e.Values {
+				if e.Values[i].Name.RenderedName() == input.strV {
+					out, err := marshalJSON(e.Values[i].Name.Name)
+					return out, candEnum, err == nil, err
+				}
+			}
+		}
+	}
+	return nil, 0, false, nil
 }
 
 // coerceFlatClassUnion scores a flat disjoint-key class union (coerce_union.rs

--- a/internal/debaml/coerce_scalar_union_test.go
+++ b/internal/debaml/coerce_scalar_union_test.go
@@ -1,0 +1,250 @@
+package debaml
+
+import (
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// M3 slice b — SCALAR / LITERAL / ENUM (+ null) and flattened-scalar NESTED
+// unions. checkSupportedUnionShape now admits any union whose arms are all
+// fully-modeled non-composite leaves, and coerceScalarLeafUnion resolves them
+// TWO-PHASE like BAML: a phase-1 try_cast pass (the first arm whose STRICT
+// native-JSON-type cast matches wins at score 0, before any lenient conversion)
+// and, only when no arm try_casts, a phase-2 lenient coerce pass (the M3a
+// per-kind coercers + early first-score-0 + array_helper::pick_best). These tests
+// pin the new claimed families, the observable try_cast / order-reversal
+// behavior, enum arms (including alias/description forms the corpus IR cannot
+// express), and the hard guards that STAY fallback (array-to-singular,
+// non-finite float, no-match, list-element unions).
+
+// primUnion is a terse builder for a `u` field that is a union of the given
+// primitive type names (e.g. "string", "int", "float", "bool").
+func primUnion(prims ...string) *bamlutils.DynamicOutputSchema {
+	variants := make([]*bamlutils.DynamicTypeSpec, len(prims))
+	for i, p := range prims {
+		variants[i] = &bamlutils.DynamicTypeSpec{Type: p}
+	}
+	return unionSchema(variants...)
+}
+
+// TestScalarUnion_TryCastPrefersNativeType pins BAML's try_cast-first rule: an
+// arm whose STRICT native-JSON-type cast matches the input wins at score 0 BEFORE
+// any lenient conversion, regardless of declaration order. So a numeric STRING
+// picks the string arm (the int arm's try_cast rejects a string) and a JSON
+// number picks the int arm (the string arm's try_cast rejects a number) — in both
+// orderings.
+func TestScalarUnion_TryCastPrefersNativeType(t *testing.T) {
+	si := primUnion("string", "int")
+	is := primUnion("int", "string")
+	// A numeric STRING stays a string under BOTH orderings — the int arm's
+	// try_cast rejects a string, so the string arm's try_cast wins.
+	mustParse(t, si, `{"u":"123"}`, `{"u":"123"}`)
+	mustParse(t, is, `{"u":"123"}`, `{"u":"123"}`)
+	// A JSON NUMBER coerces to int under BOTH orderings — the string arm's
+	// try_cast rejects a number, so the int arm's try_cast wins.
+	mustParse(t, si, `{"u":5}`, `{"u":5}`)
+	mustParse(t, is, `{"u":5}`, `{"u":5}`)
+	// A plain (non-numeric) string: the string arm try_casts under both orderings,
+	// so the int arm's lenient parse never runs -> stays a string (CLAIMED).
+	mustParse(t, si, `{"u":"hello"}`, `{"u":"hello"}`)
+	mustParse(t, is, `{"u":"hello"}`, `{"u":"hello"}`)
+}
+
+// TestScalarUnion_IntFloat_Scored pins the two phases for int|float. A JSON
+// number try_casts to whichever numeric arm is first (value-equal either way). A
+// numeric STRING try_casts to neither (both need a JSON number), so the lenient
+// coerce pass runs: the int arm rounds (FloatToInt score 1) while the float arm
+// parses clean (score 0), so the float arm wins.
+func TestScalarUnion_IntFloat_Scored(t *testing.T) {
+	f := primUnion("int", "float")
+	// JSON integer: int arm (index 0) try_casts -> int.
+	mustParse(t, f, `{"u":5}`, `{"u":5}`)
+	// JSON non-integer number: int arm try_cast rejects it (as_i64 None); float arm
+	// try_casts -> 1.5.
+	mustParse(t, f, `{"u":1.5}`, `{"u":1.5}`)
+	// numeric STRING: neither arm try_casts -> lenient pass; float (score 0) beats
+	// the rounding int arm (score 1) -> 1.5 (NOT rounded to 2).
+	mustParse(t, f, `{"u":"1.5"}`, `{"u":1.5}`)
+	// float | int reversal: the float arm (index 0) try_casts the JSON integer
+	// first. Numerically 5 (differential compares numbers by value).
+	rev := primUnion("float", "int")
+	mustParse(t, rev, `{"u":5}`, `{"u":5}`)
+}
+
+// TestScalarUnion_BoolString_Scored pins that a bool-looking JSON string is
+// claimed by the string arm in phase 1: bool try_cast rejects strings, then
+// string try_cast succeeds, so StringToBool phase-2 scoring never runs.
+func TestScalarUnion_BoolString_Scored(t *testing.T) {
+	bs := primUnion("bool", "string")
+	// JSON bool: bool try_cast accepts it in phase 1 -> true.
+	mustParse(t, bs, `{"u":true}`, `{"u":true}`)
+	// bool-looking STRING: bool try_cast rejects strings; string try_cast succeeds
+	// in phase 1 -> stays "true" (no StringToBool scoring).
+	mustParse(t, bs, `{"u":"true"}`, `{"u":"true"}`)
+}
+
+// colorStringUnion builds `Color | string` (enum arm first) with the given enum
+// values, so an exact enum token try_casts (phase 1) ahead of the string arm.
+func colorStringUnion(values []*bamlutils.DynamicEnumValue) *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type:  "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{{Ref: "Color"}, {Type: "string"}},
+		})),
+		Enums: bamlutils.MustOrderedMap(bamlutils.OrderedKV("Color", &bamlutils.DynamicEnum{
+			Values: values,
+		})),
+	}
+}
+
+// TestScalarUnion_EnumWithStringArm pins that an enum's try_cast is EXACT
+// (rendered-name equality, no fuzz), so it only wins the try_cast pass on an
+// exact token; every other string try_casts to the string arm before the enum's
+// fuzzy coerce even runs. `Color | string`.
+func TestScalarUnion_EnumWithStringArm(t *testing.T) {
+	s := colorStringUnion([]*bamlutils.DynamicEnumValue{{Name: "RED"}, {Name: "GREEN"}, {Name: "BLUE"}})
+	// exact token: enum arm (index 0) try_casts -> canonical name.
+	mustParse(t, s, `{"u":"GREEN"}`, `{"u":"GREEN"}`)
+	// lowercase "green": enum try_cast is case-SENSITIVE (miss), so the string arm
+	// try_casts first -> stays "green" (the fuzzy enum coerce is never reached).
+	mustParse(t, s, `{"u":"green"}`, `{"u":"green"}`)
+	// a non-enum string: string arm try_casts -> whole string.
+	mustParse(t, s, `{"u":"the color green please"}`, `{"u":"the color green please"}`)
+}
+
+// TestScalarUnion_EnumFuzzyInCoercePass pins the enum arm's FUZZY match forms
+// (case fold, description, "rendered: description") — reachable only in the
+// lenient coerce pass, i.e. when NO arm try_casts. `Color | literal_int 999`
+// (the literal_int arm never try_casts a string, so the enum's coerce runs). The
+// corpus FuzzEnum IR carries no alias/description, so this is unit-test only.
+func TestScalarUnion_EnumFuzzyInCoercePass(t *testing.T) {
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type: "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{
+				{Ref: "Color"},
+				{Type: "literal_int", Value: int64(999)},
+			},
+		})),
+		Enums: bamlutils.MustOrderedMap(bamlutils.OrderedKV("Color", &bamlutils.DynamicEnum{
+			Values: []*bamlutils.DynamicEnumValue{
+				{Name: "GREEN", Alias: "Verde"},
+				{Name: "RED", Description: "the red one"},
+			},
+		})),
+	}
+	// "Verde" is GREEN's RENDERED name (alias), so the enum arm TRY_CASTS it
+	// (exact rendered-name equality) -> canonical "GREEN".
+	mustParse(t, s, `{"u":"Verde"}`, `{"u":"GREEN"}`)
+	// "verde" (lowercase alias): try_cast is case-sensitive (miss), so the coerce
+	// pass runs; the enum arm case-folds "verde" == "Verde" -> GREEN (score 0).
+	// (The canonical "GREEN" is NOT a match candidate once an alias is set.)
+	mustParse(t, s, `{"u":"verde"}`, `{"u":"GREEN"}`)
+	// description and "rendered: description" forms match only in the coerce pass.
+	mustParse(t, s, `{"u":"the red one"}`, `{"u":"RED"}`)
+	mustParse(t, s, `{"u":"RED: the red one"}`, `{"u":"RED"}`)
+}
+
+// TestScalarUnion_NullableAllProvenErrorClaimsNull pins that when every non-null
+// arm is a PROVEN BAML error, only the null arm (score 110) survives and native
+// claims null. `1 | 2 | null` with 5 (coerces to int but equals neither literal).
+func TestScalarUnion_NullableAllProvenErrorClaimsNull(t *testing.T) {
+	s := unionSchema(
+		&bamlutils.DynamicTypeSpec{Type: "literal_int", Value: int64(1)},
+		&bamlutils.DynamicTypeSpec{Type: "literal_int", Value: int64(2)},
+		&bamlutils.DynamicTypeSpec{Type: "null"},
+	)
+	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	mustParse(t, s, `{"u":5}`, `{"u":null}`)
+}
+
+// TestScalarUnion_NoMatchAndArrayDecline pins the hard guards. A no-match scalar
+// union declines the whole union; ARRAY input to a union with an int/float/bool
+// arm declines (array-to-singular is M3d).
+func TestScalarUnion_NoMatchAndArrayDecline(t *testing.T) {
+	// int | bool with a non-numeric non-bool string: both arms declineCoerce
+	// (native-can't-prove) -> whole union declines.
+	requireUnsupported(t, primUnion("int", "bool"), `{"u":"hello"}`)
+	// ARRAY input to string | int: the string arm stringifies (JsonToString) but
+	// the int arm's array-to-singular is M3d and declines -> whole union declines.
+	requireUnsupported(t, primUnion("string", "int"), `{"u":[1,2]}`)
+}
+
+// TestScalarUnion_NonFiniteFloatDeclines pins the non-finite-float fallback. A
+// float|int union with an "inf"/"nan" STRING: no arm try_casts (both need a JSON
+// number), so the coerce pass runs; the float arm parses a non-finite value with
+// no JSON spelling (declines) and the int arm declines too -> whole union falls
+// back. (A `float | string` union would instead let the string arm try_cast the
+// literal "inf" to a string, so it is deliberately not used here.)
+func TestScalarUnion_NonFiniteFloatDeclines(t *testing.T) {
+	fi := primUnion("float", "int")
+	requireUnsupported(t, fi, `{"u":"inf"}`)
+	requireUnsupported(t, fi, `{"u":"nan"}`)
+}
+
+// TestScalarUnion_ListElementUnionDeclines pins the M3b hint guard: a MULTI-ARM
+// union as a LIST ELEMENT declines (BAML threads ctx.union_variant_hint between
+// array elements; native has no hint, so per-element arm selection can diverge —
+// array hints are M3d). A single-non-null-arm optional element, a TOP-LEVEL
+// scalar union, and a MAP VALUE union all stay CLAIMED (map values / class fields
+// reset the hint, and an optional's only hint is its one arm).
+func TestScalarUnion_ListElementUnionDeclines(t *testing.T) {
+	// list<int | string> — multi-arm union element -> DECLINE (hint gap).
+	listUnion := oneField(&bamlutils.DynamicProperty{
+		Type: "list",
+		Items: &bamlutils.DynamicTypeSpec{
+			Type:  "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{{Type: "int"}, {Type: "string"}},
+		},
+	})
+	requireUnsupported(t, listUnion, `{"u":["a",1]}`)
+	// list<Color | string> — the enum|string shape the reviewer flagged -> DECLINE.
+	listEnumUnion := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type: "list",
+			Items: &bamlutils.DynamicTypeSpec{
+				Type:  "union",
+				OneOf: []*bamlutils.DynamicTypeSpec{{Ref: "Color"}, {Type: "string"}},
+			},
+		})),
+		Enums: bamlutils.MustOrderedMap(bamlutils.OrderedKV("Color", &bamlutils.DynamicEnum{
+			Values: []*bamlutils.DynamicEnumValue{{Name: "GREEN"}, {Name: "RED"}},
+		})),
+	}
+	requireUnsupported(t, listEnumUnion, `{"u":["other","GREEN"]}`)
+
+	// list<int?> — a single-non-null-arm optional element is hint-safe -> CLAIMED.
+	listOptional := oneField(&bamlutils.DynamicProperty{
+		Type:  "list",
+		Items: &bamlutils.DynamicTypeSpec{Type: "optional", Inner: &bamlutils.DynamicTypeSpec{Type: "int"}},
+	})
+	mustParse(t, listOptional, `{"u":[1,2]}`, `{"u":[1,2]}`)
+
+	// TOP-LEVEL scalar union still claims (the gate change is list-element-only).
+	mustParse(t, primUnion("string", "int"), `{"u":"x"}`, `{"u":"x"}`)
+
+	// MAP value union still claims — coerce_map resets the hint (enter_scope), so
+	// map<_, union> has no hint gap.
+	mapUnion := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("m", &bamlutils.DynamicProperty{
+			Type: "map",
+			Keys: &bamlutils.DynamicTypeSpec{Type: "string"},
+			Values: &bamlutils.DynamicTypeSpec{
+				Type:  "union",
+				OneOf: []*bamlutils.DynamicTypeSpec{{Type: "string"}, {Type: "int"}},
+			},
+		})),
+	}
+	mustParse(t, mapUnion, `{"m":{"a":"x"}}`, `{"m":{"a":"x"}}`)
+}
+
+// TestScalarUnion_LiteralStringSubstringTie_PickFirst pins the pick_best index
+// tiebreak for a scalar union: an ARRAY whose Display substring-matches BOTH
+// disjoint string-literal arms scores 4 on each (ObjectToString 2 + SubstringMatch
+// 2), so the lower-index arm wins. (Same as the M3a two-substring fixture, now
+// routed through the broadened coerceScalarLeafUnion.)
+func TestScalarUnion_LiteralStringSubstringTie_PickFirst(t *testing.T) {
+	s := unionSchema(litStr("foo"), litStr("bar"))
+	mustParse(t, s, `{"u":["foo","bar"]}`, `{"u":"foo"}`)
+}

--- a/internal/debaml/coerce_test.go
+++ b/internal/debaml/coerce_test.go
@@ -80,10 +80,11 @@ func TestWrappersPropagateHardErrors(t *testing.T) {
 		// counting loop hits FindClass and must propagate the hard error.
 		return coerceFlatClassUnion(b, []schema.Type{ghostClass, ghostClass}, obj, false, nil)
 	})
-	run("coerceLiteralUnion-counting", "literal type missing value", func() (interface{}, error) {
-		// A literal variant with a nil payload is a hard invariant failure.
+	run("coerceScalarLeafUnion-counting", "literal type missing value", func() (interface{}, error) {
+		// A literal variant with a nil payload is a hard invariant failure surfaced
+		// by phase-1 tryCastScalarArm before the scored coerce loop runs.
 		bad := schema.Type{Kind: schema.TypeLiteral, Literal: nil}
-		return coerceLiteralUnion([]schema.Type{bad, bad}, value{kind: valString, strV: "x"}, false, nil)
+		return coerceScalarLeafUnion(b, []schema.Type{bad, bad}, value{kind: valString, strV: "x"}, false, nil)
 	})
 }
 

--- a/internal/debaml/coerce_union_revisit_test.go
+++ b/internal/debaml/coerce_union_revisit_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // M3 slice a — SCORE MODEL + safe-family pick_best. The safe-family union
-// coercers (coerceLiteralUnion / coerceFlatClassUnion) now score every arm with
+// coercers (coerceScalarLeafUnion / coerceFlatClassUnion) now score every arm with
 // the types.rs inherent model, apply BAML's early first-score-0 winner rule, and
 // otherwise run a faithful array_helper::pick_best over the successful candidates
 // plus (when nullable) the null arm (DefaultButHadValue, score 110). No gate
@@ -65,8 +65,8 @@ func TestLiteralUnion_NullableFlaggedArm_Scored(t *testing.T) {
 
 	sStr := unionSchema(litStr("5"), litStr("6"), &bamlutils.DynamicTypeSpec{Type: "null"})
 	mustParse(t, sStr, `{"u":null}`, `{"u":null}`)
-	mustParse(t, sStr, `{"u":"5"}`, `{"u":"5"}`) // clean exact (score 0) wins immediately
-	mustParse(t, sStr, `{"u":5}`, `{"u":"5"}`)   // ObjectToString score 2 < 110 -> claim
+	mustParse(t, sStr, `{"u":"5"}`, `{"u":"5"}`) // phase-1 try_cast exact match, no phase-2 scoring
+	mustParse(t, sStr, `{"u":5}`, `{"u":"5"}`)   // number: phase-2 ObjectToString score 2 < 110 -> claim
 }
 
 // TestClassUnion_Stringification_OneSuccess pins that a flat disjoint-key class

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -152,6 +152,24 @@ func checkSupportedType(b *schema.Bundle, t schema.Type) error {
 		if t.Elem == nil {
 			return unsupported("list without element")
 		}
+		// A MULTI-ARM union as a LIST ELEMENT is out of scope for M3b. BAML threads
+		// the previous element's winning arm into the next element as
+		// ctx.union_variant_hint (coerce_array.rs enter_scope_with_hint, the ONLY
+		// setter of the hint) and tries that arm FIRST in both the try_cast and
+		// lenient phases (coerce_union.rs); native coerces each element
+		// independently with no hint, so an array like list<Color | string> can
+		// pick a different arm per element than BAML (e.g. a hinted string arm keeps
+		// an exact enum token as a string). The hint only flows when the elements
+		// are THEMSELVES unions (the hint is the previous element's OUTERMOST
+		// UnionMatch, which a map/class/list element never carries), and map values
+		// and class fields RESET the hint (enter_scope / visit_class_value_pair), so
+		// map<_, union> and class union fields stay in scope. A single-non-null-arm
+		// optional element (T?) is safe — its only hint is that one arm. Declining
+		// the multi-arm case is the scope's conservative answer; the array
+		// union_variant_hint is modeled in M3d.
+		if isMultiArmUnion(*t.Elem) {
+			return unsupported("list element is a multi-arm union (array union_variant_hint is M3d)")
+		}
 		return checkSupportedType(b, *t.Elem)
 	case schema.TypeUnion:
 		if t.Union == nil {
@@ -266,60 +284,84 @@ func isStringLiteralUnionType(t schema.Type) bool {
 }
 
 // checkSupportedUnionShape reports whether the NON-NULL variant set of a
-// multi-variant union (len(Variants) >= 2) is one of the two M2c safe
-// families. It is the structural half of the M2c claim: it proves BAML
-// cannot leniently succeed on a SECOND arm (which would force BAML's scored
-// pick_best, where native's single pick may diverge). The value-level guard
-// in coerceUnionSafe then proves BAML sees exactly one clean winner for the
-// concrete input.
+// multi-variant union (len(Variants) >= 2) is one of the supported families.
+// It is the structural half of the union claim: it admits only variant sets
+// whose scored selection native reproduces exactly, so BAML's array_helper::
+// pick_best never diverges from native's.
 //
-// The two safe families are:
+// The two supported families are:
 //
-//   - HOMOGENEOUS LITERAL-ONLY union: every variant is a literal of the SAME
-//     kind. For string literals the value set must be pairwise disjoint under
-//     a conservative match_string SUPERSET (matchStringMightMatch) — exact
-//     disjointness is not enough because BAML fuzzy-matches string literals.
-//     int/bool literals need no extra check: BAML matches them by value
-//     equality, which (after dedup) no two distinct literals can both satisfy.
-//   - HOMOGENEOUS FLAT CLASS union: every variant is a constraint-free class
-//     ref whose class has >= 2 fields, every field REQUIRED and a FLAT LEAF
-//     (primitive scalar / literal / enum — no union/map/list/optional/
-//     recursive-alias/nested-class), and whose rendered field-name sets are
-//     pairwise disjoint under the same conservative key-match superset.
+//   - SCALAR-LEAF union (M3b): every variant is a fully-modeled non-composite
+//     LEAF — a primitive scalar (int/float/bool/string), a literal (any kind),
+//     or an enum. No structural disjointness sub-check is needed: the M3a score
+//     model + pick_best + early first-score-0 rule pick BAML's exact winner
+//     across these arms (each is coerced by the SAME per-kind coercer BAML uses
+//     and scored with the types.rs inherent model), two-plus lenient successes
+//     are resolved by pick_best rather than declined, and a within-arm
+//     match_string tie (StrMatchOneFromMany) fails that arm exactly as BAML
+//     errors it. Per-arm native-can't-prove declines and case-fold uncertainty
+//     decline the WHOLE union at coerce time (selectUnionArms), so over-claim is
+//     impossible — the only residual is under-claim (safe). Nested scalar unions
+//     arrive here already flattened into this variant set by simplifyUnion.
+//   - FLAT CLASS union: every variant is a constraint-free class ref whose class
+//     has >= 2 fields, every field REQUIRED and a FLAT LEAF (primitive scalar /
+//     literal / enum — no union/map/list/optional/recursive-alias/nested-class),
+//     and whose rendered field-name sets are pairwise disjoint under a
+//     conservative key-match superset.
 //
-// Every other shape — a bare primitive variant, a list/map variant, a nested
-// union, mixed literal kinds, literal-vs-class, enum-vs-anything, overlapping
-// or single-field classes — declines, because BAML could leniently succeed on
-// a second arm there.
+// Every OTHER shape declines: a mixed scalar+class family, any list/map variant,
+// overlapping or single-field classes (M3c/M3d). A list/map/array-to-singular
+// arm is out of scope until its scoring is modeled.
 func checkSupportedUnionShape(b *schema.Bundle, u *schema.UnionType) error {
 	vs := u.Variants
 	if len(vs) < 2 {
 		return unsupported("union shape: needs >= 2 non-null variants")
 	}
 	switch {
-	case allLiteralVariants(vs):
-		return checkHomogeneousLiteralUnion(vs)
 	case allClassVariants(vs):
 		return checkFlatClassUnion(b, vs)
+	case allScalarLeafVariants(vs):
+		// Nothing further to prove: coercion + the M3a scored selection are
+		// faithful for a leaf-only variant set, and every over-claim path
+		// (native-can't-prove arm, uncertain case fold, array-to-singular on an
+		// int/float/bool arm) declines the whole union at coerce time.
+		return nil
 	default:
-		// Bare primitive, list, map, nested union, or a mixed variant family:
-		// BAML's lenient coercers (stringify, string<->number, array-to-
-		// singular, fuzzy enum/literal, implied-key class, defaults) can make
-		// a second arm succeed, so native cannot prove a single winner.
-		return unsupported("union shape: not a homogeneous literal or flat class union")
+		// A mixed scalar+class family, or any list/map/array-to-singular variant:
+		// BAML's composite special ordering (class devalue, list SingleToArray/
+		// markdown, FirstMatch) is not modeled until M3c/M3d, so native cannot
+		// prove the pick_best winner — decline.
+		return unsupported("union shape: not a flat class union or a scalar/literal/enum leaf union")
 	}
 }
 
-// allLiteralVariants reports whether every variant is a constraint-free
-// literal — the precondition for the homogeneous-literal family.
-func allLiteralVariants(vs []schema.Type) bool {
+// allScalarLeafVariants reports whether every variant is a constraint-free,
+// fully-modeled non-composite LEAF: a primitive scalar (int/float/bool/string),
+// a literal, or an enum — the M3b scalar-leaf union family. It reuses
+// isFlatLeafField, which encodes the identical leaf predicate for flat
+// class-union fields, because the coercers a union arm and a class field route
+// through are the same. (Null is never a variant — it is hoisted to
+// UnionType.Nullable; media / list / map / class / nested-union variants are
+// rejected, so a mixed or composite family falls through to a decline.)
+func allScalarLeafVariants(vs []schema.Type) bool {
 	for i := range vs {
-		v := &vs[i]
-		if v.Kind != schema.TypeLiteral || v.Literal == nil || len(v.Meta.Constraints) > 0 {
+		if !isFlatLeafField(vs[i]) {
 			return false
 		}
 	}
 	return true
+}
+
+// isMultiArmUnion reports whether t is a union with two or more NON-NULL
+// variants — the hint-sensitive shape a list element must not be (see the
+// TypeList branch of checkSupportedType). A nullable multi-union keeps its two+
+// non-null variants in Variants (null is hoisted to Nullable), so it is
+// multi-arm; a single-non-null optional (T?) has one Variant and is NOT (its
+// only union_variant_hint is that lone arm, so per-element coercion cannot
+// diverge). A non-nullable single-variant union is collapsed by simplifyUnion
+// and never appears here.
+func isMultiArmUnion(t schema.Type) bool {
+	return t.Kind == schema.TypeUnion && t.Union != nil && len(t.Union.Variants) >= 2
 }
 
 // allClassVariants reports whether every variant is a constraint-free class
@@ -332,27 +374,6 @@ func allClassVariants(vs []schema.Type) bool {
 		}
 	}
 	return true
-}
-
-// checkHomogeneousLiteralUnion validates a literal-only variant set: all the
-// same literal kind, and — for string literals — pairwise match-disjoint.
-func checkHomogeneousLiteralUnion(vs []schema.Type) error {
-	kind := vs[0].Literal.Kind
-	for i := range vs {
-		if vs[i].Literal.Kind != kind {
-			return unsupported("literal union: mixed literal kinds (BAML may coerce a 2nd arm)")
-		}
-	}
-	if kind == schema.LiteralString {
-		lits := make([]string, len(vs))
-		for i := range vs {
-			lits[i] = vs[i].Literal.String
-		}
-		if !stringsPairwiseDisjoint(lits) {
-			return unsupported("string-literal union: values not pairwise match-disjoint (BAML may fuzzy-match a 2nd arm)")
-		}
-	}
-	return nil
 }
 
 // checkFlatClassUnion validates a class-only variant set as a flat,
@@ -425,19 +446,6 @@ func isFlatLeafField(t schema.Type) bool {
 	default:
 		return false
 	}
-}
-
-// stringsPairwiseDisjoint reports whether no two distinct strings in vals
-// could match under the conservative match_string superset.
-func stringsPairwiseDisjoint(vals []string) bool {
-	for i := 0; i < len(vals); i++ {
-		for j := i + 1; j < len(vals); j++ {
-			if matchStringMightMatch(vals[i], vals[j]) {
-				return false
-			}
-		}
-	}
-	return true
 }
 
 // fieldNameSetsPairwiseDisjoint reports whether no field name in any set

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -514,10 +514,12 @@ func TestParse_UnsupportedMapIntKey(t *testing.T) {
 	requireUnsupported(t, s, `{"m":{"1":1}}`)
 }
 
-func TestParse_UnsupportedMapUnionValue(t *testing.T) {
-	// A map value that is a general (multi-variant) union is out of scope:
-	// checkSupportedType rejects it via the value recursion, so the parser
-	// falls back.
+func TestParse_MapScalarUnionValueClaimed(t *testing.T) {
+	// M3b: a map VALUE that is a scalar-leaf union (string|int) is now in scope —
+	// checkSupportedType's value recursion admits it, and coerceMapValueChild
+	// routes the value through the try_cast-first scalar-union coercer. "x"
+	// try_casts to the string arm; numeric value 5 skips string try_cast and
+	// try_casts to int, so JsonToString phase-2 scoring is not reached.
 	s := &bamlutils.DynamicOutputSchema{
 		Properties: props(kv("m", &bamlutils.DynamicProperty{
 			Type: "map",
@@ -531,7 +533,11 @@ func TestParse_UnsupportedMapUnionValue(t *testing.T) {
 			},
 		})),
 	}
-	requireUnsupported(t, s, `{"m":{"a":"x"}}`)
+	mustParse(t, s, `{"m":{"a":"x"}}`, `{"m":{"a":"x"}}`)
+	mustParse(t, s, `{"m":{"a":5}}`, `{"m":{"a":5}}`)
+	// An indeterminate value (array: int arm array-to-singular is M3d, string arm
+	// stringifies) declines the whole map -> fall back (never a partial skip).
+	requireUnsupported(t, s, `{"m":{"a":[1,2]}}`)
 }
 
 // unionSchema wraps a single union property `u` with the given variants.
@@ -549,29 +555,35 @@ func litStr(v string) *bamlutils.DynamicTypeSpec {
 }
 
 func TestParse_LiteralUnionStringExactClaimed(t *testing.T) {
-	// Homogeneous string-literal union with pairwise BAML-match-disjoint
-	// values: native CLAIMS the arm that EXACTLY equals the input, because
-	// disjointness proves BAML cannot fuzzy-match a second arm.
+	// Homogeneous string-literal union: an input that EXACTLY equals a literal
+	// value try_casts to that arm in phase 1 and is CLAIMED. M3b no longer
+	// requires literal values to be pairwise match-disjoint: exact inputs still
+	// return from phase 1, while non-exact inputs that coerce against multiple
+	// arms are resolved by phase-2 scoring / pick_best.
 	s := unionSchema(litStr("small"), litStr("large"))
 	mustParse(t, s, `{"u":"small"}`, `{"u":"small"}`)
 	mustParse(t, s, `{"u":"large"}`, `{"u":"large"}`)
-	// No exact literal match → DECLINE (BAML may fuzzy-match one arm).
+	// "medium" try_casts to neither literal and match_strings neither in phase 2,
+	// so no arm succeeds → DECLINE (BAML also errors; native falls back).
 	requireUnsupported(t, s, `{"u":"medium"}`)
-	// Non-string input → DECLINE (BAML may stringify/coerce it).
+	// A JSON number try_casts to neither string literal; the phase-2 stringify
+	// (ObjectToString "5") matches neither value → no arm succeeds → DECLINE.
 	requireUnsupported(t, s, `{"u":5}`)
 }
 
-func TestParse_LiteralUnionFuzzyStringDeclinedAtGate(t *testing.T) {
-	// "on" is a substring of "only" under the conservative match_string
-	// superset, so the set is NOT provably disjoint: BAML could fuzzy-match
-	// the input "on" against the "only" arm too → scoring → native must
-	// never claim. The whole schema is rejected at the gate (fall back).
+func TestParse_LiteralUnionFuzzyStringScored(t *testing.T) {
+	// M3b: a string-literal union whose values are NOT match-disjoint
+	// ("on" | "only") is now CLAIMED by the try_cast-first scalar-union path
+	// instead of declined at the gate. "on" exact-matches arm 0 in phase 1. "only"
+	// skips arm 0's exact literal try_cast, then exact-matches arm 1 in phase 1;
+	// substring scoring / pick_best is not reached. This pins the formerly
+	// non-disjoint literal family now admitted by M3b (fixture 41).
 	s := unionSchema(litStr("on"), litStr("only"))
-	requireUnsupported(t, s, `{"u":"on"}`)
-	requireUnsupported(t, s, `{"u":"only"}`)
-	// Case/punctuation-only variants are also non-disjoint under the fold.
+	mustParse(t, s, `{"u":"on"}`, `{"u":"on"}`)
+	mustParse(t, s, `{"u":"only"}`, `{"u":"only"}`)
+	// Case/punctuation-only variants: "Yes" exact-matches arm 0 in phase-1 try_cast.
 	s2 := unionSchema(litStr("Yes"), litStr("yes!"))
-	requireUnsupported(t, s2, `{"u":"Yes"}`)
+	mustParse(t, s2, `{"u":"Yes"}`, `{"u":"Yes"}`)
 }
 
 func TestParse_LiteralUnionBoolExactClaimed(t *testing.T) {
@@ -607,12 +619,16 @@ func TestParse_LiteralUnionIntExactClaimed(t *testing.T) {
 	mustParse(t, s, `{"u":"2"}`, `{"u":2}`) // "2"→2 matches literal 2
 }
 
-func TestParse_LiteralUnionMixedKindDeclinedAtGate(t *testing.T) {
-	// Mixed literal kinds (string vs int): BAML can string-coerce/parse across
-	// kinds, so a second arm could succeed → decline at the gate.
+func TestParse_LiteralUnionMixedKindScored(t *testing.T) {
+	// M3b: a mixed-literal-kind union (literal "1" | literal 1) is a scalar-leaf
+	// family, now claimed via the try_cast-first pass rather than declined at the
+	// gate. A JSON string "1" exact-matches the string literal (arm 0) in phase 1
+	// -> "1". A JSON number 1 skips the string-literal try_cast, exact-matches the
+	// int literal in phase 1, and emits 1; ObjectToString scoring is not reached.
+	// The winner's own kind/value is emitted.
 	s := unionSchema(litStr("1"), &bamlutils.DynamicTypeSpec{Type: "literal_int", Value: int64(1)})
-	requireUnsupported(t, s, `{"u":"1"}`)
-	requireUnsupported(t, s, `{"u":1}`)
+	mustParse(t, s, `{"u":"1"}`, `{"u":"1"}`)
+	mustParse(t, s, `{"u":1}`, `{"u":1}`)
 }
 
 // classUnionSchema wraps a single union property `u` over two flat classes
@@ -900,28 +916,30 @@ func TestParse_ClassUnionNonFlatFieldDeclinedAtGate(t *testing.T) {
 	requireUnsupported(t, s, `{"u":{"title":"Go","tags":["a"]}}`)
 }
 
-func TestParse_NullableMultiUnionNullClaimed(t *testing.T) {
-	// A nullable multi-union with UNSAFE non-null arms (bare string/int):
-	// native CLAIMS the null fast path for JSON-null input, but DECLINES every
-	// non-null input (the non-null arm set is not a safe family).
+func TestParse_NullableScalarMultiUnionScored(t *testing.T) {
+	// M3b: a nullable scalar-leaf multi-union (string | int | null) is now claimed
+	// for non-null input too. The variants flatten to [string, int] (null hoisted
+	// to Nullable). JSON null uses the null fast path. "x" try_casts to string; 5
+	// skips string try_cast and try_casts to int, so both non-null cases return
+	// before phase-2 scoring or null-arm competition.
 	s := unionSchema(
 		&bamlutils.DynamicTypeSpec{Type: "string"},
 		&bamlutils.DynamicTypeSpec{Type: "int"},
 		&bamlutils.DynamicTypeSpec{Type: "null"},
 	)
 	mustParse(t, s, `{"u":null}`, `{"u":null}`)
-	// Non-null input → DECLINE (string/int arms are lenient/scored).
-	requireUnsupported(t, s, `{"u":"x"}`)
-	requireUnsupported(t, s, `{"u":5}`)
+	mustParse(t, s, `{"u":"x"}`, `{"u":"x"}`)
+	mustParse(t, s, `{"u":5}`, `{"u":5}`)
 }
 
 func TestParse_NullableSingleArmUnsupportedArmClaimsNull(t *testing.T) {
 	// A nullable single-arm union T | null where T is UNSUPPORTED (here T is a
-	// map whose value is a general string|int union — out of scope). The null
-	// fast path must CLAIM null regardless of the unsupported arm (mirroring
-	// BAML's null arm), consistently with nullable MULTI unions. A NON-null
-	// input must DECLINE: coerceUnionSafe delegates to coerce on the lone arm,
-	// which falls back because the arm is unsupported.
+	// map whose value is a union WITH A LIST ARM — string | int[] — which is not
+	// a scalar-leaf family, so it stays out of scope in M3b). The null fast path
+	// must CLAIM null regardless of the unsupported arm (mirroring BAML's null
+	// arm), consistently with nullable MULTI unions. A NON-null input must
+	// DECLINE: coerceUnionSafe delegates to coerce on the lone arm, which falls
+	// back because the map value union is unsupported.
 	s := &bamlutils.DynamicOutputSchema{
 		Properties: props(kv("u", &bamlutils.DynamicProperty{
 			Type: "optional",
@@ -929,8 +947,11 @@ func TestParse_NullableSingleArmUnsupportedArmClaimsNull(t *testing.T) {
 				Type: "map",
 				Keys: &bamlutils.DynamicTypeSpec{Type: "string"},
 				Values: &bamlutils.DynamicTypeSpec{
-					Type:  "union",
-					OneOf: []*bamlutils.DynamicTypeSpec{{Type: "string"}, {Type: "int"}},
+					Type: "union",
+					OneOf: []*bamlutils.DynamicTypeSpec{
+						{Type: "string"},
+						{Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "int"}},
+					},
 				},
 			},
 		})),
@@ -939,26 +960,33 @@ func TestParse_NullableSingleArmUnsupportedArmClaimsNull(t *testing.T) {
 	// unsupported. Before the gate fix this DECLINED (the len==1 recursion
 	// rejected the unsupported arm before the nullable check).
 	mustParse(t, s, `{"u":null}`, `{"u":null}`)
-	// Non-null → DECLINE (the lone map arm has a general-union value type).
+	// Non-null → DECLINE (the lone map arm's value union has a list arm).
 	requireUnsupported(t, s, `{"u":{"a":"x"}}`)
 }
 
-func TestParse_UnsupportedPrimitiveUnion(t *testing.T) {
-	// A bare-primitive multi-union (string|int) declines: BAML stringifies /
-	// parses across kinds, so a second arm could succeed → scoring.
+func TestParse_PrimitiveScalarUnionScored(t *testing.T) {
+	// M3b: a bare-primitive scalar-leaf union (string | int) is now claimed via
+	// the try_cast-first pass. A plain string try_casts to the string arm. A JSON
+	// number 5 is selected in phase 1: string try_cast rejects numbers, int
+	// try_cast accepts, so JsonToString scoring is skipped.
 	s := unionSchema(
 		&bamlutils.DynamicTypeSpec{Type: "string"},
 		&bamlutils.DynamicTypeSpec{Type: "int"},
 	)
-	requireUnsupported(t, s, `{"u":"x"}`)
-	requireUnsupported(t, s, `{"u":5}`)
+	mustParse(t, s, `{"u":"x"}`, `{"u":"x"}`)
+	mustParse(t, s, `{"u":5}`, `{"u":5}`)
+	// A numeric STRING try_casts to the string arm in phase 1, before the int arm
+	// is considered (mirrors fixture 37).
+	mustParse(t, s, `{"u":"123"}`, `{"u":"123"}`)
 }
 
-func TestParse_UnsupportedNestedUnionVariant(t *testing.T) {
-	// A genuinely nested union ((string | int) | bool): BAML flattens it to a
-	// bare-primitive multi-union (string|int|bool) whose scored pick_best
-	// native cannot reproduce, so native declines at the gate. (This mirrors
-	// the nested_union parse-recovery fallback fixture.)
+func TestParse_NestedScalarUnionFlattenedScored(t *testing.T) {
+	// A genuinely nested union ((string | int) | bool) flattens (simplifyUnion,
+	// mirroring BAML's TypeIR::union) to the scalar-leaf set [string, int, bool].
+	// M3b resolves it try_cast-first: for 123, the flattened string arm rejects
+	// the number in try_cast, the int arm accepts in phase 1, and the value emits
+	// as 123; JsonToString scoring is not reached. "a" try_casts to the string
+	// arm. (Mirrors fixture 46.)
 	s := unionSchema(
 		&bamlutils.DynamicTypeSpec{Type: "union", OneOf: []*bamlutils.DynamicTypeSpec{
 			{Type: "string"},
@@ -966,9 +994,12 @@ func TestParse_UnsupportedNestedUnionVariant(t *testing.T) {
 		}},
 		&bamlutils.DynamicTypeSpec{Type: "bool"},
 	)
-	requireUnsupported(t, s, `{"u":123}`)
-	requireUnsupported(t, s, `{"u":"a"}`)
-	requireUnsupported(t, s, `{"u":true}`)
+	mustParse(t, s, `{"u":123}`, `{"u":123}`)
+	mustParse(t, s, `{"u":"a"}`, `{"u":"a"}`)
+	// A JSON bool try_casts to the bool arm (index 2) at score 0 — try_cast skips
+	// the string/int arms (a bool is neither a JSON string nor a JSON number), so
+	// it is CLAIMED (the int arm's lenient decline is never reached).
+	mustParse(t, s, `{"u":true}`, `{"u":true}`)
 }
 
 func TestParse_SingleFieldClassImpliedKeyInferredObject(t *testing.T) {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## de-BAML P4 M3 slice b — scalar / literal / enum + nested-scalar union scoring

Second M3 slice (epic #546). Broadens native de-BAML union support beyond the M3a safe families (homogeneous literal, flat disjoint class) to **any union whose arms are all fully-modeled non-composite leaves** — primitive `int/float/bool/string`, literal, enum, and hoisted `null` — including nested unions that flatten to that set. Builds on the M3a score model + `array_helper::pick_best` + early first-score-0 machinery.

### The load-bearing correction: `try_cast`-first
The initial capture caught a real divergence: BAML's `TypeIR::coerce` runs `try_cast` (a **strict** native-JSON-type match, always score 0) **before** any lenient coercion (`field_type.rs`: *"try_cast is basically a way to exit early"*), and for a union that is `try_cast_union` over the non-null arms. So `int | string` with `"123"` keeps a **string** (the int arm's `try_cast` rejects a JSON string), and a JSON number picks the int/float arm regardless of declaration order. `coerceScalarLeafUnion` now reproduces both phases faithfully:
1. **try_cast pass** — first non-null arm whose strict native-type cast matches wins at score 0.
2. **lenient coerce pass** (only when no arm try_casts) — the existing `selectUnionArms` early-score-0 / `pick_best` / null-arm(110) logic.

### Changes (scope: `internal/debaml/{parse,coerce}.go` + debaml tests + `integration/bamlfuzz_parse_recovery_test.go` + corpus JSON)
- **`parse.go`** — `checkSupportedUnionShape` now admits the scalar-leaf family (`allScalarLeafVariants`, reusing `isFlatLeafField`); no structural disjointness sub-check (scoring + try_cast reproduce BAML exactly). Removed the now-subsumed `allLiteralVariants` / `checkHomogeneousLiteralUnion` / `stringsPairwiseDisjoint` helpers. Flat-class family unchanged.
- **`coerce.go`** — new `coerceScalarLeafUnion` (two-phase) + `tryCastScalarUnion` / `tryCastScalarArm` (ported `try_cast` for primitive/literal/enum); `coerceUnionSafeMulti` dispatches all-class → flat-class-union, else scalar-leaf. Subsumes the old `coerceLiteralUnion`.

### Live-captured corpus (`BAMLFUZZ_PARSE_CAPTURE=1`, gate green)
Flipped fallback → **claimed**: `37_string_int_union_numeric_string`, `38_int_float_union_number`, `41_literal_union_fuzzy_string`, `46_nested_union`.
Added: `149_int_string_union_reversal`, `150_float_int_union_reversal`, `151_bool_string_union_string_wins`, `152_enum_string_union_exact` (claimed); `153_scalar_union_no_match_fallback`, `154_scalar_union_array_input_fallback` (fallback).

Dispositions: **115 claimed / 36 fallback** (was 107 / 38). Every flip validated against live BAML `v0.223.0`.

### Stays fallback (unchanged)
Mixed scalar+class unions, list/map variant unions, array-to-scalar (M3d array-to-singular), non-finite float, map-key non-member (`28/103/104/105`) — all decline at the gate or in the lenient pass.

### Validation
`gofmt`; `go build ./...`; `go vet ./...` (+`-tags=integration`); `go test ./internal/debaml ./bamlutils ./worker ./dynclient/...`; `GOWORK=off go test ./codegen` (adapters/common); `go run ./cmd/verify-framework-adapter` (6/6); bamlfuzz parse-recovery differential capture + gate (Docker, BAML v0.223.0) — all green. New unit tests cover try_cast native-type preference, order-reversal, int/float phases, enum exact-vs-fuzzy, alias/description forms, nullable proven-error→null, no-match/array/non-finite declines, nested-scalar flattening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded scored parsing for scalar unions, including deterministic best-match selection across numeric/float types, numeric strings, booleans vs strings, enum tokens, and flattened/nested unions.
  * Improved nullable union handling for map values and list-related scenarios.
* **Bug Fixes**
  * Corrected union winner selection and no-match/fallback behavior, including decline for non-finite float inputs and improved failure handling for unsupported union shapes.
* **Tests**
  * Added fuzz parse-recovery fixtures and updated integration parity expectations to match the revised scoring/coercion outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->