### PR TITLE
debaml P3: @skip + streaming decline (slice 6, FINAL P3-static) (#586)

### DIFF
--- a/integration/static_output_format_renderer_test.go
+++ b/integration/static_output_format_renderer_test.go
@@ -65,13 +65,17 @@ import (
 // (ParityDocComments, and ParityDocVsDesc where @description wins), @assert/
 // @check constraints (ParityConstraints), and @stream.* flags (ParityStream,
 // ParityMixed) must not change a byte — BAML captures them but its output_format
-// renderer never reads them (see #586 D6-D8), and neither does ours. The
-// expected function set is asserted independently (P2) so a silently-skipped
-// fixture cannot false-pass, and the run is pinned to the exact 0.223.0 oracle
-// (P3). The corpus here is all-supported (a `///` doc comment is SUPPORTED as a
-// no-op, not a decline); genuine declines (recursion, @@dynamic, @skip, media/
-// tuple output, ...) are covered by the unit tests in internal/nativeschema, not
-// by this oracle.
+// renderer never reads them (see #586 D6-D8), and neither does ours. @skip
+// (ParitySkip, slice 6) is the inverse: it DOES change the block (a skipped
+// class field / enum value is DROPPED, and a class reachable only through a
+// skipped field disappears), and the native side must drop exactly the same
+// bytes BAML does (#586 D11). The expected function set is asserted independently
+// (P2) so a silently-skipped fixture cannot false-pass, and the run is pinned to
+// the exact 0.223.0 oracle (P3). The corpus here is all-supported (a `///` doc
+// comment is a no-op and @skip DROPS, neither is a decline); genuine declines
+// (invalid recursion cycles, @@dynamic, static streaming, media/tuple output,
+// ...) are covered by the unit tests in internal/nativeschema, not by this
+// oracle.
 func TestNativeStaticOutputFormatParity(t *testing.T) {
 	// P3: this is the load-bearing v0.223.0 parity proof, so it asserts the
 	// EXACT oracle version rather than a >=0.219 floor. The de-BAML=false render

--- a/integration/testdata/parity_baml_src/functions.baml
+++ b/integration/testdata/parity_baml_src/functions.baml
@@ -126,3 +126,12 @@ function ParityDualAlias(input: string) -> DualAliasHolder {
     client TestClient
     prompt #"{{ ctx.output_format }}"#
 }
+
+// --- slice-6: @skip. A skipped class field (SkipHolder.dropped/secret) and a
+// skipped enum value (SkipEnum.DROP_B) are DROPPED, and OnlyViaSkip — reachable
+// only through a skipped field — disappears entirely. Byte-identical to BAML
+// v0.223 (which filters skipped fields/values before the definition is built).
+function ParitySkip(input: string) -> SkipHolder {
+    client TestClient
+    prompt #"{{ ctx.output_format }}"#
+}

--- a/integration/testdata/parity_baml_src/types.baml
+++ b/integration/testdata/parity_baml_src/types.baml
@@ -299,3 +299,38 @@ class DualAliasHolder {
     list_field RecStrList
     map_field RecStrMap
 }
+
+// === slice-6: @skip ======================================================
+//
+// @skip DROPS a class field / enum value EXACTLY as BAML does: its
+// find_existing_class_field / find_enum_value returns None BEFORE the definition
+// is built, so the skipped member never renders in ctx.output_format AND its type
+// is never pushed onto the reachability stack. A class reachable ONLY through a
+// skipped field therefore disappears from the output_format entirely. This is the
+// load-bearing byte-parity proof for slice 6 — the rendered block must carry ONLY
+// the kept members (mirrors BAML's own render_output_format unit tests
+// skipped_class_fields_are_not_rendered / skipped_variants_are_not_rendered).
+//
+// BAML VALIDATION requires a @skip class field to be OPTIONAL ("Class field with
+// @skip attribute must be optional"), so the skipped fields are nullable — this
+// keeps the fixture BAML-valid so the oracle container compiles.
+
+enum SkipEnum {
+    KEEP_A
+    DROP_B @skip
+    KEEP_C
+}
+
+// OnlyViaSkip is referenced ONLY by SkipHolder.secret (a @skip field). Dropping
+// that field must also drop OnlyViaSkip from the rendered output_format — the
+// oracle proves BAML never renders it either.
+class OnlyViaSkip {
+    ghost string
+}
+
+class SkipHolder {
+    kept string
+    dropped string? @skip
+    category SkipEnum
+    secret OnlyViaSkip? @skip
+}

--- a/internal/nativeschema/build.go
+++ b/internal/nativeschema/build.go
@@ -25,7 +25,8 @@
 // container introspection step fails to compile a sibling symbol as
 // "undefined". See #586 and the slice-2 build fix.
 //
-// SCOPE (slice 5 — recursion, on top of slices 1-4):
+// SCOPE (slice 6 — @skip + streaming decline, on top of slices 1-5; the FINAL
+// P3-static slice):
 //   - Lower primitives, named class/enum refs, non-recursive aliases (inlined),
 //     lists, maps, optionals, unions, and string/int/bool literals, and emit
 //     Enums/Classes in BAML output-format reachability order (see
@@ -44,10 +45,29 @@
 //     A DIRECT/degenerate alias cycle (not mediated by a list/map, e.g.
 //     `type A = A` / `type A = A | int` / `type A = A?`) is INVALID and DECLINES
 //     fail-closed; a multi-alias structural cycle DECLINES too (single-alias
-//     structural cycles only in this slice); recursion whose output graph reaches
-//     media/tuple still DECLINES via ValidateOutput. @@dynamic recursive overlays,
-//     streaming partialization of recursive types, and @skip stay DECLINED
-//     (slice 6).
+//     structural cycles only); recursion whose output graph reaches media/tuple
+//     still DECLINES via ValidateOutput.
+//   - @skip (slice 6, D11): a @skip-marked class field / enum value is DROPPED
+//     exactly as BAML does (find_existing_class_field / find_enum_value return
+//     Ok(None) before the definition is built), so it never renders and its type
+//     is never reachable. This replaces the slice-2..5 @skip DECLINE. See
+//     ensureClass / ensureEnum / hasSkipAttribute.
+//   - STATIC STREAMING (slice 6, D12): stays a parity-DECLINE (BAML fallback).
+//     The builder emits ONLY the NonStreaming descriptor. BAML never renders a
+//     streaming output_format into the prompt: the Jinja RenderContext carries a
+//     single output_format populated with the NON-streaming definitions
+//     (engine/.../prompt_renderer/mod.rs render_prompt, line 149), while the
+//     partialized/streaming OutputFormatContent (to_streaming_type partialize)
+//     feeds ONLY the partial-response JSONish parser (mod.rs parse, allow_partials
+//     branch). So `{{ ctx.output_format }}` resolves to the non-streaming block
+//     for streaming AND non-streaming calls alike — there is NO streaming
+//     output_format artifact for the byte-parity oracle to compare against.
+//     Streaming partialization belongs to the response-PARSING subsystem
+//     (internal/debaml partial coercion), not this output_format builder; see
+//     #586 D12. @@dynamic recursive overlays stay DECLINED.
+//   - @@dynamic (slice 6): stays fail-closed DECLINED. It is tied to runtime
+//     TypeBuilder / dynamic schema mutation, NOT a static-schema feature, so it
+//     is out of P3-static scope until the native runtime front-end owns it.
 //   - Lower @alias -> Name.Alias and @description -> Description on class fields,
 //     enum values, and class/enum-level block attributes.
 //   - Lower @assert/@check -> opaque [schemadescriptor.Constraint] carrying the
@@ -60,20 +80,20 @@
 //   - Lower @stream.done/@stream.not_null/@stream.with_state into the descriptor
 //     streaming fields exactly as BAML models them: a field stream attribute
 //     reassociates onto the field's TYPE (Type.Meta.Stream), a class-level
-//     @@stream.* goes on ClassDef.Stream. Static STREAMING partialization +
-//     streaming output_format parity stay DECLINED (slice 6); this slice only
-//     carries the flags on the FINAL (non-streaming) descriptor.
+//     @@stream.* goes on ClassDef.Stream. Static STREAMING partialization stays
+//     a parity-DECLINE (D12 below); the builder only carries these flags on the
+//     FINAL (non-streaming) descriptor.
 //   - Validate STRUCTURALLY via FromStaticDescriptor + ValidateOutput. Constraints
 //     and streaming flags are metadata: they do NOT change the rendered
 //     ctx.output_format (the parity harness proves this byte-for-byte).
-//   - @@dynamic and @skip stay DECLINED (slice 6).
 //
 // Lax-vs-BAML / decline decisions logged here are also recorded on #586:
 //
 //	D1. A reachable output node may carry @alias/@description (everywhere),
-//	    @assert/@check, and @stream.* (where the descriptor can represent them).
-//	    ANY OTHER attribute (@skip, @@dynamic, or an unknown attribute) DECLINES
-//	    the function fail-closed rather than being silently dropped. Enum-LEVEL
+//	    @assert/@check, and @stream.* (where the descriptor can represent them),
+//	    and a class field / enum value may carry @skip (which DROPS it — D11).
+//	    ANY OTHER attribute (@@dynamic or an unknown attribute) DECLINES the
+//	    function fail-closed rather than being silently dropped. Enum-LEVEL
 //	    @@check/@@assert DO lower (to EnumDef.Constraints, as class @@check/@@assert
 //	    lower to ClassDef.Constraints); but a constraint or stream attribute on a
 //	    node with no descriptor home for it DECLINES: any @check/@assert/@stream.*
@@ -129,10 +149,43 @@
 //	    order is not oracle-proven in this slice); (c) recursion whose output
 //	    graph reaches media/tuple declines via ValidateOutput (a recursive class
 //	    is legal, but media/tuple output is not); (d) @@dynamic recursive
-//	    overlays, streaming partialization of recursive types, and @skip stay
-//	    DECLINED (slice 6). recursion.go reproduces BAML's finite_recursive_cycles
-//	    (class SCC) + recursive_alias_cycles (alias SCC through list/map) +
-//	    non-structural alias graph (invalid-cycle detection).
+//	    overlays and streaming partialization of recursive types stay DECLINED
+//	    (@skip on a recursive-class field is DROPPED as anywhere — D11).
+//	    recursion.go reproduces BAML's finite_recursive_cycles (class SCC) +
+//	    recursive_alias_cycles (alias SCC through list/map) + non-structural alias
+//	    graph (invalid-cycle detection); the class dependency graph is built from
+//	    ALL fields (skip-inclusive, matching BAML's finalize_dependencies), so
+//	    @skip does not change recursion classification.
+//	D11. @skip (slice 6) — IMPLEMENTED. A @skip-marked class field
+//	    (find_existing_class_field) or enum value (find_enum_value) is DROPPED
+//	    before the definition is built: it does not render, and its type is never
+//	    collected/reachable, so a class/enum reachable ONLY through a skipped
+//	    field disappears from ctx.output_format — exactly as BAML does. skip is a
+//	    field/value attribute taking no arguments; skip is checked first, so a
+//	    skipped field's other attributes are irrelevant. This replaces the
+//	    slice-2..5 @skip DECLINE. Site: ensureClass / ensureEnum /
+//	    hasSkipAttribute. Proven byte-exact by the ParitySkip oracle fixture.
+//	D12. STATIC STREAMING (slice 6) — parity-DECLINED, kept as BAML fallback.
+//	    The builder produces ONLY the NonStreaming descriptor (Bundle.Stream is
+//	    never set true, no class is emitted under StreamingMode::Streaming).
+//	    Reason (not an approximation dodge — an architectural fact): BAML NEVER
+//	    renders a streaming output_format into the prompt. render_prompt builds a
+//	    Jinja RenderContext whose single output_format field is the NON-streaming
+//	    definitions (prompt_renderer/mod.rs:149); the partialized/streaming
+//	    OutputFormatContent (output.to_streaming_type(ir), render_output_format.rs
+//	    relevant_data_models partialize=true) is built but consumed ONLY by the
+//	    partial-response JSONish parser (mod.rs parse(), allow_partials branch),
+//	    never injected into `{{ ctx.output_format }}`. So a streaming call's
+//	    prompt carries the identical non-streaming output_format, and the static
+//	    output_format byte-parity oracle has NO streaming artifact to compare
+//	    against — "streaming output_format parity" is unprovable because the thing
+//	    it would prove is never emitted. Streaming partialization affects only
+//	    response PARSING (internal/debaml partial coercion), a separate subsystem
+//	    out of this output_format builder's scope. Implementing partialization
+//	    here would produce a descriptor whose streaming render BAML never emits,
+//	    so per the parity-decline discipline it is deferred, not approximated. A
+//	    decline-boundary test (TestBuildStaticSchemasStreamingNotEmitted) pins
+//	    that the builder emits only the non-streaming descriptor.
 package nativeschema
 
 import (
@@ -445,8 +498,9 @@ func (b *descriptorBuilder) reachableRecursiveClasses() []string {
 // and in BAML order; every returned name therefore resolves in the builder's
 // by-name maps. The builder never emits a streaming-MODE class (streaming is
 // carried as metadata on the final descriptor, not as a separate streaming-mode
-// class — static streaming mode is slice 6), so a class key's mode is always
-// NonStreaming and looking classes up by canonical name is sufficient.
+// class — static streaming partialization is a parity-DECLINE, see #586 D12), so
+// a class key's mode is always NonStreaming and looking classes up by canonical
+// name is sufficient.
 func (b *descriptorBuilder) reorderByReachability(bundle *sd.Bundle, internal *schema.Bundle) {
 	enumNames, classKeys, aliasNames := internal.ReachableOrder()
 
@@ -867,8 +921,9 @@ func (b *descriptorBuilder) lowerNameRef(t *bamlparser.TypeExpr) (sd.Type, error
 // attributes lower to the class's alias/description/constraints/streaming; any
 // other block attribute (@@dynamic, ...) declines. A field's @alias/@description
 // lower to the field, and its reassociated @check/@assert/@stream.* lower onto
-// the field's TYPE metadata; any other field attribute declines. A `///` doc
-// comment is captured as a no-op (BAML never renders it — see #586 D6).
+// the field's TYPE metadata; a field's @skip DROPS it (D11); any other field
+// attribute declines. A `///` doc comment is captured as a no-op (BAML never
+// renders it — see #586 D6).
 func (b *descriptorBuilder) ensureClass(name string, tb *bamlparser.TypeBlock) error {
 	if _, done := b.classes[name]; done {
 		return nil
@@ -907,7 +962,19 @@ func (b *descriptorBuilder) ensureClass(name string, tb *bamlparser.TypeBlock) e
 		if m.Type == nil {
 			return fmt.Errorf("class %q field %q has no type", name, m.Name)
 		}
-		fm, err := extractFieldMeta(memberAttributes(m))
+		attrs := memberAttributes(m)
+		// D11: @skip DROPS the field exactly as BAML does. BAML's
+		// find_existing_class_field returns Ok(None) for a @skip-marked field
+		// BEFORE the class definition is built, so the field never renders in
+		// ctx.output_format AND its type is never pushed onto the reachability
+		// stack (a class/enum reachable ONLY through a skipped field correctly
+		// disappears from the output_format). The skipped field's other
+		// attributes are irrelevant — skip is checked first — so we drop it
+		// without lowering its type or metadata.
+		if hasSkipAttribute(attrs) {
+			continue
+		}
+		fm, err := extractFieldMeta(attrs)
 		if err != nil {
 			return fmt.Errorf("class %q field %q: %w", name, m.Name, err)
 		}
@@ -947,8 +1014,8 @@ func (b *descriptorBuilder) ensureClass(name string, tb *bamlparser.TypeBlock) e
 // OutputFormatContent) has no enum-level description or streaming home for them.
 // An enum value's @alias/@description lower to the value; @check/@assert/
 // @stream.* on a value decline (EnumValue carries no constraints/streaming
-// field); any other value attribute (@skip, ...) declines. A `///` doc comment
-// is captured as a no-op (BAML never renders it — see #586 D6).
+// field); a value's @skip DROPS it (D11); any other value attribute declines. A
+// `///` doc comment is captured as a no-op (BAML never renders it — see #586 D6).
 func (b *descriptorBuilder) ensureEnum(name string, tb *bamlparser.TypeBlock) error {
 	if _, done := b.enums[name]; done {
 		return nil
@@ -980,6 +1047,12 @@ func (b *descriptorBuilder) ensureEnum(name string, tb *bamlparser.TypeBlock) er
 	for _, m := range tb.Fields {
 		if m.Type != nil {
 			return fmt.Errorf("enum %q value %q unexpectedly carries a type", name, m.Name)
+		}
+		// D11: @skip DROPS the value exactly as BAML does — find_enum_value
+		// returns Ok(None) for a @skip-marked value before the enum definition
+		// is built, so the value never renders in ctx.output_format.
+		if hasSkipAttribute(m.Attributes) {
+			continue
 		}
 		alias, desc, err := extractMemberMeta(m.Attributes)
 		if err != nil {
@@ -1097,6 +1170,24 @@ func memberAttributes(m *bamlparser.TypeMember) []*bamlparser.Attribute {
 	return out
 }
 
+// hasSkipAttribute reports whether attrs carries a @skip field/value marker
+// (D11). BAML models @skip as a field/value attribute — never reassociated onto
+// the type (it is NOT in BAML's TYPE_ATTRIBUTE_NAMES) and taking no arguments
+// (set_skip -> Some(true)) — and filters a skipped field/value out
+// (find_existing_class_field / find_enum_value return Ok(None)) BEFORE the
+// class/enum definition is built. Treating any non-block @skip as the marker is
+// laxer-than-BAML-safe: production only ever sees BAML-valid input, where @skip
+// is always the bare argument-less form. A @@skip block form is not a BAML
+// construct; it is left to decline via extractBlockMeta.
+func hasSkipAttribute(attrs []*bamlparser.Attribute) bool {
+	for _, a := range attrs {
+		if !a.Block && a.Name == "skip" {
+			return true
+		}
+	}
+	return false
+}
+
 // fieldMeta is a class field's lowered attribute metadata. BAML routes
 // @alias/@description to the field itself and reassociates @assert/@check and
 // @stream.* onto the field's TYPE, so the caller attaches constraints/stream to
@@ -1111,9 +1202,10 @@ type fieldMeta struct {
 // extractFieldMeta partitions a class field's attributes: @alias/@description
 // (field metadata), @assert/@check (opaque constraints, reassociated to the
 // type), and @stream.done/@stream.not_null/@stream.with_state (streaming, also
-// reassociated to the type). It DECLINES fail-closed on any other attribute
-// (@skip/unknown), a duplicate @alias/@description, or a stray @@ block attribute
-// (malformed on a field). Constraints are collected in source order.
+// reassociated to the type). It DECLINES fail-closed on any other (unknown)
+// attribute, a duplicate @alias/@description, or a stray @@ block attribute
+// (malformed on a field). Constraints are collected in source order. @skip never
+// reaches here: a skipped field is dropped by ensureClass before this call (D11).
 func extractFieldMeta(attrs []*bamlparser.Attribute) (fieldMeta, error) {
 	var m fieldMeta
 	for _, a := range attrs {
@@ -1156,9 +1248,10 @@ func extractFieldMeta(attrs []*bamlparser.Attribute) (fieldMeta, error) {
 
 // extractMemberMeta partitions an ENUM VALUE's attributes into the supported
 // metadata (@alias, @description) and everything else. An EnumValue carries no
-// constraints or streaming field, so @check/@assert/@stream.* — like @skip and
-// unknowns — DECLINE fail-closed; a repeated @alias/@description and a stray @@
-// block attribute also decline.
+// constraints or streaming field, so @check/@assert/@stream.* — like unknown
+// attributes — DECLINE fail-closed; a repeated @alias/@description and a stray @@
+// block attribute also decline. @skip never reaches here: a skipped value is
+// dropped by ensureEnum before this call (D11).
 func extractMemberMeta(attrs []*bamlparser.Attribute) (alias, description *string, err error) {
 	for _, a := range attrs {
 		if a.Block {
@@ -1376,14 +1469,17 @@ func attributeStringArg(a *bamlparser.Attribute) (string, error) {
 // declineAttribute produces the stable per-function decline error for an
 // attribute this slice does not lower on this node. The substrings "attribute"
 // (field) and "block attribute" (block) are load-bearing for the decline-reason
-// tests. Reached for @skip / @@dynamic / unknown attributes, a constraint or
-// stream attribute on a node with no descriptor home (an enum value / enum-level
-// block), and any attribute on a nested type node.
+// tests. Reached for @@dynamic / unknown attributes, a constraint or stream
+// attribute on a node with no descriptor home (an enum value / enum-level
+// block), and any attribute on a nested type node. @skip is NOT reached here for
+// a class field / enum value: it is intercepted and DROPS the member (D11)
+// before this point; a @skip on a nested type node (invalid BAML) still declines
+// here.
 func declineAttribute(a *bamlparser.Attribute) error {
 	if a.Block {
 		return fmt.Errorf("block attribute @@%s is not supported here (@@dynamic and unknown block attributes are declined; @@alias/@@description/@@check/@@assert/@@stream.* are lowered where the descriptor can represent them)", a.Name)
 	}
-	return fmt.Errorf("attribute @%s is not supported here (@skip and unknown attributes are declined, and @check/@assert/@stream.* have no home on this node; @alias/@description are lowered everywhere and constraints/streaming where representable)", a.Name)
+	return fmt.Errorf("attribute @%s is not supported here (unknown attributes are declined, and @check/@assert/@stream.* have no home on this node; @alias/@description are lowered everywhere, constraints/streaming where representable, and @skip drops a class field / enum value)", a.Name)
 }
 
 // attrDisplayName renders an attribute's name with its @/@@ sigil for messages.

--- a/internal/nativeschema/build_test.go
+++ b/internal/nativeschema/build_test.go
@@ -598,6 +598,165 @@ class Streamed {
 	}
 }
 
+// TestBuildStaticSchemasSkip proves @skip DROPS a class field / enum value
+// exactly as BAML does (find_existing_class_field / find_enum_value return
+// Ok(None) before the definition is built — #586 D11): the skipped member never
+// appears in the descriptor or the rendered output_format, and a class reachable
+// ONLY through a skipped field vanishes entirely (its type is never reached).
+// This mirrors BAML's own render_output_format unit tests
+// (skipped_class_fields_are_not_rendered / skipped_variants_are_not_rendered),
+// and the ParitySkip integration fixture proves the exact bytes against the real
+// v0.223 oracle. @skip fields are optional here because BAML requires it
+// (validation "Class field with @skip attribute must be optional"); our parser is
+// laxer, but the fixtures stay BAML-valid so the oracle compiles.
+func TestBuildStaticSchemasSkip(t *testing.T) {
+	src := `
+enum SkipEnum {
+    KEEP_A
+    DROP_B @skip
+    KEEP_C
+}
+
+// OnlyViaSkip is referenced ONLY by SkipHolder.secret, which is @skip, so it
+// must disappear from the output_format entirely (its type is never reached).
+class OnlyViaSkip {
+    ghost string
+}
+
+class SkipHolder {
+    kept string
+    dropped string? @skip
+    category SkipEnum
+    secret OnlyViaSkip? @skip
+}
+` + fn("GetSkip", "SkipHolder")
+
+	bundles, declines := buildFromSource(t, src)
+	if reason, declined := declines["GetSkip"]; declined {
+		t.Fatalf("GetSkip declined, want supported (@skip DROPS, it does not decline): %s", reason)
+	}
+	b, ok := bundles["GetSkip"]
+	if !ok {
+		t.Fatalf("GetSkip built no descriptor")
+	}
+
+	// Skipped field dropped; kept fields remain in source order.
+	holder := findClass(b, "SkipHolder")
+	if holder == nil {
+		t.Fatalf("SkipHolder class not found")
+	}
+	var names []string
+	for i := range holder.Fields {
+		names = append(names, holder.Fields[i].Name.Name)
+	}
+	if want := []string{"kept", "category"}; !reflect.DeepEqual(names, want) {
+		t.Errorf("SkipHolder fields = %v, want %v (dropped + secret @skip removed)", names, want)
+	}
+
+	// A class reached ONLY through the skipped `secret` field must not be
+	// collected at all — @skip stops reachability, matching BAML (it never pushes
+	// the skipped field's type onto the stack).
+	if findClass(b, "OnlyViaSkip") != nil {
+		t.Errorf("OnlyViaSkip should be dropped (reachable only via a @skip field)")
+	}
+
+	// Skipped enum value dropped; kept values remain in source order.
+	e := findEnum(b, "SkipEnum")
+	if e == nil {
+		t.Fatalf("SkipEnum not found")
+	}
+	var vals []string
+	for i := range e.Values {
+		vals = append(vals, e.Values[i].Name.Name)
+	}
+	if want := []string{"KEEP_A", "KEEP_C"}; !reflect.DeepEqual(vals, want) {
+		t.Errorf("SkipEnum values = %v, want %v (DROP_B @skip removed)", vals, want)
+	}
+
+	// The rendered output_format carries no skipped member and no only-via-skip
+	// type (the container oracle proves the exact bytes; this pins the shape).
+	got := renderNative(t, b)
+	for _, banned := range []string{"dropped", "secret", "OnlyViaSkip", "ghost", "DROP_B"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("rendered output_format contains skipped token %q:\n%s", banned, got)
+		}
+	}
+	for _, wantTok := range []string{"kept", "category", "KEEP_A", "KEEP_C"} {
+		if !strings.Contains(got, wantTok) {
+			t.Errorf("rendered output_format missing kept token %q:\n%s", wantTok, got)
+		}
+	}
+}
+
+// TestBuildStaticSchemasStreamingNotEmitted is the slice-6 static-streaming
+// decline-boundary (#586 D12). Static streaming partialization is a parity-
+// DECLINE (kept as the BAML fallback): BAML NEVER renders a streaming
+// output_format into the prompt — the Jinja RenderContext carries a single
+// output_format populated with the NON-streaming definitions
+// (engine/.../prompt_renderer/mod.rs render_prompt, line 149), while the
+// partialized/streaming OutputFormatContent (output.to_streaming_type)
+// feeds ONLY the partial-response JSONish parser (mod.rs parse, allow_partials).
+// So `{{ ctx.output_format }}` resolves to the non-streaming block for streaming
+// AND non-streaming calls, and there is no streaming output_format artifact for
+// the byte-parity oracle to compare against. The builder therefore emits ONLY the
+// non-streaming descriptor: no bundle sets Bundle.Stream and every class is under
+// StreamingMode::NonStreaming — even for a function whose output carries @stream.*
+// (those lower as metadata on the FINAL non-streaming descriptor, slice 4, and do
+// NOT spawn a streaming-mode class). This pins that no partialized descriptor
+// leaks into the static build.
+func TestBuildStaticSchemasStreamingNotEmitted(t *testing.T) {
+	src := `
+class Streamed {
+    ready bool @stream.done
+    value string @stream.not_null @stream.with_state
+    plain int
+    @@stream.done
+}
+enum StreamEnum {
+    A
+    B
+}
+class Nested {
+    e StreamEnum
+}
+class Holder {
+    s Streamed
+    n Nested
+    items Streamed[]
+}
+` + fn("GetStreamed", "Streamed") + fn("GetHolder", "Holder")
+
+	bundles, declines := buildFromSource(t, src)
+	for _, name := range []string{"GetStreamed", "GetHolder"} {
+		if reason, declined := declines[name]; declined {
+			t.Fatalf("%s declined, want supported: %s", name, reason)
+		}
+		b, ok := bundles[name]
+		if !ok {
+			t.Fatalf("%s built no descriptor", name)
+		}
+		// D12: no streaming (partialized) descriptor is emitted.
+		if b.Stream {
+			t.Errorf("%s: Bundle.Stream = true, want false (static streaming is a parity-decline, D12)", name)
+		}
+		if b.Target.Mode == sd.Streaming {
+			t.Errorf("%s: target mode = Streaming, want NonStreaming", name)
+		}
+		for _, c := range b.Classes {
+			if c.Mode != sd.NonStreaming {
+				t.Errorf("%s: class %q mode = %q, want NonStreaming (no streaming-mode class emitted, D12)", name, c.Name.Name, c.Mode)
+			}
+		}
+	}
+
+	// Sanity: declining STREAMING partialization does not drop the @stream.*
+	// FLAGS — they are still carried on the final non-streaming descriptor
+	// (slice-4 behavior), just never used to render a distinct streaming block.
+	if cls := findClass(bundles["GetStreamed"], "Streamed"); cls == nil || cls.Stream.IsZero() {
+		t.Errorf("GetStreamed: @@stream.* metadata should ride on the non-streaming descriptor")
+	}
+}
+
 // TestBuildStaticSchemasDocCommentsNoOp proves a `///` doc comment is captured
 // as a NO-OP: BAML's output_format renderer never reads doc comments (only
 // @description renders — #586 D6, oracle-confirmed), so a doc-commented class/
@@ -1083,19 +1242,6 @@ class DynEnumOut {
 			wantReasonSub: "block attribute",
 		},
 		{
-			name:   "enum value @skip",
-			fnName: "GetSkip",
-			src: `enum SkipEnum {
-    KEEP
-    HIDE @skip
-}
-class SkipOut {
-    v SkipEnum
-}
-` + fn("GetSkip", "SkipOut"),
-			wantReasonSub: "attribute",
-		},
-		{
 			name:   "alias with non-string argument",
 			fnName: "GetBadAlias",
 			src: `class BadAlias {
@@ -1349,15 +1495,6 @@ class EnumStreamOut {
 }
 ` + fn("GetNestedBlock", "WithNested"),
 			wantReasonSub: "unsupported body content",
-		},
-		{
-			name:   "class field @skip",
-			fnName: "GetFieldSkip",
-			src: `class FieldSkip {
-    a string @skip
-}
-` + fn("GetFieldSkip", "FieldSkip"),
-			wantReasonSub: "attribute",
 		},
 		// NOTE: descriptor kinds TypeTop and TypeArrow have NO corresponding
 		// bamlparser TypeExpr node (the AST union is Unsupported/Primitive/Media/


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## de-BAML P3 native parser — Slice 6 (FINAL P3-static slice), #586

Closes the remaining P3-static declines. **@skip is IMPLEMENTED**; **static streaming is a grounded parity-DECLINE**; **@@dynamic stays fail-closed declined**. After this slice the only remaining P3-static declines are the legitimately out-of-scope ones (@@dynamic; static streaming) plus the parity-decline representation limits (media/tuple output). Slices 1–6 COMPLETE.

Test-only (no runtime routing / request-response change); config extraction + existing goldens byte-identical; embed manifest idempotent (no new embedded `.go` files); integration package compiles with `-tags=integration`.

### (1) `@skip` — IMPLEMENTED (D11)
A `@skip`-marked class field / enum value is now **DROPPED exactly as BAML does**. BAML's `find_existing_class_field` / `find_enum_value` return `Ok(None)` for a skipped member **before** the class/enum definition is built, so the member never renders in `ctx.output_format` **and its type is never pushed onto the reachability stack** — a class/enum reachable **only** through a skipped field disappears from the output entirely. This replaces the slice-2..5 `@skip` DECLINE.

- Sites: `ensureClass` / `ensureEnum` / `hasSkipAttribute` (`internal/nativeschema/build.go`).
- `recursion.go` is **unchanged** and stays faithful: BAML's class dependency graph (`finalize_dependencies`) is skip-inclusive (built structurally from all field types), so `@skip` does not change recursion classification.
- Proven byte-exact by the new **`ParitySkip`** oracle fixture — a skipped field (`dropped`), a skipped class-ref field (`secret OnlyViaSkip?`, only reference to `OnlyViaSkip`), and a skipped enum value (`DROP_B`) all vanish; the rendered block is `{ kept, category: 'KEEP_A' or 'KEEP_C' }`. `@skip` fields are optional because BAML validation requires it.
- Unit: `TestBuildStaticSchemasSkip` (drop field, drop value, drop only-via-skip type).

### (2) Static streaming — parity-DECLINED, kept as BAML fallback (D12)
Attempted with the parity-decline discipline; **declined with a decisive architectural reason, not an approximation**: **BAML never renders a streaming `output_format` into the prompt.** `render_prompt` builds a Jinja `RenderContext` whose single `output_format` field is the **NON-streaming** definitions (`engine/.../prompt_renderer/mod.rs:149`); the partialized/streaming `OutputFormatContent` (`output.to_streaming_type(ir)`, `render_output_format.rs relevant_data_models partialize=true`) is built but consumed **only** by the partial-response JSONish parser (`mod.rs parse`, `allow_partials`). So `{{ ctx.output_format }}` resolves to the non-streaming block for streaming **and** non-streaming calls alike — there is **no streaming output_format artifact** for the byte-parity oracle to compare against, and "streaming output_format parity" is unprovable because the thing it would prove is never emitted.

Streaming partialization affects only response **parsing** (`internal/debaml` partial coercion), a separate subsystem out of this output_format builder's scope. There is no reusable render-side partialization to reuse — the premise that a dynamic streaming path exposes one does not hold, precisely because no streaming output_format is ever rendered.

- The builder emits **only** the non-streaming descriptor (`Bundle.Stream` never set true; no class under `StreamingMode::Streaming`). `@stream.*` flags still ride on the FINAL non-streaming descriptor (slice-4 behavior) — declining partialization does not drop them.
- Decline-boundary unit: `TestBuildStaticSchemasStreamingNotEmitted`.

### (3) `@@dynamic` — stays DECLINED
Tied to runtime TypeBuilder / dynamic schema mutation, not a static-schema feature — out of P3-static scope. Existing decline tests unchanged.

### Validation
`gofmt` clean; `go build ./...`; `go vet ./...`; `go test ./internal/nativeschema/... ./bamlutils/bamlparser/... ./cmd/introspect/...` (config goldens **unchanged**) + `internal/schema` + `internal/schema/outputformat` all green; `go vet -tags=integration ./integration`; embed regen idempotent (zero `jj status` diff). The authoritative container byte-parity harness (`TestNativeStaticOutputFormatParity`, now incl. `ParitySkip`) runs in CI — not run locally more than validated, per disk discipline.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added P3-static `@skip` drop behavior for class fields and enum values during schema rendering, omitting skipped members from the generated output.
* **Bug Fixes**
  * Skipped-only reachable types are no longer included, including cases reachable via skipped fields.
  * Static schema generation no longer emits streaming/partialized descriptors in non-streaming builds.
* **Tests**
  * Added coverage for skipped fields/enum values, output-format omission, type reachability pruning, and non-streaming descriptor behavior.
* **Documentation**
  * Refined test-parity commentary around `@skip` and doc comment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->