### PR TITLE
debaml(p6c): BAML-as-served live-loopback differential

### DIFF
--- a/.github/workflows/nanollm-prepare.yml
+++ b/.github/workflows/nanollm-prepare.yml
@@ -69,6 +69,12 @@ env:
   # static leg links stock github.com/boundaryml/baml — both are v0.223.0-based.
   # The static leg's TestBAMLVersionPinned asserts the loaded CFFI reports this.
   NANOLLM_BAML_VERSION: "v0.223.0"
+  # The PUBLIC go-mocklm version pinned as a Go tool in the isolated module. The
+  # Phase-6 Slice 6c LIVE differential (dynamic/live_*_integration_test.go) drives
+  # BOTH legs against a go-mocklm subprocess as the second loopback responder, and
+  # the already-merged Slice-2/6b execute suite (also picked up by ./... below)
+  # uses it too. Built once as MOCKLM_BINARY so no test rebuilds it on demand.
+  GO_MOCKLM_VERSION: "v0.4.0"
 
 jobs:
   nanollm-prepare:
@@ -97,7 +103,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Assert module pins (nanollm-ffi @ v0.3.2, stock BAML @ v0.223.0) + zero-root-nanollm
+      - name: Assert module pins (nanollm-ffi @ v0.3.2, stock BAML @ v0.223.0, go-mocklm @ v0.4.0) + zero-root-nanollm
         run: |
           set -euo pipefail
           gomod=internal/nativebody/nanollmprepare/go.mod
@@ -119,11 +125,29 @@ jobs:
           # is version-checked by TestBAMLVersionPinned at runtime).
           exact_pin "github.com/boundaryml/baml" "${NANOLLM_BAML_VERSION}" \
             || { echo "test module does not pin boundaryml/baml at exactly ${NANOLLM_BAML_VERSION}"; exit 1; }
-          # Default-build isolation: the root must reference NEITHER the old
-          # nanollm nor the new nanollm-ffi module path (the prefix matches both).
-          if grep -q "github.com/viktordanov/nanollm" go.mod go.sum; then
-            echo "root go.mod/go.sum must NOT reference nanollm (default-build isolation)"; exit 1
-          fi
+          # Phase 6 Slice 6c: the live differential's go-mocklm responder is pinned
+          # at exactly v0.4.0 AND declared as a Go tool (the tool directive is what
+          # `go install tool` below builds).
+          exact_pin "github.com/viktordanov/go-mocklm" "${GO_MOCKLM_VERSION}" \
+            || { echo "test module does not pin go-mocklm at exactly ${GO_MOCKLM_VERSION}"; exit 1; }
+          # Semantic check (not a brittle text grep): `go list tool` reports the
+          # module's declared tool packages regardless of whether the tool
+          # directive is serialized one-line (`tool <path>`) or as a parenthesized
+          # `tool ( ... )` block, so the block form can never trip a false failure.
+          # Verified on the pinned Go 1.26.5 toolchain to return the go-mocklm path.
+          ( cd internal/nativebody/nanollmprepare && GOWORK=off go list tool ) \
+            | grep -qF "github.com/viktordanov/go-mocklm" \
+            || { echo "test module does not declare go-mocklm as a Go tool"; exit 1; }
+          # Default-build isolation: the root must reference NEITHER the nanollm
+          # module (the prefix matches nanollm-ffi too) NOR go-mocklm.
+          for f in go.mod go.sum go.work go.work.sum; do
+            if grep -q "github.com/viktordanov/nanollm" "$f"; then
+              echo "root $f must NOT reference nanollm (default-build isolation)"; exit 1
+            fi
+            if grep -q "github.com/viktordanov/go-mocklm" "$f"; then
+              echo "root $f must NOT reference go-mocklm (default-build isolation)"; exit 1
+            fi
+          done
 
       - name: Clean public-install smoke (scratch module, no flags)
         run: |
@@ -158,6 +182,19 @@ jobs:
           cd internal/nativebody/nanollmprepare
           GOWORK=off go mod download
 
+      - name: Build the pinned go-mocklm tool
+        run: |
+          set -euo pipefail
+          # The Phase-6 Slice 6c live differential (and the merged Slice-2/6b send
+          # suite, also run by ./... below) launches go-mocklm as a loopback
+          # subprocess. Build the module's declared tool ONCE into $RUNNER_TEMP/bin
+          # and export MOCKLM_BINARY so no test rebuilds it on demand mid-run. This
+          # mirrors nanollm-send.yml; MOCKLM_BINARY is authoritative in CI and the
+          # harness only falls back to an on-demand build when it is unset.
+          cd internal/nativebody/nanollmprepare
+          GOBIN="$RUNNER_TEMP/bin" GOWORK=off go install tool
+          echo "MOCKLM_BINARY=$RUNNER_TEMP/bin/go-mocklm" >> "$GITHUB_ENV"
+
       - name: Pre-provision + version-check both BAML CFFI runtimes
         run: |
           set -euo pipefail
@@ -185,19 +222,25 @@ jobs:
             -tags "integration nanollm_integration" \
             -count=1 -run 'TestDynamicPreparedRequestParity/single_user_message' ./dynamic/
 
-      - name: Run gated nanollm prepared-request differential (no send)
+      - name: Run gated nanollm prepared-request + live-loopback differential
         run: |
           # Doubly gated: `integration` makes the BAML CFFI dependency explicit and
           # `nanollm_integration` opts the tests in. The public nanollm-ffi module
           # embeds + links its prebuilt CGO archive automatically — no
-          # nanollm_prebuilt tag, no CGO_CFLAGS/CGO_LDFLAGS. No send / no HTTPRequest
-          # / no Do/DoStream — Prepare + BAML request capture only. Runs inside the
-          # SEPARATE test module with GOWORK=off so its go.mod (the only one that
-          # requires nanollm) is the build list — the workspace/root never sees
-          # nanollm. `go test ./...` runs each package's test binary as a SEPARATE
-          # PROCESS, so the stock and patched BAML runtimes never share an address
-          # space. Downloads are DISABLED: the CFFIs were pre-provisioned above, so
-          # a fresh runner cannot silently fetch a runtime mid-test.
+          # nanollm_prebuilt tag, no CGO_CFLAGS/CGO_LDFLAGS. This ./... run covers
+          # BOTH the Phase-4b/5.1 NO-SEND Prepare+capture differential (root /
+          # static / dynamic prepared-request parity) AND the Phase-6 Slice 6c LIVE
+          # differential (dynamic/live_*): two sequential real-loopback legs per
+          # fixture — BAML-as-served (de-BAML false) and the native 6a+6b path —
+          # against a baml-rest capture server and a go-mocklm subprocess, plus the
+          # Slice-2/6b execute send suite. Runs inside the SEPARATE test module with
+          # GOWORK=off so its go.mod (the only one that requires nanollm/go-mocklm)
+          # is the build list — the workspace/root never sees either. `go test ./...`
+          # runs each package's test binary as a SEPARATE PROCESS, so the stock and
+          # patched BAML runtimes never share an address space. BAML downloads are
+          # DISABLED (CFFIs pre-provisioned above); go-mocklm is MOCKLM_BINARY
+          # (pre-built above), and all live traffic stays on 127.0.0.1 behind each
+          # transport's loopback dial guard.
           cd internal/nativebody/nanollmprepare
           BAML_LIBRARY_DISABLE_DOWNLOAD=true GOWORK=off go test \
             -tags "integration nanollm_integration" \

--- a/internal/nativebody/nanollmprepare/dynamic/live_controls_integration_test.go
+++ b/internal/nativebody/nanollmprepare/dynamic/live_controls_integration_test.go
@@ -1,0 +1,312 @@
+//go:build integration && nanollm_integration
+
+package dynamic
+
+// De-BAML Slice 6c negative + error controls for the BAML-as-served live
+// differential (live_differential_integration_test.go). Each control must FAIL
+// as a negative — or route an error case to the intended non-SAP outcome — so the
+// positive parity above stays meaningful:
+//
+//   - flag-off: an explicit BAML_REST_USE_DEBAML falsy value makes the native leg
+//     perform ZERO sends (the umbrella switch, no new flag);
+//   - mutated method / URL / header / body: the wire comparator flags each, and
+//     no fake secret leaks into the redacted diagnostic;
+//   - mutated response: serving DIFFERENT bodies to the two legs makes the final
+//     structured output diverge (each leg still sends exactly once);
+//   - non-2xx (429): both legs fail as a provider error with the same status
+//     class, native SAP is NOT invoked, and neither leg makes a second request;
+//   - invalid-2xx (200 + non-JSON): the native leg maps it to the InvalidBody
+//     provider outcome (SAP NOT invoked), the oracle leg fails to parse, and
+//     neither leg makes a second request.
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
+	"github.com/invakid404/baml-rest/internal/debaml"
+	"github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare/execute"
+)
+
+// runBothLegs is the shared control driver: it programs the server response, runs
+// the oracle leg then the native leg against ONE loopback capture server, and
+// returns both observations plus the per-leg request counts. It asserts nothing
+// itself — each control interprets the results.
+type bothLegs struct {
+	server           *liveCaptureServer
+	oracleSpy        *liveParseSpy
+	oracleData       []byte
+	oracleErr        error
+	oracleRec        recordedLive
+	countAfterOracle int
+
+	res              *execute.AttemptResult
+	spy              *liveParseSpy
+	ran              bool
+	nativeErr        error
+	nativeRec        recordedLive
+	countAfterNative int
+}
+
+func runBothLegs(t *testing.T, status int, body []byte, tc dynFixture) *bothLegs {
+	t.Helper()
+	server := newLiveCaptureServer(t)
+	server.setResponse(status, body)
+
+	b := &bothLegs{server: server}
+	b.oracleSpy = &liveParseSpy{fn: debaml.Parse}
+	oracle := newLiveOracleClient(t, loopbackOracleHTTPClient(), b.oracleSpy)
+	nano := newLiveNativeClient(t, server.base())
+
+	b.oracleData, b.oracleErr = runOracleLeg(t, oracle, server.base(), tc)
+	b.countAfterOracle = server.count()
+	if b.countAfterOracle >= 1 {
+		b.oracleRec = server.rec(0)
+	}
+
+	b.res, b.spy, b.ran, b.nativeErr = runNativeLeg(t, nano, server.base(), tc)
+	b.countAfterNative = server.count()
+	if b.countAfterNative >= 2 {
+		b.nativeRec = server.rec(1)
+	}
+	return b
+}
+
+// TestLiveFlagOffZeroNativeSends: with the umbrella switch explicitly falsy the
+// native leg makes ZERO sends, while the oracle leg (de-BAML false regardless)
+// still sends exactly once.
+func TestLiveFlagOffZeroNativeSends(t *testing.T) {
+	t.Setenv(bamlutils.EnvUseDeBAML, "off")
+
+	server := newLiveCaptureServer(t)
+	server.setResponse(http.StatusOK, openAISuccess(`{"answer":"ok"}`))
+	oracleSpy := &liveParseSpy{fn: debaml.Parse}
+	oracle := newLiveOracleClient(t, loopbackOracleHTTPClient(), oracleSpy)
+	nano := newLiveNativeClient(t, server.base())
+	tc := dynFixtureByName(t, "single_user_message")
+
+	if _, oerr := runOracleLeg(t, oracle, server.base(), tc); oerr != nil {
+		t.Fatalf("oracle leg failed: %v", oerr)
+	}
+	if got := server.count(); got != 1 {
+		t.Fatalf("oracle leg made %d requests, want 1", got)
+	}
+
+	res, spy, ran, nerr := runNativeLeg(t, nano, server.base(), tc)
+	if ran {
+		t.Fatal("native leg ran with BAML_REST_USE_DEBAML off; it must produce zero native sends")
+	}
+	if res != nil || spy != nil || nerr != nil {
+		t.Errorf("flag-off native leg returned res=%v spy=%v err=%v, want all nil", res != nil, spy != nil, nerr)
+	}
+	if got := server.count(); got != 1 {
+		t.Errorf("server saw %d requests after a flag-off native leg, want 1 (no native send)", got)
+	}
+	if oracleSpy.calls != 0 {
+		t.Errorf("oracle native-parser spy fired %d times, want 0", oracleSpy.calls)
+	}
+}
+
+// TestLiveWireMutationControls proves the wire comparator is sensitive to each
+// mutated field and never leaks a secret into diagnostics. Mutations are applied
+// to COPIES of a genuine captured pair, so a real parity pass is the baseline.
+func TestLiveWireMutationControls(t *testing.T) {
+	t.Setenv(bamlutils.EnvUseDeBAML, "1")
+	b := runBothLegs(t, http.StatusOK, openAISuccess(`{"answer":"ok"}`), dynFixtureByName(t, "single_user_message"))
+	if b.oracleErr != nil || b.nativeErr != nil || !b.ran {
+		t.Fatalf("baseline legs failed: oracleErr=%v nativeErr=%v ran=%v", b.oracleErr, b.nativeErr, b.ran)
+	}
+	if b.countAfterOracle != 1 || b.countAfterNative != 2 {
+		t.Fatalf("baseline request counts: oracle=%d total=%d, want 1 and 2", b.countAfterOracle, b.countAfterNative)
+	}
+	// Baseline parity must hold.
+	if diffs := liveWireDiffs(b.oracleRec, b.nativeRec); len(diffs) != 0 {
+		t.Fatalf("baseline wire parity unexpectedly differs: %v", diffs)
+	}
+
+	t.Run("method", func(t *testing.T) {
+		bad := b.nativeRec
+		bad.Method = http.MethodGet
+		if len(liveWireDiffs(b.oracleRec, bad)) == 0 {
+			t.Fatal("a mutated method was not detected")
+		}
+	})
+	t.Run("target", func(t *testing.T) {
+		bad := b.nativeRec
+		bad.RequestURI = b.nativeRec.RequestURI + "/extra"
+		if len(liveWireDiffs(b.oracleRec, bad)) == 0 {
+			t.Fatal("a mutated request target was not detected")
+		}
+	})
+	t.Run("header", func(t *testing.T) {
+		bad := b.nativeRec
+		bad.Header = b.nativeRec.Header.Clone()
+		bad.Header.Set("Authorization", "Bearer tampered-key")
+		diffs := liveWireDiffs(b.oracleRec, bad)
+		if len(diffs) == 0 {
+			t.Fatal("a mutated authorization value was not detected")
+		}
+		for _, s := range diffs {
+			if bytes.Contains([]byte(s), []byte("tampered-key")) || bytes.Contains([]byte(s), []byte(fenceAPIKey)) {
+				t.Fatalf("authorization value leaked into diagnostics: %q", s)
+			}
+		}
+	})
+	t.Run("body", func(t *testing.T) {
+		bad := b.nativeRec
+		bad.Body = append([]byte(nil), b.nativeRec.Body...)
+		bad.Body[len(bad.Body)/2] ^= 0x20
+		if len(liveWireDiffs(b.oracleRec, bad)) == 0 {
+			t.Fatal("a one-byte body mutation was not detected")
+		}
+	})
+}
+
+// TestLiveResponseMutationControl proves the final-output comparison is sensitive:
+// when the server serves DIFFERENT bodies to the two legs, the structured outputs
+// diverge. Each leg still sends exactly one request.
+func TestLiveResponseMutationControl(t *testing.T) {
+	t.Setenv(bamlutils.EnvUseDeBAML, "1")
+
+	server := newLiveCaptureServer(t)
+	oracleSpy := &liveParseSpy{fn: debaml.Parse}
+	oracle := newLiveOracleClient(t, loopbackOracleHTTPClient(), oracleSpy)
+	nano := newLiveNativeClient(t, server.base())
+	tc := dynFixtureByName(t, "single_user_message")
+
+	// Oracle sees one answer, the native leg a DIFFERENT one.
+	server.setResponse(http.StatusOK, openAISuccess(`{"answer":"one"}`))
+	oracleData, oerr := runOracleLeg(t, oracle, server.base(), tc)
+	if oerr != nil {
+		t.Fatalf("oracle leg failed: %v", oerr)
+	}
+	if got := server.count(); got != 1 {
+		t.Fatalf("oracle leg made %d requests, want 1", got)
+	}
+
+	server.setResponse(http.StatusOK, openAISuccess(`{"answer":"two"}`))
+	res, spy, ran, nerr := runNativeLeg(t, nano, server.base(), tc)
+	if !ran || nerr != nil {
+		t.Fatalf("native leg failed: ran=%v err=%v", ran, nerr)
+	}
+	if got := server.count(); got != 2 {
+		t.Fatalf("native leg made %d total requests, want 2", got)
+	}
+	if res.Outcome != execute.OutcomeStructured || spy.calls != 1 {
+		t.Fatalf("native outcome=%s calls=%d, want structured + 1", res.Outcome, spy.calls)
+	}
+	// The mutated response makes the final structured outputs differ.
+	if liveJSONSemEqual(t, oracleData, res.Structured) {
+		t.Fatalf("mutated response was not detected: oracle=%s native=%s",
+			liveBodyDigest(oracleData), liveBodyDigest(res.Structured))
+	}
+}
+
+// TestLiveNon2xxSkipsSAP: a deterministic 429 makes both legs fail as a provider
+// error of the same status class, native SAP is NOT invoked, and neither leg
+// makes a second request.
+func TestLiveNon2xxSkipsSAP(t *testing.T) {
+	t.Setenv(bamlutils.EnvUseDeBAML, "1")
+	b := runBothLegs(t, http.StatusTooManyRequests, openAIError("slow down", "rate_limit_error"), dynFixtureByName(t, "single_user_message"))
+
+	// Oracle: a 429 surfaces as an llmhttp.HTTPError carrying the real status;
+	// exactly one request; native SAP never touched. Diagnostics print only the
+	// error TYPE and the status scalar — never the wrapped HTTPError.Error(),
+	// which embeds the (bounded) provider response body the redaction fence keeps
+	// out of failure logs.
+	if b.oracleErr == nil {
+		t.Fatalf("oracle leg must fail on a 429, got structured data %s", liveBodyDigest(b.oracleData))
+	}
+	var he *llmhttp.HTTPError
+	if !errors.As(b.oracleErr, &he) {
+		t.Fatalf("oracle error is not an *llmhttp.HTTPError (got %T)", b.oracleErr)
+	}
+	if he.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("oracle HTTPError status = %d, want 429", he.StatusCode)
+	}
+	if b.countAfterOracle != 1 {
+		t.Errorf("oracle leg made %d requests, want 1 (no retry)", b.countAfterOracle)
+	}
+
+	// Native: provider-error outcome, no SAP, exactly one more request.
+	if !b.ran || b.nativeErr != nil {
+		t.Fatalf("native leg failed: ran=%v err=%v", b.ran, b.nativeErr)
+	}
+	if b.res.Outcome != execute.OutcomeProviderError {
+		t.Fatalf("native outcome = %s, want provider-error", b.res.Outcome)
+	}
+	if b.res.SAPInvoked || b.spy.calls != 0 {
+		t.Errorf("native SAP invoked on a 429 (SAPInvoked=%v calls=%d); it must be skipped", b.res.SAPInvoked, b.spy.calls)
+	}
+	if b.res.ProviderStatus != http.StatusTooManyRequests {
+		t.Errorf("native provider status = %d, want 429", b.res.ProviderStatus)
+	}
+	if b.res.Translated == nil || b.res.Translated.Status != http.StatusTooManyRequests || !b.res.Translated.BodyIsJSON {
+		t.Errorf("native translated envelope not a 429 JSON body")
+	}
+	if b.countAfterNative != 2 {
+		t.Errorf("native leg made a second request (total %d), want 2", b.countAfterNative)
+	}
+	if b.oracleSpy.calls != 0 {
+		t.Errorf("oracle native-parser spy fired %d times, want 0", b.oracleSpy.calls)
+	}
+}
+
+// TestLiveInvalidBodySkipsSAP: a 200 with a non-JSON body maps to the native
+// InvalidBody provider outcome (SAP NOT invoked) and fails the oracle parse; each
+// leg makes exactly one request.
+func TestLiveInvalidBodySkipsSAP(t *testing.T) {
+	t.Setenv(bamlutils.EnvUseDeBAML, "1")
+	b := runBothLegs(t, http.StatusOK, []byte("<html>not json</html>"), dynFixtureByName(t, "single_user_message"))
+
+	// Oracle: BAML-as-served sends, then baml-rest's own response extraction
+	// rejects the non-JSON 2xx with a STABLE, body-free classifier — pinning this
+	// as the expected invalid-2xx extraction path (not some other post-send
+	// failure), exactly as the 429 control pins its HTTPError status. The
+	// classifier names only the provider, never the raw body, and the facts below
+	// are constants, so neither the assertion nor a failure diagnostic echoes the
+	// provider body — the redaction fence stays intact. One request; no native SAP.
+	if b.oracleErr == nil {
+		t.Fatalf("oracle leg must fail on an invalid 2xx body, got data %s", liveBodyDigest(b.oracleData))
+	}
+	oerrMsg := b.oracleErr.Error()
+	for _, fact := range []string{
+		"failed to extract response content",
+		"provider openai",
+		"response body is not valid JSON",
+	} {
+		if !strings.Contains(oerrMsg, fact) {
+			t.Errorf("oracle invalid-2xx error missing expected extraction fact %q (redacted: the classifier never echoes the provider body)", fact)
+		}
+	}
+	if b.countAfterOracle != 1 {
+		t.Errorf("oracle leg made %d requests, want 1", b.countAfterOracle)
+	}
+
+	// Native: InvalidBody outcome, no SAP, exactly one more request.
+	if !b.ran || b.nativeErr != nil {
+		t.Fatalf("native leg failed: ran=%v err=%v", b.ran, b.nativeErr)
+	}
+	if b.res.Outcome != execute.OutcomeInvalidBody {
+		t.Fatalf("native outcome = %s, want invalid-body", b.res.Outcome)
+	}
+	if b.res.SAPInvoked || b.spy.calls != 0 {
+		t.Errorf("native SAP invoked on an invalid 2xx (SAPInvoked=%v calls=%d); it must be skipped", b.res.SAPInvoked, b.spy.calls)
+	}
+	if b.res.ProviderStatus != http.StatusOK {
+		t.Errorf("native provider status = %d, want the raw upstream 200", b.res.ProviderStatus)
+	}
+	if b.res.Translated == nil || b.res.Translated.Status != http.StatusBadGateway {
+		t.Errorf("native translated status = %v, want the 502 InvalidBody envelope", b.res.Translated)
+	}
+	if b.countAfterNative != 2 {
+		t.Errorf("native leg made a second request (total %d), want 2", b.countAfterNative)
+	}
+	if b.oracleSpy.calls != 0 {
+		t.Errorf("oracle native-parser spy fired %d times, want 0", b.oracleSpy.calls)
+	}
+}

--- a/internal/nativebody/nanollmprepare/dynamic/live_differential_integration_test.go
+++ b/internal/nativebody/nanollmprepare/dynamic/live_differential_integration_test.go
@@ -1,0 +1,754 @@
+//go:build integration && nanollm_integration
+
+package dynamic
+
+// De-BAML Phase 6 Slice 6c: the BAML-as-served LIVE-LOOPBACK differential — the
+// core Phase 6 green bar.
+//
+// This EXTENDS the Phase-5 dynamic prepared-request oracle (this same package's
+// prepared_request_integration_test.go) from a no-send capture into an actual
+// two-leg loopback SEND. The P5 leg intercepts BAML's request at a
+// short-circuiting RoundTripper and compares it to nanollm's PREPARED plan with
+// no socket. Slice 6c instead stands up a real baml-rest-owned loopback capture
+// server and runs BOTH legs against it, one physical request each:
+//
+//	Oracle leg (BAML-as-served — what production serves today):
+//	  dynclient.DynamicCall + WithDeBAML(false)
+//	    + fake ClientRegistry(base_url=127.0.0.1:<port>/v1, fake key, no retry)
+//	  -> BAML v0.223 BuildRequest -> baml-rest llmhttp net/http SEND
+//	  -> loopback capture server -> BAML extraction + (native-disabled) final parse
+//
+//	Native leg (the 6a+6b path):
+//	  same fixture -> nativeprompt.Render -> nativebody.BuildOpenAIChat
+//	  -> nanollm Prepare -> 6a exact one-attempt transport (llmhttp ExactExecutor)
+//	  -> SAME loopback capture server
+//	  -> nanollm TranslateResponse(prep.Meta.ModelAlias) -> OpenAI extraction
+//	  -> internal/debaml.Parse (native SAP), reusing the 6b execute.RunAttempt adapter
+//
+// Both legs make EXACTLY ONE real net/http request over loopback (proven by the
+// capture server's per-leg request counter). The comparison policy (scope
+// "Comparison policy"):
+//
+//   - exactly one request per leg, no fallback/retry;
+//   - exact method / request target (path+query) / effective host / raw body bytes;
+//   - semantic header equality as a case-insensitive multimap (every value +
+//     per-name value order), with the fake authorization asserted exactly and
+//     redacted in diagnostics; global header-name ORDER/CASING is DECLINED;
+//   - only named, justified exclusions: BAML's internal `baml-original-url` and
+//     transport-generated framing fields neither planner controls;
+//   - identical deterministic upstream status/body delivered to BOTH legs;
+//   - the native translated OpenAI body + assistant text is the served content;
+//   - final structured-output equality (incl. schema field order);
+//   - negative controls (flag-off + mutated method/URL/header/body/response) fail
+//     for the intended reason; non-2xx / invalid-2xx controls prove native SAP is
+//     NOT invoked and no second request is made.
+//
+// Credential/egress fence: literal fake key/model/alias, a literal 127.0.0.1 base
+// from the running server, nanollm UseProcessEnv:false / Env:nil / MaxRetries:0,
+// both HTTP clients with Proxy:nil + a dial guard that rejects any non-loopback
+// destination, and no secret values in failure logs. No network escapes loopback.
+//
+// Runs in the go.work-excluded nanollmprepare module, gated
+// `integration && nanollm_integration` (BAML CFFI + nanollm). It reuses the 6b
+// adapter (execute.RunAttempt) — the ONLY cross-package symbol — and changes NO
+// serving behavior: nothing here is reachable from production routing.
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	stdjson "encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
+	"github.com/invakid404/baml-rest/dynclient"
+	"github.com/invakid404/baml-rest/internal/debaml"
+	"github.com/invakid404/baml-rest/internal/nativebody"
+	"github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare/execute"
+	"github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare/testutil"
+	"github.com/invakid404/baml-rest/internal/nativeprompt"
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
+)
+
+// liveCallTimeout is a generous per-leg context deadline; the live differential
+// is not a timing test.
+const liveCallTimeout = 60 * time.Second
+
+func bptr(b bool) *bool { return &b }
+
+// --- fixtures: reuse the P5-admitted dynamic fixtures + a deterministic OpenAI
+// success whose assistant content BOTH final parsers cleanly claim ---
+
+// liveFixture pairs a P5-admitted dynamic fixture with the exact assistant
+// content the shared deterministic OpenAI 2xx carries. The content must be JSON
+// that cleanly parses against the fixture's schema on BOTH legs (BAML's final
+// parse and internal/debaml.Parse) so each leg reaches final structured output.
+type liveFixture struct {
+	dynFixture
+	content string
+}
+
+// liveFixtures pairs every P5 fixture with schema-appropriate structured
+// content. Selecting by NAME (not index) keeps a reorder/extend of dynFixtures()
+// from silently rebinding content to the wrong schema.
+func liveFixtures(t *testing.T) []liveFixture {
+	t.Helper()
+	contentByName := map[string]string{
+		"single_user_message":              `{"answer":"ok"}`,
+		"system_user_ordered":              `{"answer":"ok"}`,
+		"system_user_assistant_ordered":    `{"answer":"ok"}`,
+		"special_characters_escaping":      `{"answer":"ok"}`,
+		"output_format_rendered_into_text": `{"answer":"ok","count":3}`,
+	}
+	out := make([]liveFixture, 0, len(contentByName))
+	for _, f := range dynFixtures() {
+		c, ok := contentByName[f.name]
+		if !ok {
+			t.Fatalf("no served content mapped for fixture %q", f.name)
+		}
+		out = append(out, liveFixture{dynFixture: f, content: c})
+	}
+	return out
+}
+
+// openAISuccess builds a deterministic OpenAI Chat Completions 2xx whose
+// assistant content is exactly `content`. The SAME bytes are served to both legs.
+func openAISuccess(content string) []byte {
+	m := map[string]any{
+		"id":      "chatcmpl-p6c-live",
+		"object":  "chat.completion",
+		"created": 0,
+		"model":   fenceModel,
+		"choices": []any{map[string]any{
+			"index":         0,
+			"message":       map[string]any{"role": "assistant", "content": content},
+			"finish_reason": "stop",
+		}},
+		"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+	}
+	b, err := stdjson.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// openAIError builds a deterministic OpenAI-style non-2xx error body.
+func openAIError(message, typ string) []byte {
+	m := map[string]any{"error": map[string]any{"message": message, "type": typ, "code": typ}}
+	b, err := stdjson.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// --- baml-rest-owned loopback capture server ---
+//
+// This is the wire-fidelity + final-output oracle: it records the exact method /
+// request target / effective Host / a DEEP COPY of every header value slice / the
+// byte-exact body, plus a request counter, for EVERY request. Unlike go-mocklm
+// (whose admin log records headers as map[string]string, collapsing repeats and
+// order) it can prove repeated header names and per-name value order. Both legs
+// hit the SAME server sequentially, so the per-leg count is len(recs) after each
+// leg, and recs[0]/recs[1] are the oracle/native observations.
+
+// recordedLive is one captured request. Header is a deep clone (http.Header is
+// map[string][]string; Clone copies the map AND every value slice) so a later
+// mutation of the request cannot alter the snapshot.
+type recordedLive struct {
+	Method     string
+	RequestURI string
+	Host       string
+	Header     http.Header
+	Body       []byte
+}
+
+// liveCaptureServer is a loopback httptest.Server (httptest binds 127.0.0.1) that
+// records every request and replies with a single programmable deterministic
+// fixture served IDENTICALLY to both legs.
+type liveCaptureServer struct {
+	t   *testing.T
+	srv *httptest.Server
+
+	mu         sync.Mutex
+	recs       []recordedLive
+	respStatus int
+	respBody   []byte
+}
+
+func newLiveCaptureServer(t *testing.T) *liveCaptureServer {
+	t.Helper()
+	cs := &liveCaptureServer{t: t, respStatus: http.StatusOK}
+	cs.srv = httptest.NewServer(http.HandlerFunc(cs.handle))
+	t.Cleanup(cs.srv.Close)
+	return cs
+}
+
+func (cs *liveCaptureServer) handle(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		// A client may abandon a read (never expected on this lane); record what
+		// arrived rather than crashing the handler goroutine.
+		body = append(body, []byte("<read-error>")...)
+	}
+	rec := recordedLive{
+		Method:     r.Method,
+		RequestURI: r.RequestURI,
+		Host:       r.Host,
+		Header:     r.Header.Clone(),
+		Body:       body,
+	}
+	cs.mu.Lock()
+	cs.recs = append(cs.recs, rec)
+	status, respBody := cs.respStatus, cs.respBody
+	cs.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(respBody)
+}
+
+func (cs *liveCaptureServer) base() string { return cs.srv.URL }
+
+func (cs *liveCaptureServer) setResponse(status int, body []byte) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	cs.respStatus = status
+	cs.respBody = body
+}
+
+// count is the per-leg request counter: total requests observed so far. After
+// the oracle leg it must be 1; after the native leg it must be 2.
+func (cs *liveCaptureServer) count() int {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return len(cs.recs)
+}
+
+// rec returns the i-th captured request, failing if it is absent.
+func (cs *liveCaptureServer) rec(i int) recordedLive {
+	cs.t.Helper()
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if i >= len(cs.recs) {
+		cs.t.Fatalf("no captured request at index %d (have %d)", i, len(cs.recs))
+	}
+	return cs.recs[i]
+}
+
+// --- loopback dial guard (egress fence) ---
+
+// isLoopbackLiveHost reports whether host is a loopback literal (or "localhost").
+func isLoopbackLiveHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// loopbackDial refuses any non-loopback destination: a mistyped base fails here
+// instead of leaving the machine. Shared by both legs' transports.
+func loopbackDial(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("loopback guard: unparsable dial address %q: %w", addr, err)
+	}
+	if !isLoopbackLiveHost(host) {
+		return nil, fmt.Errorf("loopback guard: refusing non-loopback dial to %q", addr)
+	}
+	var d net.Dialer
+	return d.DialContext(ctx, network, net.JoinHostPort(host, port))
+}
+
+// loopbackOracleHTTPClient is the net/http client baml-rest's llmhttp uses on the
+// ORACLE leg: Proxy nil (no proxy-auth injection) + the loopback dial guard. It
+// is otherwise a stock client so the oracle mirrors baml-rest's production send
+// behavior (this is BAML-as-served) rather than the exact lane's hardened one.
+func loopbackOracleHTTPClient() *http.Client {
+	return &http.Client{Transport: &http.Transport{
+		Proxy:       nil,
+		DialContext: loopbackDial,
+	}}
+}
+
+// liveExactExecutor is the NATIVE leg's 6a exact executor over a loopback-guarded
+// transport mirroring the exact lane's transparency guarantees: Proxy nil,
+// compression disabled (no injected Accept-Encoding / transparent decode), and
+// keep-alives disabled (no stale-connection replay, so one RoundTrip is one
+// server-visible request).
+func liveExactExecutor() *llmhttp.ExactExecutor {
+	return llmhttp.NewExactExecutor(&http.Transport{
+		Proxy:              nil,
+		DialContext:        loopbackDial,
+		DisableCompression: true,
+		DisableKeepAlives:  true,
+	})
+}
+
+// --- native-parser spy ---
+
+// liveParseSpy wraps a bamlutils.DeBAMLParseFunc and counts invocations. On the
+// native leg it is the independent proof that provider outcomes (non-2xx /
+// invalid-2xx) never reach SAP (calls == 0). On the ORACLE leg it is installed
+// via WithDeBAMLParser to prove BAML-as-served (de-BAML false) NEVER reaches the
+// native parser at all — on every fixture and every control.
+type liveParseSpy struct {
+	fn    bamlutils.DeBAMLParseFunc
+	calls int
+}
+
+func (s *liveParseSpy) Parse(ctx context.Context, req bamlutils.DeBAMLParseRequest) (bamlutils.DeBAMLParseResult, error) {
+	s.calls++
+	return s.fn(ctx, req)
+}
+
+// --- oracle + native leg wiring ---
+
+// liveOracleRegistry builds the fake client_registry with the literal fence
+// model + api key and the loopback base — the EXACT same values fed to the paired
+// nanollm config, so the two legs' request bodies are byte-identical (as the P5
+// no-send differential already proves).
+func liveOracleRegistry(base string) *dynclient.ClientRegistry {
+	return &dynclient.ClientRegistry{
+		Primary: sp("TestClient"),
+		Clients: []*dynclient.ClientProperty{{
+			Name:     "TestClient",
+			Provider: "openai",
+			Options: map[string]any{
+				"model":    fenceModel,
+				"base_url": base + "/v1",
+				"api_key":  fenceAPIKey,
+			},
+		}},
+	}
+}
+
+// newLiveOracleClient builds a dynclient bound to the loopback-guarded net/http
+// client with de-BAML DISABLED, so BAML itself renders + builds + parses (this is
+// BAML-as-served). The parser spy is installed but must never fire while de-BAML
+// is off.
+func newLiveOracleClient(t *testing.T, httpClient *http.Client, spy *liveParseSpy) *dynclient.Client {
+	t.Helper()
+	client, err := dynclient.New(
+		dynclient.WithClientMode(llmhttp.ClientModeNetHTTP),
+		dynclient.WithNetHTTPClient(httpClient),
+		dynclient.WithDeBAML(false),
+		dynclient.WithDeBAMLParser(spy.Parse),
+	)
+	if err != nil {
+		t.Fatalf("dynclient.New: %v", err)
+	}
+	return client
+}
+
+// newLiveNativeClient builds a nanollm v0.3.2 client with ONE openai alias bound
+// to the loopback base, a distinct alias vs. target, a zero retry budget, and no
+// process-env secret resolution.
+func newLiveNativeClient(t *testing.T, base string) *nanollm.Client {
+	t.Helper()
+	c, err := nanollm.New(nanollm.Config{
+		Models: []nanollm.ModelConfig{{
+			Name:       fenceAlias,
+			Model:      "openai/" + fenceModel,
+			APIKey:     fenceAPIKey,
+			BaseURL:    base + "/v1",
+			MaxRetries: 0,
+		}},
+		Env:           nil,
+		UseProcessEnv: false,
+	})
+	if err != nil {
+		t.Fatalf("nanollm.New: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// runOracleLeg performs the BAML-as-served send and returns the flattened
+// structured output. PreserveSchemaOrder pins the public-contract field order so
+// the final-output comparison can assert order, not just set membership.
+func runOracleLeg(t *testing.T, client *dynclient.Client, base string, tc dynFixture) (stdjson.RawMessage, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), liveCallTimeout)
+	defer cancel()
+	res, err := client.DynamicCall(ctx, dynclient.Request{
+		Messages:            toDynMessages(tc.messages),
+		ClientRegistry:      liveOracleRegistry(base),
+		OutputSchema:        tc.schema,
+		PreserveSchemaOrder: bptr(true),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.Data, nil
+}
+
+// runNativeLeg performs the 6a+6b native send, gated by the umbrella
+// BAML_REST_USE_DEBAML switch (default-on; disabled only on an explicit falsy
+// value) — never an ambient CI decision, and NO new flag. When the switch is off
+// it returns ran=false having made ZERO native sends. The parseSpy is the
+// independent no-SAP proof.
+func runNativeLeg(t *testing.T, nano *nanollm.Client, base string, tc dynFixture) (res *execute.AttemptResult, spy *liveParseSpy, ran bool, err error) {
+	t.Helper()
+	if bamlutils.IsFalsyEnvValue(os.Getenv(bamlutils.EnvUseDeBAML)) {
+		return nil, nil, false, nil
+	}
+	rendered, rerr := nativeprompt.Render(tc.messages, tc.schema)
+	if rerr != nil {
+		t.Fatalf("nativeprompt.Render: %v", rerr)
+	}
+	intent, ierr := nativebody.NormalizeDynamicClient(liveOracleRegistry(base), fenceAlias, false)
+	if ierr != nil {
+		t.Fatalf("NormalizeDynamicClient: %v", ierr)
+	}
+	nb, berr := nativebody.BuildOpenAIChat(rendered, intent)
+	if berr != nil {
+		t.Fatalf("BuildOpenAIChat declined a P5-admitted case: %v", berr)
+	}
+	prep, perr := nano.Prepare(nanollm.Request{
+		Model:  fenceAlias,
+		Body:   nb.Bytes(),
+		Type:   nanollm.ChatCompletion,
+		Stream: false,
+	})
+	if perr != nil {
+		t.Fatalf("Prepare rejected a P5-admitted body: %v", perr)
+	}
+	spy = &liveParseSpy{fn: debaml.Parse}
+	ctx, cancel := context.WithTimeout(context.Background(), liveCallTimeout)
+	defer cancel()
+	res, err = execute.RunAttempt(ctx, execute.AttemptConfig{
+		Client:       nano,
+		Prepared:     prep,
+		Executor:     liveExactExecutor(),
+		Parse:        spy.Parse,
+		OutputSchema: tc.schema,
+	})
+	return res, spy, true, err
+}
+
+// --- wire parity comparator ---
+
+// liveTransportOnlyHeaders are the request-header names the Go transport itself
+// frames and that no planner controls — the ONLY permitted wire-only headers,
+// excluded on BOTH sides. Empirically (a real loopback send of both legs): the
+// BAML llmhttp client leaves compression on so its transport injects
+// Accept-Encoding: gzip, while the native exact lane disables compression
+// (injecting none) and disables keep-alives (framing Connection: close); Go moves
+// the body length into Content-Length and stamps the default User-Agent on both.
+// None is a semantic header either planner emits.
+var liveTransportOnlyHeaders = map[string]bool{
+	"accept-encoding": true,
+	"content-length":  true,
+	"user-agent":      true,
+	"connection":      true,
+}
+
+// liveBAMLDeclinedHeaders are BAML-internal transport/routing headers Phase 5/6
+// EXPLICITLY DECLINE to compare (scope). BAML v0.223 emits `baml-original-url`
+// (the base URL, for its own downstream rewrite); nanollm never emits it. It is
+// excluded from the ORACLE side ONLY — if nanollm ever emitted it, it would
+// surface as a native-only header and correctly FAIL parity. Any OTHER unexpected
+// BAML header stays in the semantic set and fails the test (fail closed). A NEW
+// exclusion here requires an explicit parity-deferral note + a control.
+var liveBAMLDeclinedHeaders = map[string]bool{
+	"baml-original-url": true,
+}
+
+// liveMultiMap folds an http.Header into a lowercase-keyed multimap, dropping the
+// named transport-only headers (and, when dropDeclined, the BAML-declined ones).
+// Repeated names and per-name value order are preserved — the properties the
+// capture server exists to prove.
+func liveMultiMap(h http.Header, dropDeclined bool) map[string][]string {
+	out := map[string][]string{}
+	for k, vs := range h {
+		n := strings.ToLower(k)
+		if liveTransportOnlyHeaders[n] {
+			continue
+		}
+		if dropDeclined && liveBAMLDeclinedHeaders[n] {
+			continue
+		}
+		out[n] = append(out[n], vs...)
+	}
+	return out
+}
+
+// redactVals redacts every non-allowlisted header value for diagnostics.
+func redactVals(name string, vals []string) []string {
+	out := make([]string, len(vals))
+	for i, v := range vals {
+		out[i] = testutil.RedactValue(name, v)
+	}
+	return out
+}
+
+// liveWireDiffs is the core wire differential between the two live legs, returned
+// as a sorted list of REDACTED, human-readable differences (empty == parity):
+// exact method, request target (path+query), effective host, byte-exact body,
+// semantic header multimap equality (every value + per-name order), and the exact
+// fake authorization on both sides. Global header-name order/casing is NOT
+// compared. Every header value is redacted unless allowlisted, so a diagnostic
+// never leaks the fake bearer token.
+func liveWireDiffs(oracle, native recordedLive) []string {
+	var d []string
+
+	if oracle.Method != native.Method {
+		d = append(d, fmt.Sprintf("method: oracle=%q native=%q", oracle.Method, native.Method))
+	}
+	if oracle.RequestURI != native.RequestURI {
+		d = append(d, fmt.Sprintf("request target: oracle=%q native=%q", oracle.RequestURI, native.RequestURI))
+	}
+	if oracle.Host != native.Host {
+		d = append(d, fmt.Sprintf("effective host: oracle=%q native=%q", oracle.Host, native.Host))
+	}
+	if !bytes.Equal(oracle.Body, native.Body) {
+		d = append(d, fmt.Sprintf("raw body not byte-identical: oracle=%s native=%s",
+			liveBodyDigest(oracle.Body), liveBodyDigest(native.Body)))
+	}
+
+	oSem := liveMultiMap(oracle.Header, true)  // oracle: drop baml-original-url
+	nSem := liveMultiMap(native.Header, false) // native: nothing to decline
+	for name, ov := range oSem {
+		nv, ok := nSem[name]
+		if !ok {
+			d = append(d, fmt.Sprintf("header %q present on oracle only (values %v)", name, redactVals(name, ov)))
+			continue
+		}
+		if !slices.Equal(ov, nv) {
+			d = append(d, fmt.Sprintf("header %q values differ: oracle=%v native=%v",
+				name, redactVals(name, ov), redactVals(name, nv)))
+		}
+	}
+	for name, nv := range nSem {
+		if _, ok := oSem[name]; !ok {
+			d = append(d, fmt.Sprintf("header %q present on native only (values %v)", name, redactVals(name, nv)))
+		}
+	}
+
+	// Exact fake authorization on both sides.
+	wantAuth := "Bearer " + fenceAPIKey
+	d = append(d, authExactDiffs("oracle", oSem, wantAuth)...)
+	d = append(d, authExactDiffs("native", nSem, wantAuth)...)
+
+	sort.Strings(d)
+	return d
+}
+
+// assertLiveWireParity fails the test with every wire difference, and separately
+// pins the request target to the OpenAI chat-completions endpoint.
+func assertLiveWireParity(t *testing.T, oracle, native recordedLive) {
+	t.Helper()
+	if oracle.Method != http.MethodPost || native.Method != http.MethodPost {
+		t.Errorf("method: oracle=%q native=%q, want POST", oracle.Method, native.Method)
+	}
+	if want := "/v1/chat/completions"; oracle.RequestURI != want {
+		t.Errorf("request target = %q, want %q", oracle.RequestURI, want)
+	}
+	for _, s := range liveWireDiffs(oracle, native) {
+		t.Error(s)
+	}
+}
+
+func authExactDiffs(side string, sem map[string][]string, want string) []string {
+	vs := sem["authorization"]
+	if len(vs) != 1 {
+		return []string{fmt.Sprintf("%s: want exactly one authorization header, got %d", side, len(vs))}
+	}
+	if vs[0] != want {
+		return []string{fmt.Sprintf("%s authorization mismatch (redacted): got %s want %s",
+			side, testutil.RedactValue("authorization", vs[0]), testutil.RedactValue("authorization", want))}
+	}
+	return nil
+}
+
+// --- final structured-output parity ---
+
+// assertStructuredParity proves final structured-output equality between the two
+// legs, both semantically (object-key order ignored) and — reordered to the
+// schema's field order (the order the public dynamic response contract preserves
+// under PreserveSchemaOrder) — byte-for-byte.
+func assertStructuredParity(t *testing.T, schema *bamlutils.DynamicOutputSchema, oracle, native stdjson.RawMessage) {
+	t.Helper()
+	if !liveJSONSemEqual(t, oracle, native) {
+		t.Errorf("final structured output differs semantically: oracle=%s native=%s",
+			liveBodyDigest(oracle), liveBodyDigest(native))
+	}
+	oOrd, err := bamlutils.ReorderDynamicOutputBySchema(oracle, schema)
+	if err != nil {
+		t.Fatalf("reordering oracle output by schema: %v", err)
+	}
+	nOrd, err := bamlutils.ReorderDynamicOutputBySchema(native, schema)
+	if err != nil {
+		t.Fatalf("reordering native output by schema: %v", err)
+	}
+	if !bytes.Equal(oOrd, nOrd) {
+		t.Errorf("final structured output field order differs under the schema contract: oracle=%s native=%s",
+			liveBodyDigest(oOrd), liveBodyDigest(nOrd))
+	}
+}
+
+// --- secret-safe diagnostics ---
+
+// liveBodyDigest renders a payload as "<n>B sha256:<12hex>" — never raw bytes —
+// so a CI failure log holds no request/response payload.
+func liveBodyDigest(b []byte) string {
+	sum := sha256.Sum256(b)
+	return fmt.Sprintf("%dB sha256:%s", len(b), hex.EncodeToString(sum[:])[:12])
+}
+
+// liveJSONSemEqual reports whether a and b decode to structurally equal JSON. On
+// a decode failure it reports only a digest of the offending payload.
+func liveJSONSemEqual(t *testing.T, a, b []byte) bool {
+	t.Helper()
+	var av, bv any
+	if err := stdjson.Unmarshal(a, &av); err != nil {
+		t.Fatalf("decode oracle output (%s): %v", liveBodyDigest(a), err)
+	}
+	if err := stdjson.Unmarshal(b, &bv); err != nil {
+		t.Fatalf("decode native output (%s): %v", liveBodyDigest(b), err)
+	}
+	return jsonDeepEqual(av, bv)
+}
+
+// jsonDeepEqual compares two decoded JSON values structurally (object key order
+// ignored; numbers already normalized to float64 by encoding/json).
+func jsonDeepEqual(a, b any) bool {
+	switch av := a.(type) {
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for k, x := range av {
+			y, ok := bv[k]
+			if !ok || !jsonDeepEqual(x, y) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !jsonDeepEqual(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return a == b
+	}
+}
+
+// TestLiveDifferentialParity is the core Slice 6c live differential: for every
+// P5-admitted fixture, both legs send exactly one real loopback request, the wire
+// observations match, and both reach the same final structured output.
+func TestLiveDifferentialParity(t *testing.T) {
+	// Native leg default-on EXPLICITLY (umbrella flag), so ambient CI env cannot
+	// change the result. The oracle leg is de-BAML false regardless.
+	t.Setenv(bamlutils.EnvUseDeBAML, "1")
+
+	for _, lc := range liveFixtures(t) {
+		lc := lc
+		t.Run(lc.name, func(t *testing.T) {
+			server := newLiveCaptureServer(t)
+			served := openAISuccess(lc.content)
+			server.setResponse(http.StatusOK, served)
+
+			oracleSpy := &liveParseSpy{fn: debaml.Parse}
+			oracle := newLiveOracleClient(t, loopbackOracleHTTPClient(), oracleSpy)
+			nano := newLiveNativeClient(t, server.base())
+
+			// --- Leg A: oracle (BAML-as-served) — exactly one request. ---
+			oracleData, oerr := runOracleLeg(t, oracle, server.base(), lc.dynFixture)
+			if oerr != nil {
+				t.Fatalf("oracle DynamicCall failed on an admitted fixture: %v", oerr)
+			}
+			if got := server.count(); got != 1 {
+				t.Fatalf("oracle leg made %d requests, want exactly 1 (no retry/fallback)", got)
+			}
+			oracleRec := server.rec(0)
+
+			// --- Leg B: native (6a+6b) — exactly one more request. ---
+			res, spy, ran, nerr := runNativeLeg(t, nano, server.base(), lc.dynFixture)
+			if !ran {
+				t.Fatal("native leg did not run (umbrella flag unexpectedly off)")
+			}
+			if nerr != nil {
+				t.Fatalf("native RunAttempt failed on an admitted fixture: %v", nerr)
+			}
+			if got := server.count(); got != 2 {
+				t.Fatalf("after the native leg the server saw %d total requests, want exactly 2", got)
+			}
+			nativeRec := server.rec(1)
+
+			// (1) wire parity (method / target / host / body / semantic headers).
+			assertLiveWireParity(t, oracleRec, nativeRec)
+
+			// (2) both legs received the identical deterministic upstream 2xx body:
+			// the native leg's RAW captured provider body is byte-exact the served
+			// bytes (the exact executor returns the upstream body verbatim).
+			if res.ProviderStatus != http.StatusOK {
+				t.Errorf("native provider status = %d, want 200", res.ProviderStatus)
+			}
+			if !bytes.Equal(res.ProviderBody, served) {
+				t.Errorf("native raw provider body != served upstream body: got %s want %s",
+					liveBodyDigest(res.ProviderBody), liveBodyDigest(served))
+			}
+
+			// (3) native response side: structured output, attempted alias, the
+			// translated OpenAI body + assistant text, SAP invoked once.
+			if res.Outcome != execute.OutcomeStructured {
+				t.Fatalf("native outcome = %s, want structured", res.Outcome)
+			}
+			if res.AttemptedAlias != fenceAlias {
+				t.Errorf("native attempted alias = %q, want %q", res.AttemptedAlias, fenceAlias)
+			}
+			if !res.SAPInvoked || spy.calls != 1 {
+				t.Errorf("native SAP invocation: SAPInvoked=%v calls=%d, want invoked once", res.SAPInvoked, spy.calls)
+			}
+			if res.Translated == nil || !res.Translated.BodyIsJSON {
+				t.Fatalf("native translated response missing/!JSON")
+			}
+			// The translated OpenAI body carries the SAME response fields as the
+			// served OpenAI 2xx — compared semantically (per the adapter contract;
+			// the openai path passes the body through, so this also holds byte-for-
+			// byte here). This is what catches a translation regression that keeps
+			// the assistant text but drops/changes other OpenAI response fields —
+			// asserted BEFORE the assistant-text check below.
+			if !liveJSONSemEqual(t, res.Translated.Body, served) {
+				t.Errorf("native translated OpenAI body != served OpenAI body: got %s want %s",
+					liveBodyDigest(res.Translated.Body), liveBodyDigest(served))
+			}
+			if res.AssistantText != lc.content {
+				t.Errorf("native assistant text mismatch (%s), want the served structured JSON", liveBodyDigest([]byte(res.AssistantText)))
+			}
+
+			// (4) final structured-output equality (semantic + schema field order).
+			assertStructuredParity(t, lc.schema, oracleData, res.Structured)
+
+			// (5) BAML-as-served (de-BAML false) NEVER touched the native parser.
+			if oracleSpy.calls != 0 {
+				t.Errorf("oracle native-parser spy fired %d times; BAML-as-served must never invoke native SAP", oracleSpy.calls)
+			}
+		})
+	}
+}

--- a/internal/nativebody/nanollmprepare/dynamic/live_mocklm_integration_test.go
+++ b/internal/nativebody/nanollmprepare/dynamic/live_mocklm_integration_test.go
@@ -1,0 +1,360 @@
+//go:build integration && nanollm_integration
+
+package dynamic
+
+// De-BAML Slice 6c complementary realism proof: the SAME two live legs, but run
+// against the real go-mocklm v0.4.0 subprocess (the second of the scope's two
+// loopback responders) instead of the baml-rest capture server.
+//
+// Where the capture server proves byte-exact wire fidelity (repeated headers /
+// per-name order, exact body bytes) and final-output parity, go-mocklm proves
+// PROVIDER-NATIVE VALIDITY: both the BAML-as-served request and the native
+// PreparedRequest are real OpenAI Chat Completions requests that go-mocklm (with
+// MOCKLM_VALIDATE_RESPONSES) accepts on its /v1/chat/completions route and answers
+// deterministically, and BOTH legs reach final structured output — one request
+// each, no retry/fallback. go-mocklm records headers as a map[string]string, so
+// it cannot prove repeated headers/order; that stays the capture server's job.
+//
+// This is a compact, self-contained subprocess harness modeled on the Slice-2
+// harness in ../execute (which is package-local test code and so cannot be
+// imported across the package boundary). It imports NO BAML and NO nanollm — only
+// os/exec + admin HTTP — and its loopback dial guard + credential/proxy scrub keep
+// every byte on 127.0.0.1.
+
+import (
+	"bytes"
+	"context"
+	stdjson "encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare/execute"
+)
+
+const (
+	mockLoopbackHost    = "127.0.0.1"
+	mockStartupDeadline = 20 * time.Second
+	mockHealthPollEvery = 25 * time.Millisecond
+	mockAdminTimeout    = 10 * time.Second
+)
+
+// liveMock is a running go-mocklm subprocess plus a loopback-guarded admin client.
+type liveMock struct {
+	t       *testing.T
+	cmd     *exec.Cmd
+	baseURL string
+	admin   *http.Client
+	logs    *lockedBuf
+	dumped  sync.Once
+	done    chan struct{}
+}
+
+// lockedBuf is a concurrency-safe buffer for the child's combined stdout+stderr.
+type lockedBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuf) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+func (b *lockedBuf) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// startLiveMock launches one isolated go-mocklm on a fresh loopback port with
+// provider/proxy credentials scrubbed from the child environment, and blocks
+// until it is healthy.
+func startLiveMock(t *testing.T) *liveMock {
+	t.Helper()
+	bin := liveMockBinary(t)
+	port := freeLoopbackPortLive(t)
+
+	cfgPath := filepath.Join(t.TempDir(), "mocklm.toml")
+	cfg := fmt.Sprintf("[server]\nhost = %q\nport = %d\n", mockLoopbackHost, port)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("writing mock config: %v", err)
+	}
+
+	logs := &lockedBuf{}
+	cmd := exec.Command(bin)
+	cmd.Env = append(scrubbedEnv(),
+		"CONFIG_PATH="+cfgPath,
+		"MOCKLM_HTTP_ENABLED=1",
+		"MOCKLM_TLS_ENABLED=0",
+		"MOCKLM_VALIDATE_RESPONSES=1",
+	)
+	cmd.Stdout = logs
+	cmd.Stderr = logs
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting go-mocklm (%s): %v", bin, err)
+	}
+
+	m := &liveMock{
+		t:       t,
+		cmd:     cmd,
+		baseURL: fmt.Sprintf("http://%s:%d", mockLoopbackHost, port),
+		admin:   &http.Client{Transport: mockLoopbackTransport(), Timeout: mockAdminTimeout},
+		logs:    logs,
+		done:    make(chan struct{}),
+	}
+	go func() { _ = cmd.Wait(); close(m.done) }()
+	t.Cleanup(m.stop)
+	m.waitHealthy()
+	return m
+}
+
+// scrubbedEnv drops provider/proxy credential variables from the inherited
+// environment so a helper subprocess can never resolve or forward a real secret.
+func scrubbedEnv() []string {
+	drop := func(k string) bool {
+		up := strings.ToUpper(k)
+		return strings.Contains(up, "API_KEY") || strings.Contains(up, "APIKEY") ||
+			strings.Contains(up, "TOKEN") || strings.Contains(up, "SECRET") ||
+			strings.HasSuffix(up, "_PROXY") || up == "HTTP_PROXY" || up == "HTTPS_PROXY" ||
+			up == "ALL_PROXY" || strings.HasPrefix(up, "OPENAI") || strings.HasPrefix(up, "ANTHROPIC") ||
+			strings.HasPrefix(up, "AWS_")
+	}
+	var out []string
+	for _, kv := range os.Environ() {
+		if i := strings.IndexByte(kv, '='); i >= 0 && drop(kv[:i]) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+func (m *liveMock) stop() {
+	if m.cmd.Process != nil {
+		_ = m.cmd.Process.Kill()
+	}
+	<-m.done
+	if m.t.Failed() {
+		m.dumped.Do(func() {
+			out := strings.TrimRight(m.logs.String(), "\n")
+			if out == "" {
+				out = "(no child output captured)"
+			}
+			m.t.Logf("go-mocklm child output:\n%s", out)
+		})
+	}
+}
+
+func (m *liveMock) exited() bool {
+	select {
+	case <-m.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *liveMock) waitHealthy() {
+	m.t.Helper()
+	deadline := time.Now().Add(mockStartupDeadline)
+	var lastErr error
+	for {
+		if m.exited() {
+			m.t.Fatalf("go-mocklm exited before becoming healthy (config/port failure?)")
+		}
+		req, _ := http.NewRequest(http.MethodGet, m.baseURL+"/health", nil)
+		resp, err := m.admin.Do(req)
+		if err == nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+			lastErr = fmt.Errorf("health status %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			m.t.Fatalf("go-mocklm not healthy at %s within %s (last: %v)", m.baseURL, mockStartupDeadline, lastErr)
+		}
+		time.Sleep(mockHealthPollEvery)
+	}
+}
+
+// mockLoopbackTransport disables proxying and refuses any non-loopback dial.
+func mockLoopbackTransport() *http.Transport {
+	return &http.Transport{Proxy: nil, DialContext: loopbackDial}
+}
+
+func liveMockBinary(t *testing.T) string {
+	t.Helper()
+	if bin := os.Getenv("MOCKLM_BINARY"); bin != "" {
+		if _, err := os.Stat(bin); err != nil {
+			t.Fatalf("MOCKLM_BINARY=%q is not usable: %v", bin, err)
+		}
+		return bin
+	}
+	out := filepath.Join(t.TempDir(), "go-mocklm")
+	cmd := exec.Command("go", "build", "-o", out, "github.com/viktordanov/go-mocklm")
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("building pinned go-mocklm tool (set MOCKLM_BINARY to skip): %v\n%s", err, b)
+	}
+	return out
+}
+
+func freeLoopbackPortLive(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", net.JoinHostPort(mockLoopbackHost, "0"))
+	if err != nil {
+		t.Fatalf("reserving a loopback port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// --- admin helpers ---
+
+type mockExactOutput struct {
+	Text         string `json:"text"`
+	OutputTokens int    `json:"output_tokens,omitempty"`
+}
+
+type mockScenario struct {
+	ID       string           `json:"id"`
+	Provider string           `json:"provider"`
+	Model    string           `json:"model,omitempty"`
+	Output   *mockExactOutput `json:"output,omitempty"`
+}
+
+func (m *liveMock) adminDo(method, path string, body []byte) *http.Response {
+	m.t.Helper()
+	var r io.Reader
+	if body != nil {
+		r = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, m.baseURL+path, r)
+	if err != nil {
+		m.t.Fatalf("building admin request %s %s: %v", method, path, err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := m.admin.Do(req)
+	if err != nil {
+		m.t.Fatalf("admin request %s %s: %v", method, path, err)
+	}
+	return resp
+}
+
+func (m *liveMock) registerScenario(spec mockScenario) {
+	m.t.Helper()
+	body, err := stdjson.Marshal(spec)
+	if err != nil {
+		m.t.Fatalf("marshaling scenario %q: %v", spec.ID, err)
+	}
+	resp := m.adminDo(http.MethodPost, "/admin/scenarios", body)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		m.t.Fatalf("registering scenario %q: status %d: %s", spec.ID, resp.StatusCode, b)
+	}
+	io.Copy(io.Discard, resp.Body)
+	m.t.Cleanup(func() {
+		r := m.adminDo(http.MethodDelete, "/admin/scenarios/"+spec.ID, nil)
+		io.Copy(io.Discard, r.Body)
+		r.Body.Close()
+	})
+}
+
+func (m *liveMock) scenarioRequestCount(id string) int {
+	m.t.Helper()
+	resp := m.adminDo(http.MethodGet, "/admin/scenarios/"+id+"/request-count", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		m.t.Fatalf("request-count for scenario %q: status %d: %s", id, resp.StatusCode, b)
+	}
+	var out struct {
+		Count int `json:"count"`
+	}
+	if err := stdjson.NewDecoder(resp.Body).Decode(&out); err != nil {
+		m.t.Fatalf("decoding request-count for %q: %v", id, err)
+	}
+	return out.Count
+}
+
+// TestLiveMockLMBothLegs runs both live legs against the go-mocklm subprocess and
+// asserts each produces a provider-native request go-mocklm accepts and answers,
+// each leg hits it exactly once, and both reach the same final structured output.
+func TestLiveMockLMBothLegs(t *testing.T) {
+	t.Setenv(bamlutils.EnvUseDeBAML, "1")
+
+	m := startLiveMock(t)
+	const id = "p6c-live-openai-structured"
+	const content = `{"answer":"ok"}`
+	m.registerScenario(mockScenario{
+		ID:       id,
+		Provider: "openai",
+		Model:    fenceModel,
+		Output:   &mockExactOutput{Text: content, OutputTokens: 7},
+	})
+
+	// The parser spy is installed only to satisfy WithDeBAMLParser; de-BAML is
+	// false so it can never run.
+	oracleSpy := &liveParseSpy{fn: passthroughParse}
+	oracle := newLiveOracleClient(t, loopbackOracleHTTPClient(), oracleSpy)
+	nano := newLiveNativeClient(t, m.baseURL)
+	tc := dynFixtureByName(t, "single_user_message")
+
+	// --- oracle leg: BAML-as-served, provider-native, exactly one request. ---
+	oracleData, oerr := runOracleLeg(t, oracle, m.baseURL, tc)
+	if oerr != nil {
+		t.Fatalf("oracle leg failed against go-mocklm: %v", oerr)
+	}
+	if got := m.scenarioRequestCount(id); got != 1 {
+		t.Fatalf("oracle leg produced %d go-mocklm requests, want 1", got)
+	}
+
+	// --- native leg: 6a+6b, provider-native, exactly one more request. ---
+	res, spy, ran, nerr := runNativeLeg(t, nano, m.baseURL, tc)
+	if !ran || nerr != nil {
+		t.Fatalf("native leg failed against go-mocklm: ran=%v err=%v", ran, nerr)
+	}
+	if got := m.scenarioRequestCount(id); got != 2 {
+		t.Fatalf("native leg brought the go-mocklm count to %d, want 2 (one per leg)", got)
+	}
+
+	// Both reach structured output; the attempted alias translated the response.
+	if res.Outcome != execute.OutcomeStructured {
+		t.Fatalf("native outcome = %s, want structured", res.Outcome)
+	}
+	if res.AttemptedAlias != fenceAlias {
+		t.Errorf("native attempted alias = %q, want %q", res.AttemptedAlias, fenceAlias)
+	}
+	if !res.SAPInvoked || spy.calls != 1 {
+		t.Errorf("native SAP: SAPInvoked=%v calls=%d, want invoked once", res.SAPInvoked, spy.calls)
+	}
+	assertStructuredParity(t, tc.schema, oracleData, res.Structured)
+
+	// BAML-as-served never touched the native parser.
+	if oracleSpy.calls != 0 {
+		t.Errorf("oracle native-parser spy fired %d times, want 0", oracleSpy.calls)
+	}
+}
+
+// passthroughParse is a never-invoked parser installed on the oracle client only
+// to satisfy WithDeBAMLParser; de-BAML is false so it can never run.
+func passthroughParse(ctx context.Context, req bamlutils.DeBAMLParseRequest) (bamlutils.DeBAMLParseResult, error) {
+	return bamlutils.DeBAMLParseResult{}, fmt.Errorf("passthroughParse must never be called (de-BAML is false)")
+}


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## Phase 6 Slice 6c — BAML-as-served live-loopback differential (core green bar)

Extends the Phase-5 **dynamic** prepared-request oracle (`internal/nativebody/nanollmprepare/dynamic`) from a no-send capture into an actual **two-leg loopback SEND** differential. Both legs make **exactly one real `net/http` request** against a shared baml-rest-owned loopback capture server; a go-mocklm subprocess is the second responder. Test-only, gated `integration && nanollm_integration`, **no serving change**.

### The two legs
- **Oracle (BAML-as-served — what production serves today):** `dynclient.DynamicCall` + `WithDeBAML(false)` + fake `ClientRegistry(base_url=127.0.0.1:<port>/v1, fake key, no retry)` → BAML v0.223 `BuildRequest` → baml-rest `llmhttp` net/http send → loopback → BAML extraction + native-disabled final parse. A native-parser spy is installed and asserted to **never** fire (de-BAML-off ⇒ no native SAP).
- **Native (6a+6b):** same fixture → `nativeprompt.Render` → `nativebody.BuildOpenAIChat` → nanollm `Prepare` → 6a `llmhttp.ExactExecutor` (loopback-guarded) → **same** server → `TranslateResponse(prep.Meta.ModelAlias)` → OpenAI extraction → `internal/debaml.Parse`, via the 6b `execute.RunAttempt` adapter (the only cross-package symbol reused; no parallel harness).

### Comparison policy asserted (`TestLiveDifferentialParity`, 5 fixtures)
- exactly one request per leg (per-leg counter 1 → 2), no fallback/retry;
- exact method / request-target (path+query) / effective host / **byte-exact raw body**;
- **semantic header multimap equality** (every value + per-name order, case-insensitive); exact fake `Authorization` (redacted in diagnostics); global header-name **order/casing declined**;
- only named exclusions: BAML's internal `baml-original-url` (BAML side only) + transport-generated `accept-encoding`/`content-length`/`user-agent`/`connection` (both sides), fail-closed on anything else;
- identical deterministic upstream body to both legs; native translated OpenAI body + **assistant text = served content**; **final structured-output equality** (semantic + schema field order).

### Controls
- **flag-off:** explicit `BAML_REST_USE_DEBAML` falsy ⇒ native leg makes **zero sends** (umbrella switch, no new flag); oracle still sends once.
- **mutated method / URL / header / body / response:** each is detected; no fake secret leaks into diagnostics.
- **non-2xx (429) / invalid-2xx (200 + non-JSON):** native SAP **not invoked** (parse-spy 0, `SAPInvoked=false`), mapped to `OutcomeProviderError` / `OutcomeInvalidBody`; oracle fails to parse; **no second request** on either leg.

### Fence
Fake key/model/alias; literal 127.0.0.1 base; nanollm `UseProcessEnv:false`/`Env:nil`/`MaxRetries:0`; both HTTP clients `Proxy:nil` + loopback dial guard; go-mocklm child env credential/proxy-scrubbed; every failure diagnostic redacts header values / digests bodies. No network escapes loopback.

### CI
`.github/workflows/nanollm-prepare.yml` (the P5 differential lane that provisions BAML CFFI + nanollm) already picks up the new `dynamic` tests. Added: go-mocklm **v0.4.0** exact-pin + `tool`-directive assertion + zero-root isolation, and a step that builds the go-mocklm tool once (`MOCKLM_BINARY`). nanollm-ffi **v0.3.2** + BAML **v0.223.0** pins retained; no lane weakened; the BAML-free send lane is untouched.

### Validation (Darwin/ARM64)
`gofmt`/`go vet` clean; default untagged `go build ./...` + `go test ./internal/nativebody ./internal/nativeprompt ./internal/nativeschema ./cmd/introspect` green; gated module suite `GOWORK=off go test -tags "integration nanollm_integration" ./...` all green — the new 6c live differential **and** the existing P5 pre-flight + 6b + 2a/2b + P4b. Root `go.mod`/`go.sum`/`go.work`/`go.work.sum` unchanged; root stays zero-nanollm. All 6c code is `_test.go` in the isolated non-embedded module (no embed regen).

### Next
**6d (optional hardening)** remains: literal BAML/CFFI-owned send oracle under an OS no-egress boundary; go-mocklm status/timeout fault vectors as baml-rest-attempt outcomes; diagnostic raw HTTP/1.1 header-line capture if ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new live loopback integration coverage validating parity between “oracle” and “native” request paths for success and error cases.
  - Added negative controls for live flag off, wire-level request mutations, invalid/non-2xx responses, provider error handling, SAP skipping, and no-retry behavior.
  - Added live mocklm integration to validate complete two-leg flows, request counts, and secret-safe diagnostics.
- **Chores**
  - Strengthened gated CI preparation by pinning the mock tool version, adding pre-flight isolation checks, building/using the tool binary in CI, and expanding the run coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->