### PR TITLE
debaml: basic raw_is_done=false native partials without stream annotations (M4 slice b)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/171_anyof_string_no_leak.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/171_anyof_string_no_leak.json
@@ -1,0 +1,20 @@
+{
+  "name": "anyof_string_no_leak",
+  "description": "M4b: a truncated STRING field value whose content literally contains an 'AnyOf[' rendering must surface as the STRING VALUE, never an AnyOf[...] wrapper. BAML's coerce_string extracts the string content from its internal AnyOf/string-fallback (coerce_primitive.rs:153); native has no AnyOf value kind and carries the string directly, so a partial (Incomplete) string field is kept verbatim (strings are not done-required). Per-prefix `want` values are LIVE-CAPTURED from BAML v0.223.0 parse-stream (BAMLFUZZ_PARSE_CAPTURE=1), not hand-written. Native CLAIMS every prefix here — the string value is emitted as-is, never an AnyOf rendering.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "note", "type": {"kind": "string"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "prefixes": [
+    {"name": "partial", "raw": "{\"note\":\"AnyOf[hello", "want": {"status": "success", "json": {"note": "AnyOf[hello"}}},
+    {"name": "closed", "raw": "{\"note\":\"AnyOf[hello]\"}", "want": {"status": "success", "json": {"note": "AnyOf[hello]"}}}
+  ]
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/172_list_multi_arm_union_stream.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/172_list_multi_arm_union_stream.json
@@ -1,0 +1,22 @@
+{
+  "name": "list_multi_arm_union_stream",
+  "description": "M4b NEGATIVE GUARD: a direct list<int | bool> element in STREAM mode stays NATIVE-SKIPPED. BAML threads the previous element's winning outer UnionMatch into the next element as ctx.union_variant_hint (coerce_array.rs) and tries that arm FIRST on the next element; M3 intentionally DEFERRED modeling the cross-element array union_variant_hint, so native declines list-of-multi-arm-union at the gate (checkSupported) in BOTH final and stream mode. This fixture pins that native FALLS BACK on every prefix (disposition absent from parseRecoveryStreamNativeClaim) while BAML parse-stream stays authoritative. Per-prefix `want` values are LIVE-CAPTURED from BAML v0.223.0 parse-stream (BAMLFUZZ_PARSE_CAPTURE=1), not hand-written.",
+  "preserve_schema_order": false,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "items", "type": {"kind": "list", "inner": {"kind": "union", "variants": [{"kind": "int"}, {"kind": "bool"}]}}}
+        ]
+      }
+    ],
+    "root_class": "Root",
+    "has_union": true
+  },
+  "prefixes": [
+    {"name": "list_open", "raw": "{\"items\":[1", "want": {"status": "success", "json": {"items": []}}},
+    {"name": "second_elem", "raw": "{\"items\":[1,true", "want": {"status": "success", "json": {"items": [1, true]}}},
+    {"name": "closed", "raw": "{\"items\":[1,true]}", "want": {"status": "success", "json": {"items": [1, true]}}}
+  ]
+}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -85,13 +85,14 @@ type nativeDeBAMLParser struct{}
 // Name identifies the native candidate leg in diff output and envelopes.
 func (nativeDeBAMLParser) Name() string { return "native_debaml" }
 
-// Parse drives internal/debaml.Parse for a final parse and normalizes its
-// flattened output exactly like dynclient's parse-only path. A Stream=true
-// request is passed through unchanged: internal/debaml.Parse declines every
-// stream parse (ErrDeBAMLParseUnsupported), which maps to
-// ErrParserUnavailable below, so in M4a the native candidate falls back
-// (SkippedNative) on every streaming prefix — native stream parity is not
-// claimed this slice.
+// Parse drives internal/debaml.Parse for both a final parse and (M4b) a
+// STREAMING parse, normalizing its flattened output exactly like dynclient's
+// parse-only path. A Stream=true request now routes to the native streaming path,
+// which CLAIMS the smallest useful partial surface (jsonish recovery + class
+// null-filling, no stream annotations / StreamState) and DECLINES everything else
+// with ErrDeBAMLParseUnsupported — mapped to ErrParserUnavailable below, so an
+// unclaimed prefix falls back (SkippedNative) and BAML parse-stream stands alone.
+// A claimed prefix is held to BAML byte-exact by the per-prefix differential.
 func (nativeDeBAMLParser) Parse(ctx context.Context, req bamlfuzz.ParseRequest) (bamlfuzz.ParseResult, error) {
 	lowered, err := bamlfuzz.LowerToDynamicSchema(req.Schema)
 	if err != nil {
@@ -566,15 +567,74 @@ var parseRecoveryNativeClaim = map[string]bool{
 }
 
 // parseRecoveryStreamNativeClaim pins the per-prefix native disposition for
-// streaming recovery cases: caseName -> prefixName -> claimed. In M4a the
-// native parser CLAIMS NO streaming prefix — internal/debaml.Parse declines
-// every Stream=true request — so every prefix's expected disposition is
-// fallback (false) and this map is intentionally empty (streamPrefixNativeClaim
-// defaults to false). It is the per-prefix seam a later slice (M4b+) uses to
-// flip an individual prefix from fallback to claimed without reworking the
-// harness: set caseName->prefixName to true and the per-prefix differential
-// then holds the native claim to BAML exactly.
-var parseRecoveryStreamNativeClaim = map[string]map[string]bool{}
+// streaming recovery cases: caseName -> prefixName -> claimed. A prefix set to
+// true is expected to be CLAIMED by internal/debaml.Parse(Stream=true) and held
+// to BAML parse-stream byte-exact by the per-prefix differential; a prefix absent
+// from the map defaults to false (native FALLS BACK to BAML).
+//
+// M4b flips the live-captured success prefixes whose observable behavior is
+// jsonish recovery + class null-filling WITHOUT stream annotations or displayed
+// stream state: an open/repaired root object AFTER at least one field value is
+// available (BAML's Pending null fills the missing fields), truncated /
+// markdown-fence-recovered incomplete STRING values (strings are not done-required
+// so a partial string is kept as its value — no AnyOf leak), and trailing-comma
+// list/string prefixes BAML accepts. The prefixes that stay FALLBACK (absent) are
+// the over-claim guards: a bare open brace / dangling key / dangling colon and
+// bare prose / just-opened fence (NO field value yet — the empty-object and
+// allow_as_string→class recovery paths are not claimed), which M4b deliberately
+// over-declines. Completed done-required scalars are claimed only where the
+// enclosing structure proves them done (the closed full_object); an INCOMPLETE
+// done-required scalar and any semantic child deletion stay fallback (M4c).
+var parseRecoveryStreamNativeClaim = map[string]map[string]bool{
+	// 20_streaming_growing_object (Root{name:string, age:int}). The bare `{`,
+	// key-only, and dangling-colon prefixes have no field value yet → fallback;
+	// every prefix from the first present field value on is claimed (missing fields
+	// null-filled, the closed int kept).
+	"streaming_growing_object": {
+		"partial_string": true,
+		"full_string":    true,
+		"second_key":     true,
+		"full_object":    true,
+	},
+	// 21_streaming_markdown_fence (Root{name:string, age:int}). Bare prose and the
+	// just-opened fence have no JSON content → fallback; the object emerging inside
+	// the (still-open, then closed) fence is claimed.
+	"streaming_markdown_fence": {
+		"object_partial": true,
+		"object_full":    true,
+		"fence_close":    true,
+	},
+	// 22_streaming_truncated_string (Root{name:string}). Every prefix carries a
+	// present (possibly empty / truncated / incomplete) STRING value, which is not
+	// done-required, so all four are claimed as the exact string value.
+	"streaming_truncated_string": {
+		"open":          true,
+		"mid_string":    true,
+		"closed_string": true,
+		"closed_object": true,
+	},
+	// 23_streaming_trailing_comma (Root{name:string, tags:list<string>}). Both
+	// fields are present with completed string / list-of-completed-string values,
+	// and the dangling trailing comma is dropped, so all four are claimed.
+	"streaming_trailing_comma": {
+		"list_open":      true,
+		"trailing_comma": true,
+		"list_closed":    true,
+		"object_closed":  true,
+	},
+	// anyof_string_no_leak (Root{note:string}): a truncated string value BAML
+	// represents internally as an AnyOf must surface as the STRING value natively,
+	// never an AnyOf[...] rendering — claimed from the first present value on.
+	"anyof_string_no_leak": {
+		"partial": true,
+		"closed":  true,
+	},
+	// list_multi_arm_union_stream (Root{items:list<int|bool>}): a direct
+	// list<multi-arm-union> element stays NATIVE-SKIPPED in stream mode — BAML's
+	// cross-element union_variant_hint (coerce_array.rs) was intentionally deferred
+	// after M3, so native declines at the gate (checkSupported) on every prefix and
+	// BAML parse-stream stays authoritative. No prefix is claimed (absent → false).
+}
 
 // streamPrefixNativeClaim returns the expected native disposition for one
 // streaming prefix: true = native is expected to CLAIM it (and be diffed
@@ -611,9 +671,9 @@ type parseRecoveryStats struct {
 // both the final-parse and streaming legs are live differentials. Streaming
 // cases additionally drive the direct BAML parse-stream oracle
 // (DynamicParse with Stream=true) per accumulated prefix and gate BAML
-// against the live-captured prefix `want`; the native candidate declines
-// every stream parse in M4a, so each streaming prefix records a fallback
-// disposition (SkippedNative) rather than a native claim.
+// against the live-captured prefix `want`; the native candidate CLAIMS the M4b
+// partial surface (per parseRecoveryStreamNativeClaim) and is held to BAML
+// byte-exact there, and FALLS BACK (SkippedNative) on every other prefix.
 //
 // Run with BAMLFUZZ_PARSE_CAPTURE=1 to log BAML's observed final-parse AND
 // per-prefix parse-stream outcomes instead of gating — used to (re)capture
@@ -657,7 +717,7 @@ func TestBamlfuzzParseRecovery(t *testing.T) {
 		})
 	}
 	t.Logf("native de-BAML final-parse dispositions: %d claimed, %d fell back to BAML", stats.claimed, stats.fallback)
-	t.Logf("native de-BAML parse-stream dispositions: %d claimed, %d fell back to BAML (M4a expects 0 claimed)", stats.streamClaimed, stats.streamFallback)
+	t.Logf("native de-BAML parse-stream dispositions: %d claimed, %d fell back to BAML (M4b claims the basic-partial surface)", stats.streamClaimed, stats.streamFallback)
 }
 
 // runParseRecoveryCase drives the final and/or streaming legs of one
@@ -770,12 +830,11 @@ func runParseRecoveryCase(t *testing.T, baml, native bamlfuzz.Parser, c bamlfuzz
 						characterizeStreamPrefix(t, c, p, res.BAML)
 					}
 
-					// Native-vs-BAML per-prefix differential. In M4a native
-					// declines every stream prefix, so SkippedNative is the
-					// expected shape and this gate never fires for a native
-					// mismatch; it DOES fire on a BAML harness failure
-					// (SkippedNative=false with failures) or, once a later
-					// slice claims a prefix, on real native drift.
+					// Native-vs-BAML per-prefix differential. For an M4b-claimed
+					// prefix native returns real JSON and this gate holds it to
+					// BAML byte-exact; for a fallback prefix SkippedNative is the
+					// expected shape and this gate never fires. It also fires on a
+					// BAML harness failure (SkippedNative=false with failures).
 					if !res.SkippedNative && len(res.Failures) > 0 {
 						dumpParseDiffAndFail(t, parseRecoveryArtifactDir,
 							parseDiffEnvelope(c, idx, i, p.Name, p.Raw, true, res),
@@ -797,7 +856,7 @@ func runParseRecoveryCase(t *testing.T, baml, native bamlfuzz.Parser, c bamlfuzz
 						t.Logf("native FELL BACK to BAML for stream prefix %q/%q", c.Name, p.Name)
 					}
 					if claimed != want {
-						t.Errorf("native stream disposition for %q/%q: got claimed=%v, want claimed=%v (M4a: every stream prefix falls back)", c.Name, p.Name, claimed, want)
+						t.Errorf("native stream disposition for %q/%q: got claimed=%v, want claimed=%v (M4b cut-line drift)", c.Name, p.Name, claimed, want)
 					}
 				})
 			}

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -3228,3 +3228,191 @@ func ambiguousMatch(target, input string) error {
 func declineCoerce(target string, input value) error {
 	return unsupported(fmt.Sprintf("%s: got %s (native stricter than BAML)", target, input.kind.String()))
 }
+
+// --- M4b: streaming (raw_is_done=false) coercion --------------------------
+//
+// coerceStream coerces a value recovered by the streaming parser
+// (streamExtractCandidate / streamFix) into the flattened dynamic output JSON for
+// type t. It models the SUBSET of BAML's semantic_streaming.rs whose observable
+// output for an UNANNOTATED dynamic schema is an ordinary object/list/string with
+// NO StreamState wrappers:
+//
+//   - class: assign present object keys to fields (BAML's input-key-first fuzzy
+//     match), coerce each present field's value through coerceStream, and NULL-FILL
+//     every MISSING field (BAML's Pending null under raw_is_done=false). Requires at
+//     least one field to receive a present value — see coerceStreamClass.
+//   - list: coerce each element through coerceStream and keep it; a non-array input
+//     or an element BAML would DELETE declines the whole list — see coerceStreamList.
+//   - string: NOT done-required, so a JSON string is emitted as-is whether COMPLETE
+//     or INCOMPLETE (a truncated / markdown-recovered string keeps its partial value).
+//     This is the "AnyOf string does not leak" surface: native carries the string
+//     value directly, so the output is the string, never an AnyOf rendering. A
+//     non-string into a string target declines (stream JsonToString deferred).
+//   - int / float / bool / null / enum / literal (DONE-REQUIRED): an INCOMPLETE value
+//     DECLINES (BAML deletes it — semantic deletion is M4c); a COMPLETE value is
+//     coerced through the SAME final leaf coercer (stream == final for a done value).
+//   - map / union: DECLINE (deferred — over-decline is safe).
+//
+// Every path either reproduces BAML's exact partial output or DECLINES
+// (ErrDeBAMLParseUnsupported → fall back to BAML). It never claims a value BAML
+// would delete, wrap in StreamState, or produce differently.
+func coerceStream(b *schema.Bundle, t schema.Type, input value) (json.RawMessage, error) {
+	switch t.Kind {
+	case schema.TypePrimitive:
+		if t.Primitive == schema.PrimitiveString {
+			if input.kind == valString {
+				return marshalJSON(input.strV)
+			}
+			return nil, unsupported("stream: non-string into string target (JsonToString deferred)")
+		}
+		return coerceStreamDoneLeaf(b, t, input)
+	case schema.TypeLiteral, schema.TypeEnum:
+		return coerceStreamDoneLeaf(b, t, input)
+	case schema.TypeClass:
+		return coerceStreamClass(b, t.Name, t.Mode, input)
+	case schema.TypeList:
+		return coerceStreamList(b, t.Elem, input)
+	case schema.TypeMap:
+		return nil, unsupported("stream: map target (deferred)")
+	case schema.TypeUnion:
+		return nil, unsupported("stream: union target (deferred)")
+	default:
+		return nil, unsupported(fmt.Sprintf("stream: type kind %q", t.Kind))
+	}
+}
+
+// coerceStreamDoneLeaf coerces a DONE-REQUIRED leaf (int / float / bool / null /
+// enum / literal) in stream mode. An INCOMPLETE value would be DELETED by BAML's
+// semantic streaming (the type requires done), which M4b does not model, so it
+// DECLINES. A COMPLETE value is coerced through the SAME final leaf coercer — for
+// a done value stream and final coercion are identical — and any final decline or
+// proven error DECLINES the whole stream parse (fall back to BAML).
+func coerceStreamDoneLeaf(b *schema.Bundle, t schema.Type, input value) (json.RawMessage, error) {
+	if input.incomplete {
+		return nil, unsupported(fmt.Sprintf("stream: incomplete %s value requires done (semantic deletion deferred)", t.Kind))
+	}
+	out, err := coerce(b, t, input, &coerceFlags{})
+	if err != nil {
+		return nil, unsupported(fmt.Sprintf("stream: done-required leaf did not cleanly coerce: %v", err))
+	}
+	return out, nil
+}
+
+// coerceStreamClass coerces an object into a class in stream mode, porting the
+// slice of coerce_class.rs whose streaming output is an ordinary object: assign
+// present input keys to fields (BAML's input-key-first fuzzy match, keep-first on
+// duplicates, extra keys ignored), coerce each present field's value through
+// coerceStream, and NULL-FILL every field with no present value (BAML's Pending
+// null under raw_is_done=false — emitted as an explicit null in schema declaration
+// order, so it survives the downstream InjectAbsentOptionals + reorder identically
+// to BAML's flattened output).
+//
+// It DECLINES (fall back) for the shapes M4b does not model:
+//   - NON-object input (a scalar/array → class implied-key / inferred-object /
+//     array-to-singular is deferred);
+//   - a class where NO field received a present value — the "open/repaired root
+//     object AFTER ≥1 field value is available" guard: a bare `{`, a key with no
+//     value, a dangling colon, or an all-extra-keys object stays fallback;
+//   - a present field whose value does not cleanly coerce in stream (an incomplete
+//     done-required field, a deferred leaf conversion) — its decline propagates and
+//     the whole class falls back;
+//   - a field-key match that hinges on a non-ASCII case fold native cannot prove
+//     equals BAML.
+func coerceStreamClass(b *schema.Bundle, name string, mode schema.StreamingMode, input value) (json.RawMessage, error) {
+	cls, ok := b.FindClass(name, mode)
+	if !ok {
+		return nil, fmt.Errorf("debaml: unknown class %q", name)
+	}
+	if input.kind != valObject {
+		return nil, unsupported(fmt.Sprintf("stream: class %q from %s (implied-key/inferred/array-to-singular deferred)", name, input.kind))
+	}
+	nF := len(cls.Fields)
+	matched := make([]bool, nF)
+	assigned := make([]value, nF)
+	present := 0
+	// Input-key-first assignment: each key to the FIRST field it fuzzily matches
+	// (no substring); a key matching an already-filled field is a duplicate
+	// (keep-first, ignored); a key matching no field is an extra (ignored).
+	for i := range input.objV {
+		key := input.objV[i].key
+		mf := -1
+		for j := range cls.Fields {
+			m, unc := matchesStringToString(key, cls.Fields[j].Name.RenderedName())
+			if unc {
+				return nil, unsupported(fmt.Sprintf("stream: class %q field-key non-ASCII case-fold uncertainty", name))
+			}
+			if m {
+				mf = j
+				break
+			}
+		}
+		if mf < 0 || matched[mf] {
+			continue
+		}
+		assigned[mf] = input.objV[i].val
+		matched[mf] = true
+		present++
+	}
+	if present == 0 {
+		return nil, unsupported(fmt.Sprintf("stream: class %q has no present field value yet (open root object before ≥1 field)", name))
+	}
+
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for j := range cls.Fields {
+		if j > 0 {
+			buf.WriteByte(',')
+		}
+		key, err := marshalJSON(cls.Fields[j].Name.Name)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(key)
+		buf.WriteByte(':')
+		if matched[j] {
+			o, err := coerceStream(b, cls.Fields[j].Type, assigned[j])
+			if err != nil {
+				return nil, err
+			}
+			buf.Write(o)
+		} else {
+			buf.WriteString("null") // BAML Pending null for a missing field.
+		}
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// coerceStreamList coerces an array into a list in stream mode. Each element is
+// coerced through coerceStream and KEPT; the list is emitted in element order. A
+// list is never done-required, so an unterminated (Incomplete) list is fine as
+// long as every element it contains cleanly coerces.
+//
+// It DECLINES (fall back) for the cases M4b does not model:
+//   - a NON-array input (SingleToArray wrapping is deferred);
+//   - an element that would be DELETED by semantic streaming — coerceStream on the
+//     element declines (an incomplete done-required element, or a value the leaf
+//     coercer cannot cleanly claim / BAML would skip) — so the WHOLE list falls back
+//     rather than reproduce the semantic child deletion (M4c).
+func coerceStreamList(b *schema.Bundle, elem *schema.Type, input value) (json.RawMessage, error) {
+	if elem == nil {
+		return nil, fmt.Errorf("debaml: list type missing element")
+	}
+	if input.kind != valArray {
+		return nil, unsupported(fmt.Sprintf("stream: list from %s (SingleToArray deferred)", input.kind))
+	}
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	for i := range input.arrV {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		o, err := coerceStream(b, *elem, input.arrV[i])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(o)
+	}
+	buf.WriteByte(']')
+	return buf.Bytes(), nil
+}

--- a/internal/debaml/extract.go
+++ b/internal/debaml/extract.go
@@ -207,3 +207,145 @@ func extractBalancedSpan(raw string) (span string, end int, ok bool) {
 	}
 	return "", 0, false
 }
+
+// --- M4b: streaming (raw_is_done=false) candidate extraction --------------
+//
+// streamExtractCandidate finds the JSON candidate in a raw prefix captured
+// mid-generation and decodes it with streaming recovery, in the SAME
+// BAML-recovery priority order as extractCandidate: the whole input (strict),
+// then a markdown fenced block (open-to-close OR open-to-EOF while still
+// streaming), then the first balanced-or-truncated object/array embedded in
+// prose. A strict whole-input success is a fully-closed value whose children are
+// all complete; every other path routes through decodeSpanStream, which recovers
+// the incomplete structure via streamFix and tags per-value completion.
+//
+// The second return is false (DECLINE) when no candidate can be found — no
+// JSON-looking content at all (bare prose / a just-opened fence with no body), or
+// a construct outside the streaming fixing subset. Extraction NEVER claims a
+// parse error: a claim only happens when a candidate is found AND stream
+// coercion against the schema succeeds (handled by the caller).
+func streamExtractCandidate(raw string) (value, bool) {
+	// 1. Strict whole-input parse — a fully-closed, complete value.
+	if trimmed := strings.TrimSpace(raw); trimmed != "" {
+		if v, err := strictDecode(trimmed); err == nil {
+			return v, true
+		}
+	}
+
+	// 2. Markdown fenced block: content between the opening fence and the closing
+	//    fence, or — while still streaming — everything after the opening fence to
+	//    EOF. Strict, then streaming fix, on the fence content.
+	if content, ok := extractFenceContentStream(raw); ok {
+		return decodeSpanStream(strings.TrimSpace(content))
+	}
+
+	// 3. First balanced-or-truncated object/array span embedded in prose.
+	if span, end, closed, ok := extractBalancedSpanStream(raw); ok {
+		if closed && containsUnquotedBracket(raw[end:]) {
+			// A second top-level structure follows the first CLOSED span: BAML's
+			// multiple-values / inferred-array case (scored), which M4b defers — so
+			// decline rather than claim the first span.
+			return value{}, false
+		}
+		return decodeSpanStream(strings.TrimSpace(span))
+	}
+
+	return value{}, false
+}
+
+// decodeSpanStream decodes a selected candidate span with streaming recovery:
+// strict first (a fully-closed span whose values are all complete), then the
+// streaming fixing pass (which recovers open objects/arrays/strings, drops
+// still-streaming keys, and tags per-value completion). A span the streaming
+// subset declines returns false (fall back to BAML).
+func decodeSpanStream(span string) (value, bool) {
+	if v, err := strictDecode(span); err == nil {
+		return v, true
+	}
+	return streamFix(span)
+}
+
+// extractFenceContentStream is the streaming variant of extractFenceContent: it
+// returns the body between the first opening ``` fence line and the next closing
+// fence line, OR — when no closing fence has arrived yet (still streaming) —
+// everything after the opening fence line to EOF. The second return is false when
+// no opening fence line is present. Both fences are line-anchored, exactly as in
+// the final extractor, so an inline ``` inside a string value does not truncate.
+func extractFenceContentStream(raw string) (string, bool) {
+	const fence = "```"
+	lines := strings.Split(raw, "\n")
+	open := -1
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimLeft(line, " \t"), fence) {
+			open = i
+			break
+		}
+	}
+	if open < 0 {
+		return "", false
+	}
+	for j := open + 1; j < len(lines); j++ {
+		if strings.HasPrefix(strings.TrimLeft(lines[j], " \t"), fence) {
+			return strings.Join(lines[open+1:j], "\n"), true
+		}
+	}
+	// No closing fence yet: take everything after the opening fence line to EOF.
+	return strings.Join(lines[open+1:], "\n"), true
+}
+
+// extractBalancedSpanStream is the streaming variant of extractBalancedSpan: it
+// anchors on the first '{' or '[' outside double-quoted content and returns the
+// span to its matching close (closed=true) OR, when the structure never closes
+// (a truncated response BAML recovers at is_done=false), the span from the anchor
+// to EOF (closed=false). end is the index just past a closed span (len(raw) for a
+// truncated one) so the caller can scan the remainder for a second top-level
+// candidate. ok is false only when no opening bracket is found at all. Like the
+// final extractor, span detection is single-quote-blind and double-quote-aware.
+func extractBalancedSpanStream(raw string) (span string, end int, closed bool, ok bool) {
+	start := -1
+	depth := 0
+	var open, closing byte
+	inString := false
+	escaped := false
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		if inString {
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			continue
+		}
+		if start < 0 {
+			switch c {
+			case '{':
+				start, open, closing, depth = i, '{', '}', 1
+			case '[':
+				start, open, closing, depth = i, '[', ']', 1
+			}
+			continue
+		}
+		switch c {
+		case open:
+			depth++
+		case closing:
+			depth--
+			if depth == 0 {
+				return raw[start : i+1], i + 1, true, true
+			}
+		}
+	}
+	if start < 0 {
+		return "", 0, false, false // no anchor
+	}
+	// Unterminated: take the anchor to EOF (BAML closes it at is_done=false).
+	return raw[start:], len(raw), false, true
+}

--- a/internal/debaml/fix.go
+++ b/internal/debaml/fix.go
@@ -405,3 +405,321 @@ func (p *fixer) parseSingleQuoted() (string, error) {
 	}
 	return "", errFixUnsupported // unterminated string
 }
+
+// --- M4b: streaming (raw_is_done=false) fixing parser ---------------------
+//
+// streamFix runs the STREAMING variant of the conservative fixing pass over a
+// candidate span captured mid-generation (raw_is_done=false). On top of the M2a
+// fixing subset (trailing/leading/repeated commas, unquoted keys, single quotes,
+// unquoted true/false/null/number scalars) it RECOVERS the incomplete structures
+// BAML's jsonish closes at EOF and tags each value's CompletionState via the
+// value.incomplete bit:
+//
+//   - an object/array with no closing delimiter is closed at EOF (Incomplete);
+//   - a double/single-quoted string with no closing quote keeps its partial
+//     content and is closed at EOF (Incomplete — allow_as_string under is_done=false);
+//   - an unquoted scalar that runs to EOF is Incomplete;
+//   - an object key with no ':' — or a ':' with no value — at EOF is DROPPED: the
+//     field has no value yet, so the class null-fills it downstream (this is how
+//     BAML's `{`, `{"name"`, and `{"name":` prefixes recover an all-null object);
+//   - a value terminated by its proper delimiter (',' or a closing bracket) is
+//     Complete, so the LAST child of an incomplete container is Incomplete while
+//     earlier properly-terminated siblings stay Complete (semantic_streaming.rs).
+//
+// It DECLINES (ok=false) exactly the constructs the final fixer declines for
+// reasons OTHER than truncation — comments, backtick/triple-quoted strings,
+// escapes inside strings, and a missing comma between two PRESENT values (a
+// non-EOF junk byte) — plus any trailing content after a self-closed top-level
+// value (the multiple-values / inferred-array case). The top level must be an
+// object or array (recovery schemas target object/list/class shapes); a bare
+// scalar span declines. Completion is advisory only: stream coercion consults it
+// to DECLINE an incomplete done-required value (which BAML would delete) rather
+// than model the deletion (M4c). The final decoders never call this, so
+// value.incomplete stays false on the final-parse path.
+func streamFix(s string) (value, bool) {
+	p := &fixer{s: s}
+	p.skipWS()
+	if p.eof() {
+		return value{}, false
+	}
+	if c := p.s[p.pos]; c != '{' && c != '[' {
+		// A bare scalar span is not a recovery target (and would be handled by the
+		// strict decode that runs first for a complete one).
+		return value{}, false
+	}
+	v, err := p.parseValueStream("")
+	if err != nil {
+		return value{}, false
+	}
+	p.skipWS()
+	if !p.eof() {
+		// Trailing content after a self-closed top-level value is the
+		// multiple-values / inferred-array case BAML scores; decline. (An
+		// unterminated top-level value consumed to EOF, so this only fires when the
+		// value self-closed and more text follows.)
+		return value{}, false
+	}
+	return v, true
+}
+
+// parseValueStream parses one streaming value. The caller guarantees a non-EOF,
+// non-terminator byte at the cursor (object/array callers handle the EOF and
+// terminator cases before dispatching here). term is the terminator set for a
+// bare unquoted scalar; quoted strings, objects, and arrays self-delimit.
+func (p *fixer) parseValueStream(term string) (value, error) {
+	switch c := p.s[p.pos]; c {
+	case '{':
+		return p.parseObjectStream()
+	case '[':
+		return p.parseArrayStream()
+	case '"':
+		return p.parseDoubleQuotedStream()
+	case '\'':
+		return p.parseSingleQuotedStream()
+	case '`', '/', '#':
+		// Backtick strings and comments are deferred to BAML.
+		return value{}, errFixUnsupported
+	default:
+		return p.parseUnquotedScalarStream(term)
+	}
+}
+
+// parseObjectStream parses an object body with streaming recovery. The opening
+// '{' is at the cursor. On EOF it closes the object Incomplete; a key with no
+// ':' or a ':' with no value at EOF drops that (still-streaming) field so the
+// class null-fills it. A missing comma / separator with more input present is
+// out of the subset and declines.
+func (p *fixer) parseObjectStream() (value, error) {
+	p.pos++ // consume '{'
+	obj := value{kind: valObject}
+	for {
+		p.skipWS()
+		if p.eof() {
+			obj.incomplete = true
+			return obj, nil
+		}
+		switch p.s[p.pos] {
+		case '}':
+			p.pos++
+			return obj, nil // complete (closed)
+		case ',':
+			p.pos++ // tolerate leading / trailing / repeated commas
+			continue
+		}
+		key, ok := p.parseKeyStream()
+		if !ok {
+			// Unterminated / unparseable key → field has no value yet: drop it and
+			// close the object Incomplete.
+			obj.incomplete = true
+			return obj, nil
+		}
+		p.skipWS()
+		if p.eof() {
+			// Key present but no ':' yet → drop the still-streaming field.
+			obj.incomplete = true
+			return obj, nil
+		}
+		if p.s[p.pos] != ':' {
+			return value{}, errFixUnsupported // missing key/value separator
+		}
+		p.pos++ // consume ':'
+		p.skipWS()
+		if p.eof() {
+			// ':' with no value yet → drop the still-streaming field.
+			obj.incomplete = true
+			return obj, nil
+		}
+		v, err := p.parseValueStream(objectValueTerm)
+		if err != nil {
+			return value{}, err
+		}
+		obj.objV = append(obj.objV, field{key: key, val: v})
+
+		p.skipWS()
+		if p.eof() {
+			obj.incomplete = true
+			return obj, nil
+		}
+		switch p.s[p.pos] {
+		case '}':
+			p.pos++
+			return obj, nil
+		case ',':
+			p.pos++
+		default:
+			return value{}, errFixUnsupported // missing comma / junk
+		}
+	}
+}
+
+// parseArrayStream parses an array body with streaming recovery. The opening '['
+// is at the cursor. On EOF it closes the array Incomplete; trailing/leading/
+// repeated commas are tolerated. A missing comma with more input present declines.
+func (p *fixer) parseArrayStream() (value, error) {
+	p.pos++ // consume '['
+	arr := value{kind: valArray, arrV: []value{}}
+	for {
+		p.skipWS()
+		if p.eof() {
+			arr.incomplete = true
+			return arr, nil
+		}
+		switch p.s[p.pos] {
+		case ']':
+			p.pos++
+			return arr, nil // complete
+		case ',':
+			p.pos++
+			continue
+		}
+		v, err := p.parseValueStream(arrayValueTerm)
+		if err != nil {
+			return value{}, err
+		}
+		arr.arrV = append(arr.arrV, v)
+
+		p.skipWS()
+		if p.eof() {
+			arr.incomplete = true
+			return arr, nil
+		}
+		switch p.s[p.pos] {
+		case ']':
+			p.pos++
+			return arr, nil
+		case ',':
+			p.pos++
+		default:
+			return value{}, errFixUnsupported
+		}
+	}
+}
+
+// parseKeyStream reads an object key for the streaming parser. It returns
+// (key, true) for a fully-formed key, and ("", false) when the key is still
+// streaming (an unterminated quoted key closed by EOF) or unparseable (backtick /
+// empty) — the caller then drops the field and closes the object Incomplete.
+func (p *fixer) parseKeyStream() (string, bool) {
+	p.skipWS()
+	if p.eof() {
+		return "", false
+	}
+	switch p.s[p.pos] {
+	case '"':
+		v, err := p.parseDoubleQuotedStream()
+		if err != nil || v.incomplete {
+			return "", false
+		}
+		return v.strV, true
+	case '\'':
+		v, err := p.parseSingleQuotedStream()
+		if err != nil || v.incomplete {
+			return "", false
+		}
+		return v.strV, true
+	case '`':
+		return "", false
+	default:
+		key, err := p.parseUnquotedKey()
+		if err != nil {
+			return "", false
+		}
+		return key, true
+	}
+}
+
+// parseDoubleQuotedStream reads a double-quoted string with streaming recovery.
+// A backslash escape or triple-quoted opener still declines (deferred to BAML);
+// an unterminated string keeps its partial content and is marked Incomplete.
+func (p *fixer) parseDoubleQuotedStream() (value, error) {
+	if strings.HasPrefix(p.s[p.pos:], `"""`) {
+		return value{}, errFixUnsupported // triple-quoted string deferred
+	}
+	p.pos++ // consume opening '"'
+	var sb strings.Builder
+	for !p.eof() {
+		c := p.s[p.pos]
+		switch c {
+		case '\\':
+			return value{}, errFixUnsupported // escapes deferred to BAML
+		case '"':
+			p.pos++
+			return value{kind: valString, strV: sb.String()}, nil // complete
+		}
+		sb.WriteByte(c)
+		p.pos++
+	}
+	// Unterminated → keep partial content, mark Incomplete.
+	return value{kind: valString, strV: sb.String(), incomplete: true}, nil
+}
+
+// parseSingleQuotedStream reads a single-quoted string with streaming recovery.
+// A backslash declines (its embedded-quote close heuristic is ambiguous); an
+// unterminated string keeps its partial content and is marked Incomplete.
+func (p *fixer) parseSingleQuotedStream() (value, error) {
+	p.pos++ // consume opening '\''
+	var sb strings.Builder
+	for !p.eof() {
+		c := p.s[p.pos]
+		switch c {
+		case '\\':
+			return value{}, errFixUnsupported
+		case '\'':
+			p.pos++
+			return value{kind: valString, strV: sb.String()}, nil // complete
+		}
+		sb.WriteByte(c)
+		p.pos++
+	}
+	return value{kind: valString, strV: sb.String(), incomplete: true}, nil
+}
+
+// parseUnquotedScalarStream reads a bare scalar value with streaming recovery.
+// It classifies the token like the final parser (true/false/null and strict JSON
+// numbers only; a bareword string declines), but a token that runs to EOF is
+// marked Incomplete rather than declined. The same greedy-object-value comma
+// guard the final parser uses applies (native cannot reproduce BAML's greedy
+// unquoted-object-value scan), and a value followed by a non-terminator non-EOF
+// byte is a missing-comma case that declines.
+func (p *fixer) parseUnquotedScalarStream(term string) (value, error) {
+	start := p.pos
+	for !p.eof() {
+		c := p.s[p.pos]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			break
+		}
+		if strings.IndexByte(term, c) >= 0 {
+			break
+		}
+		if strings.IndexByte(scalarBailBytes, c) >= 0 {
+			return value{}, errFixUnsupported
+		}
+		p.pos++
+	}
+	raw := p.s[start:p.pos]
+	if strings.TrimSpace(raw) == "" {
+		return value{}, errFixUnsupported
+	}
+	p.skipWS()
+	if p.eof() {
+		// Ran to EOF with no terminator → still streaming → Incomplete.
+		v, err := classifyScalar(raw)
+		if err != nil {
+			return value{}, err
+		}
+		v.incomplete = true
+		return v, nil
+	}
+	if strings.IndexByte(term, p.s[p.pos]) < 0 {
+		return value{}, errFixUnsupported // missing comma / junk
+	}
+	if term == objectValueTerm && p.s[p.pos] == ',' {
+		next := p.pos + 1
+		if next >= len(p.s) || (p.s[next] != ' ' && p.s[next] != '\n') {
+			// BAML would consume this comma and read greedily — decline.
+			return value{}, errFixUnsupported
+		}
+	}
+	// Terminated by a proper delimiter → Complete.
+	return classifyScalar(raw)
+}

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -50,7 +50,10 @@ func Parse(ctx context.Context, req bamlutils.DeBAMLParseRequest) (bamlutils.DeB
 	_ = ctx // M1 parsing is a local CPU operation; no cancellation points.
 
 	if req.Stream {
-		return bamlutils.DeBAMLParseResult{}, unsupported("stream parse")
+		// M4b: the native STREAMING (raw_is_done=false) path claims the smallest
+		// useful partial surface; everything outside it declines. Final-parse
+		// behavior below is untouched.
+		return parseStream(req)
 	}
 	if req.OutputSchema == nil {
 		return bamlutils.DeBAMLParseResult{}, unsupported("nil output schema")
@@ -96,6 +99,130 @@ func Parse(ctx context.Context, req bamlutils.DeBAMLParseRequest) (bamlutils.DeB
 
 // Compile-time assertion that Parse satisfies the public callback type.
 var _ bamlutils.DeBAMLParseFunc = Parse
+
+// parseStream is the M4b native streaming (raw_is_done=false) parse path. It
+// claims the SMALLEST useful partial surface: ordinary dynamic partials whose
+// observable output is jsonish recovery + class null-filling, with NO stream
+// annotations and NO displayed StreamState. Everything else DECLINES with the
+// unsupported sentinel so BAML parse-stream stays authoritative.
+//
+// The claim boundary is: a dynamic schema inside the SAME structural cut-line as
+// final parse (checkSupported) AND carrying no stream annotations
+// (checkNoStreamAnnotations — defensive, since the dynamic bridge cannot express
+// them), a candidate the streaming extractor can recover
+// (streamExtractCandidate), and a value coerceStream can reproduce byte-exact
+// (open/repaired root objects after ≥1 field value, truncated/markdown-recovered
+// strings, missing-field null fillers, completed scalar/list children). Anything
+// coerceStream cannot prove — a value BAML would delete (incomplete done-required
+// scalar, semantic child deletion), a StreamState wrapper, a map/union target, an
+// implied-key/inferred class, a still-empty open object — declines. See
+// coerceStream for the per-shape boundary. A non-sentinel error is a CLAIMED
+// stream parse failure (surfaced for parity like the final path); today no
+// claimed shape produces one, so every non-claim is the fallback sentinel.
+func parseStream(req bamlutils.DeBAMLParseRequest) (bamlutils.DeBAMLParseResult, error) {
+	if req.OutputSchema == nil {
+		return bamlutils.DeBAMLParseResult{}, unsupported("nil output schema")
+	}
+	bundle, err := schema.FromDynamicOutputSchema(req.OutputSchema, schema.BuildOptions{})
+	if err != nil {
+		return bamlutils.DeBAMLParseResult{}, unsupportedErr("lower schema", err)
+	}
+	if err := bundle.ValidateOutput(); err != nil {
+		return bamlutils.DeBAMLParseResult{}, unsupportedErr("validate schema", err)
+	}
+	// The structural cut-line is IDENTICAL to final parse (recursive/constraint/
+	// out-of-scope-union/map-key rejection, and the direct list<multi-arm-union>
+	// decline that keeps the deferred array union_variant_hint fallback). Anything
+	// finer is decided at coerce time.
+	if err := checkSupported(bundle); err != nil {
+		return bamlutils.DeBAMLParseResult{}, err
+	}
+	if err := checkNoStreamAnnotations(bundle); err != nil {
+		return bamlutils.DeBAMLParseResult{}, err
+	}
+	v, ok := streamExtractCandidate(req.Raw)
+	if !ok {
+		// No cleanly-recoverable candidate (no JSON-looking content, a just-opened
+		// fence, or a construct outside the streaming fixing subset): BAML may still
+		// recover it, so DECLINE (fall back) rather than claim.
+		return bamlutils.DeBAMLParseResult{}, unsupported("stream: no cleanly-claimable JSON candidate")
+	}
+	out, err := coerceStream(bundle, bundle.Target, v)
+	if err != nil {
+		return bamlutils.DeBAMLParseResult{}, err
+	}
+	return bamlutils.DeBAMLParseResult{JSON: out}, nil
+}
+
+// checkNoStreamAnnotations DECLINES any schema carrying BAML stream metadata —
+// @stream.done / @@stream.done (StreamingBehavior.Done), @stream.not_null
+// (Needed / ClassField.StreamingNeeded), or @stream.with_state (State) — at the
+// class, field, or type level. M4b claims only UNANNOTATED partials; an annotated
+// schema keeps the BAML parse-stream path, whose semantic-deletion / not-null /
+// with-state behavior is M4c/M4d. The dynamic output bridge carries no
+// streaming-annotation channel today (every dynamic class is non-streaming with a
+// zero StreamingBehavior), so this is a defensive guard pinning the boundary
+// rather than a reachable path.
+func checkNoStreamAnnotations(b *schema.Bundle) error {
+	if err := checkTypeNoStream(b.Target); err != nil {
+		return err
+	}
+	for i := range b.Classes {
+		c := &b.Classes[i]
+		if !c.Stream.IsZero() {
+			return unsupported("stream: class-level stream annotation (@@stream.done / @stream.not_null / @stream.with_state)")
+		}
+		for j := range c.Fields {
+			if c.Fields[j].StreamingNeeded {
+				return unsupported("stream: field-level @stream.not_null annotation")
+			}
+			if err := checkTypeNoStream(c.Fields[j].Type); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// checkTypeNoStream walks one type tree rejecting any type-level stream
+// annotation (Type.Meta.Stream). Named class/enum refs are leaves — their
+// definitions are validated via the bundle's class slice in
+// checkNoStreamAnnotations.
+func checkTypeNoStream(t schema.Type) error {
+	if !t.Meta.Stream.IsZero() {
+		return unsupported("stream: type-level stream annotation")
+	}
+	switch t.Kind {
+	case schema.TypeList:
+		if t.Elem != nil {
+			return checkTypeNoStream(*t.Elem)
+		}
+	case schema.TypeMap:
+		if t.Key != nil {
+			if err := checkTypeNoStream(*t.Key); err != nil {
+				return err
+			}
+		}
+		if t.Value != nil {
+			return checkTypeNoStream(*t.Value)
+		}
+	case schema.TypeUnion:
+		if t.Union != nil {
+			for i := range t.Union.Variants {
+				if err := checkTypeNoStream(t.Union.Variants[i]); err != nil {
+					return err
+				}
+			}
+		}
+	case schema.TypeTuple:
+		for i := range t.Items {
+			if err := checkTypeNoStream(t.Items[i]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
 
 // checkSupported reports whether every type reachable from the lowered
 // bundle is inside the M1 coercion cut-line. It walks the synthetic

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -286,12 +286,19 @@ func TestParse_EnumByAlias(t *testing.T) {
 	mustParse(t, s, `{"color":"Verde"}`, `{"color":"GREEN"}`)
 }
 
-func TestParse_UnsupportedStream(t *testing.T) {
-	_, err := Parse(context.Background(), bamlutils.DeBAMLParseRequest{
+// TestParse_StreamCompleteObjectClaimed pins that a fully-closed complete object
+// in stream mode (raw_is_done=false) is now CLAIMED (M4b) and produces the same
+// ordinary output a final parse would — stream == final for a done value. The
+// broader per-prefix claim/decline surface is covered in stream_test.go.
+func TestParse_StreamCompleteObjectClaimed(t *testing.T) {
+	res, err := Parse(context.Background(), bamlutils.DeBAMLParseRequest{
 		Raw: `{"name":"Ada","age":36}`, OutputSchema: personSchema(), Stream: true,
 	})
-	if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
-		t.Fatalf("stream parse: expected ErrDeBAMLParseUnsupported, got %v", err)
+	if err != nil {
+		t.Fatalf("stream parse of complete object: unexpected error: %v", err)
+	}
+	if !jsonValueEqual(t, string(res.JSON), `{"name":"Ada","age":36}`) {
+		t.Fatalf("stream parse of complete object: got %s", res.JSON)
 	}
 }
 

--- a/internal/debaml/stream_test.go
+++ b/internal/debaml/stream_test.go
@@ -1,0 +1,167 @@
+package debaml
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// M4b streaming (raw_is_done=false) native-parse coverage. Each claimed case here
+// mirrors a LIVE-CAPTURED success prefix from the bamlfuzz parse-recovery corpus
+// (adapters/common/codegen/testdata/bamlfuzz/parse_recovery/20..23), so the
+// asserted `want` is BAML v0.223.0 parse-stream's own output — the same value the
+// Docker differential holds native to byte-exact. The declined cases pin the
+// over-claim guards: native FALLS BACK (ErrDeBAMLParseUnsupported) so BAML
+// parse-stream stays authoritative. These local tests prove value parity without
+// BAML/Docker; the integration differential is the final byte-exact gate.
+
+// parseStreamRaw drives the public callback for a streaming request.
+func parseStreamRaw(t *testing.T, s *bamlutils.DynamicOutputSchema, raw string) (string, error) {
+	t.Helper()
+	res, err := Parse(context.Background(), bamlutils.DeBAMLParseRequest{Raw: raw, OutputSchema: s, Stream: true})
+	if err != nil {
+		return "", err
+	}
+	return string(res.JSON), nil
+}
+
+// mustStream asserts a CLAIMED stream parse whose output semantically equals want.
+func mustStream(t *testing.T, s *bamlutils.DynamicOutputSchema, raw, want string) {
+	t.Helper()
+	got, err := parseStreamRaw(t, s, raw)
+	if err != nil {
+		t.Fatalf("stream Parse(%q): unexpected error: %v", raw, err)
+	}
+	if !jsonValueEqual(t, got, want) {
+		t.Errorf("stream Parse(%q):\n got %s\nwant %s", raw, got, want)
+	}
+}
+
+// requireStreamUnsupported asserts native FELL BACK (sentinel), not claimed.
+func requireStreamUnsupported(t *testing.T, s *bamlutils.DynamicOutputSchema, raw string) {
+	t.Helper()
+	_, err := Parse(context.Background(), bamlutils.DeBAMLParseRequest{Raw: raw, OutputSchema: s, Stream: true})
+	if err == nil {
+		t.Fatalf("stream Parse(%q): expected ErrDeBAMLParseUnsupported, got success", raw)
+	}
+	if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+		t.Fatalf("stream Parse(%q): expected ErrDeBAMLParseUnsupported, got %v", raw, err)
+	}
+}
+
+// nameOnlySchema is Root{name:string} — the truncated_string corpus schema.
+func nameOnlySchema() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{Properties: props(kv("name", strProp()))}
+}
+
+// nameTagsSchema is Root{name:string, tags:list<string>} — the trailing_comma
+// corpus schema.
+func nameTagsSchema() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(
+			kv("name", strProp()),
+			kv("tags", &bamlutils.DynamicProperty{Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "string"}}),
+		),
+	}
+}
+
+// --- 20_streaming_growing_object (Root{name:string, age:int}) ---
+
+func TestStream_GrowingObject(t *testing.T) {
+	s := personSchema()
+	// No field value available yet → FALLBACK (open root object before ≥1 field).
+	requireStreamUnsupported(t, s, `{`)
+	requireStreamUnsupported(t, s, `{"name"`)
+	requireStreamUnsupported(t, s, `{"name":`)
+	// ≥1 field value available → CLAIMED, missing fields null-filled.
+	mustStream(t, s, `{"name":"Ad`, `{"name":"Ad","age":null}`)
+	mustStream(t, s, `{"name":"Ada"`, `{"name":"Ada","age":null}`)
+	mustStream(t, s, `{"name":"Ada","age"`, `{"name":"Ada","age":null}`)
+	mustStream(t, s, `{"name":"Ada","age":36}`, `{"name":"Ada","age":36}`)
+}
+
+// --- 21_streaming_markdown_fence (Root{name:string, age:int}) ---
+
+func TestStream_MarkdownFence(t *testing.T) {
+	s := personSchema()
+	// Bare prose / just-opened fence: no JSON content → FALLBACK.
+	requireStreamUnsupported(t, s, "Here you go:\n")
+	requireStreamUnsupported(t, s, "Here you go:\n```json\n")
+	// Object emerging inside the (still-open) fence → CLAIMED.
+	mustStream(t, s, "Here you go:\n```json\n{\"name\":\"Ada\"", `{"name":"Ada","age":null}`)
+	mustStream(t, s, "Here you go:\n```json\n{\"name\":\"Ada\",\"age\":36}", `{"name":"Ada","age":36}`)
+	mustStream(t, s, "Here you go:\n```json\n{\"name\":\"Ada\",\"age\":36}\n```", `{"name":"Ada","age":36}`)
+}
+
+// --- 22_streaming_truncated_string (Root{name:string}) ---
+
+func TestStream_TruncatedString(t *testing.T) {
+	s := nameOnlySchema()
+	// An opened-but-empty string parses as "" (present, incomplete, kept — strings
+	// are not done-required).
+	mustStream(t, s, `{"name":"`, `{"name":""}`)
+	mustStream(t, s, `{"name":"Ad`, `{"name":"Ad"}`)
+	mustStream(t, s, `{"name":"Ada"`, `{"name":"Ada"}`)
+	mustStream(t, s, `{"name":"Ada"}`, `{"name":"Ada"}`)
+}
+
+// --- 23_streaming_trailing_comma (Root{name:string, tags:list<string>}) ---
+
+func TestStream_TrailingComma(t *testing.T) {
+	s := nameTagsSchema()
+	mustStream(t, s, `{"name":"Ada","tags":["x"`, `{"name":"Ada","tags":["x"]}`)
+	mustStream(t, s, `{"name":"Ada","tags":["x","y",`, `{"name":"Ada","tags":["x","y"]}`)
+	mustStream(t, s, `{"name":"Ada","tags":["x","y",]`, `{"name":"Ada","tags":["x","y"]}`)
+	mustStream(t, s, `{"name":"Ada","tags":["x","y",]}`, `{"name":"Ada","tags":["x","y"]}`)
+}
+
+// --- Over-claim guards ---
+
+// TestStream_IncompleteDoneRequiredScalarDeclines pins that an INCOMPLETE
+// done-required scalar (a partial int that never terminates) DECLINES: BAML would
+// DELETE it (semantic streaming), which M4b does not model, so native falls back.
+func TestStream_IncompleteDoneRequiredScalarDeclines(t *testing.T) {
+	s := personSchema()
+	// age=3 runs to EOF inside an unterminated object → Incomplete int → deleted by
+	// BAML → native declines rather than reproduce the deletion.
+	requireStreamUnsupported(t, s, `{"name":"Ada","age":3`)
+	// A trailing comma after an UNQUOTED object value at EOF (`36,`) hits the same
+	// greedy-unquoted-object-value guard the final fixer uses (BAML would consume the
+	// comma and read greedily), so native over-declines it — safe, and not a corpus
+	// prefix (the trailing_comma fixture uses quoted list elements).
+	requireStreamUnsupported(t, s, `{"name":"Ada","age":36,`)
+}
+
+// TestStream_NoStructureDeclines pins that raw text with no recoverable JSON
+// structure falls back (BAML's allow_as_string→class path is not claimed by M4b).
+func TestStream_NoStructureDeclines(t *testing.T) {
+	requireStreamUnsupported(t, personSchema(), "just some prose, no json")
+	requireStreamUnsupported(t, personSchema(), "")
+}
+
+// TestStream_ScalarToClassDeclines pins that a scalar/array into a class declines
+// in stream mode (implied-key / inferred-object / array-to-singular deferred).
+func TestStream_ScalarToClassDeclines(t *testing.T) {
+	requireStreamUnsupported(t, personSchema(), `"hello"`)
+	requireStreamUnsupported(t, personSchema(), `[1,2,3]`)
+}
+
+// TestStream_NilSchemaDeclines pins the nil-schema fallback.
+func TestStream_NilSchemaDeclines(t *testing.T) {
+	_, err := Parse(context.Background(), bamlutils.DeBAMLParseRequest{Raw: `{}`, OutputSchema: nil, Stream: true})
+	if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+		t.Fatalf("nil schema stream: expected ErrDeBAMLParseUnsupported, got %v", err)
+	}
+}
+
+// TestStream_FinalParseUnchanged is a belt-and-suspenders check that the M4b
+// stream path did not alter final (non-stream) parse behavior for the same input.
+func TestStream_FinalParseUnchanged(t *testing.T) {
+	// Final parse of a truncated object still DECLINES (M2a defers unterminated
+	// structures); only the STREAM path recovers it.
+	requireUnsupported(t, personSchema(), `{"name":"Ada"`)
+	// Final parse of a complete object is unchanged.
+	mustParse(t, personSchema(), `{"name":"Ada","age":36}`, `{"name":"Ada","age":36}`)
+}

--- a/internal/debaml/value.go
+++ b/internal/debaml/value.go
@@ -59,6 +59,17 @@ type value struct {
 	strV  string
 	arrV  []value
 	objV  []field
+
+	// incomplete records BAML's jsonish CompletionState::Incomplete for a value
+	// recovered under raw_is_done=false (M4b stream parse). It is set ONLY by the
+	// streaming fixing parser (see streamFix in fix.go): a container/string/scalar
+	// closed by EOF rather than its proper delimiter, and the last (still-building)
+	// value inside an unterminated container, are Incomplete. The final (strict /
+	// M2a fixing) decoders never set it — every value they produce is complete —
+	// so final-parse behavior is unchanged. Stream coercion uses it to DECLINE an
+	// incomplete value whose type requires done (semantic streaming would delete
+	// it), which M4b does not model. See coerceStream in coerce.go.
+	incomplete bool
 }
 
 // field is one ordered object entry. Duplicate keys are allowed (the


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## de-BAML P4 M4b — basic `raw_is_done=false` native partials without stream annotations

Claims the **smallest useful native streaming surface**. `internal/debaml.Parse(... Stream=true ...)` stops blanket-declining and now **claims** ordinary dynamic partials whose observable behavior is jsonish recovery + class null-filling, **without** stream annotations or displayed stream state. Everything else declines with the unsupported sentinel so BAML parse-stream stays authoritative. Over-decline is safe; over-claim is a bug.

### Native streaming path (`internal/debaml`)
- `value.incomplete` carries BAML's `CompletionState::Incomplete`, set **only** by the streaming fixing parser — the final decoders never set it, so **final parse is unchanged**.
- `streamFix` / `streamExtractCandidate` recover incomplete JSON the way BAML's jsonish closes it under `raw_is_done=false`: open objects/arrays/strings closed at EOF, dangling keys/colons dropped, trailing commas dropped, markdown fence open-to-EOF, and per-value completion tagging (the last child of an unterminated container is Incomplete; properly-terminated siblings stay Complete).
- `coerceStream` models the `semantic_streaming.rs` subset whose output is an ordinary object/list/string with **no `StreamState` wrappers**: null-fill missing class fields (Pending null), keep truncated/markdown-recovered strings (not done-required), keep completed scalar/list children, and reuse the final leaf coercers for a **complete** done-required value (stream == final for a done value).
- **Declines** (fall back to BAML): an incomplete done-required scalar (BAML would delete it), any semantic child deletion, an open root object before ≥1 field value, scalar/array→class, a map/union target, and — via the shared `checkSupported` gate — a direct `list<multi-arm-union>` element (M3-deferred cross-element `union_variant_hint`). A defensive `checkNoStreamAnnotations` declines `@stream.done` / `@stream.not_null` / `@stream.with_state`, which the dynamic bridge cannot express today.

### Runtime streaming is unchanged
The generated `parseStreamFn` still calls BAML `ParseStream` directly — native-first parse-stream rollout is **M4d**. M4b is parser-differential work only.

### Corpus (`BAMLFUZZ_PARSE_CAPTURE=1`, live-captured — never hand-written)
- Flipped the live-captured success prefixes of the M4a streaming fixtures (growing-object, markdown-fence, truncated-string, trailing-comma) from skip to **claimed** via `parseRecoveryStreamNativeClaim`; the no-field-value prefixes (bare open brace / dangling key / colon, bare prose / just-opened fence) stay fallback.
- Added `anyof_string_no_leak`: a truncated string value literally containing `AnyOf[` surfaces as the **string value**, never an `AnyOf[...]` rendering.
- Added `list_multi_arm_union_stream`: a **negative guard** that stays native-skipped.

### Validation
- `gofmt`, `go build ./...`, `go vet ./...` (+ `-tags=integration`), `go test ./internal/debaml/...`, `GOWORK=off go test ./codegen` (from `adapters/common`) — all green.
- bamlfuzz parse-recovery differential (Docker, BAML v0.223.0): newly-claimed prefixes match BAML byte-exact; everything else still declined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partial streaming parse recovery, allowing some in-progress inputs to produce usable output instead of failing.
  * Improved handling of incomplete objects, arrays, strings, fenced text, and mixed JSON-like content during streaming parses.
  * Added broader coverage for streaming recovery scenarios, including lists, unions, and string content that should remain literal.

* **Bug Fixes**
  * Reduced false fallbacks for fully complete streamed objects.
  * Tightened streaming claims so unsupported or ambiguous inputs still decline safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->