### PR TITLE
debaml P3: attributes + constraints — @assert/@check + @stream.* + doc-comment no-op (slice 4) (#586)

### DIFF
--- a/bamlutils/bamlparser/ast.go
+++ b/bamlutils/bamlparser/ast.go
@@ -156,12 +156,6 @@ type TypeBlock struct {
 	Methods    []string
 
 	HasUnsupportedContent bool
-
-	// Span covers the declaration keyword (`class`/`enum`/`test`). It lets a
-	// later slice locate the declaration in the source — e.g. to detect a `///`
-	// doc comment on the line above (see #586: the builder declines a reachable
-	// class/enum carrying a `///` description until doc-comment capture lands).
-	Span Span
 }
 
 // TypeAlias corresponds to `type Name = expression`. Name carries the alias

--- a/bamlutils/bamlparser/bamlparser.go
+++ b/bamlutils/bamlparser/bamlparser.go
@@ -378,7 +378,6 @@ func (tb *TypeBlock) Parse(lex *lexer.PeekingLexer) error {
 	}
 	kwTok := lex.Next()
 	tb.Keyword = kwTok.Value
-	tb.Span = tokSpan(kwTok)
 
 	if t := lex.Peek(); t.Type == identType {
 		tb.Name = lex.Next().Value

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -1392,9 +1392,7 @@ func parseBamlSourceDir(dir string) *bamlConfig {
 			return nil
 		}
 		processBAMLFile(cfg, file)
-		// Carry the raw source alongside the parsed File so the native builder
-		// can detect `///` doc comments by declaration span (see #586 D6).
-		parsedFiles = append(parsedFiles, nativeschema.SourceFile{File: file, Source: data})
+		parsedFiles = append(parsedFiles, nativeschema.SourceFile{File: file})
 		return nil
 	})
 

--- a/integration/static_output_format_renderer_test.go
+++ b/integration/static_output_format_renderer_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/invakid404/baml-rest/internal/schema/outputformat"
 )
 
-// TestNativeStaticOutputFormatParity is the de-BAML P3 slice-3 load-bearing
-// correctness proof: the native STATIC-schema pipeline must reproduce BAML's
+// TestNativeStaticOutputFormatParity is the de-BAML P3 load-bearing correctness
+// proof (slices 3-4): the native STATIC-schema pipeline must reproduce BAML's
 // real ctx.output_format byte-for-byte for a corpus of static .baml functions.
 //
 // It is the static-schema analogue of TestNativeOutputFormatRendererParity
@@ -54,17 +54,24 @@ import (
 //     outputformat.Render(bundle, outputformat.Options{}) — RenderOptions::default,
 //     matching the template's bare {{ ctx.output_format }}.
 //
-// The byte-exact comparison is the parity criterion. It proves the whole
-// slice-3 chain — parse -> reachability ordering -> @alias/@description
-// lowering -> FromStaticDescriptor -> render — matches BAML for every covered
-// function, including map KEY shapes (string, enum, literal-union) and the
-// key-then-value reachability order pinned by ParityEnumKeyMap (a hoisted
-// value-enum block renders before the hoisted key-enum block). The expected
-// function set is asserted independently (P2) so a silently-skipped fixture
-// cannot false-pass, and the run is pinned to the exact 0.223.0 oracle (P3).
-// Declines (unsupported constructs, e.g. `///` doc comments) are covered by the
-// unit tests in internal/nativeschema, not by this oracle; the corpus here is
-// all-supported.
+// The byte-exact comparison is the parity criterion. It proves the whole static
+// chain — parse -> reachability ordering -> attribute lowering (@alias/
+// @description/@assert/@check/@stream.*) -> FromStaticDescriptor -> render —
+// matches BAML for every covered function, including map KEY shapes (string,
+// enum, literal-union) and the key-then-value reachability order pinned by
+// ParityEnumKeyMap (a hoisted value-enum block renders before the hoisted
+// key-enum block). It also pins that metadata BAML does NOT render in the final
+// output_format stays invisible on the native side too: `///` doc comments
+// (ParityDocComments, and ParityDocVsDesc where @description wins), @assert/
+// @check constraints (ParityConstraints), and @stream.* flags (ParityStream,
+// ParityMixed) must not change a byte — BAML captures them but its output_format
+// renderer never reads them (see #586 D6-D8), and neither does ours. The
+// expected function set is asserted independently (P2) so a silently-skipped
+// fixture cannot false-pass, and the run is pinned to the exact 0.223.0 oracle
+// (P3). The corpus here is all-supported (a `///` doc comment is SUPPORTED as a
+// no-op, not a decline); genuine declines (recursion, @@dynamic, @skip, media/
+// tuple output, ...) are covered by the unit tests in internal/nativeschema, not
+// by this oracle.
 func TestNativeStaticOutputFormatParity(t *testing.T) {
 	// P3: this is the load-bearing v0.223.0 parity proof, so it asserts the
 	// EXACT oracle version rather than a >=0.219 floor. The de-BAML=false render
@@ -227,7 +234,7 @@ func buildNativeParityBundles(t *testing.T, dir string) map[string]sd.Bundle {
 		if err != nil {
 			t.Fatalf("parse %s: %v", path, err)
 		}
-		files = append(files, nativeschema.SourceFile{File: f, Source: data})
+		files = append(files, nativeschema.SourceFile{File: f})
 	}
 
 	bundles, declines := nativeschema.BuildStaticSchemas(files)

--- a/integration/testdata/parity_baml_src/functions.baml
+++ b/integration/testdata/parity_baml_src/functions.baml
@@ -72,3 +72,31 @@ function ParityProfile(input: string) -> Profile {
     client TestClient
     prompt #"{{ ctx.output_format }}"#
 }
+
+// --- slice-4: attributes + constraints. Each proves a metadata construct
+// (doc comment / constraint / stream flag) does NOT change ctx.output_format.
+
+function ParityDocComments(input: string) -> DocCommented {
+    client TestClient
+    prompt #"{{ ctx.output_format }}"#
+}
+
+function ParityDocVsDesc(input: string) -> DocVsDesc {
+    client TestClient
+    prompt #"{{ ctx.output_format }}"#
+}
+
+function ParityConstraints(input: string) -> Constrained {
+    client TestClient
+    prompt #"{{ ctx.output_format }}"#
+}
+
+function ParityStream(input: string) -> Streamed {
+    client TestClient
+    prompt #"{{ ctx.output_format }}"#
+}
+
+function ParityMixed(input: string) -> Mixed {
+    client TestClient
+    prompt #"{{ ctx.output_format }}"#
+}

--- a/integration/testdata/parity_baml_src/types.baml
+++ b/integration/testdata/parity_baml_src/types.baml
@@ -149,3 +149,85 @@ class Profile {
     status StatusEnum
     note string?
 }
+
+// === slice-4: attributes + constraints ===================================
+//
+// The output_format is the FINAL (non-streaming) schema. Constraints
+// (@check/@assert) are metadata and stream flags (@stream.*) affect streaming
+// mode, not the final block — so NONE of the constructs below may change the
+// rendered ctx.output_format. Each doc-comment / constraint / stream fixture
+// must render byte-identically to the same shape without them, which is exactly
+// what the native builder produces (it captures the metadata into the descriptor
+// but the renderer ignores it). This is the load-bearing proof for slice 4.
+
+// --- /// doc comments are CAPTURED AS A NO-OP -----------------------------
+//
+// BAML lowers `///` to a docstring its output_format renderer NEVER reads (only
+// @description renders — confirmed by THIS oracle). A doc-commented class /
+// field / enum / enum-value must therefore render with NO `//` description
+// lines. If BAML rendered doc comments, DocStatus would gain descriptions and
+// HOIST (changing the whole block), and DocCommented would grow `//` lines —
+// either would break byte-parity, so this fixture is the empirical proof.
+
+/// A documented enum (its enum-level doc comment must NOT render).
+enum DocStatus {
+    /// the active value (this doc comment must NOT render)
+    ACTIVE
+    INACTIVE
+}
+
+/// A documented output class.
+/// Second doc line — still must NOT render.
+class DocCommented {
+    /// the identifier field (must NOT render)
+    id string
+    /// how many items (must NOT render)
+    count int
+    status DocStatus
+}
+
+// --- doc comment vs @description precedence -------------------------------
+//
+// With BOTH a `///` and an @description on one node, @description is the SOLE
+// rendered source; the doc comment is invisible. Only "the real title" may
+// appear as a `//` line for `title`.
+
+class DocVsDesc {
+    /// doc comment on title (must NOT render)
+    title string @description("the real title")
+    body string
+}
+
+// --- @assert / @check constraints (repeated, field + block level) ---------
+//
+// Opaque constraints, never rendered. Byte-identical to a constraint-free class.
+
+class Constrained {
+    score int @check(positive, {{ this > 0 }}) @assert(bounded, {{ this < 100 }})
+    label string @assert({{ this|length > 0 }})
+    note string?
+    @@assert(consistent, {{ this.score < 100 }})
+}
+
+// --- @stream.* flags (field-level reassociated to type + class level) -----
+//
+// Streaming flags affect STREAMING mode, not the FINAL non-streaming
+// output_format this oracle renders — so byte-identical to a stream-free class.
+
+class Streamed {
+    ready bool @stream.done
+    payload string @stream.not_null @stream.with_state
+    tail int
+    @@stream.done
+}
+
+// --- mixed @alias + @description + @check + @stream on one field ----------
+//
+// Only @alias (renders as the field NAME) and @description (renders as a `//`
+// line) affect output_format; the @check and @stream.done do not.
+
+class Mixed {
+    full_name string @alias("name") @description("the full name") @check(nonempty, {{ this|length > 0 }}) @stream.done
+    status Category @description("the status category")
+    @@assert(ok, {{ this.full_name|length > 0 }})
+}

--- a/internal/nativeschema/build.go
+++ b/internal/nativeschema/build.go
@@ -25,25 +25,49 @@
 // container introspection step fails to compile a sibling symbol as
 // "undefined". See #586 and the slice-2 build fix.
 //
-// SCOPE (slice 3 — structural build + reachability ordering + alias/description):
+// SCOPE (slice 4 — attributes + constraints, on top of slices 1-3):
 //   - Lower primitives, named class/enum refs, non-recursive aliases (inlined),
-//     lists, maps, optionals, unions, and string/int/bool literals.
-//   - Emit Enums/Classes in BAML output-format reachability order (see
+//     lists, maps, optionals, unions, and string/int/bool literals, and emit
+//     Enums/Classes in BAML output-format reachability order (see
 //     [descriptorBuilder.reorderByReachability]); FromStaticDescriptor preserves
 //     order verbatim, so the STORED descriptor must already be in BAML order for
 //     the renderer to match byte-for-byte.
 //   - Lower @alias -> Name.Alias and @description -> Description on class fields,
-//     enum values, and class/enum-level block attributes. Constraints
-//     (@assert/@check), streaming (@stream.*), @@dynamic, and @skip stay
-//     DECLINED (slices 4-6).
-//   - Validate STRUCTURALLY via FromStaticDescriptor + ValidateOutput.
+//     enum values, and class/enum-level block attributes.
+//   - Lower @assert/@check -> opaque [schemadescriptor.Constraint] carrying the
+//     level, optional label, and verbatim Jinja expression text, NEVER
+//     evaluated. Repeated constraints are supported. A field constraint
+//     reassociates onto the field's TYPE
+//     (Type.Meta.Constraints, exactly as BAML's reassociate_type_attributes
+//     does); a class/enum block constraint goes on ClassDef.Constraints /
+//     EnumDef.Constraints.
+//   - Lower @stream.done/@stream.not_null/@stream.with_state into the descriptor
+//     streaming fields exactly as BAML models them: a field stream attribute
+//     reassociates onto the field's TYPE (Type.Meta.Stream), a class-level
+//     @@stream.* goes on ClassDef.Stream. Static STREAMING partialization +
+//     streaming output_format parity stay DECLINED (slice 6); this slice only
+//     carries the flags on the FINAL (non-streaming) descriptor.
+//   - Validate STRUCTURALLY via FromStaticDescriptor + ValidateOutput. Constraints
+//     and streaming flags are metadata: they do NOT change the rendered
+//     ctx.output_format (the parity harness proves this byte-for-byte).
+//   - @@dynamic and @skip stay DECLINED (slice 6); recursion stays DECLINED
+//     (slice 5).
 //
 // Lax-vs-BAML / decline decisions logged here are also recorded on #586:
 //
-//	D1. Only @alias and @description are lowered from a reachable output node
-//	    (slice 3). ANY OTHER attribute (@assert/@check/@stream.*/@@dynamic/@skip,
-//	    or an unknown attribute) still DECLINES the function fail-closed rather
-//	    than being silently dropped. This is a parity-decline, not input laxness.
+//	D1. A reachable output node may carry @alias/@description (everywhere),
+//	    @assert/@check, and @stream.* (where the descriptor can represent them).
+//	    ANY OTHER attribute (@skip, @@dynamic, or an unknown attribute) DECLINES
+//	    the function fail-closed rather than being silently dropped. Enum-LEVEL
+//	    @@check/@@assert DO lower (to EnumDef.Constraints, as class @@check/@@assert
+//	    lower to ClassDef.Constraints); but a constraint or stream attribute on a
+//	    node with no descriptor home for it DECLINES: any @check/@assert/@stream.*
+//	    on an enum VALUE (EnumValue has neither field), and an enum-LEVEL @@stream.*
+//	    (EnumDef has no streaming field). An attribute on a NESTED type node (e.g.
+//	    the inner `int` of `map<string, int @check>`, or a bare union variant)
+//	    declines too: reassociation of nested / union-variant attributes is not
+//	    performed — this slice handles only the field's OUTERMOST type, plus block
+//	    and enum-value metadata.
 //	D2. media and tuple output are lowered FAITHFULLY into the descriptor and
 //	    left for ValidateOutput to reject (it errors on tuple/arrow/top/media),
 //	    so the single authority on output-legality stays internal/schema.
@@ -54,14 +78,32 @@
 //	    outcome overrides an earlier one), matching the config walker.
 //	D5. @alias/@description arguments must be a SINGLE plain string (a quoted
 //	    string or a raw string). A missing, multi-valued, or non-string argument
-//	    (e.g. a Jinja description) declines the function — slice 3 renders the
-//	    description verbatim, so an argument it cannot reproduce byte-for-byte
-//	    fails closed rather than guessing. Slice 4 revisits richer descriptions.
-//	D6. /// doc comments are NOT captured as descriptions yet: the shared lexer
-//	    elides all //-prefixed comments, so the builder never sees them. Class/
-//	    enum/field/value descriptions come from @description only in slice 3.
-//	    Capturing /// needs a lexer change gated on byte-identical config
-//	    goldens; deferred to a fast-follow. Logged on #586.
+//	    (e.g. a Jinja description) declines the function — the description is
+//	    rendered verbatim, so an argument it cannot reproduce byte-for-byte fails
+//	    closed rather than guessing.
+//	D6. /// doc comments are CAPTURED-as-no-op. BAML lowers `///` to a docstring
+//	    that its output_format renderer NEVER reads — only @description renders,
+//	    confirmed against the v0.223 oracle (a doc-commented node byte-matches the
+//	    same node without the comment). So a `///` doc comment contributes NOTHING
+//	    to the descriptor, and a doc-commented class/field/enum/enum-value now
+//	    builds SUPPORTED. This CORRECTS slice 3, which fail-closed DECLINED doc
+//	    comments on the (then-untested) assumption they rendered as a description.
+//	    @description always wins over a doc comment because it is the sole source;
+//	    the doc comment never overrides or concatenates.
+//	D7. @assert/@check are stored OPAQUELY. The expression is the verbatim inner
+//	    text between {{ and }} (braces excluded, not trimmed) — matching BAML's
+//	    stored JinjaExpression content except we skip BAML's backslash-doubling
+//	    normalization (the value is never parsed or evaluated; evaluation is out
+//	    of scope, deferred). The optional label is the bare leading identifier. A
+//	    shape that cannot be split into (label?, {{expr}}) declines fail-closed.
+//	D8. @stream.* map, exactly as BAML's IR does: a field @stream.done/not_null/
+//	    with_state reassociates onto the field TYPE -> Type.Meta.Stream.{Done,
+//	    Needed,State}; a class @@stream.* -> ClassDef.Stream. ClassField.
+//	    StreamingNeeded is BAML's override-derived per-field bool (defaults false)
+//	    and is NOT set by a static attribute, so the builder leaves it unset.
+//	D9. type-alias RHS attributes (BAML permits @check/@assert on aliases) remain
+//	    DECLINED: alias constraint inlining is deferred (not in the slice-4
+//	    corpus), so an attributed alias fails closed rather than being dropped.
 package nativeschema
 
 import (
@@ -75,16 +117,17 @@ import (
 	"github.com/invakid404/baml-rest/internal/schema"
 )
 
-// SourceFile pairs a parsed .baml [bamlparser.File] with its raw source bytes.
-// The builder needs the source to detect `///` doc comments by declaration
-// span (see #586 D6): BAML lowers `///` to a rendered Description, but the
-// shared lexer elides all `//`-prefixed comments so the AST never retains them.
-// Carrying the source lets the builder DECLINE fail-closed on a reachable
-// doc-commented node instead of silently emitting a descriptor with a missing
-// description.
+// SourceFile wraps a parsed .baml [bamlparser.File]. It is a struct (rather than
+// a bare *File) so the builder's input contract can grow without churning every
+// caller.
+//
+// It no longer carries the raw source bytes. Slice 3 threaded the source in to
+// DETECT `///` doc comments (which the shared lexer elides) and decline them;
+// slice 4 confirmed against the v0.223 oracle that BAML's output_format renderer
+// never reads doc comments (only @description renders — see #586 D6), so a
+// doc-commented node builds byte-identically without any source inspection.
 type SourceFile struct {
-	File   *bamlparser.File
-	Source []byte
+	File *bamlparser.File
 }
 
 // BuildStaticSchemas builds a native static output-schema descriptor for every
@@ -139,18 +182,10 @@ func BuildStaticSchemas(files []SourceFile) (map[string]sd.Bundle, map[string]st
 // recorded in ambiguous; the builder declines any function that reaches a
 // poisoned name (D3) rather than silently last-wins-ing type definitions.
 type schemaTypeIndex struct {
-	classes   map[string]*typeDecl
-	enums     map[string]*typeDecl
+	classes   map[string]*bamlparser.TypeBlock
+	enums     map[string]*bamlparser.TypeBlock
 	aliases   map[string]*bamlparser.TypeAlias
 	ambiguous map[string]struct{}
-}
-
-// typeDecl is a class/enum declaration plus the raw source of its file, so the
-// builder can inspect the bytes around the declaration span (for `///` doc
-// comment detection).
-type typeDecl struct {
-	tb  *bamlparser.TypeBlock
-	src []byte
 }
 
 func (i *schemaTypeIndex) isAmbiguous(name string) bool {
@@ -163,8 +198,8 @@ func (i *schemaTypeIndex) isAmbiguous(name string) bool {
 // metadata-only posture for them.
 func buildSchemaTypeIndex(files []SourceFile) *schemaTypeIndex {
 	idx := &schemaTypeIndex{
-		classes:   make(map[string]*typeDecl),
-		enums:     make(map[string]*typeDecl),
+		classes:   make(map[string]*bamlparser.TypeBlock),
+		enums:     make(map[string]*bamlparser.TypeBlock),
 		aliases:   make(map[string]*bamlparser.TypeAlias),
 		ambiguous: make(map[string]struct{}),
 	}
@@ -179,10 +214,10 @@ func buildSchemaTypeIndex(files []SourceFile) *schemaTypeIndex {
 			switch {
 			case it.TypeBlock != nil && it.TypeBlock.Name != "" && it.TypeBlock.Keyword == "class":
 				counts[it.TypeBlock.Name]++
-				idx.classes[it.TypeBlock.Name] = &typeDecl{tb: it.TypeBlock, src: sf.Source}
+				idx.classes[it.TypeBlock.Name] = it.TypeBlock
 			case it.TypeBlock != nil && it.TypeBlock.Name != "" && it.TypeBlock.Keyword == "enum":
 				counts[it.TypeBlock.Name]++
-				idx.enums[it.TypeBlock.Name] = &typeDecl{tb: it.TypeBlock, src: sf.Source}
+				idx.enums[it.TypeBlock.Name] = it.TypeBlock
 			case it.TypeAlias != nil && it.TypeAlias.Name != "":
 				counts[it.TypeAlias.Name]++
 				idx.aliases[it.TypeAlias.Name] = it.TypeAlias
@@ -307,8 +342,10 @@ func (b *descriptorBuilder) orderedEnums() []sd.EnumDef {
 // builder collected exactly the reachable definition set (it only lowers what a
 // reachable reference names), so ReachableOrder returns each collected name once
 // and in BAML order; every returned name therefore resolves in the builder's
-// by-name maps. Slice 3 never emits streaming classes, so a class key's mode is
-// always NonStreaming and looking classes up by canonical name is sufficient.
+// by-name maps. The builder never emits a streaming-MODE class (streaming is
+// carried as metadata on the final descriptor, not as a separate streaming-mode
+// class — static streaming mode is slice 6), so a class key's mode is always
+// NonStreaming and looking classes up by canonical name is sufficient.
 func (b *descriptorBuilder) reorderByReachability(bundle *sd.Bundle, internal *schema.Bundle) {
 	enumNames, classKeys := internal.ReachableOrder()
 
@@ -339,19 +376,20 @@ func (b *descriptorBuilder) reorderByReachability(bundle *sd.Bundle, internal *s
 
 // lowerType lowers one parsed TypeExpr into a descriptor Type, collecting any
 // reachable class/enum definitions along the way. It returns a decline error
-// for any construct slice 3 cannot represent faithfully.
+// for any construct this slice cannot represent faithfully.
 func (b *descriptorBuilder) lowerType(t *bamlparser.TypeExpr) (sd.Type, error) {
 	if t == nil {
 		return sd.Type{}, fmt.Errorf("missing type expression")
 	}
 
-	// D1: attributes on a type node decline the function. @alias/@description
-	// that belong to an enclosing class field or enum value are consumed and
-	// STRIPPED by the member handler before it calls lowerFieldType, so by the
-	// time lowerType sees a node with attributes, they are either constraints/
-	// streaming/unknown attributes (declined here) or metadata on a NESTED type
-	// (which slice 3 does not support — declined here fail-closed rather than
-	// silently dropped).
+	// D1: attributes on a type node reaching here decline the function. A class
+	// field's / enum value's own metadata (@alias/@description) and its
+	// reassociated type metadata (@check/@assert/@stream.*) are consumed and the
+	// field's OUTERMOST attributes are STRIPPED by the member handler before it
+	// calls lowerFieldType. So by the time lowerType sees a node that still
+	// carries attributes, they are on a NESTED type node (e.g. `map<string,
+	// int @check>` or a bare union variant) — a shape this slice does not
+	// reassociate — and it declines fail-closed rather than silently dropping.
 	if len(t.Attributes) > 0 {
 		return sd.Type{}, declineAttribute(t.Attributes[0])
 	}
@@ -401,11 +439,13 @@ func (b *descriptorBuilder) lowerType(t *bamlparser.TypeExpr) (sd.Type, error) {
 }
 
 // lowerFieldType lowers a class-field type after its field-level metadata
-// (@alias/@description) has been consumed by the caller ([extractMemberMeta],
-// which declines any non-metadata attribute). The remaining attributes on the
-// OUTERMOST node are therefore all metadata; they are dropped via a shallow
-// copy (never mutating the shared AST, which other functions also reference)
-// before lowering. Nested-node attributes are untouched and still decline in
+// (@alias/@description) and its reassociated type metadata (@check/@assert/
+// @stream.*) have been consumed by the caller ([extractFieldMeta], which
+// declines any other attribute). The remaining attributes on the OUTERMOST node
+// are therefore all recognized metadata; they are dropped via a shallow copy
+// (never mutating the shared AST, which other functions also reference) before
+// lowering, and the caller re-attaches the constraints/streaming to the lowered
+// type's Meta. Nested-node attributes are untouched and still decline in
 // lowerType.
 func (b *descriptorBuilder) lowerFieldType(t *bamlparser.TypeExpr) (sd.Type, error) {
 	if t == nil {
@@ -655,14 +695,14 @@ func (b *descriptorBuilder) lowerNameRef(t *bamlparser.TypeExpr) (sd.Type, error
 		return sd.Type{}, fmt.Errorf("type name %q is declared more than once (duplicate class/enum/alias)", name)
 	}
 
-	if decl, ok := b.index.classes[name]; ok {
-		if err := b.ensureClass(name, decl); err != nil {
+	if tb, ok := b.index.classes[name]; ok {
+		if err := b.ensureClass(name, tb); err != nil {
 			return sd.Type{}, err
 		}
 		return sd.Type{Kind: sd.TypeClass, Name: name, Mode: sd.NonStreaming}, nil
 	}
-	if decl, ok := b.index.enums[name]; ok {
-		if err := b.ensureEnum(name, decl); err != nil {
+	if tb, ok := b.index.enums[name]; ok {
+		if err := b.ensureEnum(name, tb); err != nil {
 			return sd.Type{}, err
 		}
 		return sd.Type{Kind: sd.TypeEnum, Name: name}, nil
@@ -676,32 +716,27 @@ func (b *descriptorBuilder) lowerNameRef(t *bamlparser.TypeExpr) (sd.Type, error
 // ensureClass lowers a class definition into the collected set exactly once.
 // It declines unsupported body content (methods / nested blocks), named-argument
 // (generic) class blocks, and recursion (a class re-entered while on the active
-// path). Class-level @@alias/@@description block attributes lower to the class's
-// alias/description; any other block attribute (@@dynamic, ...) declines. Field
-// @alias/@description lower to the field's alias/description; any other field
-// attribute declines.
-func (b *descriptorBuilder) ensureClass(name string, decl *typeDecl) error {
+// path). Class-level @@alias/@@description/@@check/@@assert/@@stream.* block
+// attributes lower to the class's alias/description/constraints/streaming; any
+// other block attribute (@@dynamic, ...) declines. A field's @alias/@description
+// lower to the field, and its reassociated @check/@assert/@stream.* lower onto
+// the field's TYPE metadata; any other field attribute declines. A `///` doc
+// comment is captured as a no-op (BAML never renders it — see #586 D6).
+func (b *descriptorBuilder) ensureClass(name string, tb *bamlparser.TypeBlock) error {
 	if _, done := b.classes[name]; done {
 		return nil
 	}
 	if b.classVisiting[name] {
 		return fmt.Errorf("recursive class %q is not supported yet (slice 5)", name)
 	}
-	tb := decl.tb
 	if tb.HasUnsupportedContent {
 		return fmt.Errorf("class %q has unsupported body content (methods or nested blocks)", name)
 	}
 	if len(tb.Args) > 0 {
 		return fmt.Errorf("class %q has a named-argument list (parameterized classes are not supported)", name)
 	}
-	// D6: a `///` doc comment on the class renders a Description in BAML, which
-	// slice 3 does not capture — decline fail-closed rather than emit a
-	// descriptor with a missing description.
-	if hasDocCommentBefore(decl.src, tb.Span.Start) {
-		return fmt.Errorf("class %q carries a /// doc comment (doc-comment descriptions are not supported yet — see #586 D6)", name)
-	}
 
-	classAlias, classDesc, err := extractBlockMeta(tb.Attributes)
+	block, err := extractBlockMeta(tb.Attributes)
 	if err != nil {
 		return fmt.Errorf("class %q: %w", name, err)
 	}
@@ -714,10 +749,7 @@ func (b *descriptorBuilder) ensureClass(name string, decl *typeDecl) error {
 		if m.Type == nil {
 			return fmt.Errorf("class %q field %q has no type", name, m.Name)
 		}
-		if hasDocCommentBefore(decl.src, m.Span.Start) {
-			return fmt.Errorf("class %q field %q carries a /// doc comment (doc-comment descriptions are not supported yet — see #586 D6)", name, m.Name)
-		}
-		alias, desc, err := extractMemberMeta(memberAttributes(m))
+		fm, err := extractFieldMeta(memberAttributes(m))
 		if err != nil {
 			return fmt.Errorf("class %q field %q: %w", name, m.Name, err)
 		}
@@ -725,18 +757,26 @@ func (b *descriptorBuilder) ensureClass(name string, decl *typeDecl) error {
 		if err != nil {
 			return fmt.Errorf("class %q field %q: %w", name, m.Name, err)
 		}
+		// BAML reassociates @check/@assert/@stream.* from the field onto its
+		// TYPE, so the constraints/streaming ride on the field type's Meta, not
+		// the field itself. The lowered type here is metadata-free (any nested
+		// attribute already declined), so assigning Meta cannot clobber anything.
+		ft.Meta.Constraints = fm.constraints
+		ft.Meta.Stream = fm.stream
 		fields = append(fields, sd.ClassField{
-			Name:        sd.Name{Name: m.Name, Alias: alias},
+			Name:        sd.Name{Name: m.Name, Alias: fm.alias},
 			Type:        ft,
-			Description: desc,
+			Description: fm.description,
 		})
 	}
 
 	b.classes[name] = sd.ClassDef{
-		Name:        sd.Name{Name: name, Alias: classAlias},
-		Description: classDesc,
+		Name:        sd.Name{Name: name, Alias: block.alias},
+		Description: block.description,
 		Mode:        sd.NonStreaming,
 		Fields:      fields,
+		Constraints: block.constraints,
+		Stream:      block.stream,
 	}
 	b.classOrder = append(b.classOrder, name)
 	return nil
@@ -744,46 +784,44 @@ func (b *descriptorBuilder) ensureClass(name string, decl *typeDecl) error {
 
 // ensureEnum lowers an enum definition into the collected set exactly once. It
 // declines unsupported body content and named-argument enum blocks. Enum-level
-// @@alias/@@description block attributes lower to the enum's alias/description;
-// any other block attribute (@@dynamic, ...) declines. Enum-value @alias/
-// @description lower to the value's alias/description; any other value attribute
-// (@skip, ...) declines.
-func (b *descriptorBuilder) ensureEnum(name string, decl *typeDecl) error {
+// @@alias lowers to the enum's alias and @@check/@@assert to its constraints;
+// @@description and @@stream.* decline because the descriptor (like BAML's
+// OutputFormatContent) has no enum-level description or streaming home for them.
+// An enum value's @alias/@description lower to the value; @check/@assert/
+// @stream.* on a value decline (EnumValue carries no constraints/streaming
+// field); any other value attribute (@skip, ...) declines. A `///` doc comment
+// is captured as a no-op (BAML never renders it — see #586 D6).
+func (b *descriptorBuilder) ensureEnum(name string, tb *bamlparser.TypeBlock) error {
 	if _, done := b.enums[name]; done {
 		return nil
 	}
-	tb := decl.tb
 	if tb.HasUnsupportedContent {
 		return fmt.Errorf("enum %q has unsupported body content", name)
 	}
 	if len(tb.Args) > 0 {
 		return fmt.Errorf("enum %q has a named-argument list (parameterized enums are not supported)", name)
 	}
-	// D6: a `///` doc comment on the enum renders a Description in BAML, which
-	// slice 3 does not capture — decline fail-closed.
-	if hasDocCommentBefore(decl.src, tb.Span.Start) {
-		return fmt.Errorf("enum %q carries a /// doc comment (doc-comment descriptions are not supported yet — see #586 D6)", name)
-	}
 
-	enumAlias, enumDesc, err := extractBlockMeta(tb.Attributes)
+	block, err := extractBlockMeta(tb.Attributes)
 	if err != nil {
 		return fmt.Errorf("enum %q: %w", name, err)
 	}
 	// The descriptor model (and BAML's OutputFormatContent) has no enum-LEVEL
-	// description — only enum VALUES carry one, and BAML renders no enum-level
-	// description in ctx.output_format. An @@description on an enum is therefore
+	// description or streaming — only enum VALUES carry a description, and BAML
+	// renders neither an enum-level description nor enum-level streaming in
+	// ctx.output_format. An @@description / @@stream.* on an enum is therefore
 	// not representable; decline fail-closed rather than silently drop it.
-	if enumDesc != nil {
+	if block.description != nil {
 		return fmt.Errorf("enum %q carries @@description, which has no rendered representation (only enum values carry descriptions)", name)
+	}
+	if !block.stream.IsZero() {
+		return fmt.Errorf("enum %q carries an @@stream.* attribute, which has no enum-level representation", name)
 	}
 
 	values := make([]sd.EnumValue, 0, len(tb.Fields))
 	for _, m := range tb.Fields {
 		if m.Type != nil {
 			return fmt.Errorf("enum %q value %q unexpectedly carries a type", name, m.Name)
-		}
-		if hasDocCommentBefore(decl.src, m.Span.Start) {
-			return fmt.Errorf("enum %q value %q carries a /// doc comment (doc-comment descriptions are not supported yet — see #586 D6)", name, m.Name)
 		}
 		alias, desc, err := extractMemberMeta(m.Attributes)
 		if err != nil {
@@ -796,24 +834,27 @@ func (b *descriptorBuilder) ensureEnum(name string, decl *typeDecl) error {
 	}
 
 	b.enums[name] = sd.EnumDef{
-		Name:   sd.Name{Name: name, Alias: enumAlias},
-		Values: values,
+		Name:        sd.Name{Name: name, Alias: block.alias},
+		Values:      values,
+		Constraints: block.constraints,
 	}
 	b.enumOrder = append(b.enumOrder, name)
 	return nil
 }
 
 // resolveAlias inlines a non-recursive alias by lowering its right-hand side in
-// place (BAML substitutes non-recursive aliases). It declines alias attributes
-// (slice 3 supports none, including the @check/@assert BAML permits on
-// aliases), an unparsed RHS, and recursion (an alias re-entered while on the
-// active path — a structural recursive alias is slice 5).
+// place (BAML substitutes non-recursive aliases). D9: it declines alias
+// attributes — BAML permits @check/@assert on aliases, but inlining a
+// constraint-bearing alias onto its use sites is deferred (not in the slice-4
+// corpus), so an attributed alias fails closed rather than dropping the
+// constraint. It also declines an unparsed RHS and recursion (an alias
+// re-entered while on the active path — a structural recursive alias is slice 5).
 func (b *descriptorBuilder) resolveAlias(name string, alias *bamlparser.TypeAlias) (sd.Type, error) {
 	if b.aliasVisiting[name] {
 		return sd.Type{}, fmt.Errorf("recursive type alias %q is not supported yet (slice 5)", name)
 	}
 	if len(alias.Attributes) > 0 {
-		return sd.Type{}, fmt.Errorf("type alias %q carries attribute @%s (alias attributes are not supported yet — slice 4)", name, alias.Attributes[0].Name)
+		return sd.Type{}, fmt.Errorf("type alias %q carries attribute @%s (alias constraint inlining is deferred — see #586 D9)", name, alias.Attributes[0].Name)
 	}
 	if alias.Expr == nil {
 		return sd.Type{}, fmt.Errorf("type alias %q has an unparsed right-hand side", name)
@@ -825,11 +866,14 @@ func (b *descriptorBuilder) resolveAlias(name string, alias *bamlparser.TypeAlia
 }
 
 // memberAttributes returns the field-level attributes of a class member: the
-// member's own attributes plus the trailing field attributes the slice-1 parser
-// attaches to the OUTERMOST type node (it does not reassociate field-vs-type
-// attributes, so @alias/@description on `name string @alias("x")` land on the
-// string node). Both are field metadata; nested-node attributes are NOT
-// included (they decline in lowerType).
+// member's own attributes plus the trailing field attributes the parser attaches
+// to the OUTERMOST type node (it does not reassociate field-vs-type attributes,
+// so both @alias/@description AND @check/@assert/@stream.* on `name string
+// @alias("x") @check(...)` land on the string node). [extractFieldMeta] routes
+// each by name — @alias/@description to the field, @check/@stream.* to the
+// field's type — reproducing BAML's reassociate_type_attributes without needing
+// the parser to have done it. Nested-node attributes are NOT included (they
+// decline in lowerType).
 func memberAttributes(m *bamlparser.TypeMember) []*bamlparser.Attribute {
 	if m.Type == nil || len(m.Type.Attributes) == 0 {
 		return m.Attributes
@@ -843,12 +887,68 @@ func memberAttributes(m *bamlparser.TypeMember) []*bamlparser.Attribute {
 	return out
 }
 
-// extractMemberMeta partitions a field's / enum value's attributes into the
-// slice-3-supported metadata (@alias, @description) and everything else. It
-// returns the alias and description (nil when absent) and DECLINES fail-closed
-// on any other attribute (@assert/@check/@stream.*/@skip/unknown) or a repeated
-// @alias/@description. These are single-@ FIELD attributes; a stray @@ block
-// attribute here is malformed and also declines.
+// fieldMeta is a class field's lowered attribute metadata. BAML routes
+// @alias/@description to the field itself and reassociates @assert/@check and
+// @stream.* onto the field's TYPE, so the caller attaches constraints/stream to
+// the lowered field-type's Meta and alias/description to the field.
+type fieldMeta struct {
+	alias       *string
+	description *string
+	constraints []sd.Constraint
+	stream      sd.StreamingBehavior
+}
+
+// extractFieldMeta partitions a class field's attributes: @alias/@description
+// (field metadata), @assert/@check (opaque constraints, reassociated to the
+// type), and @stream.done/@stream.not_null/@stream.with_state (streaming, also
+// reassociated to the type). It DECLINES fail-closed on any other attribute
+// (@skip/unknown), a duplicate @alias/@description, or a stray @@ block attribute
+// (malformed on a field). Constraints are collected in source order.
+func extractFieldMeta(attrs []*bamlparser.Attribute) (fieldMeta, error) {
+	var m fieldMeta
+	for _, a := range attrs {
+		if a.Block {
+			return fieldMeta{}, declineAttribute(a)
+		}
+		switch {
+		case a.Name == "alias":
+			v, err := attributeStringArg(a)
+			if err != nil {
+				return fieldMeta{}, err
+			}
+			if m.alias != nil {
+				return fieldMeta{}, fmt.Errorf("duplicate @alias attribute")
+			}
+			m.alias = &v
+		case a.Name == "description":
+			v, err := attributeStringArg(a)
+			if err != nil {
+				return fieldMeta{}, err
+			}
+			if m.description != nil {
+				return fieldMeta{}, fmt.Errorf("duplicate @description attribute")
+			}
+			m.description = &v
+		case isConstraintAttr(a.Name):
+			c, err := constraintFromAttribute(a)
+			if err != nil {
+				return fieldMeta{}, err
+			}
+			m.constraints = append(m.constraints, c)
+		case applyStreamAttribute(&m.stream, a):
+			// flag set in place
+		default:
+			return fieldMeta{}, declineAttribute(a)
+		}
+	}
+	return m, nil
+}
+
+// extractMemberMeta partitions an ENUM VALUE's attributes into the supported
+// metadata (@alias, @description) and everything else. An EnumValue carries no
+// constraints or streaming field, so @check/@assert/@stream.* — like @skip and
+// unknowns — DECLINE fail-closed; a repeated @alias/@description and a stray @@
+// block attribute also decline.
 func extractMemberMeta(attrs []*bamlparser.Attribute) (alias, description *string, err error) {
 	for _, a := range attrs {
 		if a.Block {
@@ -880,45 +980,173 @@ func extractMemberMeta(attrs []*bamlparser.Attribute) (alias, description *strin
 	return alias, description, nil
 }
 
-// extractBlockMeta is extractMemberMeta's counterpart for class/enum-level block
-// attributes (@@alias, @@description). Any other block attribute (@@dynamic, a
-// stray non-block attribute, an unknown block attribute) declines fail-closed.
-func extractBlockMeta(attrs []*bamlparser.Attribute) (alias, description *string, err error) {
+// blockMeta is a class/enum-level block's lowered attribute metadata.
+type blockMeta struct {
+	alias       *string
+	description *string
+	constraints []sd.Constraint
+	stream      sd.StreamingBehavior
+}
+
+// extractBlockMeta partitions a class/enum-level block's attributes: @@alias
+// (name alias), @@description (description), @@check/@@assert (constraints), and
+// @@stream.* (streaming). The enum caller further declines @@description /
+// @@stream.* because an enum has no descriptor home for them. Any non-block
+// attribute here is malformed, and @@dynamic / an unknown block attribute
+// decline fail-closed.
+func extractBlockMeta(attrs []*bamlparser.Attribute) (blockMeta, error) {
+	var m blockMeta
 	for _, a := range attrs {
 		if !a.Block {
-			return nil, nil, declineAttribute(a)
+			return blockMeta{}, declineAttribute(a)
 		}
-		switch a.Name {
-		case "alias":
-			v, e := attributeStringArg(a)
-			if e != nil {
-				return nil, nil, e
+		switch {
+		case a.Name == "alias":
+			v, err := attributeStringArg(a)
+			if err != nil {
+				return blockMeta{}, err
 			}
-			if alias != nil {
-				return nil, nil, fmt.Errorf("duplicate @@alias attribute")
+			if m.alias != nil {
+				return blockMeta{}, fmt.Errorf("duplicate @@alias attribute")
 			}
-			alias = &v
-		case "description":
-			v, e := attributeStringArg(a)
-			if e != nil {
-				return nil, nil, e
+			m.alias = &v
+		case a.Name == "description":
+			v, err := attributeStringArg(a)
+			if err != nil {
+				return blockMeta{}, err
 			}
-			if description != nil {
-				return nil, nil, fmt.Errorf("duplicate @@description attribute")
+			if m.description != nil {
+				return blockMeta{}, fmt.Errorf("duplicate @@description attribute")
 			}
-			description = &v
+			m.description = &v
+		case isConstraintAttr(a.Name):
+			c, err := constraintFromAttribute(a)
+			if err != nil {
+				return blockMeta{}, err
+			}
+			m.constraints = append(m.constraints, c)
+		case applyStreamAttribute(&m.stream, a):
+			// flag set in place
 		default:
-			return nil, nil, declineAttribute(a)
+			return blockMeta{}, declineAttribute(a)
 		}
 	}
-	return alias, description, nil
+	return m, nil
+}
+
+// isConstraintAttr reports whether name is a constraint attribute (@check or
+// @assert, block or field).
+func isConstraintAttr(name string) bool {
+	return name == "check" || name == "assert"
+}
+
+// applyStreamAttribute sets the streaming flag named by a @stream.* / @@stream.*
+// attribute on sb and reports whether a was a stream attribute at all (so a
+// switch arm can both match and apply in one call). Stream markers take no
+// arguments; any are ignored (harmless — BAML-valid input never carries them).
+func applyStreamAttribute(sb *sd.StreamingBehavior, a *bamlparser.Attribute) bool {
+	switch a.Name {
+	case "stream.done":
+		sb.Done = true
+	case "stream.not_null":
+		sb.Needed = true
+	case "stream.with_state":
+		sb.State = true
+	default:
+		return false
+	}
+	return true
+}
+
+// constraintFromAttribute lowers a @check/@assert (field or block) attribute
+// into an opaque [sd.Constraint]. D7: the Jinja expression is preserved verbatim
+// (the raw inner text between {{ and }}) and NEVER parsed or evaluated —
+// evaluation is out of scope (deferred). A shape that is not (label?, {{expr}})
+// declines fail-closed.
+func constraintFromAttribute(a *bamlparser.Attribute) (sd.Constraint, error) {
+	var level sd.ConstraintLevel
+	switch a.Name {
+	case "assert":
+		level = sd.ConstraintAssert
+	case "check":
+		level = sd.ConstraintCheck
+	default:
+		return sd.Constraint{}, fmt.Errorf("attribute @%s is not a constraint", a.Name)
+	}
+	if !a.HasParens {
+		return sd.Constraint{}, fmt.Errorf("@%s requires a ({{ expression }}) argument", a.Name)
+	}
+	label, expr, err := splitConstraintArgs(a.RawArgs)
+	if err != nil {
+		return sd.Constraint{}, fmt.Errorf("@%s: %w", a.Name, err)
+	}
+	return sd.Constraint{Level: level, Label: label, Expression: expr}, nil
+}
+
+// splitConstraintArgs splits a @check/@assert argument list into its optional
+// leading label (a bare identifier) and its mandatory `{{ ... }}` Jinja
+// expression, reading the RAW source between the attribute's parentheses so the
+// Jinja text survives byte-for-byte. It never parses or evaluates the expression
+// (D7 — evaluation is deferred).
+//
+// BAML's grammar is `@check(label, {{ expr }})` or a lone `@assert({{ expr }})`
+// (a lone @check is a BAML validation error, but laxer-than-BAML is fine here:
+// we only ever see BAML-valid input in production). The stored expression is the
+// verbatim inner text between {{ and }} (braces excluded, not trimmed), matching
+// BAML's JinjaExpression content modulo BAML's backslash-doubling normalization,
+// which is deliberately skipped (the value is opaque and never evaluated).
+func splitConstraintArgs(rawArgs string) (label *string, expression string, err error) {
+	open := strings.Index(rawArgs, "{{")
+	if open < 0 {
+		return nil, "", fmt.Errorf("constraint expression must be a {{ ... }} Jinja block")
+	}
+	rest := rawArgs[open+2:]
+	closeRel := strings.Index(rest, "}}")
+	if closeRel < 0 {
+		return nil, "", fmt.Errorf("constraint expression is missing its closing }}")
+	}
+	expression = rest[:closeRel]
+	// The Jinja block is the LAST argument; anything after its closing }} is an
+	// unsupported shape (BAML permits at most a label plus one expression).
+	if trailing := strings.TrimSpace(rest[closeRel+2:]); trailing != "" {
+		return nil, "", fmt.Errorf("unexpected trailing argument after the {{ ... }} expression")
+	}
+	labelPart := strings.TrimSpace(rawArgs[:open])
+	labelPart = strings.TrimSpace(strings.TrimSuffix(labelPart, ","))
+	if labelPart == "" {
+		return nil, expression, nil
+	}
+	if !isBareIdentifier(labelPart) {
+		return nil, "", fmt.Errorf("constraint label %q must be a bare identifier", labelPart)
+	}
+	l := labelPart
+	return &l, expression, nil
+}
+
+// isBareIdentifier reports whether s is a single BAML-style identifier
+// (`[A-Za-z_][A-Za-z0-9_]*`), used to validate a constraint label.
+func isBareIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '_':
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z':
+		case c >= '0' && c <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // attributeStringArg extracts the single plain-string argument of an @alias/
 // @description attribute (a quoted string or a raw string; both arrive with
 // their delimiters stripped by the parser's normalization pass). D5: a missing,
-// multi-valued, or non-string argument declines — slice 3 renders the alias/
-// description verbatim, so an argument it cannot reproduce byte-for-byte fails
+// multi-valued, or non-string argument declines — the alias/description is
+// rendered verbatim, so an argument it cannot reproduce byte-for-byte fails
 // closed rather than guessing.
 func attributeStringArg(a *bamlparser.Attribute) (string, error) {
 	if len(a.Args) != 1 {
@@ -935,53 +1163,17 @@ func attributeStringArg(a *bamlparser.Attribute) (string, error) {
 	}
 }
 
-// hasDocCommentBefore reports whether the physical source line immediately
-// above the declaration at byte offset `start` is a BAML `///` doc comment.
-//
-// BAML lowers `///` to a Description that renders in ctx.output_format, but the
-// shared lexer elides all `//`-prefixed comments (#586 D6), so the AST never
-// retains them. Rather than silently emit a descriptor with a MISSING
-// description — the wrong failure mode for a parity slice — the builder uses
-// this DETECTION (not capture) to DECLINE fail-closed any reachable class /
-// field / enum / enum-value that carries a doc comment. Capturing `///` and
-// lowering it to a Description is a documented fast-follow.
-//
-// It inspects only the single physical line directly above the declaration:
-// BAML doc comments sit immediately above (no blank line in between), and a
-// multi-line `///` block still has a `///` line directly above the
-// declaration, so one line is sufficient for presence detection. A `///`
-// prefix (three-or-more slashes) is a doc comment; a bare `//` is an ordinary
-// comment and is ignored, matching BAML's doc_comment-before-comment grammar.
-func hasDocCommentBefore(src []byte, start int) bool {
-	if start <= 0 || start > len(src) {
-		return false
-	}
-	// Rewind to the start of the declaration's own line.
-	lineStart := start
-	for lineStart > 0 && src[lineStart-1] != '\n' {
-		lineStart--
-	}
-	if lineStart == 0 {
-		return false // declaration is on the first line; nothing precedes it
-	}
-	// The preceding physical line is [prevStart, prevEnd), where prevEnd is the
-	// '\n' that terminates it (at lineStart-1).
-	prevEnd := lineStart - 1
-	prevStart := prevEnd
-	for prevStart > 0 && src[prevStart-1] != '\n' {
-		prevStart--
-	}
-	return strings.HasPrefix(strings.TrimSpace(string(src[prevStart:prevEnd])), "///")
-}
-
 // declineAttribute produces the stable per-function decline error for an
-// attribute slice 3 does not lower. The substrings "attribute" (field) and
-// "block attribute" (block) are load-bearing for the decline-reason tests.
+// attribute this slice does not lower on this node. The substrings "attribute"
+// (field) and "block attribute" (block) are load-bearing for the decline-reason
+// tests. Reached for @skip / @@dynamic / unknown attributes, a constraint or
+// stream attribute on a node with no descriptor home (an enum value / enum-level
+// block), and any attribute on a nested type node.
 func declineAttribute(a *bamlparser.Attribute) error {
 	if a.Block {
-		return fmt.Errorf("block attribute @@%s is not supported yet (slice 3 lowers only @@alias/@@description; @@dynamic and other block attributes are declined)", a.Name)
+		return fmt.Errorf("block attribute @@%s is not supported here (@@dynamic and unknown block attributes are declined; @@alias/@@description/@@check/@@assert/@@stream.* are lowered where the descriptor can represent them)", a.Name)
 	}
-	return fmt.Errorf("attribute @%s is not supported yet (slice 3 lowers only @alias/@description; constraints, streaming, and @skip are declined)", a.Name)
+	return fmt.Errorf("attribute @%s is not supported here (@skip and unknown attributes are declined, and @check/@assert/@stream.* have no home on this node; @alias/@description are lowered everywhere and constraints/streaming where representable)", a.Name)
 }
 
 // attrDisplayName renders an attribute's name with its @/@@ sigil for messages.

--- a/internal/nativeschema/build_test.go
+++ b/internal/nativeschema/build_test.go
@@ -2,6 +2,7 @@ package nativeschema
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -102,15 +103,14 @@ func fn(name, ret string) string {
 }
 
 // buildFromSource parses src as a single .baml file and runs the native
-// static-schema builder over it (carrying the source so `///` doc-comment
-// detection has the bytes it needs).
+// static-schema builder over it.
 func buildFromSource(t *testing.T, src string) (map[string]sd.Bundle, map[string]string) {
 	t.Helper()
 	file, err := bamlparser.ParseString("build_test.baml", src)
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
-	return BuildStaticSchemas([]SourceFile{{File: file, Source: []byte(src)}})
+	return BuildStaticSchemas([]SourceFile{{File: file}})
 }
 
 // TestBuildStaticSchemasSupported proves the supported corpus builds a
@@ -408,6 +408,304 @@ class Item {
 	}
 }
 
+// TestBuildStaticSchemasConstraints proves @assert/@check lower into opaque
+// schemadescriptor.Constraints on the right descriptor nodes — field
+// constraints reassociate onto the field's TYPE (Type.Meta.Constraints), class/
+// enum block constraints onto ClassDef/EnumDef.Constraints — with the level,
+// nil-vs-present label, and verbatim {{ }} inner expression preserved, repeated
+// constraints kept in order, and the whole thing round-tripping through
+// FromStaticDescriptor (which must preserve every constraint) + ValidateOutput.
+func TestBuildStaticSchemasConstraints(t *testing.T) {
+	src := `
+enum Ranked {
+    LOW
+    HIGH
+    @@assert(has_values, {{ this|length > 0 }})
+}
+class Constrained {
+    score int @check(positive, {{ this > 0 }}) @assert(bounded, {{ this < 100 }})
+    name string @assert({{ this|length > 0 }})
+    rank Ranked
+    @@assert(class_ok, {{ this.score < 100 }})
+}
+` + fn("GetConstrained", "Constrained")
+
+	bundles, declines := buildFromSource(t, src)
+	if reason, declined := declines["GetConstrained"]; declined {
+		t.Fatalf("GetConstrained declined, want supported: %s", reason)
+	}
+	b := bundles["GetConstrained"]
+
+	cls := findClass(b, "Constrained")
+	if cls == nil {
+		t.Fatalf("Constrained class not found: %+v", b.Classes)
+	}
+	// Class-level @@assert(class_ok, {{ ... }}).
+	if len(cls.Constraints) != 1 {
+		t.Fatalf("class constraints = %+v, want 1", cls.Constraints)
+	}
+	assertConstraint(t, "class Constrained", cls.Constraints[0], sd.ConstraintAssert, ptr("class_ok"), " this.score < 100 ")
+
+	// Field `score`: two constraints in source order, both on the field TYPE.
+	score := findField(cls, "score")
+	if score == nil {
+		t.Fatalf("score field not found: %+v", cls.Fields)
+	}
+	if len(score.Type.Meta.Constraints) != 2 {
+		t.Fatalf("score type constraints = %+v, want 2", score.Type.Meta.Constraints)
+	}
+	assertConstraint(t, "score[0]", score.Type.Meta.Constraints[0], sd.ConstraintCheck, ptr("positive"), " this > 0 ")
+	assertConstraint(t, "score[1]", score.Type.Meta.Constraints[1], sd.ConstraintAssert, ptr("bounded"), " this < 100 ")
+
+	// Field `name`: a lone-expression @assert (no label).
+	nameField := findField(cls, "name")
+	if nameField == nil {
+		t.Fatalf("name field not found: %+v", cls.Fields)
+	}
+	if len(nameField.Type.Meta.Constraints) != 1 {
+		t.Fatalf("name type constraints = %+v, want 1", nameField.Type.Meta.Constraints)
+	}
+	assertConstraint(t, "name[0]", nameField.Type.Meta.Constraints[0], sd.ConstraintAssert, nil, " this|length > 0 ")
+
+	// Field `rank` (enum ref) carries no constraint metadata.
+	rank := findField(cls, "rank")
+	if rank == nil || len(rank.Type.Meta.Constraints) != 0 {
+		t.Fatalf("rank field should carry no constraints: %+v", rank)
+	}
+
+	// Enum-level @@assert(has_values, {{ ... }}).
+	enm := findEnum(b, "Ranked")
+	if enm == nil || len(enm.Constraints) != 1 {
+		t.Fatalf("Ranked enum constraints = %+v, want 1", enm)
+	}
+	assertConstraint(t, "enum Ranked", enm.Constraints[0], sd.ConstraintAssert, ptr("has_values"), " this|length > 0 ")
+
+	// Round-trip: FromStaticDescriptor must preserve every constraint, and the
+	// bundle must still validate as an output.
+	internal, err := schema.FromStaticDescriptor(b)
+	if err != nil {
+		t.Fatalf("FromStaticDescriptor: %v", err)
+	}
+	if err := internal.ValidateOutput(); err != nil {
+		t.Fatalf("ValidateOutput: %v", err)
+	}
+	iCls, ok := internal.FindClass("Constrained", schema.NonStreaming)
+	if !ok {
+		t.Fatalf("internal Constrained class not found")
+	}
+	if len(iCls.Constraints) != 1 || iCls.Constraints[0].Expression != " this.score < 100 " {
+		t.Errorf("internal class constraint not preserved: %+v", iCls.Constraints)
+	}
+	var iScore *schema.ClassField
+	for i := range iCls.Fields {
+		if iCls.Fields[i].Name.Name == "score" {
+			iScore = &iCls.Fields[i]
+		}
+	}
+	if iScore == nil || len(iScore.Type.Meta.Constraints) != 2 {
+		t.Fatalf("internal score field constraints not preserved: %+v", iScore)
+	}
+	if iScore.Type.Meta.Constraints[0].Expression != " this > 0 " || iScore.Type.Meta.Constraints[1].Expression != " this < 100 " {
+		t.Errorf("internal score constraints not preserved in order: %+v", iScore.Type.Meta.Constraints)
+	}
+	iEnum, ok := internal.FindEnum("Ranked")
+	if !ok || len(iEnum.Constraints) != 1 || iEnum.Constraints[0].Expression != " this|length > 0 " {
+		t.Errorf("internal enum constraint not preserved: %+v", iEnum)
+	}
+}
+
+// TestBuildStaticSchemasStreaming proves @stream.done/@stream.not_null/
+// @stream.with_state lower into the descriptor streaming fields exactly as BAML
+// models them: a field stream attribute reassociates onto the field's TYPE
+// (Type.Meta.Stream), a class-level @@stream.* onto ClassDef.Stream, while
+// ClassField.StreamingNeeded stays unset (BAML's override-derived bool, D8). It
+// round-trips through FromStaticDescriptor.
+func TestBuildStaticSchemasStreaming(t *testing.T) {
+	src := `
+class Streamed {
+    ready bool @stream.done
+    value string @stream.not_null @stream.with_state
+    plain int
+    @@stream.done
+    @@stream.with_state
+}
+` + fn("GetStreamed", "Streamed")
+
+	bundles, declines := buildFromSource(t, src)
+	if reason, declined := declines["GetStreamed"]; declined {
+		t.Fatalf("GetStreamed declined, want supported: %s", reason)
+	}
+	b := bundles["GetStreamed"]
+	cls := findClass(b, "Streamed")
+	if cls == nil {
+		t.Fatalf("Streamed class not found")
+	}
+
+	if want := (sd.StreamingBehavior{Done: true, State: true}); cls.Stream != want {
+		t.Errorf("class Stream = %+v, want %+v", cls.Stream, want)
+	}
+
+	ready := findField(cls, "ready")
+	if want := (sd.StreamingBehavior{Done: true}); ready == nil || ready.Type.Meta.Stream != want {
+		t.Errorf("ready field type Stream = %+v, want %+v", ready, want)
+	}
+	value := findField(cls, "value")
+	if value == nil {
+		t.Fatalf("value field not found: %+v", cls.Fields)
+	}
+	if want := (sd.StreamingBehavior{Needed: true, State: true}); value.Type.Meta.Stream != want {
+		t.Errorf("value field type Stream = %+v, want %+v", value.Type.Meta.Stream, want)
+	}
+	// D8: @stream.not_null goes on the TYPE, NOT the override-derived
+	// ClassField.StreamingNeeded bool, which a static attribute never sets.
+	if value.StreamingNeeded {
+		t.Errorf("value.StreamingNeeded = true, want false (override-derived per D8)")
+	}
+	plain := findField(cls, "plain")
+	if plain == nil || !plain.Type.Meta.Stream.IsZero() {
+		t.Errorf("plain field should carry no streaming: %+v", plain)
+	}
+
+	// Round-trip: FromStaticDescriptor preserves the streaming triple.
+	internal, err := schema.FromStaticDescriptor(b)
+	if err != nil {
+		t.Fatalf("FromStaticDescriptor: %v", err)
+	}
+	if err := internal.ValidateOutput(); err != nil {
+		t.Fatalf("ValidateOutput: %v", err)
+	}
+	iCls, ok := internal.FindClass("Streamed", schema.NonStreaming)
+	if !ok {
+		t.Fatalf("internal Streamed class not found")
+	}
+	if want := (schema.StreamingBehavior{Done: true, State: true}); iCls.Stream != want {
+		t.Errorf("internal class Stream = %+v, want %+v", iCls.Stream, want)
+	}
+	// REQUIRE the round-tripped `value` field to exist rather than only asserting
+	// when found — a dropped/renamed field must fail loudly, not silently pass.
+	var iValue *schema.ClassField
+	for i := range iCls.Fields {
+		if iCls.Fields[i].Name.Name == "value" {
+			iValue = &iCls.Fields[i]
+		}
+	}
+	if iValue == nil {
+		t.Fatalf("internal Streamed.value field not found: %+v", iCls.Fields)
+	}
+	if want := (schema.StreamingBehavior{Needed: true, State: true}); iValue.Type.Meta.Stream != want {
+		t.Errorf("internal value type Stream = %+v, want %+v", iValue.Type.Meta.Stream, want)
+	}
+}
+
+// TestBuildStaticSchemasDocCommentsNoOp proves a `///` doc comment is captured
+// as a NO-OP: BAML's output_format renderer never reads doc comments (only
+// @description renders — #586 D6, oracle-confirmed), so a doc-commented class/
+// field/enum/enum-value builds SUPPORTED, produces NO description, and yields a
+// descriptor byte-identical to the same shapes without doc comments. It also
+// pins the precedence: with BOTH a `///` and an @description on one node, the
+// @description wins (the doc comment is invisible).
+func TestBuildStaticSchemasDocCommentsNoOp(t *testing.T) {
+	docSrc := `
+/// A documented class.
+/// Second line.
+class Doc {
+    /// the value field
+    value string
+    plain int
+}
+/// A documented enum.
+enum DocEnum {
+    /// the first value
+    A
+    B
+}
+class DocOut {
+    d Doc
+    e DocEnum
+}
+` + fn("GetDoc", "DocOut")
+
+	plainSrc := `
+class Doc {
+    value string
+    plain int
+}
+enum DocEnum {
+    A
+    B
+}
+class DocOut {
+    d Doc
+    e DocEnum
+}
+` + fn("GetDoc", "DocOut")
+
+	docBundles, docDeclines := buildFromSource(t, docSrc)
+	if reason, declined := docDeclines["GetDoc"]; declined {
+		t.Fatalf("doc-commented GetDoc declined, want supported (doc comments are no-ops): %s", reason)
+	}
+	plainBundles, plainDeclines := buildFromSource(t, plainSrc)
+	if reason, declined := plainDeclines["GetDoc"]; declined {
+		t.Fatalf("plain GetDoc declined: %s", reason)
+	}
+
+	// No description came from any /// doc comment.
+	docCls := findClass(docBundles["GetDoc"], "Doc")
+	if docCls == nil {
+		t.Fatalf("Doc class not found")
+	}
+	if docCls.Description != nil {
+		t.Errorf("class Doc got description %q from a /// doc comment; want nil", *docCls.Description)
+	}
+	for i := range docCls.Fields {
+		if docCls.Fields[i].Description != nil {
+			t.Errorf("field %q got description %q from a /// doc comment; want nil", docCls.Fields[i].Name.Name, *docCls.Fields[i].Description)
+		}
+	}
+	docEnum := findEnum(docBundles["GetDoc"], "DocEnum")
+	if docEnum == nil {
+		t.Fatalf("DocEnum not found")
+	}
+	for i := range docEnum.Values {
+		if docEnum.Values[i].Description != nil {
+			t.Errorf("enum value %q got a description from a /// doc comment; want nil", docEnum.Values[i].Name.Name)
+		}
+	}
+
+	// The doc-commented descriptor must be byte-identical to the plain one, so
+	// the rendered output_format cannot differ (proven end-to-end by the oracle).
+	if !reflect.DeepEqual(docBundles["GetDoc"], plainBundles["GetDoc"]) {
+		t.Errorf("doc-commented descriptor differs from the plain one:\n doc:   %+v\n plain: %+v", docBundles["GetDoc"], plainBundles["GetDoc"])
+	}
+}
+
+// TestBuildStaticSchemasDocVsDescriptionPrecedence proves that when a node
+// carries BOTH a `///` doc comment and an @description, the @description is the
+// sole source of the rendered description (the doc comment is invisible — D6).
+func TestBuildStaticSchemasDocVsDescriptionPrecedence(t *testing.T) {
+	src := `
+class DocVsDesc {
+    /// doc comment on the field
+    field string @description("the real description")
+    plain int
+}
+` + fn("GetDocVsDesc", "DocVsDesc")
+
+	bundles, declines := buildFromSource(t, src)
+	if reason, declined := declines["GetDocVsDesc"]; declined {
+		t.Fatalf("GetDocVsDesc declined, want supported: %s", reason)
+	}
+	cls := findClass(bundles["GetDocVsDesc"], "DocVsDesc")
+	if cls == nil {
+		t.Fatalf("DocVsDesc class not found")
+	}
+	f := findField(cls, "field")
+	if f == nil {
+		t.Fatalf("field not found: %+v", cls.Fields)
+	}
+	assertDesc(t, "field with both /// and @description", f.Description, "the real description")
+}
+
 // TestBuildStaticSchemasUnionNormalization proves that union members which
 // lower into their own union (a non-recursive alias or a parenthesized group)
 // or into a bare null (an alias to null) are flattened/hoisted so the
@@ -539,24 +837,6 @@ func TestBuildStaticSchemasDeclines(t *testing.T) {
 			wantReasonSub: "recursive type alias",
 		},
 		{
-			name:   "field constraint attribute",
-			fnName: "GetChecked",
-			src: `class Checked {
-    name string @check(non_empty, {{ this|length > 0 }})
-}
-` + fn("GetChecked", "Checked"),
-			wantReasonSub: "attribute",
-		},
-		{
-			name:   "field stream attribute",
-			fnName: "GetStreamed",
-			src: `class Streamed {
-    value string @stream.done
-}
-` + fn("GetStreamed", "Streamed"),
-			wantReasonSub: "attribute",
-		},
-		{
 			name:   "class block attribute @@dynamic",
 			fnName: "GetDynamic",
 			src: `class DynamicOutput {
@@ -619,54 +899,6 @@ class SkipOut {
 }
 ` + fn("GetCollide", "Collide"),
 			wantReasonSub: "duplicate",
-		},
-		{
-			name:   "class-level /// doc comment",
-			fnName: "GetDocClass",
-			src: `/// A documented class.
-class DocClass {
-    value string
-}
-` + fn("GetDocClass", "DocClass"),
-			wantReasonSub: "doc comment",
-		},
-		{
-			name:   "field-level /// doc comment",
-			fnName: "GetDocField",
-			src: `class DocField {
-    /// the value field
-    value string
-}
-` + fn("GetDocField", "DocField"),
-			wantReasonSub: "doc comment",
-		},
-		{
-			name:   "enum-level /// doc comment",
-			fnName: "GetDocEnum",
-			src: `/// A documented enum.
-enum DocEnum {
-    A
-    B
-}
-class DocEnumOut {
-    e DocEnum
-}
-` + fn("GetDocEnum", "DocEnumOut"),
-			wantReasonSub: "doc comment",
-		},
-		{
-			name:   "enum-value /// doc comment",
-			fnName: "GetDocValue",
-			src: `enum DocValueEnum {
-    /// the first value
-    A
-    B
-}
-class DocValueOut {
-    e DocValueEnum
-}
-` + fn("GetDocValue", "DocValueOut"),
-			wantReasonSub: "doc comment",
 		},
 		{
 			name:          "tuple output",
@@ -805,6 +1037,73 @@ class DupValueOut {
 			wantReasonSub: "attribute",
 		},
 		{
+			name:   "enum value constraint (no descriptor home)",
+			fnName: "GetValConstraint",
+			src: `enum ValConstraint {
+    A @check(pos, {{ this }})
+    B
+}
+class ValConstraintOut {
+    v ValConstraint
+}
+` + fn("GetValConstraint", "ValConstraintOut"),
+			wantReasonSub: "attribute",
+		},
+		{
+			name:   "enum value stream attribute (no descriptor home)",
+			fnName: "GetValStream",
+			src: `enum ValStream {
+    A @stream.done
+    B
+}
+class ValStreamOut {
+    v ValStream
+}
+` + fn("GetValStream", "ValStreamOut"),
+			wantReasonSub: "attribute",
+		},
+		{
+			name:   "enum-level @@stream block attribute (no descriptor home)",
+			fnName: "GetEnumStream",
+			src: `enum EnumStream {
+    A
+    B
+    @@stream.done
+}
+class EnumStreamOut {
+    v EnumStream
+}
+` + fn("GetEnumStream", "EnumStreamOut"),
+			wantReasonSub: "stream",
+		},
+		{
+			name:   "nested-type constraint (reassociation not performed)",
+			fnName: "GetNestedConstraint",
+			src: `class NestedConstraint {
+    m map<string, int @check(pos, {{ this > 0 }})>
+}
+` + fn("GetNestedConstraint", "NestedConstraint"),
+			wantReasonSub: "attribute",
+		},
+		{
+			name:   "constraint missing {{ }} expression",
+			fnName: "GetBadConstraint",
+			src: `class BadConstraint {
+    x int @assert(foo)
+}
+` + fn("GetBadConstraint", "BadConstraint"),
+			wantReasonSub: "Jinja",
+		},
+		{
+			name:   "constraint label is not a bare identifier",
+			fnName: "GetBadLabel",
+			src: `class BadLabel {
+    x int @check("lbl", {{ this > 0 }})
+}
+` + fn("GetBadLabel", "BadLabel"),
+			wantReasonSub: "identifier",
+		},
+		{
 			name:   "class method / expr_fn",
 			fnName: "GetMethodClass",
 			src: `class WithMethod {
@@ -918,9 +1217,11 @@ class DynamicOutput {
 }
 
 // TestBuildStaticSchemasRegularCommentNotDeclined proves an ordinary `//`
-// comment (two slashes) is NOT mistaken for a `///` doc comment: it does not
-// decline, and the function builds normally. This pins that the doc-comment
-// decline is specific to the three-slash BAML doc-comment form.
+// comment (two slashes) does not perturb the build: the shared lexer elides it,
+// so a class/enum/field/value preceded by a regular comment builds normally.
+// A `///` doc comment is likewise a no-op — NOT a decline — captured by BAML but
+// never rendered in ctx.output_format (see TestBuildStaticSchemasDocCommentsNoOp
+// and #586 D6); neither comment form affects the built descriptor.
 func TestBuildStaticSchemasRegularCommentNotDeclined(t *testing.T) {
 	src := `// a regular comment, not a doc comment
 class Commented {
@@ -982,6 +1283,38 @@ func findEnum(b sd.Bundle, name string) *sd.EnumDef {
 		}
 	}
 	return nil
+}
+
+func findField(c *sd.ClassDef, name string) *sd.ClassField {
+	for i := range c.Fields {
+		if c.Fields[i].Name.Name == name {
+			return &c.Fields[i]
+		}
+	}
+	return nil
+}
+
+// ptr returns a pointer to s, for building expected nil-vs-present values.
+func ptr(s string) *string { return &s }
+
+// assertConstraint checks a constraint's level, expression, and nil-vs-present
+// label against expectations.
+func assertConstraint(t *testing.T, what string, c sd.Constraint, level sd.ConstraintLevel, label *string, expr string) {
+	t.Helper()
+	if c.Level != level {
+		t.Errorf("%s: level = %q, want %q", what, c.Level, level)
+	}
+	if c.Expression != expr {
+		t.Errorf("%s: expression = %q, want %q", what, c.Expression, expr)
+	}
+	switch {
+	case label == nil && c.Label != nil:
+		t.Errorf("%s: label = %q, want nil", what, *c.Label)
+	case label != nil && c.Label == nil:
+		t.Errorf("%s: label = nil, want %q", what, *label)
+	case label != nil && c.Label != nil && *label != *c.Label:
+		t.Errorf("%s: label = %q, want %q", what, *c.Label, *label)
+	}
 }
 
 func assertAlias(t *testing.T, what string, n sd.Name, want string) {


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## de-BAML P3 native-parser — Slice 4: attributes + constraints (#586)

Lowers the **remaining** schema attributes into the native `schemadescriptor`, on top of slice 3 (#591). Test-only: no runtime routing, no request/response change, config goldens byte-identical.

### What changed

1. **`@assert` / `@check` → opaque `schemadescriptor.Constraint`.** Level + optional label + the **verbatim `{{ }}` inner expression text** (braces excluded, not trimmed), **never parsed or evaluated** (evaluation is deferred/out of scope). Repeated constraints are supported and kept in source order. Field constraints reassociate onto the field **type** (`Type.Meta.Constraints`, mirroring BAML's `reassociate_type_attributes`); class/enum block `@@check`/`@@assert` → `ClassDef`/`EnumDef.Constraints`.

2. **`@stream.done` / `@stream.not_null` / `@stream.with_state` → descriptor streaming fields, exactly as BAML's IR maps them.** Field stream attrs reassociate onto the field **type** → `Type.Meta.Stream.{Done,Needed,State}`; class `@@stream.*` → `ClassDef.Stream`. `ClassField.StreamingNeeded` is BAML's override-derived per-field bool (defaults false) and is left unset. Static streaming partialization + streaming output-format parity stay **DECLINED (slice 6)** — this slice only carries the flags on the FINAL (non-streaming) descriptor.

3. **`///` doc comments captured as a NO-OP — and this corrects slice 3.** Verified against the BAML v0.223 Rust source (with file:line citations) that the `output_format` renderer **never reads doc comments** — every rendered description comes solely from `@description`; `///` lowers to a `docstring` used only by LSP/codegen. Slice 3 had fail-closed **DECLINED** doc comments on the *untested* assumption they rendered as a description; that was wrong. Slice 4 stops declining them: a doc-commented class/field/enum/enum-value now builds **SUPPORTED** and renders byte-identically to the same node without the comment. Precedence: `@description` is the sole source; a doc comment never overrides/concatenates. The now-dead `SourceFile.Source` + doc-detection plumbing was removed.

`@alias`/`@description` (slice 3) still work.

### Parity + round-trip proof

- Extended `integration/testdata/parity_baml_src` with 5 fixtures — `ParityDocComments`, `ParityDocVsDesc`, `ParityConstraints`, `ParityStream`, `ParityMixed` — all BAML-valid and native-SUPPORTED (corpus stays all-supported).
- **`TestNativeStaticOutputFormatParity` is GREEN vs the real BAML v0.223.0 oracle** (container run, all 17 subtests): BAML compiled + introspected every fixture and rendered `ctx.output_format` **byte-identically** to the native renderer. Constraints/stream flags/doc comments do **not** change the final block; `@description` wins over a doc comment; `@alias` renders as the field name.
- Descriptor **round-trip**: `FromStaticDescriptor` preservation of constraints + stream + `StreamingNeeded` + descriptions is covered by `internal/schema/static_descriptor_test.go`; new `internal/nativeschema` builder tests prove the builder POPULATES those from source and they round-trip through `FromStaticDescriptor` + `ValidateOutput`.

### Decline boundary (fail-closed, no approximation)

Constraint/stream on an **enum value** or **enum-level** block (no descriptor home), attributes on **nested / union-variant** nodes (reassociation not performed), **malformed** constraint arg shapes, type-alias RHS attributes (D9, deferred). Unchanged: recursion (slice 5), `@@dynamic`/`@skip`/static streaming (slice 6), tuple/media output, invalid map keys. Constraint **evaluation** stays out of scope (opaque only).

### Validation

- `gofmt` clean; `go build ./...`; `go vet` clean on changed packages (pre-existing participle struct-tag warnings in `bamlparser` are unrelated).
- `go test ./internal/... ./cmd/introspect/... ./bamlutils/...` GREEN — **introspect config goldens UNCHANGED**.
- `go vet -tags=integration ./integration` compiles; the byte-parity harness ran GREEN under the integration build.
- Embed manifest idempotent (re-ran `cmd/embed`; zero diff — no files added under embedded trees). `build.sh` package-form untouched.

New lax/decline decisions (D6 corrected, D7–D9) are logged on #586 + in-code (`internal/nativeschema/build.go` package doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved static schema generation to correctly lower metadata, constraints, and `@stream.*` annotations, with consistent FINAL (non-streaming) output-format behavior and fail-closed handling for unsupported attribute placements.

* **Bug Fixes**
  * `///` doc comments no longer influence rendered output where they shouldn’t.
  * `@description` correctly overrides co-located `///` doc comments.
  * `@check/@assert` and `@stream.*` are applied to the correct descriptor targets and no longer affect FINAL output unexpectedly.

* **Tests**
  * Expanded parity corpus and added stronger regression coverage, including byte-identical descriptor assertions for doc comments, constraint lowering/reassociation, and streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->