### PR TITLE
chore: bump Go 1.26.3 -> 1.26.5

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -51,7 +51,7 @@ permissions:
   actions: read
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.5"
 
 jobs:
   get-versions:
@@ -195,7 +195,7 @@ jobs:
         with:
           path: warm-images/debian.tar
           key: warm-image-${{ runner.os }}-debian-${{ steps.resolve.outputs.debian }}
-      - name: Cache golang:1.26.3-alpine tarball
+      - name: Cache golang:1.26.5-alpine tarball
         id: cache-golang
         uses: actions/cache@v6.1.0
         with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -15,7 +15,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.5"
 
 jobs:
   # Build Linux binaries on release

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.5"
 
 jobs:
   get-versions:
@@ -198,7 +198,7 @@ jobs:
         with:
           path: warm-images/debian.tar
           key: warm-image-${{ runner.os }}-debian-${{ steps.resolve.outputs.debian }}
-      - name: Cache golang:1.26.3-alpine tarball
+      - name: Cache golang:1.26.5-alpine tarball
         id: cache-golang
         uses: actions/cache@v6.1.0
         with:

--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: ${{ github.event.head_commit.author.name != 'github-actions[bot]' }}
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.5"
 
 jobs:
   sync:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.5"
 
 jobs:
   unit-tests:

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -3,7 +3,7 @@
 # Can be used as a base image for faster builds
 
 # Go version (defined once, re-declared in each stage that needs it)
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.5
 
 # ============================================================================
 # Stage 1: Builder (native platform for fast builds with cross-compilation)

--- a/adapters/adapter_v0_204_0/go.mod
+++ b/adapters/adapter_v0_204_0/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/adapters/adapter_v0_204_0
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/boundaryml/baml v0.204.0

--- a/adapters/adapter_v0_215_0/go.mod
+++ b/adapters/adapter_v0_215_0/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/adapters/adapter_v0_215_0
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/boundaryml/baml v0.215.0

--- a/adapters/adapter_v0_219_0/go.mod
+++ b/adapters/adapter_v0_219_0/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/adapters/adapter_v0_219_0
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/boundaryml/baml v0.219.0

--- a/adapters/common/go.mod
+++ b/adapters/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/adapters/common
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/boundaryml/baml v0.204.0

--- a/bamlutils/go.mod
+++ b/bamlutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/bamlutils
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4

--- a/cmd/build/Dockerfile.tmpl
+++ b/cmd/build/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Go version (defined once, re-declared in each stage that needs it)
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.5
 
 {{- if and .bamlSource (not .prebuiltCffi) }}
 # Rust builder stage: Build BAML CFFI library and CLI from source.

--- a/dynclient/go.mod
+++ b/dynclient/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/dynclient
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/bytedance/sonic v1.15.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.26.3
+go 1.26.5
 
 // NOTE: ./adapters/adapter_v* and ./adapters/common are intentionally NOT
 // included in this workspace. Each adapter pins a specific

--- a/integration/mockllm/Dockerfile
+++ b/integration/mockllm/Dockerfile
@@ -1,5 +1,5 @@
 # renovate: datasource=docker
-FROM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
 WORKDIR /app
 

--- a/introspected/go.mod
+++ b/introspected/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/introspected
 
-go 1.26.3
+go 1.26.5
 
 require github.com/invakid404/baml-rest/bamlutils v0.0.48
 

--- a/pool/go.mod
+++ b/pool/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/pool
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/bytedance/sonic v1.15.2

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/worker
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/bytedance/sonic v1.15.2

--- a/workerplugin/go.mod
+++ b/workerplugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/invakid404/baml-rest/workerplugin
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/hashicorp/go-plugin v1.8.0


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

Mechanical version-bump only: **Go 1.26.3 → 1.26.5** across the whole project. No source changes.

## What changed
- `go 1.26.5` directive in every workspace + standalone `go.mod` (root, `introspected`, `dynclient`, `bamlutils`, `workerplugin`, `worker`, `pool`, `adapters/{common,adapter_v0_204_0,adapter_v0_215_0,adapter_v0_219_0}`) and in `go.work`.
- `integration/mockllm/Dockerfile`: `golang:1.26.4-alpine` → `golang:1.26.5-alpine`, digest updated to the real `1.26.5-alpine` index digest `sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2`.
- `cmd/build/Dockerfile.tmpl` and `Dockerfile.builder`: `ARG GO_VERSION=1.26.5`.
- CI workflows: `GO_VERSION: "1.26.5"` in `unit-tests`, `renovate-sync`, `build-and-publish`, `integration-tests`, `bamlfuzz-nightly`; plus the `golang:1.26.5-alpine` tarball-cache step labels in `integration-tests` + `bamlfuzz-nightly`.

`dynclient/baml-patched/go.mod` (`go 1.24.0`, generated/vendored) intentionally left untouched. No `toolchain` directives exist in the tree. `go.sum` / `go.work.sum` unaffected.

## Validation (local, under go1.26.5 via `GOTOOLCHAIN=auto`)
- `go build ./...` and `go vet ./...` clean.
- `go test ./...` green on root + standalone modules (`adapters/common`, `bamlutils`, `dynclient`, `introspected`, `worker`, `workerplugin`, `pool`).
- `go work sync` clean; `GOWORK=off go mod tidy` idempotent (no `go.mod`/`go.sum` drift).
- Embed regen (`go run ./cmd/embed`) is a no-op — a go-directive bump adds no files, so the embed manifests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go toolchain to version 1.26.5 across builds, tests, integrations, modules, and container images.
  * Refreshed build and CI caching configuration to use the updated Go Alpine image.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->