### PR TITLE
debaml(greedyrec §5.9.1): reproduce BAML greedy-recovery partial cadence — CLAIM comment+enum+extra-field+bare-scalar; retain embedded-quote + nested-brace-cascade (#583)

### DIFF
--- a/integration/stream_typespace_differential_test.go
+++ b/integration/stream_typespace_differential_test.go
@@ -56,26 +56,26 @@ import (
 //     exercised inside; UNSAFE nested classes (>=4 fields, >=2 lists, or a bare enum/literal —
 //     BAML's start cadence native cannot reproduce) are oracle-asserted DECLINES.
 //
-// THREE battery classes, asserted differently and honestly:
-//   - STRICT inputs: byte-exact partial+final vs live BAML. This is the 0-divergence gate.
-//   - OVER-DECLINE inputs — an invalid enum member ("badmember"), an extra non-schema field
-//     mid-stream ("extra_field"), a lone incomplete comment marker ("mid_comment"): native
-//     may SAFELY SKIP the ambiguous/non-conforming/transient frame where BAML recovers a
-//     value (BAML stream-nulls a bad enum but its FINAL both-declines; BAML transiently nulls
-//     the real field while an extra key streams; a lone `/` is not yet `/*` vs `//`). The
-//     contract stays strict — native EITHER matches BAML byte-exact OR skips; if it emits it
-//     must be byte-exact — so an over-claim is still caught, only the safe under-emit is
-//     permitted. FINAL stays byte-exact.
-//   - DEFERRED inputs — a bare unquoted scalar in a string field ("num_in"), and a string
-//     whose content has an EMBEDDED quote from \" ("escapedq"): both trigger a BAML jsonish
-//     greedy-recovery heuristic (bare-scalar raw-span / embedded-quote close) that only
-//     appears at INCOMPLETE-object prefixes, that BAML itself discards at the final frame, and
-//     that native cannot yet reproduce byte-exact (#583 owed debt). Native's contract is a
-//     PURE UNDER-approximation: at those frames native NO-EMITS (skips) rather than emit a
-//     byte-different value. This leg ENFORCES that bound — native EITHER skips OR emits
-//     byte-exact vs BAML; a byte-different native emission is a divergent/over-claim emit and
-//     FAILS (BAML queried only when native emits). FINAL stays byte-exact. The live companion
-//     TestStream7CDeferredHeuristics proves the same on the two canonical specimens.
+// TWO battery classes, asserted honestly (§5.9.1 greedy-recovery collapsed the old OVER-DECLINE
+// leg into STRICT — the covered triggers now emit BAML's transient partials byte-exact):
+//   - STRICT inputs: byte-exact partial+final vs live BAML at EVERY valid-UTF-8 prefix. This is
+//     the 0-divergence gate. §5.9.1's CLAIMED greedy-recovery triggers live here now — an invalid
+//     enum member ("badmember", BAML nulls the unparseable class field in the partial; FINAL
+//     both-declines), an extra non-schema field after an unquoted scalar ("extra_field", BAML's
+//     greedy InObjectValue cascade transiently nulls it), a lone incomplete comment marker
+//     ("mid_comment"/"nested_comment", BAML's pending-comment drop), and a bare unquoted scalar
+//     in a list<string> ELEMENT ("num_in_elem"). Native reproduces every one byte-exact or FAILS.
+//   - DEFERRED inputs — a bare unquoted scalar in a DIRECT string field ("num_in") and a string
+//     whose content has an EMBEDDED quote from \" ("escapedq"): §5.9.1 made MOST of these prefixes
+//     strict (native now emits the flat cascade + evolving display byte-exact), but a concrete
+//     tracked-#583 RESIDUAL remains — the direct-field NESTED-BRACE cascade (the greedy span
+//     absorbs a nested `}` then trailing content, spilling into BAML's multiple-JSON candidate
+//     selection) and the embedded-quote close. Native's contract on the residual is a PURE
+//     UNDER-approximation: it NO-EMITS (skips) rather than emit a byte-different value. This leg
+//     ENFORCES that bound — native EITHER skips OR emits byte-exact; a byte-different emission is a
+//     divergent/over-claim emit and FAILS (BAML queried only when native emits). FINAL stays
+//     byte-exact. The live companion TestStream591GreedyRecovery proves the CLAIMED triggers'
+//     exact cadence, and TestStream7CDeferredHeuristics proves the residual bound.
 //
 // Fields are emitted in SCHEMA order (the order BAML renders in the prompt and LLMs
 // follow); the FINAL is order-agnostic via reorder. 0 STRICT (and deferred-emit) divergences
@@ -845,24 +845,45 @@ func enumerate() []genShape {
 
 // batInput is one battery member.
 //
-// deferred marks an input on whose incomplete-object prefixes BAML applies a jsonish
-// greedy-recovery heuristic native intentionally does not mirror (bare-scalar raw-span for a
-// string field, or the embedded-quote close heuristic); its FINAL is byte-exact on both sides
-// and asserted, but its partial prefixes are driven through native for no-crash only (see the
-// file doc + TestStream7CDeferredHeuristics).
+// deferred marks an input whose incomplete-object prefixes STILL carry a BAML greedy-recovery
+// behavior native does not FULLY reproduce byte-exact (embedded-quote close; the residual
+// NESTED-BRACE bare-scalar cascade that spills into BAML's multiple-JSON candidate selection —
+// #583). Its contract is a PURE under-approximation: at those prefixes native must EITHER
+// no-emit (a permitted safe skip) OR emit byte-exact — a byte-different emit is an over-claim
+// and FAILS. §5.9.1 greedy-recovery made most previously-deferred prefixes STRICT; what remains
+// deferred is the concrete tracked-#583 residual. FINAL stays byte-exact on both sides.
 //
-// overDecline marks an input whose partial prefixes native may SAFELY SKIP (emit nothing)
-// where BAML recovers a value — a non-conforming/ambiguous/transient frame native declines
-// rather than reproduce: an invalid enum member (BAML stream-nulls it, but final BOTH decline),
-// an extra non-schema field mid-stream (BAML transiently nulls the real field, a quirk it
-// discards at final), or a lone incomplete comment marker `/`. The contract stays strict —
-// native must EITHER match BAML byte-exact OR skip; if it emits, it must be byte-exact — so
-// this never hides an over-claim, it only permits the safe under-emit. FINAL stays byte-exact.
+// Every OTHER input is STRICT: byte-for-byte equality (success AND payload) at every valid-UTF-8
+// prefix — the 0-divergence gate. §5.9.1 moved the covered greedy-recovery triggers (lone-comment
+// marker, invalid-enum, transient-extra-field, and bare-scalar in a list<string> element) OUT of
+// the old relaxed (overDecline/deferred) legs INTO this strict gate: native now reproduces their
+// transient partial cadence byte-exact.
 type batInput struct {
-	name        string
-	raw         string
-	deferred    bool
-	overDecline bool
+	name     string
+	raw      string
+	deferred bool
+}
+
+// recoveryClass labels a battery input by the §5.9.1 greedy-recovery trigger it exercises (or ""
+// for a non-recovery input), for the per-trigger emission/skip count pins that guard against a
+// generator regression silently dropping a claimed trigger from the proof.
+func recoveryClass(name string) string {
+	switch {
+	case strings.HasPrefix(name, "num_in_elem"):
+		return "barescalar_elem" // STRICT (list<string> element)
+	case strings.HasPrefix(name, "num_in"):
+		return "barescalar" // DEFERRED residual (direct-field nested-brace cascade, #583)
+	case strings.HasPrefix(name, "escapedq"):
+		return "embeddedquote" // DEFERRED (#583)
+	case strings.HasPrefix(name, "badmember"):
+		return "invalidenum" // STRICT
+	case strings.HasPrefix(name, "extra_field"):
+		return "extrafield" // STRICT
+	case name == "mid_comment" || strings.HasPrefix(name, "nested_comment"):
+		return "comment" // STRICT
+	default:
+		return ""
+	}
 }
 
 func batteryFor(root *ft) []batInput {
@@ -871,18 +892,24 @@ func batteryFor(root *ft) []batInput {
 		{name: "complete", raw: complete},
 		{name: "block_comment", raw: strings.Replace(complete, "{", "{/* c */", 1)},
 		{name: "line_comment", raw: strings.Replace(complete, "{", "{\n// n\n", 1)},
-		// A block comment mid-structure: native strips a COMPLETE `/*…*/`, but safely declines
-		// the lone incomplete marker byte `/` (ambiguous: `/*` vs `//`) until it disambiguates.
-		{name: "mid_comment", raw: strings.Replace(complete, ",", ",/* m */", 1), overDecline: true},
+		// A block comment mid-structure. native strips a COMPLETE `/*…*/`; an unterminated
+		// `/*…`/`//…` is stripped too; the lone terminal marker byte `/` (ambiguous `/*` vs `//`)
+		// is BAML's PENDING COMMENT — dropped as the object key is (parseUnquotedKey), or ignored
+		// in array-element position (parseArrayStream). §5.9.1 makes this trigger STRICT: native
+		// reproduces BAML byte-exact at every prefix (comment-marker CLAIMED).
+		{name: "mid_comment", raw: strings.Replace(complete, ",", ",/* m */", 1)},
 		{name: "trailing_comma", raw: strings.TrimSuffix(complete, "}") + `,}`},
 		{name: "leading_comma", raw: "{," + strings.TrimPrefix(complete, "{")},
 		{name: "whitespace", raw: strings.ReplaceAll(strings.ReplaceAll(complete, ":", " : "), ",", " , ")},
 		{name: "unclosed", raw: strings.TrimSuffix(complete, "}")},
 		{name: "unclosed_comma", raw: strings.TrimSuffix(complete, "}") + ","},
-		// An EXTRA non-schema field: BAML transiently NULLS the last real field while the
-		// unknown key streams (a quirk it discards at the final frame, where the extra key is
-		// ignored and both agree); native safely over-declines those frames.
-		{name: "extra_field", raw: strings.TrimSuffix(complete, "}") + `,"zz9":"e"}`, overDecline: true},
+		// An EXTRA non-schema field: when the last real field is an UNQUOTED SCALAR, BAML's
+		// greedy InObjectValue scan absorbs `,"zz9":"e"` into that field's raw span (Incomplete),
+		// so a done-required int/enum is deleted and transiently NULLED while the unknown key
+		// streams; the valid final object restores it (extra key ignored, both agree). §5.9.1
+		// reproduces that cascade (greedyObjectValueTail) so this trigger is STRICT — native emits
+		// the transient partial byte-exact at every prefix (transient-extra-field CLAIMED).
+		{name: "extra_field", raw: strings.TrimSuffix(complete, "}") + `,"zz9":"e"}`},
 		{name: "prose", raw: "Here:\n" + complete + "\nDone."},
 		{name: "fenced", raw: "```json\n" + complete + "\n```"},
 	}
@@ -895,8 +922,14 @@ func batteryFor(root *ft) []batInput {
 		switch fp.t.kind {
 		case "string":
 			inputs = append(inputs,
-				// Bare unquoted scalar in a string field: NON-conforming #583 deferred trigger.
-				// native purely UNDER-emits (skips); FINAL matches.
+				// Bare unquoted scalar in a DIRECT string field. §5.9.1 greedy-recovery
+				// reproduces the flat cascade + evolving-display byte-exact (a huge under-approx
+				// reduction: 7→~21 emits per canonical specimen); native emits are ENFORCED
+				// byte-exact by the deferred leg. The RESIDUAL still-deferred prefixes are the
+				// NESTED-BRACE cascade (the greedy span absorbs a nested object `}` then trailing
+				// content, which pulls in BAML's multiple-JSON candidate/pick-first selection —
+				// outside this recovery state), retained-declined #583 (owner: attempt, retain if
+				// it spills into candidate/scoring). native STILL purely under-emits on those.
 				batInput{name: "num_in_" + pn, raw: buildMutated(root, fp.path, false, "5e0"), deferred: true},
 				// Escapes WITHOUT an embedded quote (\\ \n \t): native DECODES byte-exact. STRICT.
 				batInput{name: "escaped_" + pn, raw: buildMutated(root, fp.path, false, `"a\\b\nc\td"`)},
@@ -908,10 +941,14 @@ func batteryFor(root *ft) []batInput {
 		case "enum", "literal":
 			inputs = append(inputs, batInput{name: "casefold_" + pn, raw: buildMutated(root, fp.path, false, strings.ToLower(canon(fp.t)))})
 			if fp.t.kind == "enum" {
-				// An INVALID enum member: BAML stream-nulls it while native over-declines the
-				// partial (the FINAL both DECLINE — a bad required enum errors the class on both
-				// sides), so this is a safe over-decline, not an over-claim.
-				inputs = append(inputs, batInput{name: "badmember_" + pn, raw: buildMutated(root, fp.path, false, `"NOPE"`), overDecline: true})
+				// An INVALID enum member: while incomplete it is deleted (done-required) → null;
+				// once COMPLETE, BAML's partial path records the unparseable enum and null-fills
+				// the class field (a PROVEN match_string miss, bamlunicode). §5.9.1 reproduces that
+				// disposition (coerceStreamDoneLeaf → errStreamDeleted for a proven complete miss)
+				// so this trigger is STRICT — native nulls the field byte-exact at every partial;
+				// the FINAL still BOTH-declines (a bad required enum errors the class on both
+				// sides). invalid-enum CLAIMED.
+				inputs = append(inputs, batInput{name: "badmember_" + pn, raw: buildMutated(root, fp.path, false, `"NOPE"`)})
 			}
 		case "list":
 			// list bad-child: a non-coercible element for a typed list (BAML drops it).
@@ -931,9 +968,12 @@ func batteryFor(root *ft) []batInput {
 				inputs = append(inputs,
 					batInput{name: "escaped_elem_" + pn, raw: buildMutated(root, fp.path, false, `["a\\b\nc\td","txt"]`)},
 					batInput{name: "unicode_elem_" + pn, raw: buildMutated(root, fp.path, false, `["café ☃ 日本","txt"]`)},
-					// embedded quote / bare scalar in a string ELEMENT — #583 deferred triggers.
+					// embedded quote in a string ELEMENT — #583 embedded-quote deferred trigger.
 					batInput{name: "escapedq_elem_" + pn, raw: buildMutated(root, fp.path, false, `["a\"b\\c\n","txt"]`), deferred: true},
-					batInput{name: "num_in_elem_" + pn, raw: buildMutated(root, fp.path, false, `[5e0,"txt"]`), deferred: true})
+					// Bare scalar in a string LIST ELEMENT: an array closes each element at ',' /
+					// ']' (no object-value greedy cascade, no nested-brace spill), so §5.9.1
+					// reproduces it byte-exact — STRICT. bare-scalar in list<string> CLAIMED.
+					batInput{name: "num_in_elem_" + pn, raw: buildMutated(root, fp.path, false, `[5e0,"txt"]`)})
 			case "enum":
 				inputs = append(inputs, batInput{name: "casefold_elem_" + pn, raw: buildMutated(root, fp.path, false, `["red","GREEN"]`)})
 			case "litstr":
@@ -945,7 +985,10 @@ func batteryFor(root *ft) []batInput {
 			// and a trailing comma placed within the nested class's own braces.
 			nc := canon(fp.t)
 			inputs = append(inputs,
-				batInput{name: "nested_comment_" + pn, raw: buildMutated(root, fp.path, false, strings.Replace(nc, "{", "{/* c */", 1)), overDecline: true},
+				// A mid-comment inside a NESTED object. STRICT (§5.9.1): the leading marker is in
+				// object-key position (parseUnquotedKey drops the pending key); a complete/
+				// unterminated comment is stripped. native reproduces every prefix byte-exact.
+				batInput{name: "nested_comment_" + pn, raw: buildMutated(root, fp.path, false, strings.Replace(nc, "{", "{/* c */", 1))},
 				batInput{name: "nested_trailcomma_" + pn, raw: buildMutated(root, fp.path, false, strings.TrimSuffix(nc, "}")+",}")})
 		}
 	}
@@ -1042,7 +1085,13 @@ func TestStream7CTypeSpaceDifferential(t *testing.T) {
 	shapes := enumerate()
 	admittedN, declinedN := 0, 0
 	perArityAdmit := map[int]int{} // admitted ROOT classes by arity (for the anti-omission pin)
-	var finalCmp, strictCmp, deferredWalk, invalidWalk, overDeclineWalk, mism int
+	var finalCmp, strictCmp, deferredWalk, invalidWalk, mism int
+	// Per-recovery-class emission/skip pins (§5.9.1 anti-omission). classEmit counts native
+	// byte-exact partial emissions; classSkip counts permitted under-emits (native skip where
+	// BAML emits) — nonzero ONLY for the still-deferred #583 residual classes.
+	classEmit := map[string]int{}
+	classSkip := map[string]int{}     // GENUINE residual: BAML emits && native skips
+	classBothSkip := map[string]int{} // agreement: BAML skips && native skips (NOT a residual)
 	cmp := func(kind, shape, in, raw string, b string, bok bool, n string, nok bool) {
 		if bok != nok || (bok && nok && b != n) {
 			mism++
@@ -1065,6 +1114,7 @@ func TestStream7CTypeSpaceDifferential(t *testing.T) {
 			perArityAdmit[len(sh.root.flds)]++
 		}
 		for _, in := range batteryFor(sh.root) {
+			rc := recoveryClass(in.name)
 			// FINAL byte-exact for EVERY input (incl. deferred — the complete frame
 			// closes cleanly on both sides).
 			bf, bfok := bamlRaw(s, in.raw, false)
@@ -1085,36 +1135,109 @@ func TestStream7CTypeSpaceDifferential(t *testing.T) {
 					continue
 				}
 				if in.deferred {
-					// #583 owed-debt bound (owner A′ / reviewer): native must PURELY
-					// under-approximate. A no-emit (skip) is a permitted under-emit; ANY native
-					// EMISSION MUST be byte-exact vs BAML — a byte-different emit is a
-					// divergent/over-claim emit and FAILS here. We query BAML ONLY when native
-					// emits: native skips the greedy-recovery prefixes, which also dodges BAML's
-					// pathological embedded-quote backtracking on them.
+					// #583 owed-debt bound: native must PURELY under-approximate on the STILL
+					// -deferred residual (embedded-quote close; direct-field NESTED-BRACE
+					// bare-scalar cascade — both spill outside the bounded recovery state). BAML
+					// is queried on EVERY prefix (emit AND skip) so the residual is PROVEN a
+					// genuine under-approximation, not a vacuous both-skip: a no-emit is permitted
+					// ONLY where BAML also emits (a real under-emit) or where BAML also skips
+					// (agreement); ANY native EMISSION MUST be byte-exact vs BAML — a byte
+					// -different emit is a divergent/over-claim emit and FAILS here.
+					bp, bpok := bamlRaw(s, p, true)
 					if !npok {
 						deferredWalk++
+						if bpok {
+							// GENUINE #583 residual: BAML EMITS, native SKIPS — a real
+							// under-approximation on this named-witness input class (num_in →
+							// nested-brace bare-scalar; escapedq → embedded-quote). Counted so the
+							// retained-declined pin proves a true residual (not a both-skip).
+							classSkip[rc]++
+						} else {
+							// Both skip: agreement (BAML also emits nothing here), NOT a residual.
+							classBothSkip[rc]++
+						}
 						continue
 					}
-					bp, bpok := bamlRaw(s, p, true)
 					cmp("DEFERRED-EMIT", sh.name, in.name+":prefix", p, bp, bpok, np, npok)
 					strictCmp++
+					if rc != "" && npok && bpok && np == bp {
+						classEmit[rc]++
+					}
 					continue
 				}
+				// STRICT: byte-for-byte at every prefix. §5.9.1's covered triggers
+				// (comment / invalid-enum / extra-field / bare-scalar-list-element) live HERE
+				// now — native reproduces BAML byte-exact or the cmp FAILS (a skip where BAML
+				// emits is a divergence, not a permitted under-emit).
 				bp, bpok := bamlRaw(s, p, true)
-				if in.overDecline && !npok && bpok {
-					// Safe over-decline: native emitted nothing where BAML recovered a value
-					// (invalid enum member / transient extra field / lone `/`). Permitted —
-					// native never emits a wrong value; if it DOES emit it is checked below.
-					overDeclineWalk++
-					continue
-				}
 				cmp("PARTIAL", sh.name, in.name+":prefix", p, bp, bpok, np, npok)
 				strictCmp++
+				if rc != "" && npok && bpok && np == bp {
+					classEmit[rc]++
+				}
 			}
 		}
 	}
-	t.Logf("RIGOROUS TYPE-SPACE: %d shapes (%d admitted, %d declined) | %d final + %d strict-partial byte-exact vs live BAML | %d safe-over-decline + %d deferred-partial + %d mid-rune native-no-crash walks | %d divergences",
-		len(shapes), admittedN, declinedN, finalCmp, strictCmp, overDeclineWalk, deferredWalk, invalidWalk, mism)
+	t.Logf("RIGOROUS TYPE-SPACE: %d shapes (%d admitted, %d declined) | %d final + %d strict-partial byte-exact vs live BAML | %d deferred-partial + %d mid-rune native-no-crash walks | %d divergences",
+		len(shapes), admittedN, declinedN, finalCmp, strictCmp, deferredWalk, invalidWalk, mism)
+	// §5.9.1 per-trigger emission/skip pins — a claimed trigger emits byte-exact partials, and
+	// only the tracked-#583 residual classes are allowed a GENUINE under-emit (BAML emits &&
+	// native skips); a both-skip prefix (BAML also emits nothing) is agreement, not a residual.
+	for _, rc := range []string{"comment", "invalidenum", "extrafield", "barescalar_elem", "barescalar", "embeddedquote"} {
+		t.Logf("  recovery-class %-16s: %d byte-exact partial emits, %d GENUINE under-emits(BAML-emits,native-skips #583), %d both-skip agreements",
+			rc, classEmit[rc], classSkip[rc], classBothSkip[rc])
+	}
+	// CLAIMED triggers: each must emit byte-exact partials (anti-omission — a generator
+	// regression that drops the trigger sends this to 0 and FAILS) AND have ZERO under-emits (a
+	// skip would already FAIL the strict cmp above; this pins the invariant explicitly).
+	for _, rc := range []string{"comment", "invalidenum", "extrafield", "barescalar_elem"} {
+		if classEmit[rc] == 0 {
+			t.Errorf("anti-omission: CLAIMED recovery-class %q produced 0 byte-exact partial emits (generator/trigger regression)", rc)
+		}
+		if classSkip[rc] != 0 {
+			t.Errorf("STRICT recovery-class %q had %d under-emit(s) — a claimed trigger must reproduce every BAML partial byte-exact", rc, classSkip[rc])
+		}
+	}
+	// RETAINED-DECLINED triggers (tracked #583): each still emits many byte-exact partials
+	// (§5.9.1 hugely reduced the under-approximation) but retains a GENUINE (BAML emits && native
+	// skips) residual — bare-scalar direct-field NESTED-BRACE cascade (multiple-JSON candidate
+	// spill) and embedded-quote close. Both must remain a PURE under-approximation (0 divergent
+	// emits, gated by the deferred cmp above). The residual is counted only when BAML ALSO emits
+	// (a real under-emit), never a vacuous both-skip — those are tallied separately.
+	for _, rc := range []string{"barescalar", "embeddedquote"} {
+		if classEmit[rc] == 0 {
+			t.Errorf("anti-omission: deferred recovery-class %q produced 0 byte-exact partial emits", rc)
+		}
+	}
+	// EXACT genuine-residual count pins CONFINE the #583 debt to the intended condition
+	// (review P1 sub-issue 2): every counted skip is (BAML emits && native skips) on the named
+	// input class (num_in → nested-brace bare-scalar; escapedq → embedded-quote). A NEW genuine
+	// under-emit — e.g. a claimed FLAT direct-field frame regressing to a skip, or a new spill —
+	// RAISES the count and FAILS; a CLOSED residual LOWERS it and FAILS (forcing a promote-to
+	// -STRICT + #583 ledger update). Deterministic under the pinned generator (289/153/136); move
+	// only with an intentional grammar/behavior change. TestStream591GreedyRecoveryResidual pins a
+	// concrete witness of each so the mechanism itself can't silently vanish.
+	// barescalar is PARTIALLY claimed (flat direct-field is strict), so its residual is pinned
+	// EXACT in BOTH directions: a new under-emit (e.g. a claimed flat frame now skipping) RAISES
+	// it and FAILS, a closed residual LOWERS it and FAILS. The 20 nested-brace prefixes are short
+	// and embedded-quote-free, so this count is timeout-stable.
+	const wantBareScalarResidual = 20
+	if classSkip["barescalar"] != wantBareScalarResidual {
+		t.Errorf("barescalar GENUINE residual drift: got %d want %d (nested-brace bare-scalar cascade). A higher count = a new under-emit (possibly a claimed flat frame now skipping); a lower count = residual closed. Update only after confirming intended.",
+			classSkip["barescalar"], wantBareScalarResidual)
+	}
+	// embeddedquote is FULLY declined; its residual is measured at 12587 genuine under-emits. A
+	// FLOOR (not an exact pin) catches a residual COLLAPSE — the debt silently closing — while
+	// tolerating a handful of BAML close-heuristic slow calls without flaking. A concrete
+	// embedded-quote witness is additionally pinned in TestStream591GreedyRecoveryResidual.
+	const minEmbeddedQuoteResidual = 12000
+	if classSkip["embeddedquote"] < minEmbeddedQuoteResidual {
+		t.Errorf("embeddedquote GENUINE residual collapse: got %d, want >=%d (measured 12587). If embedded-quote is now reproduced, promote it to STRICT and update the #583 ledger; else investigate the drop.",
+			classSkip["embeddedquote"], minEmbeddedQuoteResidual)
+	}
+	if bs, eq := classBothSkip["barescalar"], classBothSkip["embeddedquote"]; bs != 0 || eq != 0 {
+		t.Logf("note: both-skip agreements (BAML also emits nothing) barescalar=%d embeddedquote=%d (informational; not residuals)", bs, eq)
+	}
 
 	// ---- COUNT PIN + anti-omission structural invariants ----
 	// Structural invariant: the generative enumerator must produce >=1 ADMITTED root at EVERY
@@ -1227,5 +1350,267 @@ func TestStream7CDeferredHeuristics(t *testing.T) {
 			emit++
 		}
 		t.Logf("DEFERRED %s: FINAL byte-exact; %d/%d partials native under-emitted (skip), %d emitted byte-exact — 0 divergent/over-claim emits", c.name, skip, len(c.raw), emit)
+	}
+}
+
+// TestStream591GreedyRecovery is the §5.9.1 canonical exact-cadence proof for the CLAIMED
+// greedy-recovery triggers — the ones native now reproduces BAML byte-for-byte (removing the 7C
+// under-approximation). For each specimen it walks EVERY prefix and asserts native's partial is
+// byte-IDENTICAL to live BAML (emit-or-not AND payload) — a STRICT 0-skip cadence, not the
+// deferred under-approximation bound. It also pins a few golden frames from the §5.9.1 scope
+// transcript so a BAML behavior drift is caught even if native tracks it. The FINAL is asserted
+// separately (a valid-final trigger closes byte-exact; the invalid-enum final BOTH-errors).
+//
+// Covered (CLAIMED, strict): bare scalar in a list<string> ELEMENT; bare scalar in a DIRECT
+// string field for the FLAT placements (first/last/multi-string/then-int — no nested-brace
+// cascade); invalid direct enum; a transient extra field after a last unquoted scalar; a lone
+// slash before block- vs line-comment disambiguation (object-key AND array-element positions);
+// leading and nested pending comments; PLUS a non-trigger control (an extra field after a QUOTED
+// value — no cascade, both agree). Only the RETAINED-DECLINED residuals stay non-strict: the
+// direct-field NESTED-BRACE bare-scalar cascade and the embedded quote, whose genuine
+// (BAML-emits, native-skips) under-approximation is proven by TestStream591GreedyRecoveryResidual
+// and the differential's genuine-skip pins.
+func TestStream591GreedyRecovery(t *testing.T) {
+	dynclientCallGate(t)
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		t.Fatalf("NewDynclient: %v", err)
+	}
+	preserve := true
+	baml := func(s *bamlutils.DynamicOutputSchema, raw string, stream bool) (string, bool) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		res, e := dyn.DynamicParseRaw(ctx, dynclient.ParseRequest{Raw: raw, OutputSchema: s, PreserveSchemaOrder: &preserve, Stream: stream})
+		if e != nil {
+			return "", false
+		}
+		return string(res.Data), true
+	}
+	nat := func(s *bamlutils.DynamicOutputSchema, raw string) (string, bool) {
+		j, e := debaml.ParseNativeStreamPartial(context.Background(), s, raw)
+		if e != nil || j == nil {
+			return "", false
+		}
+		return string(j), true
+	}
+
+	listLast := tcls(fld("f", tlist(tstr())), fld("last", tstr())) // {f:list<string>,last:string}
+	enumLast := tcls(fld("f", tenum()), fld("last", tstr()))       // {f:E1,last:string}
+	nameAge := tcls(fld("name", tstr()), fld("age", tint()))       // {name:string,age:int}
+	strLast := tcls(fld("f", tstr()), fld("last", tstr()))         // {f:string,last:string}
+	nameF := tcls(fld("name", tstr()), fld("f", tstr()))           // {name:string,f:string}
+	abc := tcls(fld("a", tstr()), fld("b", tstr()), fld("c", tstr())) // {a:string,b:string,c:string}
+	fN := tcls(fld("f", tstr()), fld("n", tint()))                 // {f:string,n:int}
+
+	cases := []struct {
+		name       string
+		root       *ft
+		raw        string
+		finalError bool           // FINAL BOTH-errors (invalid enum)
+		golden     map[int]string // pinned §5.9.1 transcript frames (prefix len → exact BAML/native payload)
+	}{
+		{
+			name: "bare_scalar_list_element", root: listLast,
+			raw: `{"f":[5e0,"txt"],"last":"txt"}`,
+			golden: map[int]string{7: `{"f":["5"],"last":null}`, 9: `{"f":["5.0"],"last":null}`, 11: `{"f":["5.0",""],"last":null}`},
+		},
+		// CLAIMED direct-field bare scalar — FLAT placements (no nested-brace cascade), asserted
+		// STRICT here (0 skips, byte-exact every prefix). A regression that skips a claimed flat
+		// direct-field frame FAILS (the differential's num_in leg is deferred, so this focused
+		// live-oracle test is what enforces the flat direct-field claim — review P1 sub-issue 1).
+		{
+			// first field, followed by a string: the greedy cascade absorbs `,"last":"txt"` into
+			// f's raw span (evolving), and the evolving numeric display (5→"5", 5e→"5e", 5e0→"5.0").
+			name: "bare_scalar_direct_first", root: strLast,
+			raw: `{"f":5e0,"last":"txt"}`,
+			golden: map[int]string{6: `{"f":"5","last":null}`, 7: `{"f":"5e","last":null}`, 8: `{"f":"5.0","last":null}`, 10: `{"f":"5e0,\"","last":null}`, 21: `{"f":"5e0,\"last\":\"txt\"","last":null}`},
+		},
+		{
+			// LAST field: no following content, so a pure evolving-display case (no cascade).
+			name: "bare_scalar_direct_last", root: nameF,
+			raw: `{"name":"x","f":5e0}`,
+			golden: map[int]string{17: `{"name":"x","f":"5"}`, 19: `{"name":"x","f":"5.0"}`},
+		},
+		{
+			// first of three strings: a flat multi-field cascade (all following content quoted, no
+			// nested braces) — the greedy span absorbs `,"b":"y","c":"z"` and runs to EOF.
+			name: "bare_scalar_direct_multi", root: abc,
+			raw: `{"a":5e0,"b":"y","c":"z"}`,
+			golden: map[int]string{6: `{"a":"5","b":null,"c":null}`, 10: `{"a":"5e0,\"","b":null,"c":null}`},
+		},
+		{
+			// followed by an int field: the cascade absorbs `,"n":7` into f's raw string span; n is
+			// then absent → null. Still a FLAT cascade (no braces).
+			name: "bare_scalar_direct_then_int", root: fN,
+			raw: `{"f":5e0,"n":7}`,
+			golden: map[int]string{8: `{"f":"5.0","n":null}`, 10: `{"f":"5e0,\"","n":null}`},
+		},
+		{
+			name: "invalid_enum_direct", root: enumLast,
+			raw: `{"f":"NOPE","last":"txt"}`, finalError: true,
+			golden: map[int]string{11: `{"f":null,"last":null}`, 21: `{"f":null,"last":"t"}`, 25: `{"f":null,"last":"txt"}`},
+		},
+		{
+			name: "extra_field_after_unquoted_scalar", root: nameAge,
+			raw: `{"name":"Ada","age":36,"zz9":"e"}`,
+			golden: map[int]string{23: `{"name":"Ada","age":36}`, 24: `{"name":"Ada","age":null}`, 32: `{"name":"Ada","age":null}`},
+		},
+		{
+			// NON-trigger control: the extra field follows a QUOTED value (the last field is a
+			// string, closing at its own '"'), so there is NO greedy cascade — native already
+			// parsed+ignored the extra key like BAML, at every prefix. (An all-string class stays
+			// admitted; a non-last unquoted scalar would be declined by graphHasGreedyCommaRisk.)
+			name: "extra_field_after_quoted_control", root: tcls(fld("name", tstr()), fld("tag", tstr())),
+			raw: `{"name":"Ada","tag":"x","zz9":"e"}`,
+		},
+		{
+			name: "mid_comment_block", root: nameAge,
+			raw: `{"name":"Ada",/* m */"age":36}`,
+			golden: map[int]string{15: `{"name":"Ada","age":null}`, 21: `{"name":"Ada","age":null}`},
+		},
+		{
+			name: "mid_comment_line", root: nameAge,
+			raw: "{\"name\":\"Ada\",// m\n\"age\":36}",
+			golden: map[int]string{15: `{"name":"Ada","age":null}`},
+		},
+		{
+			name: "leading_comment", root: nameAge,
+			raw: `{/* c */"name":"Ada","age":36}`,
+			golden: map[int]string{2: `{"name":null,"age":null}`},
+		},
+		{
+			// Lone slash inside an ARRAY element (the §5.9.1 pending-comment array witness):
+			// block- and line-comment variants share the identical lone-`/` prefix, so native must
+			// emit the same partial for both until disambiguation.
+			name: "list_mid_comment_block", root: listLast,
+			raw: `{"f":["a",/* c */"b"],"last":"x"}`,
+			golden: map[int]string{11: `{"f":["a"],"last":null}`},
+		},
+		{
+			name: "list_mid_comment_line", root: listLast,
+			raw: "{\"f\":[\"a\",// c\n\"b\"],\"last\":\"x\"}",
+			golden: map[int]string{11: `{"f":["a"],"last":null}`},
+		},
+	}
+
+	for _, c := range cases {
+		s := tsSchema(c.root)
+		if debaml.SupportsNativeStream(s) != nil {
+			t.Fatalf("precondition: %s must be admitted", c.name)
+		}
+		// FINAL frame.
+		bf, bfok := baml(s, c.raw, false)
+		nf, nferr := debaml.ParseNativeStreamFinal(context.Background(), s, c.raw)
+		if c.finalError {
+			if bfok || nferr == nil {
+				t.Errorf("[%s FINAL] expected BOTH-error; BAML ok=%v, native err=%v", c.name, bfok, nferr)
+			}
+		} else if !bfok || nferr != nil || bf != string(nf) {
+			t.Errorf("[%s FINAL not byte-exact] BAML=%q(ok=%v) NATIVE=%q(err=%v)", c.name, bf, bfok, string(nf), nferr)
+		}
+		// STRICT partial cadence: native == BAML byte-exact at EVERY prefix (0 skips).
+		emit := 0
+		for i := 1; i <= len(c.raw); i++ {
+			p := c.raw[:i]
+			if !utf8.ValidString(p) {
+				continue
+			}
+			np, npok := nat(s, p)
+			bp, bpok := baml(s, p, true)
+			if npok != bpok || (npok && bpok && np != bp) {
+				t.Errorf("[%s STRICT %d] p=%q BAML(%v)=%s NATIVE(%v)=%s", c.name, i, p, bpok, bp, npok, np)
+			}
+			if g, ok := c.golden[i]; ok {
+				if !bpok || bp != g {
+					t.Errorf("[%s GOLDEN DRIFT %d] p=%q BAML=%q(ok=%v) want golden %q", c.name, i, p, bp, bpok, g)
+				}
+				if !npok || np != g {
+					t.Errorf("[%s GOLDEN %d] p=%q native=%q(ok=%v) want %q", c.name, i, p, np, npok, g)
+				}
+			}
+			if npok {
+				emit++
+			}
+		}
+		t.Logf("CLAIMED %s: %d/%d prefixes byte-exact vs live BAML (strict, 0 divergences)", c.name, emit, len(c.raw))
+	}
+}
+
+// TestStream591GreedyRecoveryResidual proves the two RETAINED-DECLINED #583 residuals are GENUINE
+// under-approximations — at a NAMED witness, BAML EMITS a partial while native SKIPS (a real
+// under-emit), and native NEVER over-claims (any emit is byte-exact). This confines the residual
+// to the intended condition (nested-brace bare-scalar cascade / embedded-quote close, review P1
+// sub-issue 2): the differential's genuine-skip pin only counts (BAML emits && native skips) per
+// named input class, and THIS test pins a concrete witness so a silently-closed residual (the
+// debt fully reproduced) or a drifted witness FAILS loudly instead of the pin passing vacuously.
+func TestStream591GreedyRecoveryResidual(t *testing.T) {
+	dynclientCallGate(t)
+	dyn, err := testutil.NewDynclient(TestEnv)
+	if err != nil {
+		t.Fatalf("NewDynclient: %v", err)
+	}
+	preserve := true
+	baml := func(s *bamlutils.DynamicOutputSchema, raw string) (string, bool) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		res, e := dyn.DynamicParseRaw(ctx, dynclient.ParseRequest{Raw: raw, OutputSchema: s, PreserveSchemaOrder: &preserve, Stream: true})
+		if e != nil {
+			return "", false
+		}
+		return string(res.Data), true
+	}
+	nat := func(s *bamlutils.DynamicOutputSchema, raw string) (string, bool) {
+		j, e := debaml.ParseNativeStreamPartial(context.Background(), s, raw)
+		if e != nil || j == nil {
+			return "", false
+		}
+		return string(j), true
+	}
+
+	witnesses := []struct {
+		name string
+		root *ft
+		raw  string
+	}{
+		// NESTED-BRACE bare-scalar cascade: the greedy span absorbs the nested object and closes
+		// at the INNER '}', leaving trailing content native's streamFix declines — this is the
+		// spill into BAML's multiple-JSON candidate/pick-first selection the owner scoped OUT.
+		{"nested_brace_bare_scalar",
+			tcls(fld("a", tstr()), fld("outer", tcls(fld("inner", tcls(fld("s", tstr())))))),
+			`{"a":5e0,"outer":{"inner":{"s":"y"}}}`},
+		// EMBEDDED-QUOTE close: an unescaped mid-string quote from \" triggers BAML's close
+		// heuristic (greedily re-absorbing past the apparent close) native does not reproduce.
+		{"embedded_quote",
+			tcls(fld("f", tstr()), fld("last", tstr())),
+			`{"f":"a\"b\\c\n","last":"txt"}`},
+	}
+	for _, w := range witnesses {
+		s := tsSchema(w.root)
+		if debaml.SupportsNativeStream(s) != nil {
+			t.Fatalf("precondition: residual witness %q must be admitted", w.name)
+		}
+		genuine, overClaim := 0, 0
+		for i := 1; i <= len(w.raw); i++ {
+			p := w.raw[:i]
+			if !utf8.ValidString(p) {
+				continue
+			}
+			np, npok := nat(s, p)
+			bp, bpok := baml(s, p)
+			switch {
+			case npok && (!bpok || np != bp):
+				overClaim++
+				t.Errorf("[%s OVER-CLAIM %d] p=%q native=%q BAML=%q(ok=%v)", w.name, i, p, np, bp, bpok)
+			case !npok && bpok:
+				genuine++ // BAML EMITS, native SKIPS — a genuine under-approximation
+			}
+		}
+		if genuine == 0 {
+			t.Errorf("residual %q: expected >=1 GENUINE under-emit (BAML emits, native skips); got 0 — the residual may have SILENTLY CLOSED (promote to STRICT + update the #583 ledger) or the witness drifted", w.name)
+		}
+		if overClaim != 0 {
+			t.Errorf("residual %q: %d over-claim emit(s) — a retained-declined trigger must NEVER emit a byte-different partial", w.name, overClaim)
+		}
+		t.Logf("RESIDUAL %q: %d genuine under-emits (BAML emits, native skips), 0 over-claims — a PURE under-approximation", w.name, genuine)
 	}
 }

--- a/internal/debaml/coerce.go
+++ b/internal/debaml/coerce.go
@@ -3350,14 +3350,20 @@ func coerceStream(b *schema.Bundle, t schema.Type, input value) (json.RawMessage
 			// {"f":5e0} streams f:"5.0", the same as the final). coercePrimitiveString
 			// reproduces the display byte-exact (displayNumber / displayFloat64).
 			//
-			// An INCOMPLETE non-string (a bare unquoted scalar mid-token) is a #583 deferred
-			// greedy-recovery trigger: BAML streams an EVOLVING raw-span string (`{"f":5` →
-			// f:"5", `{"f":5e0` → f:"5.0") that native cannot reproduce byte-exact. Rather
-			// than emit a byte-DIFFERENT filler (the earlier null-replace path did), DECLINE
-			// the partial so native purely UNDER-emits / skips — never a divergent emit
-			// (owner A′ / ledger #583; the FINAL, a complete delimited scalar, still coerces).
+			// §5.9.1 greedy-recovery — bare-scalar pre-comma display. An INCOMPLETE unquoted
+			// NUMBER mid-token in a string field is streamed by BAML as its evolving serde/ryu
+			// display (`{"f":5`→f:"5", `{"f":5e0`→f:"5.0"), byte-IDENTICAL to the complete
+			// display below (semantic streaming does not gate a string target on done).
+			// coercePrimitiveString reproduces it byte-exact. An incomplete raw span that is
+			// not a valid number arrives as an Incomplete valString and is handled above
+			// (marshalJSON of the raw span — e.g. `5e`→"5e"). Any OTHER incomplete non-string
+			// (an incomplete bool/null keyword, never emitted into an admitted string field on
+			// this matrix) stays declined — a safe under-claim, never a byte-divergent emit.
 			if input.incomplete {
-				return nil, unsupported("stream: incomplete non-string into string field (#583 bare-scalar greedy-recovery deferred)")
+				if input.kind == valNumber {
+					return coercePrimitiveString(input, &coerceFlags{})
+				}
+				return nil, unsupported("stream: incomplete non-number/non-string into string field (greedy-recovery)")
 			}
 			return coercePrimitiveString(input, &coerceFlags{})
 		}
@@ -3393,9 +3399,53 @@ func coerceStreamDoneLeaf(b *schema.Bundle, t schema.Type, input value) (json.Ra
 	}
 	out, err := coerce(b, t, input, &coerceFlags{})
 	if err != nil {
+		// §5.9.1 greedy-recovery — invalid-enum partial disposition. A COMPLETE
+		// done-required leaf that PROVABLY fails coercion is, in PARTIAL (stream) mode,
+		// BAML's partial-unparseable disposition, NOT a whole-parse fallback: the leaf
+		// coerces to an error, the class/list/map records the field as unparsed, and the
+		// PARTIAL value is emitted with that field nulled (class deletion_nulls) / dropped
+		// (list/map), while the FINAL non-stream parse still errors on the required field
+		// (LIVE-CAPTURED: {f:E1,last:string} with "NOPE" streams {"f":null,"last":...} then
+		// the terminal final ERRORS — same as BAML). Reuse errStreamDeleted (the parent
+		// container already null-fills / drops it, identical to an incomplete done value).
+		//
+		// Scoped to a PROVEN match_string miss — a complete enum or string-literal value
+		// from a STRING input, whose fold is now BAML-exact (bamlunicode, #555 Slice 2), so
+		// a native coercion failure equals a BAML failure. This is the SAME proven-error
+		// whitelist coerceStreamList already uses (provenListItemError) to drop a bad
+		// list<enum>/list<litstr> child, so a direct enum FIELD and an enum LIST ELEMENT now
+		// share one disposition. An UNPROVEN failure (native stricter than BAML — a numeric
+		// overflow, an ambiguous conversion) still DECLINES so the whole stream falls back;
+		// never a blanket null on every coercion failure.
+		if streamCompleteLeafUnparseable(t, input) {
+			return nil, errStreamDeleted
+		}
 		return nil, unsupported(fmt.Sprintf("stream: done-required leaf did not cleanly coerce: %v", err))
 	}
 	return out, nil
+}
+
+// streamCompleteLeafUnparseable reports whether a COMPLETE leaf value that FAILED
+// coercion is a PROVEN BAML non-match native may treat as a partial-unparseable
+// deletion (class null / list-map drop) rather than a whole-stream fallback. It is
+// deliberately NARROW — a match_string target (enum, string-literal) coerced from a
+// STRING, where the fold is proven BAML-exact (bamlunicode) so a native miss is a
+// certain BAML miss. Numeric / bool / int-or-bool-literal leaves are NOT included:
+// native is stricter than BAML there (inf/overflow/hex/underscore), so a failure is
+// not proven and must keep declining. Mirrors provenListItemError's enum/litstr arms
+// so a class enum field and a list<enum> element resolve identically.
+func streamCompleteLeafUnparseable(t schema.Type, input value) bool {
+	if input.kind != valString {
+		return false
+	}
+	switch t.Kind {
+	case schema.TypeEnum:
+		return true
+	case schema.TypeLiteral:
+		return t.Literal != nil && t.Literal.Kind == schema.LiteralString
+	default:
+		return false
+	}
 }
 
 // coerceStreamClass coerces an object into a class in stream mode, porting the

--- a/internal/debaml/fix.go
+++ b/internal/debaml/fix.go
@@ -3,6 +3,7 @@ package debaml
 import (
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 )
 
@@ -630,6 +631,22 @@ func (p *fixer) parseArrayStream() (value, error) {
 			p.pos++
 			continue
 		}
+		if p.s[p.pos] == '/' && p.pos == len(p.s)-1 {
+			// §5.9.1 lone-comment marker. A lone TERMINAL '/' in array-element position is
+			// BAML's PENDING COMMENT: not yet disambiguated '/*' vs '//', so in a non-object
+			// collection BAML's fixing parser IGNORES it (find_any_starting_value '/' with no
+			// next byte pushes nothing) and closes the array Incomplete at EOF — the pending
+			// element never materializes (LIVE-CAPTURED: {"v":["txt",/ streams {"v":["txt"]}).
+			// A complete '/*…*/' / '//…\n' AND an unterminated '/*…' / '//…' are already
+			// removed by stripJSONComments, so ONLY the lone terminal '/' reaches here; a '/'
+			// with a following non-comment byte stays declined (deferred to BAML). Object-KEY
+			// position is handled separately (parseUnquotedKey reads the '/' key, dropped at
+			// EOF); object-VALUE keeps declining (BAML keeps a '/' value as an unquoted string,
+			// not a pending comment — no admitted witness).
+			p.pos = len(p.s) // consume the pending marker so streamFix sees a clean EOF
+			arr.incomplete = true
+			return arr, nil
+		}
 		v, err := p.parseValueStream(arrayValueTerm)
 		if err != nil {
 			return value{}, err
@@ -777,7 +794,15 @@ func (p *fixer) parseUnquotedScalarStream(term string) (value, error) {
 		// Ran to EOF with no terminator → still streaming → Incomplete.
 		v, err := classifyScalar(raw)
 		if err != nil {
-			return value{}, err
+			// A token that is not (yet) a valid JSON number/bool/null literal — e.g. the
+			// partial `5e` of a streaming `5e0`. §5.9.1 greedy-recovery: for a STRING target
+			// BAML keeps the raw unquoted span as an Incomplete string (allow_as_string),
+			// streaming `{"f":5e`→f:"5e"; reproduce that raw span rather than decline. A
+			// done-required target (int/enum/…) sees an INCOMPLETE value and null-fills
+			// regardless of kind (coerceStreamDoneLeaf), so the raw span is safe there too.
+			// Only reachable at EOF (still streaming); a COMPLETE bare token terminated by a
+			// delimiter still classifies strictly below (a complete bareword stays declined).
+			return value{kind: valString, strV: raw, incomplete: true}, nil
 		}
 		v.incomplete = true
 		return v, nil
@@ -791,11 +816,13 @@ func (p *fixer) parseUnquotedScalarStream(term string) (value, error) {
 			// Comma FOLLOWED BY tight (non-space/newline, non-close) content: BAML's
 			// fixing parser CONSUMES the comma and keeps reading the unquoted object
 			// value PAST it (json_parse_state.rs InObjectValue), a GREEDY CASCADE that
-			// swallows every following field into one failed value — native's per-field
-			// parse cannot reproduce it (#546), so it DECLINES. Admission additionally
-			// declines any schema with a NON-LAST unquoted-scalar field, so no ADMITTED
-			// stream can reach this prefix.
-			return value{}, errFixUnsupported
+			// absorbs the following bytes into one raw string span. §5.9.1 greedy-recovery
+			// REPRODUCES that scan (greedyObjectValueTail) so native emits BAML's transient
+			// partial byte-exact: a string-target field keeps the raw swallowed span; an
+			// int/enum/other done-required field sees an INCOMPLETE span and null-fills
+			// (semantic-streaming deletion). The full valid object still wins at the final
+			// via strict parse. See greedyObjectValueTail for the exact InObjectValue rule.
+			return p.greedyObjectValueTail(start)
 		}
 		// Comma at EOF of the streamed prefix (next >= len) OR immediately followed by
 		// '}' (a TRAILING comma before the close, with no following field to greedy-
@@ -807,4 +834,79 @@ func (p *fixer) parseUnquotedScalarStream(term string) (value, error) {
 	}
 	// Terminated by a proper delimiter → Complete.
 	return classifyScalar(raw)
+}
+
+// greedyObjectValueTail reproduces BAML's fixing-parser InObjectValue greedy scan
+// (json_parse_state.rs should_close_unescaped_string, Pos::InObjectValue). It is
+// entered with p.pos AT a comma that BAML would CONSUME (the comma is followed by
+// tight content — not a space/newline/'}' and not EOF). `start` is the first byte
+// of the object value already read. From here BAML keeps absorbing bytes into the
+// current unquoted string until it reaches a genuine close, then classifies the
+// whole raw span as ONE string value:
+//
+//   - a comma whose NEXT byte is '\n'                → close BEFORE the comma, Complete;
+//   - a comma whose NEXT byte is ' ' AND the span so far is a "possible value"
+//     (numeric / true / false / null / identifier)  → close BEFORE the comma, Complete;
+//   - a comma at EOF (no following byte)             → close BEFORE the comma, Complete;
+//   - a '}'                                          → close BEFORE the '}', Complete;
+//   - any other byte (incl. the tight comma itself, quotes, colons, digits, tab, CR)
+//                                                    → absorb it, keep scanning;
+//   - EOF of the scan                                → close, Incomplete.
+//
+// The span is returned as a raw valString (never a number: it always contains at
+// least the absorbed comma, so it is not a strict JSON number). p.pos is left at the
+// close byte (comma / '}') or at EOF, so parseObjectStream resumes exactly as BAML's
+// object parser does. The comma+space+NON-possible-value BAML sub-branch (a buffer
+// look-ahead for a comment/new-key marker) is the one InObjectValue case not
+// reproduced here; it does not arise on the admitted matrix (an unquoted object
+// value there is always numeric → possible), so it DECLINES rather than risk an
+// over-claim. incomplete is set only at EOF, matching BAML's CompletionState.
+func (p *fixer) greedyObjectValueTail(start int) (value, error) {
+	i := p.pos
+	n := len(p.s)
+	closeAt := func(end int, incomplete bool) (value, error) {
+		p.pos = end
+		return value{kind: valString, strV: p.s[start:end], incomplete: incomplete}, nil
+	}
+	for i < n {
+		switch p.s[i] {
+		case ',':
+			if i+1 >= n {
+				return closeAt(i, false) // comma at EOF: close before comma, Complete
+			}
+			switch p.s[i+1] {
+			case '\n':
+				return closeAt(i, false)
+			case ' ':
+				if isPossibleUnquotedValue(p.s[start:i]) {
+					return closeAt(i, false)
+				}
+				// comma+space+non-possible: BAML's buffer look-ahead sub-branch (not
+				// reproduced) — decline so native under-claims instead of over-claiming.
+				return value{}, errFixUnsupported
+			default:
+				i++ // tight content after the comma → absorb the comma, keep scanning
+			}
+		case '}':
+			return closeAt(i, false) // close before '}', Complete
+		default:
+			i++
+		}
+	}
+	return closeAt(n, true) // scan ran to EOF → Incomplete
+}
+
+// isPossibleUnquotedValue mirrors BAML's InObjectValue is_possible_value test used
+// to decide whether a comma+space closes the unquoted object value: the trimmed span
+// parses as a float, equals true/false/null case-insensitively, or is an identifier
+// (contains neither a space nor a '(').
+func isPossibleUnquotedValue(span string) bool {
+	s := strings.TrimSpace(span)
+	if _, err := strconv.ParseFloat(s, 64); err == nil {
+		return true
+	}
+	if strings.EqualFold(s, "true") || strings.EqualFold(s, "false") || strings.EqualFold(s, "null") {
+		return true
+	}
+	return !strings.ContainsAny(span, " (")
 }

--- a/internal/debaml/stream_test.go
+++ b/internal/debaml/stream_test.go
@@ -141,13 +141,15 @@ func TestStream_IncompleteDoneRequiredScalarNulls(t *testing.T) {
 	// now CLAIMS it as COMPLETE (age=36), matching BAML parse-stream byte-exact
 	// (LIVE-CAPTURED). This closes the tight-comma-at-EOF transient.
 	mustStream(t, s, `{"name":"Ada","age":36,`, `{"name":"Ada","age":36}`)
-	// A comma FOLLOWED BY tight content (`36,"x"`) is BAML's GREEDY read: the
-	// unquoted value is consumed past the comma in a cascade native's per-field
-	// parse cannot reproduce (#546), so native DECLINES. Admission declines any
-	// schema with a NON-LAST unquoted-scalar field so no admitted stream reaches
-	// this prefix (here `age` IS last, so this raw is only an over-decline guard —
-	// not an admitted prefix).
-	requireStreamUnsupported(t, s, `{"name":"Ada","age":36,"extra"`)
+	// A comma FOLLOWED BY tight content (`36,"extra"`) is BAML's GREEDY InObjectValue
+	// read: the unquoted value is consumed PAST the comma as one raw span
+	// (`36,"extra"`), Incomplete. §5.9.1 greedy-recovery now REPRODUCES that cascade
+	// (greedyObjectValueTail): the greedy span is an Incomplete done-required int, so it
+	// is deleted and the class field is null-replaced — native CLAIMS the transient
+	// partial byte-exact (LIVE-CAPTURED: BAML streams {"name":"Ada","age":null} for a
+	// tight extra field after the last unquoted scalar; the full valid object restores
+	// age at the final). This is the transient-extra-field trigger (#583).
+	mustStream(t, s, `{"name":"Ada","age":36,"extra"`, `{"name":"Ada","age":null}`)
 }
 
 // TestStream_NumbersListDropsIncompleteTail pins the NUMBERS behavior: a partial

--- a/internal/nativebody/nanollmprepare/dynamic/stream_differential_integration_test.go
+++ b/internal/nativebody/nanollmprepare/dynamic/stream_differential_integration_test.go
@@ -238,6 +238,9 @@ func streamDiffFixtures() []streamDiffFixture {
 		Classes:    bamlutils.MustOrderedMap(bamlutils.OrderedKV("Inner", &bamlutils.DynamicClass{Properties: bamlutils.MustOrderedMap(bamlutils.OrderedKV("x", dstr()), bamlutils.OrderedKV("y", dint()))})),
 	}
 	answerScore := dsch(bamlutils.OrderedKV("answer", dstr()), bamlutils.OrderedKV("score", dint()))
+	// §5.9.1 greedy-recovery: bare scalar in a list<string> ELEMENT (the array closes each
+	// element at ',' / ']', no object-value cascade — CLAIMED strict).
+	fListLast := dsch(bamlutils.OrderedKV("f", &bamlutils.DynamicProperty{Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "string"}}), bamlutils.OrderedKV("last", dstr()))
 
 	return []streamDiffFixture{
 		{name: "person", schema: person, messages: userMsg("Give a person."),
@@ -254,6 +257,27 @@ func streamDiffFixtures() []streamDiffFixture {
 			deltas: contentDeltas("Here you go:\n", "```json\n", `{`, `"name": "`, `Ada`, `", "age": `, `36`, `}`, "\n`", "``", "`")},
 		{name: "answer_reasoning", schema: answerScore, messages: userMsg("Reason then answer."), reasoning: true,
 			deltas: []sseDelta{{Reasoning: "let me think"}, {Content: `{`}, {Content: `"answer": "`}, {Reasoning: " still"}, {Content: `hi`}, {Content: `", "score": `}, {Content: `5`}, {Content: `}`}}},
+		// §5.9.1 greedy-recovery — TRANSIENT EXTRA FIELD after a last unquoted scalar. The
+		// `36,` frame closes age=36 (comma at EOF); the tight extra key `"zz9"` then triggers
+		// BAML's greedy InObjectValue cascade absorbing `,"zz9":"e"` into age's raw span
+		// (Incomplete) so age is DELETED → transiently NULLED; the valid final restores age=36.
+		// Native reproduces that 36→null→36 cadence byte-exact over BOTH native legs with zero
+		// fallback (extra key ignored at final). CLAIMED.
+		{name: "extra_field", schema: person, messages: userMsg("Give a person."),
+			deltas: contentDeltas(`{`, `"name":"`, `Ada`, `","age":`, `36,`, `"zz9":"`, `e`, `"}`)},
+		// §5.9.1 greedy-recovery — LONE COMMENT MARKER. The delta `/` on its own is the pending
+		// comment (not yet `/*` vs `//`): native drops it and re-emits the prior class state,
+		// then the completed `/* m */` is stripped and the same state re-emitted (duplicate
+		// cadence), before age closes. CLAIMED. (A separate `/`-then-`*` split guarantees the
+		// duplicate partial cannot be coalesced away.)
+		{name: "mid_comment", schema: person, messages: userMsg("Give a person."),
+			deltas: contentDeltas(`{`, `"name":"`, `Ada`, `",`, `/`, `*`, ` m */`, `"age":`, `36`, `}`)},
+		// §5.9.1 greedy-recovery — BARE SCALAR in a list<string> ELEMENT. The evolving numeric
+		// token streams as its serde/ryu display (`5`→"5", `5e`→"5e", `5e0`→"5.0") inside the
+		// array element, then the array comma closes it and the second element grows normally.
+		// CLAIMED strict (no object-value cascade in an array).
+		{name: "bare_list_scalar", schema: fListLast, messages: userMsg("Give f and last."),
+			deltas: contentDeltas(`{`, `"f":[`, `5`, `e`, `0`, `,`, `"txt"`, `]`, `,"last":"`, `txt`, `"}`)},
 	}
 }
 
@@ -690,7 +714,9 @@ func assertRequestBodyParity(t *testing.T, oracle, native recordedLive) {
 // socket per leg — across several admitted fixtures and both modes.
 func TestStreamDifferential_Fragmentation(t *testing.T) {
 	all := streamDiffFixtures()
-	pick := map[string]bool{"person": true, "name_tags": true, "nested": true, "answer_reasoning": true}
+	pick := map[string]bool{"person": true, "name_tags": true, "nested": true, "answer_reasoning": true,
+		// §5.9.1 greedy-recovery triggers under byte-level TCP fragmentation on BOTH native legs.
+		"extra_field": true, "mid_comment": true, "bare_list_scalar": true}
 	for _, f := range all {
 		if !pick[f.name] {
 			continue


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## §5.9.1 greedy-recovery — reproduce BAML's greedy-recovery partial cadence (#583)

Reproduces BAML's jsonish **greedy-recovery transient partial cadence BYTE-FOR-BYTE** so the native streaming lane **CLAIMS** the bounded triggers — removing the 7C "final-consistent under-approximation" — **without ever over-claiming** on the no-fallback streaming path. Builds on #555 Slice 2 (`bamlunicode` `match_string`). BAML oracle: stock **v0.223.0** (`85247f4`).

### Triggers: CLAIMED vs RETAINED-DECLINED

| Trigger | Result | Mechanism |
|---|---|---|
| Lone `/` comment marker | **CLAIMED (strict)** | object-key drop already exact; **array-element** lone terminal `/` → BAML pending-comment drop → close Incomplete |
| Invalid enum member | **CLAIMED (strict)** | complete PROVEN-invalid enum/str-literal (match_string miss, bamlunicode) → partial deletion → class null / list-map drop; **FINAL still errors** |
| Transient extra field | **CLAIMED (strict)** | greedy `InObjectValue` scan absorbs `,"zz9":"e"` into the last unquoted scalar's raw span (Incomplete) → done-required delete → transient null; valid final restores it |
| Bare scalar in `list<string>` element | **CLAIMED (strict)** | array closes each element at `,`/`]` (no object-value cascade); evolving serde/ryu display `5`→"5", `5e`→"5e", `5e0`→"5.0" |
| Bare scalar in a DIRECT string field | **CLAIMED (flat + display)**, residual **RETAINED-DECLINED** | flat cascade + evolving display byte-exact (per-specimen skips 15→0). **Residual = the NESTED-BRACE cascade** (greedy span absorbs a nested `}` + trailing content), which spills into BAML's multiple-JSON candidate/pick-first selection → tracked **#583** (owner: *attempt; retain if it spills into candidate/scoring machinery*) |
| Embedded quote in a string | **RETAINED-DECLINED** | unchanged; tracked **#583** (condition: a funded 6–10-week jsonish fixing-parser port) |

Native purely under-approximates every residual (**0 divergent emits**).

### Native changes (confined to `internal/debaml`)
- **`fix.go`** — `greedyObjectValueTail` (ports `json_parse_state.rs` `InObjectValue`: comma+tight → absorb raw span; close before a comma-with-close-lookahead / `}` / EOF); incomplete non-number token kept as a raw string span (`allow_as_string`); array-element lone-terminal-`/` pending-comment drop.
- **`coerce.go`** — complete PROVEN-invalid enum/string-literal → `errStreamDeleted` in stream/partial (final unchanged, still errors); incomplete unquoted number in a string field → serde/ryu display.

### Proof (`internal/debaml` + streaming differential tests)
- **289-shape type-space differential made STRICT** for the covered triggers: **290,822 strict-partial byte-exact comparisons** vs live BAML across every valid-UTF-8 prefix, **0 divergences**; new per-recovery-class emission/skip pins (comment 13084/0, invalidenum 5284/0, extrafield 10323/0, barescalar_elem 6995/0 — all **0-skip**; barescalar 14508/**20**, embeddedquote 11472/**12587** — tracked-#583 residual).
- **`TestStream591GreedyRecovery`** — canonical live-BAML transcript, 9 specimens incl. a non-trigger control (extra field after a QUOTED value), block/line disambiguation, and array-position pending-comment; strict 0-skip + pinned golden frames.
- **Two-native-leg loopback** extended with `extra_field` / `mid_comment` / `bare_list_scalar` fixtures under **byte-level TCP fragmentation** — byte-exact wire parity on both native legs, **zero BAML fallback, one socket**.

### Invariants held
- **No admission widening** — `SupportsNativeStream` unchanged; 289/153/136 count pin held.
- No change to `stream_serve` fallback wiring, `nativeserve/admission`, `nanollmprepare` production, `provideroracle`, `embed.go`, or `nativeworker_module.tar` (byte-fresh; `internal/debaml` is not in it). The only `nanollmprepare` touch is **test-only** loopback fixtures.
- 7C invariants intact: transport-claim = point of no return, exactly one physical request, decline pre-transport only, native-only partial+final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming recovery for incomplete numbers, unquoted values, comments, and list elements.
  * Better handling of malformed or incomplete values, including safely removing unrecoverable fields instead of abandoning the entire stream.
  * Improved recovery for trailing slashes and tightly formatted object values.

* **Tests**
  * Expanded streaming compatibility coverage across UTF-8 prefixes and fragmented network delivery.
  * Added validation for greedy recovery and confirmed remaining deferred cases do not over-claim output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->