### PR TITLE
debaml(583 field-alias): admit non-colliding field @alias — static BAML v0.223 alias-only parity

### DIFF
--- a/integration/stream_admitted_acceptance_test.go
+++ b/integration/stream_admitted_acceptance_test.go
@@ -11,10 +11,12 @@ package integration
 //     native-only FINAL closure reproduces BAML's final byte-for-byte (and every
 //     streaming PREFIX partial matches BAML's parse-stream) — so no admitted fixture
 //     can be a BAML-success / native-fallback on the native-only lane (I6 / §5.9);
-//   - the §11-narrowed shapes (single string-absorbing root, non-string map key, field
-//     @alias, union/optional, scalar map value) DECLINE pre-transport (#555 Slice 2 admits
+//   - the §11-narrowed shapes (single string-absorbing root, non-string map key,
+//     union/optional, scalar map value) DECLINE pre-transport (#555 Slice 2 admits
 //     non-ASCII literal/enum/name, field @description, and class/enum @alias/@description;
-//     only field @alias stays narrowed — the canonical-key divergence, #583);
+//     #583 teardown admits a NON-colliding field @alias too — native's rendered-name-only
+//     matcher is byte-exact vs static BAML v0.223's alias-only jsonish coercer — while a
+//     FUZZY alias/canonical rendered-name collision stays a #583 residual decline);
 //   - comment-bearing FINALS — including UNTERMINATED (to-EOF) block and line
 //     comments after a closed object — match BAML byte-exact (the P1/P2-c cases).
 //

--- a/integration/stream_typespace_differential_test.go
+++ b/integration/stream_typespace_differential_test.go
@@ -331,6 +331,35 @@ func boolOrFloat(t *ft) bool {
 	return false
 }
 
+// shapeHasFieldAlias reports whether any class in the shape tree carries a field @alias. Such
+// shapes are ADMITTED (the #583 gate is gone) but MUST be carved out of this harness's BAML
+// byte-comparison: the BAML leg is dynclient.DynamicParseRaw, whose TypeBuilder bridge DROPS
+// field aliases (canonical-only), so comparing native(alias-only) vs BAML(canonical-only) would
+// FALSELY diverge on every alias-key input. Their final + every-streaming-prefix byte parity is
+// proven vs the STATIC BAML v0.223 oracle in internal/debaml (TestParse_Alias*), never here.
+func shapeHasFieldAlias(t *ft) bool {
+	if t.kind == "class" {
+		for _, f := range t.flds {
+			if f.alias != "" {
+				return true
+			}
+			if shapeHasFieldAlias(f.t) {
+				return true
+			}
+		}
+		return false
+	}
+	if t.elem != nil && shapeHasFieldAlias(t.elem) {
+		return true
+	}
+	for _, a := range t.arms {
+		if shapeHasFieldAlias(a) {
+			return true
+		}
+	}
+	return false
+}
+
 func graphBad(t *ft) bool {
 	switch t.kind {
 	case "map":
@@ -365,14 +394,18 @@ func graphBad(t *ft) bool {
 		return t.litKind == "bool"
 	case "class":
 		// #555 Slice 2: a non-ASCII class/field NAME, a class @alias/@description, and a
-		// field @description are ADMITTED (they don't change key matching / are handled by
-		// the final coercer). A field @alias is the ONE metadata shape that DIVERGES
-		// (LIVE-PROVEN): native's field-key matcher checks only Name.RenderedName() (the
-		// alias), missing the canonical key BAML also matches — so it stays declined (#583).
+		// field @description are ADMITTED. #583 teardown: a NON-colliding field @alias is now
+		// ADMITTED too — native's rendered-name-only matcher (coerceClass/coerceStreamClass,
+		// Name.RenderedName()) is byte-exact vs static BAML v0.223's alias-only jsonish coercer.
+		// (The earlier "BAML matches the canonical key too" premise was the DYNAMIC parse
+		// bridge DROPPING aliases -> canonical-only, NOT static BAML.) Only a FUZZY
+		// alias/canonical rendered-name COLLISION stays declined in production
+		// (aliasRenderedNameCollision); this enumerator emits no colliding aliases, so no shape
+		// trips it — the per-shape admission assertion (SupportsNativeStream == expectAdmit)
+		// keeps that honest. The alias shapes' BYTE parity is proven separately by the STATIC
+		// oracle (internal/debaml TestParse_Alias*), NOT this dynamic-oracle byte leg (which
+		// drops aliases and cannot judge them — see the carve-out in the differential loop).
 		for i, f := range t.flds {
-			if f.alias != "" {
-				return true
-			}
 			if i < len(t.flds)-1 && unquotedScalar(f.t) {
 				return true
 			}
@@ -570,7 +603,9 @@ type genShape struct {
 //	   field @alias (ASCII + non-ASCII) / @description / non-ASCII name; enum @alias /
 //	   non-ASCII name; enum-VALUE @alias / @DESCRIPTION / non-ASCII value; non-ASCII
 //	   string-literal value} at each applicable position {root field, nested field, nested
-//	   class, enum value, list element} — plus class-in-container and union. All DECLINE.
+//	   class, enum value, list element} — these metadata kinds all ADMIT (#555 Slice 2 + the
+//	   #583 field-@alias teardown; field-@alias shapes are carved out of the BAML byte leg and
+//	   proven vs the static oracle), while the class-in-container and union specimens DECLINE.
 //
 // The recovery battery (batteryFor) is applied BY FIELD PATH into nested classes AND into
 // permitted LIST ELEMENTS (escaped/Unicode/deferred string, enum/literal casefold, bad-child),
@@ -776,9 +811,11 @@ func enumerate() []genShape {
 
 	// C. metadata × position (#555 Slice 2). Non-ASCII names/values, field @description, and
 	// class/enum @alias/@description ADMIT (no key-matching divergence — folds via bamlunicode,
-	// enum values via enumMatchCandidates); the battery byte-walks them vs live BAML. Field
-	// @alias is the ONE case that DECLINES (graphBad) — native's field-key matcher checks only
-	// the rendered alias and misses the canonical key BAML also matches (#583).
+	// enum values via enumMatchCandidates); the battery byte-walks them vs live BAML. #583
+	// teardown: a NON-colliding field @alias now ADMITS too (native's rendered-name-only matcher
+	// is byte-exact vs static BAML v0.223's alias-only jsonish coercer) — but because THIS
+	// harness's BAML leg (DynamicParseRaw) DROPS field aliases, alias shapes are carved out of the
+	// byte comparison (shapeHasFieldAlias) and proven vs the STATIC oracle in internal/debaml.
 	// class-level metadata on a NESTED class (the dynamic root has no class object).
 	for _, m := range []struct {
 		name string
@@ -1113,6 +1150,18 @@ func TestStream7CTypeSpaceDifferential(t *testing.T) {
 		if sh.root.kind == "class" {
 			perArityAdmit[len(sh.root.flds)]++
 		}
+		// #583 carve-out: a field-@alias shape IS admitted (the admission assertion above
+		// already proved SupportsNativeStream claims it), but its BYTE parity is NOT judgeable
+		// by this harness — the BAML leg (DynamicParseRaw) drops field aliases, so the battery's
+		// canonical-key inputs (rootObj emits f.name, the CANONICAL name) would make BAML
+		// canonical-only match while native is alias-only, a guaranteed FALSE divergence. Byte
+		// parity for these shapes is proven vs the STATIC oracle (internal/debaml
+		// TestParse_AliasedFieldMatchesRenderedNameOnly + TestParse_AliasStreamRenderedName-
+		// Equivalence: final + every valid-UTF-8 prefix). NEVER native-alias-only vs
+		// dynamic-canonical-only (scope §"Reconcile the type-space differential").
+		if shapeHasFieldAlias(sh.root) {
+			continue
+		}
 		for _, in := range batteryFor(sh.root) {
 			rc := recoveryClass(in.name)
 			// FINAL byte-exact for EVERY input (incl. deferred — the complete frame
@@ -1214,7 +1263,7 @@ func TestStream7CTypeSpaceDifferential(t *testing.T) {
 	// input class (num_in → nested-brace bare-scalar; escapedq → embedded-quote). A NEW genuine
 	// under-emit — e.g. a claimed FLAT direct-field frame regressing to a skip, or a new spill —
 	// RAISES the count and FAILS; a CLOSED residual LOWERS it and FAILS (forcing a promote-to
-	// -STRICT + #583 ledger update). Deterministic under the pinned generator (289/153/136); move
+	// -STRICT + #583 ledger update). Deterministic under the pinned generator (289/157/132); move
 	// only with an intentional grammar/behavior change. TestStream591GreedyRecoveryResidual pins a
 	// concrete witness of each so the mechanism itself can't silently vanish.
 	// barescalar is PARTIALLY claimed (flat direct-field is strict), so its residual is pinned
@@ -1250,9 +1299,16 @@ func TestStream7CTypeSpaceDifferential(t *testing.T) {
 	}
 	// Exact pinned totals — any future omission (or accidental addition) changes these and fails.
 	// #555 Slice 2 admitted the non-ASCII name/value shapes + field @description + class/enum
-	// @alias/@description (134→153); field @alias stays declined (the ONE LIVE-PROVEN
-	// canonical-key divergence — native's matcher checks only the rendered alias, #583).
-	const wantTotal, wantAdmit, wantDeclined = 289, 153, 136
+	// @alias/@description (134→153). #583 teardown then admitted the 4 NON-colliding field-@alias
+	// shapes — meta_{root,nested}fld_fldalias and their _nonascii twins — moving 153→157 admitted
+	// and 136→132 declined: native's rendered-name-only matcher (coerceClass/coerceStreamClass)
+	// is byte-exact vs static BAML v0.223's ALIAS-ONLY jsonish coercer, so the blanket decline was
+	// dropped. Those 4 are carved OUT of the DynamicParseRaw byte leg above (that bridge drops
+	// field aliases -> canonical-only and cannot judge alias parity) and are proven vs the STATIC
+	// oracle instead (internal/debaml TestParse_AliasedFieldMatchesRenderedNameOnly +
+	// TestParse_AliasStreamRenderedNameEquivalence). A FUZZY alias/canonical rendered-name
+	// collision would still decline (aliasRenderedNameCollision), but this enumerator emits none.
+	const wantTotal, wantAdmit, wantDeclined = 289, 157, 132
 	if len(shapes) != wantTotal || admittedN != wantAdmit || declinedN != wantDeclined {
 		t.Errorf("COUNT PIN drift: got total=%d admitted=%d declined=%d; want total=%d admitted=%d declined=%d "+
 			"(update the pin only after confirming the grammar/loops intentionally changed)",

--- a/internal/debaml/parse_test.go
+++ b/internal/debaml/parse_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/invakid404/baml-rest/bamlutils"
 )
@@ -1278,24 +1280,146 @@ func TestParse_TopLevelArrayDeclines(t *testing.T) {
 	requireUnsupported(t, personSchema(), `[1,2,3]`)
 }
 
+// TestParse_AliasedFieldMatchesRenderedNameOnly is the STATIC-ORACLE alias FINAL matrix.
+// Native reproduces static/jsonish BAML v0.223 EXACTLY: a field @alias is ALIAS-ONLY — a
+// class key is matched against the field's RENDERED (alias) name only (jsonish
+// coerce_class.rs:205-222 uses Name::rendered_name, never real_name), and the OUTPUT is
+// keyed by the canonical real_name. The canonical name is therefore an EXTRA key, and the
+// aliased field is supplied ONLY by its alias.
+//
+// This is the parity oracle the served-native path targets, NOT the dynamic bridge: the
+// live output_format renderer EMITS the alias (internal/schema/outputformat/render.go:412,
+// f.Name.RenderedName()), so a model told to emit `heading` emits `heading` and native
+// parses `heading` — self-consistent (#583 Step-0). The dynamic DynamicParseRaw bridge drops
+// aliases (canonical-only) and cannot judge this — it is deliberately NOT the oracle here.
 func TestParse_AliasedFieldMatchesRenderedNameOnly(t *testing.T) {
-	// Field `name` is rendered as alias `full_name`. BAML's jsonish class
-	// coercer matches the rendered (alias) key ONLY; the canonical key
-	// `name` is an extra key and the rendered field is missing. Native must
-	// agree to stay drift-free.
+	// Multi-field root so single-field implied-object recovery cannot mask key behavior
+	// (scope §"Differential proof plan").
 	s := &bamlutils.DynamicOutputSchema{
 		Properties: props(
-			kv("name", &bamlutils.DynamicProperty{Type: "string", Alias: "full_name"}),
-			kv("age", intProp()),
+			kv("title", &bamlutils.DynamicProperty{Type: "string", Alias: "heading"}),
+			kv("last", strProp()),
 		),
 	}
-	// Alias present (exact) -> claimed; emitted under the canonical field name.
-	mustParse(t, s, `{"full_name":"Ada","age":36}`, `{"name":"Ada","age":36}`)
-	// Canonical name present instead of the rendered alias -> the rendered
-	// field `full_name` has no EXACT key match -> DECLINE. (BAML may even
-	// fuzzy-match "name" as a substring of "full_name" and succeed, so native
-	// must not claim a missing-required error.)
-	requireUnsupported(t, s, `{"name":"Ada","age":36}`)
+	// alias key (exact) -> claimed; emitted under the CANONICAL field name.
+	mustParse(t, s, `{"heading":"Ada","last":"z"}`, `{"title":"Ada","last":"z"}`)
+	// case-fold alias key -> match_string case-insensitive pass; canonical output.
+	mustParse(t, s, `{"HEADING":"Ada","last":"z"}`, `{"title":"Ada","last":"z"}`)
+	// accent-fold alias key -> match_string accent/NFKD pass (proven byte-exact via
+	// bamlunicode, #555). Same rendered-name match path the canonical name would use.
+	mustParse(t, s, `{"héading":"Ada","last":"z"}`, `{"title":"Ada","last":"z"}`)
+	// both keys, EITHER raw order: only the alias `heading` is a candidate, so it supplies
+	// `title`; the canonical `title` key stays an extra (no canonical-vs-alias precedence
+	// rule, because canonical is not a candidate). Scope table, alias-scope.md:72.
+	mustParse(t, s, `{"title":"C","heading":"Ada","last":"z"}`, `{"title":"Ada","last":"z"}`)
+	mustParse(t, s, `{"heading":"Ada","title":"C","last":"z"}`, `{"title":"Ada","last":"z"}`)
+	// canonical key ONLY -> the aliased field has no rendered-name match -> it is MISSING
+	// (required, non-defaultable). Static BAML errors on this final too; native returns the
+	// fallback sentinel rather than claim a byte-different value (parity-safe: never over-claim).
+	requireUnsupported(t, s, `{"title":"C","last":"z"}`)
+
+	// @description ALONGSIDE @alias adds NO extra key candidate: class field-key matching
+	// destructures only Name (alias-scope.md:96-102); the description is separate state.
+	sd := &bamlutils.DynamicOutputSchema{
+		Properties: props(
+			kv("title", &bamlutils.DynamicProperty{Type: "string", Alias: "heading", Description: "the title"}),
+			kv("last", strProp()),
+		),
+	}
+	mustParse(t, sd, `{"heading":"Ada","last":"z"}`, `{"title":"Ada","last":"z"}`)
+	requireUnsupported(t, sd, `{"title":"C","last":"z"}`)
+
+	// NESTED-class alias field: the alias applies inside the child object identically
+	// (rendered-name-only match, canonical output key).
+	sn := &bamlutils.DynamicOutputSchema{
+		Properties: props(
+			kv("name", strProp()),
+			kv("inner", &bamlutils.DynamicProperty{Ref: "Inner"}),
+		),
+		Classes: bamlutils.MustOrderedMap(
+			bamlutils.OrderedKV("Inner", &bamlutils.DynamicClass{
+				Properties: props(
+					kv("title", &bamlutils.DynamicProperty{Type: "string", Alias: "heading"}),
+					kv("y", intProp()),
+				),
+			}),
+		),
+	}
+	mustParse(t, sn, `{"name":"n","inner":{"heading":"Ada","y":5}}`, `{"name":"n","inner":{"title":"Ada","y":5}}`)
+	requireUnsupported(t, sn, `{"name":"n","inner":{"title":"C","y":5}}`)
+}
+
+// TestParse_AliasStreamRenderedNameEquivalence proves the STATIC-ORACLE alias parity at the
+// FINAL and at EVERY valid-UTF-8 streaming prefix, WITHOUT a live BAML call.
+//
+// The insight: an @alias changes ONLY (a) the rendered name used for KEY matching and (b) the
+// canonical name used for the OUTPUT key — nothing about streaming cadence. So native's
+// stream/final for an ALIAS schema {title @alias("heading"), last} must equal, byte-for-byte,
+// native's stream/final for the EQUIVALENT schema whose field is literally NAMED by that
+// rendered name {heading, last}, with the output key relabeled canonical<-rendered. The
+// no-alias (rendered==canonical) coercion is a plain 2-string-field class already proven
+// byte-exact vs LIVE BAML by the type-space differential; this equivalence transfers that live
+// proof onto the alias schema — exactly static BAML v0.223 (Name::rendered_name for matching,
+// real_name for output). The battery includes conforming (alias key), case/accent/punct/NFKD
+// variants (all routed through the SAME match_string path), the non-conforming canonical key
+// (field missing on BOTH), both-keys, and the absent field.
+func TestParse_AliasStreamRenderedNameEquivalence(t *testing.T) {
+	aliasS := func() *bamlutils.DynamicOutputSchema {
+		return &bamlutils.DynamicOutputSchema{Properties: props(
+			kv("title", &bamlutils.DynamicProperty{Type: "string", Alias: "heading"}),
+			kv("last", strProp()),
+		)}
+	}
+	renderedS := func() *bamlutils.DynamicOutputSchema {
+		return &bamlutils.DynamicOutputSchema{Properties: props(
+			kv("heading", strProp()),
+			kv("last", strProp()),
+		)}
+	}
+	// Relabel the equivalent schema's canonical output key `heading` -> `title`. Only the
+	// object KEY ever spells `"heading":`; string values in this battery never do.
+	rename := func(s string) string { return strings.ReplaceAll(s, `"heading":`, `"title":`) }
+
+	ctx := context.Background()
+	for _, raw := range []string{
+		`{"heading":"h","last":"y"}`,             // alias key (conforming)
+		`{"HEADING":"h","last":"y"}`,             // case-fold alias key
+		`{"héading":"h","last":"y"}`,             // accent/NFKD alias key
+		`{"head-ing":"h","last":"y"}`,            // punctuation variant (same match_string path)
+		`{"title":"x","last":"y"}`,               // canonical key (non-conforming: field missing on BOTH)
+		`{"heading":"h","title":"x","last":"y"}`, // both keys
+		`{"last":"y"}`,                           // aliased field absent
+	} {
+		a, r := aliasS(), renderedS()
+		// FINAL: same success/error disposition; on success, byte-identical after the relabel.
+		af, aerr := ParseNativeStreamFinal(ctx, a, raw)
+		rf, rerr := ParseNativeStreamFinal(ctx, r, raw)
+		if (aerr == nil) != (rerr == nil) {
+			t.Errorf("[%s] FINAL disposition mismatch: alias err=%v rendered err=%v", raw, aerr, rerr)
+		} else if aerr == nil && string(af) != rename(string(rf)) {
+			t.Errorf("[%s] FINAL byte mismatch:\n alias   =%s\n rendered=%s\n renamed =%s", raw, af, rf, rename(string(rf)))
+		}
+		// PARTIAL cadence at every valid-UTF-8 prefix — emit/skip AND bytes must agree.
+		for i := 1; i <= len(raw); i++ {
+			p := raw[:i]
+			if !utf8.ValidString(p) {
+				continue // a mid-rune split; native is still exercised but not compared
+			}
+			ap, aperr := ParseNativeStreamPartial(ctx, a, p)
+			rp, rperr := ParseNativeStreamPartial(ctx, r, p)
+			if aperr != nil || rperr != nil {
+				t.Errorf("[%s @%d] unexpected partial error alias=%v rendered=%v", raw, i, aperr, rperr)
+				continue
+			}
+			if (ap == nil) != (rp == nil) {
+				t.Errorf("[%s @%d=%q] partial emit/skip mismatch: aliasEmit=%v renderedEmit=%v", raw, i, p, ap != nil, rp != nil)
+				continue
+			}
+			if ap != nil && string(ap) != rename(string(rp)) {
+				t.Errorf("[%s @%d=%q] PARTIAL byte mismatch:\n alias   =%s\n rendered=%s\n renamed =%s", raw, i, p, ap, rp, rename(string(rp)))
+			}
+		}
+	}
 }
 
 func TestParse_FencedJSONWithInlineBackticks(t *testing.T) {

--- a/internal/debaml/round6_stream_test.go
+++ b/internal/debaml/round6_stream_test.go
@@ -60,9 +60,10 @@ func TestRound6_StreamCadenceAndNarrows(t *testing.T) {
 	}
 
 	// §11 narrows: each disallowed shape declines pre-transport; int-last stays admitted.
-	// #555 Slice 2: field @description ADMITS (doesn't change key matching); field @alias
-	// DECLINES — native's field-key matcher checks only the rendered alias and misses the
-	// canonical key BAML also matches (LIVE-PROVEN divergence, #583 teardown).
+	// #555 Slice 2: field @description ADMITS (doesn't change key matching). #583 teardown:
+	// a NON-colliding field @alias now ADMITS too — native's rendered-name-only matcher is
+	// byte-exact vs static BAML v0.223's alias-only jsonish coercer; only a fuzzy alias/canonical
+	// rendered-name COLLISION stays declined (order-dependent BAML resolution unpinned, #583).
 	dp := func(p *bamlutils.DynamicProperty) *bamlutils.DynamicOutputSchema {
 		return sc(bamlutils.OrderedKV("name", str()), bamlutils.OrderedKV("v", p))
 	}
@@ -76,7 +77,8 @@ func TestRound6_StreamCadenceAndNarrows(t *testing.T) {
 		{"float", dp(&bamlutils.DynamicProperty{Type: "float"}), true},
 		{"map", dp(mapProp), true},
 		{"listbool", dp(&bamlutils.DynamicProperty{Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "bool"}}), true},
-		{"field_alias", sc(bamlutils.OrderedKV("title", &bamlutils.DynamicProperty{Type: "string", Alias: "ÉTAT"}), bamlutils.OrderedKV("last", str())), true},
+		{"field_alias", sc(bamlutils.OrderedKV("title", &bamlutils.DynamicProperty{Type: "string", Alias: "ÉTAT"}), bamlutils.OrderedKV("last", str())), false},
+		{"field_alias_collision", sc(bamlutils.OrderedKV("a", &bamlutils.DynamicProperty{Type: "string", Alias: "Foo"}), bamlutils.OrderedKV("bb", &bamlutils.DynamicProperty{Type: "string", Alias: "foo"})), true},
 		{"field_desc", sc(bamlutils.OrderedKV("title", &bamlutils.DynamicProperty{Type: "string", Description: "the title"}), bamlutils.OrderedKV("last", str())), false},
 		{"str_int_admitted", na, false},
 		{"str_liststr_admitted", sc(bamlutils.OrderedKV("name", str()), bamlutils.OrderedKV("tags", &bamlutils.DynamicProperty{Type: "list", Items: &bamlutils.DynamicTypeSpec{Type: "string"}})), false},

--- a/internal/debaml/stream_serve.go
+++ b/internal/debaml/stream_serve.go
@@ -93,11 +93,17 @@ func SupportsNativeStream(s *bamlutils.DynamicOutputSchema) error {
 // an UNSAFE nested class — >=4 fields, >=2 lists, or a bare enum/string-literal field (BAML's
 // nested-class start cadence there native cannot reproduce byte-exact); any non-last unquoted
 // scalar; any union/optional; ANY map<string,*> (declined outright — BAML
-// overwrite-on-duplicate-key); any non-string map key; ANY field @alias (BAML matches the
-// canonical field key too; native's matcher checks only the rendered alias — #583); ANY bool
-// or float (incl. bool literal); ANY bare null-typed field (the null-keyword streaming cadence);
-// and any class inside a list element or map value. (A field @description, class/enum
-// @alias/@description, and non-ASCII names/values are ADMITTED — no key-matching divergence.)
+// overwrite-on-duplicate-key); any non-string map key; a FUZZY field alias/canonical
+// rendered-name COLLISION (two fields whose rendered names fold-collide through match_string,
+// at least one an @alias — the byte-equal collision is already rejected at lowering,
+// internal/schema/index.go; BAML's order-dependent collision resolution across ordinary-coerce
+// vs try_cast is unpinned, a tracked #583 residual decline); ANY bool or float (incl. bool
+// literal); ANY bare null-typed field (the null-keyword streaming cadence); and any class inside
+// a list element or map value. (A NON-colliding field @alias is now ADMITTED — native reproduces
+// static BAML v0.223's ALIAS-ONLY rendered-name matching byte-exact: coerceClass/coerceStreamClass
+// match Name.RenderedName() only, so the alias is the sole key candidate and the canonical name is
+// an extra key, exactly as jsonish coerce_class does. A field @description, class/enum
+// @alias/@description, and non-ASCII names/values are ADMITTED too — no key-matching divergence.)
 //
 // NOTE (§5.9 owed debt, ledger #583): for these admitted schemas, five NON-conforming /
 // BAML-jsonish greedy-recovery INPUT classes — a bare unquoted scalar in a string field, an
@@ -184,22 +190,22 @@ func checkStreamRootSupported(b *schema.Bundle) error {
 		// cannot, so it excludes the shape pre-transport.)
 		return unsupported("stream: map with a non-string key type (BAML keeps non-member enum/literal keys native declines)")
 	}
-	if graphHasFieldAlias(b) {
-		// A field @alias is the ONE metadata case that DIVERGES (LIVE-PROVEN vs BAML
-		// v0.223.0): BAML matches a class key against the field's CANONICAL name too,
-		// but native's coerceClass/coerceStreamClass field-key matcher checks only
-		// Name.RenderedName() — which is the ALIAS when present — so it MISSES a response
-		// key that uses the canonical name. E.g. field `title @alias("heading")` on
-		// `{"title":"x",...}`: BAML emits {"title":"x"}, native emits {"title":null}.
-		// Decline any field @alias pre-transport. #583 teardown condition: make the
-		// field-key matcher check BOTH the canonical name AND the alias (like BAML), then
-		// drop this gate. Field @description, class/enum @alias/@description, non-ASCII
-		// names/values, and enum-VALUE @alias carry no such divergence and STAY admitted:
-		// class/enum type metadata is never matched as a key; a field description does not
-		// change the key candidate; and a complete enum/literal VALUE is coerced through
-		// the final coercer whose enumMatchCandidates already models rendered-name/alias/
-		// description candidates.
-		return unsupported("stream: field @alias (BAML also matches the canonical field key; native's matcher checks only the rendered alias — #583)")
+	if aliasRenderedNameCollision(b) {
+		// A FUZZY alias/canonical rendered-name COLLISION: two fields of one class whose
+		// rendered names fold-collide through the SAME match_string path the coercers use
+		// (case / accent / punctuation / NFKD), with at least one carrying an @alias, yet
+		// are NOT byte-equal (the byte-equal collision — e.g. `a @alias("b")` + literal `b`,
+		// or two equal aliases — is already rejected at lowering by the rendered-name index,
+		// internal/schema/index.go:145). A non-colliding field @alias is otherwise ADMITTED:
+		// native reproduces static BAML v0.223's alias-only rendered-name matching byte-exact
+		// (coerceClass/coerceStreamClass match Name.RenderedName() only). The collision case is
+		// held back because BAML's resolution is order-dependent and NOT uniform across the two
+		// coercion paths (ordinary Class::coerce is find-first in declaration order; try_cast
+		// builds a rendered-name map), and no v0.223 test pins whether the schema compiler even
+		// admits such a class. Until a live probe pins that (schema admission + final + every
+		// stream prefix, both declaration and key orders), native declines it pre-transport
+		// rather than over-claim a parity it cannot prove — a tracked #583 residual.
+		return unsupported("stream: fuzzy field alias/canonical rendered-name collision (BAML's order-dependent resolution unpinned — #583 residual)")
 	}
 	if typeGraphHasMap(b) {
 		// ANY map<string,*>. BAML's generic map coercion is INSERT/OVERWRITE-on-
@@ -451,18 +457,35 @@ func classSubtreeHasList(b *schema.Bundle, t schema.Type, seen map[string]bool) 
 	return false
 }
 
-// graphHasFieldAlias reports whether any class field carries an @alias. It is the ONE
-// metadata shape the native stream/final lane cannot yet reproduce byte-exact: BAML
-// matches a class key against the field's canonical name AND its alias, but native's
-// coerceClass/coerceStreamClass matcher checks only Name.RenderedName() (the alias when
-// present), so a canonical-name response key that BAML matches is missed. Class/enum
-// @alias/@description and field @description do NOT change key matching and are admitted.
-// See checkStreamRootSupported (#583 teardown: match both name and alias).
-func graphHasFieldAlias(b *schema.Bundle) bool {
+// aliasRenderedNameCollision reports whether any class has two fields whose RENDERED names
+// fuzzy-collide — i.e. some response key could match BOTH through the coercers' field-key
+// matcher (matchesStringToString: trim / case-fold / accent / punctuation-strip / NFKD, no
+// substring) — where at least one of the two carries an @alias. The BYTE-equal rendered
+// collision (a @alias("b") + literal b, or two equal aliases) is already rejected earlier at
+// lowering by the rendered-name index (internal/schema/index.go:145), so this catches only the
+// FUZZY residue the exact index misses (e.g. @alias("Foo") vs @alias("foo"); @alias("héading")
+// vs literal heading).
+//
+// It is scoped to alias-bearing collisions — the shapes admission newly reaches now that the
+// blanket field-@alias decline is gone. A pure canonical/canonical fuzzy pair (no alias) is a
+// pre-existing shape outside this teardown and is intentionally left untouched. Genuine
+// alias/canonical collisions stay a tracked #583 residual decline until a live BAML probe pins
+// the order-dependent resolution; see checkStreamRootSupported.
+func aliasRenderedNameCollision(b *schema.Bundle) bool {
 	for i := range b.Classes {
-		for j := range b.Classes[i].Fields {
-			if b.Classes[i].Fields[j].Name.Alias != nil {
-				return true
+		fields := b.Classes[i].Fields
+		for a := range fields {
+			for c := a + 1; c < len(fields); c++ {
+				if fields[a].Name.Alias == nil && fields[c].Name.Alias == nil {
+					continue
+				}
+				ra, rc := fields[a].Name.RenderedName(), fields[c].Name.RenderedName()
+				// Check both directions: a response key equal to either rendered form
+				// must be unambiguous. The fold is symmetric for our passes, but probe
+				// both to be defensive against any combining-mark edge asymmetry.
+				if matchesStringToString(ra, rc) || matchesStringToString(rc, ra) {
+					return true
+				}
 			}
 		}
 	}

--- a/internal/debaml/stream_serve_test.go
+++ b/internal/debaml/stream_serve_test.go
@@ -131,20 +131,71 @@ func TestSupportsNativeStream_MetadataAdmitted(t *testing.T) {
 	}
 }
 
-// TestSupportsNativeStream_FieldAliasDeclines pins the ONE metadata divergence
-// (LIVE-PROVEN vs BAML v0.223.0): a field @alias declines because BAML matches a class
-// key against the field's CANONICAL name too, while native's coerceStreamClass matcher
-// checks only Name.RenderedName() (the alias) and misses the canonical key. #583 teardown:
-// match both the name and the alias, then drop this gate.
-func TestSupportsNativeStream_FieldAliasDeclines(t *testing.T) {
+// TestSupportsNativeStream_FieldAliasAdmitted pins the #583 teardown: a NON-colliding field
+// @alias now ADMITS on both native serving lanes. The scope finding overturned the earlier
+// "BAML matches the canonical key too" premise — that was an artifact of the DYNAMIC parse
+// bridge dropping aliases, not static BAML v0.223. Static/jsonish BAML is ALIAS-ONLY (it
+// matches a class key against the field's rendered name only), and native's coerceClass/
+// coerceStreamClass do exactly that (Name.RenderedName() only), so removing the blanket gate
+// makes native byte-exact vs static BAML.
+func TestSupportsNativeStream_FieldAliasAdmitted(t *testing.T) {
 	fieldAliasS := &bamlutils.DynamicOutputSchema{
 		Properties: props(kv("title", &bamlutils.DynamicProperty{Type: "string", Alias: "banner"}), kv("count", intProp())),
 	}
-	if err := SupportsNativeStream(fieldAliasS); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
-		t.Errorf("SupportsNativeStream(field-alias): want decline (canonical-key divergence), got %v", err)
+	if err := SupportsNativeStream(fieldAliasS); err != nil {
+		t.Errorf("SupportsNativeStream(field-alias): want admit (nil), got %v", err)
 	}
-	if err := SupportsNativeFinal(fieldAliasS); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
-		t.Errorf("SupportsNativeFinal(field-alias): want decline, got %v", err)
+	if err := SupportsNativeFinal(fieldAliasS); err != nil {
+		t.Errorf("SupportsNativeFinal(field-alias): want admit (nil), got %v", err)
+	}
+}
+
+// TestSupportsNativeStream_FieldAliasCollisionDeclines pins the retained #583 residual: a
+// rendered-name COLLISION involving an @alias still declines, because BAML's collision
+// resolution is order-dependent and NOT uniform across its two coercion paths, and no v0.223
+// test pins whether the schema compiler even admits such a class.
+//
+//   - The BYTE-equal rendered collision (`a @alias("b")` + literal `b`) is rejected at
+//     lowering by the rendered-name index (internal/schema/index.go), surfaced as the
+//     unsupported sentinel by lowerForSupport — it never reaches the coercers.
+//   - The FUZZY collision between two ALIASES (`@alias("Foo")` vs `@alias("foo")` — fold-equal,
+//     byte-distinct) slips past the exact index, so aliasRenderedNameCollision declines it.
+//   - The FUZZY collision between an ALIAS and a PLAIN unaliased canonical sibling
+//     (`a @alias("Foo")` vs literal field `foo`) ALSO slips past the exact byte-equal index
+//     ("Foo" != "foo"), and aliasRenderedNameCollision catches it too — the pair qualifies
+//     because at least one side carries an @alias. (CodeRabbit r3616424315.)
+func TestSupportsNativeStream_FieldAliasCollisionDeclines(t *testing.T) {
+	exact := &bamlutils.DynamicOutputSchema{
+		Properties: props(kv("a", &bamlutils.DynamicProperty{Type: "string", Alias: "b"}), kv("b", strProp())),
+	}
+	fuzzy := &bamlutils.DynamicOutputSchema{
+		Properties: props(
+			kv("a", &bamlutils.DynamicProperty{Type: "string", Alias: "Foo"}),
+			kv("bb", &bamlutils.DynamicProperty{Type: "string", Alias: "foo"}),
+		),
+	}
+	// alias @alias("Foo") vs a PLAIN unaliased canonical sibling `foo` (fold-collision the
+	// byte-equal index MISSES; the gate must catch it).
+	fuzzyPlainCanonical := &bamlutils.DynamicOutputSchema{
+		Properties: props(
+			kv("a", &bamlutils.DynamicProperty{Type: "string", Alias: "Foo"}),
+			kv("foo", strProp()),
+		),
+	}
+	for _, c := range []struct {
+		name string
+		s    *bamlutils.DynamicOutputSchema
+	}{
+		{"exact-collision(index)", exact},
+		{"fuzzy-collision-alias-vs-alias(gate)", fuzzy},
+		{"fuzzy-collision-alias-vs-plain-canonical(gate)", fuzzyPlainCanonical},
+	} {
+		if err := SupportsNativeStream(c.s); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			t.Errorf("SupportsNativeStream(%s): want decline, got %v", c.name, err)
+		}
+		if err := SupportsNativeFinal(c.s); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			t.Errorf("SupportsNativeFinal(%s): want decline, got %v", c.name, err)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

## #583 field `@alias` teardown — Option A (static BAML v0.223 alias-only parity)

Native now **CLAIMS** non-colliding field-`@alias` schemas instead of blanket-declining them, byte-exact vs **static/jsonish BAML v0.223** (which is ALIAS-ONLY). The matcher was already correct (rendered-name-only); the only thing wrongly declining these schemas was the blanket `graphHasFieldAlias` support gate — a premise that came from the **dynamic** parse bridge dropping aliases (canonical-only), **not** static BAML.

### Step-0 HARD GATE — the live renderer HONORS field aliases ✅ (proceed)
For `title @alias("heading")` the live `output_format` renderer emits the **rendered (alias)** name:
- `internal/schema/outputformat/render.go:412` — `name := f.Name.RenderedName()` (in `classRender`)
- `internal/schema/schema.go:82-85` — `RenderedName()` returns the alias when present
- `internal/schema/build.go:224` — the field alias is populated from the dynamic property
- live serving path: `internal/debaml/render.go:31-37` (`DeBAMLRenderFunc`, used by cmd/serve & cmd/worker)

Served-native is therefore self-consistent: the prompt tells the model to emit `heading`, native parses `heading`. The renderer does **not** drop aliases → Option A is safe.

### Production change (`internal/debaml/stream_serve.go` only)
- **Removed** the blanket `graphHasFieldAlias` decline from `checkStreamRootSupported` — shared by `SupportsNativeStream` **and** `SupportsNativeFinal`, so both widen together.
- **Kept** the rendered-name-only matcher (`coerceClass:1402` / `coerceStreamClass:3502`) and the byte-equal rendered-name collision reject at `internal/schema/index.go:145` (untouched — `a @alias("b")` + literal `b` still declines at lowering).
- **Added** `aliasRenderedNameCollision`: a targeted pre-transport decline for the **fuzzy** alias/canonical rendered-name collision (case/accent/NFKD fold) the exact index misses — BAML's order-dependent resolution there is unpinned, a tracked **#583 residual**.

### Proof
- **Static-oracle alias matrix** (`internal/debaml/parse_test.go`): FINAL + **every valid-UTF-8 streaming prefix** — alias-key → field set; canonical-key → field missing (both native and static BAML error); both-keys (either raw order) → only alias is a candidate; case/accent/punct fold via the same `match_string` path; nested-class alias field; `@description` alongside `@alias` (no extra candidate). `TestParse_AliasStreamRenderedNameEquivalence` proves the alias is a pure rendered-name/output-key relabeling by byte-equivalence to the equivalent no-alias schema at every prefix — transferring the differential's live-BAML proof onto the alias schema.
- **Type-space differential** (`integration/stream_typespace_differential_test.go`): its BAML leg is `DynamicParseRaw` (alias-DROPPING), so field-alias shapes are **carved out** of the byte comparison (`shapeHasFieldAlias`) and proven by the static oracle instead — while STILL asserting admission (`SupportsNativeStream == §11 oracle`). **Count pins recomputed `289 / 157 / 132`** (was `289 / 153 / 136`; +4 field-alias shapes admitted, −4 declined); admission-mismatches = 0. The full live differential passes.

### Boundary
Prod change confined to `internal/debaml/stream_serve.go` (+ comment fixes). No new production `.go` file → root `embed.go` and `cmd/build/nativeworker_module.tar` stay byte-fresh. `internal/schema` untouched. Host/root stays zero-nanollm/CGO-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Native streaming now supports non-colliding field `@alias` definitions.
  - Alias matching is based on rendered field names (including case/accent/punctuation variants).

- **Bug Fixes**
  - Alias collisions are still safely rejected, including fuzzy rendered-name collisions.
  - Improved alignment of alias behavior across serving and parsing (including success vs error outcomes and partial input handling).

- **Tests**
  - Expanded alias/parity coverage for rendered-name equivalence, nested cases, and streaming admission/decline rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->