### PR TITLE
debaml(s2b): gated fault matrix — fallback, timeout, uniform Do envelope, DoStream D11

### DIFF
--- a/internal/nativebody/nanollmprepare/execute/send_integration_test.go
+++ b/internal/nativebody/nanollmprepare/execute/send_integration_test.go
@@ -13,9 +13,23 @@ package execute
 //
 // The SAME raw body bytes drive both provider aliases; nanollm rewrites the
 // top-level model to each configured target and (for Anthropic) reshapes the
-// OpenAI body into a provider-native Messages request. This file implements only
-// the three happy-path rows (OpenAI Do parity, Anthropic Do parity, Anthropic
-// DoStream). Fallback / timeout / uniform-error-envelope rows are Slice 2b.
+// OpenAI body into a provider-native Messages request.
+//
+// Slice 2a (happy path) rows: OpenAI Do parity, Anthropic Do parity, Anthropic
+// DoStream. Slice 2b (fault matrix) rows, layered on the SAME harness, prove the
+// executor's failure/fallback contract:
+//
+//   - returned-503 fallback: a returned non-2xx advances a configured chain;
+//   - delay-induced client-timeout fallback: the ONLY public observable proof
+//     the internal transport classifier marked a timeout retryable (asserted as
+//     behavior — backup wins — NEVER by importing the off-limits internal
+//     classifier or reproducing its message-sensitive reason);
+//   - uniform Do error envelope: a non-2xx is normalized into the ONE uniform
+//     JSON error envelope (classified OpenAI-safe error.type, native type under
+//     error.code, bounded raw + status/provider under details);
+//   - DoStream stream-start non-2xx: the deliberate v0.3.2 "D11" divergence —
+//     no envelope, a wrapped *ProviderStatusError carrying the bounded raw
+//     provider-native error body — pinned here as the contract.
 //
 // Provider/response JSON structs are LOCAL and narrow: no production abstraction
 // is introduced around nanollm. Every credential is a literal fake, every
@@ -23,8 +37,11 @@ package execute
 // runs on the loopback-guarded transport. Tests are SERIAL (no t.Parallel).
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -58,7 +75,109 @@ const (
 	callTimeout = 30 * time.Second
 )
 
+const (
+	// Slice 2b fault-matrix aliases + provider targets. Each 2b test runs
+	// against its OWN isolated mock process, so these never collide at runtime
+	// with the 2a happy-path keys or with each other.
+	//
+	// The fallback rows (4, 5) put a healthy Anthropic backup in the OpenAI
+	// primary's Fallbacks, proving cross-provider chain advance.
+	fbPrimaryAlias  = "s2b-fb-primary"
+	fbBackupAlias   = "s2b-fb-backup"
+	fbPrimaryTarget = "s2b-fb-primary-target" // openai (the faulting primary)
+	fbBackupTarget  = "s2b-fb-backup-target"  // anthropic (the healthy backup)
+
+	// The uniform-envelope / DoStream-divergence rows (6, 7) drive an
+	// Anthropic-only, no-fallback alias so the single non-2xx surfaces at the
+	// API boundary instead of advancing a chain.
+	faultAlias  = "s2b-fault"
+	faultTarget = "s2b-fault-target" // anthropic
+
+	// timeoutClientDeadline is the SHORT deadline set on the HTTP CLIENT (not on
+	// the shared context.Context — that would cancel the healthy backup too).
+	// It is far below the primary scenario's 2s delay and far above the
+	// immediate backup's real latency, so the classification outcome is
+	// deterministic without asserting millisecond-exact elapsed time.
+	timeoutClientDeadline = 400 * time.Millisecond
+	primaryDelayMs        = 2000
+
+	// maxRawBytes mirrors nanollm's errorBodyReadCap (ERROR_BODY_READ_CAP, 64
+	// KiB): the ceiling on both the DoStream *ProviderStatusError raw body and
+	// the raw upstream nested under the uniform envelope's details. Used only as
+	// a bounded-ness sanity ceiling — the mock's error bodies are tiny.
+	maxRawBytes = 64 * 1024
+)
+
 func sp(s string) *string { return &s }
+
+// newFallbackClient builds a v0.3.2 client whose OpenAI primary names the
+// Anthropic backup in its Fallbacks, so FallbackChain(primary) == [primary,
+// backup]. MaxRetries:0 on both aliases keeps the observation a CROSS-model
+// advance (never a hidden same-model retry); UseProcessEnv:false forbids
+// process-env secret resolution. Used by the returned-503 and timeout rows.
+func newFallbackClient(t *testing.T, mockBase string) *nanollm.Client {
+	t.Helper()
+	c, err := nanollm.New(nanollm.Config{
+		Models: []nanollm.ModelConfig{
+			{
+				Name:       fbPrimaryAlias,
+				Model:      "openai/" + fbPrimaryTarget,
+				APIKey:     fakeAPIKey,
+				BaseURL:    mockBase + "/v1",
+				MaxRetries: 0,
+				Fallbacks:  []string{fbBackupAlias},
+			},
+			{
+				Name:       fbBackupAlias,
+				Model:      "anthropic/" + fbBackupTarget,
+				APIKey:     fakeAPIKey,
+				BaseURL:    mockBase + "/v1",
+				MaxRetries: 0,
+			},
+		},
+		Env:           nil,
+		UseProcessEnv: false,
+	})
+	if err != nil {
+		t.Fatalf("nanollm.New (fallback): %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// newFaultClient builds a v0.3.2 client with a single Anthropic alias and NO
+// fallbacks, so a returned non-2xx surfaces at the API boundary (uniform
+// envelope for Do, *ProviderStatusError for DoStream) rather than advancing a
+// chain. Used by the uniform-envelope and DoStream-divergence rows.
+func newFaultClient(t *testing.T, mockBase string) *nanollm.Client {
+	t.Helper()
+	c, err := nanollm.New(nanollm.Config{
+		Models: []nanollm.ModelConfig{
+			{
+				Name:       faultAlias,
+				Model:      "anthropic/" + faultTarget,
+				APIKey:     fakeAPIKey,
+				BaseURL:    mockBase + "/v1",
+				MaxRetries: 0,
+			},
+		},
+		Env:           nil,
+		UseProcessEnv: false,
+	})
+	if err != nil {
+		t.Fatalf("nanollm.New (fault): %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// timeoutClient returns a loopback-guarded http.Client with a SHORT client-level
+// timeout. The deadline lives on the HTTP client, not on the request context, so
+// each attempt (primary AND backup) gets its own fresh budget — the primary's 2s
+// delay trips the timeout while the immediate backup completes well within it.
+func timeoutClient(d time.Duration) *http.Client {
+	return &http.Client{Transport: loopbackTransport(), Timeout: d}
+}
 
 // newSendClient builds a v0.3.2 client with the two literal, fake aliases bound
 // to the mock's loopback base. MaxRetries:0 keeps attempt counts unambiguous;
@@ -441,6 +560,364 @@ func TestStreamAnthropic(t *testing.T) {
 	if !areq.Stream {
 		t.Errorf("captured body stream = false, want true")
 	}
+	if got := m.scenarioAttemptCount(id); got != 1 {
+		t.Errorf("scenario attempt count = %d, want 1", got)
+	}
+}
+
+// ============================================================================
+// Slice 2b — fault / fallback / error-envelope matrix (rows 4–7)
+// ============================================================================
+
+// TestFallbackReturned503 — row 4: a RETURNED provider non-2xx advances a
+// configured chain. The OpenAI primary is armed to return 503 on its first (and
+// only) attempt; the healthy Anthropic backup then answers 200 and its exact
+// content is what the caller sees. This proves v0.3.2's rule that a returned
+// non-2xx advances a configured chain — it deliberately does NOT claim the 503
+// status was itself "retryable" (that is the separate classification concern
+// exercised by row 5).
+func TestFallbackReturned503(t *testing.T) {
+	m := startMock(t)
+	client := newFallbackClient(t, m.baseURL)
+	body := sharedNativeBody(t)
+
+	const primaryID = "s2b-fb503-primary"
+	const backupID = "s2b-fb503-backup"
+	const wantText = "fb503-backup-ok"
+
+	// Primary: deterministic 503 on the first attempt (fail_first_n:1 +
+	// error_status:503). No Output — it never produces a success body.
+	m.registerScenario(scenarioSpec{
+		ID:       primaryID,
+		Provider: "openai",
+		Model:    fbPrimaryTarget,
+		Config:   json.RawMessage(`{"fail_first_n":1,"error_status":503}`),
+	})
+	// Backup: healthy + exact content; strict Anthropic so a 200 proves a
+	// provider-native body crossed the FFI.
+	m.registerScenario(scenarioSpec{
+		ID:       backupID,
+		Provider: "anthropic",
+		Model:    fbBackupTarget,
+		Output:   &exactOutput{Text: wantText, OutputTokens: 7},
+		Config:   json.RawMessage(`{"strict":true}`),
+	})
+
+	// The configured chain is exactly [primary, backup].
+	chain := client.FallbackChain(fbPrimaryAlias)
+	if len(chain) != 2 || chain[0] != fbPrimaryAlias || chain[1] != fbBackupAlias {
+		t.Fatalf("FallbackChain(%q) = %v, want [%s %s]", fbPrimaryAlias, chain, fbPrimaryAlias, fbBackupAlias)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
+	defer cancel()
+	resp, err := client.Do(ctx, nanollm.Request{
+		Model: fbPrimaryAlias,
+		Body:  body,
+		Type:  nanollm.ChatCompletion,
+	}, nanollm.WithHTTPClient(loopbackClient()))
+	if err != nil {
+		t.Fatalf("Do(fallback-503): %v", err)
+	}
+
+	// The backup's exact 200/content is the caller-visible result.
+	assertOpenAIResult(t, resp, wantText, "stop")
+
+	// Each alias was attempted exactly once: primary failed 503, the chain
+	// advanced, the backup answered — no same-model retry (MaxRetries:0).
+	if got := m.scenarioAttemptCount(primaryID); got != 1 {
+		t.Errorf("primary attempt count = %d, want 1", got)
+	}
+	if got := m.scenarioAttemptCount(backupID); got != 1 {
+		t.Errorf("backup attempt count = %d, want 1", got)
+	}
+
+	// The winning response came off the Anthropic backup route.
+	if cap := m.lastRequest(backupID); cap.Path != "/v1/messages" {
+		t.Errorf("backup captured path = %q, want /v1/messages", cap.Path)
+	}
+}
+
+// TestFallbackTimeoutClassification — row 5: a delay-induced CLIENT timeout on
+// the primary advances to the healthy backup. This is the ONLY public observable
+// proof that nanollm's internal transport classifier marked the timeout
+// retryable: that classifier is private and its Reason never reaches the caller,
+// so the test asserts the OUTCOME (backup wins) — never the reason, and NEVER by
+// importing internal/ffi.ClassifyError or reproducing the message-sensitive
+// classifier.
+//
+// The short deadline lives on the HTTP CLIENT (timeoutClient), NOT on the shared
+// context — a context deadline would also cancel the immediate backup. MaxRetries
+// is 0, so the advance is cross-model, not a same-model retry. Assertions are on
+// counters + content, not millisecond-exact elapsed time.
+func TestFallbackTimeoutClassification(t *testing.T) {
+	m := startMock(t)
+	client := newFallbackClient(t, m.baseURL)
+	body := sharedNativeBody(t)
+
+	const primaryID = "s2b-timeout-primary"
+	const backupID = "s2b-timeout-backup"
+	const wantText = "timeout-backup-ok"
+
+	// Primary: attempt 1 holds ~2s (a cancel-aware delay), attempt 2 clean. With
+	// MaxRetries:0 the client times out on attempt 1 and the chain advances, so
+	// the empty attempt-2 slot is never reached. attempt_faults (not a global
+	// delay) keeps the fault scoped to the first attempt.
+	m.registerScenario(scenarioSpec{
+		ID:       primaryID,
+		Provider: "openai",
+		Model:    fbPrimaryTarget,
+		Config:   json.RawMessage(fmt.Sprintf(`{"attempt_faults":[[{"mode":"delay","delay_ms":%d}],[]]}`, primaryDelayMs)),
+	})
+	// Backup: healthy + immediate.
+	m.registerScenario(scenarioSpec{
+		ID:       backupID,
+		Provider: "anthropic",
+		Model:    fbBackupTarget,
+		Output:   &exactOutput{Text: wantText, OutputTokens: 7},
+		Config:   json.RawMessage(`{"strict":true}`),
+	})
+
+	// Generous parent context; the SHORT deadline is on the client only.
+	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
+	defer cancel()
+	resp, err := client.Do(ctx, nanollm.Request{
+		Model: fbPrimaryAlias,
+		Body:  body,
+		Type:  nanollm.ChatCompletion,
+	}, nanollm.WithHTTPClient(timeoutClient(timeoutClientDeadline)))
+	if err != nil {
+		t.Fatalf("Do(fallback-timeout): %v", err)
+	}
+
+	// The backup's exact 200/content wins.
+	assertOpenAIResult(t, resp, wantText, "stop")
+
+	// Each alias was attempted exactly once (primary timed out, backup answered).
+	if got := m.scenarioAttemptCount(primaryID); got != 1 {
+		t.Errorf("primary attempt count = %d, want 1 (single timed-out attempt)", got)
+	}
+	if got := m.scenarioAttemptCount(backupID); got != 1 {
+		t.Errorf("backup attempt count = %d, want 1", got)
+	}
+
+	// The parent context is still live: only the per-attempt CLIENT deadline
+	// fired, so the backup was free to succeed on a fresh budget.
+	if ctx.Err() != nil {
+		t.Errorf("parent context error = %v, want nil (only the client deadline should fire)", ctx.Err())
+	}
+}
+
+// uniformErrorEnvelope is the LOCAL, narrow view of nanollm's uniform non-2xx
+// error envelope — the shape Do returns for every normalized non-2xx. The stable
+// details block is nested UNDER the top-level error object (error.details), which
+// carries the caller-facing status/provider plus the bounded raw upstream body.
+// Assertions against it are STRUCTURAL and additive-field tolerant: they pin the
+// stable semantic fields and require the raw upstream to be nested + bounded, but
+// never assert an exact key set or JSON byte order.
+type uniformErrorEnvelope struct {
+	Error struct {
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Details struct {
+			StatusCode int    `json:"status_code"`
+			Provider   string `json:"provider"`
+			Raw        string `json:"raw"`
+			Truncated  bool   `json:"truncated"`
+		} `json:"details"`
+	} `json:"error"`
+}
+
+// TestUniformErrorEnvelopeDo — row 6: Do NORMALIZES an Anthropic 529
+// overloaded_error into the ONE uniform JSON error envelope. Do returns a
+// Response (err == nil) whose Status is the real 529 and whose JSON body carries
+// the classified OpenAI-safe error.type, the native type under error.code, the
+// marker-bearing message, and details.{status_code,provider} with the raw
+// upstream nested + bounded. This is the uniform-envelope boundary; its DoStream
+// companion (row 7) deliberately diverges.
+func TestUniformErrorEnvelopeDo(t *testing.T) {
+	m := startMock(t)
+	client := newFaultClient(t, m.baseURL)
+	body := sharedNativeBody(t)
+
+	const id = "s2b-uniform-529"
+	// Unique marker that must survive into the envelope's error.message and into
+	// the raw upstream nested under details.
+	const marker = "s2b-uniform-marker-2f7c9a"
+	m.registerScenario(scenarioSpec{
+		ID:       id,
+		Provider: "anthropic",
+		Model:    faultTarget,
+		Config:   json.RawMessage(fmt.Sprintf(`{"faults":[{"mode":"error","error_status":529,"error_type":"overloaded_error","error_message":%q}]}`, marker)),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
+	defer cancel()
+	// WithoutFallback is an explicit guard: this alias has no chain anyway, so
+	// the single non-2xx must surface as the normalized Response.
+	resp, err := client.Do(ctx, nanollm.Request{
+		Model: faultAlias,
+		Body:  body,
+		Type:  nanollm.ChatCompletion,
+	}, nanollm.WithHTTPClient(loopbackClient()), nanollm.WithoutFallback())
+	if err != nil {
+		t.Fatalf("Do(uniform-529) returned error, want a normalized Response: %v", err)
+	}
+	if resp.Status != 529 {
+		t.Fatalf("Response.Status = %d, want 529 (body: %s)", resp.Status, resp.Body)
+	}
+	if !resp.BodyIsJSON {
+		t.Errorf("BodyIsJSON = false, want true")
+	}
+
+	// Structural envelope fields.
+	var env uniformErrorEnvelope
+	if err := json.Unmarshal(resp.Body, &env); err != nil {
+		t.Fatalf("envelope body is not JSON: %v\n%s", err, resp.Body)
+	}
+	if env.Error.Type != "server_error" {
+		t.Errorf("error.type = %q, want %q (classified OpenAI-safe type)", env.Error.Type, "server_error")
+	}
+	if env.Error.Code != "overloaded_error" {
+		t.Errorf("error.code = %q, want %q (native type preserved)", env.Error.Code, "overloaded_error")
+	}
+	if !strings.Contains(env.Error.Message, marker) {
+		t.Errorf("error.message = %q, want it to carry marker %q", env.Error.Message, marker)
+	}
+	if env.Error.Details.StatusCode != 529 {
+		t.Errorf("error.details.status_code = %d, want 529", env.Error.Details.StatusCode)
+	}
+	if env.Error.Details.Provider != "anthropic" {
+		t.Errorf("error.details.provider = %q, want anthropic", env.Error.Details.Provider)
+	}
+
+	// The raw upstream is preserved under bounded error.details.raw — the
+	// verbatim provider-native Anthropic error, carrying the go-mocklm request_id
+	// and the native overloaded_error type — and flagged as not truncated (the
+	// tiny mock error fits well under the raw cap).
+	rawUpstream := env.Error.Details.Raw
+	if rawUpstream == "" {
+		t.Fatalf("error.details.raw is empty, want the raw provider-native Anthropic error")
+	}
+	if len(rawUpstream) > maxRawBytes {
+		t.Errorf("error.details.raw = %d bytes, want <= %d (bounded raw)", len(rawUpstream), maxRawBytes)
+	}
+	if env.Error.Details.Truncated {
+		t.Errorf("error.details.truncated = true, want false (the raw upstream fits under the cap)")
+	}
+	if !strings.Contains(rawUpstream, marker) || !strings.Contains(rawUpstream, "req_mock_") {
+		t.Errorf("error.details.raw = %q, want it to carry the marker and the go-mocklm request_id", rawUpstream)
+	}
+
+	// The raw Anthropic wrapper (its top-level type:"error" and request_id)
+	// survives ONLY nested under details.raw — never dumped at the envelope top
+	// level, whose sole member is the classified error object.
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(resp.Body, &top); err != nil {
+		t.Fatalf("envelope top-level is not a JSON object: %v", err)
+	}
+	if _, ok := top["request_id"]; ok {
+		t.Errorf("top-level request_id survived; the raw Anthropic error must not be dumped at the envelope top level")
+	}
+	if raw, ok := top["type"]; ok {
+		var ts string
+		_ = json.Unmarshal(raw, &ts)
+		if ts == "error" {
+			t.Errorf(`top-level type == "error" survived; the raw Anthropic error must not be dumped at the envelope top level`)
+		}
+	}
+
+	// The scenario fired exactly once.
+	if got := m.scenarioAttemptCount(id); got != 1 {
+		t.Errorf("scenario attempt count = %d, want 1", got)
+	}
+}
+
+// TestStreamStartProviderStatusError — row 7: the DoStream companion to row 6,
+// documenting the DELIBERATE v0.3.2 "D11" divergence. On a stream-start non-2xx,
+// DoStream does NOT normalize into the uniform envelope; it returns a wrapped
+// *nanollm.ProviderStatusError carrying the bounded, provider-NATIVE Anthropic
+// error body (<= 64 KiB). This is Viktor-confirmed intended behavior, pinned
+// upstream by TestDoStreamErrorBody — it must NOT be mislabeled as the uniform
+// envelope (row 6), nor hidden behind a baml-rest wrapper.
+func TestStreamStartProviderStatusError(t *testing.T) {
+	m := startMock(t)
+	client := newFaultClient(t, m.baseURL)
+	body := sharedNativeBody(t)
+
+	const id = "s2b-d11-529"
+	const marker = "s2b-d11-marker-8b13e0"
+	m.registerScenario(scenarioSpec{
+		ID:       id,
+		Provider: "anthropic",
+		Model:    faultTarget,
+		Config:   json.RawMessage(fmt.Sprintf(`{"faults":[{"mode":"error","error_status":529,"error_type":"overloaded_error","error_message":%q}]}`, marker)),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
+	defer cancel()
+	stream, err := client.DoStream(ctx, nanollm.Request{
+		Model: faultAlias,
+		Body:  body,
+		Type:  nanollm.ChatCompletion,
+	}, nanollm.WithHTTPClient(loopbackClient()), nanollm.WithoutFallback())
+	if stream != nil {
+		stream.Close()
+		t.Fatalf("DoStream returned a non-nil stream on a stream-start 529, want nil stream + error")
+	}
+	if err == nil {
+		t.Fatalf("DoStream returned nil error on a stream-start 529, want *ProviderStatusError (D11)")
+	}
+
+	// Wrapped through the chain-exhaustion error: use errors.As, not a direct
+	// type assertion.
+	var statusErr *nanollm.ProviderStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("error is not (wrapping) a *ProviderStatusError (D11): %v", err)
+	}
+	if statusErr.Status != 529 {
+		t.Errorf("ProviderStatusError.Status = %d, want 529", statusErr.Status)
+	}
+	if len(statusErr.Body) == 0 {
+		t.Fatalf("ProviderStatusError.Body is empty, want the provider-native Anthropic error JSON")
+	}
+	if len(statusErr.Body) > maxRawBytes {
+		t.Errorf("ProviderStatusError.Body = %d bytes, want <= %d (bounded raw)", len(statusErr.Body), maxRawBytes)
+	}
+
+	// The body is the PROVIDER-NATIVE Anthropic error JSON (NOT the uniform
+	// envelope): top-level type:"error", a nested error.type carrying the native
+	// overloaded_error, and the marker message.
+	var native struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(statusErr.Body, &native); err != nil {
+		t.Fatalf("ProviderStatusError.Body is not JSON: %v\n%s", err, statusErr.Body)
+	}
+	if native.Type != "error" {
+		t.Errorf("native top-level type = %q, want \"error\" (raw Anthropic shape, NOT the uniform envelope)", native.Type)
+	}
+	if native.Error.Type != "overloaded_error" {
+		t.Errorf("native error.type = %q, want overloaded_error", native.Error.Type)
+	}
+	if !strings.Contains(native.Error.Message, marker) {
+		t.Errorf("native error.message = %q, want marker %q", native.Error.Message, marker)
+	}
+	// Confirm this is the RAW body and NOT the uniform envelope: the classified
+	// "server_error" type and the details block are absent from a native body.
+	if bytes.Contains(statusErr.Body, []byte("server_error")) {
+		t.Errorf("D11 body contains \"server_error\"; it must carry the NATIVE error, not the uniform envelope\n%s", statusErr.Body)
+	}
+	if bytes.Contains(statusErr.Body, []byte(`"details"`)) {
+		t.Errorf("D11 body contains a details block; it must carry the NATIVE error, not the uniform envelope\n%s", statusErr.Body)
+	}
+
+	// The scenario fired exactly once.
 	if got := m.scenarioAttemptCount(id); got != 1 {
 		t.Errorf("scenario attempt count = %d, want 1", got)
 	}


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## Slice 2b — nanollm-ffi fault matrix (COMPLETES Slice 2)

Layers the four Slice 2b fault/error rows onto the **landed Slice 2a functional-send harness** (`internal/nativebody/nanollmprepare/execute/`), completing Slice 2. This is **test-only**: the root/default build stays **zero-nanollm and CGO-free** (the isolated `nanollmprepare` module is not a `go.work` member), there is no serving change, and every credential is a literal fake against `127.0.0.1` only. The only file changed is `execute/send_integration_test.go`.

### The four rows (all driven via go-mocklm v0.4.0 over loopback)

- **Row 4 — returned-503 fallback.** OpenAI primary armed with `fail_first_n:1` + `error_status:503`, healthy Anthropic backup in the primary's `Fallbacks`. Asserts `FallbackChain(primary) == [primary, backup]`, the caller sees the backup's exact 200/content, and each scenario's attempt count is exactly 1. Proves the returned-non-2xx-advances-the-chain rule — **without** claiming status retryability.
- **Row 5 — timeout classification fallback.** Primary `attempt_faults:[[{delay 2000ms}],[]]`; the short deadline is set on the **HTTP client** (~400 ms), *not* the shared `context.Context` (which would cancel the backup); healthy immediate backup; `MaxRetries:0`. Asserts the backup's exact 200/content wins, each attempt count is 1, and the parent context is still live. This is the **only public observable proof** the internal transport classifier marked the timeout retryable — asserted as behavior, never by importing the off-limits `internal/ffi.ClassifyError` or reproducing its message-sensitive reason.
- **Row 6 — uniform `Do` error envelope.** Anthropic-only/no-fallback pre-body `error` fault (status 529, native `overloaded_error`, unique marker), `WithoutFallback` guard. `Do` returns `err == nil`, `Response.Status == 529`, `BodyIsJSON`, and the uniform envelope: `error.type == "server_error"` (classified OpenAI-safe), `error.code == "overloaded_error"` (native type preserved), marker-bearing message, `error.details.{status_code:529, provider:"anthropic"}`, with the raw upstream preserved + bounded under `error.details.raw` (`truncated:false`). The raw Anthropic wrapper (`type:"error"`/`request_id`) survives **only** nested under details, never dumped at the envelope top level. Assertions are structural + additive-field-tolerant.
- **Row 7 — `DoStream` stream-start non-2xx (D11 companion).** Re-arms the Anthropic 529 and calls `DoStream` without a fallback. `errors.As(err, *nanollm.ProviderStatusError)` succeeds through the exhaustion wrapper, `Status == 529`, and `Body` is the provider-native Anthropic error JSON (bounded ≤ 64 KiB) — **not** the uniform envelope. This deliberately documents the v0.3.2 **"D11"** streaming divergence.

### Viktor-confirmed API-boundary items

Both open nanollm-ffi questions are resolved per Viktor's confirmed v0.3.2 error-handling contract:

- **No exported transport classifier at v0.3.2** → the timeout case asserts *behavior* (backup wins), never the literal `Reason`; the internal classifier is off-limits and not reproduced.
- **`Do` vs `DoStream` divergence is the deliberate, tracked "D11"** (pinned upstream by `TestDoStreamErrorBody`) → `Do` normalizes into the uniform envelope while `DoStream` returns a raw `*ProviderStatusError`; this PR **pins the raw behavior as the contract** rather than hiding it behind a wrapper.

### Validation (local, Darwin/ARM64)

- `gofmt` clean; default (untagged) `go build ./...`, targeted `go test`, and `go vet ./...` green — the default graph never touches nanollm/CGO.
- Gated lane `cd internal/nativebody/nanollmprepare && GOWORK=off go test -tags nanollm_integration -count=1 ./execute/` — all 7 rows (3 landed 2a happy-path + 4 new 2b faults) pass, each fault fires exactly once, classification and status policy are not conflated, and error bodies are asserted at the correct API boundary (`Do` = uniform envelope, `DoStream` = `ProviderStatusError`).
- Root `go.mod`/`go.sum`/`go.work`/`go.work.sum` and the `nanollmprepare` module manifests are unchanged; P4b/P5 and `nanollm-prepare.yml` are untouched. The existing advisory `nanollm-send.yml` lane runs `./execute/`, so it picks up the new rows with no workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded integration coverage for multi-step fallback behavior across server-error and timeout scenarios.
  * Added cases confirming that, when the primary fails, a healthy backup can satisfy the request while the parent context remains nil/active.
  * Verified `Do` consistently normalizes provider overload errors into a uniform JSON error envelope (including preserved codes, marker-carrying messages, and bounded raw details).
  * Verified `DoStream` start failures intentionally return provider-native status errors without uniform envelope normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->