### PR TITLE
TPBP-A: Anthropic provider-correctness oracle + shared no-send harness (test-only, tar-free)

### DIFF
--- a/internal/nativebody/nanollmprepare/provideroracle/anthropic_test.go
+++ b/internal/nativebody/nanollmprepare/provideroracle/anthropic_test.go
@@ -1,0 +1,648 @@
+//go:build integration && nanollm_integration
+
+package provideroracle
+
+// TPBP-A Anthropic provider-correctness differential (scope §6.2).
+//
+// For every corpus row this proves native emits a PROVIDER-CORRECT Anthropic
+// Messages request and records the BAML divergence as a checked-in allowlist
+// entry:
+//
+//   - exact method (POST), exact endpoint (service-root/v1/messages after S2's
+//     /v1 adapter), and the required semantic header SET (x-api-key,
+//     anthropic-version, content-type, plus any safe custom header) compared
+//     through the shared redacted testutil comparator;
+//   - both bodies decoded into the Anthropic contract DTO and compared for
+//     required meaning: the fence model, max_tokens, top-level system text, the
+//     ordered user/assistant turns, and mapped temperature/top_p/top_k/
+//     stop_sequences — with NO system/developer role surviving into messages;
+//   - native's OWN header order pinned independently (BAML's is unclaimed);
+//   - the expected top-level key-order divergence + the one-sided
+//     `baml-original-url` header asserted against the per-row allowlist. Each
+//     side's exact order is pinned, so an unlisted reorder/new key FAILS
+//     (controls_test.go drives the negatives).
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
+
+	"github.com/invakid404/baml-rest/nativeserve/testutil"
+)
+
+// anthropicRow is one corpus case. The SAME structured inputs (serviceRoot,
+// messages, opts, customHeaders) drive both legs — BAML through a generated
+// in-memory `.baml` source, native through the canonical OpenAI builder — so the
+// two requests cannot silently drift apart. bamlOrder/nanoOrder are the checked-in
+// expected top-level member orders (the expected-divergence allowlist).
+type anthropicRow struct {
+	name          string
+	serviceRoot   string // "" => provider default (api.anthropic.com)
+	messages      []corpusMessage
+	opts          bodyOptions
+	customHeaders map[string]string
+
+	bamlOrder []string
+	nanoOrder []string
+}
+
+// anthropicCorpus is the §6.2 Anthropic corpus.
+func anthropicCorpus() []anthropicRow {
+	sys := corpusMessage{role: "system", text: "You are a concise assistant."}
+	return []anthropicRow{
+		{
+			// default service root; system + user; default max_tokens; no options.
+			name:        "default_root_system_user_default_max_tokens",
+			serviceRoot: "",
+			messages: []corpusMessage{
+				sys,
+				{role: "user", text: "Tell me about cats."},
+			},
+			opts:      bodyOptions{maxTokens: -1},
+			bamlOrder: []string{"model", "max_tokens", "system", "messages"},
+			nanoOrder: []string{"model", "messages", "system", "max_tokens"},
+		},
+		{
+			// custom service root; system + ordered user/assistant text.
+			name:        "custom_root_system_user_assistant",
+			serviceRoot: fenceServiceRoot,
+			messages: []corpusMessage{
+				sys,
+				{role: "user", text: "Name one fact about the moon."},
+				{role: "assistant", text: "It has no atmosphere to speak of."},
+			},
+			opts:      bodyOptions{maxTokens: -1},
+			bamlOrder: []string{"model", "max_tokens", "system", "messages"},
+			nanoOrder: []string{"model", "messages", "system", "max_tokens"},
+		},
+		{
+			// explicit max_tokens (moves the member into the input body).
+			name:        "explicit_max_tokens",
+			serviceRoot: fenceServiceRoot,
+			messages: []corpusMessage{
+				sys,
+				{role: "user", text: "Summarize photosynthesis."},
+			},
+			opts:      bodyOptions{maxTokens: 100},
+			bamlOrder: []string{"model", "max_tokens", "system", "messages"},
+			nanoOrder: []string{"model", "messages", "max_tokens", "system"},
+		},
+		{
+			// temperature / top_p / top_k / stop->stop_sequences + Unicode & escaping.
+			name:        "sampling_options_unicode_escaping",
+			serviceRoot: fenceServiceRoot,
+			messages: []corpusMessage{
+				sys,
+				{role: "user", text: `Escape café ☕ "q" and a backslash \b then 🙂.`},
+			},
+			opts: bodyOptions{
+				maxTokens:     100,
+				temperature:   f64(0.7),
+				topP:          f64(0.9),
+				topK:          iptr(5),
+				stopSequences: []string{"STOP", "END"},
+			},
+			bamlOrder: []string{"model", "temperature", "top_p", "top_k", "max_tokens", "stop_sequences", "system", "messages"},
+			nanoOrder: []string{"max_tokens", "messages", "model", "stop_sequences", "temperature", "top_k", "top_p", "system"},
+		},
+		{
+			// one safe custom header; user only (no system in the body).
+			name:          "custom_header_user_only",
+			serviceRoot:   fenceServiceRoot,
+			customHeaders: map[string]string{fenceCustomHdrKey: fenceCustomHdrVal},
+			messages: []corpusMessage{
+				{role: "user", text: "Ping."},
+			},
+			opts:      bodyOptions{maxTokens: -1},
+			bamlOrder: []string{"model", "max_tokens", "messages"},
+			nanoOrder: []string{"model", "messages", "max_tokens"},
+		},
+	}
+}
+
+func f64(v float64) *float64 { return &v }
+func iptr(v int) *int        { return &v }
+
+// wantMaxTokens resolves the expected max_tokens for a row (both builders default
+// an absent value to 4096).
+func (r anthropicRow) wantMaxTokens() int {
+	if r.opts.maxTokens >= 0 {
+		return r.opts.maxTokens
+	}
+	return 4096
+}
+
+// wantSystemBlocks is the EXACT provider-native system block sequence a row's
+// system turns must produce: one {type:"text", text} block each, in order (the
+// provider request lifts them to top-level `system`). Nil when the row has no
+// system turn.
+func (r anthropicRow) wantSystemBlocks() []anthropicBlock {
+	var texts []string
+	for _, m := range r.messages {
+		if m.role == "system" {
+			texts = append(texts, m.text)
+		}
+	}
+	if len(texts) == 0 {
+		return nil
+	}
+	return textBlockSeq(texts...)
+}
+
+// wantProviderMessages is the row's non-system turns, in order — what must remain
+// in the provider `messages` array (system/developer never survive there).
+func (r anthropicRow) wantProviderMessages() []corpusMessage {
+	var out []corpusMessage
+	for _, m := range r.messages {
+		if m.role == "system" || m.role == "developer" {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// --- BAML in-memory source generation (keeps the two legs coupled). ---
+
+// bamlAnthropicSource renders the tiny in-memory `.baml` project for a row: one
+// anthropic client at the fence values with the row's mapped options, and one
+// zero-arg function whose prompt is the row's ordered role turns.
+func bamlAnthropicSource(r anthropicRow) (src, fn string) {
+	fn = "OracleFn"
+	var opt strings.Builder
+	fmt.Fprintf(&opt, "    model %q\n", fenceModel)
+	fmt.Fprintf(&opt, "    api_key %q\n", fenceAPIKey)
+	if r.serviceRoot != "" {
+		fmt.Fprintf(&opt, "    base_url %q\n", r.serviceRoot)
+	}
+	// Body-affecting options in the EXACT order that fixes BAML's top-level member
+	// order (bamlOrder). Only emit those a row sets.
+	if r.opts.temperature != nil {
+		fmt.Fprintf(&opt, "    temperature %v\n", *r.opts.temperature)
+	}
+	if r.opts.topP != nil {
+		fmt.Fprintf(&opt, "    top_p %v\n", *r.opts.topP)
+	}
+	if r.opts.topK != nil {
+		fmt.Fprintf(&opt, "    top_k %d\n", *r.opts.topK)
+	}
+	if r.opts.maxTokens >= 0 {
+		fmt.Fprintf(&opt, "    max_tokens %d\n", r.opts.maxTokens)
+	}
+	if len(r.opts.stopSequences) > 0 {
+		quoted := make([]string, len(r.opts.stopSequences))
+		for i, s := range r.opts.stopSequences {
+			quoted[i] = fmt.Sprintf("%q", s)
+		}
+		fmt.Fprintf(&opt, "    stop_sequences [%s]\n", strings.Join(quoted, ", "))
+	}
+	if len(r.customHeaders) > 0 {
+		opt.WriteString("    headers {\n")
+		for k, v := range r.customHeaders {
+			fmt.Fprintf(&opt, "      %q %q\n", k, v)
+		}
+		opt.WriteString("    }\n")
+	}
+
+	var prompt strings.Builder
+	for _, m := range r.messages {
+		fmt.Fprintf(&prompt, "    {{ _.role(%q) }}\n    %s\n", m.role, bamlPromptLine(m.text))
+	}
+
+	src = fmt.Sprintf(`
+client<llm> OracleAnthropic {
+  provider anthropic
+  options {
+%s  }
+}
+
+function %s() -> string {
+  client OracleAnthropic
+  prompt #"
+%s  "#
+}
+`, opt.String(), fn, prompt.String())
+	return src, fn
+}
+
+// bamlPromptLine returns literal message text safe to embed verbatim in a BAML
+// raw-string (#"..."#) prompt block: raw strings are verbatim, so a backslash
+// stays a backslash and matches the native Go literal — but a stray newline would
+// break the single-line-per-turn shape, so it is rejected loudly (the corpus keeps
+// each turn single-line).
+func bamlPromptLine(text string) string {
+	if strings.ContainsAny(text, "\n\r") {
+		panic("corpus turn text must be single-line (no embedded newline)")
+	}
+	return text
+}
+
+// --- Row runner. ---
+
+type rowCapture struct {
+	baml     bamlCapture
+	prep     *nanollm.PreparedRequest
+	nanoSnap testutil.Snapshot
+}
+
+func runRow(t *testing.T, r anthropicRow) rowCapture {
+	t.Helper()
+	src, fn := bamlAnthropicSource(r)
+	baml := captureBAMLAnthropic(t, src, fn, nil)
+
+	client := newAnthropicClient(t, r.serviceRoot, r.customHeaders)
+	req := buildCanonicalRequest(t, r.messages, r.opts)
+	prep, nanoSnap := prepareNative(t, client, req)
+	return rowCapture{baml: baml, prep: prep, nanoSnap: nanoSnap}
+}
+
+// TestAnthropicProviderCorrectness is the core differential over the corpus.
+func TestAnthropicProviderCorrectness(t *testing.T) {
+	for _, r := range anthropicCorpus() {
+		r := r
+		t.Run(r.name, func(t *testing.T) {
+			cap := runRow(t, r)
+			wantURL := messagesURL(r.serviceRoot)
+
+			// (1) Method + endpoint exact on BOTH legs (not merely baml==nano).
+			for _, leg := range []struct {
+				name string
+				snap testutil.Snapshot
+			}{{"baml", cap.baml.snap}, {"nanollm", cap.nanoSnap}} {
+				if leg.snap.Method != "POST" {
+					t.Errorf("%s method = %q, want POST", leg.name, leg.snap.Method)
+				}
+				if leg.snap.URL != wantURL {
+					// Never print the actual URL (it can carry query creds): report its
+					// length and the fixed expected endpoint only.
+					t.Errorf("%s endpoint mismatch: got_len=%d want=%q", leg.name, len(leg.snap.URL), wantURL)
+				}
+			}
+
+			// (2) method + URL + required semantic header SET, via the shared redacted
+			// comparator, with the body EXCLUDED (its member order is the expected
+			// divergence, handled in step 4). baml-original-url is exempted on the
+			// oracle side by testutil; any other header mismatch fails here.
+			if diffs := testutil.Diff(headerOnly(cap.baml.snap), headerOnly(cap.nanoSnap)); len(diffs) != 0 {
+				t.Errorf("method/URL/semantic-header differential mismatch:\n%s", strings.Join(diffs, "\n"))
+			}
+
+			// (3) Required provider MEANING on each leg (absolute anchors), then
+			// cross-leg equality.
+			bamlC := decodeAnthropic(t, "baml", cap.baml.body)
+			nanoC := decodeAnthropic(t, "nanollm", cap.prep.Body)
+			assertRequiredContract(t, "baml", bamlC, r)
+			assertRequiredContract(t, "nanollm", nanoC, r)
+			assertContractsEquivalent(t, bamlC, nanoC)
+
+			// (4) Auth/version/content-type + native header order + the expected
+			// key-order & baml-original-url divergence allowlist.
+			assertAuthVersionContentType(t, cap.baml.snap.Headers, cap.nanoSnap.Headers)
+			assertNativeHeaderOrder(t, cap.prep, r)
+			assertExpectedDivergence(t, r, cap)
+		})
+	}
+}
+
+// TestAnthropicDeveloperRoleDisposition covers the required `developer`-source
+// turn (§6.2 "absence of system/developer roles from provider messages"). BAML
+// and native DISPOSE of a developer turn DIFFERENTLY — a documented, provider-
+// valid divergence (a #583 fact, not a native defect):
+//
+//   - NATIVE (provider-correct): lifts the developer text into top-level `system`
+//     alongside the system turn (OpenAI's developer-as-system semantics); provider
+//     `messages` keep only the user/assistant turns.
+//   - BAML: keeps top-level `system` = the system turn only and FOLDS the developer
+//     text into the following user message's content as a leading text block.
+//
+// Both are valid Anthropic Messages requests; native's developer->system mapping
+// is the provider-correct one. This test pins native's exact disposition, records
+// BAML's divergent disposition, and asserts the divergence is real — so a future
+// change that breaks native's mapping (or silently converges) is caught. It is NOT
+// a cross-leg-equivalent row, so it runs outside the generic corpus loop.
+func TestAnthropicDeveloperRoleDisposition(t *testing.T) {
+	r := anthropicRow{
+		name:        "developer_role",
+		serviceRoot: fenceServiceRoot,
+		messages: []corpusMessage{
+			{role: "system", text: "Sys turn."},
+			{role: "developer", text: "Dev turn."},
+			{role: "user", text: "User turn."},
+		},
+		opts: bodyOptions{maxTokens: -1},
+	}
+	cap := runRow(t, r)
+	wantURL := messagesURL(r.serviceRoot)
+
+	// Transport still matches across legs: method, endpoint, required header set.
+	for _, leg := range []struct {
+		name string
+		snap testutil.Snapshot
+	}{{"baml", cap.baml.snap}, {"nanollm", cap.nanoSnap}} {
+		if leg.snap.Method != "POST" {
+			t.Errorf("%s method = %q, want POST", leg.name, leg.snap.Method)
+		}
+		if leg.snap.URL != wantURL {
+			t.Errorf("%s endpoint mismatch: got_len=%d want=%q", leg.name, len(leg.snap.URL), wantURL)
+		}
+	}
+	if diffs := testutil.Diff(headerOnly(cap.baml.snap), headerOnly(cap.nanoSnap)); len(diffs) != 0 {
+		t.Errorf("method/URL/semantic-header differential mismatch:\n%s", strings.Join(diffs, "\n"))
+	}
+	assertAuthVersionContentType(t, cap.baml.snap.Headers, cap.nanoSnap.Headers)
+
+	bamlC := decodeAnthropic(t, "baml", cap.baml.body)
+	nanoC := decodeAnthropic(t, "nanollm", cap.prep.Body)
+
+	// NATIVE provider-correct disposition: developer lifted into top-level system.
+	wantNativeSystem := textBlockSeq("Sys turn.", "Dev turn.")
+	if !blocksEqual(nanoC.System, wantNativeSystem) {
+		t.Errorf("native: developer turn not lifted into top-level system (system_blocks=%d, want 2)", len(nanoC.System))
+	}
+	assertNoForbiddenRoles(t, "nanollm", nanoC.Messages)
+	if len(nanoC.Messages) != 1 || nanoC.Messages[0].Role != "user" {
+		t.Errorf("native: messages must be exactly [user], got %d turns", len(nanoC.Messages))
+	} else if !blocksEqual(nanoC.Messages[0].Content, textBlockSeq("User turn.")) {
+		t.Errorf("native: user content mismatch (blocks=%d)", len(nanoC.Messages[0].Content))
+	}
+
+	// BAML disposition (DOCUMENTED divergence): system = [Sys] only; developer text
+	// folded into the user message content as a leading block.
+	if !blocksEqual(bamlC.System, textBlockSeq("Sys turn.")) {
+		t.Errorf("baml: expected system=[Sys] only (developer folded into user), got system_blocks=%d", len(bamlC.System))
+	}
+	assertNoForbiddenRoles(t, "baml", bamlC.Messages)
+	if len(bamlC.Messages) != 1 || bamlC.Messages[0].Role != "user" {
+		t.Errorf("baml: messages must be exactly [user], got %d turns", len(bamlC.Messages))
+	} else if !blocksEqual(bamlC.Messages[0].Content, textBlockSeq("Dev turn.", "User turn.")) {
+		t.Errorf("baml: expected developer folded into user content [Dev, User], got content_blocks=%d", len(bamlC.Messages[0].Content))
+	}
+
+	// The disposition genuinely DIVERGES: native's top-level system carries the
+	// developer text, BAML's does not. Assert the divergence is real so a silent
+	// convergence (or a broken native mapping) is caught.
+	if blocksEqual(nanoC.System, bamlC.System) {
+		t.Error("expected a documented BAML/native developer-disposition divergence in top-level system")
+	}
+}
+
+// assertNoForbiddenRoles requires no system/developer role to survive into
+// provider `messages` (Anthropic has neither; both must be lifted/mapped out).
+func assertNoForbiddenRoles(t *testing.T, leg string, msgs []anthropicMessage) {
+	t.Helper()
+	for i, m := range msgs {
+		if m.Role == "system" || m.Role == "developer" {
+			t.Errorf("%s: message[%d] retained forbidden role %q", leg, i, m.Role)
+		}
+	}
+}
+
+// headerOnly returns a body-less copy of a snapshot so testutil.Diff compares
+// only method/URL/semantic headers (both bodies nil => equal); the body's member
+// order is the intended divergence, proven separately.
+func headerOnly(s testutil.Snapshot) testutil.Snapshot {
+	return testutil.Snapshot{Method: s.Method, URL: s.URL, Headers: s.Headers, Body: nil}
+}
+
+// assertRequiredContract pins the provider-required meaning of one decoded leg
+// against the row's expectations — the absolute anchors that fail even a bug that
+// corrupts BOTH legs identically. Text values are compared but reported by LENGTH
+// only (never the raw content).
+func assertRequiredContract(t *testing.T, leg string, c anthropicContract, r anthropicRow) {
+	t.Helper()
+	if c.Model != fenceModel {
+		t.Errorf("%s: model = %q, want %q", leg, c.Model, fenceModel)
+	}
+	if c.MaxTokens == nil {
+		t.Errorf("%s: max_tokens absent; Anthropic requires it", leg)
+	} else if *c.MaxTokens != r.wantMaxTokens() {
+		t.Errorf("%s: max_tokens = %d, want %d", leg, *c.MaxTokens, r.wantMaxTokens())
+	}
+
+	// System lifted to top-level `system` (never left in messages): assert the
+	// EXACT block sequence — count, per-block type, and text — not just the
+	// concatenated text (a text-only compare would accept a missing/invalid block
+	// `type`, a provider-invalid system block).
+	wantSysBlocks := r.wantSystemBlocks()
+	if len(c.System) != len(wantSysBlocks) {
+		t.Errorf("%s: system block count = %d, want %d", leg, len(c.System), len(wantSysBlocks))
+	} else {
+		for i, blk := range c.System {
+			if blk.Type != "text" {
+				t.Errorf("%s: system block[%d] type = %q, want text", leg, i, blk.Type)
+			}
+			if blk.Text != wantSysBlocks[i].Text {
+				t.Errorf("%s: system block[%d] text mismatch (got_len=%d want_len=%d)", leg, i, len(blk.Text), len(wantSysBlocks[i].Text))
+			}
+		}
+	}
+
+	// Provider messages: exact ordered non-system turns, each a single text block.
+	wantMsgs := r.wantProviderMessages()
+	if len(c.Messages) != len(wantMsgs) {
+		t.Fatalf("%s: messages count = %d, want %d", leg, len(c.Messages), len(wantMsgs))
+	}
+	for i, m := range c.Messages {
+		if m.Role == "system" || m.Role == "developer" {
+			t.Errorf("%s: message[%d] retained forbidden role %q", leg, i, m.Role)
+		}
+		if m.Role != wantMsgs[i].role {
+			t.Errorf("%s: message[%d] role = %q, want %q", leg, i, m.Role, wantMsgs[i].role)
+		}
+		if len(m.Content) != 1 {
+			t.Fatalf("%s: message[%d] content blocks = %d, want 1", leg, i, len(m.Content))
+		}
+		if m.Content[0].Type != "text" {
+			t.Errorf("%s: message[%d] block type = %q, want text", leg, i, m.Content[0].Type)
+		}
+		if m.Content[0].Text != wantMsgs[i].text {
+			t.Errorf("%s: message[%d] text mismatch (got_len=%d want_len=%d)", leg, i, len(m.Content[0].Text), len(wantMsgs[i].text))
+		}
+	}
+
+	// Mapped sampling options.
+	assertPtrFloat(t, leg, "temperature", c.Temperature, r.opts.temperature)
+	assertPtrFloat(t, leg, "top_p", c.TopP, r.opts.topP)
+	assertPtrInt(t, leg, "top_k", c.TopK, r.opts.topK)
+	if !equalStrings(c.StopSequences, r.opts.stopSequences) {
+		t.Errorf("%s: stop_sequences count = %d, want %d", leg, len(c.StopSequences), len(r.opts.stopSequences))
+	}
+}
+
+// assertContractsEquivalent proves the two legs carry the SAME provider meaning —
+// a diagnostic cross-check layered on the absolute anchors (never an escape hatch:
+// the divergence allowlist still pins each side's byte-order independently).
+func assertContractsEquivalent(t *testing.T, a, b anthropicContract) {
+	t.Helper()
+	if a.Model != b.Model {
+		t.Errorf("cross-leg model mismatch: baml=%q nanollm=%q", a.Model, b.Model)
+	}
+	if !equalPtrInt(a.MaxTokens, b.MaxTokens) {
+		t.Error("cross-leg max_tokens mismatch")
+	}
+	// Exact system block sequence (type+text+order), not concatenated text.
+	if !blocksEqual(a.System, b.System) {
+		t.Errorf("cross-leg system block mismatch (baml_blocks=%d nanollm_blocks=%d)", len(a.System), len(b.System))
+	}
+	if len(a.Messages) != len(b.Messages) {
+		t.Fatalf("cross-leg message count mismatch: baml=%d nanollm=%d", len(a.Messages), len(b.Messages))
+	}
+	for i := range a.Messages {
+		if a.Messages[i].Role != b.Messages[i].Role {
+			t.Errorf("cross-leg message[%d] role mismatch: baml=%q nanollm=%q", i, a.Messages[i].Role, b.Messages[i].Role)
+		}
+		// Exact content block sequence (type+text+order), not concatenated text.
+		if !blocksEqual(a.Messages[i].Content, b.Messages[i].Content) {
+			t.Errorf("cross-leg message[%d] content block mismatch (baml_blocks=%d nanollm_blocks=%d)", i, len(a.Messages[i].Content), len(b.Messages[i].Content))
+		}
+	}
+	if !equalPtrFloat(a.Temperature, b.Temperature) {
+		t.Error("cross-leg temperature mismatch")
+	}
+	if !equalPtrFloat(a.TopP, b.TopP) {
+		t.Error("cross-leg top_p mismatch")
+	}
+	if !equalPtrInt(a.TopK, b.TopK) {
+		t.Error("cross-leg top_k mismatch")
+	}
+	if !equalStrings(a.StopSequences, b.StopSequences) {
+		t.Error("cross-leg stop_sequences mismatch")
+	}
+}
+
+// assertAuthVersionContentType pins the required Anthropic auth/version/content
+// headers on BOTH legs: exactly the fake x-api-key (redacted), a non-empty
+// anthropic-version, JSON content-type, and NO OpenAI-style bearer authorization.
+func assertAuthVersionContentType(t *testing.T, bamlHeaders, nanoHeaders map[string]string) {
+	t.Helper()
+	for _, leg := range []struct {
+		name string
+		h    map[string]string
+	}{{"baml", bamlHeaders}, {"nanollm", nanoHeaders}} {
+		if v, ok := leg.h["x-api-key"]; !ok || v != fenceAPIKey {
+			t.Errorf("%s: x-api-key missing or mismatched (present=%v, matched=%v)", leg.name, ok, v == fenceAPIKey)
+		}
+		if v, ok := leg.h["anthropic-version"]; !ok || v != anthropicVersion {
+			t.Errorf("%s: anthropic-version = %q (present=%v), want %q", leg.name, v, ok, anthropicVersion)
+		}
+		if v, ok := leg.h["content-type"]; !ok || !strings.HasPrefix(v, "application/json") {
+			t.Errorf("%s: content-type = %q (present=%v), want application/json", leg.name, v, ok)
+		}
+		if _, ok := testutil.Authorization(leg.h); ok {
+			t.Errorf("%s: unexpected OpenAI-style authorization header on an Anthropic request", leg.name)
+		}
+	}
+}
+
+// assertNativeHeaderOrder pins native's OWN emitted header order — Content-Type,
+// x-api-key, anthropic-version, then any custom headers — and is NEVER compared to
+// BAML (whose header order/casing is explicitly unclaimed).
+func assertNativeHeaderOrder(t *testing.T, prep *nanollm.PreparedRequest, r anthropicRow) {
+	t.Helper()
+	wantPrefix := []string{"Content-Type", "x-api-key", "anthropic-version"}
+	if len(prep.Headers) != len(wantPrefix)+len(r.customHeaders) {
+		t.Fatalf("native emitted %d headers, want %d", len(prep.Headers), len(wantPrefix)+len(r.customHeaders))
+	}
+	for i, want := range wantPrefix {
+		if prep.Headers[i][0] != want {
+			t.Errorf("native header[%d] name = %q, want %q", i, prep.Headers[i][0], want)
+		}
+	}
+	// Custom headers follow the fixed prefix (order among them is unclaimed).
+	for name, val := range r.customHeaders {
+		found := false
+		for _, p := range prep.Headers[len(wantPrefix):] {
+			if p[0] == name {
+				found = true
+				if p[1] != val {
+					t.Errorf("native custom header %q value mismatch (len got=%d want=%d)", name, len(p[1]), len(val))
+				}
+			}
+		}
+		if !found {
+			t.Errorf("native missing custom header %q", name)
+		}
+	}
+}
+
+// assertExpectedDivergence is the checked-in expected-divergence allowlist: it
+// pins each side's EXACT top-level member order, proves the two orders differ but
+// carry the same key SET, and proves `baml-original-url` is the ONE, one-sided
+// BAML-only header (native emits none such). No semantic-equality escape hatch:
+// an unlisted reorder/new key fails the pinned-order assertion.
+func assertExpectedDivergence(t *testing.T, r anthropicRow, cap rowCapture) {
+	t.Helper()
+
+	bamlKeys := topLevelKeys(t, "baml", cap.baml.body)
+	nanoKeys := topLevelKeys(t, "nanollm", cap.prep.Body)
+
+	if !sameOrder(bamlKeys, r.bamlOrder) {
+		t.Errorf("BAML top-level order = %v, want allowlisted %v", bamlKeys, r.bamlOrder)
+	}
+	if !sameOrder(nanoKeys, r.nanoOrder) {
+		t.Errorf("native top-level order = %v, want allowlisted %v", nanoKeys, r.nanoOrder)
+	}
+	if !sameKeySet(bamlKeys, nanoKeys) {
+		t.Errorf("top-level key SETS differ (not a pure ordering divergence): baml=%v nanollm=%v", bamlKeys, nanoKeys)
+	}
+	if sameOrder(bamlKeys, nanoKeys) {
+		t.Errorf("expected a member-order divergence but BAML and native emitted identical order %v", bamlKeys)
+	}
+
+	// One-sided baml-original-url: BAML carries exactly it (beyond the shared
+	// semantic set); native carries no such transport header.
+	_, bamlTransport := testutil.SplitSemantic(cap.baml.snap.Headers)
+	if _, ok := bamlTransport["baml-original-url"]; !ok {
+		t.Error("expected BAML to carry its internal baml-original-url transport header")
+	}
+	if len(bamlTransport) != 1 {
+		t.Errorf("BAML carries %d transport-only headers, want exactly baml-original-url", len(bamlTransport))
+	}
+	if _, ok := cap.nanoSnap.Headers["baml-original-url"]; ok {
+		t.Error("native must NOT emit baml-original-url")
+	}
+}
+
+// --- small typed comparison helpers (redacted diagnostics). ---
+
+func assertPtrFloat(t *testing.T, leg, field string, got, want *float64) {
+	t.Helper()
+	if !equalPtrFloat(got, want) {
+		t.Errorf("%s: %s presence/value mismatch (got_set=%v want_set=%v)", leg, field, got != nil, want != nil)
+	}
+}
+
+func assertPtrInt(t *testing.T, leg, field string, got, want *int) {
+	t.Helper()
+	if !equalPtrInt(got, want) {
+		t.Errorf("%s: %s presence/value mismatch (got_set=%v want_set=%v)", leg, field, got != nil, want != nil)
+	}
+}
+
+func equalPtrFloat(a, b *float64) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func equalPtrInt(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/nativebody/nanollmprepare/provideroracle/baml_stock_test.go
+++ b/internal/nativebody/nanollmprepare/provideroracle/baml_stock_test.go
@@ -1,0 +1,202 @@
+//go:build integration && nanollm_integration
+
+package provideroracle
+
+// Stock-BAML capture helpers + version guards for the TPBP-A Anthropic oracle.
+//
+// The DIAGNOSTIC oracle is the real stock BAML v0.223.0 provider request, built
+// in-memory through the public Go API (baml.CreateRuntime + runtime.BuildRequest)
+// with NO socket and NO checked-in generated source: each row hands BAML a tiny
+// `main.baml` string with fixed FAKE creds / model / base / prompt and reads the
+// pre-send Request (method, URL, header map, exact Body.Text()). A version guard
+// pins the loaded CFFI runtime AND this module's go.mod require to stock
+// v0.223.0, so a green result can never be attributed to a different runtime.
+
+import (
+	"context"
+	"os"
+	"runtime/debug"
+	"testing"
+
+	baml_go "github.com/boundaryml/baml/engine/language_client_go/baml_go"
+	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
+	"golang.org/x/mod/modfile"
+
+	"github.com/invakid404/baml-rest/nativeserve/testutil"
+)
+
+const (
+	// moduleGoModPath is this test-only module's go.mod (it — not root — pins the
+	// stock BAML + nanollm the oracle binary links), relative to this package dir.
+	moduleGoModPath = "../go.mod"
+
+	bamlModulePath         = "github.com/boundaryml/baml"
+	wantBAMLModuleVersion  = "v0.223.0"
+	wantBAMLRuntimeVersion = "0.223.0"
+
+	nanollmModulePath        = "github.com/viktordanov/nanollm-ffi/go"
+	wantNanollmModuleVersion = "v0.4.3"
+	// wantNanollmRuntimeVersion is the EXACT embedded Rust crate version the loaded
+	// engine must report — pinned in-binary just like the BAML runtime guard, so a
+	// mismatched native engine cannot green-light the oracle.
+	wantNanollmRuntimeVersion = "0.4.3"
+)
+
+// bamlCapture is a captured stock-BAML Anthropic request: the runtime-neutral
+// snapshot (method/URL/normalized headers/body) plus the exact body bytes and the
+// raw header map (retained for the one-sided baml-original-url divergence proof).
+type bamlCapture struct {
+	snap    testutil.Snapshot
+	body    []byte
+	headers map[string]string
+}
+
+// captureBAMLAnthropic builds the in-memory BAML project from src, drives
+// BuildRequest for fn with kwargs (adding the stock `stream:false` arg the
+// generated client always passes), and returns the pre-send capture. It fails
+// closed on an empty body, a missing method/URL, or duplicate/multi-value
+// headers. It NEVER sends. Per the secret-free failure contract it reports only a
+// fixed STAGE token (and the fixed function name) on error — never the raw
+// CFFI/runtime error, which could echo the generated source, the prompt, the
+// fake credential, or the body bytes.
+func captureBAMLAnthropic(t *testing.T, src, fn string, kwargs map[string]any) bamlCapture {
+	t.Helper()
+
+	rt, err := baml.CreateRuntime(".", map[string]string{"main.baml": src}, map[string]string{})
+	if err != nil {
+		t.Fatal("BAML capture failed at stage=create_runtime")
+	}
+
+	kw := make(map[string]any, len(kwargs)+1)
+	for k, v := range kwargs {
+		kw[k] = v
+	}
+	kw["stream"] = false // the generated Request.<fn> always encodes this
+	args := baml.BamlFunctionArguments{Kwargs: kw, Env: map[string]string{}}
+	encoded, err := args.Encode()
+	if err != nil {
+		t.Fatal("BAML capture failed at stage=encode_args")
+	}
+
+	req, err := rt.BuildRequest(context.Background(), fn, encoded)
+	if err != nil {
+		t.Fatalf("BAML capture failed at stage=build_request (fn=%s)", fn)
+	}
+	method, err := req.Method()
+	if err != nil {
+		t.Fatal("BAML capture failed at stage=method")
+	}
+	url, err := req.Url()
+	if err != nil {
+		t.Fatal("BAML capture failed at stage=url")
+	}
+	hdrs, err := req.Headers()
+	if err != nil {
+		t.Fatal("BAML capture failed at stage=headers")
+	}
+	bodyObj, err := req.Body()
+	if err != nil {
+		t.Fatal("BAML capture failed at stage=body")
+	}
+	bodyText, err := bodyObj.Text()
+	if err != nil {
+		t.Fatal("BAML capture failed at stage=body_text")
+	}
+	if bodyText == "" {
+		t.Fatal("BAML body is empty — the request build failed before producing a body")
+	}
+	if method == "" || url == "" || len(hdrs) == 0 {
+		t.Fatalf("incomplete BAML capture: method_empty=%v url_empty=%v headers=%d", method == "", url == "", len(hdrs))
+	}
+
+	body := []byte(bodyText)
+	snap, err := testutil.NewSnapshot(method, url, testutil.PairsFromStringMap(hdrs), body)
+	if err != nil {
+		t.Fatal("BAML request has a duplicate/multi-value header (stage=snapshot)")
+	}
+	return bamlCapture{snap: snap, body: body, headers: hdrs}
+}
+
+// --- version guards ---
+
+// TestBAMLVersionPinned requires the LOADED CFFI runtime AND this module's go.mod
+// require to be exactly stock BAML v0.223.0 (not replaced), so a green oracle can
+// never be attributed to a different runtime.
+func TestBAMLVersionPinned(t *testing.T) {
+	if got := baml_go.BamlVersion(); got != wantBAMLRuntimeVersion {
+		t.Fatalf("loaded BAML CFFI runtime reports %q, want exactly %q", got, wantBAMLRuntimeVersion)
+	}
+	version, replaced, found := moduleRequire(t, moduleGoModPath, bamlModulePath)
+	if !found {
+		t.Fatalf("module go.mod does not pin %s", bamlModulePath)
+	}
+	if replaced {
+		t.Fatalf("module go.mod replaces %s; the oracle must link the stock module", bamlModulePath)
+	}
+	if version != wantBAMLModuleVersion {
+		t.Fatalf("module go.mod pins %s %s, want exactly %s", bamlModulePath, version, wantBAMLModuleVersion)
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range bi.Deps {
+			if dep == nil || dep.Path != bamlModulePath {
+				continue
+			}
+			if dep.Replace != nil {
+				t.Fatalf("build info reports %s replaced (%s %s)", bamlModulePath, dep.Replace.Path, dep.Replace.Version)
+			}
+			if dep.Version != wantBAMLModuleVersion {
+				t.Fatalf("build info reports %s %s, want %s", bamlModulePath, dep.Version, wantBAMLModuleVersion)
+			}
+		}
+	}
+}
+
+// TestNanollmVersionPinned requires this module's go.mod require for the public
+// nanollm-ffi module to be exactly v0.4.3 (not replaced) and the loaded engine to
+// report a non-empty crate version — the native leg's runtime pin.
+func TestNanollmVersionPinned(t *testing.T) {
+	version, replaced, found := moduleRequire(t, moduleGoModPath, nanollmModulePath)
+	if !found {
+		t.Fatalf("module go.mod does not pin %s", nanollmModulePath)
+	}
+	if replaced {
+		t.Fatalf("module go.mod replaces %s; the oracle must link the stock nanollm-ffi module", nanollmModulePath)
+	}
+	if version != wantNanollmModuleVersion {
+		t.Fatalf("module go.mod pins %s %s, want exactly %s", nanollmModulePath, version, wantNanollmModuleVersion)
+	}
+	if got := nanollm.Version(); got != wantNanollmRuntimeVersion {
+		t.Fatalf("loaded nanollm engine reports crate version %q, want exactly %q", got, wantNanollmRuntimeVersion)
+	}
+}
+
+// moduleRequire parses a go.mod with the canonical modfile parser and returns the
+// EXACT require version for modulePath, whether it is replaced, and whether the
+// require was found (exact string match — a prerelease pin fails the == check).
+func moduleRequire(t *testing.T, goModPath, modulePath string) (version string, replaced, found bool) {
+	t.Helper()
+	// goModPath is a fixed manifest path (non-secret); still report only the fixed
+	// path + stage token, never the raw I/O/parse error, to keep every failure path
+	// in this package uniformly free of formatted engine/decode errors.
+	data, err := os.ReadFile(goModPath)
+	if err != nil {
+		t.Fatalf("read %s failed (stage=read_gomod)", goModPath)
+	}
+	mf, err := modfile.Parse(goModPath, data, nil)
+	if err != nil {
+		t.Fatalf("parse %s failed (stage=parse_gomod)", goModPath)
+	}
+	for _, r := range mf.Require {
+		if r.Mod.Path == modulePath {
+			version = r.Mod.Version
+			found = true
+		}
+	}
+	for _, rep := range mf.Replace {
+		if rep.Old.Path == modulePath {
+			replaced = true
+		}
+	}
+	return version, replaced, found
+}

--- a/internal/nativebody/nanollmprepare/provideroracle/common_test.go
+++ b/internal/nativebody/nanollmprepare/provideroracle/common_test.go
@@ -1,0 +1,412 @@
+//go:build integration && nanollm_integration
+
+// Package provideroracle is the de-BAML TPBP-A gated, TEST-ONLY, no-send
+// Anthropic PROVIDER-CORRECTNESS oracle plus the shared trusted-provider oracle
+// harness (scope §6.1/§6.2, tpbp-scope.md).
+//
+// # The bar (owner-ruled): provider-correctness, NOT BAML byte-equality
+//
+// BAML v0.223.0 and native nanollm v0.4.3 both emit a VALID Anthropic Messages
+// request for the same admitted call, but they are DELIBERATELY not byte-equal:
+// the top-level JSON member ORDER differs, and BAML additionally carries its own
+// internal `baml-original-url` transport header. This suite therefore does NOT
+// chase byte-equality. It proves that native emits a PROVIDER-CORRECT Anthropic
+// request — correct method / endpoint / auth / version / content-type and every
+// mapped semantic value present — and records every BAML divergence as a
+// CHECKED-IN, secret-free expected-divergence allowlist entry with FAILING
+// controls (controls_test.go). There is no "semantic-equal = pass" escape hatch:
+// each side's exact top-level key order is pinned independently, so an UNLISTED
+// reorder or an extra/missing key FAILS.
+//
+// # Shape
+//
+// For each corpus row the harness:
+//
+//   - builds a tiny in-memory BAML project with the stock public Go API
+//     (baml.CreateRuntime + runtime.BuildRequest) with fixed FAKE creds / model /
+//     base / prompt, and captures the REAL stock v0.223.0 Anthropic request
+//     (method, URL, header map, exact Body.Text()) with NO socket and NO
+//     checked-in generated source (baml_stock_test.go);
+//   - builds the SAME S2 canonical OpenAI-shaped request (public
+//     nanollm.ChatRequest builder, ordered content-part blocks matching S2's
+//     canonicalTextBlock) and calls nanollm Prepare with NO send;
+//   - compares method / URL / the required semantic header SET exactly through
+//     the shared, redacted nativeserve/testutil comparator (which already exempts
+//     BAML's `baml-original-url` on the oracle side only);
+//   - decodes both bodies into an Anthropic contract DTO and compares the REQUIRED
+//     MEANING (model, max_tokens, system text, ordered message roles/text with NO
+//     system/developer role, temperature/top_p/top_k/stop_sequences);
+//   - asserts the expected top-level key-order divergence + the one-sided
+//     `baml-original-url` header via the checked-in allowlist (anthropic_test.go).
+//
+// # Redaction
+//
+// Every diagnostic is secret-free: header values redact through
+// testutil.RedactValue (only content-type / accept / anthropic-version print);
+// bodies, URLs, and prompt/credential-derived text NEVER print raw — mismatches
+// report a field path plus a length or a fixed structural token, never the value
+// and never a content-derived hash.
+//
+// # Isolation
+//
+// Every file is `_test.go` (excluded from the native-worker tar) behind
+// `integration && nanollm_integration`. It runs in the go.work-excluded
+// nanollmprepare module, links stock BAML v0.223.0 + the public nanollm-ffi
+// prebuilt FFI archive, and touches NO production package. It shares the pure,
+// runtime-neutral nativeserve/testutil comparator with the OpenAI Phase-5.1 legs
+// but keeps every Anthropic-specific normalization here in `_test.go`.
+package provideroracle
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
+
+	"github.com/invakid404/baml-rest/nativeserve/testutil"
+)
+
+// --- The literal fake fence (secret-free; never dialed, never a real key). ---
+//
+// The `.invalid` base is non-routable and this suite never sends, so the fake
+// key and unreachable host are never contacted. The alias is deliberately
+// distinct from the target so a plan that leaks the alias into the body fails.
+const (
+	fenceModel        = "claude-fixture-model"
+	fenceAPIKey       = "fake-anthropic-oracle-key"
+	fenceAlias        = "tpbpa-anthropic-alias"
+	fenceServiceRoot  = "https://anthropic-oracle.invalid" // BAML service root (no /v1)
+	fenceCustomHdrKey = "x-custom-oracle"
+	fenceCustomHdrVal = "safe-custom-header-value"
+
+	// anthropicVersion is the pinned default Anthropic API version both builders
+	// emit unless overridden (a fixed, non-secret token — safe to print).
+	anthropicVersion = "2023-06-01"
+
+	// defaultServiceRoot / defaultMessagesURL are the provider defaults BAML and
+	// nanollm both resolve when no base_url is configured.
+	defaultServiceRoot  = "https://api.anthropic.com"
+	defaultMessagesPath = "/v1/messages"
+)
+
+// messagesURL returns the exact Anthropic Messages endpoint for a BAML service
+// root (or the provider default when serviceRoot is empty). BAML appends
+// /v1/messages to its service root; S2 converts the service root to nanollm's API
+// root by appending /v1, and nanollm appends /messages — the same effective URL.
+func messagesURL(serviceRoot string) string {
+	if serviceRoot == "" {
+		serviceRoot = defaultServiceRoot
+	}
+	return serviceRoot + defaultMessagesPath
+}
+
+// canonTextBlock mirrors S2 admission's canonicalTextBlock: an ordered
+// {type,text} content part. Using a struct (not a map) reproduces S2's exact
+// content-part member order, so the ONLY body divergence from BAML is the
+// documented TOP-LEVEL member order — nested block order matches byte-for-byte.
+type canonTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func textBlocks(text string) []canonTextBlock {
+	return []canonTextBlock{{Type: "text", Text: text}}
+}
+
+// corpusMessage is one rendered chat turn used to build BOTH legs' request: BAML
+// renders it from the prompt template, native builds the same canonical OpenAI
+// content-part message. Exactly one text block per turn (the corpus shape).
+type corpusMessage struct {
+	role string
+	text string
+}
+
+// bodyOptions are the mapped sampling/limit options a row exercises. Pointers
+// distinguish "unset" from a valid zero. maxTokens uses -1 as the "unset"
+// sentinel (nil default is emitted by both builders as 4096).
+type bodyOptions struct {
+	maxTokens     int // -1 => unset (both default to 4096)
+	temperature   *float64
+	topP          *float64
+	topK          *int
+	stopSequences []string
+}
+
+// --- nanollm (native) leg: build the S2-equivalent canonical request. ---
+
+// newAnthropicClient builds a native nanollm engine for one Anthropic alias at
+// the fake fence values, with a zero retry budget, no fallbacks, no process env,
+// and optional custom headers (injected verbatim via Params["headers"], exactly
+// as S2's newMappedClient does). serviceRoot is the BAML service root; the
+// nanollm API base appends /v1 to it (S2's anthropicNanollmBase), or is left
+// unset for the provider default.
+func newAnthropicClient(t *testing.T, serviceRoot string, customHeaders map[string]string) *nanollm.Client {
+	t.Helper()
+	mc := nanollm.ModelConfig{
+		Name:       fenceAlias,
+		Model:      "anthropic/" + fenceModel,
+		APIKey:     fenceAPIKey,
+		MaxRetries: 0,
+	}
+	if serviceRoot != "" {
+		mc.BaseURL = serviceRoot + "/v1" // S2 anthropicNanollmBase: service root + /v1
+	}
+	if len(customHeaders) > 0 {
+		mc.Params = map[string]any{"headers": customHeaders}
+	}
+	c, err := nanollm.New(nanollm.Config{
+		Models:        []nanollm.ModelConfig{mc},
+		Env:           nil,
+		UseProcessEnv: false,
+	})
+	if err != nil {
+		// The engine error can echo the config (fake key/base) — report the stage only.
+		t.Fatal("nanollm.New(anthropic) failed at stage=engine_new")
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// buildCanonicalRequest builds the S2 canonical OpenAI-shaped request bytes for
+// the given messages + options via the public nanollm.ChatRequest builder — the
+// same construction S2 admission performs (typed common fields, top_k through
+// Extra). It sets Request.Model to the alias so Prepare rewrites the body model
+// to the configured target, exactly like S2.
+func buildCanonicalRequest(t *testing.T, msgs []corpusMessage, opts bodyOptions) nanollm.Request {
+	t.Helper()
+	cr := nanollm.ChatRequest{Model: fenceAlias}
+	for _, m := range msgs {
+		cr.Messages = append(cr.Messages, nanollm.ChatMessage{Role: m.role, Content: textBlocks(m.text)})
+	}
+	if opts.maxTokens >= 0 {
+		mt := opts.maxTokens
+		cr.MaxTokens = &mt
+	}
+	cr.Temperature = opts.temperature
+	cr.TopP = opts.topP
+	if len(opts.stopSequences) > 0 {
+		cr.Stop = opts.stopSequences
+	}
+	if opts.topK != nil {
+		// top_k is an Anthropic provider extension: S2 carries it through
+		// ChatRequest.Extra (unmodeled top-level field), never a typed field.
+		cr.Extra = map[string]any{"top_k": *opts.topK}
+	}
+	req, err := cr.Build(json.Marshal)
+	if err != nil {
+		// A marshal error can echo the request body — report the stage only.
+		t.Fatal("canonical ChatRequest.Build failed at stage=marshal")
+	}
+	req.Model = fenceAlias
+	return req
+}
+
+// prepareNative runs nanollm Prepare (NO send) and returns the plan plus a
+// runtime-neutral snapshot (rejecting a duplicate/multi-value header).
+func prepareNative(t *testing.T, c *nanollm.Client, req nanollm.Request) (*nanollm.PreparedRequest, testutil.Snapshot) {
+	t.Helper()
+	prep, err := c.Prepare(req)
+	if err != nil {
+		// A Prepare error can echo the request body — report the stage only.
+		t.Fatal("nanollm Prepare rejected a canonical Anthropic body (stage=prepare)")
+	}
+	snap, err := testutil.NewSnapshot(prep.Method, prep.URL, prep.Headers, prep.Body)
+	if err != nil {
+		t.Fatal("nanollm plan has a duplicate/multi-value header (stage=snapshot)")
+	}
+	return prep, snap
+}
+
+// --- Anthropic contract DTO (required-meaning comparison). ---
+
+// anthropicContract is the subset of the Anthropic Messages request whose MEANING
+// both builders must agree on. Decoding discards member order (the intended
+// divergence) and lets a semantic comparison run over provider-native fields.
+type anthropicContract struct {
+	Model         string             `json:"model"`
+	MaxTokens     *int               `json:"max_tokens"`
+	System        []anthropicBlock   `json:"system"`
+	Messages      []anthropicMessage `json:"messages"`
+	Temperature   *float64           `json:"temperature"`
+	TopP          *float64           `json:"top_p"`
+	TopK          *int               `json:"top_k"`
+	StopSequences []string           `json:"stop_sequences"`
+}
+
+type anthropicBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type anthropicMessage struct {
+	Role    string           `json:"role"`
+	Content []anthropicBlock `json:"content"`
+}
+
+// Fixed, secret-free strict-decode outcomes (never echo body bytes/field values).
+var (
+	errStrictDecode = errors.New("provideroracle: body is not a recognized single Anthropic Messages request")
+	errTrailingJSON = errors.New("provideroracle: body carries trailing data after the JSON value")
+)
+
+// strictDecodeAnthropic is the SINGLE strict fail-closed decode path shared by
+// every provideroracle site that parses a captured/prepared request body. It:
+//
+//   - rejects unknown top-level/nested fields (DisallowUnknownFields);
+//   - requires EXACTLY ONE top-level JSON value — a second value appended after
+//     the request (trailing JSON) is rejected, while trailing WHITESPACE is
+//     tolerated (a bare json.Decoder.Decode would silently accept both).
+//
+// It returns only fixed, secret-free sentinels — never the raw decoder error,
+// which could echo body bytes.
+func strictDecodeAnthropic(body []byte) (anthropicContract, error) {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	var c anthropicContract
+	if err := dec.Decode(&c); err != nil {
+		return anthropicContract{}, errStrictDecode
+	}
+	// Exactly one value: a second decode must reach clean EOF (only whitespace may
+	// remain). A successful second value, or malformed trailing bytes, fails closed.
+	var extra json.RawMessage
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		return anthropicContract{}, errTrailingJSON
+	}
+	return c, nil
+}
+
+// decodeAnthropic strictly decodes a captured/prepared body into the contract DTO
+// via the shared exact-one-value path. It never prints the raw body on error —
+// only a fixed stage token + length.
+func decodeAnthropic(t *testing.T, leg string, body []byte) anthropicContract {
+	t.Helper()
+	c, err := strictDecodeAnthropic(body)
+	if err != nil {
+		stage := "decode"
+		if errors.Is(err, errTrailingJSON) {
+			stage = "trailing_json"
+		}
+		t.Fatalf("%s body is not a recognized single Anthropic Messages request (stage=%s, len=%d)", leg, stage, len(body))
+	}
+	return c
+}
+
+// blocksEqual compares two content/system block sequences for EXACT equality —
+// count, per-block type, and per-block text, in order. This is the primitive the
+// system-block assertions and their mutation control share, so a block with the
+// same text but a wrong/absent `type`, or a reordered/extra block, is caught
+// (never reduced to concatenated text).
+func blocksEqual(a, b []anthropicBlock) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Type != b[i].Type || a[i].Text != b[i].Text {
+			return false
+		}
+	}
+	return true
+}
+
+// textBlockSeq builds the expected provider-native block sequence for the given
+// texts: one {type:"text", text} block each, in order.
+func textBlockSeq(texts ...string) []anthropicBlock {
+	out := make([]anthropicBlock, 0, len(texts))
+	for _, tx := range texts {
+		out = append(out, anthropicBlock{Type: "text", Text: tx})
+	}
+	return out
+}
+
+// --- Top-level member-order extraction (the divergence primitive). ---
+
+// topLevelKeys returns the top-level object member names of a JSON body in their
+// EXACT serialized order, without decoding into an (unordered) map. It is the
+// primitive the expected-divergence allowlist pins on each side. It relies on
+// json.Decoder's object-state tracking: after the opening '{', dec.Token()
+// returns each member KEY, and skipJSONValue consumes that member's value
+// (scalar or nested container) so the next Token() is the following key.
+func topLevelKeys(t *testing.T, leg string, body []byte) []string {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(body))
+	tok, err := dec.Token()
+	if err != nil {
+		// The tokenizer error can echo body bytes — report stage + length only.
+		t.Fatalf("%s body: stage=open_token (len=%d)", leg, len(body))
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		t.Fatalf("%s body is not a JSON object (len=%d)", leg, len(body))
+	}
+	var keys []string
+	for dec.More() {
+		ktok, err := dec.Token()
+		if err != nil {
+			t.Fatalf("%s body: stage=member_key (len=%d)", leg, len(body))
+		}
+		key, ok := ktok.(string)
+		if !ok {
+			t.Fatalf("%s body: stage=non_string_key (len=%d)", leg, len(body))
+		}
+		keys = append(keys, key)
+		skipJSONValue(t, leg, dec)
+	}
+	return keys
+}
+
+// skipJSONValue consumes exactly one JSON value from dec: a scalar is one token;
+// an object/array is walked to its matching close. Errors report only a fixed
+// stage token — a raw tokenizer error could echo body bytes.
+func skipJSONValue(t *testing.T, leg string, dec *json.Decoder) {
+	t.Helper()
+	tok, err := dec.Token()
+	if err != nil {
+		t.Fatalf("%s body: stage=value_token", leg)
+	}
+	d, ok := tok.(json.Delim)
+	if !ok {
+		return // scalar value already consumed
+	}
+	if d != '{' && d != '[' {
+		t.Fatalf("%s body: stage=unexpected_delim", leg)
+	}
+	depth := 1
+	for depth > 0 {
+		tk, err := dec.Token()
+		if err != nil {
+			t.Fatalf("%s body: stage=nested_value", leg)
+		}
+		if dd, ok := tk.(json.Delim); ok {
+			switch dd {
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+			}
+		}
+	}
+}
+
+func sameKeySet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]int, len(a))
+	for _, k := range a {
+		seen[k]++
+	}
+	for _, k := range b {
+		seen[k]--
+	}
+	for _, n := range seen {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func sameOrder(a, b []string) bool { return reflect.DeepEqual(a, b) }

--- a/internal/nativebody/nanollmprepare/provideroracle/controls_test.go
+++ b/internal/nativebody/nanollmprepare/provideroracle/controls_test.go
@@ -1,0 +1,349 @@
+//go:build integration && nanollm_integration
+
+package provideroracle
+
+// TPBP-A mutation controls (scope §6.1 step 7). Each proves a POSITIVE assertion
+// in anthropic_test.go is load-bearing by driving the SAME comparator primitive
+// (testutil.Diff / NewSnapshot / topLevelKeys / strict DTO decode / sameOrder /
+// sameKeySet) against a deliberate mutation and requiring it to be DETECTED. A
+// control that failed to detect its mutation would mean the paired positive could
+// pass on a broken request — so every control fails closed (t.Fatal when the
+// mutation slips through). There is deliberately NO "semantic-equal = pass"
+// escape hatch: an UNLISTED member reorder, an extra key, or a renamed field all
+// fail even though the request stays semantically valid.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	nanollm "github.com/viktordanov/nanollm-ffi/go"
+
+	"github.com/invakid404/baml-rest/nativeserve/testutil"
+)
+
+// controlRow is a small system+user row reused by the controls.
+func controlRow() anthropicRow {
+	return anthropicRow{
+		name:        "control",
+		serviceRoot: fenceServiceRoot,
+		messages: []corpusMessage{
+			{role: "system", text: "You are a concise assistant."},
+			{role: "user", text: "Tell me about cats."},
+		},
+		opts:      bodyOptions{maxTokens: -1},
+		bamlOrder: []string{"model", "max_tokens", "system", "messages"},
+		nanoOrder: []string{"model", "messages", "system", "max_tokens"},
+	}
+}
+
+// strictDecodeErr routes through the SHARED exact-one-value strict decode path
+// (strictDecodeAnthropic: DisallowUnknownFields + trailing-JSON rejection) and
+// returns its fixed, secret-free error (nil on success) WITHOUT failing the test —
+// the controls assert on whether a mutation is rejected.
+func strictDecodeErr(body []byte) error {
+	_, err := strictDecodeAnthropic(body)
+	return err
+}
+
+// TestControlWrongPath: a mutated endpoint path must be caught by the shared
+// method/URL/header comparator.
+func TestControlWrongPath(t *testing.T) {
+	cap := runRow(t, controlRow())
+	bad := headerOnly(cap.nanoSnap)
+	bad.URL = strings.Replace(bad.URL, defaultMessagesPath, "/v1/complete", 1)
+	if bad.URL == cap.nanoSnap.URL {
+		t.Fatal("path mutation did not change the URL")
+	}
+	if diffs := testutil.Diff(headerOnly(cap.baml.snap), bad); len(diffs) == 0 {
+		t.Fatal("a wrong endpoint path was NOT detected by the differential")
+	}
+}
+
+// TestControlMissingAuth: dropping the required x-api-key must be caught (it is a
+// semantic header, present on the BAML oracle and required on native).
+func TestControlMissingAuth(t *testing.T) {
+	cap := runRow(t, controlRow())
+	bad := testutil.Snapshot{Method: cap.nanoSnap.Method, URL: cap.nanoSnap.URL, Headers: map[string]string{}}
+	for k, v := range cap.nanoSnap.Headers {
+		if k == "x-api-key" {
+			continue
+		}
+		bad.Headers[k] = v
+	}
+	diffs := testutil.Diff(headerOnly(cap.baml.snap), bad)
+	if len(diffs) == 0 {
+		t.Fatal("a missing x-api-key was NOT detected by the differential")
+	}
+}
+
+// TestControlDuplicateAuth: a duplicate auth header must be REJECTED at snapshot
+// construction (fail closed), never silently merged.
+func TestControlDuplicateAuth(t *testing.T) {
+	cap := runRow(t, controlRow())
+	dup := append(append([][2]string(nil), cap.prep.Headers...), [2]string{"x-api-key", "second-fake-key"})
+	if _, err := testutil.NewSnapshot(cap.prep.Method, cap.prep.URL, dup, cap.prep.Body); err == nil {
+		t.Fatal("a duplicate x-api-key was NOT rejected by the comparator")
+	}
+}
+
+// TestControlAuthValueRedacted: a tampered x-api-key VALUE is detected AND never
+// leaks into the diagnostics (redaction proof).
+func TestControlAuthValueRedacted(t *testing.T) {
+	cap := runRow(t, controlRow())
+	bad := testutil.Snapshot{Method: cap.nanoSnap.Method, URL: cap.nanoSnap.URL, Headers: map[string]string{}}
+	for k, v := range cap.nanoSnap.Headers {
+		bad.Headers[k] = v
+	}
+	bad.Headers["x-api-key"] = "tampered-fake-key"
+	diffs := testutil.Diff(headerOnly(cap.baml.snap), bad)
+	if len(diffs) == 0 {
+		t.Fatal("a tampered x-api-key value was NOT detected")
+	}
+	joined := strings.Join(diffs, "\n")
+	tamperedLeaked := strings.Contains(joined, "tampered-fake-key")
+	fenceLeaked := strings.Contains(joined, fenceAPIKey)
+	if tamperedLeaked || fenceLeaked {
+		// Report only WHICH secret leaked (booleans) — never re-print the diagnostic
+		// content itself, or this redaction control would leak the value it protects.
+		t.Fatalf("x-api-key value leaked into diagnostics (tampered_present=%v fence_present=%v)", tamperedLeaked, fenceLeaked)
+	}
+}
+
+// TestControlWrongTarget: a native client whose configured target differs from
+// the BAML model produces a body model the required-meaning anchor rejects
+// (nanollm rewrites the top-level model to the configured target).
+func TestControlWrongTarget(t *testing.T) {
+	const wrongTarget = "wrong-oracle-target"
+	c, err := nanollm.New(nanollm.Config{
+		Models: []nanollm.ModelConfig{{
+			Name:       fenceAlias,
+			Model:      "anthropic/" + wrongTarget,
+			APIKey:     fenceAPIKey,
+			BaseURL:    fenceServiceRoot + "/v1",
+			MaxRetries: 0,
+		}},
+		UseProcessEnv: false,
+	})
+	if err != nil {
+		// The engine error can echo the config (fake key/base) — report the stage only.
+		t.Fatal("nanollm.New(anthropic) failed at stage=engine_new")
+	}
+	defer c.Close()
+
+	r := controlRow()
+	prep, _ := prepareNative(t, c, buildCanonicalRequest(t, r.messages, r.opts))
+	got := decodeAnthropic(t, "nanollm", prep.Body)
+	if got.Model == fenceModel {
+		t.Fatalf("a wrong configured target did NOT change the body model (still %q) — the model anchor is not sensitive", fenceModel)
+	}
+	if got.Model != wrongTarget {
+		t.Fatalf("expected native to rewrite the body model to the configured target %q, got a different value", wrongTarget)
+	}
+}
+
+// TestControlRenamedBodyField: a renamed top-level field (max_tokens ->
+// max_tokenz) is caught by the strict DTO decode (an unlisted field fails closed).
+func TestControlRenamedBodyField(t *testing.T) {
+	cap := runRow(t, controlRow())
+	if err := strictDecodeErr(cap.prep.Body); err != nil {
+		// A decode error can echo body bytes — report the stage only.
+		t.Fatal("the unmutated native body failed strict decode (stage=precondition_decode)")
+	}
+	mutated := bytes.Replace(cap.prep.Body, []byte(`"max_tokens"`), []byte(`"max_tokenz"`), 1)
+	if bytes.Equal(mutated, cap.prep.Body) {
+		t.Fatal("the field-rename mutation did not change the body")
+	}
+	if err := strictDecodeErr(mutated); err == nil {
+		t.Fatal("a renamed/unlisted top-level field was NOT rejected by the strict decode")
+	}
+}
+
+// TestControlTrailingJSONRejected: a body that is a valid Anthropic request
+// FOLLOWED BY a second top-level JSON value (trailing JSON) must be rejected by
+// the shared strict decode path — a bare json.Decoder.Decode consumes only the
+// first value and would silently accept the rest. Trailing WHITESPACE (not a
+// second value) must still be tolerated.
+func TestControlTrailingJSONRejected(t *testing.T) {
+	cap := runRow(t, controlRow())
+
+	// Precondition: the clean prepared body decodes.
+	if err := strictDecodeErr(cap.prep.Body); err != nil {
+		t.Fatal("the unmutated native body must decode cleanly (stage=precondition_decode)")
+	}
+
+	// A second top-level JSON object appended after the request must be rejected.
+	trailingObj := append(append([]byte(nil), cap.prep.Body...), []byte(`{"x":1}`)...)
+	if err := strictDecodeErr(trailingObj); err == nil {
+		t.Fatal("a body with a trailing JSON object after the request was NOT rejected")
+	}
+	// A trailing bare scalar is likewise rejected.
+	trailingScalar := append(append([]byte(nil), cap.prep.Body...), []byte(" 7")...)
+	if err := strictDecodeErr(trailingScalar); err == nil {
+		t.Fatal("a body with a trailing scalar after the request was NOT rejected")
+	}
+
+	// Trailing WHITESPACE only is NOT a second value and must be tolerated.
+	whitespace := append(append([]byte(nil), cap.prep.Body...), []byte("  \n\t")...)
+	if err := strictDecodeErr(whitespace); err != nil {
+		t.Fatal("trailing whitespace must be tolerated by the strict decode (stage=whitespace)")
+	}
+}
+
+// TestControlMalformedOptionValue: a corrupted stop_sequences value is caught by
+// the required-meaning comparison (the decoded slice diverges from the expected).
+func TestControlMalformedOptionValue(t *testing.T) {
+	r := anthropicRow{
+		name:        "control_stop",
+		serviceRoot: fenceServiceRoot,
+		messages:    []corpusMessage{{role: "user", text: "hi"}},
+		opts:        bodyOptions{maxTokens: 100, stopSequences: []string{"STOP"}},
+	}
+	cap := runRow(t, r)
+	got := decodeAnthropic(t, "nanollm", cap.prep.Body)
+	if equalStrings(got.StopSequences, []string{"MANGLED"}) {
+		t.Fatal("sanity: decoded stop_sequences unexpectedly equals the mangled control value")
+	}
+	if !equalStrings(got.StopSequences, r.opts.stopSequences) {
+		t.Fatalf("sanity: decoded stop_sequences diverged from the input")
+	}
+	// The comparison is value-sensitive: a wrong expectation must NOT match.
+	if equalStrings(got.StopSequences, append(r.opts.stopSequences, "EXTRA")) {
+		t.Fatal("stop_sequences comparison is not length/value sensitive")
+	}
+}
+
+// TestControlUnlistedOrderDivergence: an UNLISTED top-level member reorder (even
+// though it stays semantically valid) must fail the pinned-order allowlist. This
+// is the explicit "no semantic-equal escape hatch" control.
+func TestControlUnlistedOrderDivergence(t *testing.T) {
+	r := controlRow()
+	cap := runRow(t, r)
+
+	nanoKeys := topLevelKeys(t, "nanollm", cap.prep.Body)
+	if !sameOrder(nanoKeys, r.nanoOrder) {
+		t.Fatalf("precondition: native order %v != allowlist %v", nanoKeys, r.nanoOrder)
+	}
+	// Swap two adjacent keys => a valid but UNLISTED order.
+	reordered := append([]string(nil), nanoKeys...)
+	reordered[0], reordered[1] = reordered[1], reordered[0]
+	if sameOrder(reordered, nanoKeys) {
+		t.Fatal("the reorder mutation did not change the key order")
+	}
+	// The pinned-order allowlist must REJECT the reordered (but still valid) body.
+	if sameOrder(reordered, r.nanoOrder) {
+		t.Fatal("an unlisted reorder was accepted by the allowlist")
+	}
+	// Same key SET, different order — proves the divergence gate is order-strict,
+	// not merely set-based.
+	if !sameKeySet(reordered, r.nanoOrder) {
+		t.Fatal("the reorder should preserve the key set")
+	}
+}
+
+// TestControlExtraKeySetDivergence: an added top-level key breaks BOTH the strict
+// decode and the key-SET equality — an unlisted new field can never pass.
+func TestControlExtraKeySetDivergence(t *testing.T) {
+	r := controlRow()
+	cap := runRow(t, r)
+
+	// Inject an unlisted top-level key into the native body bytes.
+	injected := bytes.Replace(cap.prep.Body, []byte(`{"model"`), []byte(`{"unlisted_field":1,"model"`), 1)
+	if bytes.Equal(injected, cap.prep.Body) {
+		t.Fatal("the extra-key mutation did not change the body")
+	}
+	if err := strictDecodeErr(injected); err == nil {
+		t.Fatal("an injected unlisted top-level key was NOT rejected by the strict decode")
+	}
+	nanoKeys := topLevelKeys(t, "nanollm", injected)
+	if sameKeySet(nanoKeys, r.nanoOrder) {
+		t.Fatal("an injected unlisted key did NOT change the key set")
+	}
+}
+
+// TestControlSystemBlockType: a system block with a NON-text `type` (same text,
+// same top-level order) must be caught by the exact block-sequence comparison —
+// the text-only compare that P1 removed would have accepted this provider-invalid
+// block.
+func TestControlSystemBlockType(t *testing.T) {
+	r := controlRow()
+	cap := runRow(t, r)
+	want := r.wantSystemBlocks()
+
+	// Precondition: the real native system blocks match the expected sequence.
+	real := decodeAnthropic(t, "nanollm", cap.prep.Body)
+	if !blocksEqual(real.System, want) {
+		t.Fatal("precondition: native system blocks diverge from the expected sequence")
+	}
+
+	// Corrupt ONLY the system block's type (the marker prefix uniquely targets the
+	// system array; message content blocks are emitted before it in this row).
+	marker := []byte(`"system":[{"type":"text"`)
+	if !bytes.Contains(cap.prep.Body, marker) {
+		t.Fatal("precondition: could not locate the system text block to mutate")
+	}
+	mutated := bytes.Replace(cap.prep.Body, marker, []byte(`"system":[{"type":"txt"`), 1)
+
+	// The mutated body stays STRUCTURALLY decodable (type is just a string)...
+	if err := strictDecodeErr(mutated); err != nil {
+		t.Fatal("the type mutation unexpectedly broke structural decodability")
+	}
+	// ...but the provider-invalid block type must fail the exact block comparison.
+	got := decodeAnthropic(t, "nanollm", mutated)
+	if got.System[0].Type == "text" {
+		t.Fatal("the system block type mutation did not take effect")
+	}
+	if blocksEqual(got.System, want) {
+		t.Fatal("a system block with a non-text type was NOT detected (text-only escape hatch)")
+	}
+}
+
+// TestControlDeveloperRoleInMessagesRejected: a developer role surviving into
+// provider `messages` (a mapping bug) must be detected by the forbidden-role gate.
+func TestControlDeveloperRoleInMessagesRejected(t *testing.T) {
+	// A synthetic provider body that wrongly left a developer role in messages.
+	body := []byte(`{"model":"m","messages":[{"role":"developer","content":[{"type":"text","text":"d"}]}],"max_tokens":1}`)
+	got := decodeAnthropic(t, "nanollm", body)
+	if !hasForbiddenRole(got.Messages) {
+		t.Fatal("a developer role surviving in provider messages was NOT detected")
+	}
+	// A clean user-only messages array must NOT trip the gate (control sanity).
+	ok := []byte(`{"model":"m","messages":[{"role":"user","content":[{"type":"text","text":"u"}]}],"max_tokens":1}`)
+	if hasForbiddenRole(decodeAnthropic(t, "nanollm", ok).Messages) {
+		t.Fatal("a clean user-only messages array wrongly tripped the forbidden-role gate")
+	}
+}
+
+// hasForbiddenRole reports whether any message carries a system/developer role
+// (which must never survive into provider `messages`).
+func hasForbiddenRole(msgs []anthropicMessage) bool {
+	for _, m := range msgs {
+		if m.Role == "system" || m.Role == "developer" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestControlBamlOriginalUrlOneSided: if native ever emitted baml-original-url the
+// divergence gate must catch it (the exemption is one-sided). This proves the
+// gate is not a blanket two-sided pass.
+func TestControlBamlOriginalUrlOneSided(t *testing.T) {
+	cap := runRow(t, controlRow())
+	// Native must not carry it in the real capture.
+	if _, ok := cap.nanoSnap.Headers["baml-original-url"]; ok {
+		t.Fatal("precondition: native unexpectedly already carries baml-original-url")
+	}
+	// A synthetic native snapshot that DOES carry it must diverge from the BAML
+	// oracle (present-on-nanollm-only), because the testutil exemption is applied
+	// to the oracle side only.
+	bad := testutil.Snapshot{Method: cap.nanoSnap.Method, URL: cap.nanoSnap.URL, Headers: map[string]string{}}
+	for k, v := range cap.nanoSnap.Headers {
+		bad.Headers[k] = v
+	}
+	bad.Headers["baml-original-url"] = "https://anthropic-oracle.invalid"
+	diffs := testutil.Diff(headerOnly(cap.baml.snap), bad)
+	if len(diffs) == 0 {
+		t.Fatal("native emitting baml-original-url was NOT detected (the exemption must be one-sided)")
+	}
+}

--- a/nativeserve/execute/mprov_smoke_integration_test.go
+++ b/nativeserve/execute/mprov_smoke_integration_test.go
@@ -18,6 +18,7 @@ package execute
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -25,6 +26,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/invakid404/baml-rest/bamlutils"
@@ -129,6 +131,64 @@ func TestMprovSmokeAnthropic(t *testing.T) {
 		}},
 	}
 	runSmoke(t, reg, "anthropic", id, exactLoopbackExecutor(), m)
+
+	// Harden the Anthropic path: beyond the shared structured-output plumbing, assert
+	// the ONE request that crossed the wire is a provider-correct Anthropic Messages
+	// call. go-mocklm is a functional responder (a header MAP, no exact-byte order),
+	// so exact plan parity lives in the no-send provideroracle oracle; here we pin the
+	// captured request-contract facts the smoke can prove.
+	assertAnthropicSmokeContract(t, m, id, target)
+}
+
+// assertAnthropicSmokeContract pins the captured Anthropic request contract: POST
+// /v1/messages, the fake x-api-key + a present anthropic-version + JSON
+// content-type, a native Anthropic body carrying the target model and a required
+// max_tokens, the system turn lifted to top-level `system`, and NO system/developer
+// role surviving into provider `messages`. Secrets are reported by presence/match
+// only (never the raw key), and the body is digested, never dumped raw.
+func assertAnthropicSmokeContract(t *testing.T, m *mockServer, id, target string) {
+	t.Helper()
+
+	// Method/path/headers from the global request log (canonicalized header map).
+	rec := m.recordedFor("anthropic", "/v1/messages")
+	if rec.Method != http.MethodPost {
+		t.Errorf("captured Anthropic method = %q, want POST", rec.Method)
+	}
+	if v, ok := headerValue(rec.Headers, "x-api-key"); !ok || v != "sk-ant-fake" {
+		// Never print the api-key value; report presence + match only.
+		t.Errorf("x-api-key missing or mismatched (present=%v, matched=%v)", ok, v == "sk-ant-fake")
+	}
+	if v, ok := headerValue(rec.Headers, "anthropic-version"); !ok || v == "" {
+		t.Errorf("anthropic-version = %q (present=%v), want non-empty", v, ok)
+	}
+	if v, ok := headerValue(rec.Headers, "content-type"); !ok || !strings.HasPrefix(v, "application/json") {
+		t.Errorf("content-type = %q (present=%v), want application/json", v, ok)
+	}
+
+	// Byte-exact captured body: a native Anthropic Messages request.
+	cap := m.lastRequest(id)
+	if cap.Path != "/v1/messages" {
+		t.Errorf("captured path = %q, want /v1/messages", cap.Path)
+	}
+	var areq anthropicRequestBody
+	if err := json.Unmarshal(cap.Body, &areq); err != nil {
+		// Never echo the body or a content-derived digest — report stage + length only.
+		t.Fatalf("captured Anthropic body is not JSON (stage=json_unmarshal, len=%d)", len(cap.Body))
+	}
+	if areq.Model != target {
+		t.Errorf("captured model = %q, want %q", areq.Model, target)
+	}
+	if areq.MaxTokens < 1 {
+		t.Errorf("captured max_tokens = %d, want >= 1 (Anthropic requires it)", areq.MaxTokens)
+	}
+	if len(areq.System) == 0 || string(areq.System) == "null" {
+		t.Errorf("captured top-level system missing; the system turn must be lifted out of messages")
+	}
+	roles := make([]string, len(areq.Messages))
+	for i, msg := range areq.Messages {
+		roles[i] = msg.Role
+	}
+	assertMessageRoles(t, roles, "system", "developer")
 }
 
 // TestMprovSmokeCerebras: cerebras is OpenAI-wire-compatible, so nanollm's


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

## TPBP-A — Anthropic provider-correctness oracle + shared no-send harness

**Bar (owner-ruled): provider-CORRECTNESS, not BAML byte-equality.** BAML v0.223.0 and native nanollm v0.4.3 both emit a valid Anthropic `POST /v1/messages`, but differ in top-level JSON member order, and BAML additionally carries its internal `baml-original-url` header. This slice proves native emits a provider-correct Anthropic request (correct method/endpoint/auth/version/content-type, every mapped value present) and records every BAML divergence as a **checked-in, secret-free expected-divergence allowlist entry with failing controls** — no "semantic-equal = pass" escape hatch. JSON key order and global header order are never a contract; native's own header order is pinned independently and BAML header order/casing is explicitly unclaimed.

### What's here (test-only, tar-free)
New `_test.go` package `internal/nativebody/nanollmprepare/provideroracle/` behind `integration && nanollm_integration`:

- **common_test.go** — shared harness: in-memory stock BAML `CreateRuntime` + `BuildRequest` capture (no socket, no checked-in generated source), nanollm Anthropic `Prepare` (no send), reused `nativeserve/testutil` redacted header normalization, Anthropic contract DTO + ordered top-level key extraction.
- **baml_stock_test.go** — stock-BAML capture helpers + BAML v0.223.0 / nanollm v0.4.3 version guards.
- **anthropic_test.go** — the §6.2 corpus (default/custom service root; system + ordered user/assistant; default/explicit `max_tokens`; `temperature` / `top_p` / `stop`→`stop_sequences` / `top_k` / Unicode+escaping; one safe custom header). Per row: method/URL/semantic-header set compared exactly through the shared redacted comparator; both bodies decoded into the Anthropic contract DTO and compared for required meaning (system lifted out of `messages`, no system/developer role surviving); native header order pinned independently; the expected top-level key-order + one-sided `baml-original-url` divergence asserted via the checked-in allowlist.
- **controls_test.go** — mutation controls: wrong path, missing/duplicate/tampered auth, wrong target, renamed/extra body field, unlisted member reorder, and a one-sided `baml-original-url` all FAIL closed.

Also hardens the Anthropic path in `nativeserve/execute/mprov_smoke_integration_test.go` with explicit captured-request-contract assertions on the one request that crosses the wire (POST `/v1/messages`; fake `x-api-key` + `anthropic-version` + JSON content-type; native Anthropic body carrying the target model + `max_tokens`; system lifted out of `messages`).

### Boundary held
No production / `go.mod` / `go.sum` / `cmd/build/nativeworker_module.tar` / `internal/debaml` change; no `nativeserve/admission` or `mapping*.go` edit. Host stays zero-nanollm / CGO-free (root builds clean with `CGO_ENABLED=0`); every diagnostic is secret-free (header values redacted by allowlist; URLs/bodies reported by length only, never a content-derived hash).

### Gate
- new tagged `GOWORK=off` provideroracle tests green (5 corpus rows + 2 version guards + 10 controls);
- hardened `TestMprovSmoke{Anthropic,Cerebras,Bedrock}` green;
- whole `nanollmprepare` module compiles green under `integration nanollm_integration`;
- existing `nanollm-prepare` / `nanollm-send` lanes unaffected (test-only; no workflow/manifest change).

Runs parallel with #555 Slice 2 — no collision (that track is `internal/debaml` + tar; this is test-only in the go.work-excluded module).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration coverage comparing Anthropic request generation between BAML and native preparation, including strict method/endpoint checks, header validation (with provider-specific auth rules), and request-body semantic verification with top-level JSON key order pinning.
  * Added focused coverage for developer-role disposition differences, asserting expected system/message shaping on each leg.
  * Added hardened “fail-closed” mutation controls (auth/path/model/body mutations, trailing JSON, malformed options, and divergence in unlisted key/order).
  * Pinned required component versions and strengthened Anthropic smoke assertions (model, max_tokens, system presence, and system/developer roles).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->