### PR TITLE
feat(bamlprofile): Slice 2 PR-2 — enum & class host value model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/invakid404/baml-rest/pool v0.0.0-00010101000000-000000000000
 	github.com/invakid404/baml-rest/worker v0.0.48
 	github.com/invakid404/baml-rest/workerplugin v0.0.48
-	github.com/invakid404/minijinja-go/v2 v2.16.0-baml.3
+	github.com/invakid404/minijinja-go/v2 v2.16.0-baml.6
 	github.com/mitsuhiko/minijinja/minijinja-go/v2 v2.16.0
 	github.com/moby/buildkit v0.31.0
 	github.com/moby/moby/api v1.55.0

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.48 h1:PrTPsEq7RkXpkF9T2qSL+WH6YsOz0e5v6X1ObFUAh44=
 github.com/invakid404/baml-rest/dynclient/baml-patched v0.0.48/go.mod h1:FJNbj1NKP3z/E8ZXPbLXLrsDOAaPmGGS3gX+Hb2vivE=
-github.com/invakid404/minijinja-go/v2 v2.16.0-baml.3 h1:INi/olDfIA5AqvZlltJeA60W+b3GttPtOWpDODIM+9w=
-github.com/invakid404/minijinja-go/v2 v2.16.0-baml.3/go.mod h1:fUA188XOlFd80c0fWCItPtc4QC0y0onlbyBgJTYUrJs=
+github.com/invakid404/minijinja-go/v2 v2.16.0-baml.6 h1:riIcfB9KTsMrsCBoYpCYVVJ/2volxyrtt4O1t8UN848=
+github.com/invakid404/minijinja-go/v2 v2.16.0-baml.6/go.mod h1:fUA188XOlFd80c0fWCItPtc4QC0y0onlbyBgJTYUrJs=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=

--- a/go.work.sum
+++ b/go.work.sum
@@ -889,6 +889,8 @@ github.com/intel/goresctrl v0.8.0/go.mod h1:T3ZZnuHSNouwELB5wvOoUJaB7l/4Rm23rJy/
 github.com/intel/goresctrl v0.10.0 h1:Q94PBhLtQM/aVxVTKzB1j/ooMuV+9XleTN1fq2OGsSo=
 github.com/intel/goresctrl v0.10.0/go.mod h1:1S8GDqL46GuKb525bxNhIEEkhf4rhVcbSf9DuKhp7mw=
 github.com/intel/goresctrl v0.12.0/go.mod h1:5GWtmPY4BWl/a9rU8apGED9Xul5b5WoLtg/qOWaghWU=
+github.com/invakid404/minijinja-go/v2 v2.16.0-baml.6 h1:riIcfB9KTsMrsCBoYpCYVVJ/2volxyrtt4O1t8UN848=
+github.com/invakid404/minijinja-go/v2 v2.16.0-baml.6/go.mod h1:fUA188XOlFd80c0fWCItPtc4QC0y0onlbyBgJTYUrJs=
 github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
 github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/internal/bamlprofile/class.go
+++ b/internal/bamlprofile/class.go
@@ -1,0 +1,270 @@
+package bamlprofile
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/invakid404/minijinja-go/v2/value"
+)
+
+// This file is BAML v0.223's class host value model: the map object a
+// BamlValue::Class lowers to, plus the ONE hand-written Rust-debug walker
+// (debugValue/debugClass/debugList) that renders both classes and listObjects,
+// in either the alternate `{:#?}` or the non-alternate spelling.
+//
+// Authority (byte-for-byte): BAML v0.223
+//   - class lowering + object impl + Display/serialize:
+//     engine/baml-lib/jinja-runtime/src/baml_value_to_jinja_value.rs:60-80,255-334
+//   - concrete expected direct-render bytes:
+//     engine/baml-lib/jinja-runtime/src/lib.rs:1631,1888 (single field and
+//     nested class/list goldens, reproduced by the pretty renderer here).
+//
+// The load-bearing split (rs:60-80,320-334): a class stores its fields under
+// their CANONICAL names and, separately, a canonical->alias map. Attribute
+// access, iteration, length and membership use the CANONICAL names; only DIRECT
+// rendering and the serialization projection use the aliases. So `c.original`
+// works even when the field is @alias("wire"), while `{{ c }}` prints "wire".
+
+// classField is one class field in stored (declared) order.
+type classField struct {
+	canonical string      // the attribute/iteration/index name
+	aliasKey  string      // resolved alias, or the canonical name when unaliased; used only in rendering
+	value     value.Value // the field value (a scalar, none, or a host value)
+}
+
+// ClassField is one resolved class field: its canonical name, optional resolved
+// alias (nil = unaliased, so the display key is the canonical name), and value.
+// Values must be a scalar, none, or a bamlprofile host value (enum/class/list);
+// a native fork container is rejected because it would not render like BAML's
+// lowered host value.
+type ClassField struct {
+	Canonical string
+	Alias     *string
+	Value     value.Value
+}
+
+// classObject is BAML's MinijinjaBamlClass (rs:255-334): a Map-repr object keyed
+// by canonical field names, carrying the alias projection used only for display
+// and serialization.
+type classObject struct {
+	fields []classField           // ordered; drives iteration, length, and rendering order
+	byName map[string]value.Value // canonical -> value, for attribute/index access
+}
+
+// ClassValue constructs a host class value (BAML's BamlValue::Class lowering).
+// It fails loud on malformed metadata — an empty or duplicate canonical field
+// name, or a field value that is neither a scalar, none, nor a bamlprofile host
+// value — rather than building an object that renders or iterates wrong.
+func ClassValue(fields []ClassField) (value.Value, error) {
+	obj := &classObject{
+		fields: make([]classField, 0, len(fields)),
+		byName: make(map[string]value.Value, len(fields)),
+	}
+	for _, f := range fields {
+		if f.Canonical == "" {
+			return value.Undefined(), fmt.Errorf("bamlprofile: class has a field with an empty canonical name")
+		}
+		if _, dup := obj.byName[f.Canonical]; dup {
+			return value.Undefined(), fmt.Errorf("bamlprofile: class has duplicate field %q", f.Canonical)
+		}
+		if err := assertHostRenderable(f.Value); err != nil {
+			return value.Undefined(), fmt.Errorf("bamlprofile: class field %q: %w", f.Canonical, err)
+		}
+		aliasKey := f.Canonical
+		if f.Alias != nil {
+			aliasKey = *f.Alias
+		}
+		obj.fields = append(obj.fields, classField{canonical: f.Canonical, aliasKey: aliasKey, value: f.Value})
+		obj.byName[f.Canonical] = f.Value
+	}
+	return value.FromObject(obj), nil
+}
+
+// GetAttr looks a field up by its CANONICAL name (rs:322-328). An alias is not
+// an alternate attribute, and a missing field is undefined — so `c.wire_alias`
+// and `c.absent` are both undefined while `c.canonical` returns the value
+// (including a stored none, which is present, not undefined).
+func (c *classObject) GetAttr(name string) value.Value {
+	if v, ok := c.byName[name]; ok {
+		return v
+	}
+	return value.Undefined()
+}
+
+// Keys returns the canonical field names in stored order, driving `for k in c`,
+// `|length`, and truthiness (empty class falsey, nonempty truthy) — BAML's
+// Enumerator::Values over the class keys (rs:329-334).
+func (c *classObject) Keys() []string {
+	keys := make([]string, len(c.fields))
+	for i, f := range c.fields {
+		keys[i] = f.canonical
+	}
+	return keys
+}
+
+// ObjectRepr is Map (rs:257-259).
+func (c *classObject) ObjectRepr() value.ObjectRepr { return value.ObjectReprMap }
+
+// ObjectString renders the class as Rust's pretty debug-map with aliased keys
+// and nested none as null (BAML's Display, rs:260-283). A class is ALWAYS
+// alternate, whatever the surrounding context — Display forces `{map:#?}`
+// (rs:279) — so it enters the walker in debugAlternate at indent 0.
+func (c *classObject) ObjectString() string { return debugClass(c, 0) }
+
+// prettyIndentWidth is the four-space nesting Rust's alternate debug ({:#?})
+// uses; BAML renders classes/lists with `{map:#?}` / debug_list (rs:279,373).
+const prettyIndentWidth = 4
+
+// debugMode selects which Rust debug formatting a host value renders with:
+// non-alternate `{:?}` or alternate `{:#?}`. It is the Go stand-in for the Rust
+// formatter's ambient alternate flag, which BAML's Display impls read
+// (rs:373-388 for a list) or force (rs:279 for a class).
+type debugMode int
+
+const (
+	// debugCompact is Rust's `{:?}`: a list is one line, `[a, b]`, comma-space
+	// separated with no trailing comma. This is the ambient mode for a
+	// directly-rendered host list.
+	debugCompact debugMode = iota
+	// debugAlternate is Rust's `{:#?}`: multi-line, four-space nesting, one entry
+	// per line, each with a trailing comma. This is the ambient mode inside a
+	// class, which forces it.
+	debugAlternate
+)
+
+// debugValue renders one host value the way it appears inside a host class or
+// list, in the given mode at the given base indent. It is the SINGLE walker for
+// both modes: the compact and alternate spellings differ only in the list
+// layout, so keeping one object switch keeps the two from drifting.
+//
+//   - none -> "null" (BAML swaps a nested none for BamlNull, whose render is
+//     "null"; rs:270-277,383-386);
+//   - a nested class -> ALWAYS the alternate debug-map, in either mode: BAML's
+//     class Display forces `{map:#?}` (rs:279), so a class nested in a compact
+//     list is still multi-line;
+//   - a nested list -> the CURRENT mode: the alternate flag propagates through a
+//     Rust debug_list, and its absence propagates too, so a list inside a
+//     compact list stays compact and one inside a class goes alternate;
+//   - an enum member -> its BARE alias-or-canonical display (its render is
+//     Display, not a quoted string; rs:181-186);
+//   - a scalar -> the fork's Repr, which is Rust's Debug for that scalar
+//     (QuoteDebug for strings, %d for ints, Rust f64 debug for floats,
+//     true/false for bools).
+//
+// The default arms panic: ClassValue/ListValue validate every stored value with
+// assertHostRenderable and store it in an owned container, so no value that
+// reaches here can be anything else. Reaching them is an internal invariant
+// violation, and failing loud beats emitting a degraded representation.
+func debugValue(v value.Value, mode debugMode, indent int) string {
+	if v.IsNone() {
+		return "null"
+	}
+	if obj, ok := v.AsObject(); ok {
+		switch o := obj.(type) {
+		case *classObject:
+			return debugClass(o, indent)
+		case *listObject:
+			return debugList(o, mode, indent)
+		case *enumMember:
+			return o.display()
+		default:
+			panic(fmt.Sprintf("bamlprofile: internal error: cannot render host object of type %T inside a host class/list", obj))
+		}
+	}
+	switch v.Kind() {
+	case value.KindString, value.KindNumber, value.KindBool:
+		return v.Repr()
+	default:
+		panic(fmt.Sprintf("bamlprofile: internal error: cannot render value of kind %v inside a host class/list", v.Kind()))
+	}
+}
+
+// debugClass renders a class as Rust's alternate debug-map at the given base
+// indent (the column its closing brace aligns to). An empty map is `{}`;
+// otherwise each entry is `<indent+4>"aliasKey": <value>,` with a trailing comma
+// and the closing brace at the base indent. Its values are walked in
+// debugAlternate because the class forces `{map:#?}`. Verified against BAML's
+// goldens (lib.rs:1631 single field, lib.rs:1888 nested class+list).
+func debugClass(c *classObject, indent int) string {
+	if len(c.fields) == 0 {
+		return "{}"
+	}
+	var b strings.Builder
+	inner := indent + prettyIndentWidth
+	pad := strings.Repeat(" ", inner)
+	b.WriteString("{\n")
+	for _, f := range c.fields {
+		b.WriteString(pad)
+		b.WriteString(debugString(f.aliasKey))
+		b.WriteString(": ")
+		b.WriteString(debugValue(f.value, debugAlternate, inner))
+		b.WriteString(",\n")
+	}
+	b.WriteString(strings.Repeat(" ", indent))
+	b.WriteString("}")
+	return b.String()
+}
+
+// debugList renders a list as Rust's debug_list in the given mode (rs:373-388,
+// which uses the AMBIENT formatter rather than forcing alternate the way a class
+// does). An empty list is `[]` in both modes. A compact list has no indentation
+// of its own, so its items are walked at indent 0.
+func debugList(l *listObject, mode debugMode, indent int) string {
+	if len(l.items) == 0 {
+		return "[]"
+	}
+	if mode == debugCompact {
+		parts := make([]string, len(l.items))
+		for i, item := range l.items {
+			parts[i] = debugValue(item, debugCompact, 0)
+		}
+		return "[" + strings.Join(parts, ", ") + "]"
+	}
+	var b strings.Builder
+	inner := indent + prettyIndentWidth
+	pad := strings.Repeat(" ", inner)
+	b.WriteString("[\n")
+	for _, item := range l.items {
+		b.WriteString(pad)
+		b.WriteString(debugValue(item, debugAlternate, inner))
+		b.WriteString(",\n")
+	}
+	b.WriteString(strings.Repeat(" ", indent))
+	b.WriteString("]")
+	return b.String()
+}
+
+// assertHostRenderable is the construction-time guard behind debugValue's
+// panics: a class/list value must be a scalar, none, or a bamlprofile host
+// value. A native fork container (or any other object) is rejected — it would
+// render compactly via the fork's Repr instead of BAML's pretty host rendering,
+// a silent divergence.
+func assertHostRenderable(v value.Value) error {
+	if v.IsNone() {
+		return nil
+	}
+	if v.IsUndefined() {
+		return fmt.Errorf("value is undefined")
+	}
+	if obj, ok := v.AsObject(); ok {
+		switch obj.(type) {
+		case *classObject, *listObject, *enumMember:
+			return nil
+		default:
+			return fmt.Errorf("unsupported host object type %T", obj)
+		}
+	}
+	switch v.Kind() {
+	case value.KindString, value.KindNumber, value.KindBool:
+		return nil
+	default:
+		return fmt.Errorf("value must be a scalar, none, or a bamlprofile host value, got kind %v", v.Kind())
+	}
+}
+
+// debugString renders s the way Rust's `Debug for str` does (the fork's Repr for
+// a string, i.e. QuoteDebug), so class map keys are quoted and escaped exactly
+// as `{map:#?}` prints them.
+func debugString(s string) string {
+	return value.FromString(s).Repr()
+}

--- a/internal/bamlprofile/doc.go
+++ b/internal/bamlprofile/doc.go
@@ -1,5 +1,5 @@
 // Package bamlprofile is baml-rest's leaf BAML profile over the pinned pure-Go
-// minijinja fork github.com/invakid404/minijinja-go/v2@v2.16.0-baml.3.
+// minijinja fork github.com/invakid404/minijinja-go/v2@v2.16.0-baml.6.
 //
 // The fork is a generic, BAML-exact minijinja ENGINE. It deliberately does not
 // carry BAML's environment configuration: a consumer still owns BAML's
@@ -21,9 +21,9 @@
 // test-only differential oracle behind the `integration` build tag
 // (see ./profileoracle), mirroring internal/nativeprompt/staticoracle.
 //
-// # What this slice (Slice 2 PR-1) builds
+// # What this slice builds
 //
-// The get_env engine configuration, sans the host value model:
+// PR-1 — the get_env engine configuration:
 //   - trim_blocks + lstrip_blocks, autoescape off, set_debug(true);
 //   - the none -> "null" top-level formatter;
 //   - the fork's BAML-exact builtin filter/test/function registry PLUS BAML's
@@ -35,15 +35,46 @@
 // Authority: jinja_helpers.rs get_env() in BAML v0.223
 // (engine/baml-lib/baml-core/src/ir/jinja_helpers.rs:7-36).
 //
-// # What is DEFERRED to later PRs (explicitly NOT built here)
+// PR-2 — the enum & class host value model (enum.go, class.go, list.go):
+//   - per-enum namespace globals installed from Config.Enums (Environment.
+//     AddGlobal), keyed by canonical variant name, non-enumerable;
+//   - enum-member objects with separate canonical / alias / enum-name fields:
+//     display is alias-or-canonical, `.value` is canonical only, and
+//     ObjectWithValueCmp is BAML's exact enum comparator — closing the #597
+//     enum-`==` fence at the profile level (both operand orders + membership);
+//   - class objects (canonical attribute/iteration/index access, alias only in
+//     display), host list objects, and a hand-written Rust debug renderer for
+//     direct class/list rendering (nested none -> null, aliased keys, four-space
+//     nesting, trailing commas), in both the alternate `{:#?}` and the
+//     non-alternate spelling BAML's two Display impls select.
 //
-//   - The host value model: enum/class/map/media host value objects, enum
-//     globals, the enum ValueCmp that closes the #597 enum-`==` fence, and the
-//     object-aware formatter dispatch (ObjectWithString) those need.
-//   - The prompt lowerer and the constraint lowerer / predicate façade.
+// The host objects render through value.ObjectWithString and signal their
+// non-enumerability by being ObjectReprMap objects that implement no
+// value.MapObject/MapGetter. Both are GENERIC fork seams (v2.16.0-baml.4
+// PATCHES #102-#105, extended in -baml.6 PATCHES #106-#108 to pycompat
+// str.join/keys/values/items/get, dictsort, and the pprint/debug renderers):
+// the fork's Value.String/Value.Repr and the alternate-debug renderers dispatch
+// ObjectWithString, its equality/ordering/iteration/join branch on the ok
+// boolean of Value.MapKeys, and its map API reaches a host map through
+// MapKeys/GetItem rather than AsMap. So this package adds no per-filter,
+// per-container, or per-operator special case, and no comparator answer BAML's
+// own comparator would not give.
 //
-// New leaves a clear boundary for these (see env.go): the returned
-// *minijinja.Environment is the get_env engine config; the host value model is
-// layered on top by later slices (enum globals via AddGlobal; host values
-// produced by the lowerers and passed as render context), never faked here.
+// Authority: baml_value_to_jinja_value.rs and lib.rs in BAML v0.223 (cited at
+// each type). Byte-exactness is proven by the stock-CFFI differential in
+// ./profileoracle.
+//
+// # What is DEFERRED / DECLINED (explicitly NOT built here)
+//
+//   - Media host values (Image/Audio/Pdf/Video, URL/Base64/File): BAML's serde
+//     marker must be parsed by prompt lowering into a provider media body, which
+//     this unwired leaf has no path for. There is no media constructor, so a
+//     media value cannot enter a render context at all. Tracked on #602.
+//   - BAML's render-layer format(type=json|yaml|toon) host-serialization
+//     override: the get_env-level `format` is the fork's printf filter, so a
+//     class|format(type=...) ERRORS rather than silently emitting a
+//     serialization (proven in host_test.go). Tracked on #602.
+//   - The prompt lowerer and the constraint lowerer / predicate façade, and the
+//     descriptor/parser layer that would supply resolved enum/class aliases and
+//     ordered fields in production (PR-2 consumes them as explicit typed inputs).
 package bamlprofile

--- a/internal/bamlprofile/enum.go
+++ b/internal/bamlprofile/enum.go
@@ -1,0 +1,262 @@
+package bamlprofile
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/invakid404/minijinja-go/v2/value"
+)
+
+// This file is the BAML v0.223 enum host value model: the per-enum namespace
+// global BAML injects at render time, and the enum-member object it lowers a
+// BamlValue::Enum to. Together with the ObjectWithValueCmp comparator here, they
+// reproduce BAML's enum equality/ordering/membership — the behavior the #597
+// enum-`==` fence documented as diverging on the old external engine.
+//
+// Authority (byte-for-byte): BAML v0.223
+//   - enum member lowering + object impl + value_cmp:
+//     engine/baml-lib/jinja-runtime/src/baml_value_to_jinja_value.rs:43-58,173-256
+//   - enum namespace type + per-enum global injection:
+//     engine/baml-lib/jinja-runtime/src/baml_value_to_jinja_value.rs:148-171
+//     and engine/baml-lib/jinja-runtime/src/lib.rs:316-327,642-658
+//
+// The enum member deliberately keeps THREE separate fields — canonical variant
+// name, optional resolved alias, and enum name — because BAML does:
+//   - display / serialization is alias-or-canonical (rs:183-196);
+//   - `.value` is the canonical name ONLY (rs:205-225: no `.name`/`.alias`);
+//   - comparison identity is canonical then Option<alias>, and enum_name is
+//     NOT part of it (rs:235-253) — hence cross-enum members with equal
+//     canonical+alias compare EQUAL.
+// Collapsing those into one string would lose one of these behaviors.
+
+// EnumValue is one resolved enum variant: its canonical variant name (the
+// comparison identity, e.g. "RED") and an optional resolved alias (its display
+// value, e.g. "rouge"). Alias is nil when the variant has no @alias. Aliases are
+// RESOLVED inputs; this leaf does not parse BAML source or evaluate alias
+// expressions (that IR/EvaluationContext work is a later descriptor-adapter
+// slice, per the scope).
+type EnumValue struct {
+	Canonical string
+	Alias     *string
+}
+
+// EnumDef is one resolved enum declaration: its name and its variants in
+// declared order. It is the profile analogue of an IR enum walked by
+// render_prompt (lib.rs:642-658); New installs one namespace global per EnumDef.
+type EnumDef struct {
+	Name   string
+	Values []EnumValue
+}
+
+// enumMember is BAML's MinijinjaBamlEnumValue: a lowered enum value. The same Go
+// type backs BOTH an enum member reached through a namespace global (Color.RED)
+// and one passed as a function argument, exactly as BAML uses one Rust type for
+// both — which is what makes cross-enum members downcast to the same type and so
+// compare by canonical+alias while ignoring enum_name.
+type enumMember struct {
+	canonical string  // variant name; the comparison identity and `.value`
+	alias     *string // resolved alias, or nil; the display/serialization value when present
+	enumName  string  // retained (BAML stores it) but NEVER exposed and NEVER compared
+}
+
+// newEnumMember builds a validated enum member. canonical and enumName must be
+// non-empty; a malformed descriptor fails loud here rather than rendering a
+// degraded value later.
+func newEnumMember(enumName, canonical string, alias *string) (*enumMember, error) {
+	if enumName == "" {
+		return nil, fmt.Errorf("bamlprofile: enum member has empty enum name (canonical %q)", canonical)
+	}
+	if canonical == "" {
+		return nil, fmt.Errorf("bamlprofile: enum %q has an enum member with empty canonical name", enumName)
+	}
+	// Own the alias, like ListValue owns its items and ClassValue its field keys:
+	// the caller's *string must not stay live inside a constructed member, or
+	// writing through it afterwards would silently change the member's display AND
+	// its Option<alias> comparison identity. The POINTER-ness is load-bearing and
+	// kept — nil (no @alias) and non-nil "" (@alias("")) are different values — so
+	// this copies the pointee rather than collapsing to a string.
+	var owned *string
+	if alias != nil {
+		a := *alias
+		owned = &a
+	}
+	return &enumMember{canonical: canonical, alias: owned, enumName: enumName}, nil
+}
+
+// EnumMember constructs a host enum-member value (BAML's BamlValue::Enum
+// lowering) for use as a render argument. alias is the resolved alias or nil. It
+// fails loud on malformed metadata rather than emitting a degraded value.
+func EnumMember(enumName, canonical string, alias *string) (value.Value, error) {
+	m, err := newEnumMember(enumName, canonical, alias)
+	if err != nil {
+		return value.Undefined(), err
+	}
+	return value.FromObject(m), nil
+}
+
+// display is the enum member's rendered/serialized string: the alias when
+// present, otherwise the canonical variant name (rs:183-196).
+func (e *enumMember) display() string {
+	if e.alias != nil {
+		return *e.alias
+	}
+	return e.canonical
+}
+
+// GetAttr exposes ONLY `.value`, returning the canonical variant name — exactly
+// the single key BAML's get_value answers (rs:205-225, with its explicit "do not
+// add more fields here"). `.name`, `.alias`, and the stored enum name are absent,
+// so `Color.RED.name is undefined` is true.
+func (e *enumMember) GetAttr(name string) value.Value {
+	if name == "value" {
+		return value.FromString(e.canonical)
+	}
+	return value.Undefined()
+}
+
+// ObjectRepr is Map, matching BAML's MinijinjaBamlEnumValue::repr (rs:207-209).
+//
+// LOAD-BEARING NEGATIVE CAPABILITY: the member is a Map-repr object that
+// deliberately implements NEITHER value.MapObject NOR value.MapGetter. That
+// omission is not an oversight — it is the fork-level spelling of BAML's
+// `Enumerator::NonEnumerable` with an unknown length (rs:211-217). A member is
+// NOT an empty map: an ordinary `{}` has a known, empty pair iterator, whereas
+// BAML's `try_iter_pairs()` for this object is absent entirely.
+//
+// The fork encodes exactly that distinction in the boolean of
+// Value.MapKeys() ([]string, bool): (nil, false) here versus ([], true) for a
+// known-empty map. Equality, ordering, membership, iteration, `is iterable` and
+// the debug/pprint walkers all branch on it (fork v2.16.0-baml.4, PATCHES #102,
+// #103, #105). So `Color.RED == Color` and `Color.RED == {}` are false while
+// BAML's asymmetric `{} == Color.RED` stays true, and ordering two of them
+// faults instead of inventing a result.
+//
+// Adding a Keys()/Map() method here — even one returning nothing — would turn
+// the member into a known-empty map and silently reintroduce every one of those
+// divergences. TestEnumHostObjectsAreNonEnumerableMaps guards it.
+func (e *enumMember) ObjectRepr() value.ObjectRepr { return value.ObjectReprMap }
+
+// ObjectString is the member's render: alias-or-canonical, bare (rs:181-186,
+// 227-229). The fork's Value.String and Value.Repr both dispatch
+// value.ObjectWithString (PATCHES #104), which is the fork analogue of BAML's
+// object Display/Debug being the same call — so this text composes through
+// native containers, |join, |upper, `~`, string coercion and the output
+// formatter with no per-consumer help from this package.
+func (e *enumMember) ObjectString() string { return e.display() }
+
+// ValueCmp is BAML's MinijinjaBamlEnumValue::value_cmp + custom_cmp
+// (rs:227-253), the comparator that closes the #597 fence. It is reached from
+// BOTH operand positions by the fork's Value.Equal/Value.Compare, so reverse
+// equality, `!=`, sequence equality and membership all inherit it.
+//
+//   - Against a string: compare the CANONICAL name (not the alias),
+//     case-sensitively — preserving pre-0.206 enum-as-string behavior. So
+//     `Color.RED == 'RED'` is true and `Color.RED == 'rouge'` is false.
+//   - Against another enum member (same Go type, any enum): compare canonical,
+//     then Option<alias> with nil<non-nil then lexical. enum_name is NOT
+//     compared, so equal-canonical+equal-alias members of different enums are
+//     equal.
+//   - Against anything else (int, float, bool, none, an unrelated object):
+//     DECLINE with (0, false). Declining is not "not equal"; it lets the fork
+//     apply its ordinary rules. The profile never invents equality or order for
+//     a type BAML's comparator refuses.
+func (e *enumMember) ValueCmp(other value.Value) (int, bool) {
+	if s, ok := other.AsString(); ok {
+		return strings.Compare(e.canonical, s), true
+	}
+	if obj, ok := other.AsObject(); ok {
+		if o, ok := obj.(*enumMember); ok {
+			if c := strings.Compare(e.canonical, o.canonical); c != 0 {
+				return c, true
+			}
+			return compareOptionalAlias(e.alias, o.alias), true
+		}
+		// A different object type: BAML's custom_cmp downcast_ref fails and
+		// returns None. Decline.
+		return 0, false
+	}
+	return 0, false
+}
+
+// compareOptionalAlias is Rust's Option<String>::cmp: None < Some, and two Somes
+// compare lexically. It is the alias tie-breaker of the enum comparator
+// (rs:249-252, `self.alias.cmp(&other.alias)`).
+func compareOptionalAlias(a, b *string) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	default:
+		return strings.Compare(*a, *b)
+	}
+}
+
+// enumType is BAML's MinijinjaBamlEnumType: the per-enum namespace global. It
+// maps each CANONICAL variant name to its member (Color.RED -> member), and is
+// non-enumerable — you reach members by name, you do not iterate the namespace
+// (rs:148-171). New installs one per EnumDef via Environment.AddGlobal.
+type enumType struct {
+	name    string
+	members map[string]*enumMember
+}
+
+// newEnumType builds a validated namespace from a resolved EnumDef. It fails
+// loud on an empty enum name or a duplicate canonical variant rather than
+// silently dropping or overwriting a variant.
+func newEnumType(def EnumDef) (*enumType, error) {
+	if def.Name == "" {
+		return nil, fmt.Errorf("bamlprofile: enum definition has an empty name")
+	}
+	members := make(map[string]*enumMember, len(def.Values))
+	for _, v := range def.Values {
+		m, err := newEnumMember(def.Name, v.Canonical, v.Alias)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := members[v.Canonical]; dup {
+			return nil, fmt.Errorf("bamlprofile: enum %q has duplicate variant %q", def.Name, v.Canonical)
+		}
+		members[v.Canonical] = m
+	}
+	return &enumType{name: def.Name, members: members}, nil
+}
+
+// GetAttr looks a variant up by its canonical name and returns its member
+// (rs:158-164). An unknown name is undefined.
+func (t *enumType) GetAttr(name string) value.Value {
+	if m, ok := t.members[name]; ok {
+		return value.FromObject(m)
+	}
+	return value.Undefined()
+}
+
+// ObjectRepr is Map (rs:154-156). Like enumMember, the namespace deliberately
+// implements NEITHER value.MapObject NOR value.MapGetter: that is BAML's
+// `Enumerator::NonEnumerable` with an unknown length (rs:165-171), and it makes
+// the fork's Value.MapKeys report ok == false rather than a known-empty map. See
+// enumMember.ObjectRepr for why that negative capability is load-bearing; it is
+// what keeps `Color == Color.RED`, `{% for x in Color %}`, and `Color.RED < Color`
+// behaving as stock BAML does. TestEnumHostObjectsAreNonEnumerableMaps guards it.
+func (t *enumType) ObjectRepr() value.ObjectRepr { return value.ObjectReprMap }
+
+// ObjectString renders the namespace as `{}`.
+//
+// MinijinjaBamlEnumType declares NO Display/render of its own (rs:148-171,
+// unlike the member at rs:181-186), so stock MiniJinja falls back to the default
+// `Object::render` for an ObjectRepr::Map: a debug_map built from the object's
+// pairs. Its enumerator is NonEnumerable, so there are no pairs and the result is
+// the empty map. Verified on stock BAML v0.223 CFFI in every position —
+// `{{ Color }}`, `{{ [Color] }}`, `{{ Color|string }}`, `{{ Color ~ "!" }}`,
+// `{{ Color|upper }}`, and as a native map value — all `{}`.
+//
+// This must be spelled out HERE, not inherited. The fork's Value.String/Repr
+// dispatch value.ObjectWithString and otherwise fall through to Go's `%v`; they
+// deliberately do NOT synthesize an engine-style default render for an object
+// implementing neither ObjectWithString nor fmt.Stringer (v2.16.0-baml.4,
+// "Known, not fixed"). Without this method the namespace rendered as
+// `&{Color map[RED:0x14000a2c1e0 ...]}` — Go struct formatting, carrying heap
+// ADDRESSES, so the output also differed between runs.
+func (t *enumType) ObjectString() string { return "{}" }

--- a/internal/bamlprofile/env.go
+++ b/internal/bamlprofile/env.go
@@ -1,6 +1,8 @@
 package bamlprofile
 
 import (
+	"fmt"
+
 	minijinja "github.com/invakid404/minijinja-go/v2"
 	"github.com/invakid404/minijinja-go/v2/pycompat"
 	"github.com/invakid404/minijinja-go/v2/syntax"
@@ -10,10 +12,11 @@ import (
 // Config carries the per-render inputs the get_env-equivalent environment needs
 // that are not fixed engine configuration.
 //
-// It is intentionally small for this slice. It is the typed boundary where the
-// deferred host value model plugs in later (enum globals, class/map/media
-// lowering, the enum ValueCmp for #597); those are layered onto the returned
-// Environment or passed as render context by later slices, not stubbed here.
+// It is the typed boundary where the host value model plugs in: Enums installs
+// BAML's per-enum namespace globals; class/enum/list host VALUES enter through
+// the render context, built with EnumMember / ClassValue / ListValue. Aliases
+// and ordered fields are RESOLVED inputs — this leaf does not parse BAML source
+// or import BAML IR (that descriptor-adapter is a later slice).
 type Config struct {
 	// OutputFormat is the pre-rendered ctx.output_format block that BAML installs
 	// before rendering (it is the schema description a prompt reaches via
@@ -23,6 +26,15 @@ type Config struct {
 	// later-slice concern; this slice takes it pre-rendered, exactly as
 	// internal/nativeprompt/env.go does today.
 	OutputFormat string
+
+	// Enums are the resolved enum declarations. New installs one namespace global
+	// per enum (Color -> Color.RED), reproducing BAML's render-time per-enum
+	// global injection (jinja-runtime/src/lib.rs:316-327,642-658). BAML injects a
+	// global for EVERY enum declared in the project, not only referenced ones, so
+	// a caller passes the full resolved set. Order is irrelevant (globals are
+	// keyed by name); it is a slice, not a map, to keep it an explicit ordered
+	// input rather than implying map-iteration semantics.
+	Enums []EnumDef
 }
 
 // New constructs a fork *minijinja.Environment configured exactly like BAML
@@ -59,7 +71,12 @@ type Config struct {
 // proven behavior (a global is available in every render; the observable
 // result is the same). Because ctx carries a per-render OutputFormat, New builds
 // a fresh environment per render, exactly as nativeprompt.buildEnv does.
-func New(cfg Config) *minijinja.Environment {
+//
+// New returns an error only when Config.Enums is malformed (an empty enum or
+// variant name, a duplicate variant, or two EnumDefs with the same Name). That
+// is a resolved-metadata contract violation, so it fails loud here rather than
+// installing a global that renders or compares wrong.
+func New(cfg Config) (*minijinja.Environment, error) {
 	env := minijinja.NewEnvironment()
 
 	// BAML's custom formatter: a top-level none renders as the literal "null"
@@ -67,11 +84,16 @@ func New(cfg Config) *minijinja.Environment {
 	// engine's escaping path. Under AutoEscapeNone the escape func is the
 	// identity, so this is none -> "null", else the value's display string.
 	//
-	// Nested none inside a host class/list is handled by those host values'
-	// display impls in BAML; that is part of the deferred host value model. Until
-	// it lands there are no host render values here, so this top-level rule is the
-	// whole formatter. When the host model lands it gains ObjectWithString
-	// dispatch here (see doc.go).
+	// Nested none inside a host class/list is handled by the host debug walker
+	// (debugValue in class.go); this top-level rule is the none -> "null" that
+	// BAML's jinja_helpers formatter applies before rendering.
+	//
+	// Object rendering is NOT this formatter's business. The fork's Value.String
+	// dispatches value.ObjectWithString itself (v2.16.0-baml.4, PATCHES #104),
+	// which is BAML's escape_formatter reaching an object's own render/Display —
+	// and, being at the fork's primitive, it composes through native containers,
+	// |join, filter coercions and `~` as well, which a formatter-only branch here
+	// never could. The top-level none -> "null" rule is the only get_env delta.
 	env.SetFormatter(func(_ *minijinja.State, val value.Value, escape func(string) string) string {
 		if val.IsNone() {
 			return escape("null")
@@ -99,9 +121,63 @@ func New(cfg Config) *minijinja.Environment {
 	env.AddFilter("sum", sumFilter) // overrides the engine builtin sum
 	env.SetUnknownMethodCallback(pycompat.UnknownMethodCallback)
 
-	// Simple globals matching internal/nativeprompt/env.go.
-	env.AddGlobal("_", value.FromObject(roleHelper{}))
-	env.AddGlobal("ctx", value.FromObject(ctxObject{outputFormat: cfg.OutputFormat}))
+	// The get_env simple globals, matching internal/nativeprompt/env.go. Declared
+	// ONCE so the reserved-name preflight below derives its set from this same
+	// list: a future third get_env global is then automatically protected against
+	// an enum-name collision, with no second place to keep in sync.
+	simpleGlobals := []struct {
+		name  string
+		value value.Value
+	}{
+		{"_", value.FromObject(roleHelper{})},
+		{"ctx", value.FromObject(ctxObject{outputFormat: cfg.OutputFormat})},
+	}
+	for _, g := range simpleGlobals {
+		env.AddGlobal(g.name, g.value)
+	}
 
-	return env
+	// Per-enum namespace globals: Color -> {RED: <member>, ...}, keyed by
+	// canonical variant name, non-enumerable — BAML's render-time injection
+	// (lib.rs:316-327). A malformed enum descriptor fails loud.
+	//
+	// PREFLIGHT, then install: every EnumDef is validated and every name checked
+	// for a collision BEFORE the first AddGlobal. Environment.AddGlobal is a plain
+	// map assignment, so a colliding name silently REPLACES whatever was there —
+	// a malformed resolved-metadata set rendering as a valid-but-wrong template.
+	// Preflighting also keeps the failure atomic: a rejected Config never yields a
+	// half-populated environment.
+	//
+	// The reserved names are DERIVED from the simpleGlobals installed just above,
+	// so this check tracks that list rather than restating it. Without it an
+	// EnumDef named "ctx" or "_" would clobber a get_env global (those go in
+	// FIRST, so the enum would win) and `ctx.output_format` would go silently
+	// empty. Neither name can occur in real resolved metadata anyway: stock BAML
+	// v0.223 REJECTS `enum ctx {...}` and `enum _ {...}` at CreateRuntime, so a
+	// caller supplying one is supplying something BAML could never have produced.
+	// Rejecting it is the conservative, fail-loud decline.
+	namespaces := make([]*enumType, 0, len(cfg.Enums))
+	reserved := make(map[string]struct{}, len(simpleGlobals))
+	for _, g := range simpleGlobals {
+		reserved[g.name] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(cfg.Enums))
+	for _, def := range cfg.Enums {
+		t, err := newEnumType(def)
+		if err != nil {
+			return nil, err
+		}
+		if _, bad := reserved[def.Name]; bad {
+			return nil, fmt.Errorf("bamlprofile: enum definition %q collides with the get_env global of the same name", def.Name)
+		}
+		if _, dup := seen[def.Name]; dup {
+			return nil, fmt.Errorf("bamlprofile: duplicate enum definition %q", def.Name)
+		}
+		seen[def.Name] = struct{}{}
+		namespaces = append(namespaces, t)
+	}
+	for _, ns := range namespaces {
+		env.AddGlobal(ns.name, value.FromObject(ns))
+	}
+
+	return env, nil
 }

--- a/internal/bamlprofile/env_test.go
+++ b/internal/bamlprofile/env_test.go
@@ -18,7 +18,11 @@ import (
 
 func render(t *testing.T, cfg Config, src string) string {
 	t.Helper()
-	tmpl, err := New(cfg).TemplateFromNamedString("smoke.txt", src)
+	env, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New(%+v): %v", cfg, err)
+	}
+	tmpl, err := env.TemplateFromNamedString("smoke.txt", src)
 	if err != nil {
 		t.Fatalf("compile %q: %v", src, err)
 	}
@@ -90,7 +94,11 @@ func TestSmokeRoleErrorKinds(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpl, err := New(Config{}).TemplateFromNamedString("smoke.txt", tc.src)
+			env, err := New(Config{})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			tmpl, err := env.TemplateFromNamedString("smoke.txt", tc.src)
 			if err != nil {
 				t.Fatalf("compile %q: %v", tc.src, err)
 			}

--- a/internal/bamlprofile/host_test.go
+++ b/internal/bamlprofile/host_test.go
@@ -1,0 +1,780 @@
+package bamlprofile
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	minijinja "github.com/invakid404/minijinja-go/v2"
+	"github.com/invakid404/minijinja-go/v2/value"
+)
+
+// These are pure-Go GUARDRAIL tests for the enum/class/list host value model.
+// They pin the obvious observable behavior for fast feedback; the byte-exact
+// AUTHORITY is the stock-BAML-v0.223 differential in ./profileoracle
+// (integration tag). The goldens here are hand-derived from BAML's Rust source
+// and its own test expectations, then confirmed by the differential.
+
+func strptr(s string) *string { return &s }
+
+// colorEnum is the discriminating enum used across these tests: RED has an alias
+// that DIFFERS from its canonical name, so alias-vs-canonical confusions surface.
+func colorEnum() EnumDef {
+	return EnumDef{Name: "Color", Values: []EnumValue{
+		{Canonical: "RED", Alias: strptr("rouge")},
+		{Canonical: "GREEN"},
+		{Canonical: "BLUE"},
+	}}
+}
+
+func renderHost(t *testing.T, cfg Config, src string, ctx map[string]any) (string, error) {
+	t.Helper()
+	env, err := New(cfg)
+	if err != nil {
+		return "", err
+	}
+	tmpl, err := env.TemplateFromNamedString("host_test", src)
+	if err != nil {
+		return "", err
+	}
+	if ctx == nil {
+		ctx = map[string]any{}
+	}
+	return tmpl.Render(ctx)
+}
+
+func mustRender(t *testing.T, cfg Config, src string, ctx map[string]any) string {
+	t.Helper()
+	out, err := renderHost(t, cfg, src, ctx)
+	if err != nil {
+		t.Fatalf("render %q: %v", src, err)
+	}
+	return out
+}
+
+// TestEnumPresentation pins display (alias-or-canonical), .value (canonical
+// only), and that .name/.alias are absent.
+func TestEnumPresentation(t *testing.T) {
+	cfg := Config{Enums: []EnumDef{colorEnum()}}
+	cases := []struct{ name, src, want string }{
+		{"display_alias", `{{ Color.RED }}`, "rouge"},
+		{"display_noalias", `{{ Color.GREEN }}`, "GREEN"},
+		{"value_alias", `{{ Color.RED.value }}`, "RED"},
+		{"value_noalias", `{{ Color.GREEN.value }}`, "GREEN"},
+		{"name_absent", `{{ Color.RED.name is undefined }}`, "true"},
+		{"alias_absent", `{{ Color.RED.alias is undefined }}`, "true"},
+		{"value_present", `{{ Color.RED.value is undefined }}`, "false"},
+		{"unknown_member", `{{ Color.PURPLE is undefined }}`, "true"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mustRender(t, cfg, tc.src, nil); got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.src, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEnumValueCmp597 pins the six #597 cases in both operand orders plus
+// membership, and the decline edges — the profile-level closure of the fence.
+func TestEnumValueCmp597(t *testing.T) {
+	// A second enum whose RED has the SAME canonical+alias as Color.RED, and a
+	// third whose RED has NO alias, to probe enum_name omission and the
+	// Some/None alias tie-break.
+	shade := EnumDef{Name: "Shade", Values: []EnumValue{{Canonical: "RED", Alias: strptr("rouge")}}}
+	size := EnumDef{Name: "Size", Values: []EnumValue{{Canonical: "RED"}, {Canonical: "SMALL", Alias: strptr("petit")}}}
+	cfg := Config{Enums: []EnumDef{colorEnum(), shade, size}}
+	cases := []struct{ name, src, want string }{
+		// the six
+		{"canon_eq_fwd", `{{ Color.RED == 'RED' }}`, "true"},
+		{"canon_eq_rev", `{{ 'RED' == Color.RED }}`, "true"},
+		{"same_member", `{{ Color.RED == Color.RED }}`, "true"},
+		{"in_list", `{{ 'RED' in [Color.RED] }}`, "true"},
+		{"alias_str_false", `{{ Color.RED == 'rouge' }}`, "false"},
+		{"diff_member", `{{ Color.RED == Color.BLUE }}`, "false"},
+		// extras
+		{"member_in_strlist", `{{ Color.RED in ['RED'] }}`, "true"},
+		{"alias_str_rev", `{{ 'rouge' == Color.RED }}`, "false"},
+		{"ne_member", `{{ Color.RED != Color.BLUE }}`, "true"},
+		{"ne_same", `{{ Color.RED != Color.RED }}`, "false"},
+		// cross-enum: enum_name omitted (same canonical+alias -> equal); alias IS
+		// part of identity (same canonical, Some vs None -> not equal).
+		{"cross_enum_eq", `{{ Color.RED == Shade.RED }}`, "true"},
+		{"cross_enum_in_list", `{{ Shade.RED in [Color.RED] }}`, "true"},
+		{"same_canon_diff_alias", `{{ Color.RED == Size.RED }}`, "false"},
+		// ordering
+		{"order_str_lt", `{{ Color.GREEN < 'RED' }}`, "true"},
+		{"order_str_gt", `{{ Color.RED < 'GREEN' }}`, "false"},
+		{"order_member_none_lt_some", `{{ Size.RED < Color.RED }}`, "true"},
+		{"order_member_some_gt_none", `{{ Color.RED < Size.RED }}`, "false"},
+		// decline non-string primitives (never invent equality)
+		{"decline_int_eq", `{{ Color.RED == 5 }}`, "false"},
+		{"decline_int_ne", `{{ Color.RED != 5 }}`, "true"},
+		{"decline_bool", `{{ Color.RED == true }}`, "false"},
+		{"decline_none_eq", `{{ Color.RED == none }}`, "false"},
+		{"decline_none_ne", `{{ Color.RED != none }}`, "true"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mustRender(t, cfg, tc.src, nil); got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.src, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassAccessAndRender pins canonical access / alias-undefined / map
+// behavior and the exact {map:#?} direct-render bytes (single field, nested
+// class+list, nested none, and scalar escaping). The nested golden is BAML's own
+// render_nested_class expectation (lib.rs:1888).
+func TestClassAccessAndRender(t *testing.T) {
+	single, err := ClassValue([]ClassField{{Canonical: "prop1", Alias: strptr("key1"), Value: value.FromString("value")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bList, err := ListValue([]value.Value{value.FromString("item1"), value.FromString("item2")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inner, err := ClassValue([]ClassField{
+		{Canonical: "b_prop1", Alias: strptr("alias_b_prop1"), Value: value.FromString("value_b")},
+		{Canonical: "b_prop2", Value: bList},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	nested, err := ClassValue([]ClassField{
+		{Canonical: "a_prop1", Alias: strptr("alias_a_prop1"), Value: value.FromString("value_a")},
+		{Canonical: "a_prop2", Value: inner},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	noneField, err := ClassValue([]ClassField{
+		{Canonical: "maybe", Alias: strptr("perhaps"), Value: value.None()},
+		{Canonical: "always", Value: value.FromString("x")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	esc, err := ClassValue([]ClassField{{Canonical: "raw", Alias: strptr("escaped"), Value: value.FromString("a\"b\tc\nd")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct{ name, src, want string }{
+		{"canonical_access", `{{ c.prop1 }}`, "value"},
+		{"alias_undefined", `{{ c.key1 is undefined }}`, "true"},
+		{"canonical_defined", `{{ c.prop1 is undefined }}`, "false"},
+		{"missing_undefined", `{{ c.nope is undefined }}`, "true"},
+		{"truthy", `{% if c %}yes{% else %}no{% endif %}`, "yes"},
+		{"render_single", `{{ c }}`, "{\n    \"key1\": \"value\",\n}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mustRender(t, Config{}, tc.src, map[string]any{"c": single}); got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.src, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("iter_and_length", func(t *testing.T) {
+		if got := mustRender(t, Config{}, `{% for k in c %}{{ k }},{% endfor %}/{{ c|length }}`, map[string]any{"c": nested}); got != "a_prop1,a_prop2,/2" {
+			t.Errorf("iter/length = %q", got)
+		}
+	})
+	t.Run("render_nested", func(t *testing.T) {
+		want := "{\n    \"alias_a_prop1\": \"value_a\",\n    \"a_prop2\": {\n        \"alias_b_prop1\": \"value_b\",\n        \"b_prop2\": [\n            \"item1\",\n            \"item2\",\n        ],\n    },\n}"
+		if got := mustRender(t, Config{}, `{{ c }}`, map[string]any{"c": nested}); got != want {
+			t.Errorf("render_nested =\n%q\nwant\n%q", got, want)
+		}
+	})
+	t.Run("render_nested_none", func(t *testing.T) {
+		want := "{\n    \"perhaps\": null,\n    \"always\": \"x\",\n}"
+		if got := mustRender(t, Config{}, `{{ c }}`, map[string]any{"c": noneField}); got != want {
+			t.Errorf("render_nested_none = %q, want %q", got, want)
+		}
+	})
+	t.Run("render_escaping", func(t *testing.T) {
+		want := "{\n    \"escaped\": \"a\\\"b\\tc\\nd\",\n}"
+		if got := mustRender(t, Config{}, `{{ c }}`, map[string]any{"c": esc}); got != want {
+			t.Errorf("render_escaping = %q, want %q", got, want)
+		}
+	})
+	// The leaf preserves the EXACT insertion order it is given — it does not sort
+	// fields. This is the multi-field ordering the CFFI differential cannot pin
+	// (a class ARGUMENT's field order is the Go client's random map order there),
+	// so it is proven here: reversed-alphabetical fields render reversed, and the
+	// render_nested golden above is BAML's own multi-field expectation
+	// (jinja-runtime/src/lib.rs:1888) reproduced byte-for-byte.
+	t.Run("insertion_order_preserved", func(t *testing.T) {
+		c, err := ClassValue([]ClassField{
+			{Canonical: "zebra", Value: value.FromString("z")},
+			{Canonical: "apple", Value: value.FromString("a")},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantRender := "{\n    \"zebra\": \"z\",\n    \"apple\": \"a\",\n}"
+		if got := mustRender(t, Config{}, `{{ c }}`, map[string]any{"c": c}); got != wantRender {
+			t.Errorf("render = %q, want %q (must NOT be alphabetized)", got, wantRender)
+		}
+		if got := mustRender(t, Config{}, `{% for k in c %}{{ k }},{% endfor %}`, map[string]any{"c": c}); got != "zebra,apple," {
+			t.Errorf("iteration = %q, want insertion order zebra,apple,", got)
+		}
+	})
+
+	t.Run("empty_class_falsey", func(t *testing.T) {
+		empty, err := ClassValue(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := mustRender(t, Config{}, `{% if c %}yes{% else %}no{% endif %}/{{ c|length }}/{{ c }}`, map[string]any{"c": empty}); got != "no/0/{}" {
+			t.Errorf("empty class = %q, want %q", got, "no/0/{}")
+		}
+	})
+}
+
+// TestListRenderAndBehavior pins host-list rendering (pretty debug-list with
+// BARE enum aliases and nested none -> null) plus indexing/length/membership.
+func TestListRenderAndBehavior(t *testing.T) {
+	cfg := Config{Enums: []EnumDef{colorEnum()}}
+	red, err := EnumMember("Color", "RED", strptr("rouge"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	green, err := EnumMember("Color", "GREEN", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enumList, err := ListValue([]value.Value{red, green})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("render_enum_list", func(t *testing.T) {
+		// A directly-rendered host list is COMPACT (non-alternate debug-list);
+		// enum members render as their BARE aliases.
+		want := "[rouge, GREEN]"
+		if got := mustRender(t, cfg, `{{ xs }}`, map[string]any{"xs": enumList}); got != want {
+			t.Errorf("render_enum_list = %q, want %q", got, want)
+		}
+	})
+	t.Run("index_and_cmp", func(t *testing.T) {
+		if got := mustRender(t, cfg, `{{ xs[0] == 'RED' }}/{{ xs[0] }}/{{ xs[1] }}/{{ xs|length }}`, map[string]any{"xs": enumList}); got != "true/rouge/GREEN/2" {
+			t.Errorf("index_and_cmp = %q", got)
+		}
+	})
+	t.Run("membership", func(t *testing.T) {
+		if got := mustRender(t, cfg, `{{ 'RED' in xs }}/{{ 'BLUE' in xs }}`, map[string]any{"xs": enumList}); got != "true/false" {
+			t.Errorf("membership = %q", got)
+		}
+	})
+	t.Run("render_none_item", func(t *testing.T) {
+		l, err := ListValue([]value.Value{value.FromString("a"), value.None()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := `["a", null]`
+		if got := mustRender(t, Config{}, `{{ xs }}`, map[string]any{"xs": l}); got != want {
+			t.Errorf("render_none_item = %q, want %q", got, want)
+		}
+	})
+	t.Run("render_empty", func(t *testing.T) {
+		empty, err := ListValue(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := mustRender(t, Config{}, `{{ xs }}`, map[string]any{"xs": empty}); got != "[]" {
+			t.Errorf("render_empty = %q, want []", got)
+		}
+	})
+}
+
+// TestHostConstructionFailsLoud pins that malformed enum/class metadata is
+// rejected at construction (a DECLINE/fail-loud), never silently accepted into a
+// value that would render or compare wrong.
+func TestHostConstructionFailsLoud(t *testing.T) {
+	t.Run("new_empty_enum_name", func(t *testing.T) {
+		if _, err := New(Config{Enums: []EnumDef{{Name: "", Values: []EnumValue{{Canonical: "X"}}}}}); err == nil {
+			t.Error("New accepted an enum with an empty name")
+		}
+	})
+	t.Run("new_empty_canonical", func(t *testing.T) {
+		if _, err := New(Config{Enums: []EnumDef{{Name: "E", Values: []EnumValue{{Canonical: ""}}}}}); err == nil {
+			t.Error("New accepted a variant with an empty canonical name")
+		}
+	})
+	t.Run("new_dup_variant", func(t *testing.T) {
+		if _, err := New(Config{Enums: []EnumDef{{Name: "E", Values: []EnumValue{{Canonical: "X"}, {Canonical: "X"}}}}}); err == nil {
+			t.Error("New accepted a duplicate variant")
+		}
+	})
+	t.Run("enum_member_empty_canonical", func(t *testing.T) {
+		if _, err := EnumMember("E", "", nil); err == nil {
+			t.Error("EnumMember accepted an empty canonical name")
+		}
+	})
+	t.Run("enum_member_empty_enum_name", func(t *testing.T) {
+		if _, err := EnumMember("", "X", nil); err == nil {
+			t.Error("EnumMember accepted an empty enum name")
+		}
+	})
+	t.Run("class_empty_field", func(t *testing.T) {
+		if _, err := ClassValue([]ClassField{{Canonical: "", Value: value.FromString("x")}}); err == nil {
+			t.Error("ClassValue accepted an empty field name")
+		}
+	})
+	t.Run("class_dup_field", func(t *testing.T) {
+		if _, err := ClassValue([]ClassField{
+			{Canonical: "a", Value: value.FromString("x")},
+			{Canonical: "a", Value: value.FromString("y")},
+		}); err == nil {
+			t.Error("ClassValue accepted a duplicate field name")
+		}
+	})
+	t.Run("class_rejects_native_container", func(t *testing.T) {
+		// A native fork slice as a field value would render compactly via Repr, not
+		// as BAML's pretty host list — reject it rather than silently diverge.
+		native := value.FromSlice([]value.Value{value.FromString("x")})
+		if _, err := ClassValue([]ClassField{{Canonical: "a", Value: native}}); err == nil {
+			t.Error("ClassValue accepted a native fork slice as a field value")
+		}
+	})
+	t.Run("list_rejects_native_container", func(t *testing.T) {
+		native := value.FromSlice([]value.Value{value.FromString("x")})
+		if _, err := ListValue([]value.Value{native}); err == nil {
+			t.Error("ListValue accepted a native fork slice as an item")
+		}
+	})
+	// Environment.AddGlobal is a plain map assignment, so without a preflight the
+	// SECOND definition would silently replace the first and `Duplicate.A` would
+	// become undefined while the Config still looked accepted. This is the exact
+	// construction from the PR-2 review.
+	// "ctx" and "_" are installed by New itself, BEFORE the enum namespaces, so an
+	// EnumDef with either name would win the AddGlobal race and silently blank out
+	// ctx.output_format. Stock BAML v0.223 rejects `enum ctx {}` / `enum _ {}` at
+	// CreateRuntime, so such a definition cannot come from real resolved metadata
+	// — declining it is the conservative match.
+	t.Run("new_enum_named_like_a_reserved_global", func(t *testing.T) {
+		for _, name := range []string{"ctx", "_"} {
+			cfg := Config{OutputFormat: "SCHEMA", Enums: []EnumDef{{Name: name, Values: []EnumValue{{Canonical: "A"}}}}}
+			if _, err := New(cfg); err == nil {
+				t.Errorf("New accepted an enum named %q, which would clobber the %q global", name, name)
+			}
+		}
+	})
+	// The alias pointer must be OWNED, like ListValue's items: writing through the
+	// caller's *string afterwards must not change the member's display or its
+	// Option<alias> comparison identity.
+	t.Run("enum_member_owns_its_alias", func(t *testing.T) {
+		alias := "rouge"
+		m, err := EnumMember("Color", "RED", &alias)
+		if err != nil {
+			t.Fatal(err)
+		}
+		alias = "vert"
+		if got := mustRender(t, Config{}, `{{ m }}`, map[string]any{"m": m}); got != "rouge" {
+			t.Errorf("member display after caller mutation = %q, want rouge", got)
+		}
+	})
+	t.Run("new_dup_enum_definition", func(t *testing.T) {
+		_, err := New(Config{Enums: []EnumDef{
+			{Name: "Duplicate", Values: []EnumValue{{Canonical: "A"}}},
+			{Name: "Duplicate", Values: []EnumValue{{Canonical: "B"}}},
+		}})
+		if err == nil {
+			t.Fatal("New accepted two EnumDefs with the same Name")
+		}
+		if !strings.Contains(err.Error(), "duplicate enum definition") {
+			t.Errorf("duplicate-enum error = %q, want a 'duplicate enum definition' message", err.Error())
+		}
+	})
+	// ListValue validates every item, then stores an OWNED copy. Without the copy
+	// a caller could swap in a native container after construction and turn the
+	// debug walker's "unreachable" panic into a reachable one — the review's
+	// disproof of the construction-time invariant.
+	t.Run("list_ingress_copy_defeats_post_construction_mutation", func(t *testing.T) {
+		items := []value.Value{value.FromString("safe")}
+		xs, err := ListValue(items)
+		if err != nil {
+			t.Fatal(err)
+		}
+		items[0] = value.FromSlice([]value.Value{value.FromString("mutated")})
+		if got := mustRender(t, Config{}, `{{ xs }}`, map[string]any{"xs": xs}); got != `["safe"]` {
+			t.Errorf("render after caller mutation = %q, want [\"safe\"] (ListValue must own its items)", got)
+		}
+	})
+	// The same ingress contract for a list nested in a class: the class stores the
+	// already-owned host list value, so the caller's slice is equally inert.
+	t.Run("class_field_list_unaffected_by_caller_mutation", func(t *testing.T) {
+		items := []value.Value{value.FromString("safe")}
+		xs, err := ListValue(items)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c, err := ClassValue([]ClassField{{Canonical: "items", Alias: strptr("data"), Value: xs}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		items[0] = value.FromSlice([]value.Value{value.FromString("mutated")})
+		want := "{\n    \"data\": [\n        \"safe\",\n    ],\n}"
+		if got := mustRender(t, Config{}, `{{ c }}`, map[string]any{"c": c}); got != want {
+			t.Errorf("nested render after caller mutation = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestOptionalAliasNoneVsEmptySome pins the distinction a regression collapsing
+// EnumValue.Alias from *string to a plain string would ERASE: an absent @alias
+// (nil, Option::None) and an explicit @alias("") (non-nil "", Some("")) are
+// DIFFERENT values, and None sorts strictly BELOW Some(""). BAML's comparator is
+// Rust's `Option<String>::cmp` (rs:249-252), which this reproduces.
+//
+// Every OTHER alias assertion in this file stays green under that collapse,
+// because they only ever use a non-empty alias or no alias; only the
+// None-vs-Some("") pair separates the two representations. This is the CGO-free
+// twin of the enum_empty_alias corpus row.
+func TestOptionalAliasNoneVsEmptySome(t *testing.T) {
+	// The comparator primitive, directly: None < Some(""), and neither is equal
+	// across the nil boundary.
+	empty := ""
+	for _, tc := range []struct {
+		name string
+		a, b *string
+		want int
+	}{
+		{`None < Some("")`, nil, &empty, -1},
+		{`Some("") > None`, &empty, nil, 1},
+		{"None == None", nil, nil, 0},
+		{`Some("") == Some("")`, &empty, &empty, 0},
+	} {
+		if got := compareOptionalAlias(tc.a, tc.b); got != tc.want {
+			t.Errorf("compareOptionalAlias(%s) = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+
+	// And end-to-end through two members with the SAME canonical name: the
+	// absent-alias member sorts below the explicit-empty-alias one, and they are
+	// NOT equal. If the alias were a plain string, both would be "" and this would
+	// render `false/true/false`.
+	noAlias, err := EnumMember("E", "X", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyAlias, err := EnumMember("E", "X", strptr(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := mustRender(t, Config{}, `{{ a < b }}/{{ a == b }}/{{ a != b }}`,
+		map[string]any{"a": noAlias, "b": emptyAlias})
+	if got != "true/false/true" {
+		t.Errorf(`None-vs-Some("") member comparison = %q, want "true/false/true"`, got)
+	}
+}
+
+// TestEnumHostObjectsAreNonEnumerableMaps is the LEAF GUARDRAIL for the
+// non-enumerable-map wiring. Both enum host objects are ObjectReprMap and
+// implement NEITHER value.MapObject NOR value.MapGetter, which is how BAML's
+// `Enumerator::NonEnumerable` with an unknown length is spelled at the fork's
+// generic value-model seam.
+//
+// The fork encodes the distinction in the boolean of Value.MapKeys: a
+// known-empty `{}` answers ([], true); an object with no enumerable pairs
+// answers (nil, false). Equality, ordering, membership, iteration and `is
+// iterable` all branch on that boolean (v2.16.0-baml.4, PATCHES #102/#103/#105),
+// so if a Keys()/Map() method were ever added to either type — even one
+// returning nothing — the member would become a KNOWN-EMPTY map and every one of
+// those behaviors would silently diverge from stock BAML.
+//
+// The behavioral consequences are proven byte-for-byte against stock BAML CFFI
+// in ./profileoracle (enum_cmp_opaque_* and enum_non_enumerable_state); this
+// test pins the underlying capability directly so the cause is visible at the
+// leaf even without CGO.
+func TestEnumHostObjectsAreNonEnumerableMaps(t *testing.T) {
+	member, err := EnumMember("Color", "RED", strptr("rouge"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	namespace, err := newEnumType(colorEnum())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		val  value.Value
+	}{
+		{"member", member},
+		{"namespace", value.FromObject(namespace)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.val.Kind(); got != value.KindMap {
+				t.Errorf("Kind() = %v, want KindMap (BAML's ObjectRepr::Map)", got)
+			}
+			keys, ok := tc.val.MapKeys()
+			if ok {
+				t.Errorf("MapKeys() reported ok = true (keys %v); a %s is NON-ENUMERABLE, "+
+					"not a known-empty map — it must not implement MapObject/MapGetter", keys, tc.name)
+			}
+			if keys != nil {
+				t.Errorf("MapKeys() returned keys %v alongside ok = false", keys)
+			}
+			obj, _ := tc.val.AsObject()
+			if _, isMapObject := obj.(value.MapObject); isMapObject {
+				t.Errorf("%s implements value.MapObject; that makes it an enumerable map", tc.name)
+			}
+			if _, isMapGetter := obj.(value.MapGetter); isMapGetter {
+				t.Errorf("%s implements value.MapGetter; that makes it an enumerable map", tc.name)
+			}
+		})
+	}
+
+	// A known-empty class is the CONTROL: same KindMap, but its pairs ARE
+	// enumerable, so it answers ([], true). This is exactly the distinction the
+	// fork's equality/ordering seam reads.
+	t.Run("empty_class_control_is_enumerable", func(t *testing.T) {
+		empty, err := ClassValue(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		keys, ok := empty.MapKeys()
+		if !ok {
+			t.Fatal("an empty host class reported ok = false; it is a KNOWN-empty map")
+		}
+		if len(keys) != 0 {
+			t.Errorf("empty class MapKeys() = %v, want no keys", keys)
+		}
+	})
+}
+
+// TestEnumOpaqueMapSemantics pins the observable behavior the non-enumerable
+// wiring buys, at the leaf, for fast CGO-free feedback. Every expectation here
+// is stock BAML v0.223 CFFI authority, proven byte-for-byte by the
+// enum_cmp_opaque_* corpus rows in ./profileoracle.
+//
+// Note the deliberate ASYMMETRY: `Color.RED == {}` is false but `{} ==
+// Color.RED` is true, because BAML's map fallback short-circuits on the LEFT
+// operand's absent pair iterator and otherwise counts a non-enumerable right
+// side as length zero. Membership inherits it through the orientation of
+// `item.Equal(needle)`. That is stock behavior, not a defect to smooth over.
+func TestEnumOpaqueMapSemantics(t *testing.T) {
+	shade := EnumDef{Name: "Shade", Values: []EnumValue{{Canonical: "RED", Alias: strptr("rouge")}}}
+	cfg := Config{Enums: []EnumDef{colorEnum(), shade}}
+	cases := []struct{ name, src, want string }{
+		// Namespace/member equality: the comparator declines, and the map fallback
+		// must NOT then call two non-enumerable maps structurally equal.
+		{"member_eq_namespace", `{{ Color.RED == Color }}`, "false"},
+		{"namespace_eq_member", `{{ Color == Color.RED }}`, "false"},
+		{"member_ne_namespace", `{{ Color.RED != Color }}`, "true"},
+		{"namespace_ne_member", `{{ Color != Color.RED }}`, "true"},
+		// Membership through both orientations.
+		{"member_in_namespace_list", `{{ Color.RED in [Color] }}`, "false"},
+		{"namespace_in_member_list", `{{ Color in [Color.RED] }}`, "false"},
+		{"namespace_in_namespace_list", `{{ Color in [Shade] }}`, "false"},
+		{"member_in_mixed_list", `{{ Color.RED in [Color, Shade] }}`, "false"},
+		// The empty-map row, both orientations. Asymmetric ON PURPOSE.
+		{"member_eq_empty_map", `{{ Color.RED == {} }}`, "false"},
+		{"empty_map_eq_member", `{{ {} == Color.RED }}`, "true"},
+		{"member_ne_empty_map", `{{ Color.RED != {} }}`, "true"},
+		{"empty_map_ne_member", `{{ {} != Color.RED }}`, "false"},
+		{"member_in_empty_map_list", `{{ Color.RED in [{}] }}`, "true"},
+		{"empty_map_in_member_list", `{{ {} in [Color.RED] }}`, "false"},
+		// Map representation is NOT enumerability, and neither is truthiness.
+		{"is_mapping", `{{ Color.RED is mapping }}/{{ Color is mapping }}`, "true/true"},
+		{"is_iterable", `{{ Color.RED is iterable }}/{{ Color is iterable }}`, "false/false"},
+		{"truthy", `{% if Color.RED %}T{% else %}F{% endif %}/{% if Color %}T{% else %}F{% endif %}`, "T/T"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mustRender(t, cfg, tc.src, nil); got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.src, got, tc.want)
+			}
+		})
+	}
+
+	// Ordering two non-enumerable maps is stock MiniJinja's `unreachable!()`. The
+	// profile must FAULT, never render a conservative `false` — a native success
+	// where BAML fails internally is the parity-decline rule's out-do.
+	t.Run("order_faults", func(t *testing.T) {
+		for _, src := range []string{
+			`{{ Color.RED < Color }}`,
+			`{{ Color < Color.RED }}`,
+			`{{ Color.RED > Color }}`,
+			`{{ Color.RED <= Color }}`,
+		} {
+			out, err := renderHostRecovering(t, cfg, src, nil)
+			if err == nil {
+				t.Errorf("%s rendered %q; ordering two non-enumerable maps must FAULT the way stock BAML's unreachable!() does", src, out)
+			}
+		}
+	})
+
+	// Iterating either object errors ("map is not iterable"); it is NOT silently
+	// an empty loop.
+	t.Run("for_faults", func(t *testing.T) {
+		for _, src := range []string{
+			`{% for x in Color.RED %}{{ x }}{% endfor %}`,
+			`{% for x in Color %}{{ x }}{% endfor %}`,
+		} {
+			out, err := renderHostRecovering(t, cfg, src, nil)
+			if err == nil {
+				t.Errorf("%s rendered %q; a non-enumerable map is not an empty iterable", src, out)
+			}
+		}
+	})
+}
+
+// renderHostRecovering renders like renderHost but also converts the fork's
+// recoverable ordering panic (value.UnorderableMaps, the fork's spelling of
+// MiniJinja's `unreachable!()`) into an error, so a fault row can be asserted
+// without crashing the test binary.
+func renderHostRecovering(t *testing.T, cfg Config, src string, ctx map[string]any) (out string, err error) {
+	t.Helper()
+	defer func() {
+		if rec := recover(); rec != nil {
+			if u, ok := rec.(value.UnorderableMaps); ok {
+				err = u
+				return
+			}
+			panic(rec)
+		}
+	}()
+	return renderHost(t, cfg, src, ctx)
+}
+
+// TestHostDebugWalkerModes pins the ONE debug walker's two modes and the exact
+// mode each nesting position selects — the semantics the previously duplicated
+// compactDebug/prettyDebug pair carried. A directly-rendered list is compact
+// (ambient non-alternate debug_list, rs:373-388); a class is ALWAYS alternate
+// (Display forces `{map:#?}`, rs:279); a list nested in a class inherits
+// alternate; a list nested in a compact list stays compact; a nested none is
+// null and a nested enum member is its BARE alias in both modes.
+func TestHostDebugWalkerModes(t *testing.T) {
+	red, err := EnumMember("Color", "RED", strptr("rouge"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	inner, err := ListValue([]value.Value{value.FromString("a"), value.None(), red})
+	if err != nil {
+		t.Fatal(err)
+	}
+	nestedInList, err := ListValue([]value.Value{inner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cls, err := ClassValue([]ClassField{{Canonical: "items", Alias: strptr("data"), Value: inner}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clsInList, err := ListValue([]value.Value{cls})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name, want string
+		val        value.Value
+	}{
+		{"direct_list_is_compact", `["a", null, rouge]`, inner},
+		{"list_in_list_stays_compact", `[["a", null, rouge]]`, nestedInList},
+		{"list_in_class_goes_alternate",
+			"{\n    \"data\": [\n        \"a\",\n        null,\n        rouge,\n    ],\n}", cls},
+		// A class inside a COMPACT list is still multi-line, at indent 0: its
+		// Display forces the alternate map regardless of the ambient flag.
+		{"class_in_compact_list_is_still_alternate",
+			"[{\n    \"data\": [\n        \"a\",\n        null,\n        rouge,\n    ],\n}]", clsInList},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mustRender(t, Config{}, `{{ v }}`, map[string]any{"v": tc.val}); got != tc.want {
+				t.Errorf("render = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHostObjectStringComposes pins that host display reaches ORDINARY Jinja
+// containers, coercions and concatenation — not just the top-level formatter.
+// The fork's Value.String and Value.Repr dispatch value.ObjectWithString
+// (v2.16.0-baml.4, PATCHES #104), so every consumer built on those two
+// primitives inherits it and NO per-filter shim exists in this package.
+//
+// Each case also asserts the output carries no Go-format leakage (`&{` or a
+// `0x` pointer), which is what these paths emitted before the fork fix — and
+// which was nondeterministic output, not merely ugly. The byte authority is the
+// object_string_* corpus rows in ./profileoracle.
+func TestHostObjectStringComposes(t *testing.T) {
+	cfg := Config{Enums: []EnumDef{colorEnum()}}
+	red, err := EnumMember("Color", "RED", strptr("rouge"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	xs, err := ListValue([]value.Value{red})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := ClassValue([]ClassField{{Canonical: "prop1", Alias: strptr("key1"), Value: value.FromString("value")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := map[string]any{"xs": xs, "c": c}
+
+	cases := []struct{ name, src, want string }{
+		{"native_enum_list", `{{ [Color.RED] }}`, "[rouge]"},
+		{"join", `{{ [Color.RED]|join(",") }}`, "rouge"},
+		{"upper", `{{ Color.RED|upper }}`, "ROUGE"},
+		{"concat", `{{ Color.RED ~ "!" }}`, "rouge!"},
+		{"filter_string", `{{ Color.RED|string }}`, "rouge"},
+		{"native_host_list", `{{ [xs] }}`, "[[rouge]]"},
+		{"native_class", `{{ [c] }}`, "[{\n    \"key1\": \"value\",\n}]"},
+		// The NAMESPACE object: BAML gives MinijinjaBamlEnumType no Display, so the
+		// engine's default Map render produces `{}` from its (absent) pairs. Every
+		// position, because this is the object whose Go `%v` carried heap addresses.
+		{"namespace_bare", `[{{ Color }}]`, "[{}]"},
+		{"namespace_in_list", `{{ [Color] }}`, "[{}]"},
+		{"namespace_string", `[{{ Color|string }}]`, "[{}]"},
+		{"namespace_concat", `{{ Color ~ "!" }}`, "{}!"},
+		{"namespace_upper", `{{ Color|upper }}`, "{}"},
+		{"namespace_in_map", `{{ {"k": Color} }}`, `{"k": {}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mustRender(t, cfg, tc.src, ctx)
+			if got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.src, got, tc.want)
+			}
+			if strings.Contains(got, "&{") || strings.Contains(got, "0x") {
+				t.Errorf("%s leaked Go formatting: %q", tc.src, got)
+			}
+		})
+	}
+}
+
+// TestFormatTypeDeclined pins that BAML's render-layer format(type=...) host
+// serialization is NOT reproduced by the profile: the get_env-level `format` is
+// the fork's printf filter, so `class|format(type="json")` ERRORS ("value is not
+// a string") rather than silently emitting a JSON/YAML/TOON serialization. This
+// is a real, non-silent boundary — the deferral is tracked on #602. (Media host
+// values are likewise declined: the profile exposes no media constructor, so a
+// media value cannot enter the render context in the first place.)
+func TestFormatTypeDeclined(t *testing.T) {
+	c, err := ClassValue([]ClassField{{Canonical: "prop1", Alias: strptr("key1"), Value: value.FromString("value")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = renderHost(t, Config{}, `{{ c|format(type="json") }}`, map[string]any{"c": c})
+	if err == nil {
+		t.Fatal("format(type=\"json\") on a class did not error — the profile must NOT silently claim BAML's format serialization")
+	}
+	// Only the error KIND is asserted: ErrInvalidOperation is the documented
+	// contract, while the message text ("... not a string") is an incidental
+	// detail of which printf-filter arm declines and is not a contract to pin.
+	var me *minijinja.Error
+	if !errors.As(err, &me) || me.Kind != minijinja.ErrInvalidOperation {
+		t.Errorf("format decline error = %v (kind %v), want ErrInvalidOperation", err, kindOf(err))
+	}
+}

--- a/internal/bamlprofile/list.go
+++ b/internal/bamlprofile/list.go
@@ -1,0 +1,84 @@
+package bamlprofile
+
+import (
+	"fmt"
+
+	"github.com/invakid404/minijinja-go/v2/value"
+)
+
+// listObject is BAML's MinijinjaBamlList: the host value a BamlValue::List lowers
+// to (baml_value_to_jinja_value.rs:34-40,337-388). It is a sequence — normal
+// indexing, length, iteration and membership — whose rendering is Rust's
+// debug_list with nested none rendered as null: COMPACT when rendered directly
+// (the ambient formatter is non-alternate there) and multi-line when nested
+// inside a class, which forces alternate.
+//
+// Authority: BAML v0.223 engine/baml-lib/jinja-runtime/src/
+// baml_value_to_jinja_value.rs:337-388 (Seq repr, debug_list Display with the
+// none->null replacement, seq serialization).
+//
+// A host list is used, rather than a plain fork []Value, because the fork's
+// native slice renders compactly via each item's Repr, whereas BAML renders a
+// lowered list as a multi-line pretty debug-list. The distinction is only
+// observable in DIRECT rendering; indexing/length/iteration/membership match a
+// plain sequence, so those go through the fork's ordinary Seq handling.
+type listObject struct {
+	items []value.Value
+}
+
+// ListValue constructs a host list value (BAML's BamlValue::List lowering) for
+// use as a render argument or a nested class/list element. Like ClassValue it
+// fails loud when an item is not a scalar, none, or a bamlprofile host value —
+// a native fork container would render compactly via the fork's Repr instead of
+// BAML's pretty host rendering, a silent divergence.
+//
+// The validated items are stored as an OWNED shallow copy, not the caller's
+// slice. Without the copy a caller could invalidate the construction-time proof
+// after the fact (`items[0] = value.FromSlice(...)`), and the renderer's
+// "unreachable" panic in debugValue would become reachable from ordinary API
+// use. ClassValue already builds its own []classField; this makes the list's
+// ingress contract identical. The copy is shallow because each element is an
+// immutable fork value.Value — only the slice header/backing array is aliased,
+// and only that aliasing is what assertHostRenderable cannot re-check later.
+func ListValue(items []value.Value) (value.Value, error) {
+	for i, it := range items {
+		if err := assertHostRenderable(it); err != nil {
+			return value.Undefined(), fmt.Errorf("bamlprofile: list item %d: %w", i, err)
+		}
+	}
+	owned := make([]value.Value, len(items))
+	copy(owned, items)
+	return value.FromObject(&listObject{items: owned}), nil
+}
+
+// ObjectRepr is Seq (rs:369-371): the list iterates, indexes and measures like a
+// sequence.
+func (l *listObject) ObjectRepr() value.ObjectRepr { return value.ObjectReprSeq }
+
+// GetAttr has no attributes; a list is indexed, not attribute-accessed. The fork
+// routes index access through SeqItem, not GetAttr.
+func (l *listObject) GetAttr(string) value.Value { return value.Undefined() }
+
+// SeqLen / SeqItem give the fork ordinary sequence length, indexing, iteration
+// and membership. Items are returned verbatim (a none stays none, so `is none`
+// and comparisons see the real value); the none->null substitution is
+// display-only and lives in the pretty renderer (rs:373-388: only Display
+// swaps).
+func (l *listObject) SeqLen() int { return len(l.items) }
+
+func (l *listObject) SeqItem(i int) value.Value {
+	if i < 0 || i >= len(l.items) {
+		return value.Undefined()
+	}
+	return l.items[i]
+}
+
+// ObjectString renders the list at TOP LEVEL, where it is COMPACT
+// (`[a, b, c]`). BAML's MinijinjaBamlList Display calls the ambient formatter's
+// debug_list (rs:373-388), which is non-alternate at the top level, so a
+// directly-rendered list is single-line — unlike a class, whose Display forces
+// `{map:#?}` and is always multi-line. A list NESTED inside a class inherits the
+// alternate flag and renders multi-line; that path goes through the walker's
+// alternate mode, not here. The fork's Value.String/Value.Repr dispatch this
+// (PATCHES #104), so it composes through containers and coercions too.
+func (l *listObject) ObjectString() string { return debugList(l, debugCompact, 0) }

--- a/internal/bamlprofile/profileoracle/corpus.go
+++ b/internal/bamlprofile/profileoracle/corpus.go
@@ -23,12 +23,14 @@ package profileoracle
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"unicode"
 
 	"github.com/invakid404/baml-rest/internal/bamlprofile"
+	"github.com/invakid404/minijinja-go/v2/value"
 )
 
 // BAML role-marker literals (engine/baml-lib/jinja-runtime/src/lib.rs), copied
@@ -83,6 +85,61 @@ type Row struct {
 	// Chat is true when the template uses _.role/_.chat: the rendered output is a
 	// message list, compared message-by-message rather than as one completion.
 	Chat bool
+	// Fault, when non-empty, declares that stock BAML v0.223 does NOT render this
+	// row successfully, and WHICH failure class it produces. A fault row is
+	// compared by classified OUTCOME instead of by rendered bytes: it is green only
+	// when the profile fails in the same class, never because the profile rendered
+	// a conservative value where BAML faulted (the de-BAML parity-decline rule).
+	// The declaration is asserted against the live stock leg, so it cannot rot.
+	//
+	// It also selects HOW the stock leg is run: an OutcomeError row renders
+	// in-process, while an OutcomePanic row MUST go through the subprocess leg —
+	// see the Outcome docs.
+	Fault OutcomeKind
+}
+
+// OutcomeKind classifies how a render attempt ended. It is the comparison unit
+// for a fault row; a successful row still compares its bytes.
+type OutcomeKind string
+
+const (
+	// OutcomeRendered: the engine produced output. Text carries the bytes.
+	OutcomeRendered OutcomeKind = "rendered"
+	// OutcomeError: the engine raised a normal, recoverable template error (for
+	// example "map is not iterable"). The render failed; the process is healthy.
+	OutcomeError OutcomeKind = "error"
+	// OutcomePanic: the engine hit an INTERNAL invariant failure — stock BAML's
+	// `unreachable!()` (minijinja value/mod.rs:660) or, on the profile leg, the
+	// fork's value.UnorderableMaps. This is not a recoverable template error.
+	//
+	// On the stock CFFI leg it cannot be contained in-process at all: the Rust
+	// panic kills the tokio worker that owns the request, so BuildRequest never
+	// returns and blocks FOREVER (observed: a 600s test timeout, with the panic on
+	// stderr). That is why an OutcomePanic row runs stock BAML in a SUBPROCESS —
+	// the panic is read off the child's stderr and the child is killed. There is
+	// no in-process recover() that could turn it into a value, and the harness
+	// must never present it as one.
+	OutcomePanic OutcomeKind = "panic"
+)
+
+// Outcome is a classified render result from one leg.
+//
+// Only Kind (and, for OutcomeRendered, Text) is COMPARED. Detail is diagnostic
+// only: the stock Rust panic text and the fork's Go panic text are different
+// strings for the same invariant failure, and requiring them to match would pin
+// a message rather than a behavior.
+type Outcome struct {
+	Kind   OutcomeKind
+	Text   string // rendered bytes; set only when Kind is OutcomeRendered
+	Detail string // error/panic text; DIAGNOSTIC ONLY, never compared
+}
+
+// String renders an Outcome for a test failure message.
+func (o Outcome) String() string {
+	if o.Kind == OutcomeRendered {
+		return fmt.Sprintf("%s(%q)", o.Kind, o.Text)
+	}
+	return fmt.Sprintf("%s(%s)", o.Kind, o.Detail)
 }
 
 // FuncName is the BAML function name generated for a row.
@@ -155,18 +212,114 @@ func dedentAndTrim(s string) string {
 // rendered bytes, after reproducing BAML's template preprocessing. ctx.output_
 // format is empty for every corpus function (all return string, which has no
 // schema), so Config carries an empty OutputFormat — the same value BAML's ctx
-// exposes for these functions.
+// exposes for these functions. Config.Enums installs the shared enum namespace
+// globals, matching the globals BAML injects for every enum declared in
+// types.baml.
+//
+// A host-shaped argument (enum/class/list) is lowered to the same profile host
+// value BAML builds for that typed argument (types.go hostValue); a plain scalar
+// is passed through as-is. The fork's render context passes an existing
+// value.Value through unchanged (value.FromAny), so a host value.Value placed in
+// the ctx map reaches the template as that host object.
 func RenderProfile(r Row) (string, error) {
 	src := dedentAndTrim(r.blockContent())
-	tmpl, err := bamlprofile.New(bamlprofile.Config{}).TemplateFromNamedString("profile_oracle", src)
+	// Setup and lowering failures are wrapped as *harnessError so the fault-leg
+	// classifier can tell them apart from a genuine engine render error. Building
+	// the environment, compiling the template and lowering a host argument are the
+	// HARNESS's job; only tmpl.Render below is the ENGINE.
+	env, err := bamlprofile.New(bamlprofile.Config{Enums: profileEnums()})
 	if err != nil {
-		return "", err
+		return "", &harnessError{fmt.Errorf("bamlprofile.New: %w", err)}
 	}
-	ctx := map[string]any{}
+	tmpl, err := env.TemplateFromNamedString("profile_oracle", src)
+	if err != nil {
+		return "", &harnessError{fmt.Errorf("template compile: %w", err)}
+	}
+	ctx, err := profileContext(r)
+	if err != nil {
+		return "", &harnessError{err}
+	}
+	return tmpl.Render(ctx)
+}
+
+// harnessError marks a failure of the profile HARNESS itself — building the
+// environment, compiling the corpus template, or lowering a host argument — as
+// distinct from the ENGINE raising a recoverable template error while rendering.
+//
+// Only a genuine engine render error is an [OutcomeError]. Classifying a harness
+// failure as one would let a fault row that declares OutcomeError PASS because
+// the harness broke (e.g. it failed to lower an argument) rather than because the
+// engine faulted — a silent hole in the fault-outcome proof. [RenderProfileOutcome]
+// therefore re-raises a *harnessError loudly instead of classifying it.
+type harnessError struct{ err error }
+
+func (e *harnessError) Error() string { return e.err.Error() }
+func (e *harnessError) Unwrap() error { return e.err }
+
+// profileContext builds a row's render context: every Arg verbatim, with each
+// host-shaped DECLARED parameter replaced by its lowered host value.
+//
+// The host lowering walks r.Params in DECLARED order, not the r.Args map, so a
+// conversion failure always names the same parameter for the same row — a Go map
+// range would report a random one when several are malformed. A failure is
+// wrapped with the row ID, the parameter name, and its BAML type, because
+// hostValue's own message ("expects a []any arg, got string") is unattributable
+// once it surfaces from a 150-row suite. Diagnostic only: a successful render is
+// byte-identical either way.
+func profileContext(r Row) (map[string]any, error) {
+	ctx := make(map[string]any, len(r.Args))
 	for k, v := range r.Args {
 		ctx[k] = v
 	}
-	return tmpl.Render(ctx)
+	for _, p := range r.Params {
+		if !needsHostValue(p.BamlType) {
+			continue
+		}
+		arg, ok := r.Args[p.Name]
+		if !ok {
+			return nil, fmt.Errorf("profileoracle: row %q param %q (%s): declared but absent from Args", r.ID, p.Name, p.BamlType)
+		}
+		hv, err := hostValue(p.BamlType, arg)
+		if err != nil {
+			return nil, fmt.Errorf("profileoracle: row %q param %q (%s): %w", r.ID, p.Name, p.BamlType, err)
+		}
+		ctx[p.Name] = hv
+	}
+	return ctx, nil
+}
+
+// RenderProfileOutcome renders a row through the profile leg and CLASSIFIES the
+// result, so a fault row can be compared against stock BAML by outcome class.
+//
+// It recovers exactly one panic type: value.UnorderableMaps, the fork's
+// recoverable spelling of stock MiniJinja's `unreachable!()` when ordering two
+// mappings that cannot be enumerated (v2.16.0-baml.4, PATCHES #103). Any other
+// panic is re-raised — it would be a genuine defect in this package, and
+// swallowing it would turn a crash into a quietly-classified "fault" that a
+// stock panic row would then happily match.
+func RenderProfileOutcome(r Row) (o Outcome) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			u, ok := rec.(value.UnorderableMaps)
+			if !ok {
+				panic(rec)
+			}
+			o = Outcome{Kind: OutcomePanic, Detail: u.Error()}
+		}
+	}()
+	out, err := RenderProfile(r)
+	if err != nil {
+		// A harness setup/lowering failure is NOT an engine outcome. Failing
+		// loudly here is the whole point: silently classifying it as OutcomeError
+		// would let a fault row match on a broken harness instead of a real engine
+		// fault. Only an error that came out of the engine's render classifies.
+		var he *harnessError
+		if errors.As(err, &he) {
+			panic(fmt.Sprintf("profileoracle: row %q: profile harness failed before the engine rendered (not an engine outcome): %v", r.ID, err))
+		}
+		return Outcome{Kind: OutcomeError, Detail: err.Error()}
+	}
+	return Outcome{Kind: OutcomeRendered, Text: out}
 }
 
 // Message is a role + concatenated text, the canonical shape both legs reduce to
@@ -225,6 +378,7 @@ func GenerateBAMLSource(rows []Row) map[string]string {
 
 	return map[string]string{
 		"clients.baml":   clientSource(),
+		"types.baml":     typesBAMLSource(),
 		"functions.baml": fns.String(),
 	}
 }

--- a/internal/bamlprofile/profileoracle/corpus_test.go
+++ b/internal/bamlprofile/profileoracle/corpus_test.go
@@ -129,8 +129,15 @@ func TestFunctionSourcePanicsOnUnrepresentableBody(t *testing.T) {
 	_ = functionSource(Row{ID: "overflow", Template: `x"#####y`})
 }
 
+// TestProfileLegRendersEveryRow covers every row that does NOT declare a Fault.
+// A fault row is expected to fail on both legs, so requiring it to render here
+// would contradict its own declaration; TestProfileFaultRowsFaultOnProfileLeg
+// asserts the other half.
 func TestProfileLegRendersEveryRow(t *testing.T) {
 	for _, r := range Corpus() {
+		if r.Fault != "" {
+			continue
+		}
 		t.Run(r.ID, func(t *testing.T) {
 			out, err := RenderProfile(r)
 			if err != nil {
@@ -143,4 +150,85 @@ func TestProfileLegRendersEveryRow(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestProfileFaultRowsFaultOnProfileLeg is the CGO-free half of the fault
+// contract: a row that declares stock BAML faults must ALSO fault on the profile
+// leg, in the declared class. Rendering a value where BAML faults is the
+// parity-decline rule's out-do, and this catches it without CFFI.
+//
+// The stock half — that BAML really produces the declared class — needs the live
+// runtime and lives in TestProfileFaultDifferential (integration tag).
+func TestProfileFaultRowsFaultOnProfileLeg(t *testing.T) {
+	seen := 0
+	for _, r := range Corpus() {
+		if r.Fault == "" {
+			continue
+		}
+		seen++
+		t.Run(r.ID, func(t *testing.T) {
+			switch r.Fault {
+			case OutcomeError, OutcomePanic:
+			default:
+				t.Fatalf("Fault=%q is not a failure class", r.Fault)
+			}
+			if o := RenderProfileOutcome(r); o.Kind != r.Fault {
+				t.Errorf("profile outcome = %s, want class %s", o, r.Fault)
+			}
+		})
+	}
+	if seen == 0 {
+		t.Fatal("no fault rows in the corpus; the fault contract must not silently cover nothing")
+	}
+}
+
+// TestProfileFaultDeclarationsAreFailureClasses guards the one way a row could
+// silently escape the differential entirely.
+//
+// Row.Fault routes a row: empty sends it to the byte-exact
+// TestProfileDifferential, non-empty sends it to the outcome-class
+// TestProfileFaultDifferential. So `Fault: OutcomeRendered` would be accepted by
+// the compiler, removed from the byte comparison as a "fault row", and then
+// trivially satisfied by a successful render — a row that looks covered twice
+// and is actually proved by nothing. Only a FAILURE class may appear here.
+func TestProfileFaultDeclarationsAreFailureClasses(t *testing.T) {
+	byteCompared, outcomeCompared := 0, 0
+	for _, r := range Corpus() {
+		switch r.Fault {
+		case "":
+			byteCompared++
+		case OutcomeError, OutcomePanic:
+			outcomeCompared++
+		default:
+			t.Errorf("row %q declares Fault=%q, which is not a failure class; "+
+				"only %q and %q route a row to the outcome differential",
+				r.ID, r.Fault, OutcomeError, OutcomePanic)
+		}
+	}
+	t.Logf("corpus: %d rows — %d byte-compared, %d outcome-compared",
+		len(Corpus()), byteCompared, outcomeCompared)
+}
+
+// TestRenderProfileOutcomeFailsLoudOnHarnessError proves the fault-outcome proof
+// cannot be satisfied by a broken HARNESS. A row whose declared host parameter is
+// missing from Args fails during arg lowering — a *harnessError — not during the
+// engine's render. Classifying that as OutcomeError would let a fault row that
+// declares OutcomeError pass because the harness failed to set the row up rather
+// than because the engine faulted. RenderProfileOutcome re-raises it instead, so
+// the row cannot masquerade as an engine outcome.
+func TestRenderProfileOutcomeFailsLoudOnHarnessError(t *testing.T) {
+	r := Row{
+		ID:       "harness_failure_probe",
+		Fault:    OutcomeError,
+		Params:   []Param{{Name: "c", BamlType: "C"}},
+		Args:     map[string]any{}, // the declared host arg is absent -> lowering fails
+		Template: `{{ c }}`,
+	}
+	defer func() {
+		if rec := recover(); rec == nil {
+			t.Fatal("RenderProfileOutcome classified a harness setup failure as an outcome instead of failing loudly")
+		}
+	}()
+	o := RenderProfileOutcome(r)
+	t.Fatalf("RenderProfileOutcome returned %v instead of re-raising the harness failure", o)
 }

--- a/internal/bamlprofile/profileoracle/fault_integration_test.go
+++ b/internal/bamlprofile/profileoracle/fault_integration_test.go
@@ -1,0 +1,416 @@
+//go:build integration
+
+package profileoracle
+
+// The FAULT leg of the stock-BAML differential.
+//
+// Most corpus rows render, and are compared byte-for-byte. A few do not: stock
+// BAML v0.223 either raises a normal template error or hits an INTERNAL
+// invariant failure. Those rows are compared by classified outcome instead
+// (Row.Fault), because the de-BAML parity-decline rule says a native success
+// where BAML fails is an out-do — the profile must fault in the same class, and
+// a conservative rendered `false` is NOT green.
+//
+// The hard part is the panic class. Stock BAML's `unreachable!()` cannot be
+// observed in-process at all:
+//
+//	thread 'tokio-runtime-worker' panicked at minijinja/src/value/mod.rs:660:42:
+//	internal error: entered unreachable code
+//
+// The panic unwinds the tokio worker that owns the request, so the CFFI call
+// never delivers a result and BuildRequest blocks in its select FOREVER
+// (measured: a 600s test timeout, with the panic already on stderr). There is no
+// recover() on the Go side — the panic is in Rust, across the FFI boundary — so
+// an OutcomePanic row runs the stock leg in a SUBPROCESS, reads the panic off
+// the child's stderr, and kills the child. A stock panic is therefore never
+// converted into a rendered string; it is reported as what it is.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+)
+
+const (
+	// faultChildRowEnv names the row a helper-process invocation should run. Its
+	// presence is what distinguishes a child from an ordinary test run.
+	faultChildRowEnv = "PROFILE_ORACLE_FAULT_CHILD_ROW"
+	// faultChildMarker prefixes the child's single stdout result line. A child that
+	// panics in Rust never reaches it, which is precisely the signal.
+	faultChildMarker = "PROFILEORACLE-OUTCOME"
+	// faultChildHarnessKind is the marker kind the child emits when a STOCK-side
+	// HARNESS step fails (CreateRuntime, arg encode, body/text/decode, or the
+	// one-system-message shape invariant) rather than the engine faulting. It is
+	// deliberately NOT an OutcomeKind: the parent fails LOUD on it instead of
+	// classifying it, so a harness bug can never masquerade as an engine outcome.
+	faultChildHarnessKind = "harness-failure"
+	// faultChildTimeout bounds a child. A healthy child answers in well under a
+	// second once the CFFI runtime is built; a panicking one hangs forever, so this
+	// is the deadline that turns the hang into a verdict rather than a stuck suite.
+	faultChildTimeout = 90 * time.Second
+	// rustPanicNeedle is stock Rust's panic banner on stderr. It is the POSITIVE
+	// evidence that a hung child hung because the engine panicked — without it, a
+	// timeout is just a timeout and the harness must not claim a panic.
+	rustPanicNeedle = "panicked at"
+)
+
+// TestProfileOracleFaultChild is the helper process for an OutcomePanic row. It
+// is inert in a normal run; a parent invokes it with faultChildRowEnv set, via
+// the very test binary it is already running in.
+//
+// It renders exactly one row through stock BAML and prints ONE marker line to
+// stdout. If the Rust engine panics, the process never gets here and the parent
+// classifies from stderr instead.
+func TestProfileOracleFaultChild(t *testing.T) {
+	id := os.Getenv(faultChildRowEnv)
+	if id == "" {
+		t.Skip("helper process for the fault leg; runs only with " + faultChildRowEnv + " set")
+	}
+	row, ok := rowByID(id)
+	if !ok {
+		fmt.Printf("%s unknown-row %s\n", faultChildMarker, strconv.Quote(id))
+		return
+	}
+	env := envVars()
+	rt, err := baml.CreateRuntime("./baml_src", GenerateBAMLSource([]Row{row}), env)
+	if err != nil {
+		// CreateRuntime is HARNESS setup, not the engine render.
+		fmt.Printf("%s %s %s\n", faultChildMarker, faultChildHarnessKind, strconv.Quote("CreateRuntime: "+err.Error()))
+		return
+	}
+	msgs, err := bamlRenderErr(&rt, row, env)
+	if err != nil {
+		// Only a genuine ENGINE error (rt.BuildRequest) is an `error` marker, which
+		// the parent classifies as OutcomeError. A *harnessError is a distinct
+		// harness marker the parent fails loud on. For a panic row the engine
+		// panics rather than returning, so a returned error here is almost always
+		// the harness — but the distinction is kept exact rather than assumed.
+		kind := string(OutcomeError)
+		var he *harnessError
+		if errors.As(err, &he) {
+			kind = faultChildHarnessKind
+		}
+		fmt.Printf("%s %s %s\n", faultChildMarker, kind, strconv.Quote(err.Error()))
+		return
+	}
+	if len(msgs) != 1 || msgs[0].Role != "system" {
+		// The one-system-message shape is a HARNESS/codegen invariant, not an
+		// engine fault, so it is a harness marker (loud), never an OutcomeError.
+		fmt.Printf("%s %s %s\n", faultChildMarker, faultChildHarnessKind, strconv.Quote(fmt.Sprintf("expected one system message, got %#v", msgs)))
+		return
+	}
+	fmt.Printf("%s rendered %s\n", faultChildMarker, strconv.Quote(msgs[0].Text))
+}
+
+// rowByID finds a corpus row.
+func rowByID(id string) (Row, bool) {
+	for _, r := range Corpus() {
+		if r.ID == id {
+			return r, true
+		}
+	}
+	return Row{}, false
+}
+
+// bamlRenderErr is bamlRender without a *testing.T: it RETURNS the failure
+// instead of calling t.Fatal, so the child can classify it as OutcomeError
+// rather than dying with a test failure the parent would have to parse.
+func bamlRenderErr(rt *baml.BamlRuntime, r Row, env map[string]string) ([]Message, error) {
+	kwargs := map[string]any{"stream": false}
+	for k, v := range r.Args {
+		kwargs[k] = v
+	}
+	args := baml.BamlFunctionArguments{Kwargs: kwargs, Env: env}
+	// Only rt.BuildRequest runs the ENGINE (it renders the template); every other
+	// step here is the stock-side HARNESS — encoding the Go args, extracting the
+	// request body, and decoding the rendered messages. They are wrapped as
+	// *harnessError (the same type the profile leg uses in corpus.go) so
+	// bamlOutcomeInProcess can tell them apart from a genuine engine template
+	// error and never classify a harness failure as an OutcomeError. This is the
+	// stock-leg mirror of the profile-leg fix, keeping the two legs symmetric.
+	encoded, err := args.Encode()
+	if err != nil {
+		return nil, &harnessError{fmt.Errorf("encode args: %w", err)}
+	}
+	req, err := rt.BuildRequest(context.Background(), r.FuncName(), encoded)
+	if err != nil {
+		return nil, fmt.Errorf("BuildRequest: %w", err) // ENGINE error — stays plain
+	}
+	body, err := req.Body()
+	if err != nil {
+		return nil, &harnessError{fmt.Errorf("request Body(): %w", err)}
+	}
+	text, err := body.Text()
+	if err != nil {
+		return nil, &harnessError{fmt.Errorf("body Text(): %w", err)}
+	}
+	msgs, err := decodeMessages([]byte(text))
+	if err != nil {
+		return nil, &harnessError{fmt.Errorf("decode messages: %w", err)}
+	}
+	return msgs, nil
+}
+
+// bamlOutcomeInProcess classifies a row stock BAML can safely be asked to render
+// in this process — a successful row or an OutcomeError fault row.
+func bamlOutcomeInProcess(rt *baml.BamlRuntime, r Row, env map[string]string) Outcome {
+	msgs, err := bamlRenderErr(rt, r, env)
+	if err != nil {
+		// Only a genuine ENGINE error (rt.BuildRequest) is an OutcomeError. A
+		// stock-side harness failure is re-raised loudly instead of classified, so
+		// a fault row declaring OutcomeError cannot match because the stock harness
+		// broke rather than because the engine faulted — the symmetric guard to
+		// the profile leg's RenderProfileOutcome.
+		var he *harnessError
+		if errors.As(err, &he) {
+			panic(fmt.Sprintf("profileoracle: row %q: stock BAML harness failed around the engine render (not an engine outcome): %v", r.ID, err))
+		}
+		return Outcome{Kind: OutcomeError, Detail: err.Error()}
+	}
+	if len(msgs) != 1 || msgs[0].Role != "system" {
+		// The one-system-message shape is a HARNESS/codegen invariant — every
+		// corpus function wraps its content in exactly one system-role message —
+		// not an engine fault. A mismatch is a harness bug: failing loud here, like
+		// the *harnessError guard above, keeps it from classifying as OutcomeError
+		// and matching a fault row on a broken harness.
+		panic(fmt.Sprintf("profileoracle: row %q: stock BAML rendered but not as one system message (harness invariant, not an engine outcome): %#v", r.ID, msgs))
+	}
+	return Outcome{Kind: OutcomeRendered, Text: msgs[0].Text}
+}
+
+// panicWatcher buffers a child's stderr and signals the instant Rust's panic
+// banner appears in it.
+//
+// Without this the harness would have to wait out faultChildTimeout on every
+// panic row — the child hangs by construction, so it never exits on its own. The
+// banner is written immediately, so watching for it turns a 90-second wait into
+// a sub-second one WITHOUT weakening the evidence: the verdict still requires the
+// banner, never a bare timeout.
+type panicWatcher struct {
+	mu    sync.Mutex
+	buf   bytes.Buffer
+	seen  chan struct{}
+	fired bool
+}
+
+func newPanicWatcher() *panicWatcher { return &panicWatcher{seen: make(chan struct{})} }
+
+func (w *panicWatcher) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	before := w.buf.Len()
+	n, err := w.buf.Write(p)
+	if !w.fired {
+		// Scan only the newly-written bytes plus a needle-length overlap, so a child
+		// that emits a large backtrace does not turn this into a quadratic rescan of
+		// the whole buffer on every chunk. The overlap is what keeps a needle split
+		// across two writes detectable.
+		from := max(before-len(rustPanicNeedle)+1, 0)
+		if strings.Contains(string(w.buf.Bytes()[from:]), rustPanicNeedle) {
+			w.fired = true
+			close(w.seen)
+		}
+	}
+	return n, err
+}
+
+func (w *panicWatcher) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// bamlOutcomeSubprocess classifies an OutcomePanic row by running the stock leg
+// in a child process and reading its fate.
+//
+// Three outcomes are possible and all three are handled explicitly:
+//
+//   - the child printed a marker line -> that classification (so a row declared
+//     as a panic that stock BAML actually RENDERS is caught, not silently green);
+//   - the child produced no marker but Rust's panic banner is on stderr ->
+//     OutcomePanic, whether it exited or had to be killed;
+//   - neither -> the harness FAILS. An unexplained hang or crash is never
+//     upgraded into a matching fault.
+func bamlOutcomeSubprocess(t *testing.T, r Row) Outcome {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), faultChildTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestProfileOracleFaultChild$", "-test.timeout=0")
+	cmd.Env = append(os.Environ(), faultChildRowEnv+"="+r.ID)
+	var stdout bytes.Buffer
+	stderr := newPanicWatcher()
+	cmd.Stdout = &stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("fault row %q: start stock BAML child: %v", r.ID, err)
+	}
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+
+	var runErr error
+	select {
+	case runErr = <-waitCh:
+		// The child finished on its own: it either reported an outcome or died.
+	case <-stderr.seen:
+		// The engine panicked. The child will now block forever in BuildRequest, so
+		// stop waiting and reap it; Wait still has to return before the buffers are
+		// safe to read.
+		cancel()
+		runErr = <-waitCh
+	case <-ctx.Done():
+		runErr = <-waitCh
+	}
+
+	// A stock-side harness failure is never an engine outcome: fail loud rather
+	// than let it be classified. Checked before parseChildOutcome so it can never
+	// be read as an OutcomeError/OutcomeRendered marker.
+	if msg, ok := childMarker(stdout.String(), faultChildHarnessKind); ok {
+		t.Fatalf("fault row %q: the stock BAML harness failed, not the engine (%s).\n"+
+			"A harness invariant is never an engine outcome and must not classify one.", r.ID, msg)
+	}
+	if o, ok := parseChildOutcome(stdout.String()); ok {
+		return o
+	}
+	if line, ok := rustPanicLine(stderr.String()); ok {
+		return Outcome{Kind: OutcomePanic, Detail: line}
+	}
+	t.Fatalf("fault row %q: the stock BAML child neither reported an outcome nor panicked.\n"+
+		"run error: %v\nstdout:\n%s\nstderr:\n%s", r.ID, runErr, stdout.String(), stderr.String())
+	return Outcome{}
+}
+
+// parseChildOutcome reads the child's single marker line.
+func parseChildOutcome(stdout string) (Outcome, bool) {
+	for _, line := range strings.Split(stdout, "\n") {
+		rest, ok := strings.CutPrefix(strings.TrimSpace(line), faultChildMarker+" ")
+		if !ok {
+			continue
+		}
+		kind, quoted, ok := strings.Cut(rest, " ")
+		if !ok {
+			continue
+		}
+		payload, err := strconv.Unquote(quoted)
+		if err != nil {
+			continue
+		}
+		switch OutcomeKind(kind) {
+		case OutcomeRendered:
+			return Outcome{Kind: OutcomeRendered, Text: payload}, true
+		case OutcomeError:
+			return Outcome{Kind: OutcomeError, Detail: payload}, true
+		}
+	}
+	return Outcome{}, false
+}
+
+// childMarker returns the payload of the child's marker line of the given kind,
+// if the child emitted one. It is how the parent reads the out-of-band
+// harness-failure marker, which is deliberately not an OutcomeKind and so is not
+// recognized by parseChildOutcome.
+func childMarker(stdout, kind string) (string, bool) {
+	for _, line := range strings.Split(stdout, "\n") {
+		rest, ok := strings.CutPrefix(strings.TrimSpace(line), faultChildMarker+" ")
+		if !ok {
+			continue
+		}
+		k, quoted, ok := strings.Cut(rest, " ")
+		if !ok || k != kind {
+			continue
+		}
+		if payload, err := strconv.Unquote(quoted); err == nil {
+			return payload, true
+		}
+	}
+	return "", false
+}
+
+// rustPanicLine extracts the stock engine's panic banner (and the line after it,
+// which carries the actual message) from a child's stderr.
+func rustPanicLine(stderr string) (string, bool) {
+	lines := strings.Split(stderr, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, rustPanicNeedle) {
+			continue
+		}
+		detail := strings.TrimSpace(line)
+		if i+1 < len(lines) {
+			if next := strings.TrimSpace(lines[i+1]); next != "" {
+				detail += " | " + next
+			}
+		}
+		return detail, true
+	}
+	return "", false
+}
+
+// TestProfileFaultDifferential is the fault-row proof. For every row that
+// declares a Fault, it asserts BOTH that stock BAML really produces the declared
+// failure class (so the declaration cannot rot into a fiction) AND that the
+// profile fails in the same class.
+//
+// It never compares the two failure MESSAGES: Rust's "internal error: entered
+// unreachable code" and the fork's "cannot order these mappings: …" describe the
+// same invariant failure in different words, and pinning the text would pin a
+// string rather than a behavior. The CLASS is the contract.
+func TestProfileFaultDifferential(t *testing.T) {
+	assertBAMLAuthority(t)
+
+	var faults []Row
+	for _, r := range Corpus() {
+		if r.Fault != "" {
+			faults = append(faults, r)
+		}
+	}
+	if len(faults) == 0 {
+		t.Fatal("no fault rows in the corpus; the fault leg must not silently cover nothing")
+	}
+
+	// Only the in-process rows need a shared runtime; a panic row gets its own
+	// child. Building it from the WHOLE corpus keeps this leg's runtime identical
+	// to the ordinary differential's.
+	env := envVars()
+	rt, err := baml.CreateRuntime("./baml_src", GenerateBAMLSource(Corpus()), env)
+	if err != nil {
+		t.Fatalf("CreateRuntime from in-memory corpus source: %v", err)
+	}
+
+	for _, r := range faults {
+		t.Run(r.ID, func(t *testing.T) {
+			var stock Outcome
+			switch r.Fault {
+			case OutcomePanic:
+				stock = bamlOutcomeSubprocess(t, r)
+			case OutcomeError:
+				stock = bamlOutcomeInProcess(&rt, r, env)
+			default:
+				t.Fatalf("row declares Fault %q, which is not a failure class", r.Fault)
+			}
+
+			if stock.Kind != r.Fault {
+				t.Fatalf("row declares stock BAML Fault=%s, but stock BAML actually produced %s.\n"+
+					"The declaration is stale — fix the row, not this assertion.", r.Fault, stock)
+			}
+			prof := RenderProfileOutcome(r)
+			if prof.Kind != stock.Kind {
+				t.Errorf("outcome-class mismatch\nstock BAML: %s\nprofile:    %s\n"+
+					"A fault row is green ONLY when the profile fails in BAML's class; "+
+					"rendering a conservative value where BAML faults is an out-do.", stock, prof)
+				return
+			}
+			t.Logf("both legs %s — stock: %s | profile: %s", stock.Kind, stock.Detail, prof.Detail)
+		})
+	}
+}

--- a/internal/bamlprofile/profileoracle/oracle_integration_test.go
+++ b/internal/bamlprofile/profileoracle/oracle_integration_test.go
@@ -95,7 +95,7 @@ func TestProfileOracleFixture(t *testing.T) {
 		BAMLModuleVersion:  observedModule,
 		SourceSHA256:       sourceSHA256(files),
 		RowCount:           len(Corpus()),
-		Note:               "stock BAML v0.223.0 get_env differential for internal/bamlprofile (Slice 2 PR-1)",
+		Note:               "stock BAML v0.223.0 get_env + enum/class host-value-model differential for internal/bamlprofile (Slice 2 PR-1 + PR-2)",
 	}
 
 	if os.Getenv("WRITE_PROFILE_ORACLE_FIXTURE") == "1" {
@@ -172,16 +172,31 @@ func assertBAMLAuthority(t *testing.T) {
 
 // TestProfileDifferential is the byte-exact proof: every corpus row rendered
 // through stock BAML v0.223 equals the profile leg.
+//
+// It covers the rows that RENDER. Rows that declare a Fault are excluded here
+// and proved by outcome class in TestProfileFaultDifferential instead — asking
+// stock BAML to render one of them in this process would either raise (making
+// the byte comparison meaningless) or, for the panic class, hang the suite
+// forever. Between the two tests every corpus row is covered exactly once, and
+// TestProfileFaultDeclarationsAreFailureClasses guards that split.
 func TestProfileDifferential(t *testing.T) {
 	assertBAMLAuthority(t)
 
-	rows := Corpus()
-	files := GenerateBAMLSource(rows)
+	// The runtime is still built from the WHOLE corpus (fault rows included), so
+	// both legs compile the same project and the source-map guard keeps matching.
+	files := GenerateBAMLSource(Corpus())
 	env := envVars()
 
 	rt, err := baml.CreateRuntime("./baml_src", files, env)
 	if err != nil {
 		t.Fatalf("CreateRuntime from in-memory corpus source: %v", err)
+	}
+
+	var rows []Row
+	for _, r := range Corpus() {
+		if r.Fault == "" {
+			rows = append(rows, r)
+		}
 	}
 
 	for _, r := range rows {

--- a/internal/bamlprofile/profileoracle/rows.go
+++ b/internal/bamlprofile/profileoracle/rows.go
@@ -1,11 +1,21 @@
 package profileoracle
 
-// Corpus is the PR-1 get_env differential corpus. It covers what Slice 2 PR-1
-// builds: whitespace (trim_blocks/lstrip_blocks), none/null formatting, the
-// BAML-exact builtin filter/test/FUNCTION registry, regex_match, BAML's sum
-// override, pycompat unknown-methods, macros, ctx, and the `_` role helper. The
-// host value model (enum/class/map/media, enum globals, the #597 ValueCmp) is a
-// later PR and is deliberately absent.
+// Corpus is the get_env + host-value-model differential corpus. The PR-1 rows
+// cover the get_env engine config: whitespace (trim_blocks/lstrip_blocks),
+// none/null formatting, the BAML-exact builtin filter/test/FUNCTION registry,
+// regex_match, BAML's sum override, pycompat unknown-methods, macros, ctx, and
+// the `_` role helper. The PR-2 rows (Surface enum/enum_cmp/enum_container/
+// class/class_render) cover the enum & class host value model: the per-enum
+// namespace globals, enum presentation (alias-or-canonical) and `.value`, the
+// #597 enum-`==` closure in both operand orders + membership + ordering + the
+// int/bool/none decline edges + cross-enum probes, enum-in-container/class, and
+// class canonical access / map behavior / pretty-debug rendering.
+//
+// The shared enum/class declarations live in types.go (types.baml for the stock
+// leg, profileEnums for the profile leg); host-shaped arguments are lowered to
+// profile host values by hostValue. Media host values and BAML's render-layer
+// format(type=json|yaml|toon) override are DECLINED (see host_test.go and #602),
+// not silently emitted.
 //
 // SCOPE OF THE PROOF — read before treating a green run as full get_env parity:
 //
@@ -195,5 +205,364 @@ func Corpus() []Row {
 		{ID: "role_trim_content", Surface: "role", Chat: true,
 			Params: []Param{{Name: "s", BamlType: "string"}}, Args: map[string]any{"s": "spaced"},
 			Template: "{{ _.role(\"user\") }}\n   {{ s }}   \n"},
+
+		// ===================== PR-2: enum & class host value model =====================
+
+		// --- enum: presentation & namespace globals ---
+		// Display is alias-or-canonical; .value is canonical ONLY; .name/.alias are
+		// absent (undefined); a typed enum ARGUMENT lowers with its resolved alias
+		// exactly like the global member does.
+		{ID: "enum_display_alias", Surface: "enum", Template: `{{ Color.RED }}`},         // rouge
+		{ID: "enum_display_noalias", Surface: "enum", Template: `{{ Color.GREEN }}`},     // GREEN
+		{ID: "enum_value_alias", Surface: "enum", Template: `{{ Color.RED.value }}`},     // RED
+		{ID: "enum_value_noalias", Surface: "enum", Template: `{{ Color.GREEN.value }}`}, // GREEN
+		{ID: "enum_missing_attrs", Surface: "enum",
+			Template: `{{ Color.RED.name is undefined }}/{{ Color.RED.alias is undefined }}/{{ Color.RED.value is undefined }}`}, // true/true/false
+		{ID: "enum_unknown_member", Surface: "enum", Template: `{{ Color.PURPLE is undefined }}`}, // true
+		{ID: "enum_arg_display_alias", Surface: "enum",
+			Params: []Param{{Name: "e", BamlType: "Color"}}, Args: map[string]any{"e": "RED"},
+			Template: `{{ e }}/{{ e.value }}`}, // rouge/RED
+		{ID: "enum_arg_display_noalias", Surface: "enum",
+			Params: []Param{{Name: "e", BamlType: "Color"}}, Args: map[string]any{"e": "GREEN"},
+			Template: `{{ e }}/{{ e.value }}`}, // GREEN/GREEN
+
+		// --- enum ValueCmp: the six #597 cases (both operand orders + membership) ---
+		{ID: "e597_canon_eq_fwd", Surface: "enum_cmp", Template: `{{ Color.RED == 'RED' }}`},      // true
+		{ID: "e597_canon_eq_rev", Surface: "enum_cmp", Template: `{{ 'RED' == Color.RED }}`},      // true
+		{ID: "e597_same_member", Surface: "enum_cmp", Template: `{{ Color.RED == Color.RED }}`},   // true
+		{ID: "e597_in_list", Surface: "enum_cmp", Template: `{{ 'RED' in [Color.RED] }}`},         // true
+		{ID: "e597_alias_str_false", Surface: "enum_cmp", Template: `{{ Color.RED == 'rouge' }}`}, // false (compares canonical, NOT alias)
+		{ID: "e597_diff_member", Surface: "enum_cmp", Template: `{{ Color.RED == Color.BLUE }}`},  // false
+
+		// --- enum ValueCmp: extra edges the fence and comparator require ---
+		{ID: "enum_cmp_ne_member", Surface: "enum_cmp",
+			Template: `{{ Color.RED != Color.BLUE }}/{{ Color.RED != Color.RED }}`}, // true/false
+		{ID: "enum_cmp_ne_str", Surface: "enum_cmp",
+			Template: `{{ Color.RED != 'RED' }}/{{ Color.RED != 'rouge' }}`}, // false/true
+		{ID: "enum_cmp_member_in_strlist", Surface: "enum_cmp", Template: `{{ Color.RED in ['RED'] }}`}, // true (reverse container orientation)
+		{ID: "enum_cmp_alias_str_rev", Surface: "enum_cmp", Template: `{{ 'rouge' == Color.RED }}`},     // false
+		// Cross-enum with SAME canonical+alias -> equal, proving enum_name is NOT
+		// part of the comparator; SAME canonical/different alias (Some vs None) ->
+		// not equal, proving the alias IS.
+		{ID: "enum_cmp_cross_enum_eq", Surface: "enum_cmp", Template: `{{ Color.RED == Shade.RED }}`},        // true
+		{ID: "enum_cmp_cross_enum_in_list", Surface: "enum_cmp", Template: `{{ Shade.RED in [Color.RED] }}`}, // true
+		{ID: "enum_cmp_same_canon_diff_alias", Surface: "enum_cmp", Template: `{{ Color.RED == Size.RED }}`}, // false
+		// Ordering: against a canonical string, and between members (None < Some alias).
+		{ID: "enum_cmp_order_str", Surface: "enum_cmp",
+			Template: `{{ Color.GREEN < 'RED' }}/{{ Color.RED < 'GREEN' }}`}, // true/false
+		{ID: "enum_cmp_order_member", Surface: "enum_cmp",
+			Template: `{{ Size.RED < Color.RED }}/{{ Color.RED < Size.RED }}`}, // true/false
+		// Non-string primitive edges: DECLINE, never invent equality (all false;
+		// the != negations are true).
+		{ID: "enum_cmp_decline_int", Surface: "enum_cmp",
+			Template: `{{ Color.RED == 5 }}/{{ Color.RED != 5 }}`}, // false/true
+		{ID: "enum_cmp_decline_bool", Surface: "enum_cmp",
+			Template: `{{ Color.RED == true }}/{{ Color.RED == false }}`}, // false/false
+		{ID: "enum_cmp_decline_none", Surface: "enum_cmp",
+			Template: `{{ Color.RED == none }}/{{ Color.RED != none }}`}, // false/true
+
+		// --- enum in containers / classes ---
+		// A Color[] argument lowers to a host list of enum members: rendered
+		// directly it is a COMPACT debug-list of BARE aliases (a top-level list is
+		// non-alternate, `[rouge, GREEN]`); it indexes/compares by canonical
+		// identity and answers membership. An enum member as a class field renders
+		// as its bare alias inside the class's pretty debug-map.
+		{ID: "enum_list_render", Surface: "enum_container",
+			Params: []Param{{Name: "cs", BamlType: "Color[]"}}, Args: map[string]any{"cs": []any{"RED", "GREEN"}},
+			Template: `{{ cs }}`},
+		{ID: "enum_list_index", Surface: "enum_container",
+			Params: []Param{{Name: "cs", BamlType: "Color[]"}}, Args: map[string]any{"cs": []any{"RED", "BLUE"}},
+			Template: `{{ cs[0] == 'RED' }}/{{ cs[0] }}/{{ cs[1] }}`}, // true/rouge/BLUE
+		{ID: "enum_list_membership", Surface: "enum_container",
+			Params: []Param{{Name: "cs", BamlType: "Color[]"}}, Args: map[string]any{"cs": []any{"RED", "BLUE"}},
+			Template: `{{ 'RED' in cs }}/{{ 'GREEN' in cs }}`}, // true/false
+		{ID: "enum_in_class_access", Surface: "enum_container",
+			Params: []Param{{Name: "c", BamlType: "WithColor"}}, Args: map[string]any{"c": map[string]any{"color": "RED", "n": int64(1)}},
+			Template: `{{ c.color == 'RED' }}/{{ c.color }}/{{ c.color.value }}`}, // true/rouge/RED
+		{ID: "enum_in_class_render", Surface: "enum_container",
+			Params: []Param{{Name: "c", BamlType: "Ecw"}}, Args: map[string]any{"c": map[string]any{"color": "RED"}},
+			Template: `{{ c }}`}, // {\n    "colour": rouge,\n} (enum field renders as the BARE alias)
+
+		// --- class: canonical access & map behavior ---
+		// Access/iteration/length use CANONICAL field names; an alias is not an
+		// alternate attribute; a missing field is undefined; a nonempty class is
+		// truthy. Iteration uses a single-field class so the yielded key order is
+		// deterministic (multi-field iteration order is a leaf-level proof).
+		{ID: "class_canon_access", Surface: "class",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ c.prop1 }}`}, // value
+		{ID: "class_alias_undef", Surface: "class",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ c.key1 is undefined }}/{{ c.prop1 is undefined }}`}, // true/false
+		{ID: "class_missing_undef", Surface: "class",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ c.nope is undefined }}`}, // true
+		{ID: "class_iter_key_canonical", Surface: "class",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{% for k in c %}{{ k }}{% endfor %}`}, // prop1 (the CANONICAL name, not the alias key1)
+		{ID: "class_length", Surface: "class",
+			Params: []Param{{Name: "c", BamlType: "WithColor"}}, Args: map[string]any{"c": map[string]any{"color": "RED", "n": int64(1)}},
+			Template: `{{ c|length }}`}, // 2 (order-independent)
+		{ID: "class_truthy_nonempty", Surface: "class",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{% if c %}yes{% else %}no{% endif %}`}, // yes
+		{ID: "class_cond_prop", Surface: "class",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{% if c.prop1 == 'value' %}true{% else %}false{% endif %}`}, // true (mirrors BAML's render_class_with_if_condition)
+		{ID: "class_int_compare", Surface: "class",
+			Params: []Param{{Name: "c", BamlType: "WithColor"}}, Args: map[string]any{"c": map[string]any{"color": "GREEN", "n": int64(4)}},
+			Template: `{% if c.n < 40 %}true{% else %}false{% endif %}`}, // true (mirrors render_number_comparison_with_alias)
+
+		// --- class: direct pretty/debug rendering ({map:#?} bytes) ---
+		// Aliased keys, four-space nesting, trailing commas, nested class/list,
+		// nested none -> null, and scalar escaping — the exact Rust debug bytes.
+		// Single-field wrappers keep sibling order out of the picture (see
+		// classDecls); multi-field ordered rendering is proven at the leaf against
+		// BAML's own golden.
+		{ID: "class_render_single", Surface: "class_render",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ c }}`}, // {\n    "key1": "value",\n}
+		{ID: "class_render_nested", Surface: "class_render",
+			Params: []Param{{Name: "c", BamlType: "Cw"}}, Args: map[string]any{"c": map[string]any{
+				"inner": map[string]any{"items": []any{"item1", "item2"}}}},
+			Template: `{{ c }}`}, // {\n    "nested": {\n        "data": [\n            "item1",\n            "item2",\n        ],\n    },\n}
+		{ID: "class_render_nested_none", Surface: "class_render",
+			Params: []Param{{Name: "c", BamlType: "Nw"}}, Args: map[string]any{"c": map[string]any{"maybe": nil}},
+			Template: `{{ c }}`}, // {\n    "perhaps": null,\n}
+		{ID: "class_render_present_optional", Surface: "class_render",
+			Params: []Param{{Name: "c", BamlType: "Nw"}}, Args: map[string]any{"c": map[string]any{"maybe": "here"}},
+			Template: `{{ c }}`}, // {\n    "perhaps": "here",\n}
+		{ID: "class_render_escaping", Surface: "class_render",
+			Params: []Param{{Name: "c", BamlType: "Ew"}}, Args: map[string]any{"c": map[string]any{"raw": "a\"b\tc\nd"}},
+			Template: `{{ c }}`}, // {\n    "escaped": "a\"b\tc\nd",\n} (Rust Debug-escaped scalar)
+
+		// ============ PR-2 remediation: the DISCRIMINATING host-object rows ============
+		//
+		// Everything above this line was green BEFORE the fork correction and cannot
+		// detect either defect the PR-2 review found. These rows can: each one is a
+		// direct stock-CFFI repro from the review or the settled scope.
+		//
+		// Do NOT reduce any of them to a top-level `{{ Color.RED }}` control — that
+		// control is already green above (enum_display_alias) and is exactly what
+		// missed the defects.
+
+		// --- CRITICAL: opaque-object decline -> the map fallback ---
+		//
+		// BAML's MinijinjaBamlEnumValue/EnumType are ObjectRepr::Map but return
+		// Enumerator::NonEnumerable with an UNKNOWN length: they are NOT empty maps.
+		// After the leaf comparator's required (0, false) decline, the engine's map
+		// arm (minijinja value/mod.rs:533-559) runs DIRECTIONALLY — it short-circuits
+		// on the LEFT operand's absent pair iterator, and otherwise treats a
+		// non-enumerable RIGHT side as length zero.
+		//
+		// Each operand orientation is enumerated separately on purpose: the profile
+		// was true where BAML is false in BOTH equality directions, and the empty-map
+		// asymmetry is invisible if only one orientation is asserted.
+		{ID: "enum_cmp_opaque_namespace_eq_ne", Surface: "enum_cmp_opaque",
+			Template: `{{ Color.RED == Color }}/{{ Color == Color.RED }}/{{ Color.RED != Color }}/{{ Color != Color.RED }}`}, // false/false/true/true
+		{ID: "enum_cmp_opaque_namespace_membership", Surface: "enum_cmp_opaque",
+			Template: `{{ Color.RED in [Color] }}/{{ Color in [Color.RED] }}/{{ Color in [Shade] }}/{{ Color.RED in [Color, Shade] }}`}, // false/false/false/false
+		// Deliberately ASYMMETRIC, and pinned as stock authority: `{} == Color.RED`
+		// and `Color.RED in [{}]` are TRUE (the engine's length fallback counts the
+		// opaque right side as zero, and membership asks `{} == member`), while
+		// `Color.RED == {}` and `{} in [Color.RED]` are FALSE. The profile used to be
+		// true for the latter two — the out-dos — and false for the former two.
+		{ID: "enum_cmp_opaque_empty_map_decline", Surface: "enum_cmp_opaque",
+			Template: `{{ Color.RED == {} }}/{{ {} == Color.RED }}/{{ Color.RED != {} }}/{{ {} != Color.RED }}/{{ Color.RED in [{}] }}/{{ {} in [Color.RED] }}`}, // false/true/true/false/true/false
+		// FAULT ROW. Stock BAML reaches minijinja's `unreachable!()`
+		// (value/mod.rs:660) ordering two non-enumerable mappings. The profile must
+		// fault too — a rendered `false` here would be a native success where stock
+		// BAML fails internally. Compared by OUTCOME CLASS; the stock leg runs in a
+		// subprocess because this panic hangs BuildRequest forever in-process.
+		{ID: "enum_cmp_opaque_order_unreachable", Surface: "enum_cmp_opaque", Fault: OutcomePanic,
+			Template: `{{ Color.RED < Color }}`},
+
+		// --- HIGH: ObjectWithString through ordinary containers and coercions ---
+		//
+		// BAML object Display/Debug is one call, so a host object renders the same
+		// alone, inside a native container, through a filter, and through `~`. Before
+		// the fork correction every one of these leaked Go's `%v` (`[&{RED 0x… Color}]`),
+		// which is also NONDETERMINISTIC output — the pointer changes per allocation.
+		// The three consumers are independently important: |join builds its own
+		// string, |upper coerces through Args.CoerceStr, and `~` goes through Concat.
+		{ID: "object_string_native_enum_list", Surface: "object_string",
+			Template: `{{ [Color.RED] }}`}, // [rouge]
+		{ID: "object_string_join", Surface: "object_string",
+			Template: `{{ [Color.RED]|join(",") }}`}, // rouge
+		{ID: "object_string_upper", Surface: "object_string",
+			Template: `{{ Color.RED|upper }}`}, // ROUGE
+		{ID: "object_string_concat", Surface: "object_string",
+			Template: `{{ Color.RED ~ "!" }}`}, // rouge!
+		{ID: "object_string_filter_string", Surface: "object_string",
+			Template: `{{ Color.RED|string }}`}, // rouge — the explicit coercion control
+		// A HOST list inside a native list: the host list's own compact rendering has
+		// to survive being an item of an ordinary Jinja sequence.
+		{ID: "object_string_native_host_list", Surface: "object_string",
+			Params: []Param{{Name: "xs", BamlType: "Color[]"}}, Args: map[string]any{"xs": []any{"RED"}},
+			Template: `{{ [xs] }}`}, // [[rouge]]
+		// A host CLASS inside a native list: its forced-alternate `{map:#?}` bytes,
+		// newlines and all, must appear verbatim inside the compact native list.
+		{ID: "object_string_native_class", Surface: "object_string",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ [c] }}`}, // [{\n    "key1": "value",\n}]
+		// The enum NAMESPACE is the other host object that can reach a render path,
+		// and it has no Display of its own in BAML — MiniJinja's default
+		// Object::render for a Map builds a debug_map from its pairs, and it has
+		// none, so it is `{}` everywhere. Bracketed so an empty rendering is still
+		// visible in the compared bytes. Without an explicit ObjectString on the
+		// namespace this leaked Go's `&{Color map[RED:0x…]}`, heap addresses and
+		// all — the same defect class as the member rows above, on the object the
+		// original fix missed.
+		{ID: "object_string_namespace_bare", Surface: "object_string",
+			Template: `[{{ Color }}]`}, // [{}]
+		{ID: "object_string_namespace_composed", Surface: "object_string",
+			Template: `{{ [Color] }}/{{ Color|string }}/{{ Color ~ "!" }}/{{ Color|upper }}/{{ {"k": Color} }}`}, // [{}]/{}/{}!/{}/{"k": {}}
+
+		// --- LOW: coverage holes and retained regression rows ---
+
+		// An unrelated HOST object (a class) also declines, and must then reach the
+		// engine's ordinary fallback rather than an invented enum answer. Both
+		// orientations, and both through a sequence.
+		{ID: "enum_cmp_decline_class_eq_ne", Surface: "enum_cmp_decline",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ Color.RED == c }}/{{ c == Color.RED }}/{{ Color.RED != c }}/{{ c != Color.RED }}`}, // false/false/true/true
+		{ID: "enum_cmp_decline_class_membership", Surface: "enum_cmp_decline",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ Color.RED in [c] }}/{{ c in [Color.RED] }}`}, // false/false
+		// The missing float family, plus both hook orientations.
+		{ID: "enum_cmp_decline_float_both_ways", Surface: "enum_cmp_decline",
+			Template: `{{ Color.RED == 1.5 }}/{{ Color.RED != 1.5 }}/{{ 1.5 == Color.RED }}/{{ 1.5 != Color.RED }}`}, // false/true/false/true
+		// The missing REVERSE int/bool/none declines (the forward ones are above).
+		{ID: "enum_cmp_decline_reverse_primitives", Surface: "enum_cmp_decline",
+			Template: `{{ 5 == Color.RED }}/{{ 5 != Color.RED }}/{{ true == Color.RED }}/{{ true != Color.RED }}/{{ none == Color.RED }}/{{ none != Color.RED }}`}, // false/true/false/true/false/true
+		// The reverse comparison OPERATOR for the None < Some(alias) tie-break: the
+		// existing rows only spell it with `<`.
+		{ID: "enum_cmp_alias_option_reverse_order", Surface: "enum_cmp_decline",
+			Template: `{{ Color.RED > Size.RED }}/{{ Size.RED > Color.RED }}`}, // true/false
+		// A KNOWN-empty map is falsey, has length 0, and renders `{}` — the live-CFFI
+		// control that separates it from the non-enumerable enum objects above, which
+		// are truthy and have no length at all.
+		{ID: "class_empty_truthiness", Surface: "class",
+			Params: []Param{{Name: "e", BamlType: "Empty"}}, Args: map[string]any{"e": map[string]any{}},
+			Template: `{% if e %}T{% else %}F{% endif %}/{{ e|length }}/{{ e }}`}, // F/0/{}
+		// An EXPLICIT empty alias, Some(""), against a None control with the SAME
+		// canonical name. Display is empty, but `.value` is still X. The comparator
+		// compares the CANONICAL name against a string, never the alias, so comparing
+		// the member to the empty string is false (and its negation true) even though
+		// the member DISPLAYS as nothing — the row separates presentation from
+		// comparison identity. Some("") then sorts strictly ABOVE None, so
+		// NoAliasX.X < EmptyAlias.X, while the two are NOT equal: same canonical, and
+		// the Option tie-break breaks it. None of this is expressible if an absent
+		// alias and `@alias("")` collapse to the same value.
+		{ID: "enum_empty_alias", Surface: "enum",
+			Template: `{{ EmptyAlias.X }}/{{ EmptyAlias.X.value }}/{{ EmptyAlias.X == '' }}/{{ EmptyAlias.X != '' }}/{{ NoAliasX.X < EmptyAlias.X }}/{{ EmptyAlias.X == NoAliasX.X }}`}, // /X/false/true/true/false
+		// The list-item none -> null display proof, as a checked-in CFFI row. The
+		// element type is PARENTHESIZED: BAML v0.223 rejects the bare `string?[]`
+		// spelling ("This line is invalid"), and `(string?)[]` is the accepted one.
+		{ID: "list_item_none_null", Surface: "enum_container",
+			Params: []Param{{Name: "xs", BamlType: "(string?)[]"}}, Args: map[string]any{"xs": []any{"a", nil}},
+			Template: `{{ xs }}`}, // ["a", null]
+		// Map REPRESENTATION, ENUMERABILITY and TRUTHINESS are three different things
+		// and this row separates them: both objects are mappings, neither is iterable,
+		// and both are truthy (no known length).
+		{ID: "enum_non_enumerable_state", Surface: "enum_cmp_opaque",
+			Template: `{{ Color.RED is iterable }}/{{ Color is iterable }}/{{ Color.RED is mapping }}/{{ Color is mapping }}/{% if Color.RED %}T{% else %}F{% endif %}/{% if Color %}T{% else %}F{% endif %}`}, // false/false/true/true/T/T
+		// FAULT ROWS. Iterating either object RAISES; it is not silently an empty
+		// loop. Compared by outcome class — the messages differ between Rust and Go.
+		{ID: "enum_member_for_non_enumerable", Surface: "enum_cmp_opaque", Fault: OutcomeError,
+			Template: `{% for x in Color.RED %}{{ x }}{% endfor %}`},
+		{ID: "enum_namespace_for_non_enumerable", Surface: "enum_cmp_opaque", Fault: OutcomeError,
+			Template: `{% for x in Color %}{{ x }}{% endfor %}`},
+
+		// ============ PR-2 remediation round 2: the DISCRIMINATING host-map rows ============
+		//
+		// The cold re-review found three more surfaces that reach the SAME two
+		// host-map shapes as the rows above — a non-enumerable enum member/namespace,
+		// and an enumerable class map with an alias-aware render — but through
+		// pycompat, the pprint/debug renderers and the map API, none of which the
+		// existing rows exercise. Fixed generically in fork v2.16.0-baml.6
+		// (PATCHES #106-#108). Each row is a direct stock-CFFI repro from the review.
+
+		// --- CRITICAL: pycompat str.join over a non-enumerable map (finding #1) ---
+		//
+		// FAULT ROWS. `",".join(x)` takes `values.try_iter()?`; a non-enumerable map
+		// has no iterator, so stock BAML errors `map is not iterable`. The profile
+		// used to join the nil iterator as an EMPTY list and render "" — a native
+		// success where BAML fails, the exact parity-decline violation. Compared by
+		// outcome class; both legs must error.
+		{ID: "pycompat_join_member_fault", Surface: "pycompat_map", Fault: OutcomeError,
+			Template: `{{ ",".join(Color.RED) }}`},
+		{ID: "pycompat_join_namespace_fault", Surface: "pycompat_map", Fault: OutcomeError,
+			Template: `{{ ",".join(Color) }}`},
+		// The control that separates a non-enumerable map from a KNOWN-EMPTY one: an
+		// empty map still joins to "" because its pair iterator exists and is empty.
+		{ID: "pycompat_join_empty_map_control", Surface: "pycompat_map",
+			Template: `[{{ ",".join({}) }}]`}, // [] (empty join)
+
+		// --- HIGH: pprint / debug honor the alias render (finding #2) ---
+		//
+		// `{value:#?}` of an object calls its render, and the class's alias-aware
+		// render wins over a map rebuilt from its CANONICAL keys. The profile showed
+		// `prop1` where stock shows the alias `key1`, in both alternate-debug
+		// renderers, direct and nested. debug(x) is the same `{:#?}` call as pprint.
+		{ID: "pprint_class_alias", Surface: "pprint_debug",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ c|pprint }}`}, // {\n    "key1": "value",\n}
+		{ID: "debug_class_alias", Surface: "pprint_debug",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ debug(c) }}`}, // {\n    "key1": "value",\n}
+		// Nested: the object render is re-indented by the surrounding depth, the way
+		// Rust's DebugList/DebugMap PadAdapter shifts a nested entry.
+		{ID: "pprint_class_in_list", Surface: "pprint_debug",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ [c]|pprint }}`}, // [\n    {\n        "key1": "value",\n    },\n]
+		{ID: "pprint_class_in_map", Surface: "pprint_debug",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ {"c": c}|pprint }}`}, // {\n    "c": {\n        "key1": "value",\n    },\n}
+		// The enum member and namespace render bare under pprint/debug (no pairs),
+		// the controls that keep the render dispatch from over-reaching.
+		{ID: "pprint_enum_member", Surface: "pprint_debug",
+			Template: `{{ Color.RED|pprint }}/{{ debug(Color.RED) }}`}, // rouge/rouge
+		{ID: "pprint_enum_namespace", Surface: "pprint_debug",
+			Template: `{{ Color|pprint }}`}, // {}
+
+		// --- MEDIUM: the map API on a host map (finding #3) ---
+		//
+		// pycompat keys/values/items/get and dictsort reach a host map generically
+		// (MapKeys/GetItem), not through a Go-map-only AsMap. A NON-enumerable map
+		// yields empty views and a get-fallback; an ENUMERABLE class answers by its
+		// CANONICAL keys. The profile used to decline both — `unknown method` and
+		// `cannot convert value into pair list`.
+		{ID: "pycompat_map_methods_enum", Surface: "pycompat_map",
+			Template: `{{ Color.RED.keys()|list }}/{{ Color.RED.values()|list }}/{{ Color.RED.items()|list }}/{{ Color.RED.get("x", "fallback") }}`}, // []/[]/[]/fallback
+		{ID: "pycompat_map_methods_class", Surface: "pycompat_map",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ c.keys()|list }}/{{ c.values()|list }}/{{ c.items()|list }}/{{ c.get("prop1", "fallback") }}/{{ c.get("key1", "fallback") }}`}, // ["prop1"]/["value"]/[["prop1", "value"]]/value/fallback
+		// dictsort for BOTH shapes: the class sorts its canonical pairs; the
+		// non-enumerable enum member FAULTS `map is not iterable` (`ok!(v.try_iter())`).
+		{ID: "dictsort_class", Surface: "pycompat_map",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ c|dictsort }}`}, // [["prop1", "value"]]
+		{ID: "dictsort_enum_member_fault", Surface: "pycompat_map", Fault: OutcomeError,
+			Template: `{{ Color.RED|dictsort }}`},
+		// The `|items|list` control, which already reached the class map through the
+		// filter's GetItem fallback and must keep matching.
+		{ID: "items_class_control", Surface: "pycompat_map",
+			Params: []Param{{Name: "c", BamlType: "C"}}, Args: map[string]any{"c": map[string]any{"prop1": "value"}},
+			Template: `{{ c|items|list }}`}, // [["prop1", "value"]]
+		// A host LIST under pprint/debug. This is the discriminating control for
+		// the scoping of the object-render dispatch (fork v2.16.0-baml.6): a
+		// class render forces the alternate form and equals its pprint bytes, but
+		// a list render RESPECTS the alternate flag — its debug_list is multi-line
+		// under `{:#?}` while its top-level render is compact. So a host list
+		// under pprint must be the MULTI-LINE debug_list, NOT the compact render
+		// its ObjectString returns. baml.5 regressed this by using the render for
+		// any object; baml.6 scopes the dispatch to map objects.
+		{ID: "pprint_host_list_multiline", Surface: "pprint_debug",
+			Params: []Param{{Name: "xs", BamlType: "Color[]"}}, Args: map[string]any{"xs": []any{"RED"}},
+			Template: `{{ xs|pprint }}`}, // [\n    rouge,\n]
+		{ID: "debug_host_list_multiline", Surface: "pprint_debug",
+			Params: []Param{{Name: "xs", BamlType: "Color[]"}}, Args: map[string]any{"xs": []any{"RED"}},
+			Template: `{{ debug(xs) }}`}, // [\n    rouge,\n]
 	}
 }

--- a/internal/bamlprofile/profileoracle/testdata/profile_oracle.json
+++ b/internal/bamlprofile/profileoracle/testdata/profile_oracle.json
@@ -1,7 +1,7 @@
 {
   "baml_runtime_version": "0.223.0",
   "baml_module_version": "v0.223.0",
-  "baml_source_sha256": "0038fba361a033df3eff240948a0d94441989525baf1dec82e73a36857d09723",
-  "row_count": 66,
-  "note": "stock BAML v0.223.0 get_env differential for internal/bamlprofile (Slice 2 PR-1)"
+  "baml_source_sha256": "2554332d6cd0aaeede522da7dde5c648a0cf51b55a246968c4c14da86daed51b",
+  "row_count": 150,
+  "note": "stock BAML v0.223.0 get_env + enum/class host-value-model differential for internal/bamlprofile (Slice 2 PR-1 + PR-2)"
 }

--- a/internal/bamlprofile/profileoracle/types.go
+++ b/internal/bamlprofile/profileoracle/types.go
@@ -1,0 +1,357 @@
+package profileoracle
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/invakid404/baml-rest/internal/bamlprofile"
+	"github.com/invakid404/minijinja-go/v2/value"
+)
+
+// This file is the enum/class type layer of the differential: the shared,
+// deterministic set of enum/class declarations, the types.baml source that
+// declares them for the stock BAML leg, the matching bamlprofile.Config.Enums
+// for the profile leg, and the converter that turns a row's plain-Go argument
+// into a profile host VALUE the same way BAML lowers a BamlValue::Enum/Class/List
+// on its leg.
+//
+// The declarations are AUTHOR-CONTROLLED corpus constants (fixed identifiers and
+// alias literals), exactly like Param.Name/BamlType in functionSource — not a
+// caller-fuzzed surface. A malformed one fails LOUD at CreateRuntime (a parse
+// error), never a silent valid-but-wrong render, so they are emitted verbatim
+// without a collision-proof delimiter. The enum aliases are deliberately chosen
+// to discriminate: Color.RED aliases to "rouge" (alias != canonical); Shade.RED
+// has the SAME canonical+alias as Color.RED (cross-enum equality proves the
+// comparator omits enum_name); Size.RED has NO alias (same-canonical/different-
+// alias inequality, and the None<Some alias ordering); and EmptyAlias.X /
+// NoAliasX.X are an explicit `@alias("")` and its unaliased control, which
+// separate Some("") from None in display and in the Option tie-break.
+
+// enumVarDecl is one enum variant: canonical name and OPTIONAL alias.
+//
+// alias is a *string, not a "" sentinel, because BAML distinguishes NO @alias
+// from `@alias("")`: the former leaves the resolved alias None (display falls
+// back to the canonical name, and the comparator's Option tie-break orders it
+// BELOW any Some), the latter is Some("") (display is empty, and the Option
+// tie-break puts it ABOVE None). A "" sentinel cannot express the second, and
+// the corpus needs both — see the enum_empty_alias row. nil = absent, non-nil ""
+// = `@alias("")`. This matches bamlprofile.EnumValue.Alias exactly.
+type enumVarDecl struct {
+	canonical string
+	alias     *string
+}
+
+// enumDecl is one enum declaration in declared order.
+type enumDecl struct {
+	name string
+	vars []enumVarDecl
+}
+
+// classFieldDecl is one class field: canonical name, OPTIONAL alias (nil =
+// unaliased, non-nil "" = `@alias("")`, as in enumVarDecl), and BAML type text
+// (e.g. "string", "int", "B", "string[]", "Color", "string?", "string?[]").
+type classFieldDecl struct {
+	canonical string
+	alias     *string
+	typ       string
+}
+
+// al is the corpus's alias literal: a pointer to a PRESENT alias. Its absence is
+// spelled as a plain nil in the declaration tables, so the two cases read
+// differently at every use site.
+func al(s string) *string { return &s }
+
+// classDecl is one class declaration in declared (IndexMap) order.
+type classDecl struct {
+	name   string
+	fields []classFieldDecl
+}
+
+// enumDecls is the shared enum set. It is fixed and deterministic.
+func enumDecls() []enumDecl {
+	return []enumDecl{
+		{"Color", []enumVarDecl{{"RED", al("rouge")}, {"GREEN", nil}, {"BLUE", nil}}},
+		// Same canonical AND alias as Color.RED -> Color.RED == Shade.RED is true,
+		// proving the comparator ignores enum_name.
+		{"Shade", []enumVarDecl{{"RED", al("rouge")}}},
+		// Size.RED: canonical "RED", NO alias -> same-canonical/different-alias
+		// (Some("rouge") vs None) is NOT equal, and orders None < Some.
+		{"Size", []enumVarDecl{{"RED", nil}, {"SMALL", al("petit")}}},
+		// EmptyAlias.X carries an EXPLICIT empty alias, Some(""): it displays as
+		// nothing, its .value is still "X", and it compares as Some — strictly
+		// ABOVE NoAliasX.X's None. NoAliasX.X is the None control with the same
+		// canonical name, so the pair isolates Some("") vs None without also
+		// changing the canonical string. Neither is expressible with a "" sentinel.
+		{"EmptyAlias", []enumVarDecl{{"X", al("")}}},
+		{"NoAliasX", []enumVarDecl{{"X", nil}}},
+	}
+}
+
+// classDecls is the shared class set. Every class is referenced by a function
+// parameter (directly or nested) so the stock project has no dead type.
+//
+// The DIRECT-RENDER and ITERATION rows use SINGLE-field classes (or ordered list
+// fields), on purpose. A class argument is decoded directly from the protobuf
+// map the Go client builds, whose entry order is the Go map's RANDOM iteration
+// order (serde.EncodeMapEntries does not sort), and BAML preserves that arg
+// order — so the RELATIVE order of two sibling fields is non-deterministic
+// through this harness and cannot be byte-pinned. Single-field classes make
+// every rendering mechanic (aliased key, indentation, trailing comma, nested
+// class/list, none->null, escaping) deterministic. Multi-field INSERTION-order
+// fidelity is proven at the leaf (bamlprofile.host_test.go) against BAML's own
+// documented multi-field golden (jinja-runtime/src/lib.rs:1888). Multi-field
+// classes are used ONLY where order does not matter: attribute access, length,
+// and truthiness.
+func classDecls() []classDecl {
+	return []classDecl{
+		{"C", []classFieldDecl{{"prop1", al("key1"), "string"}}},
+		// Multi-field, used only for order-independent probes (access, length,
+		// int-compare, enum-in-class access).
+		{"WithColor", []classFieldDecl{
+			{"color", al("colour"), "Color"},
+			{"n", nil, "int"},
+		}},
+		// Lw/Cw: single-field wrappers that make a nested list and a nested class
+		// deterministic, proving list-in-class, class-in-class, and the indentation
+		// depths without a sibling-order dependency.
+		{"Lw", []classFieldDecl{{"items", al("data"), "string[]"}}},
+		{"Cw", []classFieldDecl{{"inner", al("nested"), "Lw"}}},
+		// Nw: a single optional field, for the nested none -> null render row.
+		{"Nw", []classFieldDecl{{"maybe", al("perhaps"), "string?"}}},
+		// Ew: a single field carrying special characters, for scalar escaping.
+		{"Ew", []classFieldDecl{{"raw", al("escaped"), "string"}}},
+		// Ecw: a single enum field, rendered as the BARE alias inside the map.
+		{"Ecw", []classFieldDecl{{"color", al("colour"), "Color"}}},
+		// Empty: a FIELDLESS class. It is a KNOWN-empty map — falsey, length 0,
+		// rendering as `{}` — which is exactly what a non-enumerable enum object is
+		// NOT, so it is the live-CFFI control for the opaque-map rows.
+		{"Empty", nil},
+	}
+}
+
+// typesBAMLSource is the deterministic types.baml declaring every shared enum and
+// class for the stock BAML leg. Included in every generated project so the enum
+// namespace globals (which BAML injects for ALL declared enums) exist on both
+// legs identically.
+func typesBAMLSource() string {
+	var b strings.Builder
+	for _, e := range enumDecls() {
+		b.WriteString("enum ")
+		b.WriteString(e.name)
+		b.WriteString(" {\n")
+		for _, v := range e.vars {
+			b.WriteString("  ")
+			b.WriteString(v.canonical)
+			// A PRESENT alias is emitted even when it is the empty string: `@alias("")`
+			// is a distinct declaration from no @alias at all, and the corpus asserts
+			// the difference.
+			if v.alias != nil {
+				b.WriteString(` @alias("`)
+				b.WriteString(*v.alias)
+				b.WriteString(`")`)
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("}\n\n")
+	}
+	for _, c := range classDecls() {
+		b.WriteString("class ")
+		b.WriteString(c.name)
+		b.WriteString(" {\n")
+		for _, f := range c.fields {
+			b.WriteString("  ")
+			b.WriteString(f.canonical)
+			b.WriteString(" ")
+			b.WriteString(f.typ)
+			if f.alias != nil {
+				b.WriteString(` @alias("`)
+				b.WriteString(*f.alias)
+				b.WriteString(`")`)
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("}\n\n")
+	}
+	return b.String()
+}
+
+// profileEnums is the bamlprofile.Config.Enums matching typesBAMLSource, so the
+// profile leg installs the same namespace globals BAML injects.
+func profileEnums() []bamlprofile.EnumDef {
+	decls := enumDecls()
+	out := make([]bamlprofile.EnumDef, 0, len(decls))
+	for _, e := range decls {
+		vals := make([]bamlprofile.EnumValue, len(e.vars))
+		for i, v := range e.vars {
+			vals[i] = bamlprofile.EnumValue{Canonical: v.canonical, Alias: v.alias}
+		}
+		out = append(out, bamlprofile.EnumDef{Name: e.name, Values: vals})
+	}
+	return out
+}
+
+func enumByName(name string) (enumDecl, bool) {
+	for _, e := range enumDecls() {
+		if e.name == name {
+			return e, true
+		}
+	}
+	return enumDecl{}, false
+}
+
+func classByName(name string) (classDecl, bool) {
+	for _, c := range classDecls() {
+		if c.name == name {
+			return c, true
+		}
+	}
+	return classDecl{}, false
+}
+
+// unparen strips one layer of BAML's grouping parentheses. BAML v0.223 rejects a
+// bare `string?[]` and requires `(string?)[]` for a list of optionals, so the
+// element type this walker recurses into can arrive parenthesized.
+func unparen(typ string) string {
+	t := strings.TrimSpace(typ)
+	if len(t) >= 2 && t[0] == '(' && t[len(t)-1] == ')' {
+		return strings.TrimSpace(t[1 : len(t)-1])
+	}
+	return t
+}
+
+// needsHostValue reports whether a parameter type must be converted into a
+// profile host value on the profile leg. Enums, classes, and ANY list (BAML
+// lowers a list arg to MinijinjaBamlList) are host-shaped; plain scalars are not.
+func needsHostValue(typ string) bool {
+	base := strings.TrimSuffix(unparen(typ), "?")
+	if strings.HasSuffix(base, "[]") {
+		return true
+	}
+	base = unparen(base)
+	if _, ok := enumByName(base); ok {
+		return true
+	}
+	_, ok := classByName(base)
+	return ok
+}
+
+// hostValue lowers a plain-Go argument to the profile host value BAML would
+// build for the same typed argument: an enum canonical string -> EnumMember, a
+// map -> ClassValue over the class's resolved fields, a slice -> ListValue, a
+// scalar -> the matching fork scalar. It fails loud on a shape that does not
+// match the declared type rather than fabricating a value.
+func hostValue(typ string, arg any) (value.Value, error) {
+	// Grouping parentheses first: `(string?)[]` decomposes to the element type
+	// `(string?)`, which only becomes `string?` once unwrapped.
+	typ = unparen(typ)
+	// Optional: a nil arg is none; otherwise unwrap and recurse.
+	if strings.HasSuffix(typ, "?") {
+		if arg == nil {
+			return value.None(), nil
+		}
+		return hostValue(strings.TrimSuffix(typ, "?"), arg)
+	}
+	// List -> host list (MinijinjaBamlList).
+	if strings.HasSuffix(typ, "[]") {
+		elem := strings.TrimSuffix(typ, "[]")
+		items, ok := arg.([]any)
+		if !ok {
+			return value.Undefined(), fmt.Errorf("profileoracle: type %q expects a []any arg, got %T", typ, arg)
+		}
+		vals := make([]value.Value, len(items))
+		for i, it := range items {
+			hv, err := hostValue(elem, it)
+			if err != nil {
+				return value.Undefined(), err
+			}
+			vals[i] = hv
+		}
+		return bamlprofile.ListValue(vals)
+	}
+	// Enum -> enum member with the resolved alias for that canonical variant.
+	if e, ok := enumByName(typ); ok {
+		canonical, ok := arg.(string)
+		if !ok {
+			return value.Undefined(), fmt.Errorf("profileoracle: enum %q expects a string canonical, got %T", typ, arg)
+		}
+		for _, v := range e.vars {
+			if v.canonical == canonical {
+				return bamlprofile.EnumMember(e.name, canonical, v.alias)
+			}
+		}
+		return value.Undefined(), fmt.Errorf("profileoracle: enum %q has no variant %q", typ, canonical)
+	}
+	// Class -> class value over the class's declared fields. A directly-rendered
+	// class here is always single-field (classDecls), so field order is trivially
+	// deterministic; multi-field classes are used only for order-independent
+	// probes (access/length), where the build order does not affect the result.
+	// (A class ARGUMENT's field order is otherwise the Go client's random map
+	// order, which BAML preserves — see classDecls — so it cannot be byte-pinned;
+	// multi-field insertion order is proven at the leaf against BAML's own
+	// documented golden.)
+	if c, ok := classByName(typ); ok {
+		m, ok := arg.(map[string]any)
+		if !ok {
+			return value.Undefined(), fmt.Errorf("profileoracle: class %q expects a map[string]any arg, got %T", typ, arg)
+		}
+		// Every key in the arg map must name a DECLARED canonical field. A key
+		// that does not — a misspelled OPTIONAL-field name, say — would otherwise
+		// be silently dropped: the real field goes absent -> none on both legs, so
+		// the differential stays green while proving less than the row reads. Fail
+		// loud instead.
+		declared := make(map[string]struct{}, len(c.fields))
+		for _, fd := range c.fields {
+			declared[fd.canonical] = struct{}{}
+		}
+		for k := range m {
+			if _, ok := declared[k]; !ok {
+				return value.Undefined(), fmt.Errorf("profileoracle: class %q has no field %q (arg map has an unknown key — a misspelled field name?)", typ, k)
+			}
+		}
+		fields := make([]bamlprofile.ClassField, 0, len(c.fields))
+		for _, fd := range c.fields {
+			fv, present := m[fd.canonical]
+			if !present {
+				if !strings.HasSuffix(fd.typ, "?") {
+					return value.Undefined(), fmt.Errorf("profileoracle: class %q missing required field %q", typ, fd.canonical)
+				}
+				fv = nil // an absent optional field is none
+			}
+			hv, err := hostValue(fd.typ, fv)
+			if err != nil {
+				return value.Undefined(), err
+			}
+			fields = append(fields, bamlprofile.ClassField{Canonical: fd.canonical, Alias: fd.alias, Value: hv})
+		}
+		return bamlprofile.ClassValue(fields)
+	}
+	// Scalar.
+	switch typ {
+	case "string":
+		s, ok := arg.(string)
+		if !ok {
+			return value.Undefined(), fmt.Errorf("profileoracle: string field got %T", arg)
+		}
+		return value.FromString(s), nil
+	case "int":
+		i, ok := arg.(int64)
+		if !ok {
+			return value.Undefined(), fmt.Errorf("profileoracle: int field got %T (use int64)", arg)
+		}
+		return value.FromInt(i), nil
+	case "float":
+		f, ok := arg.(float64)
+		if !ok {
+			return value.Undefined(), fmt.Errorf("profileoracle: float field got %T (use float64)", arg)
+		}
+		return value.FromFloat(f), nil
+	case "bool":
+		b, ok := arg.(bool)
+		if !ok {
+			return value.Undefined(), fmt.Errorf("profileoracle: bool field got %T", arg)
+		}
+		return value.FromBool(b), nil
+	default:
+		return value.Undefined(), fmt.Errorf("profileoracle: unsupported host type %q", typ)
+	}
+}

--- a/internal/bamlprofile/registry_test.go
+++ b/internal/bamlprofile/registry_test.go
@@ -27,7 +27,11 @@ import (
 // render), or nil.
 func probeErr(t *testing.T, src string) error {
 	t.Helper()
-	tmpl, cerr := New(Config{}).TemplateFromNamedString("registry_probe", src)
+	env, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tmpl, cerr := env.TemplateFromNamedString("registry_probe", src)
 	if cerr != nil {
 		return cerr
 	}


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## Slice 2 PR-2 — `bamlprofile` enum & class host value model

Lands the BAML v0.223 **enum & class host value model** in the `internal/bamlprofile` leaf, over the pinned pure-Go minijinja fork. Test-only, unwired, pure-Go, differential-proven byte-exact against stock BAML v0.223 CFFI.

### What it lands
- **Enum** (`enum.go`): per-enum namespace globals via `Environment.AddGlobal` (canonical keys, non-enumerable); enum-member objects with **separate** `canonical` / `alias` / `enumName` fields — display is alias-or-canonical, `.value` is canonical **only** (no `.name`/`.alias`); `ObjectWithValueCmp` exactly per BAML (string → compare **canonical**; same member type → canonical then `Option<alias>` with `enum_name` **omitted**; every other type → **decline** `(0,false)`).
- **Class/list** (`class.go`, `list.go`): canonical attribute/iteration/index access, alias **only** in direct display; a hand-written Rust `{:#?}` pretty debug renderer (aliased keys, 4-space nesting, trailing commas, nested `none → null`) plus a compact top-level list renderer (BAML renders a directly-rendered list non-alternate, but a list nested in a class inherits alternate). Formatter extended to dispatch `ObjectWithString`.
- **Input contract**: enum/class metadata (canonical names, resolved aliases, ordered fields) enters as **explicit typed inputs** — no BAML source parsing, no IR import.

### #597 enum-`==` closed at the profile level
The six fence cases pass through the new profile in **both operand orders** + membership, differential-verified vs stock BAML: `Color.RED=='RED'` (both orders) → true, `Color.RED==Color.RED` → true, `'RED' in [Color.RED]` → true, `Color.RED=='rouge'` → false (compares canonical, not alias), `Color.RED==Color.BLUE` → false. Plus cross-enum (same canonical+alias → equal, proving `enum_name` omitted), same-canonical/different-alias → not equal, and int/bool/none decline edges. The e2e `nativeprompt` fence stays for Slice 7.1.

### Declined (real boundaries, tracked #602)
- **Media** host values — no constructor exists, so a media value can't enter a render context; BAML's serde marker needs the prompt lowerer/body path this unwired leaf lacks.
- **`format(type=json|yaml|toon)`** — the `get_env`-level `format` is the fork's printf filter, so `class|format(type=...)` **errors** rather than silently serializing (pinned by `TestFormatTypeDeclined`).

Posted: https://github.com/invakid404/baml-rest/issues/602#issuecomment-5141150344

### Proof
- `profileoracle` extended with typed enum/class declarations (deterministic `types.baml` + per-row signatures; reuses the dynamic raw-string-delimiter helper) and all scope proof rows, byte-compared against stock BAML v0.223 CFFI (`BuildRequest`, no send) behind `//go:build integration`; version/module/source-SHA guard kept; fixture regenerated.
- **Multi-field class field order is proven at the leaf** against BAML's own documented golden (`jinja-runtime/src/lib.rs:1888`): a class **argument's** field order is the Go client's random protobuf-map order (which BAML preserves), so the differential uses single-field wrapper classes for order-dependent rows and pins multi-field insertion order in `host_test.go`.

### Gates (all green)
`CGO_ENABLED=0 go build ./...`; leaf `go test` (pure-Go, CGO-free); `CGO_ENABLED=1 go test -tags integration ./internal/bamlprofile/profileoracle` (248 pass); `gofmt` clean; `go vet` (default + integration); dep-purity (leaf default closure = fork + stdlib only); `.embedignore` still excludes the leaf.

Test-only / unwired / pure-Go. Does **not** merge (human-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for enum, class, and list values in templates.
  * Enum values support aliases, comparisons, membership checks, and namespace access.
  * Class values support field access, iteration, map-style usage, and nested rendering.
  * Lists support indexing, iteration, membership, and compact formatting.
  * Added conversion for optional and nested typed values.

* **Bug Fixes**
  * Invalid values and malformed definitions now produce clear errors.

* **Documentation**
  * Expanded coverage of supported values, formatting, and rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->