### PR TITLE
ci: bind warm mock-LLM bases to local aliases (#541)

### DIFF
--- a/.github/workflows/bamlfuzz-nightly.yml
+++ b/.github/workflows/bamlfuzz-nightly.yml
@@ -326,9 +326,12 @@ jobs:
           path: warm-images
 
       - name: Load warm base images
-        # `docker load` the warmed tarballs before the go-test steps so
-        # testcontainers' tag-based `FROM` builds reuse them locally instead of
-        # pulling from Docker Hub.
+        # `docker load` the warmed tarballs before the go-test steps. Load
+        # restores each base as its ordinary `repo:tag`, but NOT the repo-digest
+        # mapping — so the mock Dockerfile's pinned `FROM repo:tag@sha256:…`
+        # would still re-resolve that manifest against Docker Hub (the #541
+        # "context deadline exceeded" flake). The next step binds the pinned
+        # bases to local aliases before testcontainers builds the mock image.
         run: |
           set -euo pipefail
           for tar in warm-images/*.tar; do
@@ -336,6 +339,15 @@ jobs:
             docker load -i "$tar"
           done
           docker image ls
+
+      - name: Bind warm mock bases to local aliases
+        # Tag the loaded golang/alpine bases to deterministic local aliases and
+        # rewrite this ephemeral Dockerfile checkout to consume them, so the mock
+        # build never re-resolves a pinned digest against Docker Hub (#541). The
+        # committed Dockerfile stays digest-pinned; only the CI checkout is
+        # rewritten. The helper also prints each base's RepoDigests as a
+        # diagnostic (empty after save/load — the root cause this works around).
+        run: integration/mockllm/ci-use-warm-bases.sh
 
       - name: Set up Go
         uses: actions/setup-go@v6.5.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -319,9 +319,12 @@ jobs:
           path: warm-images
 
       - name: Load warm base images
-        # `docker load` the warmed tarballs before the go-test step so
-        # testcontainers' tag-based `FROM` builds reuse them locally instead of
-        # pulling from Docker Hub.
+        # `docker load` the warmed tarballs before the go-test step. Load
+        # restores each base as its ordinary `repo:tag`, but NOT the repo-digest
+        # mapping — so the mock Dockerfile's pinned `FROM repo:tag@sha256:…`
+        # would still re-resolve that manifest against Docker Hub (the #541
+        # "context deadline exceeded" flake). The next step binds the pinned
+        # bases to local aliases before testcontainers builds the mock image.
         run: |
           set -euo pipefail
           for tar in warm-images/*.tar; do
@@ -329,6 +332,15 @@ jobs:
             docker load -i "$tar"
           done
           docker image ls
+
+      - name: Bind warm mock bases to local aliases
+        # Tag the loaded golang/alpine bases to deterministic local aliases and
+        # rewrite this ephemeral Dockerfile checkout to consume them, so the mock
+        # build never re-resolves a pinned digest against Docker Hub (#541). The
+        # committed Dockerfile stays digest-pinned; only the CI checkout is
+        # rewritten. The helper also prints each base's RepoDigests as a
+        # diagnostic (empty after save/load — the root cause this works around).
+        run: integration/mockllm/ci-use-warm-bases.sh
 
       - name: Set up Go
         uses: actions/setup-go@v6.5.0
@@ -437,9 +449,12 @@ jobs:
           path: warm-images
 
       - name: Load warm base images
-        # `docker load` the warmed tarballs before the go-test step so
-        # testcontainers' tag-based `FROM` builds reuse them locally instead of
-        # pulling from Docker Hub.
+        # `docker load` the warmed tarballs before the go-test step. Load
+        # restores each base as its ordinary `repo:tag`, but NOT the repo-digest
+        # mapping — so the mock Dockerfile's pinned `FROM repo:tag@sha256:…`
+        # would still re-resolve that manifest against Docker Hub (the #541
+        # "context deadline exceeded" flake). The next step binds the pinned
+        # bases to local aliases before testcontainers builds the mock image.
         run: |
           set -euo pipefail
           for tar in warm-images/*.tar; do
@@ -447,6 +462,15 @@ jobs:
             docker load -i "$tar"
           done
           docker image ls
+
+      - name: Bind warm mock bases to local aliases
+        # Tag the loaded golang/alpine bases to deterministic local aliases and
+        # rewrite this ephemeral Dockerfile checkout to consume them, so the mock
+        # build never re-resolves a pinned digest against Docker Hub (#541). The
+        # committed Dockerfile stays digest-pinned; only the CI checkout is
+        # rewritten. The helper also prints each base's RepoDigests as a
+        # diagnostic (empty after save/load — the root cause this works around).
+        run: integration/mockllm/ci-use-warm-bases.sh
 
       - name: Set up Go
         uses: actions/setup-go@v6.5.0
@@ -537,9 +561,12 @@ jobs:
           path: warm-images
 
       - name: Load warm base images
-        # `docker load` the warmed tarballs before the go-test step so
-        # testcontainers' tag-based `FROM` builds reuse them locally instead of
-        # pulling from Docker Hub.
+        # `docker load` the warmed tarballs before the go-test step. Load
+        # restores each base as its ordinary `repo:tag`, but NOT the repo-digest
+        # mapping — so the mock Dockerfile's pinned `FROM repo:tag@sha256:…`
+        # would still re-resolve that manifest against Docker Hub (the #541
+        # "context deadline exceeded" flake). The next step binds the pinned
+        # bases to local aliases before testcontainers builds the mock image.
         run: |
           set -euo pipefail
           for tar in warm-images/*.tar; do
@@ -547,6 +574,15 @@ jobs:
             docker load -i "$tar"
           done
           docker image ls
+
+      - name: Bind warm mock bases to local aliases
+        # Tag the loaded golang/alpine bases to deterministic local aliases and
+        # rewrite this ephemeral Dockerfile checkout to consume them, so the mock
+        # build never re-resolves a pinned digest against Docker Hub (#541). The
+        # committed Dockerfile stays digest-pinned; only the CI checkout is
+        # rewritten. The helper also prints each base's RepoDigests as a
+        # diagnostic (empty after save/load — the root cause this works around).
+        run: integration/mockllm/ci-use-warm-bases.sh
 
       - name: Set up Go
         uses: actions/setup-go@v6.5.0
@@ -809,9 +845,12 @@ jobs:
           path: warm-images
 
       - name: Load warm base images
-        # `docker load` the warmed tarballs before the go-test step so
-        # testcontainers' tag-based `FROM` builds reuse them locally instead of
-        # pulling from Docker Hub.
+        # `docker load` the warmed tarballs before the go-test step. Load
+        # restores each base as its ordinary `repo:tag`, but NOT the repo-digest
+        # mapping — so the mock Dockerfile's pinned `FROM repo:tag@sha256:…`
+        # would still re-resolve that manifest against Docker Hub (the #541
+        # "context deadline exceeded" flake). The next step binds the pinned
+        # bases to local aliases before testcontainers builds the mock image.
         run: |
           set -euo pipefail
           for tar in warm-images/*.tar; do
@@ -819,6 +858,15 @@ jobs:
             docker load -i "$tar"
           done
           docker image ls
+
+      - name: Bind warm mock bases to local aliases
+        # Tag the loaded golang/alpine bases to deterministic local aliases and
+        # rewrite this ephemeral Dockerfile checkout to consume them, so the mock
+        # build never re-resolves a pinned digest against Docker Hub (#541). The
+        # committed Dockerfile stays digest-pinned; only the CI checkout is
+        # rewritten. The helper also prints each base's RepoDigests as a
+        # diagnostic (empty after save/load — the root cause this works around).
+        run: integration/mockllm/ci-use-warm-bases.sh
 
       - name: Checkout BAML Source
         uses: actions/checkout@v7.0.0

--- a/integration/mockllm/ci-use-warm-bases.sh
+++ b/integration/mockllm/ci-use-warm-bases.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# ci-use-warm-bases.sh — bind the warm-loaded mock-LLM base images to local
+# aliases so testcontainers builds the mock Dockerfile with zero Docker Hub
+# calls.
+#
+# Why this exists
+# ---------------
+# The warm-images job resolves each pinned base by its immutable digest,
+# pulls it ONCE (authenticated), and `docker save`s it under its ordinary
+# `repo:tag`. Consuming cells `docker load` that tarball. But `docker
+# save`/`load` restores the image, its layers, and the `repo:tag` — it does
+# NOT restore the repo-digest association (`RepoDigests` comes back empty).
+#
+# The mock Dockerfile pins its bases as digest-qualified `FROM repo:tag@sha256:…`
+# references. With no local repo-digest mapping, the classic builder re-resolves
+# that manifest against Docker Hub on every `FROM`, which is exactly the
+# anonymous registry call that flakes with "registry-1.docker.io … context
+# deadline exceeded" (#447 / #541).
+#
+# `github.com/moby/moby/client` rejects a digest-TARGET tag, so we cannot
+# `docker tag <id> repo@sha256:…` to re-create the mapping, and a
+# `docker pull repo@digest` would only restore it by making the very registry
+# request that flakes. The Rust base already dodges this with a local-alias
+# pattern (see the warm-images job's rust step); this helper mirrors it for the
+# golang/alpine mock bases.
+#
+# What it does (fail-closed) — for each of `golang` and `alpine`:
+#   1. require exactly one `^FROM <repo>:<tag>@sha256:<64hex>` in the mock
+#      Dockerfile (same guard shape the warm job uses);
+#   2. split it into `source_tag` (repo:tag), the 64-hex `digest`, and a
+#      deterministic local alias `baml-rest-warm/mockllm-<repo>:<64hex-digest>`;
+#   3. require `docker image inspect "$source_tag"` to succeed post-load and
+#      capture its image ID (the loaded pinned artifact);
+#   4. `docker tag <loaded-image-ID> "$alias"` — the source is the image ID, not
+#      a digest-target ref (the docker client would reject the latter);
+#   5. rewrite the ephemeral CI checkout of the Dockerfile so that FROM consumes
+#      `$alias` instead of the `source_tag@sha256:<digest>` ref (line 2 keeps its
+#      `AS builder` stage name);
+#   6. assert alias ID == source ID.
+# Finally it asserts the runtime Dockerfile contains exactly the two expected
+# `baml-rest-warm/mockllm-*` FROMs and NO mock-base `sha256:` reference remains.
+#
+# The COMMITTED Dockerfile stays digest-pinned (Renovate + local builds are
+# unaffected); this helper only rewrites the throwaway CI checkout in place.
+#
+# Usage:
+#   integration/mockllm/ci-use-warm-bases.sh            # real CI path (needs docker)
+#   integration/mockllm/ci-use-warm-bases.sh --dry-run  # parse+rewrite only, no docker
+#
+set -euo pipefail
+
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    *)
+      echo "::error::unknown argument: $arg (supported: --dry-run)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# The Dockerfile lives next to this script; resolve relative to the script so
+# the helper works regardless of the caller's working directory (and so a local
+# smoke test can run it against a throwaway copy).
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+DOCKERFILE="${SCRIPT_DIR}/Dockerfile"
+
+if [ ! -f "$DOCKERFILE" ]; then
+  echo "::error::mock Dockerfile not found at ${DOCKERFILE}" >&2
+  exit 1
+fi
+
+# Escape a literal string for use as a BRE (sed search). `#` is the sed
+# delimiter below, so it is escaped here too; the pinned refs contain none of
+# these beyond the `.` in a tag, but keep it robust against future pins.
+bre_escape() {
+  printf '%s' "$1" | sed -e 's/[][\\.*^$#]/\\&/g'
+}
+
+bind_base() {
+  local repo="$1"
+
+  # Escape regex metacharacters in the repo so the grep -E patterns match it
+  # literally (the repos here have none, but keep it robust — mirrors the warm
+  # job's resolve step).
+  local repo_re
+  repo_re=$(printf '%s' "$repo" | sed -E 's/[][(){}.^$*+?|\\]/\\&/g')
+
+  # Same guard as the warm job: exactly one pinned `FROM <repo>:<tag>@sha256:`.
+  local matches
+  matches=$(grep -cE "^FROM ${repo_re}:[^[:space:]]+@sha256:[0-9a-f]{64}" "$DOCKERFILE" || true)
+  if [ "$matches" -ne 1 ]; then
+    echo "::error file=${DOCKERFILE}::expected exactly one pinned 'FROM ${repo}:<tag>@sha256:' line, found ${matches}" >&2
+    exit 1
+  fi
+
+  # ref = repo:tag@sha256:<64hex>; split into source_tag, digest, alias.
+  # Anchor extraction to `^FROM ` too so it can only come from a validated FROM
+  # line; `-o` prints the literal `FROM ` prefix, so strip it before splitting.
+  local ref source_tag digest alias
+  ref=$(grep -oE "^FROM ${repo_re}:[^[:space:]]+@sha256:[0-9a-f]{64}" "$DOCKERFILE" | head -n1)
+  ref="${ref#FROM }"
+  source_tag="${ref%@*}"
+  digest="${ref##*@sha256:}"
+  alias="baml-rest-warm/mockllm-${repo}:${digest}"
+
+  # Sanity on the literal ref before touching docker: it must appear exactly
+  # once in the file (fail closed on zero/multiple).
+  local ref_count
+  ref_count=$(grep -Fc -e "$ref" "$DOCKERFILE" || true)
+  if [ "$ref_count" -ne 1 ]; then
+    echo "::error file=${DOCKERFILE}::expected exactly one literal '${ref}' occurrence, found ${ref_count}" >&2
+    exit 1
+  fi
+
+  echo "mockllm base ${repo}: source_tag=${source_tag} alias=${alias}"
+
+  local source_id="<dry-run>"
+  if [ "$DRY_RUN" = false ]; then
+    # The loaded pinned artifact must be present as its ordinary tag.
+    if ! source_id=$(docker image inspect "$source_tag" --format '{{.Id}}' 2>/dev/null); then
+      echo "::error::loaded source image '${source_tag}' not found — was the warm tarball loaded before this step?" >&2
+      exit 1
+    fi
+
+    # Diagnostic (NOT a gate): save/load does not restore repo-digest mappings,
+    # so RepoDigests is expected to be empty even though the tag resolves — this
+    # is the association the alias below stands in for. A future engine that DOES
+    # restore it must not fail CI, hence diagnostic-only.
+    local repo_digests
+    repo_digests=$(docker image inspect "$source_tag" --format '{{json .RepoDigests}}' 2>/dev/null || echo '<inspect failed>')
+    echo "[diagnostic] ${source_tag} id=${source_id} repoDigests=${repo_digests} (expected empty after save/load; not a gate)"
+
+    # Tag the LOADED IMAGE ID to the alias. Source is the image ID, never a
+    # digest-target ref (docker client rejects `docker tag … repo@sha256:…`).
+    docker tag "$source_id" "$alias"
+
+    local alias_id
+    alias_id=$(docker image inspect "$alias" --format '{{.Id}}' 2>/dev/null || echo '')
+    if [ "$alias_id" != "$source_id" ]; then
+      echo "::error::alias '${alias}' id (${alias_id}) != loaded source '${source_tag}' id (${source_id})" >&2
+      exit 1
+    fi
+    echo "tagged ${source_tag} (${source_id}) -> ${alias}"
+  fi
+
+  # Rewrite ONLY the `source_tag@sha256:<digest>` ref to the alias in the
+  # ephemeral CI checkout; any trailing stage name (`AS builder`) is preserved.
+  # Write via a temp then `cat` back so the Dockerfile keeps its original mode
+  # and inode (a bare `mv` of a mktemp file would leave it mode 600).
+  local search tmp
+  search=$(bre_escape "$ref")
+  tmp=$(mktemp)
+  sed "s#${search}#${alias}#" "$DOCKERFILE" > "$tmp"
+  cat "$tmp" > "$DOCKERFILE"
+  rm -f "$tmp"
+
+  # Post-rewrite, the alias must be present and the pinned ref gone.
+  if ! grep -qF -e "$alias" "$DOCKERFILE"; then
+    echo "::error file=${DOCKERFILE}::alias '${alias}' missing after rewrite" >&2
+    exit 1
+  fi
+  if grep -qF -e "$ref" "$DOCKERFILE"; then
+    echo "::error file=${DOCKERFILE}::pinned ref '${ref}' still present after rewrite" >&2
+    exit 1
+  fi
+}
+
+bind_base golang
+bind_base alpine
+
+# Structural gates on the rewritten runtime Dockerfile.
+alias_count=$(grep -cE '^FROM baml-rest-warm/mockllm-' "$DOCKERFILE" || true)
+if [ "$alias_count" -ne 2 ]; then
+  echo "::error file=${DOCKERFILE}::expected exactly two 'FROM baml-rest-warm/mockllm-*' lines, found ${alias_count}" >&2
+  exit 1
+fi
+if ! grep -qE '^FROM baml-rest-warm/mockllm-golang:[0-9a-f]{64} AS builder$' "$DOCKERFILE"; then
+  echo "::error file=${DOCKERFILE}::missing expected 'FROM baml-rest-warm/mockllm-golang:<digest> AS builder'" >&2
+  exit 1
+fi
+if ! grep -qE '^FROM baml-rest-warm/mockllm-alpine:[0-9a-f]{64}$' "$DOCKERFILE"; then
+  echo "::error file=${DOCKERFILE}::missing expected 'FROM baml-rest-warm/mockllm-alpine:<digest>'" >&2
+  exit 1
+fi
+# No digest-qualified base reference may remain — the aliases carry the digest
+# as a plain tag, so the file must be free of any `@sha256:` reference (the
+# exact form that would re-trigger a Docker Hub manifest pull).
+sha_left=$(grep -cE '@sha256:' "$DOCKERFILE" || true)
+if [ "$sha_left" -ne 0 ]; then
+  echo "::error file=${DOCKERFILE}::found ${sha_left} leftover '@sha256:' reference(s) after rewrite" >&2
+  exit 1
+fi
+
+echo "mock Dockerfile now consumes local warm aliases (no Docker Hub base pull):"
+grep -nE '^FROM ' "$DOCKERFILE"


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## CI #541 — mock-LLM container still hits Docker Hub despite the warm step

### Root cause (RepoDigests)
The `warm-images` job resolves each pinned base by digest, pulls it once
(authenticated), and `docker save`s it under its ordinary `repo:tag`. Consuming
cells `docker load` that tarball — but `docker save`/`load` restores the image,
its layers, and the `repo:tag`, and **not** the repo-digest association
(`docker image inspect … --format '{{json .RepoDigests}}'` comes back `[]`).

The mock Dockerfile pins its bases as digest-qualified
`FROM repo:tag@sha256:…`. With no local repo-digest mapping, the classic
builder re-resolves that manifest against Docker Hub on every `FROM`, which is
exactly the anonymous registry call that intermittently fails with
`registry-1.docker.io … context deadline exceeded` — the container-setup flake
this issue tracks, still firing despite the warm step.

The docker client **rejects a digest-target tag** (`docker tag <id> repo@sha256:…`
→ `refusing to create a tag with a digest reference`), and a post-load
`docker pull repo@digest` would only restore `RepoDigests` by making the very
registry request that flakes. So neither is a reliability fix.

### Fix — Rust-style local alias
`build-baml-cffi` already dodges this for the Rust base with a deterministic
local alias (`baml-rest-warm/rust-bookworm:<digest>`), consuming the alias
after transfer instead of the digest-qualified Docker Hub ref. This PR mirrors
that pattern for the golang/alpine mock bases:

New helper **`integration/mockllm/ci-use-warm-bases.sh`** (fail-closed,
`set -euo pipefail`). For each of `golang` and `alpine` it:
- requires exactly one `^FROM <repo>:<tag>@sha256:<64hex>` line in the mock
  Dockerfile (same guard shape the warm job already uses);
- derives `source_tag`, the 64-hex `digest`, and a deterministic alias
  `baml-rest-warm/mockllm-<repo>:<digest>`;
- requires `docker image inspect "$source_tag"` to succeed post-load and
  captures the loaded image **ID**;
- `docker tag <loaded-image-ID> "$alias"` (source is the image ID, never a
  digest-target ref);
- rewrites **only the ephemeral CI checkout** of
  `integration/mockllm/Dockerfile` so that `FROM` consumes `$alias` (line 2
  keeps its `AS builder` stage name).

It then **asserts**: each alias ID equals its loaded source ID; the runtime
Dockerfile contains exactly the two expected `baml-rest-warm/mockllm-*` FROMs
and **no** leftover mock-base `sha256:` reference. It fails closed on
zero/multiple matches or a missing loaded source tag, and prints each base's
`RepoDigests` as a **non-gating diagnostic** (empty after save/load — the root
cause, recorded directly rather than inferred).

The **committed** Dockerfile stays digest-pinned — Renovate's docker manager
and local builds are unaffected; only the throwaway CI checkout is rewritten.
The helper parses the same pinned lines as the warm job, so it's resilient to
future Renovate tag/digest bumps, and no warm-cache format or cache-key change
is needed.

### Wiring (CI-infra only)
The helper runs immediately after each mock-building job's `docker load` block:
- `.github/workflows/integration-tests.yml` — normal, in-process, de-BAML-off,
  and BAML-source matrices (4 sites);
- `.github/workflows/bamlfuzz-nightly.yml` — the fuzz cell.

`build-baml-cffi` is **not** touched — it doesn't build mock-LLM and already
runs the Rust alias. The adjacent "tag-based" load-block comments are updated
to explain that load restores ordinary tags, then the helper binds the pinned
bases to local aliases before testcontainers builds.

### Scope / boundary
CI-infra only: the two workflow files + the new helper, and the helper's
runtime-only mutation of `integration/mockllm/Dockerfile:2,16`. No changes to
`integration/testutil/**`, `cmd/build/**`, `nativeserve/**`, admission, or any
native-worker module code — collision-clean with the parallel streaming-7D /
multi-provider-S2 tracks. (node/debian/golang in `cmd/build/**` share the same
exposure but are intentionally left out of #541.)

### Validation (local; full CI can't run here)
- `shellcheck integration/mockllm/ci-use-warm-bases.sh` — clean.
- `actionlint` on both workflows — no new findings (two pre-existing
  `info`/`style` notes in unrelated, untouched steps remain).
- **Dry-run** (`--dry-run`, no docker) against the committed Dockerfile: parses
  exactly one FROM per base, computes the right aliases, rewrites both FROM
  lines, `AS builder` preserved, zero leftover `sha256:`.
- **Docker smoke**: tagged a throwaway local image to the two `source_tag`s
  (simulating the loaded warm bases), ran the helper non-dry-run → alias IDs
  equal the loaded source ID, rewrite correct, diagnostic prints
  `repoDigests=[]`. Fail-closed paths verified (missing loaded source → exit 1;
  unknown arg → exit 2).
- Confirmed the **committed** `integration/mockllm/Dockerfile` is byte-identical
  before/after (helper only rewrites the CI checkout).

Closes #541.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly fuzzing and integration-test reliability by preventing unnecessary Docker Hub lookups for warmed mock-LLM images.
  * Reduced intermittent failures when using digest-pinned container images in CI.

* **Chores**
  * Added automated validation to ensure warmed images are correctly tagged and used during mock image builds.
  * Added safeguards to detect invalid or incomplete Dockerfile rewrites before tests run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->