### PR TITLE
debaml: class + mixed-class union scoring (M3 slice c)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/156_class_union_single_string_implied_devalue.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/156_class_union_single_string_implied_devalue.json
@@ -1,0 +1,45 @@
+{
+  "name": "class_union_single_string_implied_devalue",
+  "description": "M3c: pins the pick_best classSingleImplied devalue. A{s string} | B{x int, y int} with an object carrying x,y plus 4 EXTRA keys. Neither arm try_casts (A sees x,y,e* as extras; B sees e* as extras). Phase 2: A absorbs the whole object into its lone STRING field via implied-key (JsonToString 2 + ImpliedKey 2 = 4, classSingleImplied), B keeps x,y and flags 4 extras (ExtraKey 4 = 4). Scores TIE at 4, so the single-string-implied devalue (under a union target) picks the OTHER arm B. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "class_ref", "ref": "A"},
+                {"kind": "class_ref", "ref": "B"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "A",
+        "properties": [
+          {"name": "s", "type": {"kind": "string"}}
+        ]
+      },
+      {
+        "name": "B",
+        "properties": [
+          {"name": "x", "type": {"kind": "int"}},
+          {"name": "y", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"x\":1,\"y\":2,\"e0\":1,\"e1\":1,\"e2\":1,\"e3\":1}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"x": 1, "y": 2}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/157_class_union_all_default_stays_fallback.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/157_class_union_all_default_stays_fallback.json
@@ -1,0 +1,44 @@
+{
+  "name": "class_union_all_default_stays_fallback",
+  "description": "M3c FALLBACK (M3d guard): a class union with a DEFAULTABLE-field arm stays fallback. A{items string[]} | B{name string} with an empty object. BAML: A fills items via TypeIR::default_value ([], DefaultFromNoValue 100) -> an ALL-DEFAULT class; B errors (missing required string). pick_best picks the all-default A. Native declines at the union gate (A has a non-flat-leaf list field), so the all-default class devalue / default-fill scoring inside a union is deferred to M3d. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "class_ref", "ref": "A"},
+                {"kind": "class_ref", "ref": "B"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "A",
+        "properties": [
+          {"name": "items", "type": {"kind": "list", "inner": {"kind": "string"}}}
+        ]
+      },
+      {
+        "name": "B",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{}}",
+  "want": {
+    "status": "success",
+    "json": {"u": {"items": []}}
+  }
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/158_literal_class_union_object_to_primitive_literal_wins.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/158_literal_class_union_object_to_primitive_literal_wins.json
@@ -1,0 +1,38 @@
+{
+  "name": "literal_class_union_object_to_primitive_literal_wins",
+  "description": "M3c: a mixed literal-vs-class union (\"active\" | Other{tag int}) with a single-key object whose key does NOT match the class field. Neither arm try_casts. Phase 2: the literal arm extracts the inner primitive via object-to-primitive (coerce_literal single-key object) and matches \"active\" (ObjectToPrimitive 2), while the class arm's implied-key coercion of {x:\"active\"} into an int field PROVABLY fails (missing required int) and is EXCLUDED. The literal wins. Pins the mixed family + ObjectToPrimitive + provable-losing-class-arm exclusion. want captured from BAML final parse.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {
+            "name": "u",
+            "type": {
+              "kind": "union",
+              "variants": [
+                {"kind": "literal", "literal": {"kind": "string", "string": "active"}},
+                {"kind": "class_ref", "ref": "Other"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Other",
+        "properties": [
+          {"name": "tag", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "enums": null,
+    "root_class": "Root",
+    "has_union": true
+  },
+  "raw": "{\"u\":{\"x\":\"active\"}}",
+  "want": {
+    "status": "success",
+    "json": {"u": "active"}
+  }
+}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -227,7 +227,7 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"nullable_multi_union_null":  true,
 	// M3b SCALAR-LEAF unions: checkSupportedUnionShape now admits any union whose
 	// arms are all fully-modeled non-composite leaves (primitive int/float/bool/
-	// string, literal, enum, + hoisted null), and coerceScalarLeafUnion scores
+	// string, literal, enum, + hoisted null), and coerceUnionSafeMulti scores
 	// each arm through the same per-kind coercer BAML uses, applying the early
 	// first-score-0 rule + pick_best. Bare-primitive, mixed-scalar, non-disjoint
 	// string-literal, and (post-flatten) nested-scalar unions are now CLAIMED —
@@ -241,20 +241,42 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"float_int_union_reversal":        true,
 	"bool_string_union_string_wins":   true,
 	"enum_string_union_exact":         true,
-	// Fallback: unions where a 2nd BAML arm invokes COMPOSITE scored pick_best or
-	// array-to-singular native does not yet model — mixed scalar+class, overlapping/
-	// single-field classes, literal/enum-vs-class, list/single-to-array, map
-	// partials (M3c/M3d) — plus scalar unions where no arm proves a winner (all
-	// arms error) or the winner is array-to-singular. Native declines (fallback)
-	// rather than risk a scored divergence.
-	"class_union_overlapping_keys":            false,
-	"single_field_class_union_implied_key":    false,
-	"literal_class_union_object_to_primitive": false,
-	"enum_class_union_object_to_string":       false,
-	"union_list_singleton_ambiguity":          false,
-	"union_map_value_partial":                 false,
-	"scalar_union_no_match_fallback":          false,
-	"scalar_union_array_input_fallback":       false,
+	// M3c CLAIMED — CLASS + MIXED literal/enum/class union scoring. The union gate
+	// now admits class arms (required flat-leaf fields, single-field allowed,
+	// overlapping keys allowed) and mixes of scalar/literal/enum/class, and
+	// coerceUnionSafeMulti resolves them TWO-PHASE like BAML: a phase-1 try_cast pass
+	// (tryCastClass ports Class::try_cast — a STRICT exact-key object cast) and, only
+	// when NO arm try_casts, a phase-2 lenient coerce + array_helper::pick_best (with
+	// the class / scalar-vs-composite special ordering). These four resolve
+	// byte-identical to live BAML:
+	//   - overlapping-key classes where one arm's full field set try_casts (39);
+	//   - single-field class arms with a scalar input inferred-object-absorbed (40);
+	//   - a literal|class mix where the class try_casts first (42);
+	//   - an enum|class mix scored in phase 2 (43).
+	"class_union_overlapping_keys":            true,
+	"single_field_class_union_implied_key":    true,
+	"literal_class_union_object_to_primitive": true,
+	"enum_class_union_object_to_string":       true,
+	// M3c added coverage: the pick_best classSingleImplied devalue (a single-string
+	// implied-key class ties an ordinary class on score and loses the tie under the
+	// union target), and a mixed literal|class where the class arm provably errors so
+	// the literal wins via ObjectToPrimitive — both CLAIMED green vs live BAML.
+	"class_union_single_string_implied_devalue":            true,
+	"literal_class_union_object_to_primitive_literal_wins": true,
+	// M3d guard: a class union with a DEFAULTABLE-field arm (a list field defaulting
+	// to [], an all-default class) stays fallback — its default-fill / all-default
+	// devalue scoring inside a union is not modeled until M3d, so native declines at
+	// the gate (the arm has a non-flat-leaf field).
+	"class_union_all_default_stays_fallback": false,
+	// Fallback: unions where a 2nd BAML arm invokes a list/map composite scored
+	// pick_best or array-to-singular native does not yet model — list/single-to-array,
+	// map partials (M3d) — plus scalar unions where no arm proves a winner (all arms
+	// error) or the winner is array-to-singular. Native declines (fallback) rather
+	// than risk a scored divergence.
+	"union_list_singleton_ambiguity":    false,
+	"union_map_value_partial":           false,
+	"scalar_union_no_match_fallback":    false,
+	"scalar_union_array_input_fallback": false,
 	// A multi-arm union as a LIST ELEMENT declines: BAML threads the previous
 	// element's arm as ctx.union_variant_hint (coerce_array.rs) but native has no
 	// hint, so per-element arm selection can diverge. Array union hints are M3d.

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -2428,62 +2428,53 @@ func coerceUnionSafe(b *schema.Bundle, u *schema.UnionType, input value, cf *coe
 	return coerceUnionSafeMulti(b, u.Variants, input, u.Nullable, cf)
 }
 
-// coerceUnionSafeMulti dispatches a proven-safe multi-variant union to its
-// family's scored coercer. nullable is the union's Nullable flag, threaded so
-// selectUnionArms adds the null arm as a scored candidate.
-// checkSupportedUnionShape has already proven the variant set is one of the two
-// families, so an all-class set is the flat class union and everything else is
-// the scalar/literal/enum leaf family.
-func coerceUnionSafeMulti(b *schema.Bundle, variants []schema.Type, input value, nullable bool, cf *coerceFlags) (json.RawMessage, error) {
-	if allClassVariants(variants) {
-		return coerceFlatClassUnion(b, variants, input, nullable, cf)
-	}
-	return coerceScalarLeafUnion(b, variants, input, nullable, cf)
-}
-
-// coerceScalarLeafUnion resolves a union whose every arm is a fully-modeled
-// non-composite LEAF — a primitive scalar (int/float/bool/string), a literal
-// (any kind), or an enum (checkSupportedUnionShape's M3b scalar-leaf family) —
-// reproducing BAML's TWO-PHASE union coercion exactly:
+// coerceUnionSafeMulti resolves a proven-safe multi-variant union (a scalar/
+// literal/enum leaf family, a required-flat-leaf CLASS family, or any MIX of them —
+// checkSupportedUnionShape) reproducing BAML's TWO-PHASE union coercion exactly:
 //
-//  1. try_cast pass (tryCastScalarUnion): the FIRST non-null arm whose STRICT
-//     native-JSON-type cast succeeds wins at score 0, BEFORE any lenient
-//     conversion. This is BAML's field_type.rs "try_cast is basically a way to
-//     exit early" over try_cast_union, and is why `int | string` keeps a numeric
-//     string as a STRING and a JSON number picks the int/float arm regardless of
-//     declaration order (the string arm's try_cast rejects a number, the int
-//     arm's rejects a string).
-//  2. lenient coerce pass (only when no arm try_casts): each arm is coerced
-//     through coerce(), which dispatches to the SAME per-kind coercer BAML uses
-//     (coercePrimitive / coerceLiteral / coerceEnum), so a lenient conversion
-//     (numeric-string parse, float→int round, string→bool, stringify+match,
-//     substring/fuzzy hit, single-key extraction) scores exactly as BAML would.
+//  1. try_cast pass (tryCastUnion): field_type.rs runs self.try_cast BEFORE the
+//     lenient coerce for EVERY value ("try_cast is basically a way to exit early");
+//     for a union that is try_cast_union over iter_skip_null (the non-null arms in
+//     order). The FIRST arm whose STRICT native-type cast succeeds is BAML's
+//     immediate winner at score 0 — a scalar/literal/enum by exact native-JSON-type
+//     match (tryCastArm), a CLASS by an exact-key object match whose every required
+//     flat-leaf field try_casts (tryCastClass). No numeric parse, stringify, fuzzy
+//     match, single-key extraction, class implied-key, or default happens here. This
+//     is why `int | string` keeps a numeric STRING as a string, a JSON number picks
+//     the int/float arm regardless of order, and a class whose full field set is
+//     present (fixtures 35/39/42) returns immediately regardless of the other arms.
+//  2. lenient coerce pass (only when NO arm try_casts): each arm is coerced through
+//     coerce(), which dispatches to the SAME per-kind coercer BAML uses
+//     (coercePrimitive / coerceLiteral / coerceEnum / coerceClass), so a lenient
+//     conversion (numeric-string parse, float→int round, string→bool, stringify+
+//     match, substring/fuzzy hit, single-key extraction, class implied-key /
+//     inferred-object / extra-key / default) scores exactly as BAML would.
 //     selectUnionArms applies the early first-score-0 rule and otherwise runs
 //     array_helper::pick_best over the successes (plus the null arm, score 110,
-//     when nullable). Every arm being a leaf, pick_best collapses to (score,
-//     index) — no list/class/scalar-vs-composite case fires — so the winner is
-//     exact.
+//     when nullable) — whose list/class/scalar-vs-composite special ordering native
+//     reproduces in cmpCandidates.
 //
-// In the lenient pass a non-matching or value-mismatched arm is a PROVEN BAML
-// error (excluded from ranking); an arm native's stricter coercer merely DECLINED
-// (native-can't-prove — a non-numeric string to an int arm, or ARRAY input to an
-// int/float/bool arm whose array-to-singular is M3d) or a case-fold-UNCERTAIN arm
-// declines the WHOLE union, because BAML might succeed it via a deferred path and
-// change the winner. The winner's own output is emitted directly.
+// In the lenient pass a non-matching / value-mismatched / missing-required arm is a
+// PROVEN BAML error (excluded from ranking); an arm native's stricter coercer merely
+// DECLINED (native-can't-prove — a non-numeric string to an int arm, or ARRAY input
+// to an int/float/bool/class arm whose array-to-singular is M3d) or a case-fold-
+// UNCERTAIN arm declines the WHOLE union, because BAML might succeed it via a
+// deferred path and change the winner. The winner's own output is emitted directly
+// (in the winner's schema field order for a class).
 //
-// It SUBSUMES the pre-M3b homogeneous-literal path (a literal arm try_casts on an
-// exact match and otherwise coerces identically), which is why the old
-// string-literal disjointness gate is gone: two lenient successes are resolved by
-// pick_best rather than declined.
-func coerceScalarLeafUnion(b *schema.Bundle, variants []schema.Type, input value, nullable bool, cf *coerceFlags) (json.RawMessage, error) {
+// It SUBSUMES the pre-M3c per-family paths: a scalar/literal/enum-only variant set
+// behaves exactly as the M3b scalar-leaf coercer (phase-1 leaf try_cast, phase-2
+// per-kind scoring), and an all-class or mixed set adds the class try_cast (phase 1)
+// and the class pick_best special ordering (phase 2). The old disjoint-key /
+// >=2-field class gate is gone: overlapping and single-field class arms are resolved
+// by pick_best rather than declined.
+func coerceUnionSafeMulti(b *schema.Bundle, variants []schema.Type, input value, nullable bool, cf *coerceFlags) (json.RawMessage, error) {
 	// Phase 1: try_cast pass (coerce_union.rs try_cast_union, run by field_type.rs
 	// BEFORE the lenient coerce). The FIRST non-null arm whose STRICT native-type
-	// cast succeeds is BAML's winner at score 0 — before any numeric parse,
-	// stringify, fuzzy match, or extraction. This is why `int | string` keeps a
-	// numeric STRING as a string and a JSON number picks the int/float arm.
-	if w, ok, err := tryCastScalarUnion(b, variants, input); err != nil {
+	// cast succeeds is BAML's winner at score 0.
+	if w, matched, err := tryCastUnion(b, variants, input); err != nil {
 		return nil, err
-	} else if ok {
+	} else if matched {
 		setWinnerCf(cf, w)
 		return w.output, nil
 	}
@@ -2502,24 +2493,32 @@ func coerceScalarLeafUnion(b *schema.Bundle, variants []schema.Type, input value
 	return w.output, nil
 }
 
-// tryCastScalarUnion ports BAML's try_cast_union (coerce_union.rs) for the
-// scalar-leaf family. field_type.rs runs self.try_cast BEFORE the lenient coerce
-// for EVERY value ("try_cast is basically a way to exit early"); for a union that
-// is try_cast_union over iter_skip_null (the non-null arms in order). A scalar /
-// literal / enum arm's try_cast succeeds ONLY when the input's native JSON type
-// already matches the arm — no numeric parse, stringify, fuzzy/substring match,
-// or single-key extraction — and it always scores 0. So the FIRST arm that
+// tryCastUnion ports BAML's try_cast_union (coerce_union.rs) for the supported
+// union families. field_type.rs runs self.try_cast BEFORE the lenient coerce for
+// EVERY value; for a union that is try_cast_union over iter_skip_null (the non-null
+// arms in order). Each arm's try_cast (tryCastArm — a scalar/literal/enum by strict
+// native-JSON-type match, a CLASS by tryCastClass) succeeds ONLY when the input's
+// native shape already matches, adding NO score-bearing flag: within the supported
+// families a try_cast always scores 0 (leaf arms are strict; a required-flat-leaf
+// class has empty own conditions and score-0 field try_casts). So the FIRST arm that
 // try_casts is BAML's immediate winner (UnionMatch), returned before the lenient
 // coerce pass. The null arm is excluded here (the JSON-null input fast path is in
 // coerceUnionSafe; a non-null input never try_casts to null).
 //
+// Because every supported arm's try_cast is 0-or-no-match, BAML's try_cast_union
+// non-zero-collection + pick_best sub-path is never reached and is intentionally not
+// modeled: if a future gate admits an arm whose try_cast can score non-zero (e.g. a
+// class with an OPTIONAL field → a missing OptionalDefaultFromNoValue), that sub-path
+// must be ported before it is claimed (checkUnionClassVariant enforces this today by
+// rejecting non-flat-leaf/optional class fields).
+//
 // Returns (winner, true, nil) on a hit; (_, false, nil) when no arm try_casts
 // (caller runs the lenient pass); (_, false, err) only for a value native cannot
-// emit (a JSON number that parses to a non-finite float), which declines the
-// whole union rather than risk emitting an invalid token.
-func tryCastScalarUnion(b *schema.Bundle, variants []schema.Type, input value) (candidate, bool, error) {
+// emit (a JSON number that parses to a non-finite float) or a hard/invariant failure
+// (unknown class / malformed arm type), which declines/propagates.
+func tryCastUnion(b *schema.Bundle, variants []schema.Type, input value) (candidate, bool, error) {
 	for i := range variants {
-		out, kind, matched, err := tryCastScalarArm(b, variants[i], input)
+		out, kind, matched, err := tryCastArm(b, variants[i], input)
 		if err != nil {
 			return candidate{}, false, err
 		}
@@ -2530,10 +2529,9 @@ func tryCastScalarUnion(b *schema.Bundle, variants []schema.Type, input value) (
 	return candidate{}, false, nil
 }
 
-// tryCastScalarArm ports the per-kind try_cast for the scalar-leaf family
-// (coerce_primitive.rs / coerce_literal.rs / coerce_enum.rs try_cast): a STRICT
-// native-type match that adds no score-bearing flag. It returns the emitted JSON,
-// the BAML value kind (for pick_best/setWinnerCf), and whether the arm matched.
+// tryCastArm ports the per-kind try_cast (field_type.rs::try_cast dispatch): a
+// STRICT native-type match that adds no score-bearing flag. It returns the emitted
+// JSON, the BAML value kind (for pick_best/setWinnerCf), and whether the arm matched.
 //
 //   - string:  a JSON string (verbatim).
 //   - int:     a JSON number whose token is an i64-range integer (as_i64 Some) —
@@ -2546,7 +2544,15 @@ func tryCastScalarUnion(b *schema.Bundle, variants []schema.Type, input value) (
 //     ==, int by as_i64 ==, bool by ==) — no stringify/parse/fuzzy.
 //   - enum:    a JSON string EXACTLY equal to a value's rendered name (no
 //     description forms, no case fold, no substring); emits the canonical name.
-func tryCastScalarArm(b *schema.Bundle, t schema.Type, input value) (json.RawMessage, candKind, bool, error) {
+//   - class:   an OBJECT whose keys EXACTLY match a subset of the fields with NO
+//     extras and every required flat-leaf field try_casting (tryCastClass).
+//
+// Every other kind (list / map / union / recursive alias) never appears as a
+// supported union arm (checkSupportedUnionShape), so it returns not-matched.
+func tryCastArm(b *schema.Bundle, t schema.Type, input value) (json.RawMessage, candKind, bool, error) {
+	if t.Kind == schema.TypeClass {
+		return tryCastClass(b, t.Name, t.Mode, input)
+	}
 	switch t.Kind {
 	case schema.TypePrimitive:
 		switch t.Primitive {
@@ -2614,35 +2620,92 @@ func tryCastScalarArm(b *schema.Bundle, t schema.Type, input value) (json.RawMes
 	return nil, 0, false, nil
 }
 
-// coerceFlatClassUnion scores a flat disjoint-key class union (coerce_union.rs
-// over class arms). Each arm is coerced through coerceClass; the disjoint-key
-// gate guarantees at most one arm matches an input's full field set unless the
-// input carries a second arm's fields too, in which case BOTH succeed and
-// pickBest chooses the lower-score class (then lower index). A non-matching arm
-// missing its required fields is a PROVEN BAML error (excluded); an arm native's
-// stricter coercer left INDETERMINATE is native-can't-prove and declines the
-// whole union (BAML might succeed it and pick it). When nullable, the null arm
-// (score 110) competes — so an extra-key-heavy class scoring above 110 loses to
-// null, while a class scoring below 110 wins. The winner's own coercion output
-// is emitted directly, in that class's schema field order.
-func coerceFlatClassUnion(b *schema.Bundle, variants []schema.Type, input value, nullable bool, cf *coerceFlags) (json.RawMessage, error) {
+// tryCastClass ports Class::try_cast (ir_ref/coerce_class.rs) — the STRICT phase-1
+// class coercion. It matches ONLY a JSON OBJECT whose keys EXACTLY equal (by
+// rendered name — a case-sensitive BamlMap key lookup, NOT the lenient fuzzy
+// matches_string_to_string coerce uses) a subset of the class fields with NO extra
+// key, where every present field's value try_casts (recursively, via tryCastArm)
+// and every field is present. The M3c gate (checkUnionClassVariant) guarantees all
+// fields are REQUIRED flat leaves, so there are no optional fills and a class
+// try_cast that matches always scores 0 (own conditions empty, every field try_cast
+// score 0) — hence it is BAML's immediate union winner, and no non-zero try_cast
+// score arises for the caller to pick_best over.
+//
+// Returns (out, candClass, true, nil) on a strict match (emitted in SCHEMA field
+// order under canonical field names, byte-identical to the class's clean lenient
+// coerce output); (nil, candClass, false, nil) when the object does not strictly
+// match (extra key, missing field, or a field that does not try_cast — the caller
+// falls to the lenient phase, or the next arm); (nil, _, false, err) only for a
+// hard/invariant failure (unknown class, or a malformed field arm type).
+func tryCastClass(b *schema.Bundle, name string, mode schema.StreamingMode, input value) (json.RawMessage, candKind, bool, error) {
+	cls, ok := b.FindClass(name, mode)
+	if !ok {
+		return nil, 0, false, fmt.Errorf("debaml: unknown class %q", name)
+	}
 	if input.kind != valObject {
-		// Non-object to a >=2-required-field class union: every arm misses its
-		// required fields (a proven error), leaving only the null arm — but native
-		// cannot prove BAML has no other object/inference path for a scalar, so it
-		// stays conservative and DECLINES (unchanged pre-M3 behavior).
-		return nil, declineCoerce("class union", input)
+		// Class try_cast handles objects only (a scalar/array/null never try_casts
+		// to a class; those are the lenient inferred-object / array-to-singular
+		// paths, not the strict cast).
+		return nil, candClass, false, nil
 	}
-	w, err := selectUnionArms(len(variants), nullable, func(i int) (json.RawMessage, *coerceFlags, error) {
-		armF := &coerceFlags{}
-		out, e := coerceClass(b, variants[i].Name, variants[i].Mode, input, armF)
-		return out, armF, e
-	})
-	if err != nil {
-		return nil, err
+	nF := len(cls.Fields)
+	assigned := make([]value, nF)
+	present := make([]bool, nF)
+	for i := range input.objV {
+		key := input.objV[i].key
+		mf := -1
+		for j := range cls.Fields {
+			// EXACT rendered-name match (BAML's fill_result.get_mut(k)); the gate
+			// rejects duplicate rendered names, so the first match is unique.
+			if cls.Fields[j].Name.RenderedName() == key {
+				mf = j
+				break
+			}
+		}
+		if mf < 0 {
+			// try_cast rejects objects with ANY extra key (stricter matching).
+			return nil, candClass, false, nil
+		}
+		if present[mf] {
+			continue // duplicate key for an already-set field: keep first.
+		}
+		present[mf] = true
+		assigned[mf] = input.objV[i].val
 	}
-	setWinnerCf(cf, w)
-	return w.output, nil
+
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	first := true
+	for j := range cls.Fields {
+		if !present[j] {
+			// The gate guarantees every field is REQUIRED (no optional), so a field
+			// with no input key fails the strict cast (BAML returns None; the lenient
+			// phase would default/error it instead).
+			return nil, candClass, false, nil
+		}
+		fout, _, matched, err := tryCastArm(b, cls.Fields[j].Type, assigned[j])
+		if err != nil {
+			return nil, candClass, false, err
+		}
+		if !matched {
+			// A field's value does not strictly cast to its type → the class
+			// try_cast fails (BAML returns None; the lenient phase may still coerce).
+			return nil, candClass, false, nil
+		}
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		key, err := marshalJSON(cls.Fields[j].Name.Name)
+		if err != nil {
+			return nil, candClass, false, err
+		}
+		buf.Write(key)
+		buf.WriteByte(':')
+		buf.Write(fout)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), candClass, true, nil
 }
 
 // isOptional reports whether t is an optional (a nullable union), the only

--- a/internal/debaml/coerce_class_test.go
+++ b/internal/debaml/coerce_class_test.go
@@ -352,14 +352,15 @@ func TestCoerceClass_NullableScored(t *testing.T) {
 	mustParse(t, clean, `{"u":null}`, `{"u":null}`)
 }
 
-// TestCoerceClass_Fixture40ShapeStaysFallback is the LOAD-BEARING over-claim
-// guard: a union of SINGLE-field classes (fixture 40 shape) with a scalar input
-// must STAY fallback. It declines at the SCHEMA GATE (checkFlatClassUnion rejects
-// a <2-field class-union variant), and — were the gate lifted — the lenient
-// coerceClass makes BOTH single-field arms succeed via inferred-object, so the
-// flat-class-union counter would see >=2 successes and decline. This must hold
-// after coerceClass became lenient.
-func TestCoerceClass_Fixture40ShapeStaysFallback(t *testing.T) {
+// TestCoerceClass_Fixture40SingleFieldUnionClaimed pins fixture 40 (M3c): a union
+// of SINGLE-field classes A{val} | B{num} with a scalar input now CLAIMS. No arm
+// try_casts (a scalar is not an object), so the lenient phase runs: BOTH single-
+// field arms absorb 5 via inferred-object (ImpliedKey score 2), and pick_best picks
+// the lower-index arm A (both ordinary int-implied classes, so classSingleImplied /
+// classAllDefault do not fire — the winner is (score, index)). This is the flip the
+// pre-M3c gate declined; the inferred-object absorption that made it fallback is now
+// exactly what makes it claimable under the scored two-phase model.
+func TestCoerceClass_Fixture40SingleFieldUnionClaimed(t *testing.T) {
 	// Root{u: A | B}, A{val int}, B{num int}, input {"u":5}.
 	s := &bamlutils.DynamicOutputSchema{
 		Properties: props(kv("u", &bamlutils.DynamicProperty{
@@ -371,10 +372,10 @@ func TestCoerceClass_Fixture40ShapeStaysFallback(t *testing.T) {
 			bamlutils.OrderedKV("B", &bamlutils.DynamicClass{Properties: props(kv("num", intProp()))}),
 		),
 	}
-	requireUnsupported(t, s, `{"u":5}`)
+	mustParse(t, s, `{"u":5}`, `{"u":{"val":5}}`)
 
-	// Both single-field classes DO absorb the scalar via inferred-object (which
-	// is exactly why the union must stay fallback): each coerceClass succeeds.
+	// Both single-field classes DO absorb the scalar via inferred-object: each
+	// coerceClass succeeds (the phase-2 successes pick_best chooses between).
 	bA, aT := classBundle(t, s, "A")
 	if _, err := coerceClass(bA, aT.Name, aT.Mode, numV("5"), nil); err != nil {
 		t.Errorf("A{val int} must absorb scalar 5 via inferred-object: %v", err)

--- a/internal/debaml/coerce_class_union_test.go
+++ b/internal/debaml/coerce_class_union_test.go
@@ -1,0 +1,219 @@
+package debaml
+
+import (
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// M3 slice c — CLASS + MIXED literal/enum/class union scoring.
+// checkSupportedUnionShape now admits CLASS arms (constraint-free, required
+// flat-leaf fields, single-field allowed, overlapping keys allowed) and any MIX of
+// scalar/literal/enum/class. coerceUnionSafeMulti resolves them TWO-PHASE like BAML:
+// a phase-1 try_cast pass (tryCastClass ports Class::try_cast — a STRICT exact-key
+// object cast) and, only when NO arm try_casts, a phase-2 lenient coerce +
+// array_helper::pick_best (with the class / scalar-vs-composite special ordering).
+// These tests pin the class try_cast phase directly, the mixed families end-to-end,
+// and the hard guards that STAY fallback.
+
+// abClassUnionSchema builds Root{u: A | B} over two classes with the given field
+// specs, for the class-union end-to-end tests.
+func abClassUnionSchema(aFields, bFields bamlutils.OrderedMap[*bamlutils.DynamicProperty]) *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type:  "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{{Ref: "A"}, {Ref: "B"}},
+		})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("A", &bamlutils.DynamicClass{Properties: aFields}),
+			bamlutils.OrderedKV("B", &bamlutils.DynamicClass{Properties: bFields}),
+		),
+	}
+}
+
+// TestTryCastClass_Strict pins Class::try_cast (tryCastClass): it matches ONLY an
+// object whose keys EXACTLY equal a subset of the fields with NO extra key and every
+// field present and value-type-matching, emitting in SCHEMA field order. Any other
+// shape returns not-matched (the caller falls to the lenient phase).
+func TestTryCastClass_Strict(t *testing.T) {
+	s := abClassUnionSchema(
+		props(kv("id", intProp()), kv("name", strProp())),
+		props(kv("id", intProp()), kv("label", strProp())),
+	)
+	b, aT := classBundle(t, s, "A") // A{id int, name string}
+
+	assertMatch := func(name string, in value, wantOut string, wantMatched bool) {
+		out, kind, matched, err := tryCastClass(b, aT.Name, aT.Mode, in)
+		if err != nil {
+			t.Fatalf("%s: unexpected err: %v", name, err)
+		}
+		if matched != wantMatched {
+			t.Errorf("%s: matched=%v, want %v", name, matched, wantMatched)
+			return
+		}
+		if kind != candClass {
+			t.Errorf("%s: kind=%v, want candClass", name, kind)
+		}
+		if matched && string(out) != wantOut {
+			t.Errorf("%s: out=%s, want %s", name, out, wantOut)
+		}
+	}
+
+	// Exact full-field-set match -> score-0 cast, schema field order.
+	assertMatch("exact", objVal(fld("id", numV("1")), fld("name", strVv("x"))), `{"id":1,"name":"x"}`, true)
+	// Reordered input keys still emit in SCHEMA order (id before name).
+	assertMatch("reordered", objVal(fld("name", strVv("x")), fld("id", numV("1"))), `{"id":1,"name":"x"}`, true)
+	// An EXTRA key rejects the strict cast (BAML try_cast returns None on extras).
+	assertMatch("extra key", objVal(fld("id", numV("1")), fld("name", strVv("x")), fld("z", numV("9"))), "", false)
+	// A MISSING required field rejects the cast (no optional fills in the gate).
+	assertMatch("missing field", objVal(fld("id", numV("1"))), "", false)
+	// A field VALUE whose native JSON type mismatches (string into int) rejects the
+	// cast — try_cast is strict, so a numeric STRING "1" does not cast to int.
+	assertMatch("field type mismatch", objVal(fld("id", strVv("1")), fld("name", strVv("x"))), "", false)
+	// A non-object never casts to a class (the lenient inferred-object path is not
+	// try_cast).
+	assertMatch("scalar input", numV("5"), "", false)
+	assertMatch("array input", value{kind: valArray, arrV: []value{numV("1")}}, "", false)
+	assertMatch("null input", nullVal(), "", false)
+}
+
+// TestClassUnion_TryCastFirstWinner pins the phase-1 fast path for class unions: an
+// input whose full field set is exactly one arm's fields returns that arm at score 0
+// BEFORE the other arm (or any lenient scoring) is considered — even when the arms
+// share a field name (fixture 39, formerly declined at the disjoint-key gate).
+func TestClassUnion_TryCastFirstWinner(t *testing.T) {
+	// A{id,name} | B{id,label} — overlapping `id`. Input == A's full field set.
+	s := abClassUnionSchema(
+		props(kv("id", intProp()), kv("name", strProp())),
+		props(kv("id", intProp()), kv("label", strProp())),
+	)
+	mustParse(t, s, `{"u":{"id":1,"name":"x"}}`, `{"u":{"id":1,"name":"x"}}`)
+	// Input == B's full field set -> B try_casts (A rejects the extra `label`).
+	mustParse(t, s, `{"u":{"id":2,"label":"y"}}`, `{"u":{"id":2,"label":"y"}}`)
+	// An input carrying BOTH `name` and `label` casts to NEITHER arm (each sees an
+	// extra key) -> phase 2: A keeps id,name (label extra, ExtraKey 1), B keeps
+	// id,label (name extra, ExtraKey 1); both score 1, so the lower-index arm A wins.
+	mustParse(t, s, `{"u":{"id":1,"name":"x","label":"y"}}`, `{"u":{"id":1,"name":"x"}}`)
+}
+
+// TestMixedUnion_LiteralClass_TryCast pins fixture 42: a mixed literal-vs-class
+// union ("active" | Status{tag}) with a single-key object. The literal arm's
+// try_cast rejects an object; the class arm's try_cast matches Status{tag:"active"}
+// at score 0, so it wins in phase 1 (the literal's object-to-primitive extraction —
+// a phase-2 path — is never reached).
+func TestMixedUnion_LiteralClass_TryCast(t *testing.T) {
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type: "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{
+				{Type: "literal_string", Value: "active"},
+				{Ref: "Status"},
+			},
+		})),
+		Classes: bamlutils.MustOrderedMap(bamlutils.OrderedKV("Status", &bamlutils.DynamicClass{
+			Properties: props(kv("tag", strProp())),
+		})),
+	}
+	mustParse(t, s, `{"u":{"tag":"active"}}`, `{"u":{"tag":"active"}}`)
+	// A bare string "active" try_casts the LITERAL arm (index 0) instead.
+	mustParse(t, s, `{"u":"active"}`, `{"u":"active"}`)
+}
+
+// TestMixedUnion_EnumClass_Scored pins fixture 43: an enum-vs-class union (Color |
+// Detail{a,b}) with an object carrying both class fields AND an enum token as an
+// EXTRA key. Neither arm try_casts (the enum needs a string; the class sees the
+// extra `color` key), so phase 2 runs: the enum stringifies the object and
+// substring-matches RED (ObjectToString 2 + SubstringMatch 2 = 4) while Detail keeps
+// a,b and flags the extra `color` (ExtraKey 1). Detail's lower score wins.
+func TestMixedUnion_EnumClass_Scored(t *testing.T) {
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{
+			Type: "union",
+			OneOf: []*bamlutils.DynamicTypeSpec{
+				{Ref: "Color"},
+				{Ref: "Detail"},
+			},
+		})),
+		Classes: bamlutils.MustOrderedMap(bamlutils.OrderedKV("Detail", &bamlutils.DynamicClass{
+			Properties: props(kv("a", intProp()), kv("b", intProp())),
+		})),
+		Enums: bamlutils.MustOrderedMap(bamlutils.OrderedKV("Color", &bamlutils.DynamicEnum{
+			Values: []*bamlutils.DynamicEnumValue{{Name: "RED"}, {Name: "GREEN"}, {Name: "BLUE"}},
+		})),
+	}
+	mustParse(t, s, `{"u":{"a":1,"b":2,"color":"RED"}}`, `{"u":{"a":1,"b":2}}`)
+}
+
+// TestClassUnion_SingleFieldInferredScored pins fixture 40: a union of single-field
+// classes A{val int} | B{num int} with a bare scalar. No arm try_casts (a scalar is
+// not an object), so phase 2 runs: both absorb 5 via inferred-object (ImpliedKey
+// score 2); classSingleImplied is FALSE for both (the implied field is an int, not a
+// string), so no devalue fires and the lower-index arm A wins on (score, index).
+func TestClassUnion_SingleFieldInferredScored(t *testing.T) {
+	s := abClassUnionSchema(props(kv("val", intProp())), props(kv("num", intProp())))
+	mustParse(t, s, `{"u":5}`, `{"u":{"val":5}}`)
+}
+
+// TestClassUnion_ChildScoreDecides pins a class union resolved purely by child
+// (field) scores in phase 2. A{a int, b string} | B{c int, d string} with an input
+// whose keys hit both arms' field sets: neither try_casts (each sees the other arm's
+// keys as extras), so phase 2 scores A (ExtraKey 2) vs B (ExtraKey 2); the tie breaks
+// to the lower-index arm A (fixture 75 shape).
+func TestClassUnion_ChildScoreDecides(t *testing.T) {
+	s := abClassUnionSchema(
+		props(kv("a", intProp()), kv("b", strProp())),
+		props(kv("c", intProp()), kv("d", strProp())),
+	)
+	mustParse(t, s, `{"u":{"a":1,"b":"x","c":"5","d":"y"}}`, `{"u":{"a":1,"b":"x"}}`)
+	// A JsonToString field score tips the winner: A's `b` takes a number, so A
+	// scores 2 (JsonToString) + 2 (c,d extras) = 4 while B scores 2 (c=5 clean, a,b
+	// extras ExtraKey 2) -> B wins.
+	mustParse(t, s, `{"u":{"a":1,"b":2,"c":5,"d":"y"}}`, `{"u":{"c":5,"d":"y"}}`)
+}
+
+// TestClassUnion_ProvableLosingArmExcluded pins that a class arm whose REQUIRED field
+// provably fails to coerce is EXCLUDED from scoring (not a whole-union decline), so
+// the other arm claims — through the broadened gate. A{a int,b string} | B{c int,d
+// string}: c="bad" provably fails int coercion -> B errors -> A wins.
+func TestClassUnion_ProvableLosingArmExcluded(t *testing.T) {
+	s := abClassUnionSchema(
+		props(kv("a", intProp()), kv("b", strProp())),
+		props(kv("c", intProp()), kv("d", strProp())),
+	)
+	mustParse(t, s, `{"u":{"a":1,"b":"x","c":"bad","d":"y"}}`, `{"u":{"a":1,"b":"x"}}`)
+}
+
+// TestClassUnion_HardGuardsStayFallback pins the load-bearing over-claim guards for
+// M3c class/mixed unions.
+func TestClassUnion_HardGuardsStayFallback(t *testing.T) {
+	// A class arm with an OPTIONAL field declines at the gate (its non-zero try_cast
+	// / default scoring in a union is M3d).
+	optField := abClassUnionSchema(
+		props(kv("a", intProp()), kv("b", optProp(&bamlutils.DynamicTypeSpec{Type: "string"}))),
+		props(kv("c", intProp()), kv("d", strProp())),
+	)
+	requireUnsupported(t, optField, `{"u":{"a":1,"b":"x"}}`)
+
+	// A class arm with a LIST field declines at the gate (single-to-array is M3d).
+	listField := abClassUnionSchema(
+		props(kv("a", intProp()), kv("tags", &bamlutils.DynamicProperty{Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "string"}})),
+		props(kv("c", intProp()), kv("d", strProp())),
+	)
+	requireUnsupported(t, listField, `{"u":{"a":1,"tags":["x"]}}`)
+
+	// A class arm with a MAP field declines at the gate.
+	mapField := abClassUnionSchema(
+		props(kv("a", intProp()), kv("m", &bamlutils.DynamicProperty{Type: "map", Keys: &bamlutils.DynamicTypeSpec{Type: "string"}, Values: &bamlutils.DynamicTypeSpec{Type: "int"}})),
+		props(kv("c", intProp()), kv("d", strProp())),
+	)
+	requireUnsupported(t, mapField, `{"u":{"a":1,"m":{"k":1}}}`)
+
+	// ARRAY input to a class union declines: BAML runs coerce_array_to_singular /
+	// pick_best over the items (array-to-singular is M3d), which native does not
+	// model, so every class arm declines the array and the union falls back.
+	arr := abClassUnionSchema(
+		props(kv("a", intProp()), kv("b", strProp())),
+		props(kv("c", intProp()), kv("d", strProp())),
+	)
+	requireUnsupported(t, arr, `{"u":[{"a":1,"b":"x"}]}`)
+}

--- a/internal/debaml/coerce_scalar_union_test.go
+++ b/internal/debaml/coerce_scalar_union_test.go
@@ -8,8 +8,8 @@ import (
 
 // M3 slice b — SCALAR / LITERAL / ENUM (+ null) and flattened-scalar NESTED
 // unions. checkSupportedUnionShape now admits any union whose arms are all
-// fully-modeled non-composite leaves, and coerceScalarLeafUnion resolves them
-// TWO-PHASE like BAML: a phase-1 try_cast pass (the first arm whose STRICT
+// fully-modeled non-composite leaves, and the unified coerceUnionSafeMulti resolves
+// them TWO-PHASE like BAML: a phase-1 try_cast pass (the first arm whose STRICT
 // native-JSON-type cast matches wins at score 0, before any lenient conversion)
 // and, only when no arm try_casts, a phase-2 lenient coerce pass (the M3a
 // per-kind coercers + early first-score-0 + array_helper::pick_best). These tests
@@ -243,7 +243,7 @@ func TestScalarUnion_ListElementUnionDeclines(t *testing.T) {
 // tiebreak for a scalar union: an ARRAY whose Display substring-matches BOTH
 // disjoint string-literal arms scores 4 on each (ObjectToString 2 + SubstringMatch
 // 2), so the lower-index arm wins. (Same as the M3a two-substring fixture, now
-// routed through the broadened coerceScalarLeafUnion.)
+// routed through the unified coerceUnionSafeMulti.)
 func TestScalarUnion_LiteralStringSubstringTie_PickFirst(t *testing.T) {
 	s := unionSchema(litStr("foo"), litStr("bar"))
 	mustParse(t, s, `{"u":["foo","bar"]}`, `{"u":"foo"}`)

--- a/internal/debaml/coerce_test.go
+++ b/internal/debaml/coerce_test.go
@@ -75,16 +75,16 @@ func TestWrappersPropagateHardErrors(t *testing.T) {
 		u := &schema.UnionType{Variants: []schema.Type{ghostEnum}, Nullable: true}
 		return coerceUnionSafe(b, u, value{kind: valString, strV: "x"}, nil)
 	})
-	run("coerceFlatClassUnion-counting", "unknown class", func() (interface{}, error) {
-		// Bypasses checkSupportedUnionShape (a unit-level wrapper probe): the
-		// counting loop hits FindClass and must propagate the hard error.
-		return coerceFlatClassUnion(b, []schema.Type{ghostClass, ghostClass}, obj, false, nil)
+	run("coerceUnionSafeMulti-class-counting", "unknown class", func() (interface{}, error) {
+		// Bypasses checkSupportedUnionShape (a unit-level wrapper probe): phase-1
+		// tryCastUnion → tryCastClass hits FindClass and must propagate the hard error.
+		return coerceUnionSafeMulti(b, []schema.Type{ghostClass, ghostClass}, obj, false, nil)
 	})
-	run("coerceScalarLeafUnion-counting", "literal type missing value", func() (interface{}, error) {
+	run("coerceUnionSafeMulti-literal-counting", "literal type missing value", func() (interface{}, error) {
 		// A literal variant with a nil payload is a hard invariant failure surfaced
-		// by phase-1 tryCastScalarArm before the scored coerce loop runs.
+		// by phase-1 tryCastArm before the scored coerce loop runs.
 		bad := schema.Type{Kind: schema.TypeLiteral, Literal: nil}
-		return coerceScalarLeafUnion(b, []schema.Type{bad, bad}, value{kind: valString, strV: "x"}, false, nil)
+		return coerceUnionSafeMulti(b, []schema.Type{bad, bad}, value{kind: valString, strV: "x"}, false, nil)
 	})
 }
 

--- a/internal/debaml/coerce_union_revisit_test.go
+++ b/internal/debaml/coerce_union_revisit_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/invakid404/baml-rest/bamlutils"
 )
 
-// M3 slice a — SCORE MODEL + safe-family pick_best. The safe-family union
-// coercers (coerceScalarLeafUnion / coerceFlatClassUnion) now score every arm with
-// the types.rs inherent model, apply BAML's early first-score-0 winner rule, and
-// otherwise run a faithful array_helper::pick_best over the successful candidates
+// M3 slice a — SCORE MODEL + safe-family pick_best. The unified union coercer
+// (coerceUnionSafeMulti) scores every arm with
+// the types.rs inherent model, applies BAML's early first-score-0 winner rule, and
+// otherwise runs a faithful array_helper::pick_best over the successful candidates
 // plus (when nullable) the null arm (DefaultButHadValue, score 110). No gate
 // broadening — only the existing literal/class safe families are scored. These
 // tests pin the flips from the pre-M3 clean-only rule to scored selection.

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -284,72 +284,117 @@ func isStringLiteralUnionType(t schema.Type) bool {
 }
 
 // checkSupportedUnionShape reports whether the NON-NULL variant set of a
-// multi-variant union (len(Variants) >= 2) is one of the supported families.
-// It is the structural half of the union claim: it admits only variant sets
-// whose scored selection native reproduces exactly, so BAML's array_helper::
-// pick_best never diverges from native's.
+// multi-variant union (len(Variants) >= 2) is one native reproduces exactly. It
+// is the structural half of the union claim: it admits only variant sets whose
+// two-phase scored selection native matches, so BAML's try_cast_union / lenient
+// coerce_union + array_helper::pick_best never diverges from native's.
 //
-// The two supported families are:
+// It admits a variant set in which EVERY variant is either:
 //
-//   - SCALAR-LEAF union (M3b): every variant is a fully-modeled non-composite
-//     LEAF — a primitive scalar (int/float/bool/string), a literal (any kind),
-//     or an enum. No structural disjointness sub-check is needed: the M3a score
-//     model + pick_best + early first-score-0 rule pick BAML's exact winner
-//     across these arms (each is coerced by the SAME per-kind coercer BAML uses
-//     and scored with the types.rs inherent model), two-plus lenient successes
-//     are resolved by pick_best rather than declined, and a within-arm
-//     match_string tie (StrMatchOneFromMany) fails that arm exactly as BAML
-//     errors it. Per-arm native-can't-prove declines and case-fold uncertainty
-//     decline the WHOLE union at coerce time (selectUnionArms), so over-claim is
-//     impossible — the only residual is under-claim (safe). Nested scalar unions
-//     arrive here already flattened into this variant set by simplifyUnion.
-//   - FLAT CLASS union: every variant is a constraint-free class ref whose class
-//     has >= 2 fields, every field REQUIRED and a FLAT LEAF (primitive scalar /
-//     literal / enum — no union/map/list/optional/recursive-alias/nested-class),
-//     and whose rendered field-name sets are pairwise disjoint under a
-//     conservative key-match superset.
+//   - a fully-modeled non-composite LEAF — a primitive scalar (int/float/bool/
+//     string), a literal (any kind), or an enum (the M3b scalar-leaf family); or
+//   - a constraint-free, resolvable class ref whose class is constraint-free and
+//     has only REQUIRED FLAT-LEAF fields (primitive scalar / literal / enum — no
+//     optional/union/map/list/nested-class/recursive field) with no duplicate
+//     rendered field names (the M3c class family).
 //
-// Every OTHER shape declines: a mixed scalar+class family, any list/map variant,
-// overlapping or single-field classes (M3c/M3d). A list/map/array-to-singular
-// arm is out of scope until its scoring is modeled.
+// A MIX of the two (literal/enum/class, scalar/class) is admitted too — both
+// families flow through the SAME two-phase coercer (coerceUnionSafeMulti): a
+// phase-1 try_cast pass (the first arm whose STRICT native-type cast matches wins
+// at score 0 — coerce_union.rs try_cast_union, with class try_cast ported by
+// tryCastClass) and, only when no arm try_casts, a phase-2 lenient coerce +
+// array_helper::pick_best (whose list/class/scalar-vs-composite special ordering
+// native reproduces in cmpCandidates). Nested scalar unions arrive here already
+// flattened into this variant set by simplifyUnion.
+//
+// Every over-claim path declines the WHOLE union at coerce time — an arm native
+// cannot prove (a non-proven ErrDeBAMLParseUnsupported), a case-fold-uncertain
+// verdict, or ARRAY input to an int/float/bool/class arm (array-to-singular is
+// M3d) — so over-claim is impossible; the only residual is safe under-claim.
+//
+// Every OTHER shape declines: a list/map variant (its SingleToArray / markdown /
+// FirstMatch / array-of-union-hint scoring is M3d), a class with any non-flat-leaf
+// or optional field (its default/partial/implied scoring inside a union is not yet
+// proven), a constrained or recursive class, or a surviving nested union.
 func checkSupportedUnionShape(b *schema.Bundle, u *schema.UnionType) error {
 	vs := u.Variants
 	if len(vs) < 2 {
 		return unsupported("union shape: needs >= 2 non-null variants")
 	}
-	switch {
-	case allClassVariants(vs):
-		return checkFlatClassUnion(b, vs)
-	case allScalarLeafVariants(vs):
-		// Nothing further to prove: coercion + the M3a scored selection are
-		// faithful for a leaf-only variant set, and every over-claim path
-		// (native-can't-prove arm, uncertain case fold, array-to-singular on an
-		// int/float/bool arm) declines the whole union at coerce time.
-		return nil
-	default:
-		// A mixed scalar+class family, or any list/map/array-to-singular variant:
-		// BAML's composite special ordering (class devalue, list SingleToArray/
-		// markdown, FirstMatch) is not modeled until M3c/M3d, so native cannot
-		// prove the pick_best winner — decline.
-		return unsupported("union shape: not a flat class union or a scalar/literal/enum leaf union")
-	}
-}
-
-// allScalarLeafVariants reports whether every variant is a constraint-free,
-// fully-modeled non-composite LEAF: a primitive scalar (int/float/bool/string),
-// a literal, or an enum — the M3b scalar-leaf union family. It reuses
-// isFlatLeafField, which encodes the identical leaf predicate for flat
-// class-union fields, because the coercers a union arm and a class field route
-// through are the same. (Null is never a variant — it is hoisted to
-// UnionType.Nullable; media / list / map / class / nested-union variants are
-// rejected, so a mixed or composite family falls through to a decline.)
-func allScalarLeafVariants(vs []schema.Type) bool {
 	for i := range vs {
-		if !isFlatLeafField(vs[i]) {
-			return false
+		if err := checkUnionVariant(b, vs[i]); err != nil {
+			return err
 		}
 	}
-	return true
+	return nil
+}
+
+// checkUnionVariant reports whether one union variant is in the supported set: a
+// fully-modeled scalar/literal/enum LEAF (isFlatLeafField — the identical predicate
+// flat class-union fields use, because a union arm and a class field route through
+// the same coercers), or a modelable CLASS ref (checkUnionClassVariant). Every
+// other kind — list, map, nested union, media, recursive alias — declines, because
+// its scored selection (array-to-singular, list special ordering, array-of-union
+// hint) is not modeled until M3d. Null is never a variant here (it is hoisted to
+// UnionType.Nullable).
+func checkUnionVariant(b *schema.Bundle, v schema.Type) error {
+	if isFlatLeafField(v) {
+		return nil
+	}
+	if v.Kind == schema.TypeClass {
+		return checkUnionClassVariant(b, v)
+	}
+	return unsupported(fmt.Sprintf("union variant kind %q: not a scalar/literal/enum leaf or a required-flat-leaf class (list/map/nested-union arms are M3d)", v.Kind))
+}
+
+// checkUnionClassVariant validates one CLASS variant of a union as a fully-modeled
+// arm: constraint-free, resolvable, whose class is constraint-free and every field
+// is a REQUIRED FLAT LEAF (primitive scalar / literal / enum — isFlatLeafField),
+// with no duplicate rendered field names. This is the shape whose STRICT try_cast
+// (tryCastClass) and LENIENT coerce (coerceClass) native reproduces byte-exact, so
+// the two-phase union selection matches BAML.
+//
+// SINGLE-field classes ARE admitted (unlike the pre-M3c flat-disjoint family that
+// rejected them): the implied-key / inferred-object paths and the pick_best
+// classSingleImplied devalue are now modeled, so a single-field class arm is a
+// faithful pick_best participant. NO disjoint-key requirement either — overlapping
+// field-name sets are resolved by pick_best now, not declined.
+//
+// A class with ANY optional / list / map / union / nested-class field declines: its
+// try_cast can score non-zero (a missing optional → OptionalDefaultFromNoValue) and
+// its lenient default/partial/implied scoring inside a union is not yet proven (that
+// broadening, plus the try_cast_union non-zero-collection sub-path, is M3d+). A
+// zero-field class declines too (its NoFields / empty-object try_cast is unmodeled).
+func checkUnionClassVariant(b *schema.Bundle, v schema.Type) error {
+	if len(v.Meta.Constraints) > 0 {
+		return unsupported("class-union variant has type constraints")
+	}
+	cls, ok := b.FindClass(v.Name, v.Mode)
+	if !ok {
+		return fmt.Errorf("debaml: unknown class %q", v.Name)
+	}
+	if len(cls.Constraints) > 0 {
+		return unsupported("class-union variant class has constraints")
+	}
+	if len(cls.Fields) == 0 {
+		return unsupported("class-union variant class has no fields (NoFields/empty-object try_cast unmodeled)")
+	}
+	seen := make(map[string]struct{}, len(cls.Fields))
+	for j := range cls.Fields {
+		f := &cls.Fields[j]
+		if !isFlatLeafField(f.Type) {
+			// Any optional/union/map/list/nested-class/recursive field opens BAML
+			// leniency (defaults, implied keys, partial maps, single-to-array) whose
+			// union scoring native does not yet prove — decline (M3d).
+			return unsupported("class-union variant class has a non-flat-leaf or optional field (M3c models required flat-leaf class fields only)")
+		}
+		rn := f.Name.RenderedName()
+		if _, dup := seen[rn]; dup {
+			return unsupported("class-union variant class has duplicate rendered field names")
+		}
+		seen[rn] = struct{}{}
+	}
+	return nil
 }
 
 // isMultiArmUnion reports whether t is a union with two or more NON-NULL
@@ -362,65 +407,6 @@ func allScalarLeafVariants(vs []schema.Type) bool {
 // and never appears here.
 func isMultiArmUnion(t schema.Type) bool {
 	return t.Kind == schema.TypeUnion && t.Union != nil && len(t.Union.Variants) >= 2
-}
-
-// allClassVariants reports whether every variant is a constraint-free class
-// ref — the precondition for the flat-class family.
-func allClassVariants(vs []schema.Type) bool {
-	for i := range vs {
-		v := &vs[i]
-		if v.Kind != schema.TypeClass || len(v.Meta.Constraints) > 0 {
-			return false
-		}
-	}
-	return true
-}
-
-// checkFlatClassUnion validates a class-only variant set as a flat,
-// disjoint-key discriminated union: every variant class is constraint-free,
-// has >= 2 required FLAT-LEAF fields, has no duplicate rendered field names,
-// and the variants' rendered field-name sets are pairwise disjoint under the
-// conservative key-match superset.
-func checkFlatClassUnion(b *schema.Bundle, vs []schema.Type) error {
-	sets := make([][]string, len(vs))
-	for i := range vs {
-		v := &vs[i]
-		cls, ok := b.FindClass(v.Name, v.Mode)
-		if !ok {
-			return fmt.Errorf("debaml: unknown class %q", v.Name)
-		}
-		if len(cls.Constraints) > 0 {
-			return unsupported("class-union variant class has constraints")
-		}
-		if len(cls.Fields) < 2 {
-			// A single-field class is implied-key/inferred-object risk: BAML
-			// can absorb a scalar or a differently-keyed object into the lone
-			// field, succeeding where native's exact match fails.
-			return unsupported("class-union variant class has < 2 fields (BAML implied-key risk)")
-		}
-		names := make([]string, 0, len(cls.Fields))
-		seen := make(map[string]struct{}, len(cls.Fields))
-		for j := range cls.Fields {
-			f := &cls.Fields[j]
-			if !isFlatLeafField(f.Type) {
-				// Any optional/union/map/list/nested-class/recursive field opens
-				// BAML leniency (defaults, implied keys, partial maps, single-to-
-				// array), so the class is not a clean discriminated arm.
-				return unsupported("class-union variant has a non-flat-leaf or optional field")
-			}
-			rn := f.Name.RenderedName()
-			if _, dup := seen[rn]; dup {
-				return unsupported("class-union variant has duplicate rendered field names")
-			}
-			seen[rn] = struct{}{}
-			names = append(names, rn)
-		}
-		sets[i] = names
-	}
-	if !fieldNameSetsPairwiseDisjoint(sets) {
-		return unsupported("class-union field-name sets not pairwise match-disjoint (BAML may fuzzy-match keys to a 2nd arm)")
-	}
-	return nil
 }
 
 // isFlatLeafField reports whether t is a flat exact leaf field type usable in
@@ -448,88 +434,15 @@ func isFlatLeafField(t schema.Type) bool {
 	}
 }
 
-// fieldNameSetsPairwiseDisjoint reports whether no field name in any set
-// could match a field name in any OTHER set under the conservative
-// match_string superset — the property that lets native prove BAML cannot
-// fuzzy-match the input keys of one class-union arm onto another arm.
-func fieldNameSetsPairwiseDisjoint(sets [][]string) bool {
-	for i := 0; i < len(sets); i++ {
-		for j := i + 1; j < len(sets); j++ {
-			for _, a := range sets[i] {
-				for _, b := range sets[j] {
-					if matchStringMightMatch(a, b) {
-						return false
-					}
-				}
-			}
-		}
-	}
-	return true
-}
-
-// matchStringMightMatch is a CONSERVATIVE SUPERSET of BAML's match_string: it
-// returns true whenever BAML could possibly match one of a/b against the
-// other, and only "wrongly" returns true in extra cases (which merely cause
-// native to DECLINE — always parity-safe). BAML's match_string normalizes
-// (trim, strip punctuation, fold case, fold accents) and then substring-
-// matches in both directions; this mirrors that and additionally treats any
-// non-ASCII residue conservatively (BAML may transliterate it in ways this
-// folder does not reproduce, e.g. ø->o, ß->ss), so a pair that still carries
-// non-ASCII letters after folding is treated as a possible match.
-func matchStringMightMatch(a, b string) bool {
-	na, asciiA := normalizeForMatchString(a)
-	nb, asciiB := normalizeForMatchString(b)
-	if !asciiA || !asciiB {
-		// Non-ASCII residue after accent folding could still transliterate-
-		// match in BAML; be conservative and treat as a possible match.
-		return true
-	}
-	if na == "" || nb == "" {
-		// An all-punctuation token normalizes empty and is a substring of
-		// everything under BAML's substring matching; treat as a match.
-		return true
-	}
-	if na == nb {
-		return true
-	}
-	return strings.Contains(na, nb) || strings.Contains(nb, na)
-}
-
-// normalizeForMatchString folds a string the way the conservative
-// match_string superset compares: NFD-decompose, drop combining marks (accent
-// fold), lowercase, and keep only letters and digits (trim + punctuation
-// strip). It also reports whether every kept rune is ASCII, so the caller can
-// treat unfoldable non-ASCII residue conservatively.
-func normalizeForMatchString(s string) (string, bool) {
-	d := norm.NFD.String(s)
-	var sb strings.Builder
-	allASCII := true
-	for _, r := range d {
-		if unicode.Is(unicode.Mn, r) {
-			// Combining mark left by NFD decomposition (the accent itself).
-			continue
-		}
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
-			continue
-		}
-		lr := unicode.ToLower(r)
-		if lr > unicode.MaxASCII {
-			allASCII = false
-		}
-		sb.WriteRune(lr)
-	}
-	return sb.String(), allASCII
-}
-
 // The production matcher below ports BAML's deserializer/coercer/match_string.rs
 // — the fuzzy matcher enum, string-literal, class-field-key, and map-key
-// coercion route through (Mcoerce-a). It is deliberately distinct from the
-// conservative matchStringMightMatch SUPERSET above: that one only gates
-// union-shape disjointness (over-declining there is parity-safe), while this
-// one is the PRODUCTION matcher whose accept/reject/ambiguous verdict and
-// matched candidate native must reproduce BAML byte-exact (a fuzzy match
-// changes the emitted value). It lives here, beside the gate, rather than in a
-// separate file so the de-BAML embed source list stays unchanged.
+// coercion route through (Mcoerce-a). It is the PRODUCTION matcher whose
+// accept/reject/ambiguous verdict and matched candidate native must reproduce
+// BAML byte-exact (a fuzzy match changes the emitted value). It lives here,
+// beside the gate, rather than in a separate file so the de-BAML embed source
+// list stays unchanged. (M3c removed the older conservative match_string
+// SUPERSET that gated class-union field-name disjointness: pick_best now
+// resolves overlapping-key class arms, so the disjointness gate is gone.)
 //
 // Null handling and non-string stringification (ObjectToString) are the
 // CALLER's job: matchString operates on an already-string input. Mcoerce-b adds

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -845,9 +845,11 @@ func TestParse_OptionalArmScored(t *testing.T) {
 	mustParse(t, s, `{"c":"the color green please"}`, `{"c":"GREEN"}`)
 }
 
-func TestParse_ClassUnionOverlappingKeysDeclinedAtGate(t *testing.T) {
-	// Two classes sharing a field name (id) are NOT disjoint: BAML could
-	// partially match either arm → scoring → decline the whole schema.
+func TestParse_ClassUnionOverlappingKeysClaimed(t *testing.T) {
+	// M3c: two classes sharing a field name (id) are NO LONGER declined at the gate
+	// — pick_best now resolves overlapping-key arms. Here the input's full field set
+	// is exactly A{id,name}, so A try_casts at score 0 in phase 1 and wins outright
+	// (fixture 39). (The B arm's try_cast rejects the extra `name` key.)
 	s := &bamlutils.DynamicOutputSchema{
 		Properties: props(kv("u", &bamlutils.DynamicProperty{
 			Type: "union",
@@ -865,12 +867,14 @@ func TestParse_ClassUnionOverlappingKeysDeclinedAtGate(t *testing.T) {
 			}),
 		),
 	}
-	requireUnsupported(t, s, `{"u":{"id":1,"name":"x"}}`)
+	mustParse(t, s, `{"u":{"id":1,"name":"x"}}`, `{"u":{"id":1,"name":"x"}}`)
 }
 
-func TestParse_ClassUnionSingleFieldDeclinedAtGate(t *testing.T) {
-	// A single-field class arm is implied-key risk → decline at the gate even
-	// though the field names are disjoint.
+func TestParse_ClassUnionSingleFieldClaimed(t *testing.T) {
+	// M3c: a single-field class arm is NO LONGER declined at the gate — the
+	// implied-key / inferred-object paths and the pick_best classSingleImplied
+	// devalue are modeled. Here the input's key set is exactly A{only}, so A
+	// try_casts at score 0 in phase 1 and wins (the B arm rejects the `only` key).
 	s := &bamlutils.DynamicOutputSchema{
 		Properties: props(kv("u", &bamlutils.DynamicProperty{
 			Type: "union",
@@ -888,7 +892,7 @@ func TestParse_ClassUnionSingleFieldDeclinedAtGate(t *testing.T) {
 			}),
 		),
 	}
-	requireUnsupported(t, s, `{"u":{"only":1}}`)
+	mustParse(t, s, `{"u":{"only":1}}`, `{"u":{"only":1}}`)
 }
 
 func TestParse_ClassUnionNonFlatFieldDeclinedAtGate(t *testing.T) {


### PR DESCRIPTION
<!-- webtty-bridge: session=s-yqyd29e14n -->
## de-BAML P4 M3 slice c — CLASS + MIXED-class union scoring

Third M3 slice (epic #546, `pick_best` milestone). Broadens the native de-BAML union gate + coercion to **CLASS unions** (beyond the flat-disjoint-key family) and **MIXED literal/enum/class** unions, applying BAML's two-phase `try_cast`-first model to class arms. Anchored to BAML `v0.223.0`.

### The crux: two-phase `try_cast`-first, ported to class arms
BAML resolves a union `try_cast`-FIRST (strict, native-type, score 0) before the lenient `coerce` + `pickBest`. M3c ports **`Class::try_cast`** (`ir_ref/coerce_class.rs`): a STRICT exact-key object cast — no fuzzy matching, no extra keys, every required flat-leaf field must itself `try_cast`. This is wired into a unified `tryCastUnion`/`tryCastArm` so a class arm returns at score 0 in phase 1 (fixtures 35/39/42) and only falls to the lenient phase + `pickBest` when NO arm `try_cast`s (fixtures 40/43).

### Changes (`internal/debaml/{parse,coerce}.go`)
- **`tryCastClass`**: faithful port of `Class::try_cast` (exact rendered-name key lookup, extras/missing-field/type-mismatch reject, schema-order emit).
- **Unified `coerceUnionSafeMulti`**: one two-phase coercer for scalar/literal/enum/class/mixed families; removes the old `coerceScalarLeafUnion`/`coerceFlatClassUnion` split and the disjoint-key / `>=2`-field / `match_string`-superset machinery.
- **Broadened `checkSupportedUnionShape`**: admits scalar/literal/enum leaves and/or constraint-free non-recursive classes whose fields are all **required flat leaves** (single-field + overlapping keys now allowed).
- **`pickBest` class special ordering** (`classSingleImplied` devalue, all-default devalue, scalar-vs-composite) was already in `cmpCandidates` since M3a — M3c makes it reachable and pins it live (fixture 156).

### Corpus (all `want` live-captured via `BAMLFUZZ_PARSE_CAPTURE=1`)
Flipped to **claimed**: `39_class_union_overlapping_keys`, `40_single_field_class_union_implied_key`, `42_literal_class_union_object_to_primitive`, `43_enum_class_union_object_to_string`.
Added: `156_class_union_single_string_implied_devalue` (claimed — pins the devalue tie-break), `157_class_union_all_default_stays_fallback` (fallback — M3d guard), `158_literal_class_union_object_to_primitive_literal_wins` (claimed).

**Dispositions: 121 claimed / 34 fallback (was 115/37).**

### Hard guards hold (stay fallback)
Constraints, recursive classes, **array input to class** (array-to-singular is M3d), list/map variant unions, the deferred `list<multi-arm-union>` (M3b guard), and **defaultable-field class arms** (optional/list/map/nested-class fields) all decline. `uncertain` and unsupported-child arms decline the whole union.

### Validation
`gofmt` / `go build ./...` / `go vet ./...` (+`-tags=integration`) clean; `go test ./internal/debaml ./bamlutils ./worker ./dynclient/...` green; `GOWORK=off go test ./codegen` green; `verify-framework-adapter` 6/6; new unit tests for the class `try_cast` phase + class `pickBest` ordering + mixed unions. **Docker bamlfuzz differential capture+gate: 0 failures, 314 subtests pass**, every claimed fixture byte-identical to live BAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded union parsing coverage to accept more input shapes, including mixed scalar/class unions and single-field class unions.

* **Bug Fixes**
  * Improved ambiguous union resolution so the most appropriate variant is selected more consistently.
  * Fixed cases where valid inputs were incorrectly rejected or unnecessarily fell back.
  * Enhanced output handling when extra fields or overlapping union shapes are present, preserving the intended parsed structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->