### PR TITLE
debaml: stream-state wrappers (declined) + native-first parse-stream runtime (M4 slice d)

### DIFF
--- a/adapters/common/codegen/codegen_buildrequest.go
+++ b/adapters/common/codegen/codegen_buildrequest.go
@@ -325,28 +325,42 @@ func (me *methodEmitter) buildRequestArgCallParam(arg string) jen.Code {
 	return me.argCallParam(arg)
 }
 
-// parseFinalFnBody returns the statements for a parseFinalFn closure. For
-// the de-BAML dynamic method it attempts the native final parser first and
-// falls through to BAML on a declined/unsupported result (ok==false &&
-// err==nil); a CLAIMED native parse error (err!=nil) propagates. For every
-// other method it is the plain BAML Parse call exactly as before. textVar
-// is the closure's raw-text parameter name ("accumulated" or "text").
+// nativeFirstParseFnBody emits the SHARED native-first-with-BAML-fallback
+// scaffolding that BOTH parseStreamFnBody and parseFinalFnBody produce for the
+// de-BAML dynamic method: the dynamic-method gate, the emittedDeBAMLCall flag (so
+// generate() writes debaml.go with the native seam helper next to adapter.go), the
+// `if result, ok, err := <nativeFn>(...); ok || err != nil { return result, err }`
+// native-first block, and the trailing BAML-fallback return. For every OTHER method
+// it is just the plain BAML call.
 //
-// The native attempt is gated at runtime inside maybeParseDeBAMLFinal on
-// adapter.DeBAMLConfig().Enabled, a carried schema, and a wired parser, so
-// emitting the call is inert until BAML_REST_USE_DEBAML is on and a parser
-// is installed.
+// Only the LEG-SPECIFIC pieces are parameters — the divergent SEMANTICS are NOT
+// merged, they live at each caller and downstream:
+//
+//   - bamlMethod:      the generated BAML client method to fall back to
+//     ("Parse" / "ParseStream");
+//   - nativeFn:        the native seam helper to try first
+//     ("maybeParseDeBAMLFinal" / "maybeParseDeBAMLStream");
+//   - nativeExtraArgs: trailing native-call args after (ctx, adapter, textVar) —
+//     the final leg's stage literal jen.Lit("final") (logged once
+//     per response on the unsupported fallback); nil for the stream
+//     leg (its per-prefix fallback is silent, so no stage);
+//   - lead:            the leading comment lines documenting the leg.
+//
+// The stream-vs-final RETURN TYPES and the newResultFn DynamicProperties unwrap
+// gating are decided elsewhere (the debaml.go helper wraps into the streaming vs
+// final envelope; codegen_methods.go gates the unwrap on the ACTUAL return shape),
+// so this helper emits only the identical control-flow scaffolding — the generated
+// output stays byte-for-byte what the two callers emitted inline.
 //
 // Gating uses the PARSE-side g.isDeBAMLDynamicMethod (matching the parse-only
 // generator in codegen_methods.go), NOT the render-side methodEmitter
 // isDeBAMLMethod: the parse seam consumes only the raw text, so it needs no
-// struct-media-param check. A de-BAML dynamic method without struct media
-// params must still get the native branch in BuildRequest/CallRequest final
-// parse, just as it does in direct Parse.
-func (me *methodEmitter) parseFinalFnBody(textVar string) []jen.Code {
+// struct-media-param check. A de-BAML dynamic method without struct media params
+// must still get the native branch in BuildRequest/CallRequest parse.
+func (me *methodEmitter) nativeFirstParseFnBody(textVar, bamlMethod, nativeFn string, nativeExtraArgs, lead []jen.Code) []jen.Code {
 	g := me.g
 	bamlCall := jen.Return(
-		jen.Qual(g.pkgs.GeneratedClientPkg, "Parse").Dot(me.methodName).Call(
+		jen.Qual(g.pkgs.GeneratedClientPkg, bamlMethod).Dot(me.methodName).Call(
 			jen.Id("ctx"),
 			jen.Id(textVar),
 			jen.Id("options").Op("..."),
@@ -356,20 +370,66 @@ func (me *methodEmitter) parseFinalFnBody(textVar string) []jen.Code {
 		return []jen.Code{bamlCall}
 	}
 	// A native parse call is emitted -> ensure generate() writes debaml.go
-	// (which holds maybeParseDeBAMLFinal) into this package.
+	// (which holds nativeFn) into this package.
 	g.emittedDeBAMLCall = true
-	return []jen.Code{
-		jen.Comment("Native de-BAML final parse first; ok==false && err==nil means"),
-		jen.Comment("declined/unsupported, so fall through to BAML-as-today."),
+	nativeArgs := append([]jen.Code{jen.Id("ctx"), jen.Id("adapter"), jen.Id(textVar)}, nativeExtraArgs...)
+	stmts := make([]jen.Code, 0, len(lead)+2)
+	stmts = append(stmts, lead...)
+	stmts = append(stmts,
 		jen.If(
 			jen.List(jen.Id("result"), jen.Id("ok"), jen.Id("err")).Op(":=").
-				Id("maybeParseDeBAMLFinal").Call(jen.Id("ctx"), jen.Id("adapter"), jen.Id(textVar), jen.Lit("final")),
+				Id(nativeFn).Call(nativeArgs...),
 			jen.Id("ok").Op("||").Id("err").Op("!=").Nil(),
 		).Block(
 			jen.Return(jen.Id("result"), jen.Id("err")),
 		),
 		bamlCall,
-	}
+	)
+	return stmts
+}
+
+// parseStreamFnBody returns the statements for a parseStreamFn closure. For
+// the de-BAML dynamic method it attempts the native STREAM parser first
+// (maybeParseDeBAMLStream, Stream=true) and falls through to BAML parse-stream on
+// a declined/unsupported result (ok==false && err==nil); a CLAIMED native parse
+// error (err!=nil) propagates so the orchestrator handles it exactly like a BAML
+// parse-stream error (non-terminal — dropped for partial emission). For every
+// other method it is the plain BAML ParseStream call. textVar is the closure's
+// raw-text parameter name ("accumulated").
+//
+// The fallback is SILENT: unlike parseFinalFnBody (whose native attempt runs ONCE
+// per response), parseStreamFn is invoked per accumulated prefix, so a per-prefix
+// decline log would be noisy — maybeParseDeBAMLStream deliberately does not log the
+// unsupported fallback (M4d), and the stream leg passes NO stage literal. The
+// shared native-first scaffolding lives in nativeFirstParseFnBody.
+func (me *methodEmitter) parseStreamFnBody(textVar string) []jen.Code {
+	return me.nativeFirstParseFnBody(textVar, "ParseStream", "maybeParseDeBAMLStream", nil, []jen.Code{
+		jen.Comment("Native de-BAML stream parse first; ok==false && err==nil means"),
+		jen.Comment("declined/unsupported, so fall through to BAML parse-stream. The"),
+		jen.Comment("fallback is SILENT (runs per accumulated prefix); a CLAIMED native"),
+		jen.Comment("error propagates and the orchestrator drops it like a BAML parse-"),
+		jen.Comment("stream error (non-terminal for partial emission)."),
+	})
+}
+
+// parseFinalFnBody returns the statements for a parseFinalFn closure. For
+// the de-BAML dynamic method it attempts the native final parser first and falls
+// through to BAML on a declined/unsupported result (ok==false && err==nil); a
+// CLAIMED native parse error (err!=nil) propagates. For every other method it is
+// the plain BAML Parse call. textVar is the closure's raw-text parameter name
+// ("accumulated" or "text").
+//
+// The native attempt is gated at runtime inside maybeParseDeBAMLFinal on
+// adapter.DeBAMLConfig().Enabled, a carried schema, and a wired parser, so emitting
+// the call is inert until BAML_REST_USE_DEBAML is on and a parser is installed. The
+// final leg passes a jen.Lit("final") stage literal (logged once per response on
+// the unsupported fallback). The shared native-first scaffolding — including the
+// PARSE-side g.isDeBAMLDynamicMethod gate — lives in nativeFirstParseFnBody.
+func (me *methodEmitter) parseFinalFnBody(textVar string) []jen.Code {
+	return me.nativeFirstParseFnBody(textVar, "Parse", "maybeParseDeBAMLFinal", []jen.Code{jen.Lit("final")}, []jen.Code{
+		jen.Comment("Native de-BAML final parse first; ok==false && err==nil means"),
+		jen.Comment("declined/unsupported, so fall through to BAML-as-today."),
+	})
 }
 
 // emitBuildRequest emits the streaming BuildRequest impl for this
@@ -498,19 +558,15 @@ func (me *methodEmitter) emitBuildRequest() {
 
 	buildRequestBody = append(buildRequestBody,
 
-		// parseStreamFn: calls ParseStream.Method(ctx, accumulated, opts...)
+		// parseStreamFn: calls ParseStream.Method(ctx, accumulated, opts...), with
+		// a native de-BAML stream-parse attempt first for the dynamic method
+		// (native-first, silent BAML fallback — see parseStreamFnBody).
 		// The context_fix hack adds ctx as first param to ParseStream methods.
 		jen.Id("parseStreamFn").Op(":=").Func().Params(
 			jen.Id("ctx").Qual("context", "Context"),
 			jen.Id("accumulated").String(),
 		).Params(jen.Any(), jen.Error()).Block(
-			jen.Return(
-				jen.Qual(g.pkgs.GeneratedClientPkg, "ParseStream").Dot(me.methodName).Call(
-					jen.Id("ctx"),
-					jen.Id("accumulated"),
-					jen.Id("options").Op("..."),
-				),
-			),
+			me.parseStreamFnBody("accumulated")...,
 		),
 
 		// parseFinalFn: calls Parse.Method(ctx, accumulated, opts...), with a

--- a/adapters/common/codegen/codegen_debaml.go
+++ b/adapters/common/codegen/codegen_debaml.go
@@ -47,6 +47,7 @@ import (
 	"strings"
 
 	bamlutils "{{.InterfacesPkg}}"
+	streamtypes "{{.StreamTypesPkg}}"
 	types "{{.TypesPkg}}"
 )
 
@@ -236,6 +237,84 @@ func wrapDeBAMLDynamicOutput(flat []byte) (types.Baml_Rest_DynamicOutput, error)
 	return out, nil
 }
 
+// maybeParseDeBAMLStream attempts the native de-BAML STREAM parse
+// (raw_is_done=false) for the dynamic method, returning the generated
+// STREAMING dynamic-output envelope on success. It is the parse-stream twin
+// of maybeParseDeBAMLFinal, driving the same wired parser with Stream=true so
+// the native partial surface (M4b jsonish recovery + M4c annotation-free
+// semantic streaming) is reproduced byte-exact where claimed. The boolean
+// reports whether native CLAIMED a result:
+//
+//   - (envelope, true, nil): native produced the partial; the caller sends it.
+//   - (zero, false, nil): native declined — de-BAML off, no carried schema, no
+//     parser wired, or bamlutils.ErrDeBAMLParseUnsupported — so the caller
+//     falls back to BAML parse-stream for this prefix.
+//   - (zero, false, err): native CLAIMED a stream parse failure; the caller
+//     propagates it, and the orchestrator drops it exactly like a BAML
+//     parse-stream error (per-prefix parse errors are NON-TERMINAL for partial
+//     emission — final response parsing still decides success/failure).
+//
+// UNLIKE maybeParseDeBAMLFinal, the unsupported fallback is SILENT: parseStreamFn
+// runs once per accumulated prefix, so a per-prefix warn would be noisy. Native
+// @stream.with_state / @stream.done / @stream.not_null are NOT representable on a
+// dynamic schema (BAML's dynamic TypeBuilder cannot attach them — see
+// FromDynamicOutputSchema), so the native parser declines any such shape and this
+// seam silently keeps BAML authoritative there.
+//
+// ctx is the caller's per-attempt request context so the native parser observes
+// the same cancellation/deadline the BAML fallback would.
+func maybeParseDeBAMLStream(ctx context.Context, adapter bamlutils.Adapter, raw string) (streamtypes.Baml_Rest_DynamicOutput, bool, error) {
+	var zero streamtypes.Baml_Rest_DynamicOutput
+	if !adapter.DeBAMLConfig().Enabled {
+		return zero, false, nil
+	}
+	outputSchema := adapter.DeBAMLOutputSchema()
+	if outputSchema == nil {
+		return zero, false, nil
+	}
+	getter, ok := adapter.(deBAMLParserGetter)
+	if !ok {
+		return zero, false, nil
+	}
+	parse := getter.DeBAMLParser()
+	if parse == nil {
+		return zero, false, nil
+	}
+	res, err := parse(ctx, bamlutils.DeBAMLParseRequest{Raw: raw, OutputSchema: outputSchema, Stream: true})
+	if err != nil {
+		if errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			// SILENT fallback (no per-prefix log): BAML parse-stream stays
+			// authoritative for this prefix.
+			return zero, false, nil
+		}
+		return zero, false, err
+	}
+	out, werr := wrapDeBAMLDynamicOutputStream(res.JSON)
+	if werr != nil {
+		// Native CLAIMED a success but produced JSON we cannot wrap into the
+		// streaming dynamic-output envelope. Per the seam contract only
+		// ErrDeBAMLParseUnsupported falls back; every other failure on a claimed
+		// result propagates so a parser/callback bug surfaces (the orchestrator
+		// still treats a stream parse error as non-terminal).
+		return zero, false, fmt.Errorf("wrap native de-BAML stream parse result: %w", werr)
+	}
+	return out, true, nil
+}
+
+// wrapDeBAMLDynamicOutputStream wraps the flattened native parse JSON into the
+// generated STREAMING dynamic-output envelope (streamtypes.Baml_Rest_DynamicOutput,
+// the type BAML's ParseStream returns), so the existing newResultFn stream-unwrap /
+// partial-emission pipeline runs unchanged. It is the parse-stream twin of
+// wrapDeBAMLDynamicOutput; both decode DynamicProperties in wire order and the
+// downstream reorder/sort pass remains the order authority.
+func wrapDeBAMLDynamicOutputStream(flat []byte) (streamtypes.Baml_Rest_DynamicOutput, error) {
+	var out streamtypes.Baml_Rest_DynamicOutput
+	if err := out.DynamicProperties.UnmarshalJSON(flat); err != nil {
+		return streamtypes.Baml_Rest_DynamicOutput{}, err
+	}
+	return out, nil
+}
+
 // logDeBAMLParseFallback records a native-parse fallback so the BAML-parse
 // path stays observable without a user-facing flag. Best-effort: no logger
 // installed means no line, never an error to the caller.
@@ -247,12 +326,14 @@ func logDeBAMLParseFallback(adapter bamlutils.Adapter, stage string, err error) 
 `
 
 // deBAMLHelperData parameterizes deBAMLHelperTemplate. Pkg is the
-// generated package name; InterfacesPkg and TypesPkg are the bamlutils
-// and per-build BAML types import paths.
+// generated package name; InterfacesPkg, TypesPkg, and StreamTypesPkg are
+// the bamlutils, per-build BAML final-types, and per-build BAML
+// streaming-types import paths.
 type deBAMLHelperData struct {
-	Pkg           string
-	InterfacesPkg string
-	TypesPkg      string
+	Pkg            string
+	InterfacesPkg  string
+	TypesPkg       string
+	StreamTypesPkg string
 }
 
 // deBAMLHelperPath returns the path the helper is written to: debaml.go
@@ -286,9 +367,10 @@ func (g *generator) maybeWriteDeBAMLHelper() {
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, deBAMLHelperData{
-		Pkg:           g.pkgs.OutputPkgName,
-		InterfacesPkg: g.pkgs.InterfacesPkg,
-		TypesPkg:      g.pkgs.GeneratedClientPkg + "/types",
+		Pkg:            g.pkgs.OutputPkgName,
+		InterfacesPkg:  g.pkgs.InterfacesPkg,
+		TypesPkg:       g.pkgs.GeneratedClientPkg + "/types",
+		StreamTypesPkg: g.pkgs.GeneratedClientPkg + "/stream_types",
 	}); err != nil {
 		panic(fmt.Sprintf("codegen: execute de-BAML helper template: %v", err))
 	}

--- a/adapters/common/codegen/codegen_debaml_test.go
+++ b/adapters/common/codegen/codegen_debaml_test.go
@@ -129,8 +129,14 @@ func TestMaybeWriteDeBAMLHelper_WritesWhenEmitted(t *testing.T) {
 		"package genx",
 		`bamlutils "github.com/invakid404/baml-rest/bamlutils"`,
 		`types "example.com/x/baml_client/types"`,
+		`streamtypes "example.com/x/baml_client/stream_types"`,
 		"func maybeApplyDeBAMLOutputFormat(",
 		"func rewriteOutputFormat(",
+		// The parse-stream (M4d native-first) seam twin is always emitted with
+		// the final seam.
+		"func maybeParseDeBAMLFinal(",
+		"func maybeParseDeBAMLStream(",
+		"func wrapDeBAMLDynamicOutputStream(",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("emitted debaml.go missing %q\n%s", want, got)

--- a/dynclient/internal/generated/adapter.go
+++ b/dynclient/internal/generated/adapter.go
@@ -720,6 +720,14 @@ func bamlRestDynamicBuildRequest(adapter bamlutils.Adapter, rawInput any, out ch
 		return req, nil
 	}
 	parseStreamFn := func(ctx context.Context, accumulated string) (any, error) {
+		// Native de-BAML stream parse first; ok==false && err==nil means
+		// declined/unsupported, so fall through to BAML parse-stream. The
+		// fallback is SILENT (runs per accumulated prefix); a CLAIMED native
+		// error propagates and the orchestrator drops it like a BAML parse-
+		// stream error (non-terminal for partial emission).
+		if result, ok, err := maybeParseDeBAMLStream(ctx, adapter, accumulated); ok || err != nil {
+			return result, err
+		}
 		return bamlclient.ParseStream.Baml_Rest_Dynamic(ctx, accumulated, options...)
 	}
 	parseFinalFn := func(ctx context.Context, accumulated string) (any, error) {

--- a/dynclient/internal/generated/debaml.go
+++ b/dynclient/internal/generated/debaml.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	bamlutils "github.com/invakid404/baml-rest/bamlutils"
+	streamtypes "github.com/invakid404/baml-rest/dynclient/internal/generated/baml_client/stream_types"
 	types "github.com/invakid404/baml-rest/dynclient/internal/generated/baml_client/types"
 )
 
@@ -194,6 +195,84 @@ func wrapDeBAMLDynamicOutput(flat []byte) (types.Baml_Rest_DynamicOutput, error)
 	var out types.Baml_Rest_DynamicOutput
 	if err := out.DynamicProperties.UnmarshalJSON(flat); err != nil {
 		return types.Baml_Rest_DynamicOutput{}, err
+	}
+	return out, nil
+}
+
+// maybeParseDeBAMLStream attempts the native de-BAML STREAM parse
+// (raw_is_done=false) for the dynamic method, returning the generated
+// STREAMING dynamic-output envelope on success. It is the parse-stream twin
+// of maybeParseDeBAMLFinal, driving the same wired parser with Stream=true so
+// the native partial surface (M4b jsonish recovery + M4c annotation-free
+// semantic streaming) is reproduced byte-exact where claimed. The boolean
+// reports whether native CLAIMED a result:
+//
+//   - (envelope, true, nil): native produced the partial; the caller sends it.
+//   - (zero, false, nil): native declined — de-BAML off, no carried schema, no
+//     parser wired, or bamlutils.ErrDeBAMLParseUnsupported — so the caller
+//     falls back to BAML parse-stream for this prefix.
+//   - (zero, false, err): native CLAIMED a stream parse failure; the caller
+//     propagates it, and the orchestrator drops it exactly like a BAML
+//     parse-stream error (per-prefix parse errors are NON-TERMINAL for partial
+//     emission — final response parsing still decides success/failure).
+//
+// UNLIKE maybeParseDeBAMLFinal, the unsupported fallback is SILENT: parseStreamFn
+// runs once per accumulated prefix, so a per-prefix warn would be noisy. Native
+// @stream.with_state / @stream.done / @stream.not_null are NOT representable on a
+// dynamic schema (BAML's dynamic TypeBuilder cannot attach them — see
+// FromDynamicOutputSchema), so the native parser declines any such shape and this
+// seam silently keeps BAML authoritative there.
+//
+// ctx is the caller's per-attempt request context so the native parser observes
+// the same cancellation/deadline the BAML fallback would.
+func maybeParseDeBAMLStream(ctx context.Context, adapter bamlutils.Adapter, raw string) (streamtypes.Baml_Rest_DynamicOutput, bool, error) {
+	var zero streamtypes.Baml_Rest_DynamicOutput
+	if !adapter.DeBAMLConfig().Enabled {
+		return zero, false, nil
+	}
+	outputSchema := adapter.DeBAMLOutputSchema()
+	if outputSchema == nil {
+		return zero, false, nil
+	}
+	getter, ok := adapter.(deBAMLParserGetter)
+	if !ok {
+		return zero, false, nil
+	}
+	parse := getter.DeBAMLParser()
+	if parse == nil {
+		return zero, false, nil
+	}
+	res, err := parse(ctx, bamlutils.DeBAMLParseRequest{Raw: raw, OutputSchema: outputSchema, Stream: true})
+	if err != nil {
+		if errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			// SILENT fallback (no per-prefix log): BAML parse-stream stays
+			// authoritative for this prefix.
+			return zero, false, nil
+		}
+		return zero, false, err
+	}
+	out, werr := wrapDeBAMLDynamicOutputStream(res.JSON)
+	if werr != nil {
+		// Native CLAIMED a success but produced JSON we cannot wrap into the
+		// streaming dynamic-output envelope. Per the seam contract only
+		// ErrDeBAMLParseUnsupported falls back; every other failure on a claimed
+		// result propagates so a parser/callback bug surfaces (the orchestrator
+		// still treats a stream parse error as non-terminal).
+		return zero, false, fmt.Errorf("wrap native de-BAML stream parse result: %w", werr)
+	}
+	return out, true, nil
+}
+
+// wrapDeBAMLDynamicOutputStream wraps the flattened native parse JSON into the
+// generated STREAMING dynamic-output envelope (streamtypes.Baml_Rest_DynamicOutput,
+// the type BAML's ParseStream returns), so the existing newResultFn stream-unwrap /
+// partial-emission pipeline runs unchanged. It is the parse-stream twin of
+// wrapDeBAMLDynamicOutput; both decode DynamicProperties in wire order and the
+// downstream reorder/sort pass remains the order authority.
+func wrapDeBAMLDynamicOutputStream(flat []byte) (streamtypes.Baml_Rest_DynamicOutput, error) {
+	var out streamtypes.Baml_Rest_DynamicOutput
+	if err := out.DynamicProperties.UnmarshalJSON(flat); err != nil {
+		return streamtypes.Baml_Rest_DynamicOutput{}, err
 	}
 	return out, nil
 }

--- a/dynclient/internal/generated/debaml_test.go
+++ b/dynclient/internal/generated/debaml_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/invakid404/baml-rest/bamlutils"
 	"github.com/invakid404/baml-rest/dynclient/internal/generated/adapter"
+	streamtypes "github.com/invakid404/baml-rest/dynclient/internal/generated/baml_client/stream_types"
 	types "github.com/invakid404/baml-rest/dynclient/internal/generated/baml_client/types"
 )
 
@@ -276,6 +277,120 @@ func TestMaybeParseDeBAMLFinal_DeclinesWhenOff(t *testing.T) {
 	mustDecline := func(name string, a bamlutils.Adapter) {
 		t.Helper()
 		if _, ok, err := maybeParseDeBAMLFinal(context.Background(), a, "raw", "final"); ok || err != nil {
+			t.Errorf("%s: expected decline (ok=false, err=nil), got ok=%v err=%v", name, ok, err)
+		}
+	}
+	claim := parserReturning(`{"answer":"hi"}`, nil)
+	mustDecline("flag off", newParserTestAdapter(false, simpleSchema(), claim))
+	mustDecline("nil schema", newParserTestAdapter(true, nil, claim))
+	mustDecline("nil parser", newParserTestAdapter(true, simpleSchema(), nil))
+}
+
+// --- M4d: native-first parse-stream seam (maybeParseDeBAMLStream) ---
+//
+// The stream seam is the parse-stream twin of maybeParseDeBAMLFinal: same
+// claim/decline/propagate contract, but it drives the wired parser with
+// Stream=true and its unsupported fallback is SILENT (parseStreamFn runs per
+// accumulated prefix). These tests pin all four dispositions plus the
+// stream-mode request flag, mirroring the final-seam tests above.
+
+// capturingParser records the last DeBAMLParseRequest it saw and returns a
+// fixed JSON/error, so a test can assert the seam forwards Stream=true.
+func capturingParser(json string, err error, seen *bamlutils.DeBAMLParseRequest) bamlutils.DeBAMLParseFunc {
+	return func(_ context.Context, req bamlutils.DeBAMLParseRequest) (bamlutils.DeBAMLParseResult, error) {
+		*seen = req
+		return bamlutils.DeBAMLParseResult{JSON: []byte(json)}, err
+	}
+}
+
+// TestMaybeParseDeBAMLStream_ClaimsValidObject pins the success path: a native
+// stream parser returning a flattened JSON object is claimed and wrapped into
+// the STREAMING dynamic-output envelope (streamtypes, not the final types).
+func TestMaybeParseDeBAMLStream_ClaimsValidObject(t *testing.T) {
+	var seen bamlutils.DeBAMLParseRequest
+	out, ok, err := maybeParseDeBAMLStream(
+		context.Background(),
+		newParserTestAdapter(true, simpleSchema(), capturingParser(`{"answer":"hi"}`, nil, &seen)),
+		"raw",
+	)
+	if err != nil || !ok {
+		t.Fatalf("expected claimed success, got ok=%v err=%v", ok, err)
+	}
+	if !seen.Stream {
+		t.Errorf("stream seam must drive the parser with Stream=true, got Stream=%v", seen.Stream)
+	}
+	var _ streamtypes.Baml_Rest_DynamicOutput = out // wrapped into the STREAMING envelope
+	if v, present := out.DynamicProperties.Get("answer"); !present || v != "hi" {
+		t.Errorf("stream envelope DynamicProperties.answer = %v (present=%v), want %q", v, present, "hi")
+	}
+}
+
+// TestMaybeParseDeBAMLStream_UnsupportedFallsBack pins that the sentinel — and
+// only the sentinel — declines (ok=false, err=nil) so the caller falls back to
+// BAML parse-stream. The fallback is silent (no per-prefix log).
+func TestMaybeParseDeBAMLStream_UnsupportedFallsBack(t *testing.T) {
+	_, ok, err := maybeParseDeBAMLStream(
+		context.Background(),
+		newParserTestAdapter(true, simpleSchema(), parserReturning("", bamlutils.ErrDeBAMLParseUnsupported)),
+		"raw",
+	)
+	if ok || err != nil {
+		t.Fatalf("unsupported must decline (ok=false, err=nil), got ok=%v err=%v", ok, err)
+	}
+}
+
+// TestMaybeParseDeBAMLStream_ClaimedErrorPropagates pins that a NON-sentinel
+// native stream error propagates (ok=false, err!=nil, NOT the unsupported
+// sentinel) so the orchestrator handles it exactly like a BAML parse-stream
+// error — dropped as non-terminal for partial emission, never a silent fallback.
+func TestMaybeParseDeBAMLStream_ClaimedErrorPropagates(t *testing.T) {
+	claimedErr := errors.New("debaml: claimed stream parse failure")
+	_, ok, err := maybeParseDeBAMLStream(
+		context.Background(),
+		newParserTestAdapter(true, simpleSchema(), parserReturning("", claimedErr)),
+		"raw",
+	)
+	if ok {
+		t.Errorf("claimed error must not claim a result (ok), got ok=true")
+	}
+	if !errors.Is(err, claimedErr) {
+		t.Errorf("claimed native stream error must PROPAGATE, got %v", err)
+	}
+	if errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+		t.Errorf("claimed error must NOT be the unsupported sentinel (would silently fall back): %v", err)
+	}
+}
+
+// TestMaybeParseDeBAMLStream_WrapFailurePropagates mirrors the final-seam R1
+// regression: a native parser that CLAIMS success but returns JSON that cannot
+// wrap into the streaming envelope must PROPAGATE (not the sentinel), so a
+// parser/callback bug can't hide behind a BAML parse-stream.
+func TestMaybeParseDeBAMLStream_WrapFailurePropagates(t *testing.T) {
+	for _, badJSON := range []string{`123`, `"scalar"`, `[1,2,3]`, `{not json`} {
+		_, ok, err := maybeParseDeBAMLStream(
+			context.Background(),
+			newParserTestAdapter(true, simpleSchema(), parserReturning(badJSON, nil)),
+			"raw",
+		)
+		if ok {
+			t.Errorf("%q: expected ok=false on wrap failure, got ok=true", badJSON)
+		}
+		if err == nil {
+			t.Errorf("%q: expected wrap failure to PROPAGATE, got nil (silent BAML fallback)", badJSON)
+		}
+		if errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			t.Errorf("%q: wrap failure must NOT be the unsupported sentinel (would fall back): %v", badJSON, err)
+		}
+	}
+}
+
+// TestMaybeParseDeBAMLStream_DeclinesWhenOff pins the runtime gates: flag off,
+// nil schema, and nil parser all decline without invoking the callback — the
+// stream seam is inert until de-BAML is enabled with a wired parser.
+func TestMaybeParseDeBAMLStream_DeclinesWhenOff(t *testing.T) {
+	mustDecline := func(name string, a bamlutils.Adapter) {
+		t.Helper()
+		if _, ok, err := maybeParseDeBAMLStream(context.Background(), a, "raw"); ok || err != nil {
 			t.Errorf("%s: expected decline (ok=false, err=nil), got ok=%v err=%v", name, ok, err)
 		}
 	}

--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -643,6 +643,16 @@ var parseRecoveryStreamNativeClaim = map[string]map[string]bool{
 	// @stream.with_state) stays fallback and has NO fixture — BAML's dynamic
 	// TypeBuilder cannot attach those annotations, so neither the BAML oracle nor the
 	// native bridge can carry them (nothing to differential-test).
+	//
+	// M4d adds NO streaming corpus fixture: its part (A) — @stream.with_state output
+	// wrappers — is UNREPRESENTABLE on a dynamic schema for exactly the reason above
+	// (schema.FromDynamicOutputSchema lowers every class with a zero StreamingBehavior),
+	// so with_state STAYS BAML fallback and there is nothing to capture here. M4d's part
+	// (B) — the native-first runtime parseStreamFn seam — wires internal/debaml.Parse
+	// (Stream=true, the SAME parser this differential holds to BAML byte-exact) into the
+	// generated streaming path; it is exercised end-to-end in
+	// dynamic_debaml_stream_seam_test.go (native-first CLAIM + silent BAML fallback),
+	// not by new corpus prefixes.
 
 	// 173_streaming_numbers_list_int (Root{nums:list<int>}). int is done-required, so
 	// a still-streaming trailing element is DROPPED and completed (comma-terminated)

--- a/integration/dynamic_debaml_stream_seam_test.go
+++ b/integration/dynamic_debaml_stream_seam_test.go
@@ -1,0 +1,223 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	stdjson "encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/dynclient"
+	"github.com/invakid404/baml-rest/internal/debaml"
+)
+
+// De-BAML M4d — native-first parse-stream RUNTIME seam (GitHub #536 / P4 M4d).
+//
+// M4d wires the native de-BAML stream parser into the generated dynamic
+// parseStreamFn: for a de-BAML-enabled request the generated closure calls
+// maybeParseDeBAMLStream (native, Stream=true) FIRST and falls back SILENTLY to
+// BAML ParseStream on the unsupported sentinel, propagating a claimed native
+// error the same way the orchestrator handles a BAML parse-stream error
+// (per-prefix parse errors are NON-TERMINAL for partial emission). These
+// integration tests exercise that generated seam in the SAME live streaming path
+// a real request uses (dynclient DynamicStream over the BuildRequest route),
+// proving BOTH native-first (claim) and fallback run there.
+//
+// The native parser is wrapped in an instrumented callback so the test can
+// observe the per-prefix disposition (claim vs unsupported-fallback) the
+// generated seam drives, without reaching into generated internals.
+
+// streamSeamCounters tallies the native parser's per-prefix stream dispositions
+// observed through the wired callback.
+type streamSeamCounters struct {
+	streamClaims    atomic.Int64 // native CLAIMED a stream prefix (native-first)
+	streamFallbacks atomic.Int64 // native declined a stream prefix (unsupported → BAML)
+	streamErrors    atomic.Int64 // native returned a CLAIMED (non-sentinel) stream error — a regression; the test fails on these
+	finalCalls      atomic.Int64 // non-stream (final) parse calls, for reference
+}
+
+// instrumentedNativeParser wraps the real native de-BAML parser
+// (internal/debaml.Parse) and records each STREAM prefix's disposition into c,
+// so a test can assert the generated seam actually drove native-first and/or
+// fell back. Behaviour is otherwise identical to the bare parser — the counters
+// are pure observation, EXCEPT that a claimed (non-sentinel) native stream error
+// also FAILS the test (see the default branch).
+func instrumentedNativeParser(t *testing.T, c *streamSeamCounters) bamlutils.DeBAMLParseFunc {
+	t.Helper()
+	return func(ctx context.Context, req bamlutils.DeBAMLParseRequest) (bamlutils.DeBAMLParseResult, error) {
+		res, err := debaml.Parse(ctx, req)
+		if !req.Stream {
+			c.finalCalls.Add(1)
+			return res, err
+		}
+		switch {
+		case err == nil:
+			c.streamClaims.Add(1)
+		case errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported):
+			c.streamFallbacks.Add(1)
+		default:
+			// A CLAIMED native stream error (any non-nil, non-sentinel error). Per-prefix
+			// stream parse errors are NON-TERMINAL — the orchestrator drops them — so
+			// BAML's final-parse recovery could SILENTLY MASK a native-stream-parser
+			// regression on the now-live seam, letting the seam tests still pass. Count
+			// it AND fail so a claimed-prefix native error can never be masked.
+			//
+			// t.Errorf (NOT Fatalf): this callback runs in the orchestrator's stream
+			// goroutine, not the test goroutine, so it must not call runtime.Goexit; all
+			// invocations complete before drainLibStream returns, so t is still live.
+			c.streamErrors.Add(1)
+			t.Errorf("native CLAIMED a stream parse error (non-sentinel) on the live parseStreamFn seam — a regression the non-terminal per-prefix path would otherwise mask: err=%v raw=%q outputSchema=%+v", err, req.Raw, req.OutputSchema)
+		}
+		return res, err
+	}
+}
+
+// drivenStreamFinal opens a de-BAML-enabled DynamicStream for req, drains it,
+// and returns the final flattened payload plus the observed native
+// dispositions.
+func drivenStreamFinal(t *testing.T, ctx context.Context, req dynclient.Request) (stdjson.RawMessage, *streamSeamCounters) {
+	t.Helper()
+	c := &streamSeamCounters{}
+	on := newDynclient(t,
+		dynclient.WithDeBAML(true),
+		dynclient.WithDeBAMLRenderer(debaml.Render),
+		dynclient.WithDeBAMLParser(instrumentedNativeParser(t, c)),
+	)
+	stream, err := on.DynamicStream(ctx, req)
+	if err != nil {
+		t.Fatalf("DynamicStream (de-BAML on): %v", err)
+	}
+	defer stream.Close()
+	final, _ := drainLibStream(t, stream)
+	return final, c
+}
+
+// TestDeBAMLStream_NativeFirstSeam drives a de-BAML-enabled DynamicStream for a
+// schema native CLAIMS on the partial surface (a plain string field), proving
+// the generated parseStreamFn calls the native parser first in the live path.
+// The final payload must match the BAML-as-today (de-BAML off) stream final —
+// stream support must not change what the request produces.
+func TestDeBAMLStream_NativeFirstSeam(t *testing.T) {
+	debamlGate(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// A long string value so the mock chunks it across several parse prefixes.
+	const content = `{"answer":"hello there, this is a reasonably long streamed answer"}`
+	opts := setupScenario(t, "test-debaml-stream-native-first", content)
+	_, libSchema := simpleAnswerSchema()
+
+	hello := "stream please"
+	req := dynclient.Request{
+		Messages:       []dynclient.Message{{Role: "user", TextContent: &hello}},
+		ClientRegistry: dynRegistry(opts.ClientRegistry),
+		OutputSchema:   libSchema,
+	}
+
+	// Baseline: de-BAML OFF (BAML-as-today) stream final.
+	off := newDynclient(t)
+	offStream, err := off.DynamicStream(ctx, req)
+	if err != nil {
+		t.Fatalf("DynamicStream (de-BAML off): %v", err)
+	}
+	offFinal, _ := drainLibStream(t, offStream)
+	offStream.Close()
+
+	onFinal, c := drivenStreamFinal(t, ctx, req)
+
+	if !jsonEqual(t, offFinal, onFinal) {
+		t.Errorf("de-BAML stream final diverged from BAML baseline:\n off=%s\n on =%s", string(offFinal), string(onFinal))
+	}
+	// The generated seam must have driven native-first at least once (a claimed
+	// stream prefix) — otherwise the seam isn't wired into the live path.
+	if got := c.streamClaims.Load(); got == 0 {
+		t.Errorf("native-first stream seam never CLAIMED a prefix (claims=%d, fallbacks=%d); parseStreamFn is not native-first",
+			got, c.streamFallbacks.Load())
+	}
+	// No CLAIMED native stream error may occur (the instrumented parser also fails
+	// on each; this is the explicit end-of-run guard against the non-terminal blind spot).
+	if got := c.streamErrors.Load(); got != 0 {
+		t.Errorf("native returned %d CLAIMED stream error(s) on the seam (want 0)", got)
+	}
+	t.Logf("native-first seam: stream claims=%d fallbacks=%d errors=%d final-calls=%d",
+		c.streamClaims.Load(), c.streamFallbacks.Load(), c.streamErrors.Load(), c.finalCalls.Load())
+}
+
+// TestDeBAMLStream_FallbackSeam drives a de-BAML-enabled DynamicStream for a
+// schema native DECLINES entirely in stream mode — a direct
+// list<multi-arm-union> element, whose cross-element union_variant_hint BAML
+// carries but native does not model (intentionally deferred after M3). Native
+// declines with the unsupported sentinel on EVERY prefix, so the generated seam
+// must fall back SILENTLY to BAML parse-stream, and the final must still match
+// the BAML-as-today baseline. This proves fallback runs in the same live
+// streaming path used by real requests.
+func TestDeBAMLStream_FallbackSeam(t *testing.T) {
+	debamlGate(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const content = `{"items":[1,true,2,false,3]}`
+	opts := setupScenario(t, "test-debaml-stream-fallback", content)
+
+	// items: list<int | bool> — a multi-arm union list element, which native
+	// declines at the structural cut-line (checkSupported) in BOTH stream and
+	// final parse, so BAML stays authoritative throughout.
+	libSchema := &dynclient.OutputSchema{
+		Properties: dynclientFromMap(map[string]*dynclient.Property{
+			"items": {
+				Type: "list",
+				Items: &dynclient.TypeSpec{
+					Type: "union",
+					OneOf: []*dynclient.TypeSpec{
+						{Type: "int"},
+						{Type: "bool"},
+					},
+				},
+			},
+		}),
+	}
+
+	hello := "stream please"
+	req := dynclient.Request{
+		Messages:       []dynclient.Message{{Role: "user", TextContent: &hello}},
+		ClientRegistry: dynRegistry(opts.ClientRegistry),
+		OutputSchema:   libSchema,
+	}
+
+	// Baseline: de-BAML OFF stream final.
+	off := newDynclient(t)
+	offStream, err := off.DynamicStream(ctx, req)
+	if err != nil {
+		t.Fatalf("DynamicStream (de-BAML off): %v", err)
+	}
+	offFinal, _ := drainLibStream(t, offStream)
+	offStream.Close()
+
+	onFinal, c := drivenStreamFinal(t, ctx, req)
+
+	if !jsonEqual(t, offFinal, onFinal) {
+		t.Errorf("de-BAML fallback stream final diverged from BAML baseline:\n off=%s\n on =%s", string(offFinal), string(onFinal))
+	}
+	// Native must have been consulted and DECLINED every stream prefix (silent
+	// BAML fallback), never claiming an unsupported shape.
+	if got := c.streamFallbacks.Load(); got == 0 {
+		t.Errorf("fallback stream seam never fell back (fallbacks=%d, claims=%d); native was not consulted on the stream path",
+			got, c.streamClaims.Load())
+	}
+	if got := c.streamClaims.Load(); got != 0 {
+		t.Errorf("native must NOT claim a list<multi-arm-union> stream prefix (over-claim), got claims=%d", got)
+	}
+	// A declining schema must still never produce a CLAIMED native stream error
+	// (it declines with the unsupported sentinel, counted as a fallback above).
+	if got := c.streamErrors.Load(); got != 0 {
+		t.Errorf("native returned %d CLAIMED stream error(s) on the seam (want 0)", got)
+	}
+	t.Logf("fallback seam: stream claims=%d fallbacks=%d errors=%d final-calls=%d",
+		c.streamClaims.Load(), c.streamFallbacks.Load(), c.streamErrors.Load(), c.finalCalls.Load())
+}

--- a/internal/debaml/stream_test.go
+++ b/internal/debaml/stream_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/schema"
 )
 
 // M4b/M4c streaming (raw_is_done=false) native-parse coverage. Each claimed case
@@ -229,6 +230,71 @@ func TestStream_NilSchemaDeclines(t *testing.T) {
 	if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
 		t.Fatalf("nil schema stream: expected ErrDeBAMLParseUnsupported, got %v", err)
 	}
+}
+
+// TestStream_WithStateAndAnnotationsDecline pins the M4d part-A boundary:
+// @stream.with_state (StreamingBehavior.State) and the other BAML stream
+// annotations — @@stream.done (Done), @stream.not_null (class Needed /
+// ClassField.StreamingNeeded), and any type-level Stream flag — are
+// UNREPRESENTABLE on a dynamic schema. bamlutils.DynamicProperty / DynamicClass /
+// DynamicTypeSpec carry NO stream-annotation channel, and
+// schema.FromDynamicOutputSchema lowers every class with a zero
+// StreamingBehavior (see its doc), so BAML's own dynamic parse-stream never sees
+// one either — there is nothing to capture and nothing to claim, and with_state
+// STAYS BAML fallback.
+//
+// checkNoStreamAnnotations is the DEFENSIVE gate that keeps that true even if a
+// future bridge extension somehow carried an annotation: any non-zero stream flag
+// DECLINES so BAML parse-stream stays authoritative. Because the live dynamic
+// bridge cannot produce such a bundle, this white-box test INJECTS each annotation
+// onto a freshly-lowered bundle (which the bridge cannot) and asserts the decline —
+// pinning that @stream.with_state can never be silently claimed on the stream path.
+func TestStream_WithStateAndAnnotationsDecline(t *testing.T) {
+	lower := func() *schema.Bundle {
+		t.Helper()
+		b, err := schema.FromDynamicOutputSchema(personSchema(), schema.BuildOptions{})
+		if err != nil {
+			t.Fatalf("lower personSchema: %v", err)
+		}
+		return b
+	}
+	requireGateDeclines := func(b *schema.Bundle, what string) {
+		t.Helper()
+		err := checkNoStreamAnnotations(b)
+		if err == nil {
+			t.Fatalf("%s: expected checkNoStreamAnnotations to DECLINE, got nil", what)
+		}
+		if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			t.Fatalf("%s: expected ErrDeBAMLParseUnsupported, got %v", what, err)
+		}
+	}
+	// A lowered dynamic schema carries NO annotations, so the gate passes (this is
+	// the ONLY shape the live bridge can ever produce — hence with_state is always
+	// unrepresentable, not merely declined).
+	if err := checkNoStreamAnnotations(lower()); err != nil {
+		t.Fatalf("annotation-free dynamic schema must pass the gate, got %v", err)
+	}
+	// Each injected annotation declines. b.Classes[0] is the synthetic
+	// Baml_Rest_DynamicOutput class (fields name, age); no nested classes.
+	b := lower()
+	b.Classes[0].Stream.State = true // @stream.with_state
+	requireGateDeclines(b, "@stream.with_state (class State)")
+
+	b = lower()
+	b.Classes[0].Stream.Done = true // @@stream.done
+	requireGateDeclines(b, "@@stream.done (class Done)")
+
+	b = lower()
+	b.Classes[0].Stream.Needed = true // @stream.not_null (class level)
+	requireGateDeclines(b, "@stream.not_null (class Needed)")
+
+	b = lower()
+	b.Classes[0].Fields[0].StreamingNeeded = true // @stream.not_null (field level)
+	requireGateDeclines(b, "@stream.not_null (field StreamingNeeded)")
+
+	b = lower()
+	b.Classes[0].Fields[0].Type.Meta.Stream.State = true // @stream.with_state on a field type
+	requireGateDeclines(b, "@stream.with_state (field type State)")
 }
 
 // TestStream_FinalParseUnchanged is a belt-and-suspenders check that the M4b


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

## De-BAML P4 M4d — Stream-State Wrappers (declined) + Native-First Parse-Stream Runtime

Final M4 slice. Base is M4c (oracle + basic partials + semantic streaming). Two deliverables.

### (A) `@stream.with_state` output wrappers — DECLINED (unrepresentable), stays BAML fallback

`@stream.with_state` (and every `@stream.*` annotation) is **not representable on a dynamic schema**, so native can never observe it and it **stays BAML fallback** — the valid, documented outcome the scope anticipated:

- `bamlutils.DynamicProperty` / `DynamicClass` / `DynamicTypeSpec` carry **no** stream-annotation channel (`interfaces.go:858-918`).
- `schema.FromDynamicOutputSchema` lowers every dynamic class with a **zero `StreamingBehavior`** (`build.go:73-76`) — BAML's own dynamic parse-stream sees no annotations either, so there is nothing to capture and nothing to claim.
- BAML's dynamic `ClassPropertyBuilder` exposes only `SetType`/description/alias — it cannot attach `with_state`/`done`/`not_null`.

`checkNoStreamAnnotations` is the **defensive gate**: any injected `State`/`Done`/`Needed` declines with the unsupported sentinel. A new white-box `internal/debaml` test pins that decline (the live bridge cannot even produce such a bundle). No streaming corpus fixtures are added — with_state is not differential-testable on the dynamic path.

### (B) Native-first parse-stream **runtime** seam

The generated dynamic `parseStreamFn` now calls **native de-BAML stream parse first** (`Stream=true`) and falls back **silently** to BAML `ParseStream` on the unsupported sentinel:

- **Native-first:** `maybeParseDeBAMLStream` drives the wired parser with `Stream=true`, wrapping a claimed result into the **streaming** `Baml_Rest_DynamicOutput` envelope (`wrapDeBAMLDynamicOutputStream`).
- **Silent fallback:** unlike the once-per-response final seam, `parseStreamFn` runs per accumulated prefix, so the unsupported fallback logs **nothing** (no noisy per-token logs).
- **Claimed-error parity:** a non-sentinel native error propagates and the orchestrator drops it **exactly like a BAML parse-stream error** — per-prefix parse errors are non-terminal; final-response parsing still decides success/failure.
- **Final-parse native-first behavior is unchanged.**

Wired via the codegen templates (`parseStreamFnBody`, `maybeParseDeBAMLStream`/`wrapDeBAMLDynamicOutputStream`) and the **regenerated dynclient** adapter + debaml helper.

### Tests / validation

- Generated-seam unit tests: claim, silent-fallback, claimed-error propagate, wrap-failure propagate, decline-when-off, and `Stream=true` request assertion.
- `internal/debaml` gate test: `checkNoStreamAnnotations` declines injected `with_state`/`done`/`not_null`.
- Integration test drives the generated `parseStreamFn` seam end-to-end in the live streaming path: native-first **CLAIM** (`claims=4`) and silent BAML **fallback** (`fallbacks=2`, `claims=0` — no over-claim on `list<multi-arm-union>`).
- Green: `gofmt`, `go build ./...`, `go vet ./...` (+`-tags=integration`), `go test ./internal/debaml/...`, `GOWORK=off go test ./codegen`, `verify-framework-adapter` (6/6, incl. adapter_v0_219 regen+build), and the bamlfuzz parse-recovery **differential** (native stream PARSER unchanged → unaffected/green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native-first de-BAML parsing for the streaming path, with automatic silent fallback to standard streaming when native parsing is unsupported.
  * Added support for streaming dynamic-output wrapping when native de-BAML parsing is successfully claimed.
* **Bug Fixes**
  * Ensured unsupported native streaming parses decline cleanly while propagated claimed-native errors still surface correctly.
  * Improved safeguards so streaming annotations are declined for unsupported dynamically-lowered schemas.
* **Tests**
  * Added integration tests validating native-claim vs fallback behavior for streaming.
  * Added unit regression coverage for annotation/state decline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->