### PR TITLE
debaml: parity-decline map-containing dynamic parse schemas

### DIFF
--- a/integration/bamlfuzz_parse_recovery_test.go
+++ b/integration/bamlfuzz_parse_recovery_test.go
@@ -184,6 +184,16 @@ func (p perCallTimeoutParser) Parse(ctx context.Context, req bamlfuzz.ParseReque
 // (an unterminated/truncated structure, which BAML recovers but M2a defers)
 // — stay fallback. Cases absent from the map (the streaming-only ones)
 // carry no final leg and are not asserted.
+//
+// MAP PARITY-DECLINE: internal/debaml.Parse now declines EVERY map-containing
+// schema (checkNoMap) because native coerceMap emits entries in parsed input-key
+// order, which cannot be proven equal to BAML's observable map-key order under
+// preserve-order. So any map-containing case FALLS BACK regardless of its pinned
+// value here — runParseRecoveryCase forces the expected disposition to fallback
+// via parseRecoverySchemaContainsMap. The map/enum/class map entries below keep
+// their pre-decline (claimed) pins as documentation of the coerceMap behavior a
+// future PR re-enables behind a proven map-order fixture; the override — not a
+// mass pin flip — is what keeps this differential green today.
 var parseRecoveryNativeClaim = map[string]bool{
 	"markdown_fence_object":    true,
 	"prose_before_after_json":  true,
@@ -715,6 +725,57 @@ func streamPrefixNativeClaim(caseName, prefixName string) bool {
 	return false
 }
 
+// parseRecoverySchemaContainsMap reports whether the schema reaches a map type
+// anywhere — the effective root, any reachable class field, or a nested list /
+// optional / union / map / class-ref edge. It backs the MAP PARITY-DECLINE
+// override: internal/debaml.Parse declines every map-containing schema
+// (checkNoMap), so such a case must fall back regardless of its pinned final /
+// streaming disposition. Class-ref cycles terminate via the visited set.
+func parseRecoverySchemaContainsMap(s bamlfuzz.FuzzSchema) bool {
+	classes := make(map[string]bamlfuzz.FuzzClass, len(s.Classes))
+	for _, c := range s.Classes {
+		classes[c.Name] = c
+	}
+	seen := make(map[string]bool, len(s.Classes))
+	var walkType func(t bamlfuzz.FuzzType) bool
+	var walkClass func(name string) bool
+	walkClass = func(name string) bool {
+		if seen[name] {
+			return false
+		}
+		seen[name] = true
+		c, ok := classes[name]
+		if !ok {
+			return false
+		}
+		for i := range c.Properties {
+			if walkType(c.Properties[i].Type) {
+				return true
+			}
+		}
+		return false
+	}
+	walkType = func(t bamlfuzz.FuzzType) bool {
+		switch t.Kind {
+		case bamlfuzz.KindMap:
+			return true
+		case bamlfuzz.KindOptional, bamlfuzz.KindList:
+			return t.Inner != nil && walkType(*t.Inner)
+		case bamlfuzz.KindUnion:
+			for i := range t.Variants {
+				if walkType(t.Variants[i]) {
+					return true
+				}
+			}
+			return false
+		case bamlfuzz.KindClassRef:
+			return walkClass(t.Ref)
+		}
+		return false
+	}
+	return walkType(s.EffectiveRoot())
+}
+
 // parseRecoveryStats tallies how many final-parse and streaming-prefix legs
 // the native parser claimed vs fell back on, logged as a summary so a shift
 // in the native cut-line is visible even when every case still passes. The
@@ -837,6 +898,12 @@ func runParseRecoveryCase(t *testing.T, baml, native bamlfuzz.Parser, c bamlfuzz
 			if !ok {
 				t.Fatalf("final-parse case %q has no pinned native disposition; add it to parseRecoveryNativeClaim (true=claimed, false=fallback)", c.Name)
 			}
+			// MAP PARITY-DECLINE: a map-containing schema always falls back
+			// (checkNoMap), overriding the pinned pre-decline claim. See
+			// parseRecoverySchemaContainsMap and the parseRecoveryNativeClaim doc.
+			if parseRecoverySchemaContainsMap(c.Schema) {
+				want = false
+			}
 			if claimed {
 				t.Logf("native CLAIMED final parse for %q", c.Name)
 			} else {
@@ -918,6 +985,12 @@ func runParseRecoveryCase(t *testing.T, baml, native bamlfuzz.Parser, c bamlfuzz
 						stats.streamFallback++
 					}
 					want := streamPrefixNativeClaim(c.Name, p.Name)
+					// MAP PARITY-DECLINE: parseStream shares the checkSupported
+					// gate, so a map-containing schema falls back on every prefix,
+					// overriding the pinned pre-decline claim.
+					if parseRecoverySchemaContainsMap(c.Schema) {
+						want = false
+					}
 					if claimed {
 						t.Logf("native CLAIMED stream prefix %q/%q", c.Name, p.Name)
 					} else {

--- a/internal/debaml/coerce_array_to_singular_test.go
+++ b/internal/debaml/coerce_array_to_singular_test.go
@@ -143,10 +143,10 @@ func TestUnion_MapArm(t *testing.T) {
 		&bamlutils.DynamicTypeSpec{Type: "map", Keys: &bamlutils.DynamicTypeSpec{Type: "string"}, Values: &bamlutils.DynamicTypeSpec{Type: "int"}},
 		&bamlutils.DynamicTypeSpec{Type: "string"},
 	)
-	mustParse(t, msu, `{"u":{"a":1}}`, `{"u":{"a":1}}`)
+	mustCoerce(t, msu, `{"u":{"a":1}}`, `{"u":{"a":1}}`)
 	// A partial-value map: the bad value is skipped (MapValueParseError), the map arm
 	// ({"a":1}) beats the string arm's stringification.
-	mustParse(t, msu, `{"u":{"a":1,"b":"x"}}`, `{"u":{"a":1}}`)
+	mustCoerce(t, msu, `{"u":{"a":1,"b":"x"}}`, `{"u":{"a":1}}`)
 
 	// OVER-CLAIM GUARD: C{a:int} | map<string,int> with an extra key → the MAP wins
 	// (the class try_cast rejects the extra key; the map try_cast keeps it). Without
@@ -163,14 +163,22 @@ func TestUnion_MapArm(t *testing.T) {
 			bamlutils.OrderedKV("C", &bamlutils.DynamicClass{Properties: props(kv("a", intProp()))}),
 		),
 	}
-	mustParse(t, cmu, `{"u":{"a":1,"extra":2}}`, `{"u":{"a":1,"extra":2}}`)
+	mustCoerce(t, cmu, `{"u":{"a":1,"extra":2}}`, `{"u":{"a":1,"extra":2}}`)
 }
 
-// TestUnion_MapArmNonStringKeyDeclines pins the gate: a map arm with an ENUM /
-// literal key stays out of scope in a union (dynamic map-key keep is unproven).
+// TestUnion_MapArmNonStringKeyDeclines pins the COERCE-TIME union-shape reproof
+// for a map union arm with a non-string (ENUM / literal) key. It drives
+// requireCoerceUnsupported — the coerceViaBundle bypass that SKIPS the public
+// checkNoMap gate — so the decline asserted here is NOT the map gate: it is
+// coerceUnionSafe re-proving the arm set via checkSupportedUnionShape, whose
+// checkUnionMapVariant rejects a non-string map key (dynamic map-key keep is
+// unproven). Under the public Parse this same schema would instead decline
+// earlier at checkNoMap (it contains a map at all); this test isolates the
+// deeper union-map-variant reproof that the bypass still exercises.
 func TestUnion_MapArmNonStringKeyDeclines(t *testing.T) {
 	// map<"a"|"b", int> | string — a string-literal-union key is a legal map key but
-	// not a plain string, so the map union arm declines at the gate.
+	// not a plain string, so coerceUnionSafe's checkSupportedUnionShape reproof
+	// (checkUnionMapVariant) declines the union at COERCE time (via the bypass).
 	litKey := &bamlutils.DynamicTypeSpec{
 		Type:  "union",
 		OneOf: []*bamlutils.DynamicTypeSpec{{Type: "literal_string", Value: "a"}, {Type: "literal_string", Value: "b"}},
@@ -179,7 +187,7 @@ func TestUnion_MapArmNonStringKeyDeclines(t *testing.T) {
 		&bamlutils.DynamicTypeSpec{Type: "map", Keys: litKey, Values: &bamlutils.DynamicTypeSpec{Type: "int"}},
 		&bamlutils.DynamicTypeSpec{Type: "string"},
 	)
-	requireUnsupported(t, s, `{"u":{"a":1}}`)
+	requireCoerceUnsupported(t, s, `{"u":{"a":1}}`)
 }
 
 // TestUnion_ListArmTryCast pins THE list-arm phase-1 try_cast (the over-claim the
@@ -214,7 +222,7 @@ func TestUnion_MapValueTryCast(t *testing.T) {
 		&bamlutils.DynamicTypeSpec{Type: "map", Keys: &bamlutils.DynamicTypeSpec{Type: "string"}, Values: &bamlutils.DynamicTypeSpec{Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "int"}}},
 		&bamlutils.DynamicTypeSpec{Type: "map", Keys: &bamlutils.DynamicTypeSpec{Type: "string"}, Values: &bamlutils.DynamicTypeSpec{Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "string"}}},
 	)
-	mustParse(t, mlu, `{"u":{"a":["1"]}}`, `{"u":{"a":["1"]}}`)
+	mustCoerce(t, mlu, `{"u":{"a":["1"]}}`, `{"u":{"a":["1"]}}`)
 
 	// map<string,int> | map<string,int|string> with {"a":"1"}: the first map's value
 	// try_cast fails (int rejects "1"), the second's inner int|string try_cast picks
@@ -226,7 +234,7 @@ func TestUnion_MapValueTryCast(t *testing.T) {
 			OneOf: []*bamlutils.DynamicTypeSpec{{Type: "int"}, {Type: "string"}},
 		}},
 	)
-	mustParse(t, muu, `{"u":{"a":"1"}}`, `{"u":{"a":"1"}}`)
+	mustCoerce(t, muu, `{"u":{"a":"1"}}`, `{"u":{"a":"1"}}`)
 }
 
 // TestCheckUnionMapVariant_ConstrainedKeyDeclines pins FIX B: a union map arm with

--- a/internal/debaml/coerce_class_test.go
+++ b/internal/debaml/coerce_class_test.go
@@ -186,9 +186,10 @@ func TestCoerceClass_RequiredDefaults(t *testing.T) {
 	listS := nestedClassSchema("C", props(kv("items", listProp(&bamlutils.DynamicTypeSpec{Type: "int"}))))
 	mustParse(t, listS, `{"u":{}}`, `{"u":{"items":[]}}`)
 
-	// Required map field absent -> {}.
+	// Required map field absent -> {}. (Via the coerce bypass: a map-containing
+	// schema declines at the checkNoMap gate, so Parse never reaches coerceClass.)
 	mapS := nestedClassSchema("C", props(kv("m", mapProp(&bamlutils.DynamicTypeSpec{Type: "int"}))))
-	mustParse(t, mapS, `{"u":{}}`, `{"u":{"m":{}}}`)
+	mustCoerce(t, mapS, `{"u":{}}`, `{"u":{"m":{}}}`)
 
 	// Required null-primitive field absent -> null.
 	nullS := nestedClassSchema("C", props(kv("n", nullProp())))
@@ -215,8 +216,8 @@ func TestCoerceClass_RequiredDefaults(t *testing.T) {
 // error, so BAML fills the map default {} and native CLAIMS it.
 func TestCoerceClass_MapFieldDefaultButUnparseable(t *testing.T) {
 	mapS := nestedClassSchema("C", props(kv("m", mapProp(&bamlutils.DynamicTypeSpec{Type: "int"}))))
-	mustParse(t, mapS, `{"u":{"m":"bad"}}`, `{"u":{"m":{}}}`)
-	mustParse(t, mapS, `{"u":{"m":[1,2]}}`, `{"u":{"m":{}}}`)
+	mustCoerce(t, mapS, `{"u":{"m":"bad"}}`, `{"u":{"m":{}}}`)
+	mustCoerce(t, mapS, `{"u":{"m":[1,2]}}`, `{"u":{"m":{}}}`)
 
 	b, ct := classBundle(t, mapS, "C")
 	cf := &coerceFlags{}
@@ -227,7 +228,7 @@ func TestCoerceClass_MapFieldDefaultButUnparseable(t *testing.T) {
 		t.Errorf("DefaultButHadUnparseableValue must flag cf (score 2)")
 	}
 	// A map field with an OBJECT value coerces normally (partial map, not a default).
-	mustParse(t, mapS, `{"u":{"m":{"a":1}}}`, `{"u":{"m":{"a":1}}}`)
+	mustCoerce(t, mapS, `{"u":{"m":{"a":1}}}`, `{"u":{"m":{"a":1}}}`)
 }
 
 // TestCoerceClass_ScalarMultiFieldAllDefaultable pins that a SCALAR into a
@@ -239,9 +240,12 @@ func TestCoerceClass_ScalarMultiFieldAllDefaultable(t *testing.T) {
 		kv("a", listProp(&bamlutils.DynamicTypeSpec{Type: "int"})),
 		kv("b", mapProp(&bamlutils.DynamicTypeSpec{Type: "int"})),
 	))
-	mustParse(t, s, `{"u":5}`, `{"u":{"a":[],"b":{}}}`)
+	// Via the coerce bypass: the map field `b` makes this a map-containing schema,
+	// which Parse declines at the checkNoMap gate; the scalar-into-multi-field
+	// default-fill under test is unchanged and exercised through coerceViaBundle.
+	mustCoerce(t, s, `{"u":5}`, `{"u":{"a":[],"b":{}}}`)
 	// An empty object behaves the same (no keys -> all defaults).
-	mustParse(t, s, `{"u":{}}`, `{"u":{"a":[],"b":{}}}`)
+	mustCoerce(t, s, `{"u":{}}`, `{"u":{"a":[],"b":{}}}`)
 }
 
 // TestCoerceClass_ArrayDeclines pins the HARD boundary: an ARRAY into a class is
@@ -427,7 +431,7 @@ func TestCoerceClass_CollectionChildFlips(t *testing.T) {
 		Properties: props(kv("u", mapProp(&bamlutils.DynamicTypeSpec{Ref: "Box"}))),
 		Classes:    bamlutils.MustOrderedMap(bamlutils.OrderedKV("Box", &bamlutils.DynamicClass{Properties: props(kv("value", intProp()))})),
 	}
-	mustParse(t, mapBox, `{"u":{"a":5,"b":6}}`, `{"u":{"a":{"value":5},"b":{"value":6}}}`)
+	mustCoerce(t, mapBox, `{"u":{"a":5,"b":6}}`, `{"u":{"a":{"value":5},"b":{"value":6}}}`)
 
 	// list<C> where C{items int[]}: an empty-object element fills the list default.
 	listDefault := &bamlutils.DynamicOutputSchema{
@@ -441,5 +445,5 @@ func TestCoerceClass_CollectionChildFlips(t *testing.T) {
 		Properties: props(kv("u", mapProp(&bamlutils.DynamicTypeSpec{Ref: "C"}))),
 		Classes:    bamlutils.MustOrderedMap(bamlutils.OrderedKV("C", &bamlutils.DynamicClass{Properties: props(kv("items", listProp(&bamlutils.DynamicTypeSpec{Type: "int"})))})),
 	}
-	mustParse(t, mapDefault, `{"u":{"k":{}}}`, `{"u":{"k":{"items":[]}}}`)
+	mustCoerce(t, mapDefault, `{"u":{"k":{}}}`, `{"u":{"k":{"items":[]}}}`)
 }

--- a/internal/debaml/coerce_class_union_test.go
+++ b/internal/debaml/coerce_class_union_test.go
@@ -201,7 +201,10 @@ func TestClassUnion_HardGuardsStayFallback(t *testing.T) {
 	)
 	requireUnsupported(t, listField, `{"u":{"a":1,"tags":["x"]}}`)
 
-	// A class arm with a MAP field declines at the gate.
+	// A class arm with a MAP field declines. The map is reachable through the
+	// class ref, so checkNoMap now declines it at the map gate (a parity-decline
+	// for map-key order) before the union-class-variant flat-leaf check runs; the
+	// decline is the same either way.
 	mapField := abClassUnionSchema(
 		props(kv("a", intProp()), kv("m", &bamlutils.DynamicProperty{Type: "map", Keys: &bamlutils.DynamicTypeSpec{Type: "string"}, Values: &bamlutils.DynamicTypeSpec{Type: "int"}})),
 		props(kv("c", intProp()), kv("d", strProp())),

--- a/internal/debaml/coerce_map_test.go
+++ b/internal/debaml/coerce_map_test.go
@@ -70,12 +70,12 @@ func mapStrPairSchema() *bamlutils.DynamicOutputSchema {
 func TestCoerceMap_ValuePartialSkip(t *testing.T) {
 	s := mapStringIntSchema()
 	// "a":1 kept, "b":"bad" skipped (proven int parse error), "c":"7" kept (7).
-	mustParseExact(t, s, `{"scores":{"a":1,"bad":"nope","c":"7"}}`, `{"scores":{"a":1,"c":7}}`)
+	mustCoerceExact(t, s, `{"scores":{"a":1,"bad":"nope","c":"7"}}`, `{"scores":{"a":1,"c":7}}`)
 	// All-bad values -> {}.
-	mustParseExact(t, s, `{"scores":{"a":"x","b":"y"}}`, `{"scores":{}}`)
+	mustCoerceExact(t, s, `{"scores":{"a":"x","b":"y"}}`, `{"scores":{}}`)
 	// Proven non-string value kinds BAML rejects with error_unexpected_type are
 	// also skipped: object, bool, null (a number is always coerced, kept).
-	mustParseExact(t, s, `{"scores":{"a":1,"b":{"x":1},"c":true,"d":null,"e":2}}`, `{"scores":{"a":1,"e":2}}`)
+	mustCoerceExact(t, s, `{"scores":{"a":1,"b":{"x":1},"c":true,"d":null,"e":2}}`, `{"scores":{"a":1,"e":2}}`)
 }
 
 // TestCoerceMap_LenientValuesKept pins that Mcoerce-a/b leaf coercions run
@@ -83,7 +83,7 @@ func TestCoerceMap_ValuePartialSkip(t *testing.T) {
 // fraction, extracted currency), in input key order.
 func TestCoerceMap_LenientValuesKept(t *testing.T) {
 	s := mapStringIntSchema()
-	mustParseExact(t, s, `{"scores":{"a":"1","b":2.6,"c":"3/2","d":"$1,234"}}`, `{"scores":{"a":1,"b":3,"c":2,"d":1234}}`)
+	mustCoerceExact(t, s, `{"scores":{"a":"1","b":2.6,"c":"3/2","d":"$1,234"}}`, `{"scores":{"a":1,"b":3,"c":2,"d":1234}}`)
 }
 
 // TestCoerceMap_ClassValueScalarSkips pins that a multi-field flat class VALUE
@@ -93,12 +93,12 @@ func TestCoerceMap_LenientValuesKept(t *testing.T) {
 func TestCoerceMap_ClassValueScalarSkips(t *testing.T) {
 	s := mapStrPairSchema()
 	// Scalar 5 skipped; the object value kept, its fields in SCHEMA order.
-	mustParseExact(t, s, `{"items":{"k":5,"p":{"b":"y","a":"x"}}}`, `{"items":{"p":{"a":"x","b":"y"}}}`)
+	mustCoerceExact(t, s, `{"items":{"k":5,"p":{"b":"y","a":"x"}}}`, `{"items":{"p":{"a":"x","b":"y"}}}`)
 	// Scalar-only -> {}.
-	mustParseExact(t, s, `{"items":{"k":5}}`, `{"items":{}}`)
+	mustCoerceExact(t, s, `{"items":{"k":5}}`, `{"items":{}}`)
 	// An object value missing a required field is NOT a proven skip (BAML may
 	// default-fill) -> decline the WHOLE map.
-	requireUnsupported(t, s, `{"items":{"a":{"a":"x","b":"y"},"b":{"a":"x"}}}`)
+	requireCoerceUnsupported(t, s, `{"items":{"a":{"a":"x","b":"y"},"b":{"a":"x"}}}`)
 }
 
 // TestCoerceMap_KeyMissDeclines pins that a KEY matching NO string-literal-union
@@ -109,12 +109,12 @@ func TestCoerceMap_ClassValueScalarSkips(t *testing.T) {
 func TestCoerceMap_KeyMissDeclines(t *testing.T) {
 	s := mapLitUnionStrSchema()
 	// All keys match -> claim, keeping ORIGINAL strings in INPUT order.
-	mustParseExact(t, s, `{"u":{"B":"y","A":"x"}}`, `{"u":{"B":"y","A":"x"}}`)
+	mustCoerceExact(t, s, `{"u":{"B":"y","A":"x"}}`, `{"u":{"B":"y","A":"x"}}`)
 	// A fuzzy (case-variant) key still matches via match_string and is KEPT under
 	// its ORIGINAL string, not the canonical literal.
-	mustParseExact(t, s, `{"u":{"a":"x"}}`, `{"u":{"a":"x"}}`)
+	mustCoerceExact(t, s, `{"u":{"a":"x"}}`, `{"u":{"a":"x"}}`)
 	// A key matching no arm -> decline the whole map (dynamic keeps it -> Mcoerce-d).
-	requireUnsupported(t, s, `{"u":{"B":"y","C":"z","A":"x"}}`)
+	requireCoerceUnsupported(t, s, `{"u":{"B":"y","C":"z","A":"x"}}`)
 }
 
 // TestCoerceMap_EnumKeyMissDeclines pins that a MISSED enum key is NOT a partial
@@ -123,8 +123,8 @@ func TestCoerceMap_KeyMissDeclines(t *testing.T) {
 func TestCoerceMap_EnumKeyMissDeclines(t *testing.T) {
 	s := mapEnumKeySchema()
 	// All keys match -> claim; a missed key -> decline (not a partial skip).
-	mustParseExact(t, s, `{"labels":{"A":"one","B":"two"}}`, `{"labels":{"A":"one","B":"two"}}`)
-	requireUnsupported(t, s, `{"labels":{"A":"one","C":"two"}}`)
+	mustCoerceExact(t, s, `{"labels":{"A":"one","B":"two"}}`, `{"labels":{"A":"one","B":"two"}}`)
+	requireCoerceUnsupported(t, s, `{"labels":{"A":"one","C":"two"}}`)
 }
 
 // TestCoerceMap_ValueThenKeyOrder pins BAML's VALUE-first order: an entry with a
@@ -146,7 +146,7 @@ func TestCoerceMap_ValueThenKeyOrder(t *testing.T) {
 		},
 		Values: &bamlutils.DynamicTypeSpec{Type: "int"},
 	})
-	mustParseExact(t, s, `{"u":{"É":"zzz"}}`, `{"u":{}}`)
+	mustCoerceExact(t, s, `{"u":{"É":"zzz"}}`, `{"u":{}}`)
 }
 
 // TestCoerceMap_DeferredValuePreemptsKeySkip pins value-first ordering: a value
@@ -161,7 +161,7 @@ func TestCoerceMap_DeferredValuePreemptsKeySkip(t *testing.T) {
 	// non-matching literal-union keys leniently -> a whole-map decline, not a
 	// partial MapKeyParseError skip; see TestCoerceMap_KeyMissDeclines). Either
 	// way the whole map declines rather than dropping an entry.
-	requireUnsupported(t, mapLitUnionStrSchema(), `{"u":{"C":5}}`)
+	requireCoerceUnsupported(t, mapLitUnionStrSchema(), `{"u":{"C":5}}`)
 }
 
 // TestCoerceMap_StringStringNonStringValueStringified pins the Mcoerce-d PR 1
@@ -171,12 +171,12 @@ func TestCoerceMap_DeferredValuePreemptsKeySkip(t *testing.T) {
 // TestCoerceMap_StringStringNonStringValueDeclines.)
 func TestCoerceMap_StringStringNonStringValueStringified(t *testing.T) {
 	s := mapStrStrSchema()
-	mustParseExact(t, s, `{"u":{"a":"x","b":"y"}}`, `{"u":{"a":"x","b":"y"}}`) // clean claim
+	mustCoerceExact(t, s, `{"u":{"a":"x","b":"y"}}`, `{"u":{"a":"x","b":"y"}}`) // clean claim
 	// Number value -> JsonToString "5", kept (fixture 107 shape).
-	mustParseExact(t, s, `{"u":{"a":"x","b":5}}`, `{"u":{"a":"x","b":"5"}}`)
-	mustParseExact(t, s, `{"u":{"a":true}}`, `{"u":{"a":"true"}}`)
+	mustCoerceExact(t, s, `{"u":{"a":"x","b":5}}`, `{"u":{"a":"x","b":"5"}}`)
+	mustCoerceExact(t, s, `{"u":{"a":true}}`, `{"u":{"a":"true"}}`)
 	// Direct null value is a proven skip; the rest is kept.
-	mustParseExact(t, s, `{"u":{"a":"x","b":null}}`, `{"u":{"a":"x"}}`)
+	mustCoerceExact(t, s, `{"u":{"a":"x","b":null}}`, `{"u":{"a":"x"}}`)
 }
 
 // TestCoerceMap_DuplicateKeyDeclines pins that ANY duplicate original input key
@@ -184,9 +184,9 @@ func TestCoerceMap_StringStringNonStringValueStringified(t *testing.T) {
 // skipped duplicate must not be reasoned to leave the rest safe).
 func TestCoerceMap_DuplicateKeyDeclines(t *testing.T) {
 	s := mapStringIntSchema()
-	requireUnsupported(t, s, `{"scores":{"a":1,"a":2}}`)
+	requireCoerceUnsupported(t, s, `{"scores":{"a":1,"a":2}}`)
 	// Duplicate whose second entry has a (proven-bad) value still declines.
-	requireUnsupported(t, s, `{"scores":{"a":1,"a":"bad"}}`)
+	requireCoerceUnsupported(t, s, `{"scores":{"a":1,"a":"bad"}}`)
 }
 
 // TestCoerceMap_NonObjectFieldDefaults pins the Mcoerce-d PR 2 flip: a REQUIRED
@@ -197,9 +197,9 @@ func TestCoerceMap_DuplicateKeyDeclines(t *testing.T) {
 // declines — only the class-field-default path is claimed here.)
 func TestCoerceMap_NonObjectFieldDefaults(t *testing.T) {
 	s := mapStringIntSchema()
-	mustParse(t, s, `{"scores":[1,2,3]}`, `{"scores":{}}`)
-	mustParse(t, s, `{"scores":"x"}`, `{"scores":{}}`)
-	mustParse(t, s, `{"scores":5}`, `{"scores":{}}`)
+	mustCoerce(t, s, `{"scores":[1,2,3]}`, `{"scores":{}}`)
+	mustCoerce(t, s, `{"scores":"x"}`, `{"scores":{}}`)
+	mustCoerce(t, s, `{"scores":5}`, `{"scores":{}}`)
 }
 
 // TestCoerceMap_NullableScored pins the M3 scored selection for maps: an
@@ -209,11 +209,11 @@ func TestCoerceMap_NonObjectFieldDefaults(t *testing.T) {
 func TestCoerceMap_NullableScored(t *testing.T) {
 	s := optionalMapStrIntSchema()
 	// JSON null -> the null fast path claims null.
-	mustParse(t, s, `{"u":null}`, `{"u":null}`)
+	mustCoerce(t, s, `{"u":null}`, `{"u":null}`)
 	// Object input -> ObjectToMap (score 1 < 110) -> claim the map, clean values.
-	mustParse(t, s, `{"u":{"a":1}}`, `{"u":{"a":1}}`)
+	mustCoerce(t, s, `{"u":{"a":1}}`, `{"u":{"a":1}}`)
 	// Empty object -> ObjectToMap (score 1 < 110) -> claim {}.
-	mustParse(t, s, `{"u":{}}`, `{"u":{}}`)
+	mustCoerce(t, s, `{"u":{}}`, `{"u":{}}`)
 }
 
 // TestProvenMapValueError pins the map-VALUE child classifier delegates to the

--- a/internal/debaml/coerce_scalar_union_test.go
+++ b/internal/debaml/coerce_scalar_union_test.go
@@ -234,8 +234,9 @@ func TestScalarUnion_ListElementUnionDeclines(t *testing.T) {
 	// TOP-LEVEL scalar union still claims (the gate change is list-element-only).
 	mustParse(t, primUnion("string", "int"), `{"u":"x"}`, `{"u":"x"}`)
 
-	// MAP value union still claims — coerce_map resets the hint (enter_scope), so
-	// map<_, union> has no hint gap.
+	// MAP value union still coerces cleanly — coerce_map resets the hint
+	// (enter_scope), so map<_, union> has no hint gap. Driven via the coerce bypass
+	// because Parse now declines every map-containing schema at the checkNoMap gate.
 	mapUnion := &bamlutils.DynamicOutputSchema{
 		Properties: props(kv("m", &bamlutils.DynamicProperty{
 			Type: "map",
@@ -246,7 +247,7 @@ func TestScalarUnion_ListElementUnionDeclines(t *testing.T) {
 			},
 		})),
 	}
-	mustParse(t, mapUnion, `{"m":{"a":"x"}}`, `{"m":{"a":"x"}}`)
+	mustCoerce(t, mapUnion, `{"m":{"a":"x"}}`, `{"m":{"a":"x"}}`)
 }
 
 // TestScalarUnion_LiteralStringSubstringTie_PickFirst pins the pick_best index

--- a/internal/debaml/coerce_stringify_test.go
+++ b/internal/debaml/coerce_stringify_test.go
@@ -388,7 +388,7 @@ func TestParse_MapStringStringify_EndToEnd(t *testing.T) {
 		Keys:   &bamlutils.DynamicTypeSpec{Type: "string"},
 		Values: &bamlutils.DynamicTypeSpec{Type: "string"},
 	})
-	mustParse(t, s, `{"u":{"a":"x","b":5}}`, `{"u":{"a":"x","b":"5"}}`) // fixture 107 shape
+	mustCoerce(t, s, `{"u":{"a":"x","b":5}}`, `{"u":{"a":"x","b":"5"}}`) // fixture 107 shape
 	// null value skipped (proven), the rest kept.
-	mustParse(t, s, `{"u":{"a":"x","b":null}}`, `{"u":{"a":"x"}}`)
+	mustCoerce(t, s, `{"u":{"a":"x","b":null}}`, `{"u":{"a":"x"}}`)
 }

--- a/internal/debaml/mapdecline_test.go
+++ b/internal/debaml/mapdecline_test.go
@@ -1,0 +1,246 @@
+package debaml
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// Map parity-decline (checkNoMap): Parse and parseStream now return the
+// unsupported sentinel for a map in ANY reachable position, because native
+// coerceMap emits entries in parsed INPUT key order and cannot PROVE that order
+// equals BAML's observable map-key order under preserve-order. The generated
+// seam falls back to BAML CFFI for those finals. coerceMap itself is UNCHANGED;
+// the tests that used to drive it through Parse now reach it through the
+// coerceViaBundle / coerceStreamViaBundle bypasses below (which skip only the
+// checkSupported gate), so the map coercion behavior stays fully covered for the
+// future PR that re-enables maps behind a proven map-order fixture.
+
+// coerceViaBundle drives the native FINAL-parse pipeline MINUS the
+// checkSupported gate: lower → validate → extract → coerce. It mirrors Parse's
+// body exactly (a lower/validate failure or a missing JSON candidate still
+// surfaces as the unsupported sentinel) and exists only so the coerceMap tests
+// can exercise the unchanged map coercion now that Parse declines every
+// map-containing schema at checkNoMap.
+func coerceViaBundle(s *bamlutils.DynamicOutputSchema, raw string) (string, error) {
+	bundle, err := schema.FromDynamicOutputSchema(s, schema.BuildOptions{})
+	if err != nil {
+		return "", unsupportedErr("lower schema", err)
+	}
+	if err := bundle.ValidateOutput(); err != nil {
+		return "", unsupportedErr("validate schema", err)
+	}
+	parsed, ok := extractCandidate(raw)
+	if !ok {
+		return "", unsupported("no cleanly-claimable JSON candidate")
+	}
+	out, err := coerce(bundle, bundle.Target, parsed, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// mustCoerce asserts coerceViaBundle succeeds and its output is SEMANTICALLY
+// equal to want (the coerce-bypass twin of mustParse).
+func mustCoerce(t *testing.T, s *bamlutils.DynamicOutputSchema, raw, want string) {
+	t.Helper()
+	got, err := coerceViaBundle(s, raw)
+	if err != nil {
+		t.Fatalf("coerceViaBundle(%q) unexpected error: %v", raw, err)
+	}
+	if !jsonValueEqual(t, got, want) {
+		t.Errorf("coerceViaBundle(%q):\n got %s\nwant %s", raw, got, want)
+	}
+}
+
+// mustCoerceExact asserts coerceViaBundle succeeds and its output matches want
+// BYTE-FOR-BYTE (the coerce-bypass twin of mustParseExact; reserved for the
+// map-key/field emission-order contract).
+func mustCoerceExact(t *testing.T, s *bamlutils.DynamicOutputSchema, raw, want string) {
+	t.Helper()
+	got, err := coerceViaBundle(s, raw)
+	if err != nil {
+		t.Fatalf("coerceViaBundle(%q) unexpected error: %v", raw, err)
+	}
+	if got != want {
+		t.Errorf("coerceViaBundle(%q): byte-exact mismatch\n got %s\nwant %s", raw, got, want)
+	}
+}
+
+// requireCoerceUnsupported asserts coerceViaBundle declined (sentinel) — a
+// coerceMap-level decline (or a lower/validate/extract decline), NOT the
+// checkNoMap gate decline (which the bypass skips).
+func requireCoerceUnsupported(t *testing.T, s *bamlutils.DynamicOutputSchema, raw string) {
+	t.Helper()
+	_, err := coerceViaBundle(s, raw)
+	if err == nil {
+		t.Fatalf("coerceViaBundle(%q): expected ErrDeBAMLParseUnsupported, got success", raw)
+	}
+	if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+		t.Fatalf("coerceViaBundle(%q): expected ErrDeBAMLParseUnsupported, got %v", raw, err)
+	}
+}
+
+// coerceStreamViaBundle drives the native STREAM-parse pipeline MINUS the
+// checkSupported gate, for the same reason as coerceViaBundle: map-containing
+// stream schemas now decline at checkNoMap, so the coerceStream map tests reach
+// coerceStreamMap through this bypass.
+func coerceStreamViaBundle(s *bamlutils.DynamicOutputSchema, raw string) (string, error) {
+	bundle, err := schema.FromDynamicOutputSchema(s, schema.BuildOptions{})
+	if err != nil {
+		return "", unsupportedErr("lower schema", err)
+	}
+	if err := bundle.ValidateOutput(); err != nil {
+		return "", unsupportedErr("validate schema", err)
+	}
+	if err := checkNoStreamAnnotations(bundle); err != nil {
+		return "", err
+	}
+	v, ok := streamExtractCandidate(raw)
+	if !ok {
+		return "", unsupported("stream: no cleanly-claimable JSON candidate")
+	}
+	out, err := coerceStream(bundle, bundle.Target, v)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// mustStreamCoerce asserts coerceStreamViaBundle succeeds and its output is
+// semantically equal to want (the stream-bypass twin of mustStream).
+func mustStreamCoerce(t *testing.T, s *bamlutils.DynamicOutputSchema, raw, want string) {
+	t.Helper()
+	got, err := coerceStreamViaBundle(s, raw)
+	if err != nil {
+		t.Fatalf("coerceStreamViaBundle(%q): unexpected error: %v", raw, err)
+	}
+	if !jsonValueEqual(t, got, want) {
+		t.Errorf("coerceStreamViaBundle(%q):\n got %s\nwant %s", raw, got, want)
+	}
+}
+
+// listOfMapSchema is Root{ u: list<map<string,int>> } — a map nested inside a
+// list element, which checkNoMap DECLINES by recursing into the list element
+// (its TypeList arm walks Elem).
+func listOfMapSchema() *bamlutils.DynamicOutputSchema {
+	return oneField(&bamlutils.DynamicProperty{
+		Type: "list",
+		Items: &bamlutils.DynamicTypeSpec{
+			Type:   "map",
+			Keys:   &bamlutils.DynamicTypeSpec{Type: "string"},
+			Values: &bamlutils.DynamicTypeSpec{Type: "int"},
+		},
+	})
+}
+
+// unionWithMapArmSchema is Root{ u: string | map<string,int> } — a map as a
+// union variant (reached via checkNoMap's union recursion, not the
+// checkSupportedType/checkUnionMapVariant gate).
+func unionWithMapArmSchema() *bamlutils.DynamicOutputSchema {
+	return oneField(&bamlutils.DynamicProperty{
+		Type: "union",
+		OneOf: []*bamlutils.DynamicTypeSpec{
+			{Type: "string"},
+			{Type: "map", Keys: &bamlutils.DynamicTypeSpec{Type: "string"}, Values: &bamlutils.DynamicTypeSpec{Type: "int"}},
+		},
+	})
+}
+
+// classWithMapFieldSchema is Root{ u: C }, C{ scores: map<string,int> } — a map
+// reachable only through a NAMED class ref (checkNoMap treats the ref as a leaf,
+// so this proves checkSupported's per-class walk catches it).
+func classWithMapFieldSchema() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("u", &bamlutils.DynamicProperty{Ref: "C"})),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("C", &bamlutils.DynamicClass{
+				Properties: props(kv("scores", &bamlutils.DynamicProperty{
+					Type:   "map",
+					Keys:   &bamlutils.DynamicTypeSpec{Type: "string"},
+					Values: &bamlutils.DynamicTypeSpec{Type: "int"},
+				})),
+			}),
+		),
+	}
+}
+
+// TestParse_MapContainingSchemasDecline pins the checkNoMap parity-decline
+// boundary: Parse returns the unsupported sentinel (so the seam falls back to
+// BAML CFFI) for a map in EVERY reachable position — a top-level field, a map
+// value, a list element, a union arm, a nested class field, and — crucially —
+// the non-null arm of an OPTIONAL map, which the checkSupportedType nullable
+// fast path would otherwise wave through (claiming null on null input). The
+// unchanged coerceMap is exercised separately via coerceViaBundle.
+func TestParse_MapContainingSchemasDecline(t *testing.T) {
+	// Top-level map field.
+	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":2}}`)
+
+	// Map nested as a map VALUE.
+	requireUnsupported(t, mapStringItemSchema(), `{"by_id":{"a":{"id":"1","label":"x"}}}`)
+
+	// Map nested as a LIST element.
+	requireUnsupported(t, listOfMapSchema(), `{"u":[{"a":1}]}`)
+
+	// Map as a UNION arm (checkNoMap's union recursion).
+	requireUnsupported(t, unionWithMapArmSchema(), `{"u":{"a":1}}`)
+
+	// Map reached only through a NAMED class ref (per-class field walk).
+	requireUnsupported(t, classWithMapFieldSchema(), `{"u":{"scores":{"a":1}}}`)
+
+	// OPTIONAL map: declines for BOTH null and non-null input. This is the
+	// nested-position guarantee checkNoMap adds over checkSupportedType's
+	// `if u.Nullable { return nil }` fast path — a null input would otherwise
+	// claim null and a non-null object would claim the map.
+	requireUnsupported(t, optionalMapStrIntSchema(), `{"u":null}`)
+	requireUnsupported(t, optionalMapStrIntSchema(), `{"u":{"a":1}}`)
+
+	// The STREAM path shares the checkSupported gate, so it declines maps too.
+	requireStreamUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1`)
+	requireStreamUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1}}`)
+}
+
+// TestCheckNoMap_Positions unit-checks checkNoMap directly across the type
+// positions it must reject, independent of the extract/coerce pipeline.
+func TestCheckNoMap_Positions(t *testing.T) {
+	strT := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveString}
+	intT := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt}
+	mapT := schema.Type{Kind: schema.TypeMap, Key: &strT, Value: &intT}
+
+	rejects := []struct {
+		name string
+		t    schema.Type
+	}{
+		{"bare map", mapT},
+		{"list of map", schema.Type{Kind: schema.TypeList, Elem: &mapT}},
+		{"map value in map", schema.Type{Kind: schema.TypeMap, Key: &strT, Value: &mapT}},
+		{"union arm map", schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{strT, mapT}}}},
+		{"nullable optional map", schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Nullable: true, Variants: []schema.Type{mapT}}}},
+		{"tuple item map", schema.Type{Kind: schema.TypeTuple, Items: []schema.Type{intT, mapT}}},
+	}
+	for _, c := range rejects {
+		if err := checkNoMap(c.t); err == nil || !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			t.Errorf("%s: expected ErrDeBAMLParseUnsupported, got %v", c.name, err)
+		}
+	}
+
+	// A map-free tree passes (named class/enum refs are leaves — their bodies
+	// are walked per-class by checkSupported, not here).
+	accepts := []struct {
+		name string
+		t    schema.Type
+	}{
+		{"primitive", strT},
+		{"list of int", schema.Type{Kind: schema.TypeList, Elem: &intT}},
+		{"scalar union", schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{strT, intT}}}},
+		{"class ref leaf", schema.Type{Kind: schema.TypeClass, Name: "C"}},
+	}
+	for _, c := range accepts {
+		if err := checkNoMap(c.t); err != nil {
+			t.Errorf("%s: expected nil, got %v", c.name, err)
+		}
+	}
+}

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -28,10 +28,16 @@ import (
 //
 //   - Stream parses (req.Stream==true) — native stream semantics are M4.
 //   - Schemas that cannot be lowered/validated, or that use general
-//     (multi-variant) unions, constraints, recursive aliases, or a map
-//     whose key/value falls outside the clean M2b map subset (see
-//     checkSupportedMapKey and coerceMap). Clean maps — object input,
-//     exact key match, in-scope value — are claimed in input key order.
+//     (multi-variant) unions, constraints, or recursive aliases.
+//   - A MAP in ANY reachable position (class field, list element, map
+//     value, union arm — including the non-null arm of an optional map).
+//     Native coerceMap emits entries in parsed input-key order, which
+//     cannot be PROVEN to equal BAML's observable map-key order under
+//     preserve-order, so every map-containing schema DECLINES at the gate
+//     (checkNoMap) rather than over-claim a map order native cannot prove.
+//     This is a parity-decline: the map coerce machinery (coerceMap,
+//     checkSupportedMapKey, tryCastMap) is retained UNCHANGED but is
+//     unreachable from Parse until a proven map-order fixture re-enables it.
 //   - Raw text whose JSON-looking candidate needs a repair outside the
 //     conservative M2a fixing subset — comments, escapes, missing commas,
 //     unterminated structures, multiple top-level values, … — which stays
@@ -267,7 +273,59 @@ func checkSupported(b *schema.Bundle) error {
 			return unsupported("class constraints")
 		}
 		for j := range c.Fields {
+			// PARITY-DECLINE: reject any reachable map BEFORE the general
+			// cut-line check. checkNoMap is a separate, broader walk than
+			// checkSupportedType's TypeMap arm because it must also catch a map
+			// hidden behind the checkSupportedType nullable-union fast path (an
+			// optional map `map<K,V>?`, where checkSupportedType returns nil
+			// without recursing into the arm). See checkNoMap.
+			if err := checkNoMap(c.Fields[j].Type); err != nil {
+				return err
+			}
 			if err := checkSupportedType(b, c.Fields[j].Type); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// checkNoMap DECLINES any type tree containing a schema.TypeMap in ANY
+// position — a list element, map value, tuple item, or union variant
+// (INCLUDING the non-null arm of an optional/nullable union, which
+// checkSupportedType's `if u.Nullable { return nil }` fast path would wave
+// through). Named class/enum refs are leaves: every reachable class is its own
+// b.Classes entry, so checkSupported walks each class's fields separately and a
+// map anywhere in the reachable graph is caught without recursing through refs.
+//
+// Why decline instead of coerce: native coerceMap emits map entries in parsed
+// INPUT key order (coerce.go), which cannot be proven to equal BAML's
+// observable map-key order under preserve-order — a semantically-equal value
+// whose ORDER native cannot prove is still an over-claim. Declining here makes
+// the generated seam (codegen_debaml.go maybeParseDeBAMLFinal) fall back to
+// BAML CFFI, which owns the authoritative map order. coerceMap and the map gate
+// (checkSupportedMapKey, checkUnionMapVariant, tryCastMap) are retained
+// UNCHANGED for a future PR that re-enables maps behind a proven map-order
+// fixture; they are simply unreachable from Parse today.
+func checkNoMap(t schema.Type) error {
+	switch t.Kind {
+	case schema.TypeMap:
+		return unsupported("map-containing schema (native map-key order unproven vs BAML preserve-order — parity-decline until a map-order fixture is added)")
+	case schema.TypeList:
+		if t.Elem != nil {
+			return checkNoMap(*t.Elem)
+		}
+	case schema.TypeUnion:
+		if t.Union != nil {
+			for i := range t.Union.Variants {
+				if err := checkNoMap(t.Union.Variants[i]); err != nil {
+					return err
+				}
+			}
+		}
+	case schema.TypeTuple:
+		for i := range t.Items {
+			if err := checkNoMap(t.Items[i]); err != nil {
 				return err
 			}
 		}
@@ -343,6 +401,12 @@ func checkSupportedType(b *schema.Bundle, t schema.Type) error {
 		// flat disjoint-key class union); checkSupportedUnionShape proves it.
 		return checkSupportedUnionShape(b, u)
 	case schema.TypeMap:
+		// NOTE: checkNoMap (run first in checkSupported) currently declines
+		// EVERY map-containing schema for map-key order parity, so this arm is
+		// unreachable from Parse today. It is retained intact for the future
+		// map re-enable PR (which narrows/removes checkNoMap behind a proven
+		// map-order fixture); the M2b claim logic below stays valid for then.
+		//
 		// M2b CLAIMS clean maps: a JSON-object input coerced under a
 		// map-key-safe key type and a value type that itself passes the
 		// cut-line. The key must be checked SPECIALLY — not via the general

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -324,19 +324,19 @@ func TestParse_MapStringInt(t *testing.T) {
 	// Clean map<string,int>: object input, string keys, in-scope int values.
 	// Byte-exact on purpose — map output MUST preserve INPUT key order (the
 	// keys here are deliberately out of lexical order), the M2b contract.
-	mustParseExact(t, mapStringIntSchema(),
+	mustCoerceExact(t, mapStringIntSchema(),
 		`{"scores":{"z":1,"a":2,"m":3}}`,
 		`{"scores":{"z":1,"a":2,"m":3}}`)
 	// Empty object is a clean empty map.
-	mustParseExact(t, mapStringIntSchema(), `{"scores":{}}`, `{"scores":{}}`)
+	mustCoerceExact(t, mapStringIntSchema(), `{"scores":{}}`, `{"scores":{}}`)
 }
 
 func TestParse_MapNonObjectFieldDefaults(t *testing.T) {
 	// Mcoerce-d PR 2: a required map class field with a non-object value is a
 	// PROVEN coerce_map error_unexpected_type, so BAML fills the map default {}
 	// (DefaultButHadUnparseableValue) and native now CLAIMS {"scores":{}}.
-	mustParse(t, mapStringIntSchema(), `{"scores":[1,2,3]}`, `{"scores":{}}`)
-	mustParse(t, mapStringIntSchema(), `{"scores":"x"}`, `{"scores":{}}`)
+	mustCoerce(t, mapStringIntSchema(), `{"scores":[1,2,3]}`, `{"scores":{}}`)
+	mustCoerce(t, mapStringIntSchema(), `{"scores":"x"}`, `{"scores":{}}`)
 }
 
 func TestParse_MapBadValuePartialSkip(t *testing.T) {
@@ -345,9 +345,9 @@ func TestParse_MapBadValuePartialSkip(t *testing.T) {
 	// a number in any form (no i64/u64/f64/fraction/extracted match), so
 	// coerce_int errors and BAML skips just that entry, keeping the rest in input
 	// order.
-	mustParseExact(t, mapStringIntSchema(), `{"scores":{"a":1,"b":"x"}}`, `{"scores":{"a":1}}`)
+	mustCoerceExact(t, mapStringIntSchema(), `{"scores":{"a":1,"b":"x"}}`, `{"scores":{"a":1}}`)
 	// All values bad -> {} (still a successful, empty map).
-	mustParseExact(t, mapStringIntSchema(), `{"scores":{"a":"x","b":"y"}}`, `{"scores":{}}`)
+	mustCoerceExact(t, mapStringIntSchema(), `{"scores":{"a":"x","b":"y"}}`, `{"scores":{}}`)
 	// A float map value is NOT "bad": Mcoerce-b rounds 2.5->3 (FloatToInt, a
 	// successful coercion BAML keeps) — see TestParse_MapLenientValueClaimed.
 }
@@ -358,15 +358,15 @@ func TestParse_MapBadValuePartialSkip(t *testing.T) {
 // to BAML. The map's own score ignores the value's FloatToInt flag (score.rs),
 // so this stays a claimable clean map.
 func TestParse_MapLenientValueClaimed(t *testing.T) {
-	mustParse(t, mapStringIntSchema(), `{"scores":{"a":1,"b":2.5}}`, `{"scores":{"a":1,"b":3}}`)
-	mustParse(t, mapStringIntSchema(), `{"scores":{"a":1,"b":"7"}}`, `{"scores":{"a":1,"b":7}}`)
+	mustCoerce(t, mapStringIntSchema(), `{"scores":{"a":1,"b":2.5}}`, `{"scores":{"a":1,"b":3}}`)
+	mustCoerce(t, mapStringIntSchema(), `{"scores":{"a":1,"b":"7"}}`, `{"scores":{"a":1,"b":7}}`)
 }
 
 func TestParse_MapDuplicateKeyDeclines(t *testing.T) {
 	// A duplicate input key would collapse to one output key; BAML's
 	// duplicate insert/overwrite ordering is unproven here, so native
 	// declines rather than claim it.
-	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"a":2}}`)
+	requireCoerceUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"a":2}}`)
 }
 
 // mapEnumKeySchema is a root class with one map<Key,string> field where Key
@@ -390,7 +390,7 @@ func TestParse_MapEnumKeysExact(t *testing.T) {
 	// Enum keys matched EXACTLY by rendered name; the emitted key is the
 	// ORIGINAL input string (here identical to the canonical name), in input
 	// key order.
-	mustParseExact(t, mapEnumKeySchema(),
+	mustCoerceExact(t, mapEnumKeySchema(),
 		`{"labels":{"A":"one","B":"two"}}`,
 		`{"labels":{"A":"one","B":"two"}}`)
 }
@@ -398,14 +398,14 @@ func TestParse_MapEnumKeysExact(t *testing.T) {
 func TestParse_MapBadEnumKeyDeclines(t *testing.T) {
 	// A key not exactly in the enum: BAML records MapKeyParseError and skips
 	// it (partial map). Native declines the whole map.
-	requireUnsupported(t, mapEnumKeySchema(), `{"labels":{"A":"one","C":"two"}}`)
+	requireCoerceUnsupported(t, mapEnumKeySchema(), `{"labels":{"A":"one","C":"two"}}`)
 }
 
 func TestParse_MapFuzzyEnumKeyClaimed(t *testing.T) {
 	// Mcoerce-a: a case/fuzzy variant ("a" for enum value A) now fuzzy-matches
 	// via match_string and is CLAIMED. The emitted key is the ORIGINAL input
 	// string "a" (maps insert the raw object key), not the canonical enum name.
-	mustParseExact(t, mapEnumKeySchema(), `{"labels":{"a":"one"}}`, `{"labels":{"a":"one"}}`)
+	mustCoerceExact(t, mapEnumKeySchema(), `{"labels":{"a":"one"}}`, `{"labels":{"a":"one"}}`)
 }
 
 func TestParse_MapEnumKeyAlias(t *testing.T) {
@@ -424,7 +424,7 @@ func TestParse_MapEnumKeyAlias(t *testing.T) {
 			}),
 		),
 	}
-	mustParseExact(t, s, `{"labels":{"Verde":"x"}}`, `{"labels":{"Verde":"x"}}`)
+	mustCoerceExact(t, s, `{"labels":{"Verde":"x"}}`, `{"labels":{"Verde":"x"}}`)
 }
 
 func TestParse_MapLiteralUnionKeysExact(t *testing.T) {
@@ -443,11 +443,11 @@ func TestParse_MapLiteralUnionKeysExact(t *testing.T) {
 			Values: &bamlutils.DynamicTypeSpec{Type: "string"},
 		})),
 	}
-	mustParseExact(t, s, `{"m":{"A":"x","B":"y"}}`, `{"m":{"A":"x","B":"y"}}`)
+	mustCoerceExact(t, s, `{"m":{"A":"x","B":"y"}}`, `{"m":{"A":"x","B":"y"}}`)
 	// A key matching NO string-literal-union arm is NOT a native partial skip: the
 	// dynamic bridge KEEPS the non-matching key (live-captured full map), so
 	// native declines the WHOLE map rather than skip an entry BAML keeps.
-	requireUnsupported(t, s, `{"m":{"A":"x","C":"z"}}`)
+	requireCoerceUnsupported(t, s, `{"m":{"A":"x","C":"z"}}`)
 }
 
 // mapStringItemSchema is a root class with one map<string, Item> field; Item
@@ -472,12 +472,12 @@ func TestParse_MapStringClassValues(t *testing.T) {
 	// of schema order in the input. The two ordering policies must coexist:
 	// map keys stay in INPUT order while class fields are re-emitted in SCHEMA
 	// order. Byte-exact on purpose — this is the dual-ordering contract.
-	mustParseExact(t, mapStringItemSchema(),
+	mustCoerceExact(t, mapStringItemSchema(),
 		`{"by_id":{"z":{"label":"zed","id":"3"},"a":{"label":"ay","id":"1"}}}`,
 		`{"by_id":{"z":{"id":"3","label":"zed"},"a":{"id":"1","label":"ay"}}}`)
 	// A map-to-class entry missing a required field DECLINES the whole map:
 	// BAML skips the bad entry (MapValueParseError), native cannot claim it.
-	requireUnsupported(t, mapStringItemSchema(),
+	requireCoerceUnsupported(t, mapStringItemSchema(),
 		`{"by_id":{"a":{"id":"1","label":"ay"},"b":{"id":"2"}}}`)
 }
 
@@ -495,7 +495,7 @@ func TestParse_MapNestedMap(t *testing.T) {
 			},
 		})),
 	}
-	mustParseExact(t, s,
+	mustCoerceExact(t, s,
 		`{"grid":{"r2":{"c1":1,"c0":2},"r1":{"c9":3}}}`,
 		`{"grid":{"r2":{"c1":1,"c0":2},"r1":{"c9":3}}}`)
 }
@@ -504,8 +504,8 @@ func TestParse_MapIncompleteDeclines(t *testing.T) {
 	// An unterminated map has no balanced span; native finds no
 	// cleanly-claimable candidate and DECLINES (BAML closes/recovers at EOF,
 	// which M2a defers) — never a claimed error.
-	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":`)
-	requireUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":2`)
+	requireCoerceUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":`)
+	requireCoerceUnsupported(t, mapStringIntSchema(), `{"scores":{"a":1,"b":2`)
 }
 
 func TestParse_UnsupportedMapIntKey(t *testing.T) {
@@ -518,7 +518,7 @@ func TestParse_UnsupportedMapIntKey(t *testing.T) {
 			Values: &bamlutils.DynamicTypeSpec{Type: "int"},
 		})),
 	}
-	requireUnsupported(t, s, `{"m":{"1":1}}`)
+	requireCoerceUnsupported(t, s, `{"m":{"1":1}}`)
 }
 
 func TestParse_MapScalarUnionValueClaimed(t *testing.T) {
@@ -540,13 +540,13 @@ func TestParse_MapScalarUnionValueClaimed(t *testing.T) {
 			},
 		})),
 	}
-	mustParse(t, s, `{"m":{"a":"x"}}`, `{"m":{"a":"x"}}`)
-	mustParse(t, s, `{"m":{"a":5}}`, `{"m":{"a":5}}`)
+	mustCoerce(t, s, `{"m":{"a":"x"}}`, `{"m":{"a":"x"}}`)
+	mustCoerce(t, s, `{"m":{"a":5}}`, `{"m":{"a":5}}`)
 	// M3d: an ARRAY value now resolves to the INT arm. As a union arm the int's
 	// array-to-singular target is the union, so Int 1 scores 1 (UnionMatch +
 	// FirstMatch) and beats the string arm's JsonToString "[1, 2]" (score 2), so
 	// the map keeps {"a":1}.
-	mustParse(t, s, `{"m":{"a":[1,2]}}`, `{"m":{"a":1}}`)
+	mustCoerce(t, s, `{"m":{"a":[1,2]}}`, `{"m":{"a":1}}`)
 }
 
 // unionSchema wraps a single union property `u` with the given variants.
@@ -945,43 +945,43 @@ func TestParse_NullableScalarMultiUnionScored(t *testing.T) {
 	mustParse(t, s, `{"u":5}`, `{"u":5}`)
 }
 
-func TestParse_NullableSingleArmUnsupportedArmClaimsNull(t *testing.T) {
-	// A nullable single-arm union T | null where T is UNSUPPORTED (here T is a map
-	// whose value is a union with a list-of-MULTI-ARM-UNION arm — string |
-	// list<int|string> — whose list element is a multi-arm union, so its array
-	// union_variant_hint is out of scope and the value union declines). The null
-	// fast path must CLAIM null regardless of the unsupported arm (mirroring BAML's
-	// null arm), consistently with nullable MULTI unions. A NON-null input must
-	// DECLINE: coerceUnionSafe delegates to coerce on the lone arm, which falls
-	// back because the map value union is unsupported.
+func TestParse_NullableUnsupportedArmClaimsNull(t *testing.T) {
+	// A nullable union whose NON-NULL arm set is UNSUPPORTED (string |
+	// list<int|string> | null — the list arm's element is a multi-arm union, so
+	// its array union_variant_hint is out of scope). The null fast path
+	// (coerceUnionSafe case 1) must CLAIM null regardless of the unsupported
+	// non-null arms, mirroring BAML's null arm. A NON-null input must DECLINE:
+	// coerceUnionSafe case 3 re-proves the non-null arm set via
+	// checkSupportedUnionShape, which rejects the list arm.
+	//
+	// This is deliberately MAP-FREE: the earlier version used an optional MAP arm,
+	// but checkNoMap now declines any map-containing schema at the gate for BOTH
+	// null and non-null input, which would mask the null-fast-path property under
+	// test. The multi-arm-union list element reproduces the same "unsupported arm,
+	// null still claims null" shape without a map.
 	s := &bamlutils.DynamicOutputSchema{
 		Properties: props(kv("u", &bamlutils.DynamicProperty{
 			Type: "optional",
 			Inner: &bamlutils.DynamicTypeSpec{
-				Type: "map",
-				Keys: &bamlutils.DynamicTypeSpec{Type: "string"},
-				Values: &bamlutils.DynamicTypeSpec{
-					Type: "union",
-					OneOf: []*bamlutils.DynamicTypeSpec{
-						{Type: "string"},
-						{Type: "list", Items: &bamlutils.DynamicTypeSpec{
-							Type: "union",
-							OneOf: []*bamlutils.DynamicTypeSpec{
-								{Type: "int"},
-								{Type: "string"},
-							},
-						}},
-					},
+				Type: "union",
+				OneOf: []*bamlutils.DynamicTypeSpec{
+					{Type: "string"},
+					{Type: "list", Items: &bamlutils.DynamicTypeSpec{
+						Type: "union",
+						OneOf: []*bamlutils.DynamicTypeSpec{
+							{Type: "int"},
+							{Type: "string"},
+						},
+					}},
 				},
 			},
 		})),
 	}
-	// JSON null → CLAIM null (null fast path), even though the lone arm is
-	// unsupported. Before the gate fix this DECLINED (the len==1 recursion
-	// rejected the unsupported arm before the nullable check).
+	// JSON null → CLAIM null (null fast path), even though the non-null arms are
+	// unsupported.
 	mustParse(t, s, `{"u":null}`, `{"u":null}`)
-	// Non-null → DECLINE (the lone map arm's value union has a list arm).
-	requireUnsupported(t, s, `{"u":{"a":"x"}}`)
+	// Non-null → DECLINE (the list arm's element is a multi-arm union).
+	requireUnsupported(t, s, `{"u":"x"}`)
 }
 
 func TestParse_PrimitiveScalarUnionScored(t *testing.T) {

--- a/internal/debaml/stream_test.go
+++ b/internal/debaml/stream_test.go
@@ -189,8 +189,11 @@ func TestStream_MissingFieldDefaultFillers(t *testing.T) {
 		),
 	}
 	// `{"a":1}` is strict-complete: a=1 kept; tags/scores/note missing → default
-	// fillers (list→[], map→{}, optional→null).
-	mustStream(t, s, `{"a":1}`, `{"a":1,"tags":[],"scores":{},"note":null}`)
+	// fillers (list→[], map→{}, optional→null). Driven via the stream coerce bypass
+	// because the `scores` map makes this a map-containing schema, which parseStream
+	// now declines at the shared checkNoMap gate; the streaming default fill under
+	// test (incl. the map→{} filler) is unchanged.
+	mustStreamCoerce(t, s, `{"a":1}`, `{"a":1,"tags":[],"scores":{},"note":null}`)
 	// A missing required scalar has no default_value → null (b never streamed).
 	s2 := &bamlutils.DynamicOutputSchema{Properties: props(kv("a", intProp()), kv("b", intProp()))}
 	mustStream(t, s2, `{"a":1}`, `{"a":1,"b":null}`)
@@ -207,7 +210,7 @@ func TestStream_MapIntDropsIncompleteValue(t *testing.T) {
 	// a=1 comma-terminated (kept); b=2 incomplete (dropped entry). The space after
 	// the comma keeps the unquoted object value out of streamFix's greedy-comma
 	// decline (an unquoted object value before a TIGHT comma declines).
-	mustStream(t, s, `{"m":{"a":1, "b":2`, `{"m":{"a":1}}`)
+	mustStreamCoerce(t, s, `{"m":{"a":1, "b":2`, `{"m":{"a":1}}`)
 }
 
 // TestStream_NoStructureDeclines pins that raw text with no recoverable JSON


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

## Problem

The de-BAML e2e differential over-claims map-containing dynamic parse schemas.
`TestBamlfuzzDynamicOracle/corpus/map_of_ints` and `corpus/map_to_class` fail
the **schema-key-ORDER** assertion on the REST leg under
`BAML_REST_USE_DEBAML=true`. The semantic `parse_diff` PASSES — native produces
a semantically-correct map — but native emits map entries in **parsed input-key
order**, which cannot be proven to equal BAML's observable map-key order under
preserve-order (map order is user-visible). Under parity-decline discipline, a
value whose ORDER native cannot prove is still an over-claim.

## Fix (decline, not match)

Add a `checkNoMap` gate so `internal/debaml.Parse` (and `parseStream`, which
shares `checkSupported`) returns `bamlutils.ErrDeBAMLParseUnsupported` for a map
in **any reachable position** — class field, list element, map value, tuple
item, or union arm, **including the non-null arm of an optional map** that
`checkSupportedType`'s nullable fast path (`if u.Nullable { return nil }`) would
otherwise wave through. The generated seam
(`codegen_debaml.go maybeParseDeBAMLFinal`) already falls back to BAML CFFI on
the sentinel, so BAML owns the authoritative map order.

`coerceMap` and the map gate (`checkSupportedMapKey`, `checkUnionMapVariant`,
`tryCastMap`) are left **unchanged** — retained but unreachable from `Parse` —
for a future PR that re-enables maps behind a proven map-order fixture. Codegen
and the render path are untouched.

## Tests

- The native-map unit tests now drive the unchanged `coerceMap` through a
  gate-bypass helper (`coerceViaBundle` / `coerceStreamViaBundle`), so map
  coercion behavior stays fully covered.
- New `TestParse_MapContainingSchemasDecline` + `TestCheckNoMap_Positions` pin
  the new gate (top-level, nested, union-arm, class-ref, optional-map, stream).
- `TestParse_NullableUnsupportedArmClaimsNull` reworked to a map-free
  unsupported arm so the nullable-fast-path property stays testable.
- The bamlfuzz parse-recovery differential forces map-containing cases to the
  fallback disposition (`parseRecoverySchemaContainsMap`) rather than flipping
  ~29 interleaved pins; the map pins remain as documentation of the coerceMap
  behavior the future PR re-enables.

## Validation

- `gofmt` / `go build ./...` / `go vet ./...` clean.
- `go test ./internal/debaml/...` green.
- `GOWORK=off go test ./codegen` (adapters/common) green.
- bamlfuzz parse-recovery differential (Docker) **green** — 54 final-parse cases
  fall back (maps now decline), no cut-line drift, native declines maps → BAML
  fallback → identical output.
- `TestBamlfuzzDynamicOracle/corpus/{map_of_ints,map_to_class}` **green** under
  `BAML_REST_USE_DEBAML=true` (the target failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Map-containing schemas now consistently decline in both parse and stream paths, including nested maps and maps reached via other schema constructs.
  * Nullable and edge-case scenarios now align more predictably with the same parity-decline behavior, while coercion-based map handling remains available for the expected outcomes.
* **Tests**
  * Updated map/union expectations to validate the coercion/claim contract instead of the older parse/unsupported sentinel behavior.
  * Added coverage to verify map rejection across many reachable schema positions.
* **Documentation**
  * Refreshed the “map” section guidance for parse recovery claim vs fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->