### PR TITLE
debaml: semantic streaming without displayed stream-state wrappers (M4 slice c)

### DIFF
--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/173_streaming_numbers_list_int.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/173_streaming_numbers_list_int.json
@@ -1,0 +1,25 @@
+{
+  "name": "streaming_numbers_list_int",
+  "description": "NUMBERS semantic-streaming behavior for Root{nums:list<int>}: a partial integer-list prefix KEEPS completed (comma-terminated) elements and DROPS the incomplete done-required trailing element (int is done-required, list is not — semantic_streaming.rs process_node List arm filter_map). Per-prefix `want` values are LIVE-CAPTURED from BAML v0.223.0 parse-stream (BAMLFUZZ_PARSE_CAPTURE=1), not hand-written. M4c native CLAIMS these (the intrinsic required-done child deletion is annotation-free and representable in the plain dynamic schema).",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "nums", "type": {"kind": "list", "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "prefixes": [
+    {"name": "open_list", "raw": "{\"nums\":[", "want": {"status": "success", "json": {"nums": []}}},
+    {"name": "one_partial", "raw": "{\"nums\":[1", "want": {"status": "success", "json": {"nums": []}}},
+    {"name": "one_done", "raw": "{\"nums\":[1,", "want": {"status": "success", "json": {"nums": [1]}}},
+    {"name": "two_partial", "raw": "{\"nums\":[1,2", "want": {"status": "success", "json": {"nums": [1]}}},
+    {"name": "three_partial", "raw": "{\"nums\":[1,2,3", "want": {"status": "success", "json": {"nums": [1, 2]}}},
+    {"name": "list_closed", "raw": "{\"nums\":[1,2,3]", "want": {"status": "success", "json": {"nums": [1, 2, 3]}}},
+    {"name": "object_closed", "raw": "{\"nums\":[1,2,3]}", "want": {"status": "success", "json": {"nums": [1, 2, 3]}}}
+  ]
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/174_streaming_class_incomplete_scalar_field.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/174_streaming_class_incomplete_scalar_field.json
@@ -1,0 +1,22 @@
+{
+  "name": "streaming_class_incomplete_scalar_field",
+  "description": "Class field null-replacement for Root{name:string, age:int}: an INCOMPLETE done-required int field is DELETED by semantic streaming and, as a class field, REPLACED WITH NULL (semantic_streaming.rs deletion_nulls), while a completed string sibling is kept. Distinguishes a string field (not done-required, partial value shown) from an int field (done-required, incomplete -> null). Per-prefix `want` values are LIVE-CAPTURED from BAML v0.223.0 parse-stream (BAMLFUZZ_PARSE_CAPTURE=1), not hand-written.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "name", "type": {"kind": "string"}},
+          {"name": "age", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "prefixes": [
+    {"name": "name_done_age_partial", "raw": "{\"name\":\"Ada\",\"age\":3", "want": {"status": "success", "json": {"name": "Ada", "age": null}}},
+    {"name": "name_done_age_more_digits", "raw": "{\"name\":\"Ada\",\"age\":36", "want": {"status": "success", "json": {"name": "Ada", "age": null}}},
+    {"name": "age_closed", "raw": "{\"name\":\"Ada\",\"age\":36}", "want": {"status": "success", "json": {"name": "Ada", "age": 36}}}
+  ]
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/175_streaming_list_class_partial_field.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/175_streaming_list_class_partial_field.json
@@ -1,0 +1,27 @@
+{
+  "name": "streaming_list_class_partial_field",
+  "description": "Nested class-in-list: Root{items:list<Inner>}, Inner{a:int}. A completed list element remains; a still-streaming trailing class element is KEPT (a class is NOT done-required) with its incomplete done-required int field NULL-REPLACED. This is the annotation-free reachable analogue of 'nested done-class-in-list' (BAML's dynamic TypeBuilder cannot express @@stream.done, so a class element is never itself dropped). Per-prefix `want` values are LIVE-CAPTURED from BAML v0.223.0 parse-stream (BAMLFUZZ_PARSE_CAPTURE=1), not hand-written.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "items", "type": {"kind": "list", "inner": {"kind": "class_ref", "ref": "Inner"}}}
+        ]
+      },
+      {
+        "name": "Inner",
+        "properties": [
+          {"name": "a", "type": {"kind": "int"}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "prefixes": [
+    {"name": "first_done_second_partial", "raw": "{\"items\":[{\"a\":1},{\"a\":2", "want": {"status": "success", "json": {"items": [{"a": 1}, {"a": null}]}}},
+    {"name": "second_closed", "raw": "{\"items\":[{\"a\":1},{\"a\":2}", "want": {"status": "success", "json": {"items": [{"a": 1}, {"a": 2}]}}},
+    {"name": "list_closed", "raw": "{\"items\":[{\"a\":1},{\"a\":2}]", "want": {"status": "success", "json": {"items": [{"a": 1}, {"a": 2}]}}}
+  ]
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/176_streaming_map_int_partial.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/176_streaming_map_int_partial.json
@@ -1,0 +1,21 @@
+{
+  "name": "streaming_map_int_partial",
+  "description": "Map value drop for Root{m:map<string,int>}: an entry whose done-required int value is INCOMPLETE has the WHOLE key/value pair DROPPED (semantic_streaming.rs Map arm filter_map — never null-kept, unlike a class field), while completed sibling entries stay in input key order. Raws keep a space after the comma so the unquoted object value stays out of streamFix's greedy-tight-comma decline. Per-prefix `want` values are LIVE-CAPTURED from BAML v0.223.0 parse-stream (BAMLFUZZ_PARSE_CAPTURE=1), not hand-written.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "m", "type": {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "int"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "prefixes": [
+    {"name": "one_done_two_partial", "raw": "{\"m\":{\"a\":1, \"b\":2", "want": {"status": "success", "json": {"m": {"a": 1}}}},
+    {"name": "two_closed", "raw": "{\"m\":{\"a\":1, \"b\":2}", "want": {"status": "success", "json": {"m": {"a": 1, "b": 2}}}},
+    {"name": "map_closed", "raw": "{\"m\":{\"a\":1, \"b\":2}}", "want": {"status": "success", "json": {"m": {"a": 1, "b": 2}}}}
+  ]
+}

--- a/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/177_streaming_missing_field_fillers.json
+++ b/adapters/common/codegen/testdata/bamlfuzz/parse_recovery/177_streaming_missing_field_fillers.json
@@ -1,0 +1,24 @@
+{
+  "name": "streaming_missing_field_fillers",
+  "description": "Missing-field fillers for Root{a:int, tags:list<string>, scores:map<string,int>, note:string?}: only `a` streams; tags/scores/note never appear. BAML fills each missing field with its TypeIR::default_value (LIVE-CAPTURED: required list→[], required map→{}, optional→null) rather than a blanket null — the streaming filler reuses the coercion-layer default fill. Per-prefix `want` values are LIVE-CAPTURED from BAML v0.223.0 parse-stream (BAMLFUZZ_PARSE_CAPTURE=1), not hand-written; the native disposition is pinned from the capture.",
+  "preserve_schema_order": true,
+  "schema": {
+    "classes": [
+      {
+        "name": "Root",
+        "properties": [
+          {"name": "a", "type": {"kind": "int"}},
+          {"name": "tags", "type": {"kind": "list", "inner": {"kind": "string"}}},
+          {"name": "scores", "type": {"kind": "map", "key": {"kind": "string"}, "inner": {"kind": "int"}}},
+          {"name": "note", "type": {"kind": "optional", "inner": {"kind": "string"}}}
+        ]
+      }
+    ],
+    "root_class": "Root"
+  },
+  "prefixes": [
+    {"name": "key_only", "raw": "{\"a\"", "want": {"status": "success", "json": {"a": null, "tags": [], "scores": {}, "note": null}}},
+    {"name": "a_partial", "raw": "{\"a\":1", "want": {"status": "success", "json": {"a": null, "tags": [], "scores": {}, "note": null}}},
+    {"name": "a_closed", "raw": "{\"a\":1}", "want": {"status": "success", "json": {"a": 1, "tags": [], "scores": {}, "note": null}}}
+  ]
+}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -634,6 +634,64 @@ var parseRecoveryStreamNativeClaim = map[string]map[string]bool{
 	// cross-element union_variant_hint (coerce_array.rs) was intentionally deferred
 	// after M3, so native declines at the gate (checkSupported) on every prefix and
 	// BAML parse-stream stays authoritative. No prefix is claimed (absent → false).
+
+	// --- M4c: annotation-free semantic streaming (required-done child deletion,
+	// class field null-replacement, map entry drop, Pending fillers). These flip
+	// prefixes M4b DECLINED (an incomplete done-required child that BAML DELETES) to
+	// CLAIMED: native now reproduces the deletion/null-replacement byte-exact. The
+	// annotation-DEPENDENT behavior (@stream.done / @@stream.done / @stream.not_null /
+	// @stream.with_state) stays fallback and has NO fixture — BAML's dynamic
+	// TypeBuilder cannot attach those annotations, so neither the BAML oracle nor the
+	// native bridge can carry them (nothing to differential-test).
+
+	// 173_streaming_numbers_list_int (Root{nums:list<int>}). int is done-required, so
+	// a still-streaming trailing element is DROPPED and completed (comma-terminated)
+	// elements are kept; the list itself is not done-required.
+	"streaming_numbers_list_int": {
+		"open_list":     true,
+		"one_partial":   true,
+		"one_done":      true,
+		"two_partial":   true,
+		"three_partial": true,
+		"list_closed":   true,
+		"object_closed": true,
+	},
+	// 174_streaming_class_incomplete_scalar_field (Root{name:string, age:int}). An
+	// incomplete done-required int class field is NULL-REPLACED; the completed string
+	// sibling is kept; the closed int is kept.
+	"streaming_class_incomplete_scalar_field": {
+		"name_done_age_partial":     true,
+		"name_done_age_more_digits": true,
+		"age_closed":                true,
+	},
+	// 175_streaming_list_class_partial_field (Root{items:list<Inner{a:int}>}). A
+	// partial trailing class element is KEPT (class not done-required) with its
+	// incomplete int field null-replaced; completed elements remain.
+	"streaming_list_class_partial_field": {
+		"first_done_second_partial": true,
+		"second_closed":             true,
+		"list_closed":               true,
+	},
+	// 176_streaming_map_int_partial (Root{m:map<string,int>}). An entry whose
+	// incomplete done-required int value is dropped WHOLE (key+value); completed
+	// entries stay in input key order.
+	"streaming_map_int_partial": {
+		"one_done_two_partial": true,
+		"two_closed":           true,
+		"map_closed":           true,
+	},
+	// 177_streaming_missing_field_fillers (Root{a:int, tags:list<string>,
+	// scores:map<string,int>, note:string?}). Missing fields are filled with BAML's
+	// TypeIR::default_value (LIVE-CAPTURED: required list→[], required map→{},
+	// optional→null), NOT null. key_only (`{"a"`) has no field value yet → native
+	// over-declines (the ≥1-present-field guard, BAML still succeeds). a_partial
+	// (`{"a":1`) has an incomplete int → deleted → a:null with the default fillers;
+	// a_closed (`{"a":1}`) has the completed int → a:1. Both claimed.
+	"streaming_missing_field_fillers": {
+		"key_only":  false,
+		"a_partial": true,
+		"a_closed":  true,
+	},
 }
 
 // streamPrefixNativeClaim returns the expected native disposition for one

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -3231,31 +3231,67 @@ func declineCoerce(target string, input value) error {
 
 // --- M4b: streaming (raw_is_done=false) coercion --------------------------
 //
+// errStreamDeleted is an INTERNAL sentinel (never surfaced to a Parse caller) a
+// coerceStream* function returns for a value BAML's semantic streaming DELETES: an
+// INCOMPLETE value whose type is done-required, which semantic_streaming.rs
+// process_node errors (`must_be_done && state != Complete → Err(IncompleteDoneValue)`).
+// It is DISTINCT from bamlutils.ErrDeBAMLParseUnsupported: a deletion is a PROVEN
+// BAML behavior native REPRODUCES (drop the list/map child, null-replace the class
+// field), whereas the unsupported sentinel means native cannot prove BAML's output
+// and must FALL BACK. Each container inspects its child's error:
+//
+//   - errStreamDeleted            → child deleted (list/map drop, class null-fill);
+//   - ErrDeBAMLParseUnsupported   → native cannot prove the child → the WHOLE stream
+//     parse falls back (propagated up unchanged);
+//   - any other error             → a CLAIMED parse failure, propagated for parity.
+//
+// It never escapes coerceStream: the top-level target is always the synthetic
+// Baml_Rest_DynamicOutput CLASS (a class is never done-required), whose
+// coerceStreamClass converts every child deletion into a null field — so a stray
+// errStreamDeleted reaching parseStream would be an invariant bug, not a claim.
+var errStreamDeleted = errors.New("debaml: stream value deleted by semantic streaming")
+
 // coerceStream coerces a value recovered by the streaming parser
 // (streamExtractCandidate / streamFix) into the flattened dynamic output JSON for
-// type t. It models the SUBSET of BAML's semantic_streaming.rs whose observable
-// output for an UNANNOTATED dynamic schema is an ordinary object/list/string with
-// NO StreamState wrappers:
+// type t. It ports the ANNOTATION-FREE slice of BAML's semantic_streaming.rs
+// process_node (M4c) whose observable output for a dynamic schema is an ordinary
+// object/list/map/string with NO StreamState wrappers.
 //
-//   - class: assign present object keys to fields (BAML's input-key-first fuzzy
-//     match), coerce each present field's value through coerceStream, and NULL-FILL
-//     every MISSING field (BAML's Pending null under raw_is_done=false). Requires at
-//     least one field to receive a present value — see coerceStreamClass.
-//   - list: coerce each element through coerceStream and keep it; a non-array input
-//     or an element BAML would DELETE declines the whole list — see coerceStreamList.
-//   - string: NOT done-required, so a JSON string is emitted as-is whether COMPLETE
-//     or INCOMPLETE (a truncated / markdown-recovered string keeps its partial value).
-//     This is the "AnyOf string does not leak" surface: native carries the string
-//     value directly, so the output is the string, never an AnyOf rendering. A
-//     non-string into a string target declines (stream JsonToString deferred).
-//   - int / float / bool / null / enum / literal (DONE-REQUIRED): an INCOMPLETE value
-//     DECLINES (BAML deletes it — semantic deletion is M4c); a COMPLETE value is
-//     coerced through the SAME final leaf coercer (stream == final for a done value).
-//   - map / union: DECLINE (deferred — over-decline is safe).
+// The dynamic output bridge (bamlutils.DynamicOutputSchema) carries no streaming-
+// annotation channel: BAML's dynamic TypeBuilder cannot attach @stream.done,
+// @@stream.done, @stream.not_null, or @stream.with_state to a dynamically-built
+// field/class (ClassPropertyBuilder exposes only SetType / description / alias), and
+// schema.FromDynamicOutputSchema lowers every class non-streaming with a zero
+// StreamingBehavior. So for a dynamic schema BAML's OWN parse-stream also sees no
+// annotations: process_node's `must_be_done` collapses to the INTRINSIC required-done
+// TYPE TABLE (semantic_streaming.rs required_done) — int / float / bool / enum /
+// literal / null / media require done; string / list / map / class / tuple /
+// recursive-alias do NOT — and needed_fields (@stream.not_null) is empty, so a class
+// never errors from a missing needed field. M4c models exactly that intrinsic
+// behavior; any annotation-dependent behavior is NOT representable and stays BAML's
+// job (checkNoStreamAnnotations is a defensive gate; a union target still declines).
 //
-// Every path either reproduces BAML's exact partial output or DECLINES
-// (ErrDeBAMLParseUnsupported → fall back to BAML). It never claims a value BAML
-// would delete, wrap in StreamState, or produce differently.
+// process_node's KEEP / DELETE / NULL-REPLACE decisions, ported per container:
+//
+//   - int / float / bool / null / enum / literal / media (DONE-REQUIRED leaf): a
+//     COMPLETE value coerces through the SAME final leaf coercer (stream == final for
+//     a done value); an INCOMPLETE value is DELETED (errStreamDeleted) — process_node
+//     errors it, and the parent drops/null-fills — see coerceStreamDoneLeaf.
+//   - string: NOT done-required, emitted as-is whether COMPLETE or INCOMPLETE (a
+//     truncated / markdown-recovered string keeps its partial value; the "AnyOf
+//     string does not leak" surface). A non-string into a string target declines.
+//   - list: coerce each element; KEEP a coerced element, DROP a DELETED element,
+//     keeping completed siblings in BAML order — see coerceStreamList.
+//   - map: same as list, but a DELETED value drops the WHOLE entry — coerceStreamMap.
+//   - class: assign present keys to fields, coerce each; a DELETED field value is
+//     REPLACED WITH NULL, a MISSING field is NULL-FILLED (Pending), fields emitted in
+//     class-definition order — see coerceStreamClass.
+//   - union: DECLINE (mixed/composite union semantic streaming stays fallback — the
+//     variant-dependent required_done and array union_variant_hint are not modeled).
+//
+// A child that DECLINES with ErrDeBAMLParseUnsupported (native cannot prove BAML's
+// output) propagates unchanged so the WHOLE stream parse falls back; a deletion is a
+// proven behavior native reproduces. Over-decline is safe; over-claim is a bug.
 func coerceStream(b *schema.Bundle, t schema.Type, input value) (json.RawMessage, error) {
 	switch t.Kind {
 	case schema.TypePrimitive:
@@ -3273,23 +3309,27 @@ func coerceStream(b *schema.Bundle, t schema.Type, input value) (json.RawMessage
 	case schema.TypeList:
 		return coerceStreamList(b, t.Elem, input)
 	case schema.TypeMap:
-		return nil, unsupported("stream: map target (deferred)")
+		return coerceStreamMap(b, t.Key, t.Value, input)
 	case schema.TypeUnion:
-		return nil, unsupported("stream: union target (deferred)")
+		return nil, unsupported("stream: union target (mixed-union semantic streaming deferred)")
 	default:
 		return nil, unsupported(fmt.Sprintf("stream: type kind %q", t.Kind))
 	}
 }
 
 // coerceStreamDoneLeaf coerces a DONE-REQUIRED leaf (int / float / bool / null /
-// enum / literal) in stream mode. An INCOMPLETE value would be DELETED by BAML's
-// semantic streaming (the type requires done), which M4b does not model, so it
-// DECLINES. A COMPLETE value is coerced through the SAME final leaf coercer — for
-// a done value stream and final coercion are identical — and any final decline or
-// proven error DECLINES the whole stream parse (fall back to BAML).
+// enum / literal / media) in stream mode, porting semantic_streaming.rs
+// process_node's done-check for a leaf. An INCOMPLETE value FAILS the check
+// (must_be_done && state != Complete → Err(IncompleteDoneValue)): BAML DELETES it,
+// so this returns errStreamDeleted and the parent container drops it (list/map) or
+// null-replaces it (class). A COMPLETE value is coerced through the SAME final leaf
+// coercer — for a done value stream and final coercion are identical — and a final
+// DECLINE / proven error DECLINES the whole stream parse (fall back): the leaf sits
+// below semantic streaming, so native cannot prove whether BAML's coercion-layer
+// skip (ArrayItemParseError) or default-fill would fire, and over-declines instead.
 func coerceStreamDoneLeaf(b *schema.Bundle, t schema.Type, input value) (json.RawMessage, error) {
 	if input.incomplete {
-		return nil, unsupported(fmt.Sprintf("stream: incomplete %s value requires done (semantic deletion deferred)", t.Kind))
+		return nil, errStreamDeleted
 	}
 	out, err := coerce(b, t, input, &coerceFlags{})
 	if err != nil {
@@ -3299,23 +3339,34 @@ func coerceStreamDoneLeaf(b *schema.Bundle, t schema.Type, input value) (json.Ra
 }
 
 // coerceStreamClass coerces an object into a class in stream mode, porting the
-// slice of coerce_class.rs whose streaming output is an ordinary object: assign
-// present input keys to fields (BAML's input-key-first fuzzy match, keep-first on
-// duplicates, extra keys ignored), coerce each present field's value through
-// coerceStream, and NULL-FILL every field with no present value (BAML's Pending
-// null under raw_is_done=false — emitted as an explicit null in schema declaration
-// order, so it survives the downstream InjectAbsentOptionals + reorder identically
-// to BAML's flattened output).
+// annotation-free slice of semantic_streaming.rs process_node's Class arm together
+// with the coerce_class.rs field assignment: assign present input keys to fields
+// (BAML's input-key-first fuzzy match, keep-first on duplicates, extra keys ignored),
+// coerce each present field's value through coerceStream, and emit every field in
+// class-definition order. A field's value becomes null in two BAML cases, both an
+// explicit null here:
 //
-// It DECLINES (fall back) for the shapes M4b does not model:
+//   - MISSING field (no input key matched): NULL-FILLED with BAML's Pending null
+//     (fields_needing_null_filler → Null{state: Pending});
+//   - DELETED field value (coerceStream returns errStreamDeleted — an incomplete
+//     done-required field value process_node errors): REPLACED WITH NULL
+//     (deletion_nulls), never dropped — a class field is null-replaced, not removed.
+//
+// Both survive the downstream InjectAbsentOptionals + reorder identically to BAML's
+// flattened output. Because the dynamic bridge carries no @stream.not_null,
+// needed_fields is empty, so a class never errors from a missing needed field (that
+// MissingNeededFields → whole-class null/drop path is not representable here).
+//
+// It DECLINES (fall back) for the shapes M4c does not model:
 //   - NON-object input (a scalar/array → class implied-key / inferred-object /
 //     array-to-singular is deferred);
 //   - a class where NO field received a present value — the "open/repaired root
 //     object AFTER ≥1 field value is available" guard: a bare `{`, a key with no
-//     value, a dangling colon, or an all-extra-keys object stays fallback;
-//   - a present field whose value does not cleanly coerce in stream (an incomplete
-//     done-required field, a deferred leaf conversion) — its decline propagates and
-//     the whole class falls back;
+//     value, a dangling colon, or an all-extra-keys object stays fallback (a matched
+//     field whose value is DELETED still counts as present, so it is claimed);
+//   - a present field whose value DECLINES in stream with the unsupported sentinel (a
+//     complete leaf that does not cleanly coerce, a deferred conversion) — its
+//     decline propagates and the whole class falls back;
 //   - a field-key match that hinges on a non-ASCII case fold native cannot prove
 //     equals BAML.
 func coerceStreamClass(b *schema.Bundle, name string, mode schema.StreamingMode, input value) (json.RawMessage, error) {
@@ -3371,29 +3422,69 @@ func coerceStreamClass(b *schema.Bundle, name string, mode schema.StreamingMode,
 		buf.WriteByte(':')
 		if matched[j] {
 			o, err := coerceStream(b, cls.Fields[j].Type, assigned[j])
-			if err != nil {
+			switch {
+			case err == nil:
+				buf.Write(o)
+			case errors.Is(err, errStreamDeleted):
+				// Field value DELETED by semantic streaming (incomplete done-required)
+				// → BAML's deletion_nulls: the field is REPLACED WITH NULL, not dropped.
+				buf.WriteString("null")
+			default:
+				// Unsupported → whole class falls back; a claimed error propagates.
 				return nil, err
 			}
-			buf.Write(o)
 		} else {
-			buf.WriteString("null") // BAML Pending null for a missing field.
+			buf.Write(streamMissingFieldFiller(cls.Fields[j].Type))
 		}
 	}
 	buf.WriteByte('}')
 	return buf.Bytes(), nil
 }
 
-// coerceStreamList coerces an array into a list in stream mode. Each element is
-// coerced through coerceStream and KEPT; the list is emitted in element order. A
-// list is never done-required, so an unterminated (Incomplete) list is fine as
-// long as every element it contains cleanly coerces.
+// streamMissingFieldFiller returns BAML's streaming filler value for a class field
+// absent from the stream, matching semantic_streaming.rs fields_needing_null_filler
+// composed with the coercion-layer default fill (coerce_class.rs) — the SAME
+// TypeIR::default_value the FINAL missing-field pass uses (defaultValue), differing
+// only in that streaming TOLERATES a missing required field rather than erroring:
 //
-// It DECLINES (fall back) for the cases M4b does not model:
+//   - OPTIONAL field → null (OptionalDefaultFromNoValue + Pending);
+//   - REQUIRED field with a default_value → that default (list→[], map→{},
+//     primitive-null→null, first-defaultable-union-arm, tuple — DefaultFromNoValue +
+//     Pending);
+//   - REQUIRED non-defaultable field (scalar / enum / literal / class) → null (the
+//     Pending null-filler; final parse would error, streaming null-fills).
+//
+// This is why a missing required list field surfaces as [] and a missing required map
+// as {} in BAML parse-stream (LIVE-CAPTURED — see corpus 177), not null. A DELETED
+// field (present but incomplete done-required) is null-replaced separately
+// (deletion_nulls), never routed here; those types are never defaultable anyway.
+func streamMissingFieldFiller(ft schema.Type) json.RawMessage {
+	if isOptional(ft) {
+		return json.RawMessage("null")
+	}
+	if d, ok := defaultValue(ft); ok {
+		return d
+	}
+	return json.RawMessage("null")
+}
+
+// coerceStreamList coerces an array into a list in stream mode, porting
+// semantic_streaming.rs process_node's List arm (filter_map over the children,
+// dropping any that error). A list is never done-required, so an unterminated
+// (Incomplete) list is fine; each element is coerced through coerceStream and:
+//
+//   - KEPT (in element order) when it coerces;
+//   - DROPPED when it is DELETED by semantic streaming (errStreamDeleted — an
+//     incomplete done-required element), keeping completed siblings in BAML order.
+//     This is the NUMBERS behavior: int[] streaming `[1,2` keeps 1 and drops the
+//     still-building 2.
+//
+// It DECLINES (fall back) for the cases M4c does not model:
 //   - a NON-array input (SingleToArray wrapping is deferred);
-//   - an element that would be DELETED by semantic streaming — coerceStream on the
-//     element declines (an incomplete done-required element, or a value the leaf
-//     coercer cannot cleanly claim / BAML would skip) — so the WHOLE list falls back
-//     rather than reproduce the semantic child deletion (M4c).
+//   - an element that returns ErrDeBAMLParseUnsupported — native cannot prove BAML's
+//     output for it (a complete leaf that does not cleanly coerce, whose
+//     coercion-layer ArrayItemParseError skip-vs-keep native does not model in
+//     stream) — so the WHOLE list falls back; a claimed element error propagates.
 func coerceStreamList(b *schema.Bundle, elem *schema.Type, input value) (json.RawMessage, error) {
 	if elem == nil {
 		return nil, fmt.Errorf("debaml: list type missing element")
@@ -3403,16 +3494,85 @@ func coerceStreamList(b *schema.Bundle, elem *schema.Type, input value) (json.Ra
 	}
 	var buf bytes.Buffer
 	buf.WriteByte('[')
+	first := true
 	for i := range input.arrV {
-		if i > 0 {
-			buf.WriteByte(',')
-		}
 		o, err := coerceStream(b, *elem, input.arrV[i])
 		if err != nil {
-			return nil, err
+			if errors.Is(err, errStreamDeleted) {
+				continue // semantic-streaming deletion: drop the element, keep siblings.
+			}
+			return nil, err // unsupported → whole list falls back; claimed error → propagate.
 		}
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
 		buf.Write(o)
 	}
 	buf.WriteByte(']')
+	return buf.Bytes(), nil
+}
+
+// coerceStreamMap coerces an object into a map in stream mode, porting
+// semantic_streaming.rs process_node's Map arm (filter_map over the entries,
+// dropping any whose VALUE errors — the WHOLE key/value pair is removed, never
+// null-kept, unlike a class field). A map is never done-required.
+//
+// It is restricted to the SIMPLE reachable subset — a STRING key (every key valid)
+// and no duplicate keys — where native reproduces BAML's partial map byte-exact.
+// A non-string key (enum / literal / string-literal union, whose dynamic lenient
+// key-keep / MapKeyParseError semantics are Mcoerce-d / unproven in stream) and a
+// duplicate key (insert/overwrite ordering unproven) DECLINE the whole map. Entries
+// are emitted in INPUT key order under their ORIGINAL key strings.
+//
+//   - KEPT: an entry whose value coerces;
+//   - DROPPED: an entry whose value is DELETED by semantic streaming
+//     (errStreamDeleted — an incomplete done-required value), keeping siblings;
+//   - WHOLE map DECLINES: a non-object input, a non-string key, a duplicate key, or a
+//     value that returns ErrDeBAMLParseUnsupported / a claimed error.
+func coerceStreamMap(b *schema.Bundle, keyT, valT *schema.Type, input value) (json.RawMessage, error) {
+	if keyT == nil || valT == nil {
+		return nil, fmt.Errorf("debaml: map type missing key or value")
+	}
+	if input.kind != valObject {
+		return nil, unsupported(fmt.Sprintf("stream: map from %s (ObjectToMap of non-object deferred)", input.kind))
+	}
+	if keyT.Kind != schema.TypePrimitive || keyT.Primitive != schema.PrimitiveString {
+		return nil, unsupported("stream: map with non-string key (enum/literal key dynamic-keep unproven in stream)")
+	}
+	// Any DUPLICATE original key declines the whole map (mirrors coerceMap): BAML's
+	// duplicate insert/overwrite ordering is unproven, so native never claims it.
+	seen := make(map[string]struct{}, len(input.objV))
+	for i := range input.objV {
+		if _, dup := seen[input.objV[i].key]; dup {
+			return nil, unsupported(fmt.Sprintf("stream: map duplicate key %q (insert/overwrite ordering unproven)", input.objV[i].key))
+		}
+		seen[input.objV[i].key] = struct{}{}
+	}
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	first := true
+	for i := range input.objV {
+		f := &input.objV[i]
+		o, err := coerceStream(b, *valT, f.val)
+		if err != nil {
+			if errors.Is(err, errStreamDeleted) {
+				continue // value deleted → drop the WHOLE entry, keep siblings.
+			}
+			return nil, err // unsupported → whole map falls back; claimed error → propagate.
+		}
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		key, err := marshalJSON(f.key)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(key)
+		buf.WriteByte(':')
+		buf.Write(o)
+	}
+	buf.WriteByte('}')
 	return buf.Bytes(), nil
 }

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -50,9 +50,11 @@ func Parse(ctx context.Context, req bamlutils.DeBAMLParseRequest) (bamlutils.DeB
 	_ = ctx // M1 parsing is a local CPU operation; no cancellation points.
 
 	if req.Stream {
-		// M4b: the native STREAMING (raw_is_done=false) path claims the smallest
-		// useful partial surface; everything outside it declines. Final-parse
-		// behavior below is untouched.
+		// M4b/M4c: the native STREAMING (raw_is_done=false) path claims the basic
+		// partial surface PLUS the annotation-free semantic-streaming shape
+		// (required-done child deletion, class field null-replacement, Pending
+		// fillers); everything outside it declines. Final-parse behavior below is
+		// untouched.
 		return parseStream(req)
 	}
 	if req.OutputSchema == nil {
@@ -100,25 +102,29 @@ func Parse(ctx context.Context, req bamlutils.DeBAMLParseRequest) (bamlutils.DeB
 // Compile-time assertion that Parse satisfies the public callback type.
 var _ bamlutils.DeBAMLParseFunc = Parse
 
-// parseStream is the M4b native streaming (raw_is_done=false) parse path. It
-// claims the SMALLEST useful partial surface: ordinary dynamic partials whose
-// observable output is jsonish recovery + class null-filling, with NO stream
-// annotations and NO displayed StreamState. Everything else DECLINES with the
-// unsupported sentinel so BAML parse-stream stays authoritative.
+// parseStream is the M4b/M4c native streaming (raw_is_done=false) parse path. It
+// claims the basic partial surface (jsonish recovery + class null-filling) PLUS the
+// ANNOTATION-FREE slice of BAML's semantic streaming — the required-done child
+// deletion, class field null-replacement, and Pending fillers that shape the
+// ordinary JSON — with NO stream annotations and NO displayed StreamState.
+// Everything else DECLINES with the unsupported sentinel so BAML parse-stream stays
+// authoritative.
 //
 // The claim boundary is: a dynamic schema inside the SAME structural cut-line as
 // final parse (checkSupported) AND carrying no stream annotations
-// (checkNoStreamAnnotations — defensive, since the dynamic bridge cannot express
-// them), a candidate the streaming extractor can recover
-// (streamExtractCandidate), and a value coerceStream can reproduce byte-exact
-// (open/repaired root objects after ≥1 field value, truncated/markdown-recovered
-// strings, missing-field null fillers, completed scalar/list children). Anything
-// coerceStream cannot prove — a value BAML would delete (incomplete done-required
-// scalar, semantic child deletion), a StreamState wrapper, a map/union target, an
-// implied-key/inferred class, a still-empty open object — declines. See
-// coerceStream for the per-shape boundary. A non-sentinel error is a CLAIMED
-// stream parse failure (surfaced for parity like the final path); today no
-// claimed shape produces one, so every non-claim is the fallback sentinel.
+// (checkNoStreamAnnotations — defensive, since the dynamic TypeBuilder cannot
+// express them), a candidate the streaming extractor can recover
+// (streamExtractCandidate), and a value coerceStream can reproduce byte-exact:
+// open/repaired root objects after ≥1 field value, truncated/markdown-recovered
+// strings, missing-field Pending nulls, completed scalar/list/map/class children,
+// and the semantic-streaming reshaping — an INCOMPLETE done-required leaf DROPPED
+// from a list / map entry or NULL-REPLACED as a class field, with completed siblings
+// kept in BAML order. Anything coerceStream cannot prove — a StreamState wrapper, a
+// mixed/composite union target, an implied-key/inferred class, a non-string map key,
+// a still-empty open object — declines. See coerceStream for the per-shape boundary.
+// A non-sentinel error is a CLAIMED stream parse failure (surfaced for parity like
+// the final path); today no claimed shape produces one, so every non-claim is the
+// fallback sentinel.
 func parseStream(req bamlutils.DeBAMLParseRequest) (bamlutils.DeBAMLParseResult, error) {
 	if req.OutputSchema == nil {
 		return bamlutils.DeBAMLParseResult{}, unsupported("nil output schema")
@@ -157,12 +163,18 @@ func parseStream(req bamlutils.DeBAMLParseRequest) (bamlutils.DeBAMLParseResult,
 // checkNoStreamAnnotations DECLINES any schema carrying BAML stream metadata —
 // @stream.done / @@stream.done (StreamingBehavior.Done), @stream.not_null
 // (Needed / ClassField.StreamingNeeded), or @stream.with_state (State) — at the
-// class, field, or type level. M4b claims only UNANNOTATED partials; an annotated
-// schema keeps the BAML parse-stream path, whose semantic-deletion / not-null /
-// with-state behavior is M4c/M4d. The dynamic output bridge carries no
-// streaming-annotation channel today (every dynamic class is non-streaming with a
-// zero StreamingBehavior), so this is a defensive guard pinning the boundary
-// rather than a reachable path.
+// class, field, or type level. M4c models the ANNOTATION-FREE intrinsic semantic
+// streaming (the required-done TYPE TABLE, deletion, null-replacement, Pending
+// fillers); the annotation-DEPENDENT behavior (a forced-done string/list/class,
+// not-null whole-class nulling, with-state wrappers) is NOT representable in the
+// native dynamic-schema data at field-level precision — BAML's dynamic TypeBuilder
+// cannot attach these annotations (ClassPropertyBuilder exposes only
+// SetType/description/alias) and schema.FromDynamicOutputSchema lowers every class
+// non-streaming with a zero StreamingBehavior. So BAML's own dynamic parse-stream
+// also sees no annotations, and any schema that somehow DID carry one must keep the
+// BAML path. Since the dynamic bridge produces no annotation today, this is a
+// defensive guard pinning the boundary rather than a reachable path (a future bridge
+// extension that carries annotations would decline here until modeled).
 func checkNoStreamAnnotations(b *schema.Bundle) error {
 	if err := checkTypeNoStream(b.Target); err != nil {
 		return err

--- a/internal/debaml/stream_test.go
+++ b/internal/debaml/stream_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/invakid404/baml-rest/bamlutils"
 )
 
-// M4b streaming (raw_is_done=false) native-parse coverage. Each claimed case here
-// mirrors a LIVE-CAPTURED success prefix from the bamlfuzz parse-recovery corpus
-// (adapters/common/codegen/testdata/bamlfuzz/parse_recovery/20..23), so the
+// M4b/M4c streaming (raw_is_done=false) native-parse coverage. Each claimed case
+// here mirrors a LIVE-CAPTURED success prefix from the bamlfuzz parse-recovery
+// corpus (adapters/common/codegen/testdata/bamlfuzz/parse_recovery/20..23 for M4b,
+// 173..177 for M4c), so the
 // asserted `want` is BAML v0.223.0 parse-stream's own output — the same value the
 // Docker differential holds native to byte-exact. The declined cases pin the
 // over-claim guards: native FALLS BACK (ErrDeBAMLParseUnsupported) so BAML
@@ -119,19 +120,93 @@ func TestStream_TrailingComma(t *testing.T) {
 
 // --- Over-claim guards ---
 
-// TestStream_IncompleteDoneRequiredScalarDeclines pins that an INCOMPLETE
-// done-required scalar (a partial int that never terminates) DECLINES: BAML would
-// DELETE it (semantic streaming), which M4b does not model, so native falls back.
-func TestStream_IncompleteDoneRequiredScalarDeclines(t *testing.T) {
+// TestStream_IncompleteDoneRequiredScalarNulls pins the M4c semantic-streaming
+// behavior for an INCOMPLETE done-required class field: an int that never
+// terminates is DELETED by BAML (must_be_done && state != Complete →
+// Err(IncompleteDoneValue)) and, as a CLASS field, REPLACED WITH NULL (deletion_nulls
+// in semantic_streaming.rs process_node). Native now CLAIMS the null-replacement
+// rather than falling back. (Captured live: see corpus 174_streaming_class_incomplete_scalar_field.)
+func TestStream_IncompleteDoneRequiredScalarNulls(t *testing.T) {
 	s := personSchema()
-	// age=3 runs to EOF inside an unterminated object → Incomplete int → deleted by
-	// BAML → native declines rather than reproduce the deletion.
-	requireStreamUnsupported(t, s, `{"name":"Ada","age":3`)
-	// A trailing comma after an UNQUOTED object value at EOF (`36,`) hits the same
-	// greedy-unquoted-object-value guard the final fixer uses (BAML would consume the
-	// comma and read greedily), so native over-declines it — safe, and not a corpus
-	// prefix (the trailing_comma fixture uses quoted list elements).
+	// age=3 runs to EOF inside an unterminated object → Incomplete int → deleted →
+	// the class field is null-replaced; the completed string sibling is kept.
+	mustStream(t, s, `{"name":"Ada","age":3`, `{"name":"Ada","age":null}`)
+	// A trailing comma after an UNQUOTED object value at EOF (`36,`) hits the
+	// greedy-unquoted-object-value guard streamFix uses (BAML would consume the comma
+	// and read greedily), so the streaming fixer DECLINES the candidate before
+	// coercion — native over-declines it, safe, and not a corpus prefix.
 	requireStreamUnsupported(t, s, `{"name":"Ada","age":36,`)
+}
+
+// TestStream_NumbersListDropsIncompleteTail pins the NUMBERS behavior: a partial
+// integer-list prefix KEEPS completed elements and DROPS the incomplete
+// done-required trailing element (semantic_streaming.rs List arm filter_map). int is
+// done-required, list is not. (Captured live: see corpus 173_streaming_numbers_list_int.)
+func TestStream_NumbersListDropsIncompleteTail(t *testing.T) {
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("nums", listProp(&bamlutils.DynamicTypeSpec{Type: "int"}))),
+	}
+	// `[1,2` → 1 is comma-terminated (Complete, kept); 2 runs to EOF (Incomplete,
+	// dropped). `[1` → the lone 1 is the incomplete trailing element → dropped → [].
+	mustStream(t, s, `{"nums":[`, `{"nums":[]}`)
+	mustStream(t, s, `{"nums":[1`, `{"nums":[]}`)
+	mustStream(t, s, `{"nums":[1,`, `{"nums":[1]}`)
+	mustStream(t, s, `{"nums":[1,2`, `{"nums":[1]}`)
+	mustStream(t, s, `{"nums":[1,2,3`, `{"nums":[1,2]}`)
+	mustStream(t, s, `{"nums":[1,2,3]`, `{"nums":[1,2,3]}`)
+	mustStream(t, s, `{"nums":[1,2,3]}`, `{"nums":[1,2,3]}`)
+}
+
+// TestStream_ListOfClassPartialFieldNulls pins that a list of NON-done-required
+// class elements KEEPS a partial trailing element (a class is not done-required)
+// while NULL-REPLACING that element's incomplete done-required field. Both list
+// elements survive; only the incomplete int becomes null. (Captured live: see corpus
+// 175_streaming_list_class_partial_field.)
+func TestStream_ListOfClassPartialFieldNulls(t *testing.T) {
+	inner := bamlutils.MustOrderedMap(kv("a", intProp()))
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("items", listProp(&bamlutils.DynamicTypeSpec{Ref: "Inner"}))),
+		Classes:    bamlutils.MustOrderedMap(bamlutils.OrderedKV("Inner", &bamlutils.DynamicClass{Properties: inner})),
+	}
+	// element 0 `{"a":1}` closed → complete → {a:1}; element 1 `{"a":2` incomplete
+	// object with incomplete int a → class kept, a null-replaced → {a:null}.
+	mustStream(t, s, `{"items":[{"a":1},{"a":2`, `{"items":[{"a":1},{"a":null}]}`)
+}
+
+// TestStream_MissingFieldDefaultFillers pins that a MISSING class field is filled
+// with BAML's TypeIR::default_value (list→[], map→{}, optional→null), NOT a blanket
+// null: BAML's streaming filler reuses the coercion-layer default fill. A missing
+// required scalar (int) still fills null (no default_value). (Captured live: see
+// corpus 177_streaming_missing_field_fillers.)
+func TestStream_MissingFieldDefaultFillers(t *testing.T) {
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(
+			kv("a", intProp()),
+			kv("tags", listProp(&bamlutils.DynamicTypeSpec{Type: "string"})),
+			kv("scores", mapProp(&bamlutils.DynamicTypeSpec{Type: "int"})),
+			kv("note", optProp(&bamlutils.DynamicTypeSpec{Type: "string"})),
+		),
+	}
+	// `{"a":1}` is strict-complete: a=1 kept; tags/scores/note missing → default
+	// fillers (list→[], map→{}, optional→null).
+	mustStream(t, s, `{"a":1}`, `{"a":1,"tags":[],"scores":{},"note":null}`)
+	// A missing required scalar has no default_value → null (b never streamed).
+	s2 := &bamlutils.DynamicOutputSchema{Properties: props(kv("a", intProp()), kv("b", intProp()))}
+	mustStream(t, s2, `{"a":1}`, `{"a":1,"b":null}`)
+}
+
+// TestStream_MapIntDropsIncompleteValue pins the map arm: an entry whose
+// done-required value is incomplete drops the WHOLE key/value pair (never
+// null-kept), keeping completed sibling entries in input key order. (Captured live:
+// see corpus 176_streaming_map_int_partial.)
+func TestStream_MapIntDropsIncompleteValue(t *testing.T) {
+	s := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("m", mapProp(&bamlutils.DynamicTypeSpec{Type: "int"}))),
+	}
+	// a=1 comma-terminated (kept); b=2 incomplete (dropped entry). The space after
+	// the comma keeps the unquoted object value out of streamFix's greedy-comma
+	// decline (an unquoted object value before a TIGHT comma declines).
+	mustStream(t, s, `{"m":{"a":1, "b":2`, `{"m":{"a":1}}`)
 }
 
 // TestStream_NoStructureDeclines pins that raw text with no recoverable JSON


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

## De-BAML P4 M4c — semantic streaming without displayed stream-state wrappers

Models BAML v0.223.0's internal streaming semantics where they shape the **ordinary JSON**, still excluding `@stream.with_state` display wrappers. `internal/debaml.Parse(... Stream=true ...)` now additionally CLAIMS these semantic behaviors and DECLINES (unsupported sentinel, so BAML parse-stream stays authoritative) anything it cannot prove.

### Claimed (new vs M4b)
- **Required-done child deletion** — an INCOMPLETE done-required leaf (`int` / `float` / `bool` / `enum` / `literal` / `null` / `media`, the exact `semantic_streaming.rs` `required_done` table) is DROPPED from a list / map entry and NULL-REPLACED as a class field, keeping completed siblings in BAML order (the NUMBERS behavior). `Incomplete` propagates from the streaming fixer into the deletion decision; `Pending` outranks `Incomplete`.
- **Pending fillers** for missing class fields use BAML's `TypeIR::default_value` (required `list→[]`, `map→{}`, optional → `null`), not a blanket `null`; class field ordering is preserved.
- Lists/maps drop children whose semantic processing fails (map entries drop whole, never null-kept); classes replace failed/missing done-required fields with `null`.

### Stays fallback (not representable / deferred)
- `@stream.done` / `@@stream.done` / `@stream.not_null` / `@stream.with_state`: BAML's dynamic TypeBuilder cannot attach these annotations (`ClassPropertyBuilder` exposes only `SetType`/description/alias) and `FromDynamicOutputSchema` lowers every dynamic class non-streaming, so the metadata is **not representable in the native dynamic-schema data at field-level precision** — neither the BAML dynamic oracle nor native can carry it, so there is nothing to differential-test (over-decline per the guard).
- Mixed-union semantic streaming, constraints/checks, direct `list<multi-arm-union>`, non-string map keys.
- Runtime native-first parse-stream rollout is **M4d**: the generated `parseStreamFn` is unchanged; this slice is parser-differential only.
- Final parse + M3 + M4b claims are unchanged.

### Corpus
New live-captured (`BAMLFUZZ_PARSE_CAPTURE=1`, never hand-written) parse-recovery fixtures `173`–`177` pin, byte-exact vs BAML v0.223.0:
- `173` NUMBERS `list<int>` — completed elements kept, incomplete done-required trailing element dropped;
- `174` class incomplete `int` field → replacement `null` (completed string sibling kept);
- `175` nested `list<Inner{a:int}>` — partial trailing class element kept, its incomplete `int` field null-replaced;
- `176` `map<string,int>` — entry with incomplete value dropped whole;
- `177` missing-field fillers — required `list→[]`, `map→{}`, optional → `null`.

### Validation
- `gofmt` clean; `go build ./...`; `go vet ./...` and with `-tags=integration`; `go test ./internal/debaml/...`; `GOWORK=off go test ./codegen` (from `adapters/common`).
- bamlfuzz parse-recovery differential (Docker, BAML 0.223.0) **green** — newly-claimed semantic-streaming prefixes byte-exact vs BAML, everything else still declined; no regressions to M3 / M4b / final parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced streaming parse recovery to better handle incomplete done-required values in lists, maps, and nested classes.
  * Streaming recovery now applies appropriate default fillers for missing fields (e.g., empty collections, `null` for optional fields).
* **Bug Fixes**
  * Partial trailing list elements and incomplete map entries are dropped without discarding previously completed data.
  * Incomplete scalar/class fields are null-replaced instead of triggering broader failures; completed siblings are preserved.
* **Tests**
  * Added new streaming parse-recovery fixtures and expanded coverage for native streaming guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->