### PR TITLE
test(llmhttp): de-flake connection-refused tests with synthetic transport injection

### DIFF
--- a/bamlutils/llmhttp/fast_backend_test.go
+++ b/bamlutils/llmhttp/fast_backend_test.go
@@ -228,18 +228,30 @@ func TestFastExecute_HeadersForwardedCasePreserved(t *testing.T) {
 }
 
 func TestFastExecute_ConnectionRefused(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	// Keep withFastClient so the public ClientModeFastHTTP selection seam stays
+	// covered, then preinstall a decisionFast cache entry whose fasthttp
+	// dialers fail with the injected refusal. executeBorrow finds the entry
+	// (no probe/DNS/proxy), context.Background + onSuccess==nil selects the
+	// buffered unaryHost lane, and its DoDeadline hits connectionRefusedDial.
+	// Injecting the refusal (not dialing a just-freed ephemeral port) makes
+	// this deterministic — see errTestConnectionRefused.
+	const target = "http://connection-refused.invalid/"
+	c := withFastClient(t, nil)
+
+	origin, err := parseOrigin(target)
 	if err != nil {
 		t.Fatal(err)
 	}
-	addr := ln.Addr().String()
-	ln.Close()
+	// Set DialTimeout on both fast lanes before install: entries are treated as
+	// immutable once published, and the two lanes should stay consistent even
+	// though this buffered path uses only unaryHost.
+	entry := c.cache.buildEntry(origin, decisionFast)
+	entry.host.DialTimeout = connectionRefusedDial
+	entry.unaryHost.DialTimeout = connectionRefusedDial
+	c.cache.install(origin.key, entry)
 
-	c := withFastClient(t, nil)
-	_, err = c.Execute(context.Background(), &Request{URL: "http://" + addr, Method: "POST", Body: `{}`}, nil)
-	if err == nil {
-		t.Fatal("expected connection-refused error")
-	}
+	_, err = c.Execute(context.Background(), &Request{URL: target, Method: "POST", Body: `{}`}, nil)
+	requireConnectionRefused(t, err)
 }
 
 // --- Streaming under ClientModeFastHTTP routes through net/http (Stage 1) ---

--- a/bamlutils/llmhttp/llmhttp_test.go
+++ b/bamlutils/llmhttp/llmhttp_test.go
@@ -213,24 +213,22 @@ func TestExecuteStreamHeadersForwarded(t *testing.T) {
 }
 
 func TestExecuteStreamConnectionRefused(t *testing.T) {
-	// Grab a free port, then close the listener so the port is guaranteed closed
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	ln.Close()
-
-	client := NewClient(nil)
-	_, err = client.ExecuteStream(context.Background(), &Request{
-		URL:    "http://" + addr,
+	// ExecuteStream unconditionally routes through net/http (openStream ->
+	// http.Client.Do), so inject the refusal into the net/http RoundTripper.
+	// The explicit ClientModeNetHTTP documents the contract and keeps this
+	// connection-failure test off any environment-driven construction. Using
+	// a synthetic refusal (not a just-freed ephemeral port) makes it
+	// deterministic — see errTestConnectionRefused.
+	client := NewClientWithOptions(ClientOptions{
+		Mode:          ClientModeNetHTTP,
+		NetHTTPClient: connectionRefusedHTTPClient(),
+	})
+	_, err := client.ExecuteStream(context.Background(), &Request{
+		URL:    "http://connection-refused.invalid/",
 		Method: "POST",
 		Body:   `{}`,
 	})
-
-	if err == nil {
-		t.Fatal("expected error for connection refused")
-	}
+	requireConnectionRefused(t, err)
 }
 
 func TestExecuteStreamInvalidURL(t *testing.T) {
@@ -550,23 +548,21 @@ func TestExecuteHeadersForwarded(t *testing.T) {
 }
 
 func TestExecuteConnectionRefused(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := ln.Addr().String()
-	ln.Close()
-
-	client := NewClient(nil)
-	_, err = client.Execute(context.Background(), &Request{
-		URL:    "http://" + addr,
+	// Pin ClientModeNetHTTP so executeBorrow skips the fast cache entry and
+	// reaches c.httpClient.Do — Auto mode would resolve a plain-http origin to
+	// fasthttp, so this generic test would otherwise never exercise the unary
+	// net/http path. The refusal is injected into the RoundTripper (no socket),
+	// making it deterministic instead of racing a just-freed ephemeral port.
+	client := NewClientWithOptions(ClientOptions{
+		Mode:          ClientModeNetHTTP,
+		NetHTTPClient: connectionRefusedHTTPClient(),
+	})
+	_, err := client.Execute(context.Background(), &Request{
+		URL:    "http://connection-refused.invalid/",
 		Method: "POST",
 		Body:   `{}`,
 	}, nil)
-
-	if err == nil {
-		t.Fatal("expected error for connection refused")
-	}
+	requireConnectionRefused(t, err)
 }
 
 func TestExecuteNilClient(t *testing.T) {
@@ -942,6 +938,62 @@ func TestExecuteOnSuccessNotFiredOnError(t *testing.T) {
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// errTestConnectionRefused is the private sentinel the connection-refused
+// tests inject into their transport seams. It wraps syscall.ECONNREFUSED so
+// the production classifier maps it to TransportFlakeConnectionRefused, and
+// its own identity lets the assertions prove the configured seam — not an
+// unrelated DNS/proxy/socket error — was what surfaced. These tests inject a
+// synthetic refusal instead of dialing a just-freed ephemeral port: closing a
+// port-0 listener and then dialing it is a TOCTOU race (a concurrent test
+// server can bind the released port and answer 2xx, making Execute return a
+// nil error), which is exactly what flaked under -race -count=100.
+var errTestConnectionRefused = fmt.Errorf(
+	"test-injected connection refusal: %w", syscall.ECONNREFUSED,
+)
+
+// connectionRefusedHTTPClient returns an *http.Client whose RoundTripper
+// always fails with errTestConnectionRefused, exercising the net/http Execute
+// and ExecuteStream paths without touching the network.
+func connectionRefusedHTTPClient() *http.Client {
+	return &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errTestConnectionRefused
+	})}
+}
+
+// connectionRefusedDial is a fasthttp DialFuncWithTimeout that always fails
+// with errTestConnectionRefused, exercising the fasthttp backend's dial path
+// without touching the network.
+func connectionRefusedDial(_ string, _ time.Duration) (net.Conn, error) {
+	return nil, errTestConnectionRefused
+}
+
+// requireConnectionRefused asserts that err is the fully classified
+// connection-refused transport error: it originated from the injected
+// sentinel, carries syscall.ECONNREFUSED and the ErrTransportFlake umbrella,
+// and is a *TransportError categorised as TransportFlakeConnectionRefused.
+func requireConnectionRefused(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected connection-refused error")
+	}
+	if !errors.Is(err, errTestConnectionRefused) {
+		t.Fatalf("error did not come from the injected refusal: %v", err)
+	}
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		t.Fatalf("errors.Is(err, syscall.ECONNREFUSED) = false: %v", err)
+	}
+	if !errors.Is(err, ErrTransportFlake) {
+		t.Fatalf("errors.Is(err, ErrTransportFlake) = false: %v", err)
+	}
+	var te *TransportError
+	if !errors.As(err, &te) {
+		t.Fatalf("error is not *TransportError: %T: %v", err, err)
+	}
+	if te.Category != TransportFlakeConnectionRefused {
+		t.Fatalf("category = %v, want %v", te.Category, TransportFlakeConnectionRefused)
+	}
+}
 
 // scriptedReader emits a fixed prefix on its first Read calls and then
 // returns finalErr once the prefix has been drained. Used to simulate a


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## De-flake the `llmhttp` connection-refused unit tests

### Root cause — freed-ephemeral-port reuse race, amplified by `-count=100`

The connection-refused tests used a reserve-release-dial pattern:

```
ln := net.Listen("127.0.0.1:0")   // kernel picks ephemeral port P
addr := ln.Addr()                  // remember P
ln.Close()                         // P returns to the kernel immediately
client.Execute("http://" + addr)   // assume P is still unbound
```

`Close` does not reserve "P must stay closed"; it frees P at once. Between
`Close` and the client's actual `connect(2)`, any listener in the job's network
namespace can bind P. When one does — and the winning handler answers 2xx —
`Execute` returns a **`nil`** error and the `err == nil` assertion fails (the
observed CI failure was exactly `err == nil`, i.e. a successful HTTP exchange,
not a wrong error category).

The Unit Tests job runs `go test -race -count=100 -timeout 20m ./...` from
`bamlutils`, and `go test` schedules package test binaries concurrently. The
always-200 `httptest` servers in `bamlutils/buildrequest` (44 static sites, each
repeated ×100) share the runner's network namespace and are a concrete competing
source of ephemeral binds. `-count=100` amplifies the three tests into ~300
release-then-dial windows per package run. This is a TOCTOU race in the tests;
`-race` only perturbs/slows scheduling (no Go memory is raced), so the race
detector never diagnoses it — it just makes the bad interleaving more reachable.

### The push-vs-PR asymmetry finding

The recent streak (last two master pushes failed the connection-refused
assertion; ~16 PR runs passed) is **probabilistic clustering, not a systematic
event-type mechanism**. Paired failed-push / passed-PR runs have byte-identical
Git trees, runner image, provisioner, Go version, build-cache key+artifact, test
command, module order, and test-relevant env. The only differences are
event/ref metadata — which no tested Go code reads (`bamlutils` never consults
`GITHUB_EVENT_NAME`/`GITHUB_REF`/`GITHUB_SHA`) — and ordinary fresh-VM
placement/timing, including per-boot socket-allocator state, which is precisely
the event-independent random input to this race. Same-region counterexamples
(a PR passed in the same `westus3` where a master run failed) rule out the one
visible infra placement difference. Conditional on exactly two failures in the
post-hoc 18-run window, both landing on the two push slots has p ≈ 1/C(18,2) =
1/153 ≈ 0.65% — a surprising but post-selected cluster, and the push sample is
only two (the three immediately preceding master runs passed). There is no
event-conditioned causal path in the logs; the fix targets the race, not the
event type.

### The fix — deterministic synthetic transport-failure injection (both backends)

The refusal cases now make **zero real socket calls** and assert the exact
classification contract instead of merely `err != nil`:

- **net/http path** — `TestExecuteConnectionRefused` and
  `TestExecuteStreamConnectionRefused` pin `ClientModeNetHTTP` and inject a
  `RoundTripper` that returns a private `ECONNREFUSED`-wrapping sentinel.
  `Execute` reaches `c.httpClient.Do`; `ExecuteStream` routes unconditionally
  through `openStream` → `http.Client.Do`. Pinning the mode also closes a
  **coverage gap**: in Auto mode a plain-http origin resolves to `decisionFast`,
  so `TestExecuteConnectionRefused` (`NewClient(nil)`) previously never
  deterministically exercised the unary net/http path at all.
- **fasthttp path** — `TestFastExecute_ConnectionRefused` keeps `withFastClient`
  (the public `ClientModeFastHTTP` selection seam) and preinstalls a
  `decisionFast` cache entry whose `HostClient.DialTimeout` returns the same
  sentinel on both fast lanes (`host` + `unaryHost`, set before `install` since
  entries are immutable once published). `context.Background()` + `onSuccess ==
  nil` selects the buffered `unaryHost` lane, whose `DoDeadline` hits the
  injected dialer; `executeFastBuffered` runs it through `classifyTransportErr`.

Shared test-only helpers assert the full chain: private sentinel →
`syscall.ECONNREFUSED` → `ErrTransportFlake` → `*TransportError` with category
`TransportFlakeConnectionRefused`. The private sentinel proves the configured
seam actually fired — an unrelated DNS/proxy/socket error cannot satisfy the
assertion — so the tests still prove `Execute` surfaces a transport error on an
unreachable upstream and are **not** weakened.

**Test-only.** Legacy `Execute` and the fast backend are byte-unchanged; only
`_test.go` files are touched (not covered by `//go:embed`, so no embed regen).

### Other instances

The investigation's whole-repo scan flagged four reserve-release-use sites.
Three are fixed here (the two named tests plus `TestExecuteStreamConnectionRefused`,
the same antipattern in the same Unit Tests package). The fourth,
`freeLoopbackPort` in
`internal/nativebody/nanollmprepare/execute/mocklm_integration_test.go`, is the
same port-handoff antipattern but lives in a separate, gated integration module
that is **not** in `go.work` / the Unit Tests loop, so it cannot cause this
failure. It also cannot be made deterministic from the consumer alone — the
pinned `go-mocklm v0.4.0` has no inherited-listener/FD seam — so the real fix
needs an upstream test-tool change (e.g. `MOCKLM_HTTP_FD` → `net.FileListener` +
`http.Serve`) plus a module pin in that isolated harness. That is out of scope
for this test-only Unit Tests PR and is left as a follow-up.

### Validation

- `gofmt` clean; `go vet ./bamlutils/...` clean for `llmhttp` (the reported
  issues are pre-existing participle grammar struct-tag false-positives in
  `bamlparser`, untouched here).
- `go test -race -count=100 -run ConnectionRefused ./llmhttp/` — PASS ×2.
- `go test -race -count=100 ./llmhttp/` (full package) — PASS ×3
  (251.8s / 210.1s / 204.6s), **zero failures**. The fixed refusal cases make no
  real socket calls, so the old race is no longer reachable.
- `go build ./...` and `go test ./bamlutils/...` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved connection-refused test coverage to produce deterministic, reliable results.
  * Added validation that connection failures are consistently classified as transport errors.
  * Removed reliance on ephemeral ports, DNS resolution, proxies, and network timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->