### PR TITLE
debaml(ffi): migrate gated nanollm Prepare/differential lane to public nanollm-ffi v0.3.2

### DIFF
--- a/.embedignore
+++ b/.embedignore
@@ -55,11 +55,14 @@ internal/schema/outputformat/testdata
 # unchanged, mirroring internal/schema/outputformat/testdata above.
 internal/nativeprompt/testdata/static_oracle
 
-# de-BAML Phase 4b gated nanollm Prepare validation: a SEPARATE, test-only Go
-# module (github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare)
-# excluded from go.work so the PRIVATE github.com/viktordanov/nanollm/go
-# dependency stays out of the root/default module graph. It carries a nanollm
-# require + a doubly build-tagged _test.go and is never a customer-build input.
+# de-BAML Phase 4b + 5.1 gated nanollm Prepare validation: a SEPARATE, test-only
+# Go module (github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare)
+# excluded from go.work so the PUBLIC github.com/viktordanov/nanollm-ffi/go
+# dependency — a cgo module that embeds + links a prebuilt Rust archive — stays
+# out of the root/default module graph. It carries a nanollm-ffi require + build-
+# tagged _test.go files gated by nanollm_integration (and integration &&
+# nanollm_integration for the P5 differential legs), and is never a customer-build
+# input.
 # Excluded here so cmd/embed does NOT discover it as an embeddable module (which
 # would add a nanollmprepare import + Sources loop to the root embed.go manifest
 # AND generate a nested embed.go), keeping the root embed manifest unchanged —

--- a/.github/workflows/nanollm-prepare.yml
+++ b/.github/workflows/nanollm-prepare.yml
@@ -1,7 +1,8 @@
 name: nanollm Prepare (gated)
 
 # De-BAML Phase 4b + Phase 5.1: gated, no-send nanollm OpenAI Prepare validation
-# AND the OpenAI prepared-request differential vs BAML.
+# AND the OpenAI prepared-request differential vs BAML, now against the PUBLIC
+# github.com/viktordanov/nanollm-ffi/go module.
 #
 # Phase 4b proves the EXACT, already-BAML-byte-proven Phase-4a canonical OpenAI
 # chat-completions body (internal/nativebody.BuildOpenAIChat) is ACCEPTED and
@@ -18,27 +19,29 @@ name: nanollm Prepare (gated)
 # A BAML-free comparator (nanollmprepare/testutil) normalizes both legs; it
 # NEVER imports either BAML runtime. Still NO HTTPRequest / Do / DoStream / send.
 #
-# It links nanollm's Rust FFI archive via the `nanollm_prebuilt` build tag
-# against a provenance-pinned prebuilt RELEASE bundle and runs the triply-gated
-# `//go:build integration && nanollm_prebuilt && nanollm_integration` tests. The
+# The public nanollm-ffi module EMBEDS its prebuilt Rust FFI archive per-platform
+# and selects it automatically (go/internal/ffi/link_embedded.go): there is NO
+# release-bundle download, NO nanollm_prebuilt tag, and NO CGO_CFLAGS/CGO_LDFLAGS
+# — only ordinary cgo (CGO_ENABLED=1 + the runner's stock C toolchain). It runs
+# the doubly-gated `//go:build integration && nanollm_integration` tests. The
 # `integration` tag makes the BAML CFFI dependency of both legs explicit; each
 # BAML runtime is pre-provisioned and version-checked below so a fresh runner
 # never surprise-downloads a CFFI during the no-send test.
 #
 # The gated tests + their nanollm dependency live in a SEPARATE, test-only module
 # (internal/nativebody/nanollmprepare) that is EXCLUDED from go.work, so the
-# PRIVATE github.com/viktordanov/nanollm dependency is entirely absent from the
-# root/default module graph. A cold, credential-less `go build ./...` /
-# `go test ./...` (no tags) never resolves, fetches, or compiles nanollm — that
-# module and this job are the only places it appears. (Stock BAML is a normal
-# public dependency already pinned by the root; the module pins it too.)
+# public nanollm-ffi dependency — a cgo package that links a substantial Rust
+# static archive — is entirely absent from the root/default module graph. A cold
+# `go build ./...` / `go test ./...` (no tags) never resolves, fetches, or
+# compiles nanollm, cgo, or a C toolchain — that module and this job are the only
+# places it appears. (Stock BAML is a normal public dependency already pinned by
+# the root; the module pins it too.)
 #
-# DELIBERATELY SEPARATE and NON-BLOCKING: it is its own workflow, NOT part of
-# the default required check matrix (Unit Tests / Integration Tests). nanollm is
-# a PRIVATE cross-repo module, so this job needs a PAT with read access to that
-# repo — supplied as the NANOLLM_FFI_TOKEN secret. When the secret is absent
-# (forks, or an unconfigured repo) every substantive step skips cleanly and the
-# job is a green no-op, so nanollm availability NEVER blocks the normal build.
+# REQUIRED-READY public check: it needs NO secret, its module is
+# proxy/sumdb-resolvable, and the committed Linux archive makes fork-PR execution
+# equivalent to internal-PR execution. It runs on every push to master and every
+# pull_request (including forks). After its first green public-module run, the
+# repo owner should enable it as a required status check in branch protection.
 
 on:
   push:
@@ -49,26 +52,18 @@ concurrency:
   group: nanollm-prepare-${{ github.ref }}
   cancel-in-progress: true
 
-# Least privilege: read the repo; the private cross-repo release asset + module
-# are fetched with NANOLLM_FFI_TOKEN, not the workflow GITHUB_TOKEN.
+# Least privilege: read-only checkout. The public nanollm-ffi module + its
+# committed prebuilt archive are fetched from the Go proxy/sumdb — no token, no
+# cross-repo credential.
 permissions:
   contents: read
 
 env:
   GO_VERSION: "1.26.5"
-  # --- Phase-4b provenance pins ---
-  # The nanollm Go module version; must match the root go.mod require.
-  NANOLLM_GO_VERSION: "v0.3.0"
-  # The ffi prebuilt RELEASE tag whose bundle links the CGO archive
-  # (ffi/v0.3.0, 2026-07-10, post-Converse — the latest release).
-  NANOLLM_FFI_TAG: "ffi/v0.3.0"
-  # Per-target bundle for the Linux x64 CI runner (macOS ARM devs use
-  # libnanollm_ffi-aarch64-apple-darwin.tar.gz locally).
-  NANOLLM_FFI_TARGET: "x86_64-unknown-linux-gnu"
-  # Pinned sha256 of libnanollm_ffi-x86_64-unknown-linux-gnu.tar.gz for
-  # ffi/v0.3.0. Asserted against the release's published .sha256, then the
-  # downloaded bundle is verified against it.
-  NANOLLM_FFI_SHA256: "bfec52d66c2c2580a5a98857a76571170919342e0abfb55280586d5b9f409fdc"
+  # The PUBLIC nanollm-ffi Go module version; must match the test module's
+  # go.mod require. The module embeds + links its prebuilt Rust FFI archive
+  # per-platform, so there is no separate release-bundle tag to pin.
+  NANOLLM_GO_VERSION: "v0.3.2"
   # The stock BAML runtime version both differential legs must load (Phase 5.1).
   # The dynamic leg links the PATCHED runtime (dynclient/baml-patched) and the
   # static leg links stock github.com/boundaryml/baml — both are v0.223.0-based.
@@ -80,47 +75,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      # Job-level so each step's own `if:` can gate on it — secrets.* can't be
-      # referenced directly in a step `if:` (same pattern as
-      # integration-tests.yml's Docker Hub login). A PAT with read access to the
-      # private viktordanov/nanollm repo (the Go module AND the ffi release
-      # assets). Absent on forks / when unset -> the job skips cleanly.
-      NANOLLM_FFI_TOKEN: ${{ secrets.NANOLLM_FFI_TOKEN }}
+      # cgo is a hard prerequisite of the public nanollm-ffi package (it links a
+      # prebuilt Rust static archive). Assert it explicitly — this is the default
+      # cgo setting, NOT a custom artifact/link configuration. There are no
+      # CGO_CFLAGS/CGO_LDFLAGS: the module supplies its own embedded linkage.
+      CGO_ENABLED: "1"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7.0.0
-
-      - name: Note skip (no NANOLLM_FFI_TOKEN)
-        if: ${{ env.NANOLLM_FFI_TOKEN == '' }}
-        run: |
-          echo "NANOLLM_FFI_TOKEN is not set (fork or unconfigured repo)."
-          echo "Skipping the gated nanollm Prepare validation — this job is"
-          echo "advisory and never blocks the default build."
+        with:
+          # Fork-safe, de-secreted lane: it runs PR-supplied Go build/test but
+          # performs NO authenticated Git operation — the public module fetch is
+          # via GOPROXY and the sibling `replace` targets are local in-repo paths,
+          # neither of which needs git credentials. Don't leave GITHUB_TOKEN in
+          # .git/config. Code is still checked out; only the stored token is
+          # dropped.
+          persist-credentials: false
 
       - name: Set up Go
-        if: ${{ env.NANOLLM_FFI_TOKEN != '' }}
         uses: actions/setup-go@v6.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Configure private module access
-        if: ${{ env.NANOLLM_FFI_TOKEN != '' }}
-        run: |
-          # nanollm/go is a PRIVATE cross-repo module: resolve it via direct git
-          # with the PAT, and keep it off the public proxy/sumdb (GOPRIVATE). The
-          # module zip + go.mod hashes are pinned in the separate test module's
-          # committed go.sum; this only supplies the fetch credential.
-          #
-          # Scope the credential-bearing rewrite to the viktordanov ORG prefix,
-          # NOT the whole github.com host — the PAT must reach only the private
-          # nanollm fetch, never any unrelated direct github.com fetch.
-          echo "GOPRIVATE=github.com/viktordanov/*" >> "$GITHUB_ENV"
-          git config --global \
-            url."https://x-access-token:${NANOLLM_FFI_TOKEN}@github.com/viktordanov/".insteadOf \
-            "https://github.com/viktordanov/"
-
-      - name: Assert module pins (nanollm @ v0.3.0, stock BAML @ v0.223.0) + zero-root-nanollm
-        if: ${{ env.NANOLLM_FFI_TOKEN != '' }}
+      - name: Assert module pins (nanollm-ffi @ v0.3.2, stock BAML @ v0.223.0) + zero-root-nanollm
         run: |
           set -euo pipefail
           gomod=internal/nativebody/nanollmprepare/go.mod
@@ -133,64 +110,55 @@ jobs:
             local esc; esc="$(printf '%s' "$2" | sed 's/[.]/\\./g')"
             grep -qE "(^|[[:space:]])$1[[:space:]]+${esc}([[:space:]]|\$)" "$gomod"
           }
-          # Provenance: the linked FFI must match the required module version.
-          # nanollm is required ONLY by the separate test-only module, never the
-          # root — the root go.mod must have zero nanollm reference.
-          exact_pin "github.com/viktordanov/nanollm/go" "${NANOLLM_GO_VERSION}" \
-            || { echo "test module does not pin nanollm/go at exactly ${NANOLLM_GO_VERSION}"; exit 1; }
+          # The PUBLIC nanollm-ffi module is required ONLY by the separate test-only
+          # module, never the root — the root go.mod must have zero nanollm reference.
+          exact_pin "github.com/viktordanov/nanollm-ffi/go" "${NANOLLM_GO_VERSION}" \
+            || { echo "test module does not pin nanollm-ffi/go at exactly ${NANOLLM_GO_VERSION}"; exit 1; }
           # Phase 5.1: the static differential leg links the STOCK BAML module, so
           # the test-only module must pin it at exactly v0.223.0 (its loaded CFFI
           # is version-checked by TestBAMLVersionPinned at runtime).
           exact_pin "github.com/boundaryml/baml" "${NANOLLM_BAML_VERSION}" \
             || { echo "test module does not pin boundaryml/baml at exactly ${NANOLLM_BAML_VERSION}"; exit 1; }
+          # Default-build isolation: the root must reference NEITHER the old
+          # nanollm nor the new nanollm-ffi module path (the prefix matches both).
           if grep -q "github.com/viktordanov/nanollm" go.mod go.sum; then
             echo "root go.mod/go.sum must NOT reference nanollm (default-build isolation)"; exit 1
           fi
 
-      - name: Fetch + verify ffi/v0.3.0 prebuilt bundle
-        if: ${{ env.NANOLLM_FFI_TOKEN != '' }}
-        env:
-          GH_TOKEN: ${{ env.NANOLLM_FFI_TOKEN }}
+      - name: Clean public-install smoke (scratch module, no flags)
         run: |
           set -euo pipefail
-          bundle="libnanollm_ffi-${NANOLLM_FFI_TARGET}.tar.gz"
-          work="$RUNNER_TEMP/nanollm-ffi"
+          # Prove the PUBLIC module installs AND LINKS from a clean scratch module
+          # that only blank-imports it — with NO token, replace, manual .a,
+          # CGO_CFLAGS/CGO_LDFLAGS, or nanollm_prebuilt tag. A successful `go build`
+          # exercises the committed embedded archive path (not merely module
+          # resolution). This is the Linux/AMD64 complement to the scope's
+          # Darwin/ARM64 packaging check; cgo (CGO_ENABLED=1) is the only prereq.
+          work="$RUNNER_TEMP/nanollm-smoke"
           mkdir -p "$work"
           cd "$work"
+          cat > main.go <<'EOF'
+          package main
 
-          # 1. Download the pinned release bundle + its published checksum.
-          gh release download "$NANOLLM_FFI_TAG" --repo viktordanov/nanollm \
-            --pattern "$bundle" --pattern "$bundle.sha256" --clobber
+          import _ "github.com/viktordanov/nanollm-ffi/go"
 
-          # 2. Provenance pin: the release's published checksum must equal the
-          #    sha256 pinned in this workflow. A re-cut release with different
-          #    bytes fails here rather than silently linking new code.
-          published="$(awk '{print $1}' "$bundle.sha256")"
-          if [ "$published" != "$NANOLLM_FFI_SHA256" ]; then
-            echo "published sha256 ($published) != pinned ($NANOLLM_FFI_SHA256)" >&2
-            exit 1
-          fi
+          func main() {}
+          EOF
+          go mod init nanollm-ffi-smoke
+          go get "github.com/viktordanov/nanollm-ffi/go@${NANOLLM_GO_VERSION}"
+          go build
 
-          # 3. Integrity: the downloaded bundle must hash to that checksum.
-          sha256sum -c "$bundle.sha256"
-
-          # 4. Unpack the three-file bundle (libnanollm_ffi.a, nanollm.h,
-          #    native-static-libs.txt) and export the prebuilt CGO linkage per
-          #    nanollm go/README.md "Using a prebuilt artifact".
-          mkdir -p lib
-          tar -xzf "$bundle" -C lib
-          # Collapse native-static-libs.txt to a SINGLE line: GITHUB_ENV is
-          # line-oriented, so any embedded newline in the libs file would emit
-          # multiple malformed records and break the CGO_LDFLAGS value.
-          native_libs="$(tr '\n' ' ' < lib/native-static-libs.txt | tr -s ' ' | sed 's/ *$//')"
-          {
-            echo "CGO_ENABLED=1"
-            echo "CGO_CFLAGS=-I$work/lib"
-            echo "CGO_LDFLAGS=$work/lib/libnanollm_ffi.a $native_libs"
-          } >> "$GITHUB_ENV"
+      - name: Resolve test-module dependencies (ordinary, pinned)
+        run: |
+          set -euo pipefail
+          # Ordinary dependency resolution for the checked-in test module: its
+          # nanollm-ffi require is already pinned in go.mod/go.sum, so download it
+          # with GOWORK=off (the module's own go.mod is authoritative). Do NOT run
+          # `go get` here — that would mutate the checked-in pin.
+          cd internal/nativebody/nanollmprepare
+          GOWORK=off go mod download
 
       - name: Pre-provision + version-check both BAML CFFI runtimes
-        if: ${{ env.NANOLLM_FFI_TOKEN != '' }}
         run: |
           set -euo pipefail
           # Phase 5.1 crosses BOTH the stock BAML (static leg) and the patched
@@ -210,27 +178,27 @@ jobs:
           # Static leg: version-check the loaded stock CFFI AND warm it with a real
           # request build (a completion row builds a BAML HTTPRequest).
           BAML_CACHE_DIR="$cache" GOWORK=off go test \
-            -tags "integration nanollm_prebuilt nanollm_integration" \
+            -tags "integration nanollm_integration" \
             -count=1 -run 'TestBAMLVersionPinned|TestStaticPreparedRequestParity/StaticCompletion/ascii' ./static/
           # Dynamic leg: warm the patched runtime with one real captured request.
           BAML_CACHE_DIR="$cache" GOWORK=off go test \
-            -tags "integration nanollm_prebuilt nanollm_integration" \
+            -tags "integration nanollm_integration" \
             -count=1 -run 'TestDynamicPreparedRequestParity/single_user_message' ./dynamic/
 
       - name: Run gated nanollm prepared-request differential (no send)
-        if: ${{ env.NANOLLM_FFI_TOKEN != '' }}
         run: |
-          # Triply gated: `integration` makes the BAML CFFI dependency explicit,
-          # nanollm_prebuilt selects the prebuilt CGO linkage, nanollm_integration
-          # opts the tests in. No send / no HTTPRequest / no Do/DoStream — Prepare
-          # + BAML request capture only. Runs inside the SEPARATE test module with
-          # GOWORK=off so its go.mod (the only one that requires nanollm) is the
-          # build list — the workspace/root never sees nanollm. `go test ./...`
-          # runs each package's test binary as a SEPARATE PROCESS, so the stock
-          # and patched BAML runtimes never share an address space. Downloads are
-          # DISABLED: the CFFIs were pre-provisioned above, so a fresh runner
-          # cannot silently fetch a runtime mid-test.
+          # Doubly gated: `integration` makes the BAML CFFI dependency explicit and
+          # `nanollm_integration` opts the tests in. The public nanollm-ffi module
+          # embeds + links its prebuilt CGO archive automatically — no
+          # nanollm_prebuilt tag, no CGO_CFLAGS/CGO_LDFLAGS. No send / no HTTPRequest
+          # / no Do/DoStream — Prepare + BAML request capture only. Runs inside the
+          # SEPARATE test module with GOWORK=off so its go.mod (the only one that
+          # requires nanollm) is the build list — the workspace/root never sees
+          # nanollm. `go test ./...` runs each package's test binary as a SEPARATE
+          # PROCESS, so the stock and patched BAML runtimes never share an address
+          # space. Downloads are DISABLED: the CFFIs were pre-provisioned above, so
+          # a fresh runner cannot silently fetch a runtime mid-test.
           cd internal/nativebody/nanollmprepare
           BAML_LIBRARY_DISABLE_DOWNLOAD=true GOWORK=off go test \
-            -tags "integration nanollm_prebuilt nanollm_integration" \
+            -tags "integration nanollm_integration" \
             -count=1 -v ./...

--- a/.github/workflows/renovate-sync.yml
+++ b/.github/workflows/renovate-sync.yml
@@ -79,10 +79,13 @@ jobs:
           # populate-then-validate sequence is identical on both passes.
           # internal/nativebody/nanollmprepare is excluded for the same reason
           # as dynclient/baml-patched: it's a SEPARATE, test-only module
-          # outside go.work (de-BAML Phase 4b), so a workspace-mode `go list`
-          # here fails, and forcing GOWORK=off would load its PRIVATE nanollm
-          # require with no credential. It carries no Renovate-managed public
-          # deps that need workspace-checksum population.
+          # outside go.work (de-BAML Phase 4b + 5.1), so a workspace-mode
+          # `go list` here fails, and it is cgo/platform-bound. Its public
+          # nanollm-ffi dependency (github.com/viktordanov/nanollm-ffi/go@v0.3.2),
+          # like the module's other direct requires, is pinned in its own
+          # go.mod/go.sum where Renovate tracks it; because the module is outside
+          # go.work its checksums never enter go.work.sum, so it needs no
+          # workspace-checksum population here.
           populate_workspace_checksums() {
             find . -name go.mod -not -path '*/adapters/adapter_*' -not -path '*/dynclient/baml-patched/*' -not -path '*/internal/nativebody/nanollmprepare/*' -exec dirname {} \; | while read -r dir; do
               if [ "$dir" = "./adapters/common" ]; then

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -72,14 +72,17 @@ jobs:
           #
           # internal/nativebody/nanollmprepare is skipped for the same
           # workspace-membership reason: it's a SEPARATE, test-only module
-          # (de-BAML Phase 4b) deliberately excluded from go.work so its
-          # PRIVATE github.com/viktordanov/nanollm/go dependency stays out of
+          # (de-BAML Phase 4b + 5.1) deliberately excluded from go.work so its
+          # PUBLIC github.com/viktordanov/nanollm-ffi/go dependency — a cgo
+          # module that embeds + links a prebuilt Rust archive — stays out of
           # the default module graph (see its go.mod). Running its `./...`
           # here would fail ("directory prefix . does not contain modules
-          # listed in go.work"), and forcing GOWORK=off would load the
-          # private nanollm require with no credential. Its SOLE execution is
-          # the gated, credentialed nanollm-prepare.yml (GOWORK=off + the
-          # prebuilt ffi bundle) — nanollm must never block normal CI.
+          # listed in go.work"), and it is cgo/platform-bound, so it does not
+          # belong in this pure-Go loop. Its SOLE execution is the gated
+          # nanollm-prepare.yml (GOWORK=off, NO secret/credential and NO release
+          # bundle — the public module is proxy/sumdb-resolvable and self-links
+          # its embedded archive), which now runs unconditionally on every PR
+          # incl. forks — nanollm must never block normal CI.
           find . -name go.mod -not -path '*/adapters/adapter_*' -not -path '*/dynclient/baml-patched/*' -not -path '*/internal/nativebody/nanollmprepare/*' -exec dirname {} \; | while read dir; do
             echo "=== Testing $dir ==="
             if [ "$dir" = "./adapters/common" ]; then

--- a/internal/nativebody/nanollmprepare/doc.go
+++ b/internal/nativebody/nanollmprepare/doc.go
@@ -1,10 +1,12 @@
 // Package nanollmprepare holds the de-BAML Phase 4b gated, no-send nanollm
-// OpenAI Prepare validation. The actual proof lives in the doubly build-tagged
-// nanollm_integration_test.go (`nanollm_prebuilt && nanollm_integration`); this
-// file exists only so the package always has a non-test source file (so tooling
-// never sees an empty package when the tags are off).
+// OpenAI Prepare validation. The actual proof lives in the build-tagged
+// nanollm_integration_test.go (`nanollm_integration`); this file exists only so
+// the package always has a non-test source file (so tooling never sees an empty
+// package when the tag is off).
 //
 // This package is a SEPARATE, test-only module (see go.mod) that is NOT part of
-// the workspace, exactly so the private nanollm dependency stays out of the
-// root/default module graph. Nothing in the default build imports it.
+// the workspace, exactly so the public github.com/viktordanov/nanollm-ffi/go
+// dependency — a cgo package that embeds and links a prebuilt Rust FFI archive —
+// stays out of the root/default module graph. Nothing in the default build
+// imports it.
 package nanollmprepare

--- a/internal/nativebody/nanollmprepare/dynamic/doc.go
+++ b/internal/nativebody/nanollmprepare/dynamic/doc.go
@@ -3,13 +3,13 @@
 // request BAML v0.223 builds through baml-rest's PATCHED runtime (dynclient), for
 // every Phase-4a-admitted dynamic fixture — test-only, no send, gated.
 //
-// The proof lives in the triply build-tagged
+// The proof lives in the doubly build-tagged
 // prepared_request_integration_test.go
-// (`integration && nanollm_prebuilt && nanollm_integration`); this file exists
-// only so the package always has a non-test source file when the tags are off
-// (so `go build ./...` never sees an empty package). Nothing in the default build
-// imports it — the whole nanollmprepare module is outside go.work and carries the
-// only nanollm dependency.
+// (`integration && nanollm_integration`); this file exists only so the package
+// always has a non-test source file when the tags are off (so `go build ./...`
+// never sees an empty package). Nothing in the default build imports it — the
+// whole nanollmprepare module is outside go.work and carries the only nanollm
+// dependency (the public, cgo nanollm-ffi module).
 //
 // It links baml-rest's patched BAML runtime (via dynclient/baml-patched) and must
 // NEVER share a binary with the stock-BAML static leg (../static); keeping the two

--- a/internal/nativebody/nanollmprepare/dynamic/prepared_request_integration_test.go
+++ b/internal/nativebody/nanollmprepare/dynamic/prepared_request_integration_test.go
@@ -1,4 +1,4 @@
-//go:build integration && nanollm_prebuilt && nanollm_integration
+//go:build integration && nanollm_integration
 
 package dynamic
 
@@ -34,8 +34,9 @@ package dynamic
 //     retry budget; the plan is unsigned (SignedAt/ExpiresAt nil, !Expired()).
 //
 // Runs in the SEPARATE, go.work-excluded nanollmprepare module; links the patched
-// BAML runtime (dynclient/baml-patched) and nanollm's Rust FFI, and must never
-// share a binary with the stock-BAML static leg (../static).
+// BAML runtime (dynclient/baml-patched) and the public nanollm-ffi module's
+// automatically-selected embedded Rust FFI archive, and must never share a binary
+// with the stock-BAML static leg (../static).
 
 import (
 	"bytes"
@@ -55,7 +56,7 @@ import (
 	"github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare/planassert"
 	"github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare/testutil"
 	"github.com/invakid404/baml-rest/internal/nativeprompt"
-	nanollm "github.com/viktordanov/nanollm/go"
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
 )
 
 // The literal auth/environment fence (scope "Concrete auth/environment fence"),

--- a/internal/nativebody/nanollmprepare/go.mod
+++ b/internal/nativebody/nanollmprepare/go.mod
@@ -1,11 +1,14 @@
 // This is a SEPARATE, TEST-ONLY Go module for de-BAML Phase 4b's gated,
 // no-send nanollm OpenAI Prepare validation. It exists solely to keep the
-// PRIVATE github.com/viktordanov/nanollm/go dependency OUT of the root
-// module's go.mod/go.sum and out of the workspace module graph, so a cold,
-// credential-less `go build ./...` / `go test ./...` (no tags) never needs
-// nanollm at all. It is deliberately NOT a go.work member (see ../../../go.work),
-// mirroring how dynclient/baml-patched and the adapters are excluded and
-// resolved via replace directives.
+// PUBLIC github.com/viktordanov/nanollm-ffi/go dependency OUT of the root
+// module's go.mod/go.sum and out of the workspace module graph. That module is
+// public and proxy/sumdb-resolvable, but it is still a CGO package that links a
+// substantial prebuilt Rust static archive committed per-platform inside the
+// module itself, so isolating it keeps a cold `go build ./...` /
+// `go test ./...` (no tags) from ever needing nanollm, cgo, or a C toolchain.
+// It is deliberately NOT a go.work member (see ../../../go.work), mirroring how
+// dynclient/baml-patched and the adapters are excluded and resolved via replace
+// directives.
 module github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare
 
 go 1.26.5
@@ -15,7 +18,7 @@ require (
 	github.com/invakid404/baml-rest v0.0.48
 	github.com/invakid404/baml-rest/bamlutils v0.0.48
 	github.com/invakid404/baml-rest/dynclient v0.0.0-00010101000000-000000000000
-	github.com/viktordanov/nanollm/go v0.3.0
+	github.com/viktordanov/nanollm-ffi/go v0.3.2
 	golang.org/x/mod v0.37.0
 )
 

--- a/internal/nativebody/nanollmprepare/go.sum
+++ b/internal/nativebody/nanollmprepare/go.sum
@@ -141,8 +141,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.72.0 h1:R7kYdoWhn1ye1fVpP+cDHDJwYm3NkwLliwgzJ/Abg7M=
 github.com/valyala/fasthttp v1.72.0/go.mod h1:zsbLTYqcpIktdQytlVBwIjY9La5d6bs990nBxWg8efk=
-github.com/viktordanov/nanollm/go v0.3.0 h1:wLF+l+rFAXBWDicraLltxZmNeLCtE1FYaoy0MbAsPrI=
-github.com/viktordanov/nanollm/go v0.3.0/go.mod h1:S/jqAtYF4jYC/5VD1aHB8yjkcNaN/V6GklE4iqzxEpw=
+github.com/viktordanov/nanollm-ffi/go v0.3.2 h1:O9U+cWBUw8zfhETJG/Xob17tLtcGyeP7cY/saSqJpZo=
+github.com/viktordanov/nanollm-ffi/go v0.3.2/go.mod h1:8XTJCU7t0yvArXD8DT1YtbA1gu4K3os/BSm34TP89VA=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/nativebody/nanollmprepare/nanollm_integration_test.go
+++ b/internal/nativebody/nanollmprepare/nanollm_integration_test.go
@@ -1,4 +1,4 @@
-//go:build nanollm_prebuilt && nanollm_integration
+//go:build nanollm_integration
 
 package nanollmprepare
 
@@ -14,25 +14,22 @@ package nanollmprepare
 // authoritative parity proof.
 //
 // It lives in a SEPARATE, test-only module (see go.mod) excluded from go.work,
-// so the private github.com/viktordanov/nanollm/go dependency stays entirely
+// so the public github.com/viktordanov/nanollm-ffi/go dependency stays entirely
 // out of the root/default module graph — a cold `go build ./...` /
-// `go test ./...` (no tags, no credentials) never needs nanollm. On top of that
-// isolation, this file is DOUBLY GATED by
-// `//go:build nanollm_prebuilt && nanollm_integration`:
+// `go test ./...` (no tags) never needs nanollm, cgo, or a C toolchain. On top
+// of that isolation, this file is GATED by `//go:build nanollm_integration`:
 //
-//   - nanollm_prebuilt selects nanollm's prebuilt-artifact CGO linkage
-//     (go/internal/ffi/link_prebuilt.go): the consumer supplies CGO_CFLAGS /
-//     CGO_LDFLAGS pointing at an unpacked, sha256-verified ffi/v0.3.0 release
-//     bundle (libnanollm_ffi.a + nanollm.h + native-static-libs.txt).
-//   - nanollm_integration additionally opts this file in.
+//   - The public nanollm-ffi module embeds its prebuilt Rust FFI archive
+//     per-platform and links it automatically
+//     (go/internal/ffi/link_embedded.go), so NO nanollm_prebuilt tag,
+//     CGO_CFLAGS, or CGO_LDFLAGS is needed. It is still a cgo package, so
+//     CGO_ENABLED=1 and a working C toolchain/linker are required.
+//   - nanollm_integration opts this file in.
 //
-// Run it (local macOS ARM) with, from an extracted aarch64-apple-darwin bundle
-// at $ART, from inside this module directory:
+// Run it (local macOS ARM, which links the committed aarch64-apple-darwin
+// archive) from inside this module directory:
 //
-//	CGO_ENABLED=1 \
-//	CGO_CFLAGS="-I$ART" \
-//	CGO_LDFLAGS="$ART/libnanollm_ffi.a $(cat $ART/native-static-libs.txt)" \
-//	GOWORK=off go test -tags "nanollm_prebuilt nanollm_integration" ./...
+//	CGO_ENABLED=1 GOWORK=off go test -tags "nanollm_integration" ./...
 //
 // It calls ONLY Client.Prepare — never HTTPRequest, never Do/DoStream, never a
 // send. baml-rest keeps retry/fallback/round-robin ownership; nanollm Fallbacks
@@ -45,7 +42,7 @@ import (
 
 	"github.com/invakid404/baml-rest/internal/nativebody"
 	"github.com/invakid404/baml-rest/internal/nativeprompt"
-	nanollm "github.com/viktordanov/nanollm/go"
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
 )
 
 const (

--- a/internal/nativebody/nanollmprepare/planassert/asserts.go
+++ b/internal/nativebody/nanollmprepare/planassert/asserts.go
@@ -1,19 +1,20 @@
-//go:build nanollm_prebuilt && nanollm_integration
+//go:build nanollm_integration
 
 package planassert
 
 // The SHARED nanollm-plan client + assertions for both Phase 5.1 legs. Gated by
-// `nanollm_prebuilt && nanollm_integration` (the CGO/FFI linkage tags): this file
-// imports nanollm, so it is only compiled when a leg's gated test binary links
-// the prebuilt FFI. It imports NO BAML runtime, so sharing it never links the two
-// legs' distinct BAML runtimes into one binary.
+// `nanollm_integration` (the opt-in tag): this file imports nanollm, so it is
+// only compiled when a leg's gated test binary links the public nanollm-ffi
+// module's automatically-selected embedded prebuilt FFI archive. It imports NO
+// BAML runtime, so sharing it never links the two legs' distinct BAML runtimes
+// into one binary.
 
 import (
 	"testing"
 
 	"github.com/invakid404/baml-rest/internal/nativebody"
 	"github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare/testutil"
-	nanollm "github.com/viktordanov/nanollm/go"
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
 )
 
 // NewPrepareClient builds a nanollm engine with ONE openai alias configured to

--- a/internal/nativebody/nanollmprepare/planassert/planassert.go
+++ b/internal/nativebody/nanollmprepare/planassert/planassert.go
@@ -12,9 +12,9 @@
 // it never couples the two legs to a shared BAML binary.
 //
 // The nanollm-touching helpers live in the build-tagged asserts.go
-// (`nanollm_prebuilt && nanollm_integration`); this file carries only the
-// dependency-free fence constants and the package doc, so a default, tag-less
-// `go build ./...` compiles this package with ZERO nanollm/CGO — preserving the
+// (`nanollm_integration`); this file carries only the dependency-free fence
+// constants and the package doc, so a default, tag-less `go build ./...`
+// compiles this package with ZERO nanollm/CGO — preserving the
 // root/default-build isolation.
 package planassert
 

--- a/internal/nativebody/nanollmprepare/static/doc.go
+++ b/internal/nativebody/nanollmprepare/static/doc.go
@@ -4,11 +4,11 @@
 // Request.<Function>()) for every Phase-4a-admitted static-corpus row —
 // test-only, no send, gated.
 //
-// The proof lives in the triply build-tagged
+// The proof lives in the doubly build-tagged
 // prepared_request_integration_test.go
-// (`integration && nanollm_prebuilt && nanollm_integration`); this file exists
-// only so the package always has a non-test source file when the tags are off.
-// Nothing in the default build imports it.
+// (`integration && nanollm_integration`); this file exists only so the package
+// always has a non-test source file when the tags are off. Nothing in the
+// default build imports it.
 //
 // It links the STOCK upstream github.com/boundaryml/baml@v0.223.0 runtime (via
 // the checked-in generated fixture client) and must NEVER share a binary with the

--- a/internal/nativebody/nanollmprepare/static/prepared_request_integration_test.go
+++ b/internal/nativebody/nanollmprepare/static/prepared_request_integration_test.go
@@ -1,4 +1,4 @@
-//go:build integration && nanollm_prebuilt && nanollm_integration
+//go:build integration && nanollm_integration
 
 package static
 
@@ -35,8 +35,9 @@ package static
 // A version guard pins the loaded CFFI + module to stock v0.223.0.
 //
 // Runs in the SEPARATE, go.work-excluded nanollmprepare module; links stock BAML
-// v0.223.0 and nanollm's Rust FFI, and must never share a binary with the
-// patched-BAML dynamic leg (../dynamic).
+// v0.223.0 and the public nanollm-ffi module's automatically-selected embedded
+// Rust FFI archive, and must never share a binary with the patched-BAML dynamic
+// leg (../dynamic).
 
 import (
 	"bytes"
@@ -60,7 +61,7 @@ import (
 	"github.com/invakid404/baml-rest/internal/nativeprompt"
 	bamlclient "github.com/invakid404/baml-rest/internal/nativeprompt/testdata/static_oracle/baml_client"
 	"github.com/invakid404/baml-rest/internal/nativeschema"
-	nanollm "github.com/viktordanov/nanollm/go"
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
 )
 
 // The literal auth/environment fence (scope "Concrete auth/environment fence"),


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

> **Retarget (2026-07-12): v0.3.1 → v0.3.2.** Upstream published `nanollm-ffi/go v0.3.2` mid-review as a drop-in over v0.3.1 (adds a linux/arm64 committed prebuilt; archives ~3× smaller; same no-flags committed-prebuilt model; API-compatible). This PR now pins **v0.3.2**; go.mod/go.sum, the CI-lane pin/assertion, and the clean-install smoke were bumped, and the full impl → review → bot_triage loop re-ran green on the v0.3.2 tip (7cfbb1d9).
## Slice 1: migrate the gated nanollm Prepare/differential lane to the public `nanollm-ffi` module

Moves the isolated, **test-only** `internal/nativebody/nanollmprepare` module from the PRIVATE `github.com/viktordanov/nanollm/go v0.3.0` to the PUBLIC `github.com/viktordanov/nanollm-ffi/go v0.3.2`. The public module commits per-platform prebuilt archives and selects/links them automatically, so there is **no token, no release bundle, no custom `CGO_CFLAGS`/`CGO_LDFLAGS`, and no `nanollm_prebuilt` tag** â it is still cgo (`CGO_ENABLED=1` + a C toolchain). This is packaging/import/Prepare only; **no serving change**, root stays **ZERO-nanollm**, and `Do`/`DoStream` remains deferred to Slice 2.

### What changed
- **Module swap** â `nanollmprepare/go.mod` require `nanollm/go v0.3.0` â `nanollm-ffi/go v0.3.2`; `go.sum` re-authored by `GOWORK=off go mod tidy` (drops the private v0.3.0 sums, writes the public v0.3.2 sums). The local baml-rest sibling `replace` block is kept; no nanollm `replace` is added.
- **Import rewrites** in the 4 gated files (alias `nanollm` kept): `nanollm_integration_test.go`, `planassert/asserts.go`, `dynamic/prepared_request_integration_test.go`, `static/prepared_request_integration_test.go`.
- **Build tags** â `nanollm_prebuilt` removed everywhere: `nanollm_prebuilt && nanollm_integration` â `nanollm_integration`; `integration && nanollm_prebuilt && nanollm_integration` â `integration && nanollm_integration`. Package docs + comments now describe a public embedded-prebuilt cgo module. `testutil` stays nanollm-free/unchanged.
- **CI lane** (`.github/workflows/nanollm-prepare.yml`) â removed `NANOLLM_FFI_TOKEN` + every secret `if:` + the fork no-op skip, `GOPRIVATE` + the `x-access-token` git-url rewrite, the FFI bundle state (tag/target/sha256/`GH_TOKEN`/download/checksum/extract/linker-env), `CGO_CFLAGS`/`CGO_LDFLAGS`, and the `nanollm_prebuilt` tag. Kept + updated the pin + zero-root-nanollm assertions (public path @ `v0.3.2`), the stock/patched BAML pre-provision + version checks, `BAML_LIBRARY_DISABLE_DOWNLOAD=true`, and the `integration`/`nanollm_integration` tags. Added a **clean-public-install smoke** (scratch module blank-import + `go build`, no flags â proves the committed archive links). Now runs on **every PR incl. forks**.

### Validation
- `gofmt` clean; `go build ./...` + `go vet ./...` (no tags) green; default zero-nanollm tests (`nativebody`, `nativeprompt`, `nativeschema`, `cmd/introspect`) green.
- Root `go.mod`/`go.sum`/`go.work`/`go.work.sum` remain **zero-nanollm**; `nanollmprepare` stays out of `go.work`. `go run ./cmd/embed` = no change; `embed.go`/`bamlutils/embed.go` unchanged; worker-plugin builds (standalone + package-form).
- Gated lane locally (Darwin/ARM64, committed aarch64 archive), no CGO flags â **52 tests pass across 5 packages**: #606 P4b (`Canonical4aBody` + `ModelSeparation`), #607 P5 dynamic parity (5 fixtures) + 7 controls, P5 static parity (14 rows) + `TestBAMLVersionPinned` + 6 controls, `testutil`. The **only** change to those test files is the import path + tag line + comments â no test logic changed.
- Clean-public-install smoke passed locally too (blank-import scratch module + `go build`, no flags).

### Owner follow-ups (two)
1. **Enable it as a required status check.** After this lane's first green public-module run, add the `nanollm-prepare` job context as required in branch protection / rulesets. It no longer needs a secret and its committed Linux archive makes fork-PR execution equivalent to internal-PR execution.
2. **Retire the now-unused `NANOLLM_FFI_TOKEN` secret.** Confirm no other workflow references it, then delete the repository secret â this migration removed its only consumer.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the prepared-request integration validation to use the public Nanollm FFI package.
  * Simplified CI execution by removing prebuilt-flag and secret-based gating for the prepared-request differential.
  * Tightened build-tag behavior so default (no-tag) builds remain isolated from Nanollm/CGO requirements.
* **Tests**
  * Added a smoke test to confirm the public Nanollm FFI package installs and links cleanly from a blank module.
* **Documentation**
  * Updated integration-test tagging and linking documentation to match the new prepared-request proof setup.
  * Refreshed CI workflow comments to reflect the public-module validation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
