### PR TITLE
debaml: direct parse-stream oracle + live-captured streaming corpus (M4 slice a)

### DIFF
--- a/adapters/common/codegen/bamlfuzz/parser.go
+++ b/adapters/common/codegen/bamlfuzz/parser.go
@@ -11,8 +11,9 @@ import (
 // ErrParserUnavailable is the sentinel a Parser returns when it cannot
 // service a request — either because it is the no-op stub (no native
 // parser has been registered yet) or because the request shape is one
-// the parser does not implement (e.g. the dynamic BAML adapter declining
-// a Stream request before direct parse-stream is plumbed).
+// the parser does not implement (e.g. the native de-BAML candidate
+// declining every Stream request, which stays fallback until a later slice
+// claims native stream parity).
 //
 // The differential comparator treats ErrParserUnavailable from the
 // *candidate* (native) parser as a skip/pass, not a parser success. The

--- a/adapters/common/codegen/codegen_methods.go
+++ b/adapters/common/codegen/codegen_methods.go
@@ -253,6 +253,11 @@ func (me *methodEmitter) emitInputAndOutputStructs() {
 	// Generate unwrap helpers for dynamic types (called at setter time, not getter time)
 	if me.isDynamicStream {
 		g.emitDynamicUnwrapFunc(me.unwrapStreamFuncName, me.streamTypePtr)
+		// Record the stream unwrap like the final one below so the parse-stream
+		// method emitter (emitParseMethods) references this helper instead of
+		// re-declaring it — without this, a dynamic method with a ParseStream
+		// counterpart emits unwrapDynamic<Method>OutputStream twice.
+		g.emittedUnwrapHelpers[me.unwrapStreamFuncName] = true
 	}
 	if me.isDynamicFinal {
 		g.emitDynamicUnwrapFunc(me.unwrapFinalFuncName, me.finalTypePtr)
@@ -961,6 +966,11 @@ func (g *generator) emitMethodsMap(methods []methodOut) {
 type parseMethodOut struct {
 	name             string
 	outputStructQual jen.Code
+	// streamFuncName is the emitted parse-stream wrapper (parse_<Method>Stream)
+	// for a method with a BAML ParseStream counterpart, or "" when the method
+	// has no parse-stream variant. When set, emitParseMethodsMap wires it as
+	// the ParseMethod's StreamImpl.
+	streamFuncName string
 }
 
 // isDeBAMLDynamicMethod reports whether methodName is the configured
@@ -1094,9 +1104,84 @@ func (g *generator) emitParseMethods() []parseMethodOut {
 			Params(jen.Any(), jen.Error()).
 			Block(parseBody...)
 
+		// Emit a parse-STREAM wrapper for a method that has a BAML ParseStream
+		// counterpart. It calls bamlclient.ParseStream.<Method> — BAML's
+		// partial parse over the accumulated prefix — and, for a dynamic
+		// method, unwraps the stream DynamicProperties in place so the worker
+		// marshals the SAME {"DynamicProperties":{...}} envelope a final parse
+		// produces. This exposes the BAML parse-stream oracle to the bamlfuzz
+		// streaming differential; the native de-BAML seam is deliberately NOT
+		// spliced here (native stream parsing stays unsupported/fallback).
+		var parseStreamFuncName string
+		if streamFuncValue, hasParseStreamFunc := g.intro.ParseStreamFuncs[methodName]; hasParseStreamFunc {
+			parseStreamFuncName = strcase.LowerCamelCase("parse_" + methodName + "_stream")
+
+			// Derive the stream-unwrap decision from the ACTUAL parse-stream
+			// return type, NOT the sync/final type's `isDynamic`. The stream
+			// and final shapes are emitted independently and can diverge (one
+			// carries DynamicProperties, the other not); gating stream unwrap
+			// on the final type would emit/call an unwrap helper for a
+			// non-dynamic stream type, or skip unwrapping when only the stream
+			// type is dynamic. Mirrors emitInputAndOutputStructs, which keys
+			// me.isDynamicStream off this same ParseStream return.
+			var streamFuncType reflect.Type
+			if streamFuncValue != nil {
+				streamFuncType = reflect.TypeOf(streamFuncValue)
+			}
+			isDynamicStream := streamFuncType != nil &&
+				streamFuncType.Kind() == reflect.Func &&
+				streamFuncType.NumOut() >= 1 &&
+				hasDynamicPropertiesForType(streamFuncType.Out(0))
+
+			// Resolve the stream-side unwrap helper. For a dynamic streaming
+			// method emitMethods already emitted it; emit it here only if a
+			// parse-only-with-stream method reached this path first.
+			var parseStreamUnwrapName string
+			if isDynamicStream {
+				parseStreamUnwrapName = strcase.LowerCamelCase(fmt.Sprintf("unwrapDynamic%sStream", strcase.UpperCamelCase(fmt.Sprintf("%sOutput", methodName))))
+				if !g.emittedUnwrapHelpers[parseStreamUnwrapName] {
+					streamTypePtr := jen.Op("*").Add(parseReflectType(streamFuncType.Out(0)).statement)
+					g.emitDynamicUnwrapFunc(parseStreamUnwrapName, streamTypePtr)
+					g.emittedUnwrapHelpers[parseStreamUnwrapName] = true
+				}
+			}
+
+			var streamBody []jen.Code
+			streamBody = append(streamBody,
+				jen.List(jen.Id("options"), jen.Id("err")).Op(":=").Id("makeOptionsFromAdapter").Call(jen.Id("adapter")),
+				jen.If(jen.Id("err").Op("!=").Nil()).Block(
+					jen.Return(jen.Nil(), jen.Id("err")),
+				),
+				jen.List(jen.Id("result"), jen.Id("parseErr")).Op(":=").
+					Qual(g.pkgs.GeneratedClientPkg, "ParseStream").Dot(methodName).Call(parseCallParams...),
+				jen.If(jen.Id("parseErr").Op("!=").Nil()).Block(
+					jen.Return(jen.Nil(), jen.Id("parseErr")),
+				),
+			)
+			// Gate the stream unwrap on the stream shape alone
+			// (parseStreamUnwrapName is set iff isDynamicStream), not the
+			// final type's isDynamic — see the derivation comment above.
+			if parseStreamUnwrapName != "" {
+				streamBody = append(streamBody,
+					jen.Id(parseStreamUnwrapName).Call(jen.Op("&").Id("result")),
+				)
+			}
+			streamBody = append(streamBody, jen.Return(jen.Id("result"), jen.Nil()))
+
+			g.out.Func().
+				Id(parseStreamFuncName).
+				Params(
+					jen.Id("adapter").Qual(g.pkgs.InterfacesPkg, "Adapter"),
+					jen.Id("raw").String(),
+				).
+				Params(jen.Any(), jen.Error()).
+				Block(streamBody...)
+		}
+
 		parseMethods = append(parseMethods, parseMethodOut{
 			name:             methodName,
 			outputStructQual: finalResultType,
+			streamFuncName:   parseStreamFuncName,
 		})
 	}
 
@@ -1113,13 +1198,19 @@ func (g *generator) emitParseMethodsMap(parseMethods []parseMethodOut) {
 	parseMapElements := make(jen.Dict)
 	for _, method := range parseMethods {
 		parseFuncName := strcase.LowerCamelCase("parse_" + method.name)
-		parseMapElements[jen.Lit(method.name)] = jen.Values(jen.Dict{
+		methodDict := jen.Dict{
 			jen.Id("MakeOutput"): jen.Func().Params().Any().
 				Block(
 					jen.Return(jen.New(method.outputStructQual)),
 				),
 			jen.Id("Impl"): jen.Id(parseFuncName),
-		})
+		}
+		// Wire the parse-stream oracle when the method has a ParseStream
+		// counterpart; the worker drives StreamImpl for a Stream=true parse.
+		if method.streamFuncName != "" {
+			methodDict[jen.Id("StreamImpl")] = jen.Id(method.streamFuncName)
+		}
+		parseMapElements[jen.Lit(method.name)] = jen.Values(methodDict)
 	}
 
 	g.out.Var().Id("ParseMethods").Op("=").

--- a/adapters/common/codegen/codegen_parse_stream_divergent_test.go
+++ b/adapters/common/codegen/codegen_parse_stream_divergent_test.go
@@ -1,0 +1,132 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/adapters/common"
+)
+
+// widgetDynamicShape carries a DynamicProperties field, so
+// hasDynamicPropertiesForType reports it dynamic; widgetPlainShape has
+// no such field and is non-dynamic. The parse / parse-stream wrappers
+// key their DynamicProperties-unwrap emission off these shapes.
+type widgetDynamicShape struct {
+	Value             string
+	DynamicProperties any
+}
+
+type widgetPlainShape struct {
+	Value string
+}
+
+// TestEmitParseMethods_StreamUnwrapTracksStreamShape locks the fix for
+// the CodeRabbit finding: the parse-STREAM unwrap helper (name + call)
+// must be gated on the ACTUAL ParseStream return shape, not the sync
+// (final) return shape. Stream and final shapes are emitted
+// independently and can diverge; the pre-fix code derived the
+// stream-unwrap decision from syncFuncType.Out(0) (the final type),
+// which could (a) emit/call an unwrap helper for a non-dynamic stream
+// type or (b) skip unwrapping when only the stream type is dynamic.
+//
+// No live M4a fixture exercises a divergent shape (every current dynamic
+// method has coinciding stream/final types), so this synthesises the
+// four stream×final dynamic/plain combinations and pins the emitted
+// helper declarations and call sites for each.
+func TestEmitParseMethods_StreamUnwrapTracksStreamShape(t *testing.T) {
+	// Only Out(0) of each func matters to the gating; the params are
+	// irrelevant, so zero-arg funcs returning the value shape (the
+	// generated helper takes *Shape, matching a value-typed return) keep
+	// the fixtures minimal.
+	finalDynamic := func() (widgetDynamicShape, error) { return widgetDynamicShape{}, nil }
+	finalPlain := func() (widgetPlainShape, error) { return widgetPlainShape{}, nil }
+	streamDynamic := func() (widgetDynamicShape, error) { return widgetDynamicShape{}, nil }
+	streamPlain := func() (widgetPlainShape, error) { return widgetPlainShape{}, nil }
+
+	// Method name "Widget" renders to the deterministic helper names
+	// below via the same strcase pipeline the emitter uses.
+	const (
+		streamHelperDecl = "func unwrapDynamicWidgetOutputStream("
+		streamUnwrapCall = "unwrapDynamicWidgetOutputStream(&result)"
+		finalHelperDecl  = "func unwrapDynamicWidgetOutputFinal("
+		finalUnwrapCall  = "unwrapDynamicWidgetOutputFinal(&result)"
+	)
+
+	cases := []struct {
+		name             string
+		finalFn          any
+		streamFn         any
+		wantStreamUnwrap bool
+		wantFinalUnwrap  bool
+	}{
+		{
+			// Coinciding dynamic shapes — the M4a status quo. Both
+			// unwraps emitted; regenerated output for real methods is
+			// unchanged by the fix because this branch is unaffected.
+			name: "both dynamic", finalFn: finalDynamic, streamFn: streamDynamic,
+			wantStreamUnwrap: true, wantFinalUnwrap: true,
+		},
+		{
+			// Coinciding plain shapes — neither side unwraps.
+			name: "both plain", finalFn: finalPlain, streamFn: streamPlain,
+			wantStreamUnwrap: false, wantFinalUnwrap: false,
+		},
+		{
+			// Divergent, bug (b): only the STREAM type is dynamic. Pre-fix
+			// isDynamic (final) is false, so the stream envelope was left
+			// un-unwrapped. The fix must emit + call the stream helper
+			// while leaving the final path untouched.
+			name: "stream dynamic, final plain", finalFn: finalPlain, streamFn: streamDynamic,
+			wantStreamUnwrap: true, wantFinalUnwrap: false,
+		},
+		{
+			// Divergent, bug (a): only the FINAL type is dynamic. Pre-fix
+			// isDynamic (final) is true, so a stream unwrap helper was
+			// emitted for the NON-dynamic stream type (whose value has no
+			// DynamicProperties field — invalid generated code) and called
+			// in the stream wrapper. The fix must suppress the stream
+			// helper entirely while keeping the final unwrap.
+			name: "final dynamic, stream plain", finalFn: finalDynamic, streamFn: streamPlain,
+			wantStreamUnwrap: false, wantFinalUnwrap: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &generator{
+				pkgs: PackageConfig{
+					OutputPkgName:      "generated",
+					GeneratedClientPkg: "example.com/x/baml_client",
+					InterfacesPkg:      "github.com/invakid404/baml-rest/bamlutils",
+				},
+				intro: Introspection{
+					ParseMethods:     map[string]struct{}{"Widget": {}},
+					SyncFuncs:        map[string]any{"Widget": tc.finalFn},
+					ParseStreamFuncs: map[string]any{"Widget": tc.streamFn},
+				},
+				out:                  common.MakeFile(),
+				selfUtilsPkg:         "example.com/x/generated/utils",
+				emittedUnwrapHelpers: map[string]bool{},
+			}
+			g.emitParseMethods()
+			rendered := g.out.GoString()
+
+			// Stream-unwrap decision must track the STREAM shape.
+			if got := strings.Contains(rendered, streamHelperDecl); got != tc.wantStreamUnwrap {
+				t.Errorf("stream unwrap helper declared = %v, want %v (gating must follow the ParseStream return shape)\n%s", got, tc.wantStreamUnwrap, rendered)
+			}
+			if got := strings.Contains(rendered, streamUnwrapCall); got != tc.wantStreamUnwrap {
+				t.Errorf("stream unwrap called in parse-stream wrapper = %v, want %v\n%s", got, tc.wantStreamUnwrap, rendered)
+			}
+
+			// Final-unwrap decision must be independent and track the
+			// sync (final) shape — unchanged by the fix.
+			if got := strings.Contains(rendered, finalHelperDecl); got != tc.wantFinalUnwrap {
+				t.Errorf("final unwrap helper declared = %v, want %v\n%s", got, tc.wantFinalUnwrap, rendered)
+			}
+			if got := strings.Contains(rendered, finalUnwrapCall); got != tc.wantFinalUnwrap {
+				t.Errorf("final unwrap called in parse wrapper = %v, want %v\n%s", got, tc.wantFinalUnwrap, rendered)
+			}
+		})
+	}
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/20_streaming_growing_object.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/20_streaming_growing_object.json
@@ -1,6 +1,6 @@
 {
   "name": "streaming_growing_object",
-  "description": "Accumulated prefixes grow through { , key, colon, partial string, full string, next key, full object. STREAMING DIFFERENTIAL IS BLOCKED ON DIRECT PARSE-STREAM EXPOSURE (deferred): the per-prefix `want` values are NOT yet BAML-characterized and the harness does not gate on them today — only the corpus format and prefix-growth monotonicity are exercised.",
+  "description": "Accumulated prefixes grow through { , key, colon, partial string, full string, next key, full object. Per-prefix `want` values are LIVE-CAPTURED from BAML v0.223.0 parse-stream (BAMLFUZZ_PARSE_CAPTURE=1), not hand-written: BAML's parse-stream is lenient enough that even a bare open-brace / partial-key / dangling-colon prefix recovers a partial object with both fields null-filled, so every prefix here is a success. Native de-BAML declines all stream parses in M4a (per-prefix fallback).",
   "preserve_schema_order": true,
   "schema": {
     "classes": [
@@ -15,9 +15,9 @@
     "root_class": "Root"
   },
   "prefixes": [
-    {"name": "open_brace", "raw": "{", "want": {"status": "error"}},
-    {"name": "first_key", "raw": "{\"name\"", "want": {"status": "error"}},
-    {"name": "colon", "raw": "{\"name\":", "want": {"status": "error"}},
+    {"name": "open_brace", "raw": "{", "want": {"status": "success", "json": {"name": null, "age": null}}},
+    {"name": "first_key", "raw": "{\"name\"", "want": {"status": "success", "json": {"name": null, "age": null}}},
+    {"name": "colon", "raw": "{\"name\":", "want": {"status": "success", "json": {"name": null, "age": null}}},
     {"name": "partial_string", "raw": "{\"name\":\"Ad", "want": {"status": "success", "json": {"name": "Ad", "age": null}}},
     {"name": "full_string", "raw": "{\"name\":\"Ada\"", "want": {"status": "success", "json": {"name": "Ada", "age": null}}},
     {"name": "second_key", "raw": "{\"name\":\"Ada\",\"age\"", "want": {"status": "success", "json": {"name": "Ada", "age": null}}},

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/21_streaming_markdown_fence.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/21_streaming_markdown_fence.json
@@ -1,6 +1,6 @@
 {
   "name": "streaming_markdown_fence",
-  "description": "Accumulated prefixes enter prose, open a ```json fence, build the object, then close the fence. STREAMING DIFFERENTIAL IS BLOCKED ON DIRECT PARSE-STREAM EXPOSURE (deferred): the per-prefix `want` values are NOT yet BAML-characterized and the harness does not gate on them today — only the corpus format and prefix-growth monotonicity are exercised.",
+  "description": "Accumulated prefixes enter prose, open a ```json fence, build the object, then close the fence. Per-prefix `want` values are LIVE-CAPTURED from BAML v0.223.0 parse-stream (BAMLFUZZ_PARSE_CAPTURE=1), not hand-written: BAML's parse-stream recovers a partial object even from bare prose or a just-opened fence (both fields null-filled), so every prefix here is a success. Native de-BAML declines all stream parses in M4a (per-prefix fallback).",
   "preserve_schema_order": true,
   "schema": {
     "classes": [
@@ -15,8 +15,8 @@
     "root_class": "Root"
   },
   "prefixes": [
-    {"name": "prose", "raw": "Here you go:\n", "want": {"status": "error"}},
-    {"name": "fence_open", "raw": "Here you go:\n```json\n", "want": {"status": "error"}},
+    {"name": "prose", "raw": "Here you go:\n", "want": {"status": "success", "json": {"name": null, "age": null}}},
+    {"name": "fence_open", "raw": "Here you go:\n```json\n", "want": {"status": "success", "json": {"name": null, "age": null}}},
     {"name": "object_partial", "raw": "Here you go:\n```json\n{\"name\":\"Ada\"", "want": {"status": "success", "json": {"name": "Ada", "age": null}}},
     {"name": "object_full", "raw": "Here you go:\n```json\n{\"name\":\"Ada\",\"age\":36}", "want": {"status": "success", "json": {"name": "Ada", "age": 36}}},
     {"name": "fence_close", "raw": "Here you go:\n```json\n{\"name\":\"Ada\",\"age\":36}\n```", "want": {"status": "success", "json": {"name": "Ada", "age": 36}}}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/22_streaming_truncated_string.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/22_streaming_truncated_string.json
@@ -1,6 +1,6 @@
 {
   "name": "streaming_truncated_string",
-  "description": "Accumulated prefixes stop inside a string value and then complete it. STREAMING DIFFERENTIAL IS BLOCKED ON DIRECT PARSE-STREAM EXPOSURE (deferred): the per-prefix `want` values are NOT yet BAML-characterized and the harness does not gate on them today — only the corpus format and prefix-growth monotonicity are exercised.",
+  "description": "Accumulated prefixes stop inside a string value and then complete it. Per-prefix `want` values are LIVE-CAPTURED from BAML v0.223.0 parse-stream (BAMLFUZZ_PARSE_CAPTURE=1), not hand-written: an opened-but-empty string parses as \"\", a truncated string keeps its partial content, and the completed forms hold the full value. Native de-BAML declines all stream parses in M4a (per-prefix fallback).",
   "preserve_schema_order": true,
   "schema": {
     "classes": [

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/23_streaming_trailing_comma.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/23_streaming_trailing_comma.json
@@ -1,6 +1,6 @@
 {
   "name": "streaming_trailing_comma",
-  "description": "Accumulated prefixes build a list with a trailing comma before the closing bracket/brace. STREAMING DIFFERENTIAL IS BLOCKED ON DIRECT PARSE-STREAM EXPOSURE (deferred): the per-prefix `want` values are NOT yet BAML-characterized and the harness does not gate on them today — only the corpus format and prefix-growth monotonicity are exercised.",
+  "description": "Accumulated prefixes build a list with a trailing comma before the closing bracket/brace. Per-prefix `want` values are LIVE-CAPTURED from BAML v0.223.0 parse-stream (BAMLFUZZ_PARSE_CAPTURE=1), not hand-written: BAML's parse-stream drops the dangling trailing comma and keeps the completed elements at every prefix. Native de-BAML declines all stream parses in M4a (per-prefix fallback).",
   "preserve_schema_order": true,
   "schema": {
     "classes": [

--- a/bamlutils/dynamic.go
+++ b/bamlutils/dynamic.go
@@ -727,6 +727,14 @@ type DynamicParseInput struct {
 	// nil inherits the server default, non-nil wins. See that field's
 	// doc comment for the full tri-state contract.
 	PreserveSchemaOrder *bool `json:"preserve_schema_order,omitempty"`
+	// Stream selects BAML parse-stream (partial) semantics: when true the
+	// worker drives the parse method's StreamImpl (BAML ParseStream) over Raw
+	// and returns the partial typed output, normalized through the SAME
+	// flatten / absent-optional-injection / ordering pipeline a final parse
+	// uses. This exposes a direct BAML parse-stream oracle to the bamlfuzz
+	// parse-recovery streaming differential; it does not enable native
+	// de-BAML stream parsing (internal/debaml.Parse still declines Stream).
+	Stream bool `json:"stream,omitempty"`
 }
 
 // Validate checks that required fields are present for parse
@@ -783,7 +791,8 @@ func (d *DynamicParseInput) ToWorkerInput() (b []byte, err error) {
 	}
 
 	internal := map[string]any{
-		"raw": d.Raw,
+		"raw":    d.Raw,
+		"stream": d.Stream,
 		"__baml_options__": &BamlOptions{
 			TypeBuilder: &TypeBuilder{
 				DynamicTypes: dynamicTypes,

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -210,6 +210,15 @@ type ParsePrompt func(adapter Adapter, raw string) (any, error)
 type ParseMethod struct {
 	MakeOutput func() any
 	Impl       ParsePrompt
+	// StreamImpl is the parse-STREAM (partial) implementation: it drives
+	// BAML's ParseStream over the accumulated raw prefix and returns the
+	// partial typed output, which the worker marshals into the same
+	// DynamicProperties envelope a final parse produces. It is nil for a
+	// method with no parse-stream counterpart; the worker treats a Stream
+	// parse request against a nil StreamImpl as unsupported. Native de-BAML
+	// stream parsing is NOT wired here — this seam exposes the BAML
+	// parse-stream oracle for the bamlfuzz streaming differential only.
+	StreamImpl ParsePrompt
 }
 
 type ClientRegistry struct {

--- a/dynclient/client.go
+++ b/dynclient/client.go
@@ -277,6 +277,14 @@ func (c *Client) DynamicCallRaw(ctx context.Context, req Request) (*CallRawResul
 
 // DynamicParse parses a raw LLM response against the request's output
 // schema and returns the flattened JSON payload.
+//
+// When req.Stream is true it drives BAML's parse-stream (partial) path over
+// the raw text instead of the final parse, exposing a direct parse-stream
+// oracle. The partial output is normalized through the identical
+// flatten / absent-optional-injection / ordering pipeline, so a streaming
+// prefix's result is directly comparable to a final parse's — this is what
+// the bamlfuzz parse-recovery streaming differential consumes. BAML may
+// reject an early prefix; that surfaces as a normal parse error here.
 func (c *Client) DynamicParse(ctx context.Context, req ParseRequest) (*ParseResult, error) {
 	if c == nil {
 		return nil, errNilClient

--- a/dynclient/internal/generated/adapter.go
+++ b/dynclient/internal/generated/adapter.go
@@ -1174,12 +1174,25 @@ func parseBamlRestDynamic(adapter bamlutils.Adapter, raw string) (any, error) {
 	unwrapDynamicBamlRestDynamicOutputFinal(&result)
 	return result, nil
 }
+func parseBamlRestDynamicStream(adapter bamlutils.Adapter, raw string) (any, error) {
+	options, err := makeOptionsFromAdapter(adapter)
+	if err != nil {
+		return nil, err
+	}
+	result, parseErr := bamlclient.ParseStream.Baml_Rest_Dynamic(adapter, raw, options...)
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	unwrapDynamicBamlRestDynamicOutputStream(&result)
+	return result, nil
+}
 
 var ParseMethods = map[string]bamlutils.ParseMethod{"Baml_Rest_Dynamic": {
 	Impl: parseBamlRestDynamic,
 	MakeOutput: func() any {
 		return new(types.Baml_Rest_DynamicOutput)
 	},
+	StreamImpl: parseBamlRestDynamicStream,
 }}
 
 func applyDynamicTypes(tb *introspected.TypeBuilder, dt *bamlutils.DynamicTypes) error {

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -29,12 +29,13 @@ const parseRecoveryCorpusDir = "../adapters/common/codegen/testdata/bamlfuzz/par
 // bamlfuzz oracle artifact dirs.
 const parseRecoveryArtifactDir = "../adapters/common/codegen/testdata/bamlfuzz/parse_recovery/_artifacts"
 
-// bamlDynamicParser adapts dynclient's final dynamic parse to the
-// bamlfuzz.Parser interface so the differential harness can drive BAML as
-// the oracle. It covers final parse only: parse-stream over accumulated
-// prefixes is not yet exposed by dynclient/worker, so a Stream request is
-// declined with ErrParserUnavailable (the streaming differential is
-// deferred — see the scope's blocked-on-plumbing note).
+// bamlDynamicParser adapts dynclient's dynamic parse to the bamlfuzz.Parser
+// interface so the differential harness can drive BAML as the oracle. It
+// covers BOTH final parse and parse-stream: a Stream=true request drives
+// BAML's parse-stream (partial) path over the accumulated prefix, normalized
+// into the SAME flattened shape a final parse produces. This exposes the
+// direct parse-stream oracle the streaming differential needs — BAML remains
+// the reference the native candidate must reproduce.
 type bamlDynamicParser struct {
 	dyn *dynclient.Client
 }
@@ -42,14 +43,14 @@ type bamlDynamicParser struct {
 // Name identifies the BAML oracle leg in diff output and envelopes.
 func (p bamlDynamicParser) Name() string { return "baml_dynamic" }
 
-// Parse drives dynclient.DynamicParse for a final parse. The returned
-// JSON is the flattened, absent-optional-injected, order-normalized
-// payload the dynamic endpoints expose — exactly the shape a native
-// parser must reproduce. Stream requests are declined (deferred).
+// Parse drives dynclient.DynamicParse for a final parse, or — when
+// req.Stream is true — BAML's parse-stream (partial) path over the same
+// raw text. The returned JSON is the flattened, absent-optional-injected,
+// order-normalized payload the dynamic endpoints expose (identical shape
+// for final and stream), exactly what a native parser must reproduce. BAML
+// may reject an early streaming prefix; that surfaces as a real parse error
+// here and the comparator records error parity.
 func (p bamlDynamicParser) Parse(ctx context.Context, req bamlfuzz.ParseRequest) (bamlfuzz.ParseResult, error) {
-	if req.Stream {
-		return bamlfuzz.ParseResult{}, bamlfuzz.ErrParserUnavailable
-	}
 	lowered, err := bamlfuzz.LowerToDynamicSchema(req.Schema)
 	if err != nil {
 		return bamlfuzz.ParseResult{}, err
@@ -59,6 +60,7 @@ func (p bamlDynamicParser) Parse(ctx context.Context, req bamlfuzz.ParseRequest)
 		Raw:                 req.Raw,
 		OutputSchema:        &lowered,
 		PreserveSchemaOrder: &preserve,
+		Stream:              req.Stream,
 	})
 	if err != nil {
 		return bamlfuzz.ParseResult{}, err
@@ -84,7 +86,12 @@ type nativeDeBAMLParser struct{}
 func (nativeDeBAMLParser) Name() string { return "native_debaml" }
 
 // Parse drives internal/debaml.Parse for a final parse and normalizes its
-// flattened output exactly like dynclient's parse-only path.
+// flattened output exactly like dynclient's parse-only path. A Stream=true
+// request is passed through unchanged: internal/debaml.Parse declines every
+// stream parse (ErrDeBAMLParseUnsupported), which maps to
+// ErrParserUnavailable below, so in M4a the native candidate falls back
+// (SkippedNative) on every streaming prefix — native stream parity is not
+// claimed this slice.
 func (nativeDeBAMLParser) Parse(ctx context.Context, req bamlfuzz.ParseRequest) (bamlfuzz.ParseResult, error) {
 	lowered, err := bamlfuzz.LowerToDynamicSchema(req.Schema)
 	if err != nil {
@@ -128,6 +135,40 @@ func (nativeDeBAMLParser) Parse(ctx context.Context, req bamlfuzz.ParseRequest) 
 		return bamlfuzz.ParseResult{}, err
 	}
 	return bamlfuzz.ParseResult{JSON: out}, nil
+}
+
+// perCallOracleTimeout is the bounded budget a SINGLE live BAML oracle call
+// gets. The final-parse and dynamic parse_diff legs already wrap their one
+// live call in context.WithTimeout(..., 30s); the streaming leg fans one live
+// call out per accumulated prefix, so it applies this SAME per-call budget to
+// each call (via perCallTimeoutParser) rather than sharing one loop-wide
+// deadline across all of them.
+const perCallOracleTimeout = 30 * time.Second
+
+// perCallTimeoutParser wraps a bamlfuzz.Parser so every Parse call derives its
+// own bounded deadline from the incoming context instead of drawing down a
+// single shared budget. DiffParserPrefixes drives the BAML oracle once per
+// accumulated prefix (up to 7 per streaming fixture) through one ctx; without
+// a per-call bound those live calls would all share one deadline and a slow
+// oracle call under CI load could starve the later prefixes. This mirrors the
+// per-call WithTimeout the single-call final-parse leg already uses. Only the
+// live BAML leg is wrapped; the native candidate declines every stream prefix
+// without a live call, so its disposition (fallback) is unaffected.
+type perCallTimeoutParser struct {
+	inner   bamlfuzz.Parser
+	timeout time.Duration
+}
+
+// Name passes through the wrapped parser's identity so diff output and
+// failure envelopes are unchanged.
+func (p perCallTimeoutParser) Name() string { return p.inner.Name() }
+
+// Parse bounds a single delegated call to p.timeout, derived from ctx so an
+// outer cancellation still wins, then forwards to the wrapped parser.
+func (p perCallTimeoutParser) Parse(ctx context.Context, req bamlfuzz.ParseRequest) (bamlfuzz.ParseResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+	return p.inner.Parse(ctx, req)
 }
 
 // parseRecoveryNativeClaim pins the native-parser cut-line per corpus case
@@ -524,14 +565,38 @@ var parseRecoveryNativeClaim = map[string]bool{
 	"primitive_int_array_empty_stays_fallback": false,
 }
 
-// parseRecoveryStats tallies how many final-parse cases the native parser
-// claimed vs fell back on, logged as a summary so a shift in the native
-// cut-line is visible even when every case still passes. The harness runs
-// the per-case subtests sequentially (no t.Parallel), so a plain
+// parseRecoveryStreamNativeClaim pins the per-prefix native disposition for
+// streaming recovery cases: caseName -> prefixName -> claimed. In M4a the
+// native parser CLAIMS NO streaming prefix — internal/debaml.Parse declines
+// every Stream=true request — so every prefix's expected disposition is
+// fallback (false) and this map is intentionally empty (streamPrefixNativeClaim
+// defaults to false). It is the per-prefix seam a later slice (M4b+) uses to
+// flip an individual prefix from fallback to claimed without reworking the
+// harness: set caseName->prefixName to true and the per-prefix differential
+// then holds the native claim to BAML exactly.
+var parseRecoveryStreamNativeClaim = map[string]map[string]bool{}
+
+// streamPrefixNativeClaim returns the expected native disposition for one
+// streaming prefix: true = native is expected to CLAIM it (and be diffed
+// against BAML), false = native FALLS BACK to BAML (the M4a default for every
+// prefix).
+func streamPrefixNativeClaim(caseName, prefixName string) bool {
+	if m, ok := parseRecoveryStreamNativeClaim[caseName]; ok {
+		return m[prefixName]
+	}
+	return false
+}
+
+// parseRecoveryStats tallies how many final-parse and streaming-prefix legs
+// the native parser claimed vs fell back on, logged as a summary so a shift
+// in the native cut-line is visible even when every case still passes. The
+// harness runs the per-case subtests sequentially (no t.Parallel), so a plain
 // pointer-shared counter needs no locking.
 type parseRecoveryStats struct {
-	claimed  int
-	fallback int
+	claimed        int
+	fallback       int
+	streamClaimed  int
+	streamFallback int
 }
 
 // TestBamlfuzzParseRecovery characterizes BAML's JSONish final-parse
@@ -542,15 +607,20 @@ type parseRecoveryStats struct {
 // for BAML behavior changes), and the differential leg holds any future
 // native parser to BAML's exact behavior.
 //
-// With the default NoopParser the differential leg is a vacuous skip, so
-// today the test is a pure BAML characterization. Streaming-prefix cases
-// validate corpus format + prefix-growth monotonicity but skip the
-// per-prefix differential, which is blocked on direct parse-stream
-// exposure (deferred).
+// The native de-BAML parser is registered as the differential candidate, so
+// both the final-parse and streaming legs are live differentials. Streaming
+// cases additionally drive the direct BAML parse-stream oracle
+// (DynamicParse with Stream=true) per accumulated prefix and gate BAML
+// against the live-captured prefix `want`; the native candidate declines
+// every stream parse in M4a, so each streaming prefix records a fallback
+// disposition (SkippedNative) rather than a native claim.
 //
-// Run with BAMLFUZZ_PARSE_CAPTURE=1 to log BAML's observed final-parse
-// outcomes instead of gating — used to (re)capture the corpus `want`
-// values when adding cases or after an intentional BAML behavior change.
+// Run with BAMLFUZZ_PARSE_CAPTURE=1 to log BAML's observed final-parse AND
+// per-prefix parse-stream outcomes instead of gating — used to (re)capture
+// the corpus `want` values when adding cases or after an intentional BAML
+// behavior change. Streaming captures carry full prefix identity (case +
+// prefix name + a `stream` marker) so a stream want can never be reused as a
+// final-parse want.
 func TestBamlfuzzParseRecovery(t *testing.T) {
 	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
 		t.Skip("Skipping: dynamic endpoints require BAML >= 0.215.0")
@@ -587,6 +657,7 @@ func TestBamlfuzzParseRecovery(t *testing.T) {
 		})
 	}
 	t.Logf("native de-BAML final-parse dispositions: %d claimed, %d fell back to BAML", stats.claimed, stats.fallback)
+	t.Logf("native de-BAML parse-stream dispositions: %d claimed, %d fell back to BAML (M4a expects 0 claimed)", stats.streamClaimed, stats.streamFallback)
 }
 
 // runParseRecoveryCase drives the final and/or streaming legs of one
@@ -660,14 +731,133 @@ func runParseRecoveryCase(t *testing.T, baml, native bamlfuzz.Parser, c bamlfuzz
 						i, c.Prefixes[i].Name, i-1, c.Prefixes[i-1].Name)
 				}
 			}
-			// The per-prefix native-vs-BAML differential needs direct
-			// BAML parse-stream over arbitrary accumulated prefixes, which
-			// dynclient/worker do not yet expose. The corpus + harness
-			// format are in place (DiffParserPrefixes); wiring the live
-			// differential is deferred to the parse-stream plumbing PR.
-			t.Skip("streaming parse-stream differential blocked on direct parse-stream exposure (deferred)")
+
+			// Per-prefix native-vs-BAML parse-stream differential. BAML is the
+			// oracle: DiffParserPrefixes forces Stream=true and diffs each
+			// accumulated prefix on its own (early accept/reject is part of the
+			// spec, so no prefix is privileged). BAML being unavailable on a
+			// prefix is a harness failure, surfaced through res.Failures with
+			// SkippedNative=false; the native candidate declining is a skip.
+			// Each accumulated prefix issues its OWN live BAML parse-stream
+			// call. Give every call the same bounded headroom the single-call
+			// final-parse leg gets (perCallOracleTimeout) instead of sharing
+			// one deadline across up to len(raws) sequential calls, so a slow
+			// oracle call under CI load can't starve the later prefixes.
+			// perCallTimeoutParser applies the per-call bound inside
+			// DiffParserPrefixes' loop; an outer budget scaled to the prefix
+			// count still caps the whole streaming leg as a backstop.
+			ctx, cancel := context.WithTimeout(context.Background(), perCallOracleTimeout*time.Duration(len(raws)))
+			defer cancel()
+			gatedBAML := perCallTimeoutParser{inner: baml, timeout: perCallOracleTimeout}
+			req := bamlfuzz.ParseRequest{
+				Schema:              c.Schema,
+				PreserveSchemaOrder: c.PreserveSchemaOrder,
+			}
+			results := bamlfuzz.DiffParserPrefixes(ctx, gatedBAML, native, req, raws, c.UnionChoices)
+
+			for i := range results {
+				i := i
+				p := c.Prefixes[i]
+				res := results[i]
+				t.Run(p.Name, func(t *testing.T) {
+					// Capture mode logs BAML's observed per-prefix outcome
+					// (with full prefix identity) instead of gating, so a
+					// developer running BAMLFUZZ_PARSE_CAPTURE=1 records the
+					// corpus `want`; otherwise gate BAML against it.
+					if capture {
+						logObservedStreamOutcome(t, c.Name, p, res.BAML)
+					} else {
+						characterizeStreamPrefix(t, c, p, res.BAML)
+					}
+
+					// Native-vs-BAML per-prefix differential. In M4a native
+					// declines every stream prefix, so SkippedNative is the
+					// expected shape and this gate never fires for a native
+					// mismatch; it DOES fire on a BAML harness failure
+					// (SkippedNative=false with failures) or, once a later
+					// slice claims a prefix, on real native drift.
+					if !res.SkippedNative && len(res.Failures) > 0 {
+						dumpParseDiffAndFail(t, parseRecoveryArtifactDir,
+							parseDiffEnvelope(c, idx, i, p.Name, p.Raw, true, res),
+							strings.Join(res.Failures, "; "))
+					}
+
+					// Per-prefix native disposition (claimed vs fallback),
+					// pinned so a later slice can flip individual prefixes.
+					claimed := !res.SkippedNative
+					if claimed {
+						stats.streamClaimed++
+					} else {
+						stats.streamFallback++
+					}
+					want := streamPrefixNativeClaim(c.Name, p.Name)
+					if claimed {
+						t.Logf("native CLAIMED stream prefix %q/%q", c.Name, p.Name)
+					} else {
+						t.Logf("native FELL BACK to BAML for stream prefix %q/%q", c.Name, p.Name)
+					}
+					if claimed != want {
+						t.Errorf("native stream disposition for %q/%q: got claimed=%v, want claimed=%v (M4a: every stream prefix falls back)", c.Name, p.Name, claimed, want)
+					}
+				})
+			}
 		})
 	}
+}
+
+// characterizeStreamPrefix gates the live BAML parse-stream outcome for one
+// accumulated prefix against the recorded `want`: status (success/error)
+// parity, plus strict JSON + key-order equality on a successful partial parse.
+// `want` is BAML's own captured parse-stream output (recorded via
+// BAMLFUZZ_PARSE_CAPTURE=1), so strict equality is correct — a divergence
+// means BAML's parse-stream behavior drifted from the checked-in
+// characterization. It reads the BAML outcome DiffParserPrefixes already
+// produced (res.BAML) rather than re-calling BAML.
+func characterizeStreamPrefix(t *testing.T, c bamlfuzz.ParseRecoveryCase, p bamlfuzz.ParseRecoveryPrefix, outcome bamlfuzz.ParseOutcome) {
+	t.Helper()
+	observed := bamlfuzz.ParseStatusSuccess
+	if outcome.Error != "" {
+		observed = bamlfuzz.ParseStatusError
+	}
+	if observed != p.Want.Status {
+		t.Errorf("stream prefix %q/%q raw=%q: BAML status %q ≠ want %q (BAML json=%s err=%s)",
+			c.Name, p.Name, p.Raw, observed, p.Want.Status, string(outcome.JSON), outcome.Error)
+		return
+	}
+	if !p.Want.IsSuccess() {
+		return // both errored — parity holds, no payload to compare.
+	}
+	diff, err := bamlfuzz.SemanticDiffStrict("want_vs_baml_stream", p.Want.JSON, outcome.JSON)
+	if err != nil {
+		t.Errorf("characterize stream %q/%q: semantic diff: %v", c.Name, p.Name, err)
+		return
+	}
+	if len(diff) > 0 {
+		t.Errorf("stream prefix %q/%q raw=%q: want ≠ BAML (semantic): %+v", c.Name, p.Name, p.Raw, diff)
+	}
+	if c.PreserveSchemaOrder {
+		od, oerr := bamlfuzz.SchemaOrderDiffWithChoices("want_vs_baml_stream", c.Schema, p.Want.JSON, outcome.JSON, c.UnionChoices)
+		if oerr != nil {
+			t.Errorf("stream prefix %q/%q: schema order: %v", c.Name, p.Name, oerr)
+		} else if len(od) > 0 {
+			t.Errorf("stream prefix %q/%q raw=%q: want ≠ BAML (order): %+v", c.Name, p.Name, p.Raw, od)
+		}
+	}
+}
+
+// logObservedStreamOutcome prints BAML's observed parse-stream outcome for one
+// accumulated prefix in a stable, greppable form so a developer running
+// BAMLFUZZ_PARSE_CAPTURE=1 can copy the values into the corpus prefix `want`.
+// It carries the full prefix identity (case + prefix name + exact raw) and a
+// `stream` marker so a stream want can never be confused with — or reused
+// from — a final-parse want. Not a gate.
+func logObservedStreamOutcome(t *testing.T, caseName string, p bamlfuzz.ParseRecoveryPrefix, outcome bamlfuzz.ParseOutcome) {
+	t.Helper()
+	if outcome.Error != "" {
+		t.Logf("CAPTURE stream case=%q prefix=%q raw=%q -> status=error err=%s", caseName, p.Name, p.Raw, outcome.Error)
+		return
+	}
+	t.Logf("CAPTURE stream case=%q prefix=%q raw=%q -> status=success json=%s", caseName, p.Name, p.Raw, string(outcome.JSON))
 }
 
 // characterizeFinal gates the live BAML final parse against the recorded

--- a/worker/parse.go
+++ b/worker/parse.go
@@ -12,7 +12,12 @@ import (
 
 // workerParseInput wraps the input for parse requests.
 type workerParseInput struct {
-	Raw     string                 `json:"raw"`
+	Raw string `json:"raw"`
+	// Stream selects the parse-STREAM (partial) path: when true, Parse drives
+	// the method's StreamImpl (BAML ParseStream) instead of the final Impl.
+	// Absent/false on every production /parse input, so the default path is
+	// unchanged; only the dynamic parse-stream oracle sets it.
+	Stream  bool                   `json:"stream,omitempty"`
 	Options *bamlutils.BamlOptions `json:"__baml_options__,omitempty"`
 }
 
@@ -47,8 +52,22 @@ func (h *Handler) Parse(ctx context.Context, methodName string, inputJSON []byte
 		}
 	}
 
-	// Call the parse method
-	result, err := method.Impl(adapter, input.Raw)
+	// Select the final or parse-stream implementation. Stream=true drives
+	// BAML's ParseStream over the accumulated prefix (the parse-stream
+	// oracle); a method with no StreamImpl cannot service a Stream request.
+	// This is a real error (the method does not expose parse-stream), not a
+	// native fallback: native de-BAML stream parsing is not wired at this
+	// seam.
+	impl := method.Impl
+	if input.Stream {
+		if method.StreamImpl == nil {
+			return nil, fmt.Errorf("parse method %q does not support stream parse", methodName)
+		}
+		impl = method.StreamImpl
+	}
+
+	// Call the selected parse implementation.
+	result, err := impl(adapter, input.Raw)
 	if err != nil {
 		// Wrap with any typed classification so the gRPC layer's
 		// errors.As against GetCode()/GetDetails() picks it up


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

## de-BAML P4 M4a — Direct parse-stream oracle + live-captured streaming corpus

Harness/seam prep for the streaming parse-recovery differential. This slice exposes a **direct BAML parse-stream oracle** to the bamlfuzz differential and un-skips the streaming leg, **without claiming any native streaming parity**. Every native stream case records a fallback (skip) disposition; `internal/debaml.Parse(… Stream=true …)` still declines.

### What changed

**Parse-stream oracle seam (BAML only):**
- `bamlutils.ParseMethod` gains a `StreamImpl` field — the parse-stream (partial) implementation. `bamlutils.DynamicParseInput` gains `Stream bool`, threaded through `ToWorkerInput`.
- Codegen (`emitParseMethods`/`emitParseMethodsMap`) now emits a `parse<Method>Stream` wrapper that calls `bamlclient.ParseStream.<Method>` and unwraps the stream `DynamicProperties` in place, wired as the `ParseMethod.StreamImpl`. The checked-in dynclient generated adapter carries the matching hand-applied output.
- `worker.Handler.Parse` dispatches to `StreamImpl` when `Stream=true` (a method with no `StreamImpl` is a real error, not a native fallback).
- `dynclient.DynamicParse` honors `req.Stream`: it drives BAML's parse-stream over the raw prefix and normalizes the partial output through the **identical** flatten / absent-optional-injection / ordering pipeline a final parse uses, so a streaming prefix is directly comparable to a final parse.

**Differential harness:**
- The integration `bamlDynamicParser` now services `Stream=true` via `DynamicParse`; the native candidate (`nativeDeBAMLParser`) passes `Stream` through to `internal/debaml.Parse`, which declines every stream parse → `SkippedNative` (fallback).
- The streaming subtest is un-skipped: it runs `DiffParserPrefixes` per accumulated prefix, characterizes live BAML against the fixture want, and asserts a **per-prefix native disposition** (`parseRecoveryStreamNativeClaim`, empty in M4a = every prefix falls back). Capture logging carries full prefix identity (`case`/`prefix`/`stream` marker) so a stream want can never be reused as a final-parse want.

**Recaptured streaming corpus (`20`–`23`), live from BAML v0.223.0 (`BAMLFUZZ_PARSE_CAPTURE=1`):**
- The previously hand-written "error" wants for early prefixes were **wrong**: BAML's parse-stream is lenient enough that `{`, `{"name"`, `{"name":`, bare prose, and a just-opened ```json fence all recover a partial object with fields null-filled (a success, not an error). Every want is now what BAML actually emits.

### Guards held
- Native unavailability is a skip; BAML-oracle unavailability is a harness failure (no hand-written wants).
- `internal/debaml.Parse(Stream=true)` still declines — no native stream, no stream-state output, no `raw_is_done=false` native parsing, no `@stream.done`/`@stream.not_null`/`@stream.with_state`.
- The runtime orchestrator's `parseStreamFn` path is untouched — per-prefix parse errors stay non-terminal.

### Validation
- `gofmt`, `go build ./...`, `go vet ./...` (+ `-tags=integration`), `go test ./internal/debaml`, `GOWORK=off go test ./codegen` (from `adapters/common`) — all green.
- The parse-recovery differential (BAML v0.223.0): all four streaming fixtures pass — 20/20 prefixes match live BAML exactly (strict semantic + schema order) and every prefix records the fallback disposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stream flag to parsing requests to enable stream/partial parsing for methods that support it.
  * Dynamic parsing now propagates stream requests through the worker pipeline to produce partial outputs.

* **Bug Fixes**
  * Improved parse-recovery for streaming by switching to live, per-prefix differential outcomes and recording native stream disposition (claimed vs fallback).
  * Added per-prefix oracle timeouts and expanded streaming recovery expectations/logging for more consistent recovery.

* **Tests**
  * Added coverage to ensure codegen unwrap helpers correctly track stream vs final output shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->