### PR TITLE
debaml(p6b): PreparedRequest adapter + unary response pipeline (BAML-free)

### DIFF
--- a/internal/nativebody/nanollmprepare/execute/attempt.go
+++ b/internal/nativebody/nanollmprepare/execute/attempt.go
@@ -1,0 +1,353 @@
+//go:build nanollm_integration
+
+package execute
+
+// De-BAML Slice 6b adapter: the BAML-free PreparedRequest -> exact transport ->
+// TranslateResponse -> native structured-output (SAP) pipeline for ONE unary
+// OpenAI attempt.
+//
+// This is the ONLY thing in the de-BAML stack that knows about nanollm aliases
+// AND about baml-rest's exact transport at the same time: it wires a fresh,
+// Phase-5-admitted nanollm.PreparedRequest through the merged Slice-6a exact
+// transport primitive (bamlutils/llmhttp ExactExecutor — ordered headers, raw
+// bytes, one RoundTrip) and then back through nanollm.TranslateResponse and the
+// native final parser. The Slice-6a primitive stays entirely nanollm-agnostic;
+// this adapter is where the two meet.
+//
+// Deliberate non-goals, matching the Phase 6 scope's Option B:
+//
+//   - NO nanollm Do/DoStream. Exactly ONE transport attempt per RunAttempt call,
+//     performed by the exact executor. There is no fallback advance, no
+//     same-model retry, and no expiry re-prepare hidden in the transport — the
+//     one owner of request-attempt policy is baml-rest.
+//   - The exact attempted alias (prep.Meta.ModelAlias) — never a primary alias —
+//     is what TranslateResponse is called with.
+//   - Non-2xx and invalid-2xx are PROVIDER OUTCOMES returned as typed data, never
+//     fed to the structured-output parser (SAP). A 2xx that the parser merely
+//     DECLINES (ErrDeBAMLParseUnsupported) is a parity-decline recorded as data;
+//     any OTHER (claimed) parse error propagates unchanged so a fallback can
+//     never masquerade as a native success.
+//   - This changes NO serving behavior: it is a gated, test-only pipeline in the
+//     out-of-workspace nanollmprepare module and is unreachable from production
+//     routing.
+
+import (
+	"context"
+	stdjson "encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/buildrequest"
+	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
+	"github.com/invakid404/baml-rest/internal/nativebody"
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
+)
+
+// ErrPlanExpired is returned when a prepared plan's signature window has passed
+// BEFORE any socket is opened. Re-preparing belongs to the outer planner, never
+// to this transport adapter, so an expired plan is rejected rather than silently
+// re-signed. (OpenAI plans are unsigned and never expire; this guards the seam
+// for the signed-plan providers a later phase adds.)
+var ErrPlanExpired = errors.New("nanollmprepare: prepared plan expired before attempt")
+
+// ErrAttemptUnsupported is the umbrella sentinel for a parity-decline: the
+// native support decision refused a plan BEFORE opening a socket, so native
+// never out-claims BAML on a shape it has not proven. Recover the stable
+// stage/reason via errors.As(&UnsupportedError{}).
+var ErrAttemptUnsupported = errors.New("nanollmprepare: prepared plan not supported by the native unary attempt")
+
+// UnsupportedError carries a stable, secret-free stage/reason for a
+// parity-decline (the "deferral record" the scope asks every decline to leave).
+// It unwraps to ErrAttemptUnsupported.
+type UnsupportedError struct {
+	Stage  string
+	Reason string
+}
+
+func (e *UnsupportedError) Error() string {
+	return fmt.Sprintf("nanollmprepare: unsupported attempt (%s): %s", e.Stage, e.Reason)
+}
+
+func (e *UnsupportedError) Unwrap() error { return ErrAttemptUnsupported }
+
+// Outcome classifies the terminal disposition of one native unary attempt.
+type Outcome int
+
+const (
+	// OutcomeStructured: a provider 2xx translated to OpenAI JSON, whose
+	// assistant text the native parser cleanly CLAIMED — the structured output
+	// is in AttemptResult.Structured.
+	OutcomeStructured Outcome = iota
+	// OutcomeParseDeclined: a provider 2xx whose assistant text the native
+	// parser DECLINED (ErrDeBAMLParseUnsupported). In a later production-routing
+	// phase this rejoins the BAML parse fallback; here it is recorded as a
+	// parity-decline (SAP WAS invoked; it simply declined).
+	OutcomeParseDeclined
+	// OutcomeProviderError: an ordinary provider non-2xx, translated to the
+	// uniform JSON error envelope. SAP is NEVER invoked. Translated carries the
+	// envelope (real status, BodyIsJSON true).
+	OutcomeProviderError
+	// OutcomeInvalidBody: a provider 2xx whose body TranslateResponse could not
+	// parse (*nanollm.InvalidBodyError), mapped to the same 502/uniform-envelope
+	// provider outcome nanollm's own Do returns. SAP is NEVER invoked.
+	OutcomeInvalidBody
+)
+
+func (o Outcome) String() string {
+	switch o {
+	case OutcomeStructured:
+		return "structured"
+	case OutcomeParseDeclined:
+		return "parse-declined"
+	case OutcomeProviderError:
+		return "provider-error"
+	case OutcomeInvalidBody:
+		return "invalid-body"
+	default:
+		return fmt.Sprintf("Outcome(%d)", int(o))
+	}
+}
+
+// AttemptResult is the typed internal result of one native unary attempt. It
+// preserves enough data for the later production-routing mapping (status, raw
+// provider body, translated response, usage) without finalizing any public
+// serving error envelope — no serving route changes in this phase.
+type AttemptResult struct {
+	Outcome Outcome
+
+	// AttemptedAlias is prep.Meta.ModelAlias — the exact alias whose Prepare
+	// produced the executed plan and which TranslateResponse was called with.
+	AttemptedAlias string
+
+	// ProviderStatus / ProviderBody are the RAW exact-transport observation for
+	// every status: the real upstream status and the bounded raw body (16 MiB
+	// success cap / 64 KiB non-2xx cap, both enforced by the exact executor).
+	ProviderStatus int
+	ProviderBody   []byte
+
+	// Translated is nanollm's translated response: OpenAI JSON on 2xx, the
+	// uniform error envelope on a translated non-2xx, or the synthesized
+	// 502/envelope Response for an invalid-2xx. Nil only never happens on a
+	// returned (nil-error) result.
+	Translated *nanollm.Response
+
+	// Usage is retained from Translated even though Phase 6 surfaces no new
+	// public metadata (scope: do not discard it in an API that will need
+	// redesign immediately afterward).
+	Usage *nanollm.Usage
+
+	// AssistantText is the OpenAI assistant text extracted from a 2xx body and
+	// fed to SAP (empty for provider outcomes, where extraction never runs).
+	AssistantText string
+
+	// Structured is the flattened native structured output on OutcomeStructured
+	// (nil otherwise) — the same flattened shape the generated wrapper consumes.
+	Structured stdjson.RawMessage
+
+	// DeclineReason is the parser's decline explanation on OutcomeParseDeclined.
+	DeclineReason string
+
+	// SAPInvoked records whether the native parser was called at all. It is the
+	// affirmative proof that provider outcomes (non-2xx / invalid-2xx) never
+	// reach SAP: those results carry SAPInvoked == false.
+	SAPInvoked bool
+}
+
+// AttemptConfig is the input to RunAttempt: the nanollm client (for
+// TranslateResponse with the attempted alias), the fresh Phase-5-admitted plan,
+// the exact transport executor (built by the caller over a loopback-guarded
+// RoundTripper — the adapter stays transport-agnostic), and the native parser +
+// carried output schema.
+type AttemptConfig struct {
+	Client           *nanollm.Client
+	Prepared         *nanollm.PreparedRequest
+	Executor         *llmhttp.ExactExecutor
+	Parse            bamlutils.DeBAMLParseFunc
+	OutputSchema     *bamlutils.DynamicOutputSchema
+	IncludeReasoning bool
+}
+
+// RunAttempt performs exactly one native unary attempt and returns the typed
+// outcome.
+//
+// Error vs. data contract:
+//
+//   - Expired plan, parity-decline, and any invalid config are rejected BEFORE
+//     the socket (Go error; no request is sent).
+//   - Transport failures (construction, cancellation/timeout, transport, read),
+//     a translate error OTHER than *InvalidBodyError, an assistant-extraction
+//     failure, and a CLAIMED native parse error all propagate as Go errors.
+//   - An ordinary non-2xx (OutcomeProviderError), an invalid-2xx
+//     (OutcomeInvalidBody), a clean structured claim (OutcomeStructured), and a
+//     parser decline (OutcomeParseDeclined) are returned as (*AttemptResult,
+//     nil) — provider/parse OUTCOMES, not errors.
+func RunAttempt(ctx context.Context, cfg AttemptConfig) (*AttemptResult, error) {
+	if cfg.Client == nil {
+		return nil, fmt.Errorf("nanollmprepare: nil nanollm client")
+	}
+	if cfg.Prepared == nil {
+		return nil, fmt.Errorf("nanollmprepare: nil prepared request")
+	}
+	if cfg.Executor == nil {
+		return nil, fmt.Errorf("nanollmprepare: nil exact executor")
+	}
+	if cfg.Parse == nil {
+		return nil, fmt.Errorf("nanollmprepare: nil parse function")
+	}
+	if cfg.OutputSchema == nil {
+		return nil, fmt.Errorf("nanollmprepare: nil output schema")
+	}
+
+	prep := cfg.Prepared
+
+	// (1) Reject an expired plan BEFORE the attempt — no re-prepare in the
+	// transport. Checked first, before the support decision, so an expired plan
+	// never even reaches support classification.
+	if prep.Expired() {
+		return nil, ErrPlanExpired
+	}
+
+	// (2) Native support decision — the parity-decline gate — runs BEFORE any
+	// socket is opened. The Phase 6 admitted surface is exactly a unary,
+	// non-streaming OpenAI ChatCompletion with a JSON response format and a
+	// present, non-empty body; anything else declines rather than out-claiming
+	// BAML on an unproven shape.
+	if err := supportDecision(prep); err != nil {
+		return nil, err
+	}
+
+	// (3) Convert the plan's exact fields into the neutral exact-attempt carrier
+	// (ordered headers, raw body). The body is present and non-empty (support
+	// decision guaranteed it), so BodyPresent is true.
+	exactReq := &llmhttp.ExactAttemptRequest{
+		Method:      prep.Method,
+		URL:         prep.URL,
+		Headers:     headerFields(prep.Headers),
+		Body:        prep.Body,
+		BodyPresent: true,
+	}
+
+	// (4) Exactly one exact-transport attempt. The executor performs a single
+	// RoundTrip and returns status + raw body as data for EVERY status; a Go
+	// error here is a non-response failure (transport-controlled-header decline,
+	// request construction, cancellation/timeout, transport, or body-read).
+	resp, err := cfg.Executor.Execute(ctx, exactReq)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &AttemptResult{
+		AttemptedAlias: prep.Meta.ModelAlias,
+		ProviderStatus: resp.StatusCode,
+		ProviderBody:   resp.Body,
+	}
+
+	// (5) Translate with the EXACT attempted alias.
+	translated, terr := cfg.Client.TranslateResponse(prep.Meta.ModelAlias, resp.StatusCode, resp.Body)
+	if terr != nil {
+		// An invalid-2xx surfaces as the typed *InvalidBodyError carrying the
+		// (caller-facing status, uniform envelope) pair. Map it into the SAME
+		// response-like provider outcome Do would return — never a misclassified
+		// network error, and never feed the malformed body to SAP.
+		var ibe *nanollm.InvalidBodyError
+		if errors.As(terr, &ibe) {
+			res.Outcome = OutcomeInvalidBody
+			res.Translated = &nanollm.Response{
+				Status:     ibe.Status,
+				Body:       ibe.Envelope,
+				BodyIsJSON: true,
+			}
+			return res, nil
+		}
+		// Any other translate failure is a genuine error (not a provider
+		// outcome, not SAP-eligible) and propagates.
+		return nil, fmt.Errorf("nanollmprepare: TranslateResponse(%s): %w", prep.Meta.ModelAlias, terr)
+	}
+
+	res.Translated = translated
+	res.Usage = translated.Usage
+
+	// (6) Ordinary non-2xx: TranslateResponse normalized it into the uniform
+	// JSON error envelope (real status, BodyIsJSON true). It is a provider
+	// outcome; SAP is NEVER invoked.
+	if translated.Status < 200 || translated.Status >= 300 {
+		res.Outcome = OutcomeProviderError
+		return res, nil
+	}
+
+	// (7) Unary 2xx: require a valid JSON body, extract the OpenAI assistant
+	// text (translated.Body is OpenAI-format regardless of the original
+	// provider), and feed it to the native parser.
+	if !translated.BodyIsJSON {
+		return nil, fmt.Errorf("nanollmprepare: 2xx translated response is not JSON (status %d)", translated.Status)
+	}
+	parseable, _, _, xerr := buildrequest.ExtractResponseContentBytes("openai", translated.Body, cfg.IncludeReasoning)
+	if xerr != nil {
+		return nil, fmt.Errorf("nanollmprepare: extracting assistant text: %w", xerr)
+	}
+	res.AssistantText = parseable
+
+	// SAP is invoked exactly here and nowhere else on the 2xx path.
+	res.SAPInvoked = true
+	parsed, perr := cfg.Parse(ctx, bamlutils.DeBAMLParseRequest{
+		Raw:          parseable,
+		OutputSchema: cfg.OutputSchema,
+		Stream:       false,
+	})
+	if perr != nil {
+		// A clean decline is a parity-decline recorded as data (no fallback
+		// rejoined here — no serving change in this phase). Any OTHER parse
+		// error is a CLAIMED native failure and propagates UNCHANGED so the
+		// differential can catch native-vs-BAML drift.
+		if errors.Is(perr, bamlutils.ErrDeBAMLParseUnsupported) {
+			res.Outcome = OutcomeParseDeclined
+			res.DeclineReason = perr.Error()
+			return res, nil
+		}
+		return nil, perr
+	}
+
+	res.Outcome = OutcomeStructured
+	res.Structured = parsed.JSON
+	return res, nil
+}
+
+// supportDecision is the parity-decline gate. It runs before any socket and
+// declines with a stable, secret-free stage/reason for anything outside the
+// Phase 6 admitted unary-OpenAI surface. Header VALUES and body bytes are never
+// referenced, so a decline diagnostic can never leak a secret.
+func supportDecision(prep *nanollm.PreparedRequest) error {
+	m := prep.Meta
+	if m.Provider != nativebody.ProviderOpenAI {
+		return &UnsupportedError{Stage: "provider", Reason: fmt.Sprintf("provider %q is not the admitted openai surface", m.Provider)}
+	}
+	if m.RequestType != nanollm.ChatCompletion {
+		return &UnsupportedError{Stage: "request_type", Reason: fmt.Sprintf("request type %q is not chat_completion", m.RequestType)}
+	}
+	if m.Stream {
+		return &UnsupportedError{Stage: "stream", Reason: "streaming is out of scope for the unary attempt (Phase 7)"}
+	}
+	if prep.ResponseFormat != nanollm.FormatJSON {
+		return &UnsupportedError{Stage: "response_format", Reason: fmt.Sprintf("response format %q is not json", prep.ResponseFormat)}
+	}
+	if prep.Method != "POST" {
+		return &UnsupportedError{Stage: "method", Reason: fmt.Sprintf("method %q is not POST", prep.Method)}
+	}
+	if len(prep.Body) == 0 {
+		return &UnsupportedError{Stage: "body", Reason: "prepared body is empty"}
+	}
+	return nil
+}
+
+// headerFields converts nanollm's ordered [][2]string plan headers into the
+// exact carrier's []HeaderField, preserving pair order and repeated names — the
+// two properties the exact lane must not lose. Values are copied verbatim; the
+// adapter never rewrites, adds, or drops a header.
+func headerFields(pairs [][2]string) []llmhttp.HeaderField {
+	out := make([]llmhttp.HeaderField, len(pairs))
+	for i, p := range pairs {
+		out[i] = llmhttp.HeaderField{Name: p[0], Value: p[1]}
+	}
+	return out
+}

--- a/internal/nativebody/nanollmprepare/execute/doc.go
+++ b/internal/nativebody/nanollmprepare/execute/doc.go
@@ -1,17 +1,30 @@
-// Package execute holds de-BAML Slice 2's gated, TEST-ONLY functional-send
-// suite for nanollm. It proves that a baml-rest-native OpenAI chat body (built
-// once by internal/nativebody.BuildOpenAIChat) round-trips through nanollm's
-// REAL executor — Do/DoStream, across the CGO/Rust translation core — to a
-// provider-native HTTP endpoint and back to an OpenAI-shaped caller result.
+// Package execute holds two gated, TEST-ONLY de-BAML nanollm suites.
 //
-// The whole suite is build-tagged `//go:build nanollm_integration`; the proof
-// lives in the tagged mocklm_integration_test.go (subprocess/admin/loopback
-// harness) and send_integration_test.go (the Do parity + DoStream matrix).
-// This file is deliberately UNTAGGED and IMPORT-FREE so that default, tagless
-// tooling (`go build ./...` / `go vet ./...` / editors) sees a normal, entirely
-// nanollm-free and go-mocklm-free package with exactly one non-test source file
-// — never an empty package, and never a reason to resolve, fetch, or link the
-// cgo nanollm-ffi archive or the go-mocklm tool.
+// Slice 2's FUNCTIONAL-SEND suite proves that a baml-rest-native OpenAI chat body
+// (built once by internal/nativebody.BuildOpenAIChat) round-trips through
+// nanollm's REAL executor — Do/DoStream, across the CGO/Rust translation core —
+// to a provider-native HTTP endpoint and back to an OpenAI-shaped caller result
+// (send_integration_test.go, over the go-mocklm harness in
+// mocklm_integration_test.go).
+//
+// Slice 6b's PREPARED-REQUEST adapter (attempt.go + prepared_*_test.go) proves
+// the OTHER, Option-B send path: a fresh, Phase-5-admitted nanollm.PreparedRequest
+// executed ONCE through baml-rest's own exact transport primitive (bamlutils/
+// llmhttp ExactExecutor — ordered headers, raw bytes, one RoundTrip), then
+// nanollm.TranslateResponse(prep.Meta.ModelAlias, ...) -> OpenAI assistant-text
+// extraction -> internal/debaml.Parse (native SAP). It uses NO Do/DoStream, no
+// fallback, and no same-model retry — exactly one attempt per call. Its
+// wire-fidelity oracle is a baml-rest-owned loopback capture server
+// (prepared_capture_test.go); prepared_mocklm_test.go reuses the same Slice-2
+// go-mocklm subprocess for a provider-native validity check.
+//
+// Every nanollm-touching file in the package — the adapter attempt.go and all
+// the _test.go files — carries `//go:build nanollm_integration`. This file
+// (doc.go) is the deliberate exception: it is the sole UNTAGGED, IMPORT-FREE
+// source, so that default, tagless tooling (`go build ./...` / `go vet ./...` /
+// editors) sees a normal, entirely nanollm-free and go-mocklm-free package with
+// exactly one non-test source file — never an empty package, and never a reason
+// to resolve, fetch, or link the cgo nanollm-ffi archive or the go-mocklm tool.
 //
 // Invariants this package upholds (asserted concretely by the tagged tests):
 //

--- a/internal/nativebody/nanollmprepare/execute/prepared_attempt_test.go
+++ b/internal/nativebody/nanollmprepare/execute/prepared_attempt_test.go
@@ -1,0 +1,507 @@
+//go:build nanollm_integration
+
+package execute
+
+// De-BAML Slice 6b shared harness: the fixtures + a baml-rest-owned loopback
+// CAPTURE server used by the PreparedRequest-adapter proofs
+// (prepared_capture_test.go) and the go-mocklm realism proof
+// (prepared_mocklm_test.go).
+//
+// The capture server is the wire-fidelity oracle: unlike go-mocklm (whose admin
+// log records headers as a map[string]string and so cannot prove repeated names
+// or per-name order), it records the exact method / request target / effective
+// Host / a deep copy of every header value slice / the byte-exact body, plus a
+// request counter — everything needed to prove the EXACT PreparedRequest bytes
+// are what hit the wire. It also returns fully deterministic success / non-2xx /
+// invalid-2xx fixtures so the response side (TranslateResponse -> extraction ->
+// native SAP) is exercised end to end.
+//
+// The fence is the same fail-closed posture as the rest of the module: a literal
+// fake API key, UseProcessEnv:false / Env:nil / MaxRetries:0, and a loopback-only
+// dial guard on the exact transport — no process-env secret resolution and no
+// public egress.
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	stdjson "encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
+	"github.com/invakid404/baml-rest/internal/nativebody"
+	"github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare/testutil"
+	"github.com/invakid404/baml-rest/internal/nativeprompt"
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
+)
+
+const (
+	// The Slice 6b fence. The alias is deliberately DISTINCT from the target so
+	// the "attempted alias, not target" claim is meaningful: nanollm rewrites the
+	// body's top-level model to the target, while TranslateResponse keys on the
+	// alias — the captured body must carry the target and never the alias.
+	p6bAlias  = "p6b-openai-alias"
+	p6bTarget = "p6b-openai-target"
+	p6bAPIKey = "sk-p6b-fake"
+
+	// p6bSourceModel is the placeholder model in the native body BEFORE nanollm
+	// rewrites it to p6bTarget — its absence from the sent body is the rewrite
+	// proof.
+	p6bSourceModel = "p6b-source-model"
+
+	// p6bTimeout is a generous per-call context deadline (the pipeline proofs are
+	// not timing tests).
+	p6bTimeout = 30 * time.Second
+)
+
+// newPreparedClient builds a v0.3.2 client with ONE openai alias bound to the
+// given loopback base (a literal 127.0.0.1 URL from a running test server).
+// MaxRetries:0 keeps the attempt count unambiguous; UseProcessEnv:false / Env:nil
+// forbid process-env secret resolution.
+func newPreparedClient(t *testing.T, base string) *nanollm.Client {
+	t.Helper()
+	c, err := nanollm.New(nanollm.Config{
+		Models: []nanollm.ModelConfig{{
+			Name:       p6bAlias,
+			Model:      "openai/" + p6bTarget,
+			APIKey:     p6bAPIKey,
+			BaseURL:    base + "/v1",
+			MaxRetries: 0,
+		}},
+		Env:           nil,
+		UseProcessEnv: false,
+	})
+	if err != nil {
+		t.Fatalf("nanollm.New (prepared): %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// p6bNativeBody builds ONE OpenAI chat body via baml-rest's own native path
+// (nativeprompt + nativebody.BuildOpenAIChat), carrying the source placeholder
+// model so nanollm's target rewrite is observable in the sent body.
+func p6bNativeBody(t *testing.T) []byte {
+	t.Helper()
+	rendered := &nativeprompt.RenderedPrompt{
+		Kind: nativeprompt.KindChat,
+		Messages: []nativeprompt.RenderedMessage{
+			{Role: "system", Parts: []nativeprompt.Part{{Text: sp("You are a precise extractor.")}}},
+			{Role: "user", Parts: []nativeprompt.Part{{Text: sp("Return the person as JSON.")}}},
+		},
+	}
+	body, err := nativebody.BuildOpenAIChat(rendered, nativebody.ClientIntent{
+		Provider:    nativebody.ProviderOpenAI,
+		TargetModel: p6bSourceModel,
+		ModelAlias:  p6bAlias,
+	})
+	if err != nil {
+		t.Fatalf("BuildOpenAIChat: %v", err)
+	}
+	return body.Bytes()
+}
+
+// preparePlan runs nanollm Prepare for the fence alias on the native body and
+// asserts the plan-shape invariants every 6b proof relies on: the attempted
+// alias, POST, the exact endpoint, the JSON response format, an unexpired plan,
+// and the target-model rewrite (alias absent from the body).
+func preparePlan(t *testing.T, nano *nanollm.Client, base string, body []byte) *nanollm.PreparedRequest {
+	t.Helper()
+	prep, err := nano.Prepare(nanollm.Request{
+		Model:  p6bAlias,
+		Body:   body,
+		Type:   nanollm.ChatCompletion,
+		Stream: false,
+	})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if prep.Meta.ModelAlias != p6bAlias {
+		t.Fatalf("plan alias = %q, want %q", prep.Meta.ModelAlias, p6bAlias)
+	}
+	if prep.Method != "POST" {
+		t.Fatalf("plan method = %q, want POST", prep.Method)
+	}
+	if want := base + "/v1/chat/completions"; prep.URL != want {
+		t.Fatalf("plan url = %q, want %q", prep.URL, want)
+	}
+	if prep.ResponseFormat != nanollm.FormatJSON {
+		t.Fatalf("plan response format = %q, want json", prep.ResponseFormat)
+	}
+	if prep.Expired() {
+		t.Fatalf("unsigned openai plan must not be Expired()")
+	}
+	// Rewrite proof: the sent body carries the configured TARGET, not the source
+	// placeholder and not the alias.
+	sbody := string(prep.Body)
+	if !strings.Contains(sbody, `"model":"`+p6bTarget+`"`) {
+		t.Fatalf("plan body missing target model rewrite (%s)", bodyDigest(prep.Body))
+	}
+	if strings.Contains(sbody, p6bSourceModel) {
+		t.Fatalf("plan body still carries the source placeholder model %q", p6bSourceModel)
+	}
+	if strings.Contains(sbody, p6bAlias) {
+		t.Fatalf("plan body leaks the alias %q (must carry the target only)", p6bAlias)
+	}
+	return prep
+}
+
+// --- exact transport: loopback-only, single physical attempt ---
+
+// exactLoopbackExecutor builds an ExactExecutor over a loopback-guarded
+// transport that mirrors the exact lane's transparency guarantees: Proxy nil (no
+// proxy-auth injection), compression disabled (no injected Accept-Encoding / no
+// transparent decode), and keep-alives disabled (no stale-connection replay, so
+// one RoundTrip is one server-visible request). A mistyped base fails the dial
+// guard rather than escaping to a public host.
+func exactLoopbackExecutor() *llmhttp.ExactExecutor {
+	return llmhttp.NewExactExecutor(&http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("loopback guard: unparsable dial address %q: %w", addr, err)
+			}
+			if !isLoopbackHost(host) {
+				return nil, fmt.Errorf("loopback guard: refusing non-loopback dial to %q", addr)
+			}
+			var d net.Dialer
+			return d.DialContext(ctx, network, net.JoinHostPort(host, port))
+		},
+		DisableCompression: true,
+		DisableKeepAlives:  true,
+	})
+}
+
+// --- native parser spy ---
+
+// parseSpy wraps a bamlutils.DeBAMLParseFunc and counts invocations. It is the
+// INDEPENDENT proof that provider outcomes (non-2xx / invalid-2xx) never reach
+// SAP: those cases must leave calls == 0, corroborating AttemptResult.SAPInvoked.
+type parseSpy struct {
+	fn    bamlutils.DeBAMLParseFunc
+	calls int
+}
+
+func (s *parseSpy) Parse(ctx context.Context, req bamlutils.DeBAMLParseRequest) (bamlutils.DeBAMLParseResult, error) {
+	s.calls++
+	return s.fn(ctx, req)
+}
+
+// --- native output schemas ---
+
+// personSchema6b is a two-field class {name string, age int} the native parser
+// cleanly CLAIMS for a well-formed JSON object, DECLINES for non-JSON prose.
+func personSchema6b() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("name", &bamlutils.DynamicProperty{Type: "string"}),
+			bamlutils.OrderedKV("age", &bamlutils.DynamicProperty{Type: "int"}),
+		),
+	}
+}
+
+// enumTieSchema6b is Root{animal: Animal enum{CAT,DOG}}; a value that
+// substring-ties both enum values is a CLAIMED parse error (BAML errors it too),
+// distinct from a decline.
+func enumTieSchema6b() *bamlutils.DynamicOutputSchema {
+	return &bamlutils.DynamicOutputSchema{
+		Properties: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("animal", &bamlutils.DynamicProperty{Ref: "Animal"}),
+		),
+		Enums: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Animal", &bamlutils.DynamicEnum{
+				Values: []*bamlutils.DynamicEnumValue{{Name: "CAT"}, {Name: "DOG"}},
+			}),
+		),
+	}
+}
+
+// --- deterministic response fixtures ---
+
+// openAISuccessBody returns a deterministic OpenAI Chat Completions success body
+// whose assistant content is exactly `content` (the structured JSON string the
+// native parser is fed) and whose usage block is fixed so the retained
+// Response.Usage is assertable.
+func openAISuccessBody(content string) []byte {
+	m := map[string]any{
+		"id":     "chatcmpl-p6b",
+		"object": "chat.completion",
+		"model":  p6bTarget,
+		"choices": []any{map[string]any{
+			"index":         0,
+			"message":       map[string]any{"role": "assistant", "content": content},
+			"finish_reason": "stop",
+		}},
+		"usage": map[string]any{"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+	}
+	b, err := stdjson.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// openAIErrorBody returns a deterministic OpenAI-style non-2xx error body.
+func openAIErrorBody(message, typ string) []byte {
+	m := map[string]any{"error": map[string]any{"message": message, "type": typ, "code": typ}}
+	b, err := stdjson.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// --- baml-rest-owned loopback capture server ---
+
+// recordedExact is one captured request: the exact method, request target
+// (path+query), effective Host, a deep copy of the header value slices, and the
+// byte-exact body.
+type recordedExact struct {
+	Method     string
+	RequestURI string
+	Host       string
+	Header     http.Header
+	Body       []byte
+}
+
+// captureServer is a loopback httptest.Server that records every request and
+// replies with a programmable deterministic fixture.
+type captureServer struct {
+	t   *testing.T
+	srv *httptest.Server
+
+	mu         sync.Mutex
+	recs       []recordedExact
+	respStatus int
+	respBody   []byte
+}
+
+// newCaptureServer starts a loopback capture server (httptest binds 127.0.0.1)
+// defaulting to a 200 + empty body until the test programs a response.
+func newCaptureServer(t *testing.T) *captureServer {
+	t.Helper()
+	cs := &captureServer{t: t, respStatus: http.StatusOK}
+	cs.srv = httptest.NewServer(http.HandlerFunc(cs.handle))
+	t.Cleanup(cs.srv.Close)
+	return cs
+}
+
+func (cs *captureServer) handle(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		// The client may deliberately abandon a read (cap / cancellation cases);
+		// record what arrived rather than failing the handler goroutine.
+		body = append(body, []byte("<read-error>")...)
+	}
+	rec := recordedExact{
+		Method:     r.Method,
+		RequestURI: r.RequestURI,
+		Host:       r.Host,
+		Header:     r.Header.Clone(),
+		Body:       body,
+	}
+	cs.mu.Lock()
+	cs.recs = append(cs.recs, rec)
+	status, respBody := cs.respStatus, cs.respBody
+	cs.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(respBody)
+}
+
+func (cs *captureServer) base() string { return cs.srv.URL }
+
+// setResponse programs the deterministic reply the handler writes next.
+func (cs *captureServer) setResponse(status int, body []byte) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	cs.respStatus = status
+	cs.respBody = body
+}
+
+func (cs *captureServer) count() int {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return len(cs.recs)
+}
+
+// only returns the single captured request, failing if there is not exactly one.
+func (cs *captureServer) only() recordedExact {
+	cs.t.Helper()
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if len(cs.recs) != 1 {
+		cs.t.Fatalf("want exactly 1 captured request, got %d", len(cs.recs))
+	}
+	return cs.recs[0]
+}
+
+// --- exact-plan-sent assertion ---
+
+// assertExactPlanSent proves the captured request is byte-identical to the
+// PreparedRequest fields supplied to the adapter: exact method, exact request
+// target + effective host, byte-exact body, and semantic header equality (every
+// plan header present with its exact value and per-name order; the ONLY wire-only
+// headers permitted are transport-generated framing fields neither planner
+// controls). Global header-name order/casing is explicitly NOT compared.
+func assertExactPlanSent(t *testing.T, prep *nanollm.PreparedRequest, rec recordedExact) {
+	t.Helper()
+
+	if rec.Method != prep.Method {
+		t.Errorf("method: wire=%q plan=%q", rec.Method, prep.Method)
+	}
+
+	u, err := url.Parse(prep.URL)
+	if err != nil {
+		t.Fatalf("parsing plan URL %q: %v", prep.URL, err)
+	}
+	wantTarget := u.EscapedPath()
+	if u.RawQuery != "" {
+		wantTarget += "?" + u.RawQuery
+	}
+	if rec.RequestURI != wantTarget {
+		t.Errorf("request target: wire=%q plan=%q", rec.RequestURI, wantTarget)
+	}
+	if rec.Host != u.Host {
+		t.Errorf("effective host: wire=%q plan=%q", rec.Host, u.Host)
+	}
+
+	if !bytes.Equal(rec.Body, prep.Body) {
+		t.Errorf("body not byte-identical: wire=%d bytes, plan=%d bytes", len(rec.Body), len(prep.Body))
+	}
+
+	assertHeaderMultisetSent(t, prep.Headers, rec.Header)
+}
+
+// transportOnlyHeaders are the request-header names net/http itself frames and
+// that no planner controls; they are the ONLY permitted wire-only headers. On
+// the server side Go moves Content-Length into r.ContentLength (so it rarely
+// appears in r.Header); User-Agent is auto-added unless the plan set it; with
+// compression disabled the transport injects no Accept-Encoding; and with
+// keep-alives disabled (the exact lane's single-physical-attempt guarantee) it
+// frames the connection with Connection: close. The allowlist stays defensive.
+var transportOnlyHeaders = map[string]bool{
+	"user-agent":      true,
+	"content-length":  true,
+	"accept-encoding": true,
+	"connection":      true,
+}
+
+func assertHeaderMultisetSent(t *testing.T, planHeaders [][2]string, wire http.Header) {
+	t.Helper()
+
+	// Group the plan's ordered pairs by lowercase name, preserving per-name
+	// value order (repeats retained).
+	planByName := map[string][]string{}
+	var planOrder []string
+	for _, p := range planHeaders {
+		n := strings.ToLower(p[0])
+		if _, seen := planByName[n]; !seen {
+			planOrder = append(planOrder, n)
+		}
+		planByName[n] = append(planByName[n], p[1])
+	}
+
+	// http.Header keys are canonical + unique; fold to lowercase for the compare.
+	wireByName := map[string][]string{}
+	for k, vs := range wire {
+		wireByName[strings.ToLower(k)] = append(wireByName[strings.ToLower(k)], vs...)
+	}
+
+	for _, n := range planOrder {
+		got := wireByName[n]
+		want := planByName[n]
+		if !slices.Equal(got, want) {
+			t.Errorf("header %q: wire values %v != plan values %v (redacted)", n, redactVals(n, got), redactVals(n, want))
+		}
+	}
+	for n := range wireByName {
+		if _, inPlan := planByName[n]; inPlan {
+			continue
+		}
+		if !transportOnlyHeaders[n] {
+			t.Errorf("unexpected wire-only header %q (not in plan, not transport-generated)", n)
+		}
+	}
+}
+
+func redactVals(name string, vals []string) []string {
+	out := make([]string, len(vals))
+	for i, v := range vals {
+		out[i] = testutil.RedactValue(name, v)
+	}
+	return out
+}
+
+// --- small JSON helper ---
+
+// jsonSemEqual reports whether a and b decode to structurally equal JSON values
+// (object key order ignored; numbers compared as float64). On a decode failure it
+// reports only a size/hash digest of the offending payload, never the raw bytes.
+func jsonSemEqual(t *testing.T, a, b []byte) bool {
+	t.Helper()
+	var av, bv any
+	if err := stdjson.Unmarshal(a, &av); err != nil {
+		t.Fatalf("decode a (%s): %v", bodyDigest(a), err)
+	}
+	if err := stdjson.Unmarshal(b, &bv); err != nil {
+		t.Fatalf("decode b (%s): %v", bodyDigest(b), err)
+	}
+	return reflect.DeepEqual(av, bv)
+}
+
+// --- secret-safe diagnostics (no-full-body-log fence) ---
+//
+// Failure diagnostics in these gated tests must never emit a full request body,
+// response body, translated envelope, structured output, assistant text, or a
+// header value/credential — even though the fixtures use fake keys. The helpers
+// below reduce every such payload to a size + short-hash summary and reduce the
+// response/result structs to their safe scalar facts, so a CI failure log holds
+// no plan or provider payload. The assertions stay exactly as strong; only the
+// message is derived from redacted facts.
+
+// bodyDigest renders a payload as "<n>B sha256:<12hex>" — never the raw bytes.
+func bodyDigest(b []byte) string {
+	sum := sha256.Sum256(b)
+	return fmt.Sprintf("%dB sha256:%s", len(b), hex.EncodeToString(sum[:])[:12])
+}
+
+// translatedSummary renders a *nanollm.Response using only its safe scalar facts
+// (status, JSON flag) plus a digest of the body — never the body bytes.
+func translatedSummary(r *nanollm.Response) string {
+	if r == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{status:%d jsonBody:%v body:%s}", r.Status, r.BodyIsJSON, bodyDigest(r.Body))
+}
+
+// resultSummary renders an *AttemptResult for a failure diagnostic using only
+// safe facts — outcome, attempted alias, statuses, the SAP flag, the decline
+// reason, and size/hash digests of the payload fields — never the raw provider /
+// translated / structured bytes or the assistant text.
+func resultSummary(res *AttemptResult) string {
+	if res == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf(
+		"{outcome:%s alias:%q sap:%v providerStatus:%d providerBody:%s translated:%s structured:%s assistantText:%s decline:%q}",
+		res.Outcome, res.AttemptedAlias, res.SAPInvoked, res.ProviderStatus,
+		bodyDigest(res.ProviderBody), translatedSummary(res.Translated),
+		bodyDigest(res.Structured), bodyDigest([]byte(res.AssistantText)), res.DeclineReason,
+	)
+}

--- a/internal/nativebody/nanollmprepare/execute/prepared_capture_test.go
+++ b/internal/nativebody/nanollmprepare/execute/prepared_capture_test.go
@@ -1,0 +1,482 @@
+//go:build nanollm_integration
+
+package execute
+
+// De-BAML Slice 6b PreparedRequest-adapter proofs against the baml-rest-owned
+// loopback CAPTURE server (prepared_attempt_test.go). These are the primary
+// wire-fidelity + response-side differential:
+//
+//	nanollm.PreparedRequest (fresh, Phase-5-admitted)
+//	  -> llmhttp ExactAttemptRequest (ordered headers, raw bytes)
+//	  -> ONE exact RoundTrip vs the loopback capture server
+//	  -> ExactAttemptResponse
+//	  -> nanollm.TranslateResponse(prep.Meta.ModelAlias, status, rawBody)
+//	  -> buildrequest.ExtractResponseContentBytes("openai", ...)  [2xx only]
+//	  -> internal/debaml.Parse (native SAP)                       [2xx only]
+//
+// There is NO Do/DoStream, NO fallback, and NO same-model retry: exactly one
+// transport attempt per call, pinned by the capture server's request counter.
+// Every credential is a literal fake; the exact transport dials loopback only.
+//
+// Tests are SERIAL (no t.Parallel): each starts its own capture server.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
+	"github.com/invakid404/baml-rest/internal/debaml"
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
+)
+
+// TestPreparedExactPlanSentAndStructured is the core 6b proof: the byte-exact
+// PreparedRequest hits the wire ONCE, the attempted alias drives translation, and
+// a clean OpenAI 2xx reaches native structured output.
+func TestPreparedExactPlanSentAndStructured(t *testing.T) {
+	cs := newCaptureServer(t)
+	nano := newPreparedClient(t, cs.base())
+	prep := preparePlan(t, nano, cs.base(), p6bNativeBody(t))
+
+	// Deterministic OpenAI success whose assistant content is JSON the parser
+	// cleanly claims against personSchema6b.
+	cs.setResponse(200, openAISuccessBody(`{"name":"Ada","age":36}`))
+
+	spy := &parseSpy{fn: debaml.Parse}
+	ctx, cancel := context.WithTimeout(context.Background(), p6bTimeout)
+	defer cancel()
+
+	res, err := RunAttempt(ctx, AttemptConfig{
+		Client:       nano,
+		Prepared:     prep,
+		Executor:     exactLoopbackExecutor(),
+		Parse:        spy.Parse,
+		OutputSchema: personSchema6b(),
+	})
+	if err != nil {
+		t.Fatalf("RunAttempt: %v", err)
+	}
+
+	// (1) exactly one request, byte-identical to the plan.
+	if got := cs.count(); got != 1 {
+		t.Fatalf("capture count = %d, want exactly 1 (no retry/fallback)", got)
+	}
+	rec := cs.only()
+	assertExactPlanSent(t, prep, rec)
+
+	// The fake Bearer auth is on the wire verbatim (asserted directly, redacted in
+	// any diagnostic).
+	if got := rec.Header.Get("Authorization"); got != "Bearer "+p6bAPIKey {
+		t.Errorf("wire Authorization mismatch (redacted): got <redacted> want <redacted> (present=%v)", got != "")
+	}
+
+	// (2) attempted alias retained + used for translation (distinct from target).
+	if res.AttemptedAlias != p6bAlias {
+		t.Errorf("attempted alias = %q, want %q", res.AttemptedAlias, p6bAlias)
+	}
+
+	// (3) structured output reached; SAP invoked exactly once.
+	if res.Outcome != OutcomeStructured {
+		t.Fatalf("outcome = %s, want structured", res.Outcome)
+	}
+	if !res.SAPInvoked {
+		t.Errorf("SAPInvoked = false, want true on a 2xx claim")
+	}
+	if spy.calls != 1 {
+		t.Errorf("parser calls = %d, want 1", spy.calls)
+	}
+	if res.AssistantText != `{"name":"Ada","age":36}` {
+		t.Errorf("assistant text mismatch (%s), want the structured JSON", bodyDigest([]byte(res.AssistantText)))
+	}
+	if !jsonSemEqual(t, res.Structured, []byte(`{"name":"Ada","age":36}`)) {
+		t.Errorf("structured output %s != want {name,age}", bodyDigest(res.Structured))
+	}
+
+	// (4) usage retained from the translated response.
+	if res.Usage == nil {
+		t.Fatalf("Usage is nil, want retained")
+	}
+	if res.Usage.PromptTokens != 5 || res.Usage.CompletionTokens != 3 {
+		t.Errorf("usage prompt=%d completion=%d, want prompt=5 completion=3", res.Usage.PromptTokens, res.Usage.CompletionTokens)
+	}
+	// The raw upstream 2xx status is preserved alongside the translation.
+	if res.ProviderStatus != 200 {
+		t.Errorf("provider status = %d, want 200", res.ProviderStatus)
+	}
+}
+
+// TestPreparedOrdinaryNon2xxSkipsSAP: an ordinary provider non-2xx becomes the
+// uniform envelope provider outcome and NEVER reaches SAP; exactly one request.
+func TestPreparedOrdinaryNon2xxSkipsSAP(t *testing.T) {
+	cs := newCaptureServer(t)
+	nano := newPreparedClient(t, cs.base())
+	prep := preparePlan(t, nano, cs.base(), p6bNativeBody(t))
+
+	cs.setResponse(429, openAIErrorBody("slow down", "rate_limit_error"))
+
+	spy := &parseSpy{fn: debaml.Parse}
+	ctx, cancel := context.WithTimeout(context.Background(), p6bTimeout)
+	defer cancel()
+
+	res, err := RunAttempt(ctx, AttemptConfig{
+		Client:       nano,
+		Prepared:     prep,
+		Executor:     exactLoopbackExecutor(),
+		Parse:        spy.Parse,
+		OutputSchema: personSchema6b(),
+	})
+	if err != nil {
+		t.Fatalf("RunAttempt returned an error, want a provider outcome: %v", err)
+	}
+
+	if res.Outcome != OutcomeProviderError {
+		t.Fatalf("outcome = %s, want provider-error", res.Outcome)
+	}
+	if res.SAPInvoked || spy.calls != 0 {
+		t.Errorf("SAP was invoked on a non-2xx (SAPInvoked=%v calls=%d); it must be skipped", res.SAPInvoked, spy.calls)
+	}
+	if res.Structured != nil {
+		t.Errorf("structured output present on a non-2xx (%s), want none", bodyDigest(res.Structured))
+	}
+	// The translated envelope carries the real status + is JSON.
+	if res.Translated == nil || res.Translated.Status != 429 || !res.Translated.BodyIsJSON {
+		t.Fatalf("translated %s, want status 429 + BodyIsJSON", translatedSummary(res.Translated))
+	}
+	if res.ProviderStatus != 429 {
+		t.Errorf("provider status = %d, want 429", res.ProviderStatus)
+	}
+	if got := cs.count(); got != 1 {
+		t.Errorf("capture count = %d, want exactly 1", got)
+	}
+}
+
+// TestPreparedInvalidBodySkipsSAP: a provider 2xx with an unparseable body
+// surfaces nanollm's typed *InvalidBodyError, mapped to the 502/uniform-envelope
+// provider outcome — never a network error, never fed to SAP.
+func TestPreparedInvalidBodySkipsSAP(t *testing.T) {
+	cs := newCaptureServer(t)
+	nano := newPreparedClient(t, cs.base())
+	prep := preparePlan(t, nano, cs.base(), p6bNativeBody(t))
+
+	// A 2xx whose body is not JSON: TranslateResponse -> *InvalidBodyError(502).
+	cs.setResponse(200, []byte("<html>not json</html>"))
+
+	spy := &parseSpy{fn: debaml.Parse}
+	ctx, cancel := context.WithTimeout(context.Background(), p6bTimeout)
+	defer cancel()
+
+	res, err := RunAttempt(ctx, AttemptConfig{
+		Client:       nano,
+		Prepared:     prep,
+		Executor:     exactLoopbackExecutor(),
+		Parse:        spy.Parse,
+		OutputSchema: personSchema6b(),
+	})
+	if err != nil {
+		t.Fatalf("RunAttempt returned an error, want the 502 provider outcome: %v", err)
+	}
+
+	if res.Outcome != OutcomeInvalidBody {
+		t.Fatalf("outcome = %s, want invalid-body", res.Outcome)
+	}
+	if res.SAPInvoked || spy.calls != 0 {
+		t.Errorf("SAP was invoked on an invalid-2xx (SAPInvoked=%v calls=%d); it must be skipped", res.SAPInvoked, spy.calls)
+	}
+	if res.Translated == nil || res.Translated.Status != 502 || !res.Translated.BodyIsJSON {
+		t.Fatalf("translated %s, want the 502 envelope + BodyIsJSON", translatedSummary(res.Translated))
+	}
+	if !strings.Contains(string(res.Translated.Body), "invalid_provider_body") {
+		t.Errorf("envelope (%s) does not carry invalid_provider_body", bodyDigest(res.Translated.Body))
+	}
+	// The RAW upstream status (200) is preserved distinct from the caller-facing
+	// 502 the envelope reports.
+	if res.ProviderStatus != 200 {
+		t.Errorf("provider status = %d, want the raw upstream 200", res.ProviderStatus)
+	}
+	if got := cs.count(); got != 1 {
+		t.Errorf("capture count = %d, want exactly 1", got)
+	}
+}
+
+// TestPreparedExpiryRejectedPreAttempt: an expired plan is rejected BEFORE any
+// socket — no request reaches the server and SAP is never invoked.
+func TestPreparedExpiryRejectedPreAttempt(t *testing.T) {
+	cs := newCaptureServer(t)
+	nano := newPreparedClient(t, cs.base())
+
+	// A synthetic, otherwise-supported plan whose signature window has passed.
+	// OpenAI plans are unsigned, so expiry is fabricated to exercise the guard.
+	past := time.Now().Add(-time.Hour)
+	prep := &nanollm.PreparedRequest{
+		Method:         "POST",
+		URL:            cs.base() + "/v1/chat/completions",
+		Headers:        [][2]string{{"Content-Type", "application/json"}, {"Authorization", "Bearer " + p6bAPIKey}},
+		Body:           []byte(`{"model":"` + p6bTarget + `","messages":[]}`),
+		ResponseFormat: nanollm.FormatJSON,
+		Meta: nanollm.PreparedMeta{
+			ModelAlias:  p6bAlias,
+			TargetModel: p6bTarget,
+			Provider:    "openai",
+			RequestType: nanollm.ChatCompletion,
+			ExpiresAt:   &past,
+		},
+	}
+
+	spy := &parseSpy{fn: debaml.Parse}
+	ctx, cancel := context.WithTimeout(context.Background(), p6bTimeout)
+	defer cancel()
+
+	res, err := RunAttempt(ctx, AttemptConfig{
+		Client:       nano,
+		Prepared:     prep,
+		Executor:     exactLoopbackExecutor(),
+		Parse:        spy.Parse,
+		OutputSchema: personSchema6b(),
+	})
+	if !errors.Is(err, ErrPlanExpired) {
+		t.Fatalf("err = %v, want ErrPlanExpired", err)
+	}
+	if res != nil {
+		t.Errorf("result = %s, want nil on a pre-attempt rejection", resultSummary(res))
+	}
+	if got := cs.count(); got != 0 {
+		t.Errorf("capture count = %d, want 0 (no socket opened)", got)
+	}
+	if spy.calls != 0 {
+		t.Errorf("parser calls = %d, want 0", spy.calls)
+	}
+}
+
+// TestPreparedUnsupportedDeclinedPreAttempt: a plan outside the admitted
+// unary-OpenAI surface declines with the parity-decline sentinel + a stable
+// stage/reason, before any socket.
+func TestPreparedUnsupportedDeclinedPreAttempt(t *testing.T) {
+	cs := newCaptureServer(t)
+	nano := newPreparedClient(t, cs.base())
+	prep := preparePlan(t, nano, cs.base(), p6bNativeBody(t))
+
+	// Mutate the plan's provider to an unproven one AFTER Prepare (a synthetic
+	// unsupported shape). The support decision must decline before a socket.
+	prep.Meta.Provider = "anthropic"
+
+	spy := &parseSpy{fn: debaml.Parse}
+	ctx, cancel := context.WithTimeout(context.Background(), p6bTimeout)
+	defer cancel()
+
+	res, err := RunAttempt(ctx, AttemptConfig{
+		Client:       nano,
+		Prepared:     prep,
+		Executor:     exactLoopbackExecutor(),
+		Parse:        spy.Parse,
+		OutputSchema: personSchema6b(),
+	})
+	if !errors.Is(err, ErrAttemptUnsupported) {
+		t.Fatalf("err = %v, want ErrAttemptUnsupported", err)
+	}
+	var ue *UnsupportedError
+	if !errors.As(err, &ue) || ue.Stage != "provider" {
+		t.Fatalf("err = %v, want an UnsupportedError with stage=provider", err)
+	}
+	if res != nil {
+		t.Errorf("result = %s, want nil on a pre-attempt decline", resultSummary(res))
+	}
+	if got := cs.count(); got != 0 {
+		t.Errorf("capture count = %d, want 0 (no socket opened)", got)
+	}
+	if spy.calls != 0 {
+		t.Errorf("parser calls = %d, want 0", spy.calls)
+	}
+}
+
+// TestPreparedSuccessBodyCapExceeded: a 2xx body over the 16 MiB success cap
+// fails the attempt (the exact executor rejects it) without reaching SAP.
+func TestPreparedSuccessBodyCapExceeded(t *testing.T) {
+	cs := newCaptureServer(t)
+	nano := newPreparedClient(t, cs.base())
+	prep := preparePlan(t, nano, cs.base(), p6bNativeBody(t))
+
+	// One byte over the 16 MiB success cap. The executor reads limit+1 and errors.
+	oversized := bytes.Repeat([]byte("a"), llmhttp.MaxResponseBodyBytes+1)
+	cs.setResponse(200, oversized)
+
+	spy := &parseSpy{fn: debaml.Parse}
+	ctx, cancel := context.WithTimeout(context.Background(), p6bTimeout)
+	defer cancel()
+
+	res, err := RunAttempt(ctx, AttemptConfig{
+		Client:       nano,
+		Prepared:     prep,
+		Executor:     exactLoopbackExecutor(),
+		Parse:        spy.Parse,
+		OutputSchema: personSchema6b(),
+	})
+	if err == nil {
+		t.Fatalf("RunAttempt succeeded, want a success-cap error; res=%s", resultSummary(res))
+	}
+	if !strings.Contains(err.Error(), "maximum size") {
+		t.Errorf("err = %v, want a body-size-cap error", err)
+	}
+	if res != nil {
+		t.Errorf("result = %s, want nil on a transport failure", resultSummary(res))
+	}
+	if spy.calls != 0 {
+		t.Errorf("parser calls = %d, want 0 (SAP never reached)", spy.calls)
+	}
+	if got := cs.count(); got != 1 {
+		t.Errorf("capture count = %d, want exactly 1", got)
+	}
+}
+
+// TestPreparedErrorBodyCapTruncated: a non-2xx body over the 64 KiB error cap is
+// truncated to exactly the cap and returned as data (still a provider outcome,
+// still no SAP).
+func TestPreparedErrorBodyCapTruncated(t *testing.T) {
+	cs := newCaptureServer(t)
+	nano := newPreparedClient(t, cs.base())
+	prep := preparePlan(t, nano, cs.base(), p6bNativeBody(t))
+
+	oversized := bytes.Repeat([]byte("a"), llmhttp.MaxExactErrorBodyBytes+128)
+	cs.setResponse(503, oversized)
+
+	spy := &parseSpy{fn: debaml.Parse}
+	ctx, cancel := context.WithTimeout(context.Background(), p6bTimeout)
+	defer cancel()
+
+	res, err := RunAttempt(ctx, AttemptConfig{
+		Client:       nano,
+		Prepared:     prep,
+		Executor:     exactLoopbackExecutor(),
+		Parse:        spy.Parse,
+		OutputSchema: personSchema6b(),
+	})
+	if err != nil {
+		t.Fatalf("RunAttempt returned an error, want a truncated provider outcome: %v", err)
+	}
+	if res.Outcome != OutcomeProviderError {
+		t.Fatalf("outcome = %s, want provider-error", res.Outcome)
+	}
+	if len(res.ProviderBody) != llmhttp.MaxExactErrorBodyBytes {
+		t.Errorf("provider body = %d bytes, want exactly the 64 KiB cap (%d)", len(res.ProviderBody), llmhttp.MaxExactErrorBodyBytes)
+	}
+	if res.ProviderStatus != 503 {
+		t.Errorf("provider status = %d, want 503", res.ProviderStatus)
+	}
+	if res.SAPInvoked || spy.calls != 0 {
+		t.Errorf("SAP was invoked on a non-2xx (SAPInvoked=%v calls=%d)", res.SAPInvoked, spy.calls)
+	}
+	if got := cs.count(); got != 1 {
+		t.Errorf("capture count = %d, want exactly 1", got)
+	}
+}
+
+// TestPreparedCancellationNoSend: a context cancelled before the attempt yields a
+// context error, no request, and no SAP.
+func TestPreparedCancellationNoSend(t *testing.T) {
+	cs := newCaptureServer(t)
+	nano := newPreparedClient(t, cs.base())
+	prep := preparePlan(t, nano, cs.base(), p6bNativeBody(t))
+	cs.setResponse(200, openAISuccessBody(`{"name":"Ada","age":36}`))
+
+	spy := &parseSpy{fn: debaml.Parse}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel BEFORE the attempt
+
+	res, err := RunAttempt(ctx, AttemptConfig{
+		Client:       nano,
+		Prepared:     prep,
+		Executor:     exactLoopbackExecutor(),
+		Parse:        spy.Parse,
+		OutputSchema: personSchema6b(),
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if res != nil {
+		t.Errorf("result = %s, want nil on cancellation", resultSummary(res))
+	}
+	if got := cs.count(); got != 0 {
+		t.Errorf("capture count = %d, want 0 (cancelled before send)", got)
+	}
+	if spy.calls != 0 {
+		t.Errorf("parser calls = %d, want 0", spy.calls)
+	}
+}
+
+// TestPreparedDeclineVsClaimedParseError asserts the two 2xx parse dispositions
+// SEPARATELY so a fallback can never masquerade as a native success: a DECLINE
+// (ErrDeBAMLParseUnsupported) is a nil-error parity outcome; a CLAIMED parse
+// error propagates as a non-sentinel Go error. Both invoke SAP exactly once.
+func TestPreparedDeclineVsClaimedParseError(t *testing.T) {
+	t.Run("decline", func(t *testing.T) {
+		cs := newCaptureServer(t)
+		nano := newPreparedClient(t, cs.base())
+		prep := preparePlan(t, nano, cs.base(), p6bNativeBody(t))
+
+		// Assistant text with no cleanly-claimable JSON candidate -> DECLINE.
+		cs.setResponse(200, openAISuccessBody("there is no json in this reply at all"))
+
+		spy := &parseSpy{fn: debaml.Parse}
+		ctx, cancel := context.WithTimeout(context.Background(), p6bTimeout)
+		defer cancel()
+
+		res, err := RunAttempt(ctx, AttemptConfig{
+			Client:       nano,
+			Prepared:     prep,
+			Executor:     exactLoopbackExecutor(),
+			Parse:        spy.Parse,
+			OutputSchema: personSchema6b(),
+		})
+		if err != nil {
+			t.Fatalf("RunAttempt returned an error, want a decline outcome: %v", err)
+		}
+		if res.Outcome != OutcomeParseDeclined {
+			t.Fatalf("outcome = %s, want parse-declined", res.Outcome)
+		}
+		if !res.SAPInvoked || spy.calls != 1 {
+			t.Errorf("SAP invocation: SAPInvoked=%v calls=%d, want invoked once", res.SAPInvoked, spy.calls)
+		}
+		if res.Structured != nil {
+			t.Errorf("structured output present on a decline (%s), want none", bodyDigest(res.Structured))
+		}
+		if res.DeclineReason == "" {
+			t.Errorf("DeclineReason empty, want the parser's decline explanation")
+		}
+	})
+
+	t.Run("claimed_error", func(t *testing.T) {
+		cs := newCaptureServer(t)
+		nano := newPreparedClient(t, cs.base())
+		prep := preparePlan(t, nano, cs.base(), p6bNativeBody(t))
+
+		// A value that substring-ties both enum values -> CLAIMED parse error.
+		cs.setResponse(200, openAISuccessBody(`{"animal":"cat dog"}`))
+
+		spy := &parseSpy{fn: debaml.Parse}
+		ctx, cancel := context.WithTimeout(context.Background(), p6bTimeout)
+		defer cancel()
+
+		res, err := RunAttempt(ctx, AttemptConfig{
+			Client:       nano,
+			Prepared:     prep,
+			Executor:     exactLoopbackExecutor(),
+			Parse:        spy.Parse,
+			OutputSchema: enumTieSchema6b(),
+		})
+		if err == nil {
+			t.Fatalf("RunAttempt succeeded, want a claimed parse error; res=%s", resultSummary(res))
+		}
+		if errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			t.Fatalf("err is the decline sentinel, want a CLAIMED parse error: %v", err)
+		}
+		if res != nil {
+			t.Errorf("result = %s, want nil when a claimed parse error propagates", resultSummary(res))
+		}
+		if spy.calls != 1 {
+			t.Errorf("parser calls = %d, want 1 (SAP invoked, then claimed)", spy.calls)
+		}
+	})
+}

--- a/internal/nativebody/nanollmprepare/execute/prepared_mocklm_test.go
+++ b/internal/nativebody/nanollmprepare/execute/prepared_mocklm_test.go
@@ -1,0 +1,108 @@
+//go:build nanollm_integration
+
+package execute
+
+// De-BAML Slice 6b realism proof: the SAME PreparedRequest-adapter pipeline, but
+// executed against the real go-mocklm v0.4.0 subprocess (reusing the Slice-2
+// harness in mocklm_integration_test.go) instead of the baml-rest capture server.
+//
+// Where the capture-server proofs pin byte-exact wire fidelity, this one pins
+// PROVIDER-NATIVE VALIDITY: the exact PreparedRequest nanollm produced is a real
+// OpenAI Chat Completions request that go-mocklm (with MOCKLM_VALIDATE_RESPONSES)
+// accepts on its /v1/chat/completions route and answers deterministically, and
+// the whole adapter pipeline (exact transport -> TranslateResponse -> OpenAI
+// extraction -> native SAP) reaches structured output — in exactly one request,
+// with no Do/DoStream, fallback, or same-model retry.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/invakid404/baml-rest/internal/debaml"
+)
+
+// TestPreparedAttemptAgainstMockLM drives the 6b adapter against the go-mocklm
+// subprocess and asserts a provider-native accepted request reaches native
+// structured output.
+func TestPreparedAttemptAgainstMockLM(t *testing.T) {
+	m := startMock(t)
+	nano := newPreparedClient(t, m.baseURL)
+	prep := preparePlan(t, nano, m.baseURL, p6bNativeBody(t))
+
+	const id = "p6b-openai-structured"
+	// The assistant text is the structured JSON the native parser cleanly claims
+	// against personSchema6b.
+	const content = `{"name":"Ada","age":36}`
+	// The fixture pins the output-token count deterministically; the translated
+	// usage's completion tokens must map to exactly this value (below), so a wrong
+	// go-mocklm-path usage translation cannot pass on a non-nil check alone.
+	const wantOutputTokens = 7
+	m.registerScenario(scenarioSpec{
+		ID:       id,
+		Provider: "openai",
+		Model:    p6bTarget,
+		Output:   &exactOutput{Text: content, OutputTokens: wantOutputTokens},
+	})
+
+	spy := &parseSpy{fn: debaml.Parse}
+	ctx, cancel := context.WithTimeout(context.Background(), p6bTimeout)
+	defer cancel()
+
+	res, err := RunAttempt(ctx, AttemptConfig{
+		Client:       nano,
+		Prepared:     prep,
+		Executor:     exactLoopbackExecutor(),
+		Parse:        spy.Parse,
+		OutputSchema: personSchema6b(),
+	})
+	if err != nil {
+		t.Fatalf("RunAttempt(go-mocklm): %v", err)
+	}
+
+	// Structured output through the full pipeline; attempted alias retained.
+	if res.Outcome != OutcomeStructured {
+		t.Fatalf("outcome = %s, want structured", res.Outcome)
+	}
+	if res.AttemptedAlias != p6bAlias {
+		t.Errorf("attempted alias = %q, want %q", res.AttemptedAlias, p6bAlias)
+	}
+	if !res.SAPInvoked || spy.calls != 1 {
+		t.Errorf("SAP invocation: SAPInvoked=%v calls=%d, want invoked once", res.SAPInvoked, spy.calls)
+	}
+	if !jsonSemEqual(t, res.Structured, []byte(content)) {
+		t.Errorf("structured output %s != want (name/age)", bodyDigest(res.Structured))
+	}
+	// Usage is retained AND its deterministic completion-token value is the
+	// translated mapping of the fixture's pinned output tokens — binding the
+	// go-mocklm-path usage translation, not merely asserting presence.
+	if res.Usage == nil {
+		t.Fatalf("Usage is nil, want retained from the translated response")
+	}
+	if res.Usage.CompletionTokens != wantOutputTokens {
+		t.Errorf("usage completion tokens = %d, want %d (fixture-pinned)", res.Usage.CompletionTokens, wantOutputTokens)
+	}
+
+	// Exactly one provider-native request; the exact plan took the OpenAI route
+	// with the rewritten target model.
+	if got := m.scenarioRequestCount(id); got != 1 {
+		t.Errorf("scenario request count = %d, want 1", got)
+	}
+	cap := m.lastRequest(id)
+	if cap.Path != "/v1/chat/completions" {
+		t.Errorf("captured path = %q, want /v1/chat/completions", cap.Path)
+	}
+	var reqBody openAIRequestBody
+	if err := json.Unmarshal(cap.Body, &reqBody); err != nil {
+		t.Fatalf("captured body is not JSON (%s): %v", bodyDigest(cap.Body), err)
+	}
+	if reqBody.Model != p6bTarget {
+		t.Errorf("captured model = %q, want %q (nanollm target rewrite)", reqBody.Model, p6bTarget)
+	}
+
+	// The fake Bearer key reached the provider-native route verbatim.
+	rec := m.recordedFor("openai", "/v1/chat/completions")
+	if v, ok := headerValue(rec.Headers, "Authorization"); !ok || v != "Bearer "+p6bAPIKey {
+		t.Errorf("Authorization present=%v value mismatch (redacted)", ok)
+	}
+}


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## Phase 6 Slice 6b — PreparedRequest adapter + unary response pipeline (BAML-free)

Wires a fresh, Phase-5-admitted nanollm `PreparedRequest` through baml-rest's own **exact transport** (the merged Slice-6a primitive) and back through the **native response side**, entirely BAML-free and test-only, in the isolated out-of-workspace `internal/nativebody/nanollmprepare` module (gated `nanollm_integration`). **No serving change.**

```text
nanollm.PreparedRequest (fresh, Phase-5-admitted)
  -> llmhttp.ExactAttemptRequest      (Slice-6a carrier: ordered headers, raw bytes)
  -> one ExactExecutor RoundTrip       vs loopback / go-mocklm
  -> ExactAttemptResponse
  -> nanollm.TranslateResponse(prep.Meta.ModelAlias, status, rawBody)
  -> buildrequest.ExtractResponseContentBytes("openai", ...)   [2xx only]
  -> internal/debaml.Parse (native SAP)                        [2xx only]
```

### What it does
- **Exactly one attempt per call** — no `Do`/`DoStream`, no fallback, no same-model retry. The Slice-6a primitive owns the single `RoundTrip`; this adapter is the only thing that knows both nanollm aliases and the exact transport.
- Uses the **exact attempted alias** (`prep.Meta.ModelAlias`), never a primary, for `TranslateResponse`.
- **Expiry** is rejected and the **native support decision** (parity-decline with a stable stage/reason) runs **before any socket**.
- **Provider outcomes never reach SAP:** an ordinary non-2xx normalizes to the uniform envelope; an invalid-2xx surfaces nanollm's typed `*InvalidBodyError` mapped to the same 502/envelope provider outcome `Do` would return.
- On a 2xx, a proven native claim returns the flattened structured output; a parser **decline** (`ErrDeBAMLParseUnsupported`) and a **claimed** parse error are surfaced **separately**. `Response.Usage` is retained in the typed result.

### Proof (gated `nanollm_integration`, loopback only)
- **baml-rest-owned capture server** (wire-fidelity oracle): the sent plan is **byte-identical** to the supplied `PreparedRequest` fields — exact method / request target / effective host / **ordered, repeated-name headers** / raw body — with `request-count == 1`. Header order/casing is explicitly not claimed; only transport-generated framing headers (User-Agent, Content-Length, Accept-Encoding, Connection) are excluded.
- Success → structured output; ordinary non-2xx → uniform envelope, **SAP not invoked**, one request; `InvalidBodyError` → 502/envelope, **SAP not invoked**; expiry rejected pre-attempt; **16 MiB / 64 KiB** caps; cancellation; decline-vs-claimed-error asserted separately (independently corroborated by a parser-invocation spy).
- **Reused Slice-2 go-mocklm subprocess** for provider-native validity: the exact plan is accepted on the OpenAI route and reaches structured output in one request.

### Isolation
- The Slice-6a primitive in `bamlutils/llmhttp` is **byte-unchanged** and stays nanollm-agnostic.
- Root stays **zero-nanollm / CGO-free**: root `go.mod`/`go.sum`/`go.work`/`go.work.sum` unchanged; the module stays out of `go.work`; default `go build ./...` / `go test ./...` need no nanollm/CGO. BAML appears in **no** 6b test.

### Validation
- `gofmt`; default `go build ./...`, `go test ./internal/nativebody ./internal/nativeprompt ./internal/nativeschema ./cmd/introspect`, `go vet ./...` — green.
- Gated (Darwin/ARM64): `cd internal/nativebody/nanollmprepare && GOWORK=off go test -tags nanollm_integration -count=1 ./...` — the new 6b pipeline tests + existing 2a/2b + P4b all green.

**Next:** Slice **6c** — the BAML-as-served live differential (the core Phase 6 green bar).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a single-attempt prepared-request execution path for supported OpenAI-compatible chat requests, returning typed outcomes for structured success, parse declines, provider errors, and invalid response bodies.
  * Adds clear error signaling for expired plans and unsupported request shapes, including consistent response handling for invalid payloads.
* **Tests**
  * Added end-to-end integration coverage validating request/response wire fidelity, single-request behavior, cancellation, body-size limits, and parse handling differences.
* **Documentation**
  * Expanded package documentation describing the gated prepared-request test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->