### PR TITLE
debaml: flip BAML_REST_USE_DEBAML default-on, keep explicit disable path

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -481,28 +481,28 @@ jobs:
         # direct in-process worker path.
         run: go test -tags=integration -v -count=1 -p 1 -timeout 40m ./integration/...
 
-  integration-tests-debaml:
+  integration-tests-debaml-off:
     needs: [get-latest-version, warm-images]
     runs-on: ubuntu-latest
-    # INFORMATIONAL, NON-BLOCKING arm. This job runs the existing integration
-    # suite end-to-end with the whole shared TestEnv flipped onto the de-BAML
-    # native dynamic response-coercion path (BAML_REST_USE_DEBAML=true), to
-    # OBSERVE which integration tests diverge under de-BAML. It is expected to
-    # be RED while de-BAML parity is still landing, so:
-    #   - `continue-on-error: true` lets the whole workflow still conclude green
-    #     for mergeability while this job's failing command/test output stays
-    #     visible in its own distinct log stream; and
+    # DISABLE-PATH arm. De-BAML is now default-ON, so the normal integration
+    # matrix already IS the flag-on suite. This job instead runs the whole
+    # shared TestEnv with de-BAML explicitly DISABLED (BAML_REST_USE_DEBAML=false)
+    # to validate the disable path — pure BAML, BAML-as-today — stays intact
+    # while the umbrella flag remains an operator escape hatch. It is expected
+    # to be GREEN (pure BAML is the long-standing baseline), but is kept
+    # NON-BLOCKING for now:
+    #   - `continue-on-error: true` keeps the job off the merge-blocking path
+    #     while its command/test output stays visible in its own log stream; and
     #   - this job is intentionally NOT added to required status checks /
-    #     branch protection. Do not promote it to blocking until de-BAML parity
-    #     is intentionally graduated from informational.
-    # Fixes for whatever this arm reveals are separate follow-up PRs, never here.
+    #     branch protection. Promote it to blocking in a follow-up once the
+    #     disable path is intentionally graduated to a required gate.
     continue-on-error: true
     # Same outer backstop as the other light cells: step timeout-minutes (45m,
     # below) bounds the go-test step; this job cap = step (45m) + a realistic
     # pre-test budget (~10m for checkout + Go setup + warm-image load). See #420.
     timeout-minutes: 55
     strategy:
-      # Single-cell today, but keep fail-fast off so adding an OFF/ON unary
+      # Single-cell today, but keep fail-fast off so adding a unary OFF/ON
       # pair later never masks one cell's failure behind another's.
       fail-fast: false
       matrix:
@@ -553,7 +553,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Run Integration Tests (de-BAML, BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }}, http-client=auto)
+      - name: Run Integration Tests (de-BAML OFF, BAML ${{ needs.get-latest-version.outputs.latest }}, unary=${{ matrix.unary-server }}, http-client=auto)
         # Step timeout (45m) and watchdog (42m) share the go-test origin;
         # watchdog fires 3m before the step is killed. #420
         timeout-minutes: 45
@@ -561,12 +561,13 @@ jobs:
           BAML_VERSION: ${{ needs.get-latest-version.outputs.latest }}
           UNARY_SERVER: ${{ matrix.unary-server }}
           BAML_REST_HTTP_CLIENT: auto
-          # The umbrella switch under test: flips the WHOLE shared TestEnv onto
-          # the de-BAML native dynamic response-coercion path. Forwarded into
-          # the baml-rest container by testutil.buildContainerEnv (the single
-          # env chokepoint), so cmd/serve and the subprocess cmd/worker both
-          # read it. "true" matches the existing dedicated de-BAML test.
-          BAML_REST_USE_DEBAML: "true"
+          # The umbrella switch under test: explicitly DISABLES de-BAML for the
+          # WHOLE shared TestEnv, validating the disable path now that de-BAML is
+          # default-ON. Forwarded into the baml-rest container by
+          # testutil.buildContainerEnv (the single env chokepoint), so cmd/serve
+          # and the subprocess cmd/worker both read it. "false" is a recognized
+          # falsy token, so the server resolves de-BAML OFF (pure BAML).
+          BAML_REST_USE_DEBAML: "false"
           # Step timeout (45m) minus 3m margin.
           BAML_REST_SUITE_WATCHDOG: 42m
           # CI-only: skip the testcontainers Ryuk reaper so setup doesn't
@@ -584,12 +585,14 @@ jobs:
           # cache), since failed/partial builds are the real residue source.
           BAMLFUZZ_STATIC_DOCKER_PRUNE_ON_FAILURE: "1"
         # Same subprocess command as the versioned/light integration cells for
-        # comparability. The `-skip` excludes the de-BAML differential tests
-        # that use the shared TestEnv as a flag-OFF control: under this global
-        # flag-ON job that OFF control is no longer off, so they fail for a
-        # HARNESS reason, not a de-BAML response-coercion parity regression.
-        # Every other test runs so the arm's RED signal is genuine parity.
-        run: go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 40m -skip '^TestDeBAMLRest_MetadataAppearsOnProductionPath$' ./integration/...
+        # comparability. No `-skip`: with the shared TestEnv explicitly de-BAML
+        # OFF, TestDeBAMLRest_MetadataAppearsOnProductionPath runs fine — it
+        # already pins BOTH its own legs (a dedicated ON container and a
+        # dedicated OFF container) rather than leaning on the shared TestEnv, so
+        # the suite-wide flag never makes its comparison on-vs-on. The full
+        # suite therefore runs with de-BAML disabled, validating the pure-BAML
+        # disable path end-to-end.
+        run: go test -tags=integration,subprocess -v -count=1 -p 1 -timeout 40m ./integration/...
 
   build-baml-cffi:
     needs: warm-images

--- a/bamlutils/debaml_config_test.go
+++ b/bamlutils/debaml_config_test.go
@@ -1,0 +1,119 @@
+package bamlutils
+
+import (
+	"os"
+	"testing"
+)
+
+// TestIsFalsyEnvValue pins the explicit-falsy accept list that backs the
+// default-ON env vars: exactly 0/false/no/off (case-insensitive) are
+// recognized as an explicit "disable"; everything else — including empty,
+// whitespace-padded variants (no trimming), truthy tokens, and unknown
+// values — is not falsy. It is the exact inverse of IsTruthyEnvValue's
+// accept list.
+func TestIsFalsyEnvValue(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"0", true},
+		{"false", true},
+		{"no", true},
+		{"off", true},
+		{"FALSE", true},
+		{"No", true},
+		{"Off", true},
+		{"OFF", true},
+		{"", false},
+		{"1", false},
+		{"true", false},
+		{"yes", false},
+		{"on", false},
+		{" false ", false}, // no whitespace trimming — mirrors IsTruthyEnvValue
+		{"falsey", false},
+		{"2", false},
+		{"disable", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			if got := IsFalsyEnvValue(tc.in); got != tc.want {
+				t.Errorf("IsFalsyEnvValue(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDeBAMLConfigFromEnv pins the DEFAULT-ON truth table for the umbrella
+// switch: native de-BAML is enabled when BAML_REST_USE_DEBAML is unset or
+// empty OR set to a truthy value, and disabled ONLY when set to a
+// recognized falsy value (0/false/no/off, case-insensitive). Any
+// unrecognized token leaves the feature on — default-on means "off only on
+// an explicit falsy value". This is NOT parallel: it mutates process env.
+func TestDeBAMLConfigFromEnv(t *testing.T) {
+	// unset -> enabled (default-on)
+	t.Run("unset", func(t *testing.T) {
+		withEnvUseDeBAMLUnset(t)
+		if got := DeBAMLConfigFromEnv(); !got.Enabled {
+			t.Errorf("DeBAMLConfigFromEnv() with %s unset = %+v, want Enabled=true (default-on)", EnvUseDeBAML, got)
+		}
+	})
+
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		// empty and truthy values -> enabled
+		{"", true},
+		{"1", true},
+		{"true", true},
+		{"yes", true},
+		{"on", true},
+		{"TRUE", true},
+		{"On", true},
+		// unrecognized tokens are NOT falsy -> stay enabled (default-on)
+		{"maybe", true},
+		{"2", true},
+		{" false ", true}, // whitespace-padded is not a recognized falsy token
+		// explicit falsy values -> disabled
+		{"0", false},
+		{"false", false},
+		{"no", false},
+		{"off", false},
+		{"FALSE", false},
+		{"Off", false},
+	}
+	for _, tc := range cases {
+		name := tc.value
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(EnvUseDeBAML, tc.value)
+			if got := DeBAMLConfigFromEnv(); got.Enabled != tc.want {
+				t.Errorf("DeBAMLConfigFromEnv() with %s=%q = %+v, want Enabled=%v", EnvUseDeBAML, tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+// withEnvUseDeBAMLUnset removes BAML_REST_USE_DEBAML for the duration of a
+// test and restores its prior state afterwards. t.Setenv only sets a value;
+// the default-on "unset" leg needs a genuine absence, so this saves/clears/
+// restores by hand.
+func withEnvUseDeBAMLUnset(t *testing.T) {
+	t.Helper()
+	prev, had := os.LookupEnv(EnvUseDeBAML)
+	if err := os.Unsetenv(EnvUseDeBAML); err != nil {
+		t.Fatalf("os.Unsetenv(%s): %v", EnvUseDeBAML, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(EnvUseDeBAML, prev)
+		} else {
+			_ = os.Unsetenv(EnvUseDeBAML)
+		}
+	})
+}

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -990,12 +990,17 @@ type RoundRobinAdvancer interface {
 // native seam — it does not select a transport/request-construction
 // route (the BuildRequest route is unconditional as of #537).
 //
-// Default (zero value) is disabled: the dynamic request path renders
-// ctx.output_format through BAML exactly as it does today.
+// The Go zero value is disabled: an unconfigured DeBAMLConfig{} renders
+// ctx.output_format through BAML exactly as it does today. Env resolution,
+// however, is default-ON — DeBAMLConfigFromEnv enables native de-BAML
+// unless BAML_REST_USE_DEBAML is explicitly set to a falsy value — so
+// server builds run native by default while the flag is retained purely as
+// a disable switch.
 type DeBAMLConfig struct {
-	// Enabled turns on every implemented native de-BAML path. When false
-	// (default) no native behaviour is attempted and the dynamic path is
-	// BAML-as-today, byte-for-byte.
+	// Enabled turns on every implemented native de-BAML path. When false no
+	// native behaviour is attempted and the dynamic path is BAML-as-today,
+	// byte-for-byte. The struct zero value is false; DeBAMLConfigFromEnv
+	// resolves it to true by default (see above).
 	Enabled bool
 }
 
@@ -1072,21 +1077,43 @@ const EnvUseDeBAML = "BAML_REST_USE_DEBAML"
 
 // DeBAMLConfigFromEnv resolves BAML_REST_USE_DEBAML into a DeBAMLConfig.
 // Shared by cmd/serve and cmd/worker so both server builds observe the
-// same value; resolved once at startup. Truthy parsing matches the
-// BuildRequest env contract (1/true/yes/on, case-insensitive, no
-// whitespace trimming); every other value (including empty) is disabled.
+// same value; resolved once at startup.
+//
+// De-BAML is DEFAULT-ON: native behaviour is enabled when the umbrella var
+// is UNSET/empty OR set to a truthy value, and DISABLED only when it is
+// explicitly set to a recognized falsy value (0/false/no/off,
+// case-insensitive, no whitespace trimming — the inverse of the
+// IsTruthyEnvValue accept list). The disable path is retained so operators
+// can turn native de-BAML back off with an explicit falsy value while the
+// rollout completes.
 func DeBAMLConfigFromEnv() DeBAMLConfig {
-	return DeBAMLConfig{Enabled: IsTruthyEnvValue(os.Getenv(EnvUseDeBAML))}
+	return DeBAMLConfig{Enabled: !IsFalsyEnvValue(os.Getenv(EnvUseDeBAML))}
 }
 
 // IsTruthyEnvValue is the single truthy-env contract shared across
-// baml-rest's boolean env vars (BAML_REST_USE_DEBAML and the serve-host
-// preserve-order default). Exactly 1/true/yes/on (case-insensitive) are
-// true; every other value — including the empty string and
-// whitespace-padded variants (no trimming) — is false.
+// baml-rest's boolean env vars (the serve-host preserve-order default and,
+// historically, BAML_REST_USE_DEBAML before it went default-on). Exactly
+// 1/true/yes/on (case-insensitive) are true; every other value — including
+// the empty string and whitespace-padded variants (no trimming) — is false.
 func IsTruthyEnvValue(v string) bool {
 	switch strings.ToLower(v) {
 	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsFalsyEnvValue is the inverse of IsTruthyEnvValue: the explicit-falsy
+// accept list for baml-rest's default-ON env vars. Exactly 0/false/no/off
+// (case-insensitive) are true (i.e. recognized as an explicit "disable");
+// every other value — including the empty string, whitespace-padded
+// variants (no trimming), and unrecognized tokens — is false. Use it for
+// default-on switches such as BAML_REST_USE_DEBAML, where a feature stays
+// on unless an operator sets one of these recognized falsy tokens.
+func IsFalsyEnvValue(v string) bool {
+	switch strings.ToLower(v) {
+	case "0", "false", "no", "off":
 		return true
 	default:
 		return false

--- a/integration/dynamic_debaml_rest_test.go
+++ b/integration/dynamic_debaml_rest_test.go
@@ -20,13 +20,19 @@ import (
 // This test proves the SAME on the REST production path: a dedicated
 // baml-rest container started with BAML_REST_USE_DEBAML=true must emit the
 // native ctx.output_format block (with the metadata BAML's dynamic
-// TypeBuilder drops) into the provider request — and the shared,
-// de-BAML-OFF TestEnv must not. The BuildRequest route is unconditional as
-// of #537, so both containers share the same route and the differential
-// isolates exactly BAML_REST_USE_DEBAML. This guards the gap where the
-// production generated adapter never actually emitted the de-BAML injection
-// (codegen only wired it for dynclient), so BAML_REST_USE_DEBAML was inert
-// for REST traffic.
+// TypeBuilder drops) into the provider request — and a dedicated
+// de-BAML-OFF container (BAML_REST_USE_DEBAML pinned to false) must not.
+// The BuildRequest route is unconditional as of #537, so both containers
+// share the same route and the differential isolates exactly
+// BAML_REST_USE_DEBAML. This guards the gap where the production generated
+// adapter never actually emitted the de-BAML injection (codegen only wired
+// it for dynclient), so BAML_REST_USE_DEBAML was inert for REST traffic.
+//
+// De-BAML is now DEFAULT-ON, so the shared TestEnv can no longer serve as
+// the flag-OFF control (it runs native by default). Both legs therefore use
+// dedicated containers with the umbrella flag pinned explicitly — ON vs OFF,
+// never ON vs the-default — so the differential stays honest regardless of
+// the suite-wide default.
 
 // restMetadataSchema mirrors oracleBSchema in the HTTP/testutil shape:
 // field description + alias, class description (+ a class alias that must
@@ -73,8 +79,9 @@ const restDeBAMLMock = `{"title":"t","addr":{"street":"s","city":"c"},"status":"
 // TestDeBAMLRest_MetadataAppearsOnProductionPath spins a dedicated
 // container with de-BAML on, sends a metadata-bearing dynamic request, and
 // asserts the native metadata is in the captured provider body — the
-// REST-production proof that BAML_REST_USE_DEBAML is live. The shared
-// de-BAML-OFF TestEnv provides the negative leg.
+// REST-production proof that BAML_REST_USE_DEBAML is live. A second
+// dedicated container with the flag pinned OFF provides the negative leg;
+// the shared TestEnv is now default-ON and cannot serve as that control.
 func TestDeBAMLRest_MetadataAppearsOnProductionPath(t *testing.T) {
 	// The native seam exists only on the BuildRequest route (BAML >= 0.219),
 	// which is unconditional as of #537.
@@ -82,33 +89,8 @@ func TestDeBAMLRest_MetadataAppearsOnProductionPath(t *testing.T) {
 		t.Skip("Skipping: de-BAML REST seam requires the BuildRequest route (BAML >= 0.219.0)")
 	}
 
-	// --- de-BAML ON: dedicated container with the de-BAML flag ---
-	opts := matrixSetupOptions()
-	opts.RuntimeEnv = map[string]string{
-		"BAML_REST_USE_DEBAML": "true",
-	}
-
-	setupCtx, setupCancel := context.WithTimeout(context.Background(), testutil.SetupBudget(opts))
-	defer setupCancel()
-
-	env, err := testutil.Setup(setupCtx, opts)
-	if err != nil {
-		t.Fatalf("Failed to setup de-BAML dedicated env: %v", err)
-	}
-	defer func() {
-		termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer termCancel()
-		if err := env.Terminate(termCtx); err != nil {
-			t.Logf("dedicated env Terminate: %v", err)
-		}
-	}()
-
-	onMock := mockllm.NewClient(env.MockLLMURL)
-	onClient := testutil.NewBAMLRestClient(env.BAMLRestURL)
-	onScenario := "test-debaml-rest-on"
-	registerDeBAMLRestScenario(t, onMock, onScenario)
-
-	onBlock := restCaptureBlock(t, onClient, onMock, env.MockLLMInternal, onScenario)
+	// --- de-BAML ON: dedicated container with the flag pinned true ---
+	onBlock := captureDeBAMLRestBlock(t, "true", "test-debaml-rest-on")
 
 	// flag-ON must carry the native metadata BAML-dynamic drops, plus the
 	// canonical class reference (so the metadata check can't be satisfied
@@ -138,14 +120,14 @@ func TestDeBAMLRest_MetadataAppearsOnProductionPath(t *testing.T) {
 		t.Errorf("flag-ON REST block unexpectedly contains class alias %q (canonical names only)\n--- ON ---\n%s", "PostalAddress", onBlock)
 	}
 
-	// de-BAML-OFF differential — the BuildRequest route is unconditional
-	// (#537), so the shared TestEnv runs the SAME route as the dedicated ON
-	// container on BAML >= 0.219 (already guaranteed by the skip above).
-	// The comparison therefore isolates exactly BAML_REST_USE_DEBAML and
-	// never the route.
-	offScenario := "test-debaml-rest-off"
-	registerDeBAMLRestScenario(t, MockClient, offScenario)
-	offBlock := restCaptureBlock(t, BAMLClient, MockClient, TestEnv.MockLLMInternal, offScenario)
+	// de-BAML-OFF differential — a dedicated container with the umbrella flag
+	// pinned OFF. The BuildRequest route is unconditional (#537), so this OFF
+	// container runs the SAME route as the dedicated ON container on
+	// BAML >= 0.219 (already guaranteed by the skip above); the comparison
+	// therefore isolates exactly BAML_REST_USE_DEBAML and never the route. The
+	// flag is pinned explicitly rather than inherited from the shared TestEnv,
+	// which is now default-ON and would make this an on-vs-on comparison.
+	offBlock := captureDeBAMLRestBlock(t, "false", "test-debaml-rest-off")
 
 	for _, tok := range nativeMetadata {
 		if strings.Contains(offBlock, tok.token) {
@@ -163,6 +145,46 @@ func TestDeBAMLRest_MetadataAppearsOnProductionPath(t *testing.T) {
 	if strings.Contains(offBlock, "PostalAddress") {
 		t.Errorf("flag-OFF REST block unexpectedly contains class alias %q\n--- OFF ---\n%s", "PostalAddress", offBlock)
 	}
+}
+
+// captureDeBAMLRestBlock spins a dedicated baml-rest container with the
+// de-BAML umbrella flag pinned explicitly to flagValue ("true" or "false"),
+// registers the REST scenario on that container's own mock, drives a
+// metadata-bearing dynamic request, and returns the first message's rendered
+// output_format block from the captured provider body.
+//
+// The explicit RuntimeEnv pin is load-bearing on BOTH legs now that de-BAML
+// is default-ON: the shared TestEnv is no longer a flag-OFF control, so each
+// leg gets its own container with the flag set to a known value. The
+// container is torn down via t.Cleanup.
+func captureDeBAMLRestBlock(t *testing.T, flagValue, scenarioID string) string {
+	t.Helper()
+
+	opts := matrixSetupOptions()
+	opts.RuntimeEnv = map[string]string{
+		bamlutils.EnvUseDeBAML: flagValue,
+	}
+
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), testutil.SetupBudget(opts))
+	defer setupCancel()
+
+	env, err := testutil.Setup(setupCtx, opts)
+	if err != nil {
+		t.Fatalf("Failed to setup dedicated de-BAML=%s env: %v", flagValue, err)
+	}
+	t.Cleanup(func() {
+		termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer termCancel()
+		if err := env.Terminate(termCtx); err != nil {
+			t.Logf("dedicated env (de-BAML=%s) Terminate: %v", flagValue, err)
+		}
+	})
+
+	mock := mockllm.NewClient(env.MockLLMURL)
+	client := testutil.NewBAMLRestClient(env.BAMLRestURL)
+	registerDeBAMLRestScenario(t, mock, scenarioID)
+
+	return restCaptureBlock(t, client, mock, env.MockLLMInternal, scenarioID)
 }
 
 func registerDeBAMLRestScenario(t *testing.T, client *mockllm.Client, scenarioID string) {

--- a/integration/testutil/container.go
+++ b/integration/testutil/container.go
@@ -672,16 +672,17 @@ const HTTPClientSelectorEnvVar = "BAML_REST_HTTP_CLIENT"
 // never overridden by the host env.
 //
 // The host BAML_REST_USE_DEBAML umbrella switch is forwarded the same way, for
-// the same reason: the informational integration-tests-debaml CI arm sets it on
-// the host go-test process to flip the WHOLE shared TestEnv onto the de-BAML
-// native dynamic response-coercion path. Without forwarding through this single
-// chokepoint the flag would never reach the baml-rest container (cmd/serve and
-// the subprocess cmd/worker both read it from the container env), so the arm
-// would be inert — the shared suite would keep running de-BAML off. Copied
-// before the RuntimeEnv loop so a dedicated test's explicit
-// opts.RuntimeEnv[BAML_REST_USE_DEBAML] pin (e.g. dynamic_debaml_rest_test.go)
-// still wins over the host value; left unset the var stays absent, preserving
-// the default-off behavior.
+// the same reason: the integration-tests-debaml-off CI arm sets it to false on
+// the host go-test process to flip the WHOLE shared TestEnv OFF the de-BAML
+// native path (validating the disable path — pure BAML). Without forwarding
+// through this single chokepoint the flag would never reach the baml-rest
+// container (cmd/serve and the subprocess cmd/worker both read it from the
+// container env), so the arm would be inert — the shared suite would keep
+// running the default. Copied before the RuntimeEnv loop so a dedicated test's
+// explicit opts.RuntimeEnv[BAML_REST_USE_DEBAML] pin (e.g.
+// dynamic_debaml_rest_test.go) still wins over the host value; left unset the
+// var stays absent, so the container inherits the server default, which is
+// de-BAML ON as of the default-on flip.
 //
 // Note: the BuildRequest route is unconditional as of #537, so there is no
 // BAML_REST_USE_BUILD_REQUEST forwarding here — the route is always attempted
@@ -700,7 +701,8 @@ func buildContainerEnv(opts SetupOptions) map[string]string {
 	// Forward the host de-BAML umbrella switch when set (non-empty), same
 	// chokepoint + precedence as the http-client selector: copied before the
 	// RuntimeEnv loop so an explicit RuntimeEnv pin still overrides it, and
-	// left absent when unset so the container stays de-BAML off by default.
+	// left absent when unset so the container inherits the server default
+	// (de-BAML ON as of the default-on flip).
 	if v := os.Getenv(bamlutils.EnvUseDeBAML); v != "" {
 		env[bamlutils.EnvUseDeBAML] = v
 	}

--- a/integration/testutil/container_debaml_env_test.go
+++ b/integration/testutil/container_debaml_env_test.go
@@ -9,12 +9,13 @@ import (
 )
 
 // TestBuildContainerEnvDeBAMLSelector is the regression guard for the
-// informational integration-tests-debaml CI arm. That arm sets
-// BAML_REST_USE_DEBAML on the host go-test process to flip the WHOLE shared
-// TestEnv onto the de-BAML native dynamic response-coercion path. The harness
-// starts baml-rest via testcontainers with an explicit Env map, so unless the
-// flag is forwarded into that map the arm is inert: the shared suite keeps
-// running de-BAML off and the arm is a false signal.
+// integration-tests-debaml-off CI arm. De-BAML is now default-ON, so that arm
+// sets BAML_REST_USE_DEBAML=false on the host go-test process to flip the WHOLE
+// shared TestEnv OFF the de-BAML native dynamic response-coercion path,
+// validating the disable path. The harness starts baml-rest via testcontainers
+// with an explicit Env map, so unless the flag is forwarded into that map the
+// arm is inert: the shared suite keeps running the server default (de-BAML ON)
+// and the arm is a false signal.
 //
 // Forwarding lives in buildContainerEnv — the single chokepoint every
 // baml-rest container's env passes through — with the SAME precedence as the
@@ -54,9 +55,10 @@ func TestBuildContainerEnvDeBAMLSelector(t *testing.T) {
 
 	t.Run("explicit RuntimeEnv pin wins over the host value", func(t *testing.T) {
 		// The dedicated de-BAML differential (dynamic_debaml_rest_test.go) pins
-		// the flag ON via RuntimeEnv for its own container; that must win even
-		// under the arm's global host BAML_REST_USE_DEBAML, and — symmetrically —
-		// a test that pins it OFF must be able to override a host ON.
+		// the flag explicitly via RuntimeEnv for its own containers (both the ON
+		// and OFF legs); that pin must win even under a global host
+		// BAML_REST_USE_DEBAML, in either direction. Here a host ON is overridden
+		// by an OFF pin.
 		t.Setenv(bamlutils.EnvUseDeBAML, "true")
 
 		opts := SetupOptions{RuntimeEnv: map[string]string{bamlutils.EnvUseDeBAML: "false"}}
@@ -68,13 +70,18 @@ func TestBuildContainerEnvDeBAMLSelector(t *testing.T) {
 		}
 	})
 
-	t.Run("host unset leaves the flag absent (default de-BAML off)", func(t *testing.T) {
+	t.Run("host unset leaves the flag absent (container inherits server default, now de-BAML ON)", func(t *testing.T) {
+		// With the host var unset/empty the forwarding must NOT inject the key,
+		// so the container inherits the server default resolved by
+		// DeBAMLConfigFromEnv — which is now de-BAML ON (default-on). Injecting a
+		// value here would override that default and defeat the disable-only
+		// contract.
 		t.Setenv(bamlutils.EnvUseDeBAML, "")
 
 		env := buildContainerEnv(SetupOptions{})
 
 		if _, ok := env[bamlutils.EnvUseDeBAML]; ok {
-			t.Fatalf("container env unexpectedly contains %s when host is unset (breaks default-off)",
+			t.Fatalf("container env unexpectedly contains %s when host is unset — the container must inherit the server default (now de-BAML ON), not a host-pinned value",
 				bamlutils.EnvUseDeBAML)
 		}
 	})


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

## Summary

Flips the de-BAML umbrella flag (`BAML_REST_USE_DEBAML`) to **default-ON** while **keeping the explicit disable path**. No release is cut until the initiative is done, so enabling native de-BAML by default is safe, and the flag is retained purely as an operator escape hatch.

## Changes

1. **`bamlutils/interfaces.go` — default-on resolution.** `DeBAMLConfigFromEnv` now returns `Enabled=true` when `BAML_REST_USE_DEBAML` is unset/empty **or** truthy, and `Enabled=false` **only** on an explicit recognized falsy value (`0/false/no/off`, case-insensitive). Adds `IsFalsyEnvValue` (the inverse of `IsTruthyEnvValue`) and updates the `DeBAMLConfigFromEnv` / `DeBAMLConfig` doc comments to state default-on, disabled only by an explicit falsy value.

2. **Unit tests.** New `bamlutils/debaml_config_test.go` pins the NEW truth table: unset/empty → `true`; truthy (`1/true/yes/on`) → `true`; unrecognized tokens → `true` (default-on); explicit falsy (`0/false/no/off`) → `false`. Also covers `IsFalsyEnvValue` directly.

3. **Test cascade.** With the default flipped, the shared integration `TestEnv` now runs de-BAML by default and can no longer serve as a flag-OFF control. `TestDeBAMLRest_MetadataAppearsOnProductionPath` now pins **both** legs to dedicated containers via `SetupOptions.RuntimeEnv` — an explicit `BAML_REST_USE_DEBAML=true` container vs an explicit `=false` container — so the differential is never on-vs-on regardless of the suite-wide default. The oracle / stream-seam tests build their own in-process dynclients (`WithDeBAML(true)` vs default-off) and are unaffected. Refreshes the now-stale "default-off" comments in `testutil.buildContainerEnv`.

4. **CI — repurpose the redundant arm.** With the default now on, the normal matrix **is** the flag-on test, so the explicit-flag-on `integration-tests-debaml` job is redundant. It is repurposed to guard the **disable** path: renamed to `integration-tests-debaml-off`, its test step now sets `BAML_REST_USE_DEBAML=false` (runs the suite with de-BAML disabled → pure BAML → green), and the now-unneeded `-skip` of `TestDeBAMLRest_MetadataAppearsOnProductionPath` is removed (it runs fine with the flag explicitly off). Kept non-required.

## Validation (local)

- `gofmt` clean; `go build ./...`; `go vet ./...` (and `go vet -tags integration,subprocess ./integration/...`) — all clean.
- `TestDeBAMLConfigFromEnv` + `TestIsFalsyEnvValue` — pass.
- `go test ./internal/debaml/...` — pass.
- Full integration suite intentionally **not** run locally: this PR's own integration matrix now runs de-BAML by default, so CI is the real validation and should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native de-BAML is now default-enabled; use `BAML_REST_USE_DEBAML` to explicitly disable it.
  * Recognizes `0`, `false`, `no`, and `off` (case-insensitive) as explicit falsy tokens.
* **Bug Fixes**
  * Prevents accidental disablement from unset/empty or unrecognized values (no whitespace-trimmed matching).
* **Tests / Integration**
  * Added unit tests locking down env-token parsing and default-on behavior.
  * Updated CI to run a dedicated “de-BAML OFF” integration path and expanded the integration suite to cover both ON and OFF consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->