### PR TITLE
debaml(p1s1): retain prompt/template data in bamlparser

### DIFF
--- a/bamlutils/bamlparser/ast.go
+++ b/bamlutils/bamlparser/ast.go
@@ -14,12 +14,14 @@ type File struct {
 //
 // Recognised semantic blocks (Generator, Client, Function, RetryPolicy)
 // carry their parsed Fields and are consumed by the semantic walker.
-// Tolerated declarations that baml-rest currently doesn't model are
-// represented by metadata-only nodes: class/enum/test → TypeBlock, type
+// Tolerated declarations that baml-rest doesn't model semantically are
+// represented by dedicated nodes: class/enum/test → TypeBlock, type
 // aliases → TypeAlias, template_string → TemplateBlock, and anything else
-// → Other. Those nodes carry the declaration keyword/name only; the
-// brace body or expression right-hand-side is consumed during parsing
-// and not retained on the AST.
+// → Other. These nodes retain as much of the declaration as later
+// descriptor slices need — TypeBlock members, TemplateBlock args/body —
+// while genuinely unmodelled brace bodies and expression right-hand-sides
+// are consumed during parsing and not retained. Other carries only the
+// leading keyword.
 //
 // The alternative order is load-bearing: keyword-shaped declarations are
 // tried first, with Other last as the catch-all so unknown punctuation /
@@ -87,6 +89,27 @@ type FunctionBlock struct {
 	// nil when the declaration omits `-> Type`.
 	Params []*Param
 	Return *TypeExpr
+
+	// PromptRaw and HasPrompt are a post-parse semantic projection of the
+	// function's `prompt` field, filled during normalisation (P1 slice 1,
+	// #586). They mirror BAML's last-field-wins behaviour without disturbing
+	// the ordered Fields slice, which remains the lossless source-order record
+	// of every field:
+	//
+	//   - HasPrompt is true when a `prompt` field is present at all — the
+	//     FINAL one in source order, since duplicate keys are last-wins. It
+	//     distinguishes an absent prompt field from a final prompt field whose
+	//     value was non-raw or otherwise unusable.
+	//   - PromptRaw points at the delimiter-stripped bytes of that final
+	//     prompt field ONLY when it is a raw-string literal. A final non-raw
+	//     prompt therefore sets HasPrompt but leaves PromptRaw nil; an earlier
+	//     raw prompt is never resurrected.
+	//
+	// PromptRaw is a convenience projection over Fields, not a replacement for
+	// it; the raw bytes are those already retained on the final prompt Field's
+	// Value.Raw (only the raw-string delimiters are removed).
+	PromptRaw *string
+	HasPrompt bool
 }
 
 // RetryPolicyBlock corresponds to `retry_policy Name { ... }`.
@@ -99,17 +122,41 @@ type RetryPolicyBlock struct {
 	Fields []*Field
 }
 
-// TemplateBlock corresponds to `template_string Name(...) #"..."#` and the
-// `template_string Name { ... }` form. The body is intentionally not parsed;
-// callers either ignore TemplateBlock entirely (introspect's posture today)
-// or read Name for documentation/index purposes.
+// TemplateBlock corresponds to a `template_string` (or the tolerated
+// historical `string_template` alias) declaration, e.g.
+// `template_string Name(args) #"body"#`. As of de-BAML P1 slice 1 (#586) the
+// declaration is retained instead of discarded:
 //
-// Parsing is implemented via Parseable in bamlparser.go because the body
-// is discarded — there is no AST field to hold the parsed parameter list
-// or body — and the body alternates between a raw string token and a
-// balanced brace block.
+//   - Keyword is the leading word as spelled in source: "template_string" or
+//     the "string_template" alias (retained spelling, not canonicalised).
+//   - Name is the declaration name.
+//   - Args holds the named-argument list, parsed via the shared parseParamList
+//     helper. Both typed (`x: string`) and bare (`x`) argument forms are
+//     accepted; a bare argument has Type == nil, exactly like a function
+//     signature parameter.
+//   - Body is the raw template body with ONLY the raw-string delimiters
+//     removed (via stripRawString). It is NOT dedented, trimmed, unescaped,
+//     re-indented, or otherwise normalised — Phase 3's renderer owns
+//     render-time dedent/trim. An empty raw body (`#""#`) is a non-nil pointer
+//     to the empty string. Body is nil when the declaration carried no raw
+//     body.
+//   - HasUnsupportedBody marks a tolerated non-raw body shape — currently the
+//     historical brace form `template_string Name { ... }`, which is
+//     balanced-skipped for parser recovery but is NOT a valid BAML raw-string
+//     template body. A brace body is never fabricated into a Body string; the
+//     later descriptor slice declines any declaration whose Body is nil or
+//     whose HasUnsupportedBody is set.
+//
+// Parsing is implemented via Parseable in bamlparser.go because the leading
+// keyword/alias, the optional `=` before the body, and the raw-vs-brace body
+// alternation are position-sensitive in ways grammar tags cannot express. The
+// argument types are parsed via the declarative participle type grammar.
 type TemplateBlock struct {
-	Name string
+	Keyword            string
+	Name               string
+	Args               []*Param
+	Body               *string
+	HasUnsupportedBody bool
 }
 
 // TypeBlock corresponds to `class Name { ... }`, `enum Name { ... }`, or

--- a/bamlutils/bamlparser/bamlparser.go
+++ b/bamlutils/bamlparser/bamlparser.go
@@ -4,10 +4,11 @@
 // semantically: class/enum/test declarations are represented as TypeBlock,
 // type aliases as TypeAlias, template_string declarations as TemplateBlock,
 // and unknown leading-identifier or leading-punctuation forms as Other.
-// These metadata-only nodes preserve source order while their bodies
-// (brace bodies, expression right-hand-sides) are consumed and not
-// retained, so the parser tolerates the full upstream BAML surface
-// without erroring.
+// These nodes preserve source order; genuinely unmodelled bodies (opaque
+// brace bodies, expression right-hand-sides) are consumed and not retained,
+// while recognised nodes (TypeBlock, TemplateBlock) retain the
+// members/args/body that later descriptor slices consume. The parser
+// tolerates the full upstream BAML surface without erroring.
 //
 // The Value type encodes literal-vs-env.IDENT provenance at parse time as a
 // first-class node. Downstream code reads Value.Literal vs Value.EnvRef to
@@ -87,7 +88,16 @@ var bamlLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: tokEnvRef, Pattern: `env\.[A-Za-z_][A-Za-z0-9_]*`},
 	{Name: tokNumber, Pattern: `-?\d+(?:\.\d+)?`},
 	{Name: tokArrow, Pattern: `->`},
-	{Name: tokIdent, Pattern: `[A-Za-z_][A-Za-z0-9_\-/]*`},
+	// FIX-EVENTUALLY (#586): the optional leading `$` admits BAML's
+	// dollar-prefixed identifier form as a single Ident token (previously the
+	// `$` fell to tokOther and split the identifier). This is a declarative
+	// lexer widening, not a hand parser, and is laxer than BAML if that syntax
+	// changed between the non-authoritative v0.222 shape check and the v0.223
+	// parity target; a build-only v0.223 grammar/acceptance fixture is the
+	// intended merge guard before any grammar-parity claim. The raw-string
+	// rule intentionally stays ahead of this rule so a `#"..."#` body is never
+	// truncated into an identifier.
+	{Name: tokIdent, Pattern: `\$?[A-Za-z_][A-Za-z0-9_\-/]*`},
 	{Name: tokPunct, Pattern: `[{}()\[\]<>,.:?=|&!*@;]`},
 	{Name: tokOther, Pattern: `.`},
 })
@@ -336,23 +346,68 @@ func (fn *FunctionBlock) Parse(lex *lexer.PeekingLexer) error {
 }
 
 // Parse implements participle.Parseable for TemplateBlock. Matches
-// `template_string Name? (params)? ( #"..."# | { ... } )`. The body is
-// metadata-only: only Name is retained.
+// `(template_string | string_template) Name? (args)? =? ( #"..."# | { ... } )`.
+// The keyword spelling, named-argument list, and raw body are retained (P1
+// slice 1, #586); a brace body is balanced-skipped for recovery and flagged
+// HasUnsupportedBody. The raw body's delimiters are stripped later in
+// normalizeItem via stripRawString — no dedent/trim happens here.
 func (tb *TemplateBlock) Parse(lex *lexer.PeekingLexer) error {
-	if !peekIdentLiteral(lex, "template_string") {
+	// FIX-EVENTUALLY (#586): `string_template` is a tolerated historical alias
+	// for `template_string`. The non-authoritative v0.222 shape check accepts
+	// both spellings; v0.223 is the parity target and a build-only v0.223
+	// grammar/acceptance fixture is the intended merge guard before any
+	// grammar-parity claim. Accepting the alias is harmlessly laxer than BAML
+	// (BAML gates invalid input at build); the retained spelling lets a later
+	// slice diagnose which form was used.
+	var keyword string
+	switch {
+	case peekIdentLiteral(lex, "template_string"):
+		keyword = "template_string"
+	case peekIdentLiteral(lex, "string_template"):
+		keyword = "string_template"
+	default:
 		return participle.NextMatch
 	}
-	lex.Next() // consume "template_string"
+	lex.Next() // consume the keyword
+	tb.Keyword = keyword
 
 	if t := lex.Peek(); t.Type == identType {
 		tb.Name = lex.Next().Value
 	}
+	// Named-argument list, parsed via the shared parseParamList (typed and
+	// bare arguments both accepted). parseParamList consumes through the
+	// matching `)`, so the post-signature token position matches the prior
+	// skipBalanced("(", ")") recovery exactly.
 	if peekPunct(lex, "(") {
-		skipBalanced(lex, "(", ")")
+		tb.Args = parseParamList(lex)
+	}
+	// FIX-EVENTUALLY (#586): consume an optional `=` before the body
+	// (`template_string Name = #"..."#`). The non-authoritative v0.222 shape
+	// check permits the optional equals; v0.223 is the parity target and a
+	// build-only v0.223 grammar/acceptance fixture is the intended merge guard
+	// before any grammar-parity claim. Accepting both the equals and
+	// equals-less forms is harmlessly laxer than BAML (BAML gates invalid input
+	// at build). Consumed when present; absent forms are unaffected.
+	if peekPunct(lex, "=") {
+		lex.Next()
 	}
 	if t := lex.Peek(); t.Type == rawStringType {
-		lex.Next()
+		// Retain the raw body token verbatim; normalizeItem strips only the
+		// raw-string delimiters. An empty raw body (`#""#`) yields a non-nil
+		// pointer to the empty string, distinct from a nil (absent) Body.
+		bodyTok := lex.Next()
+		body := bodyTok.Value
+		tb.Body = &body
 	} else if peekPunct(lex, "{") {
+		// FIX-EVENTUALLY (#586): a brace-bodied template declaration is a
+		// current parser tolerance, NOT a valid BAML raw-string template body.
+		// Retain the historical balanced-skip recovery so the following
+		// declaration still parses, but mark the body unsupported and leave
+		// Body nil so the later descriptor slice declines it rather than
+		// fabricating a string. This is laxer than BAML, which requires a
+		// raw-string body; a build-only v0.223 acceptance fixture is the
+		// intended merge guard before any grammar-parity claim.
+		tb.HasUnsupportedBody = true
 		skipBalanced(lex, "{", "}")
 	}
 	return nil
@@ -546,6 +601,11 @@ func parseBlockFieldsUntilClose(lex *lexer.PeekingLexer) []*Field {
 // elided by the lexer, so commas alone delimit parameters; the closing `)`
 // is consumed. Each parameter's type is parsed via the declarative type
 // grammar. Unrecognised tokens inside the list are skipped defensively.
+//
+// Shared by every named-argument site: function signatures
+// (FunctionBlock.Params), class/enum block arguments (TypeBlock.Args), and
+// template declarations (TemplateBlock.Args). A bare argument with no `:Type`
+// annotation has Type == nil, matching BAML's named_argument grammar.
 func parseParamList(lex *lexer.PeekingLexer) []*Param {
 	if !peekPunct(lex, "(") {
 		return nil
@@ -808,11 +868,13 @@ func skipBalanced(lex *lexer.PeekingLexer, open, close string) {
 
 // isTopLevelKeyword reports whether s is one of the keywords that introduces
 // a top-level declaration. Used by TypeAlias.Parse to terminate its RHS
-// scan when the next line begins with a known top-level construct.
+// scan when the next line begins with a known top-level construct. Both
+// template keyword spellings are included so a preceding alias scan cannot
+// consume a following template declaration (#586).
 func isTopLevelKeyword(s string) bool {
 	switch s {
 	case "generator", "client", "function", "retry_policy",
-		"template_string", "class", "enum", "test", "type":
+		"template_string", "string_template", "class", "enum", "test", "type":
 		return true
 	}
 	return false
@@ -845,6 +907,15 @@ func normalizeItem(it *Item, data []byte) {
 			normalizeTypeExpr(p.Type, data)
 		}
 		normalizeTypeExpr(it.Function.Return, data)
+		// Project the final source-ordered prompt field AFTER field values are
+		// delimiter-stripped, so PromptRaw points at the already-normalised
+		// raw bytes.
+		projectFunctionPrompt(it.Function)
+	case it.Template != nil:
+		normalizeTemplateBody(it.Template)
+		for _, p := range it.Template.Args {
+			normalizeTypeExpr(p.Type, data)
+		}
 	case it.RetryPolicy != nil:
 		normalizeFields(it.RetryPolicy.Fields)
 	case it.TypeBlock != nil:
@@ -906,6 +977,43 @@ func normalizeFields(fields []*Field) {
 			normalizeFields(f.Block.Fields)
 		}
 	}
+}
+
+// projectFunctionPrompt fills FunctionBlock.PromptRaw/HasPrompt from the
+// already-normalised Fields. It scans in source order and takes the FINAL
+// `prompt` field (last-field-wins, matching BAML's duplicate-key semantics).
+// HasPrompt records that a final prompt field is present at all; PromptRaw is
+// set only when that final field carries a raw-string value, so a final
+// non-raw prompt sets HasPrompt but leaves PromptRaw nil — an earlier raw
+// prompt is never resurrected. The ordered Fields slice is left untouched and
+// remains the lossless source-order record.
+func projectFunctionPrompt(fn *FunctionBlock) {
+	var last *Field
+	for _, f := range fn.Fields {
+		if f.Key == "prompt" {
+			last = f
+		}
+	}
+	if last == nil {
+		return
+	}
+	fn.HasPrompt = true
+	if last.Value != nil && last.Value.Raw != nil {
+		fn.PromptRaw = last.Value.Raw
+	}
+}
+
+// normalizeTemplateBody strips the raw-string delimiters from a retained
+// template body with stripRawString ONLY — no dedent, trim, unescape, or
+// re-indent (Phase 3's renderer owns those). An empty raw body (`#""#`)
+// normalises to a non-nil pointer to the empty string. A nil Body (absent or
+// brace-tolerated body) is left nil.
+func normalizeTemplateBody(tb *TemplateBlock) {
+	if tb.Body == nil {
+		return
+	}
+	s := stripRawString(*tb.Body)
+	tb.Body = &s
 }
 
 func normalizeValue(v *Value) {

--- a/bamlutils/bamlparser/bamlparser_test.go
+++ b/bamlutils/bamlparser/bamlparser_test.go
@@ -1,6 +1,8 @@
 package bamlparser
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -28,6 +30,15 @@ func findFunction(f *File, name string) *FunctionBlock {
 	for _, it := range f.Items {
 		if it.Function != nil && it.Function.Name == name {
 			return it.Function
+		}
+	}
+	return nil
+}
+
+func findTemplate(f *File, name string) *TemplateBlock {
+	for _, it := range f.Items {
+		if it.Template != nil && it.Template.Name == name {
+			return it.Template
 		}
 	}
 	return nil
@@ -142,13 +153,27 @@ function GetPerson(description: string, ctx: Context) -> Person {
 	if c == nil || c.Value == nil || c.Value.Ident == nil || *c.Value.Ident != "MyClient" {
 		t.Errorf("client field missing/wrong: %+v", c)
 	}
-	// Prompt is captured as a Raw value.
+	// Prompt is captured as a Raw value in the ordered Fields ...
 	pr := fieldByKey(fn.Fields, "prompt")
 	if pr == nil || pr.Value == nil || pr.Value.Raw == nil {
 		t.Fatalf("prompt field should carry Raw value: %+v", pr)
 	}
 	if !strings.Contains(*pr.Value.Raw, "Extract:") {
 		t.Errorf("Raw value content unexpected: %q", *pr.Value.Raw)
+	}
+	// ... and projected onto the dedicated PromptRaw/HasPrompt fields.
+	if !fn.HasPrompt {
+		t.Errorf("HasPrompt = false, want true")
+	}
+	if fn.PromptRaw == nil {
+		t.Fatalf("PromptRaw nil; want the projected raw prompt")
+	}
+	if *fn.PromptRaw != "Extract: {{ description }}" {
+		t.Errorf("PromptRaw = %q, want %q", *fn.PromptRaw, "Extract: {{ description }}")
+	}
+	// The projection is exactly the final prompt Field's normalised Raw bytes.
+	if fn.PromptRaw != pr.Value.Raw {
+		t.Errorf("PromptRaw should alias the final prompt Field's Raw value")
 	}
 }
 
@@ -327,6 +352,13 @@ function F(input: string) -> string {
 	if !strings.Contains(raw, `{ braces { ok } }`) {
 		t.Errorf("raw string lost braces: %q", raw)
 	}
+	// The dedicated projection carries the identical braces/comments verbatim.
+	if !fn.HasPrompt || fn.PromptRaw == nil {
+		t.Fatalf("HasPrompt/PromptRaw not set: HasPrompt=%v PromptRaw=%v", fn.HasPrompt, fn.PromptRaw)
+	}
+	if *fn.PromptRaw != raw {
+		t.Errorf("PromptRaw diverged from Field.Raw:\n got %q\nwant %q", *fn.PromptRaw, raw)
+	}
 }
 
 func TestParse_TopLevelClassEnumTestTolerated(t *testing.T) {
@@ -396,6 +428,26 @@ client<llm> Real {
 	}
 	if !sawTest {
 		t.Errorf("test block not captured as TypeBlock")
+	}
+	// The template declaration retains keyword, name, typed args, and raw body.
+	greeting := findTemplate(f, "Greeting")
+	if greeting == nil {
+		t.Fatalf("template Greeting not captured")
+	}
+	if greeting.Keyword != "template_string" {
+		t.Errorf("Keyword = %q, want template_string", greeting.Keyword)
+	}
+	if len(greeting.Args) != 1 || greeting.Args[0].Name != "name" {
+		t.Fatalf("args = %+v, want single arg name", greeting.Args)
+	}
+	if greeting.Args[0].Type == nil || renderType(greeting.Args[0].Type) != "string" {
+		t.Errorf("arg type = %+v, want string", greeting.Args[0].Type)
+	}
+	if greeting.Body == nil || *greeting.Body != "Hello {{ name }}" {
+		t.Errorf("Body = %v, want %q", greeting.Body, "Hello {{ name }}")
+	}
+	if greeting.HasUnsupportedBody {
+		t.Errorf("HasUnsupportedBody = true for a valid raw body")
 	}
 }
 
@@ -821,5 +873,352 @@ func TestParse_RetryPolicyMalformedNestedTokenBetweenFieldsSkipped(t *testing.T)
 	dm := fieldByKey(rp.Fields, "delay_ms")
 	if dm == nil || dm.Value == nil || dm.Value.Number == nil || *dm.Value.Number != "100" {
 		t.Errorf("delay_ms missing/wrong: %+v", dm)
+	}
+}
+
+// -----------------------------------------------------------------------
+// P1 slice 1 (#586): function prompt projection (PromptRaw / HasPrompt).
+// -----------------------------------------------------------------------
+
+func TestParse_PromptLastFieldWins(t *testing.T) {
+	// Two prompt fields: last-field-wins for the projection, while the ordered
+	// Fields slice retains BOTH in source order (lossless).
+	src := `
+function F(x: string) -> string {
+    client C
+    prompt #"first"#
+    prompt #"second"#
+}
+`
+	f := mustParse(t, src)
+	fn := findFunction(f, "F")
+	if fn == nil {
+		t.Fatalf("F missing")
+	}
+	var prompts []string
+	for _, fld := range fn.Fields {
+		if fld.Key == "prompt" && fld.Value != nil && fld.Value.Raw != nil {
+			prompts = append(prompts, *fld.Value.Raw)
+		}
+	}
+	if len(prompts) != 2 || prompts[0] != "first" || prompts[1] != "second" {
+		t.Fatalf("ordered Fields lost a prompt: %v", prompts)
+	}
+	if !fn.HasPrompt || fn.PromptRaw == nil || *fn.PromptRaw != "second" {
+		t.Errorf("projection = (%v, %v), want last-wins 'second'", fn.HasPrompt, fn.PromptRaw)
+	}
+}
+
+func TestParse_PromptFinalNonRawDeclines(t *testing.T) {
+	// An earlier raw prompt followed by a final NON-raw prompt: the projection
+	// sets HasPrompt but leaves PromptRaw nil (the earlier raw prompt is never
+	// resurrected), while Fields retains both source-order entries.
+	src := `
+function F(x: string) -> string {
+    client C
+    prompt #"earlier raw"#
+    prompt "final literal"
+}
+`
+	f := mustParse(t, src)
+	fn := findFunction(f, "F")
+	if fn == nil {
+		t.Fatalf("F missing")
+	}
+	if !fn.HasPrompt {
+		t.Errorf("HasPrompt = false; a final prompt field is present")
+	}
+	if fn.PromptRaw != nil {
+		t.Errorf("PromptRaw = %q; a final non-raw prompt must not reuse an earlier raw prompt", *fn.PromptRaw)
+	}
+	var sawEarlierRaw bool
+	for _, fld := range fn.Fields {
+		if fld.Key == "prompt" && fld.Value != nil && fld.Value.Raw != nil && *fld.Value.Raw == "earlier raw" {
+			sawEarlierRaw = true
+		}
+	}
+	if !sawEarlierRaw {
+		t.Errorf("ordered Fields lost the earlier raw prompt")
+	}
+}
+
+func TestParse_PromptAbsent(t *testing.T) {
+	src := `
+function F(x: string) -> string {
+    client C
+}
+`
+	f := mustParse(t, src)
+	fn := findFunction(f, "F")
+	if fn == nil {
+		t.Fatalf("F missing")
+	}
+	if fn.HasPrompt {
+		t.Errorf("HasPrompt = true for a function with no prompt field")
+	}
+	if fn.PromptRaw != nil {
+		t.Errorf("PromptRaw = %q, want nil", *fn.PromptRaw)
+	}
+}
+
+func TestParse_PromptExactBodyNoTrimNoDedent(t *testing.T) {
+	// A raw prompt with CRLF line endings, leading/trailing blank lines, tabs,
+	// braces, URLs and `//` double-slashes. The parser retains the body
+	// byte-for-byte after removing ONLY the raw-string delimiters: no
+	// TrimSpace, dedent, unescape, or comment stripping.
+	body := "\r\n" +
+		"\t{ \"url\": \"https://example.com//v1\" } // not a comment\r\n" +
+		"\t\tindented\r\n" +
+		"\r\n"
+	src := "function F(x: string) -> string {\n" +
+		"    client C\n" +
+		"    prompt #\"" + body + "\"#\n" +
+		"}\n"
+	f := mustParse(t, src)
+	fn := findFunction(f, "F")
+	if fn == nil {
+		t.Fatalf("F missing")
+	}
+	if fn.PromptRaw == nil {
+		t.Fatalf("PromptRaw nil")
+	}
+	if *fn.PromptRaw != body {
+		t.Errorf("PromptRaw not byte-exact:\n got %q\nwant %q", *fn.PromptRaw, body)
+	}
+}
+
+func TestParse_RealDynamicPromptExactRetention(t *testing.T) {
+	// The real cmd/build/dynamic.baml prompt is retained byte-for-byte after
+	// removing ONLY the raw-string delimiters — leading/trailing whitespace,
+	// {%- / -%}, _.role, every media branch, ctx.output_format, and the replace
+	// filter. Skipped when the file is not present (stripped-down checkout).
+	path := filepath.Join("..", "..", "cmd", "build", "dynamic.baml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skip("dynamic.baml not available")
+	}
+	f, err := ParseBytes(path, data)
+	if err != nil {
+		t.Fatalf("parse dynamic.baml: %v", err)
+	}
+	fn := findFunction(f, "Baml_Rest_Dynamic")
+	if fn == nil {
+		t.Fatalf("Baml_Rest_Dynamic function missing")
+	}
+	if !fn.HasPrompt || fn.PromptRaw == nil {
+		t.Fatalf("prompt not projected: HasPrompt=%v PromptRaw=%v", fn.HasPrompt, fn.PromptRaw)
+	}
+	// Reconstruct the expected body from source: the bytes between `prompt #"`
+	// and the closing `"#` (single-hash; the real body contains no `"#`
+	// sequence). This proves delimiter-removal-only with zero dedent/trim.
+	s := string(data)
+	const openMarker = "prompt #\""
+	oi := strings.Index(s, openMarker)
+	if oi < 0 {
+		t.Fatalf("could not locate prompt open marker")
+	}
+	bodyStart := oi + len(openMarker)
+	ci := strings.Index(s[bodyStart:], "\"#")
+	if ci < 0 {
+		t.Fatalf("could not locate prompt close marker")
+	}
+	want := s[bodyStart : bodyStart+ci]
+	if *fn.PromptRaw != want {
+		t.Errorf("PromptRaw not byte-exact:\n got %q\nwant %q", *fn.PromptRaw, want)
+	}
+	for _, needle := range []string{"{%-", "-%}", "_.role(", "ctx.output_format", `replace("{output_format}"`, "p.img", "p.aud", "p.doc", "p.vid"} {
+		if !strings.Contains(*fn.PromptRaw, needle) {
+			t.Errorf("PromptRaw lost %q", needle)
+		}
+	}
+	if !strings.HasPrefix(*fn.PromptRaw, "\n") {
+		t.Errorf("leading whitespace was trimmed from the prompt body")
+	}
+	if !strings.HasSuffix(*fn.PromptRaw, "\n  ") {
+		t.Errorf("trailing whitespace was trimmed from the prompt body")
+	}
+}
+
+// -----------------------------------------------------------------------
+// P1 slice 1 (#586): template_string / string_template retention.
+// -----------------------------------------------------------------------
+
+func TestParse_TemplateStringAliasAndEquals(t *testing.T) {
+	// Both keyword spellings, both with and without the optional `=` before the
+	// body. All four retain keyword spelling, name, typed arg, and raw body.
+	cases := []struct {
+		name    string
+		src     string
+		keyword string
+	}{
+		{"template_string no equals", `template_string A(x: string) #"hi {{x}}"#`, "template_string"},
+		{"template_string equals", `template_string B(x: string) = #"hi {{x}}"#`, "template_string"},
+		{"string_template alias", `string_template C(x: string) #"hi {{x}}"#`, "string_template"},
+		{"string_template alias equals", `string_template D(x: string) = #"hi {{x}}"#`, "string_template"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := mustParse(t, tc.src)
+			var tb *TemplateBlock
+			for _, it := range f.Items {
+				if it.Template != nil {
+					tb = it.Template
+				}
+			}
+			if tb == nil {
+				t.Fatalf("template not captured; items: %+v", f.Items)
+			}
+			if tb.Keyword != tc.keyword {
+				t.Errorf("Keyword = %q, want %q", tb.Keyword, tc.keyword)
+			}
+			if tb.HasUnsupportedBody {
+				t.Errorf("HasUnsupportedBody = true for a raw body")
+			}
+			if tb.Body == nil || *tb.Body != "hi {{x}}" {
+				t.Errorf("Body = %v, want %q", tb.Body, "hi {{x}}")
+			}
+			if len(tb.Args) != 1 || tb.Args[0].Name != "x" || renderType(tb.Args[0].Type) != "string" {
+				t.Errorf("Args = %+v, want [x: string]", tb.Args)
+			}
+		})
+	}
+}
+
+func TestParse_TemplateBareAndTypedArgs(t *testing.T) {
+	// Mixed bare (no `:type`) and typed named args; a bare arg has Type == nil.
+	src := `template_string T(a, b: string, c) #"body"#`
+	f := mustParse(t, src)
+	tb := findTemplate(f, "T")
+	if tb == nil {
+		t.Fatalf("template T missing")
+	}
+	if len(tb.Args) != 3 {
+		t.Fatalf("want 3 args, got %d: %+v", len(tb.Args), tb.Args)
+	}
+	if tb.Args[0].Name != "a" || tb.Args[0].Type != nil {
+		t.Errorf("arg[0] = %+v, want bare 'a'", tb.Args[0])
+	}
+	if tb.Args[1].Name != "b" || renderType(tb.Args[1].Type) != "string" {
+		t.Errorf("arg[1] = %+v, want 'b: string'", tb.Args[1])
+	}
+	if tb.Args[2].Name != "c" || tb.Args[2].Type != nil {
+		t.Errorf("arg[2] = %+v, want bare 'c'", tb.Args[2])
+	}
+	if tb.Body == nil || *tb.Body != "body" {
+		t.Errorf("Body = %v, want %q", tb.Body, "body")
+	}
+}
+
+func TestParse_TemplateEmptyBody(t *testing.T) {
+	// An empty raw body is a non-nil pointer to the empty string, distinct from
+	// a nil (absent / brace-tolerated) body.
+	src := `template_string Empty() #""#`
+	f := mustParse(t, src)
+	tb := findTemplate(f, "Empty")
+	if tb == nil {
+		t.Fatalf("template Empty missing")
+	}
+	if tb.Body == nil {
+		t.Fatalf("Body nil; an empty raw body must be a non-nil empty string")
+	}
+	if *tb.Body != "" {
+		t.Errorf("Body = %q, want empty string", *tb.Body)
+	}
+	if tb.HasUnsupportedBody {
+		t.Errorf("HasUnsupportedBody = true for a valid (empty) raw body")
+	}
+}
+
+func TestParse_TemplateMultiHashBody(t *testing.T) {
+	// A multi-hash template body retains an embedded `"#` sequence verbatim,
+	// with tabs preserved, and the following declaration still parses.
+	src := "template_string M() ##\"line\t\"# still inside\"##\nclient<llm> After { provider openai }\n"
+	f := mustParse(t, src)
+	tb := findTemplate(f, "M")
+	if tb == nil {
+		t.Fatalf("template M missing")
+	}
+	if tb.Body == nil || *tb.Body != "line\t\"# still inside" {
+		t.Errorf("Body = %v, want %q", tb.Body, "line\t\"# still inside")
+	}
+	if findClient(f, "After") == nil {
+		t.Errorf("client After not found after multi-hash template")
+	}
+}
+
+func TestParse_TemplateBraceBodyTolerated(t *testing.T) {
+	// The historical brace-bodied template form is tolerated for parser
+	// recovery but marked HasUnsupportedBody with a nil Body — never fabricated
+	// into a string — and the following declaration still parses.
+	src := `
+template_string Braced(x: string) {
+    this is { not } a raw body
+}
+
+client<llm> After { provider openai }
+`
+	f := mustParse(t, src)
+	tb := findTemplate(f, "Braced")
+	if tb == nil {
+		t.Fatalf("template Braced missing")
+	}
+	if !tb.HasUnsupportedBody {
+		t.Errorf("HasUnsupportedBody = false for a brace body")
+	}
+	if tb.Body != nil {
+		t.Errorf("Body = %q; a brace body must not be fabricated into a string", *tb.Body)
+	}
+	if len(tb.Args) != 1 || tb.Args[0].Name != "x" {
+		t.Errorf("Args = %+v, want [x: string]", tb.Args)
+	}
+	if findClient(f, "After") == nil {
+		t.Errorf("client After not found after brace-bodied template")
+	}
+}
+
+func TestParse_TemplateDollarIdentArg(t *testing.T) {
+	// FIX-EVENTUALLY (#586): the widened Ident admits a leading `$`, so a
+	// dollar-prefixed argument name lexes as a single Ident token rather than
+	// splitting into `$` + name.
+	src := `template_string D($input: string) #"{{ $input }}"#`
+	f := mustParse(t, src)
+	tb := findTemplate(f, "D")
+	if tb == nil {
+		t.Fatalf("template D missing")
+	}
+	if len(tb.Args) != 1 || tb.Args[0].Name != "$input" {
+		t.Fatalf("Args = %+v, want single arg $input", tb.Args)
+	}
+}
+
+func TestParse_TemplateSourceOrderAcrossFiles(t *testing.T) {
+	// Multiple macros retain File.Items source order within a file; iterating
+	// parsed files in order then File.Items in order yields a stable macro
+	// sequence — the ordering the descriptor slice relies on, never lexical.
+	fileA := `
+template_string A1() #"a1"#
+template_string A2() #"a2"#
+`
+	fileB := `
+template_string B1() #"b1"#
+`
+	fa := mustParse(t, fileA)
+	fb := mustParse(t, fileB)
+	var order []string
+	for _, src := range []*File{fa, fb} {
+		for _, it := range src.Items {
+			if it.Template != nil {
+				order = append(order, it.Template.Name)
+			}
+		}
+	}
+	want := []string{"A1", "A2", "B1"}
+	if len(order) != len(want) {
+		t.Fatalf("macro order = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("macro order = %v, want %v", order, want)
+		}
 	}
 }

--- a/bamlutils/bamlparser/typeparse_test.go
+++ b/bamlutils/bamlparser/typeparse_test.go
@@ -1053,12 +1053,16 @@ class C {
 // -----------------------------------------------------------------------
 
 func TestLexer_MultiHashRawString(t *testing.T) {
-	// A double-hash raw string can embed a `"#` sequence verbatim.
+	// A double-hash raw string can embed a `"#` sequence verbatim, both in a
+	// function prompt (Field.Raw + the PromptRaw projection) and in a retained
+	// template body (TemplateBlock.Body).
 	src := `
 function F(x: string) -> string {
     client C
     prompt ##"contains "# inside"##
 }
+
+template_string M(x: string) ##"body "# still"##
 `
 	f := mustParse(t, src)
 	fn := findFunction(f, "F")
@@ -1071,6 +1075,18 @@ function F(x: string) -> string {
 	}
 	if *pr.Value.Raw != `contains "# inside` {
 		t.Errorf("multi-hash raw content = %q, want %q", *pr.Value.Raw, `contains "# inside`)
+	}
+	// The PromptRaw projection keeps the embedded quote-hash text too.
+	if fn.PromptRaw == nil || *fn.PromptRaw != `contains "# inside` {
+		t.Errorf("PromptRaw = %v, want %q", fn.PromptRaw, `contains "# inside`)
+	}
+	// The retained template body keeps its embedded quote-hash text.
+	tb := findTemplate(f, "M")
+	if tb == nil {
+		t.Fatalf("template M not parsed")
+	}
+	if tb.Body == nil || *tb.Body != `body "# still` {
+		t.Errorf("template Body = %v, want %q", tb.Body, `body "# still`)
 	}
 }
 

--- a/internal/nativeprompt/template_test.go
+++ b/internal/nativeprompt/template_test.go
@@ -29,15 +29,16 @@ func TestDynamicTemplateDriftGuard(t *testing.T) {
 		if item.Function == nil || item.Function.Name != "Baml_Rest_Dynamic" {
 			continue
 		}
-		for _, f := range item.Function.Fields {
-			if f.Key == "prompt" && f.Value != nil {
-				promptRaw = f.Value.Raw
-			}
-		}
+		// Read the dedicated PromptRaw projection (P1 slice 1, #586) rather than
+		// reaching through the generic ordered Fields. PromptRaw is the final
+		// source-ordered prompt field's raw body with only the raw-string
+		// delimiters removed (no dedent/trim), which is exactly what this drift
+		// guard needs.
+		promptRaw = item.Function.PromptRaw
 	}
 
 	if promptRaw == nil {
-		t.Fatal("Baml_Rest_Dynamic prompt field not found in cmd/build/dynamic.baml")
+		t.Fatal("Baml_Rest_Dynamic prompt (PromptRaw) not found in cmd/build/dynamic.baml")
 	}
 	if *promptRaw != rawDynamicPrompt {
 		t.Errorf("dynamic prompt drift: the checked-in template no longer matches rawDynamicPrompt.\n--- parsed ---\n%q\n--- constant ---\n%q", *promptRaw, rawDynamicPrompt)


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## de-BAML Phase 1, Slice 1 — parser retention only

Extends baml-rest's own native parser (`bamlutils/bamlparser`) to **retain** static prompt/template representation. This is representation-only: config extraction is byte-for-byte unchanged, and there is **no serving/codegen change** (no descriptor builder, no `cmd/introspect` output change, no request-path consumer). Slice 2 (the build-only prompt descriptor sidecar) is intentionally out of scope.

### What changed

**`FunctionBlock`** gains a semantic projection of the prompt field:
- `PromptRaw *string` and `HasPrompt bool`, filled during post-parse normalization by scanning the already-normalized `Fields` in source order and taking the **final** `prompt` field (last-field-wins, matching BAML).
- A final **non-raw** prompt sets `HasPrompt` but leaves `PromptRaw` nil — an earlier raw prompt is never resurrected.
- The ordered `Fields` slice is untouched and remains the lossless record.

**`TemplateBlock`** replaces the name-only node with retained data:
- `Keyword` (`template_string` or the tolerated `string_template` alias, retained spelling), `Name`, `Args` (`[]*Param` via the shared `parseParamList` — typed and bare args), `Body` (`*string`, raw-string delimiters removed via `stripRawString` **only** — no dedent/trim/unescape), and `HasUnsupportedBody`.
- An empty raw body (`#""#`) is a non-nil pointer to the empty string.
- The historical brace-body form is balanced-skipped for recovery, marked `HasUnsupportedBody`, and **never** fabricated into a `Body` string.

**Grammar/lexer:** reuses the existing participle field grammar + RawString lexer (no Jinja grammar, no hand-rolled block parser). The `Ident` rule is widened for BAML's optional leading `$`, and `string_template` is added to the top-level-keyword stop set.

**Drift guard:** `internal/nativeprompt`'s dynamic-template drift guard now reads `FunctionBlock.PromptRaw` instead of reaching through generic `Fields`. It stays test-only.

### Laxer-than-BAML choices (logged)

Native must never out-claim BAML. Each of the following is deliberately laxer than BAML (which gates invalid input at build), carries a `FIX-EVENTUALLY (#586)` code comment, and is logged on issue #586: the `string_template` alias, the optional leading-`$` identifier, the optional `=` before the template body, and the brace-body tolerance. **No grammar-parity claim is made** — only v0.222 is present in the module cache (non-authoritative); a build-only v0.223 acceptance fixture remains the intended merge guard before any parity claim.

### Tests

Upgraded the existing prompt/raw/template parser tests to assert the dedicated fields, and added coverage for: exact-body (the real `cmd/build/dynamic.baml` prompt, byte-equal after delimiter removal), typed + bare template args, optional-equals, both keyword spellings, multi-hash bodies (function prompt + template body), empty body, CRLF/tabs/blank-line no-trim/no-dedent, last-field-wins (with a final non-raw prompt declining), the brace-tolerated case, and multi-file macro source ordering.

### Validation

- `gofmt` clean; `go build ./...`; `go vet ./...` (+ `-tags=integration`) — no new issues (only pre-existing participle struct-tag warnings).
- `go test ./bamlutils/bamlparser ./internal/nativeschema ./cmd/introspect ./internal/nativeprompt` — all pass.
- Config parser golden suite (`TestBamlConfigGoldens`) byte-identical.
- `go run ./cmd/embed` then `go run ./cmd/regenerate-dynclient` — no manifest/generated diff.
- `(cd workerplugin && GOWORK=off go test ./... -count=1)` — pass.
- `go build ./cmd/introspect` (package-form) — OK.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parser now exposes raw function prompts via dedicated prompt metadata, using last-prompt-wins while preserving the full original fields order.
  * Template parsing now retains richer template details (keyword, name, args, raw body) and flags unsupported body formats, including correct handling for empty and multi-hash raw strings.
  * Expanded template syntax support (keyword aliasing, optional assignment, and `$`-prefixed identifier args).

* **Bug Fixes**
  * Prevented template declarations from being consumed during type-related scanning.
  * Improved tolerance for legacy brace-bodied templates.

* **Tests**
  * Expanded prompt/body retention, template parsing, ordering, and edge-case coverage (including dynamic prompt drift checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->