### PR TITLE
ci: informational de-BAML integration-matrix arm (non-blocking)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -481,6 +481,116 @@ jobs:
         # direct in-process worker path.
         run: go test -tags=integration -v -count=1 -p 1 -timeout 40m ./integration/...
 
+  integration-tests-debaml:
+    needs: [get-latest-version, warm-images]
+    runs-on: ubuntu-latest
+    # INFORMATIONAL, NON-BLOCKING arm. This job runs the existing integration
+    # suite end-to-end with the whole shared TestEnv flipped onto the de-BAML
+    # native dynamic response-coercion path (BAML_REST_USE_DEBAML=true), to
+    # OBSERVE which integration tests diverge under de-BAML. It is expected to
+    # be RED while de-BAML parity is still landing, so:
+    #   - `continue-on-error: true` lets the whole workflow still conclude green
+    #     for mergeability while this job's failing command/test output stays
+    #     visible in its own distinct log stream; and
+    #   - this job is intentionally NOT added to required status checks /
+    #     branch protection. Do not promote it to blocking until de-BAML parity
+    #     is intentionally graduated from informational.
+    # Fixes for whatever this arm reveals are separate follow-up PRs, never here.
+    continue-on-error: true
+    # Same outer backstop as the other light cells: step timeout-minutes (45m,
+    # below) bounds the go-test step; this job cap = step (45m) + a realistic
+    # pre-test budget (~10m for checkout + Go setup + warm-image load). See #420.
+    timeout-minutes: 55
+    strategy:
+      # Single-cell today, but keep fail-fast off so adding an OFF/ON unary
+      # pair later never masks one cell's failure behind another's.
+      fail-fast: false
+      matrix:
+        # Single cell: latest BAML only, unary server on. http-client is pinned
+        # to `auto` (the default deployment path) in the go-test env below —
+        # de-BAML response coercion is not the llmhttp backend surface, so the
+        # http-client spread adds no de-BAML signal.
+        unary-server: [true]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Free runner disk before Docker image load
+        # This job runs TestBamlfuzzStaticOracle, which builds a fresh
+        # baml-rest image per static batch. Since #467 made the static prune
+        # failure-only (success path keeps the classic-builder cache warm),
+        # these per-batch images accumulate with no bound — so this cell
+        # needs the same disk headroom the fuzz/baml-source jobs already
+        # have, or it hits "no space left on device" (#467 follow-up).
+        # Placed before the warm-image load (docker-images:true must not
+        # delete them).
+        uses: ./.github/actions/free-disk-space
+
+      - name: Download warm base images
+        # Base images are pulled once by the warm-images job and handed over as
+        # a per-run artifact; this cell only loads them — no Docker Hub login,
+        # no pull (#447).
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: warm-images-${{ github.run_id }}
+          path: warm-images
+
+      - name: Load warm base images
+        # `docker load` the warmed tarballs before the go-test step so
+        # testcontainers' tag-based `FROM` builds reuse them locally instead of
+        # pulling from Docker Hub.
+        run: |
+          set -euo pipefail
+          for tar in warm-images/*.tar; do
+            echo "loading $tar"
+            docker load -i "$tar"
+          done
+          docker image ls
+
+      - name: Set up Go
+        uses: actions/setup-go@v6.5.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run Integration Tests (de-BAML, BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }}, http-client=auto)
+        # Step timeout (45m) and watchdog (42m) share the go-test origin;
+        # watchdog fires 3m before the step is killed. #420
+        timeout-minutes: 45
+        env:
+          BAML_VERSION: ${{ needs.get-latest-version.outputs.latest }}
+          UNARY_SERVER: ${{ matrix.unary-server }}
+          BAML_REST_HTTP_CLIENT: auto
+          # The umbrella switch under test: flips the WHOLE shared TestEnv onto
+          # the de-BAML native dynamic response-coercion path. Forwarded into
+          # the baml-rest container by testutil.buildContainerEnv (the single
+          # env chokepoint), so cmd/serve and the subprocess cmd/worker both
+          # read it. "true" matches the existing dedicated de-BAML test.
+          BAML_REST_USE_DEBAML: "true"
+          # Step timeout (45m) minus 3m margin.
+          BAML_REST_SUITE_WATCHDOG: 42m
+          # CI-only: skip the testcontainers Ryuk reaper so setup doesn't
+          # pull/create it from Docker Hub (the earliest registry touch
+          # point, which flaked in #426/#427). Safe here because GH runners
+          # are ephemeral and torn down after the job, so leaked containers
+          # are cleaned up regardless. Never set this for local runs.
+          TESTCONTAINERS_RYUK_DISABLED: true
+          # This suite includes TestBamlfuzzStaticOracle. Successful static
+          # env teardown does NOT prune: testcontainers already removes each
+          # tagged final per-batch image, and the classic-builder layer cache
+          # must survive so later batches reuse warm Go toolchain / apt /
+          # goimports layers instead of rebuilding cold (#467). This gate
+          # activates ONLY the failed-setup prune (dangling images + BuildKit
+          # cache), since failed/partial builds are the real residue source.
+          BAMLFUZZ_STATIC_DOCKER_PRUNE_ON_FAILURE: "1"
+        # Same subprocess command as the versioned/light integration cells for
+        # comparability. The `-skip` excludes the de-BAML differential tests
+        # that use the shared TestEnv as a flag-OFF control: under this global
+        # flag-ON job that OFF control is no longer off, so they fail for a
+        # HARNESS reason, not a de-BAML response-coercion parity regression.
+        # Every other test runs so the arm's RED signal is genuine parity.
+        run: go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 40m -skip '^TestDeBAMLRest_MetadataAppearsOnProductionPath$' ./integration/...
+
   build-baml-cffi:
     needs: warm-images
     runs-on: ubuntu-latest

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -671,6 +671,18 @@ const HTTPClientSelectorEnvVar = "BAML_REST_HTTP_CLIENT"
 // pin is applied last and wins, so a test that deliberately pins a backend is
 // never overridden by the host env.
 //
+// The host BAML_REST_USE_DEBAML umbrella switch is forwarded the same way, for
+// the same reason: the informational integration-tests-debaml CI arm sets it on
+// the host go-test process to flip the WHOLE shared TestEnv onto the de-BAML
+// native dynamic response-coercion path. Without forwarding through this single
+// chokepoint the flag would never reach the baml-rest container (cmd/serve and
+// the subprocess cmd/worker both read it from the container env), so the arm
+// would be inert — the shared suite would keep running de-BAML off. Copied
+// before the RuntimeEnv loop so a dedicated test's explicit
+// opts.RuntimeEnv[BAML_REST_USE_DEBAML] pin (e.g. dynamic_debaml_rest_test.go)
+// still wins over the host value; left unset the var stays absent, preserving
+// the default-off behavior.
+//
 // Note: the BuildRequest route is unconditional as of #537, so there is no
 // BAML_REST_USE_BUILD_REQUEST forwarding here — the route is always attempted
 // when the BAML version exposes a Request/StreamRequest surface.
@@ -684,6 +696,13 @@ func buildContainerEnv(opts SetupOptions) map[string]string {
 	// preserving "unset → auto".
 	if v := os.Getenv(HTTPClientSelectorEnvVar); v != "" {
 		env[HTTPClientSelectorEnvVar] = v
+	}
+	// Forward the host de-BAML umbrella switch when set (non-empty), same
+	// chokepoint + precedence as the http-client selector: copied before the
+	// RuntimeEnv loop so an explicit RuntimeEnv pin still overrides it, and
+	// left absent when unset so the container stays de-BAML off by default.
+	if v := os.Getenv(bamlutils.EnvUseDeBAML); v != "" {
+		env[bamlutils.EnvUseDeBAML] = v
 	}
 	for k, v := range opts.RuntimeEnv {
 		env[k] = v

--- a/integration/testutil/container_debaml_env_test.go
+++ b/integration/testutil/container_debaml_env_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package testutil
+
+import (
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// TestBuildContainerEnvDeBAMLSelector is the regression guard for the
+// informational integration-tests-debaml CI arm. That arm sets
+// BAML_REST_USE_DEBAML on the host go-test process to flip the WHOLE shared
+// TestEnv onto the de-BAML native dynamic response-coercion path. The harness
+// starts baml-rest via testcontainers with an explicit Env map, so unless the
+// flag is forwarded into that map the arm is inert: the shared suite keeps
+// running de-BAML off and the arm is a false signal.
+//
+// Forwarding lives in buildContainerEnv — the single chokepoint every
+// baml-rest container's env passes through — with the SAME precedence as the
+// http-client selector: the host value is copied before the opts.RuntimeEnv
+// loop so a dedicated test (dynamic_debaml_rest_test.go) that pins the flag in
+// RuntimeEnv still wins. These cases pin that contract. No docker/BAML needed.
+func TestBuildContainerEnvDeBAMLSelector(t *testing.T) {
+	t.Run("host set reaches the container env", func(t *testing.T) {
+		t.Setenv(bamlutils.EnvUseDeBAML, "true")
+
+		env := buildContainerEnv(SetupOptions{})
+
+		if got := env[bamlutils.EnvUseDeBAML]; got != "true" {
+			t.Fatalf("container env[%s] = %q, want %q (de-BAML flag did not reach the container)",
+				bamlutils.EnvUseDeBAML, got, "true")
+		}
+	})
+
+	t.Run("host set reaches the container env even with a fresh RuntimeEnv map", func(t *testing.T) {
+		// Simulates the dedicated tests that REPLACE opts.RuntimeEnv with a
+		// fresh map lacking the flag: the setup-path value would be clobbered,
+		// but the chokepoint forwarding survives.
+		t.Setenv(bamlutils.EnvUseDeBAML, "true")
+
+		opts := SetupOptions{RuntimeEnv: map[string]string{"BAML_REST_CLIENT_DEFAULTS": "{}"}}
+		env := buildContainerEnv(opts)
+
+		if got := env[bamlutils.EnvUseDeBAML]; got != "true" {
+			t.Fatalf("container env[%s] = %q, want %q (flag dropped by a replaced RuntimeEnv map)",
+				bamlutils.EnvUseDeBAML, got, "true")
+		}
+		// The test's own RuntimeEnv entries must still be forwarded too.
+		if got := env["BAML_REST_CLIENT_DEFAULTS"]; got != "{}" {
+			t.Fatalf("container env[BAML_REST_CLIENT_DEFAULTS] = %q, want %q", got, "{}")
+		}
+	})
+
+	t.Run("explicit RuntimeEnv pin wins over the host value", func(t *testing.T) {
+		// The dedicated de-BAML differential (dynamic_debaml_rest_test.go) pins
+		// the flag ON via RuntimeEnv for its own container; that must win even
+		// under the arm's global host BAML_REST_USE_DEBAML, and — symmetrically —
+		// a test that pins it OFF must be able to override a host ON.
+		t.Setenv(bamlutils.EnvUseDeBAML, "true")
+
+		opts := SetupOptions{RuntimeEnv: map[string]string{bamlutils.EnvUseDeBAML: "false"}}
+		env := buildContainerEnv(opts)
+
+		if got := env[bamlutils.EnvUseDeBAML]; got != "false" {
+			t.Fatalf("container env[%s] = %q, want %q (explicit pin overridden by host env)",
+				bamlutils.EnvUseDeBAML, got, "false")
+		}
+	})
+
+	t.Run("host unset leaves the flag absent (default de-BAML off)", func(t *testing.T) {
+		t.Setenv(bamlutils.EnvUseDeBAML, "")
+
+		env := buildContainerEnv(SetupOptions{})
+
+		if _, ok := env[bamlutils.EnvUseDeBAML]; ok {
+			t.Fatalf("container env unexpectedly contains %s when host is unset (breaks default-off)",
+				bamlutils.EnvUseDeBAML)
+		}
+	})
+}


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

## Informational de-BAML integration arm (non-blocking)

This PR adds **only** the CI/test-infra needed to run the existing integration
suite end-to-end under `BAML_REST_USE_DEBAML=true`, so REST/container traffic
exercises the de-BAML **native dynamic response-coercion** path instead of the
default BAML CFFI path.

The whole point is to **OBSERVE** what diverges under de-BAML. This arm is
**expected to be RED** while de-BAML parity is still landing, and that is fine —
it is informational, non-blocking, and kept out of required status checks. **It
contains NO fixes for the failures it reveals; those are separate follow-up
PRs.**

### What's added (exactly three things)

1. **`.github/workflows/integration-tests.yml` — new job `integration-tests-debaml`.**
   - Job-level `continue-on-error: true` and `strategy.fail-fast: false`, so the
     workflow still concludes green for mergeability while this job's failing
     command/test output stays visible in its own distinct log stream.
   - `needs: [get-latest-version, warm-images]`; mirrors the light subprocess
     cell structure (checkout → free-disk-space → download/load warm images →
     setup Go → run tests) and reuses the same job cap / watchdog / Ryuk /
     static-prune envs.
   - Single cell: **latest BAML only** (`needs.get-latest-version.outputs.latest`),
     `BAML_REST_HTTP_CLIENT=auto`, `UNARY_SERVER=true`, `BAML_REST_USE_DEBAML=true`.
   - Command: `go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 40m
     -skip '^TestDeBAMLRest_MetadataAppearsOnProductionPath$' ./integration/...`.
     That one test uses the shared `TestEnv` as a de-BAML **flag-OFF control**;
     under a global flag-ON job the OFF control is no longer off, so it fails for
     a **harness** reason, not a response-coercion parity regression. It is the
     only such OFF-control test in the suite (all other de-BAML tests spin their
     own dedicated container or use in-process dynclient with explicit
     `WithDeBAML(true)`), so every other test still runs and the RED signal is
     genuine parity.
   - **Not** added to required status checks / branch protection.

2. **`integration/testutil/container.go` — forward the host `BAML_REST_USE_DEBAML`
   into the container env.** Done at the same `buildContainerEnv` chokepoint and
   with the same precedence as `BAML_REST_HTTP_CLIENT`: the host value is copied
   first, then `opts.RuntimeEnv` is overlaid so dedicated tests
   (`dynamic_debaml_rest_test.go`) still override it. Without this the arm is
   **inert** — the harness starts baml-rest with an explicit `Env` map, so a
   workflow-only env would never reach `cmd/serve` or the subprocess `cmd/worker`
   and the shared suite would keep running de-BAML off (a false signal).

3. **`integration/testutil/container_debaml_env_test.go` — a no-docker unit test**
   pinning that `BAML_REST_USE_DEBAML` reaches the container env (even through a
   replaced `RuntimeEnv` map) and that an explicit `RuntimeEnv` pin wins.

### Local validation

`gofmt` clean · `go build ./...` · `go vet ./...` (incl. `-tags=integration`) ·
the new pin-test passes · `actionlint` on the workflow passes.

The de-BAML arm will likely be RED in CI — expected and non-blocking. Fixes for
whatever it reveals are separate follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the de-BAML setting in integration environments so the test container now matches the intended configuration more reliably.
  * Preserved override precedence, ensuring an explicit test setting takes priority over the host environment.

* **Tests**
  * Added coverage for de-BAML environment propagation, including default-off behavior and override scenarios.
  * Added a new non-blocking integration test job to validate the de-BAML path in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->