### PR TITLE
feat(bamlprofile): Slice 2 PR-3 — constraint lowerer & typed façade

### DIFF
--- a/internal/bamlprofile/constraints.go
+++ b/internal/bamlprofile/constraints.go
@@ -1,0 +1,395 @@
+package bamlprofile
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	minijinja "github.com/invakid404/minijinja-go/v2"
+	"github.com/invakid404/minijinja-go/v2/value"
+)
+
+// This file is BAML v0.223's CONSTRAINT evaluator and its narrow typed façade.
+//
+// Authority (byte-for-byte): BAML v0.223
+//   - the evaluator: engine/baml-lib/baml-core/src/ir/jinja_helpers.rs:67-93
+//   - the batch:     engine/baml-lib/jsonish/src/deserializer/coercer/mod.rs:322-338
+//   - assert/check:  engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs:180-294
+//   - the data type: engine/baml-lib/baml-types/src/constraint.rs:3-43
+//
+// BAML's evaluator is four lines and is copied, not improved:
+//
+//	pub fn evaluate_predicate(this: &BamlValue, e: &JinjaExpression) -> Result<bool> {
+//	    let ctx = HashMap::from([("this", Value::from_serialize(this))]);
+//	    match render_expression(e, &ctx)?.as_ref() {
+//	        "true"  => Ok(true),
+//	        "false" => Ok(false),
+//	        _       => Err(anyhow!("Predicate did not evaluate to a boolean")),
+//	    }
+//	}
+//	// render_expression: get_env(); format!("{{{{ {} }}}}", expression.0); render_str
+//
+// Four consequences drive every decision below:
+//
+//  1. the stored expression is BARE — BAML wraps it in `{{ ... }}` itself, so a
+//     caller passing `{{ this > 0 }}` is passing a DIFFERENT string than the
+//     reference evaluator receives and is rejected, not stripped;
+//  2. the environment is a bare get_env(), so `_`, `ctx` and the enum namespaces
+//     are undefined in a predicate (newConstraintEnvironment, env.go);
+//  3. `this` is the SERDE projection of the BamlValue, not the prompt host object
+//     (projectConstraintThis, project.go);
+//  4. classification is on the RENDERED TEXT, not a boolean downcast: exactly
+//     "true" and exactly "false"; anything else — including " true" and "True" —
+//     is an ERROR, never a failed predicate.
+//
+// The batch mirrors run_user_checks' `collect::<Result<Vec<_>>>()`: one predicate
+// error aborts the whole evaluation and yields NO partial report. A false ASSERT
+// is not an error — it is a successful evaluation whose result is terminal at the
+// serving layer (validate_asserts); a false CHECK is retained as metadata.
+//
+// What this façade does NOT own, by design: BAML source parsing, interpolation
+// stripping, Jinja typechecking, BAML IR/descriptors, prompt globals, the
+// serving `Checked<T>` envelope, its ordering policy, and assert-message wording.
+// See doc.go for the full decline list.
+
+// ConstraintLevel is a resolved BAML constraint kind
+// (baml-types/src/constraint.rs:39-43).
+//
+// The zero value is deliberately INVALID so a `Constraint{}` built without a
+// level fails the preflight instead of silently defaulting to a check or an
+// assert — the two differ in whether a false result rejects the value.
+type ConstraintLevel uint8
+
+const (
+	// ConstraintCheck is `@check(label, {{ expr }})`: a false result is retained
+	// as metadata and does NOT reject the value.
+	ConstraintCheck ConstraintLevel = iota + 1
+	// ConstraintAssert is `@assert({{ expr }})` / `@assert(label, {{ expr }})`: a
+	// false result is terminal for the parsed value at the serving layer.
+	ConstraintAssert
+)
+
+// String renders a level for diagnostics.
+func (l ConstraintLevel) String() string {
+	switch l {
+	case ConstraintCheck:
+		return "check"
+	case ConstraintAssert:
+		return "assert"
+	default:
+		return fmt.Sprintf("ConstraintLevel(%d)", uint8(l))
+	}
+}
+
+// Constraint is one already-RESOLVED BAML constraint: the exact
+// `{level, expression, label}` triple baml_types::Constraint stores.
+//
+// Expression is the BARE JinjaExpression BAML records — `this > 0`, NOT
+// `{{ this > 0 }}`. BAML's parser strips the interpolation brackets when it
+// builds the JinjaExpression, and its evaluator adds them back; a caller that
+// supplies the wrapped form is supplying a string the reference evaluator never
+// sees, and EvaluateConstraints rejects it rather than guessing which layer the
+// caller meant. Producing the bare form from a descriptor is the resolved
+// adapter's job (Slice 7.2), not this leaf's.
+//
+// Label must be non-nil for ConstraintCheck — BAML's grammar and its type
+// validator both require a check to carry an identifier
+// (parser-database/src/attributes/constraint.rs:33-38). It is optional for
+// ConstraintAssert. A non-nil label is a BAML identifier, so it is never empty.
+type Constraint struct {
+	Level      ConstraintLevel
+	Expression string
+	Label      *string
+}
+
+// clone deep-copies the label so a caller writing through its *string after the
+// call cannot retroactively change a returned result's label — the same
+// ownership rule newEnumMember applies to a resolved alias. The pointer-ness is
+// preserved (nil is "no label", which is distinct from any string).
+func (c Constraint) clone() Constraint {
+	out := c
+	if c.Label != nil {
+		l := *c.Label
+		out.Label = &l
+	}
+	return out
+}
+
+// ConstraintRequest is one evaluation: the resolved constraints in DECLARED
+// order, and the single value they are all evaluated against.
+//
+// This must be a scalar, none, or a value built by the bamlprofile host
+// constructors (EnumMember / ClassValue / ListValue). It is not an arbitrary Go
+// or fork value: it is projected into BAML's serde shape before binding, and a
+// shape with no proven projection is declined (project.go).
+type ConstraintRequest struct {
+	Constraints []Constraint
+	This        value.Value
+}
+
+// ConstraintResult is one evaluated constraint. Results appear in exactly the
+// input constraint order, matching run_user_checks' ordered iteration over the
+// type's stored constraints.
+type ConstraintResult struct {
+	Constraint Constraint
+	Passed     bool
+}
+
+// ConstraintReport is the outcome of a fully successful batch: every predicate
+// compiled, rendered, and classified as a literal "true"/"false".
+//
+// AssertFailed is DERIVED from Results (a false ConstraintAssert), reproducing
+// validate_asserts' rejection condition without reproducing its message or its
+// first-five presentation — those are the serving layer's (Slice 7.2). A false
+// CHECK is not an error and not a rejection: it stays in Results with
+// Passed == false, which is what the caller turns into a ResponseCheck.
+//
+// This is deliberately NOT a `Checked<T>` envelope. The client-facing
+// `{value, checks}` shape and its stable ordering are a later representation
+// layer; PR-3 only guarantees that Results is in declared input order so that
+// layer has a stable source order to work from.
+type ConstraintReport struct {
+	Results      []ConstraintResult
+	AssertFailed bool
+}
+
+// ConstraintStage names WHERE an evaluation failed. It is part of the typed
+// error so a caller can tell a caller-contract violation (validate/project)
+// apart from a predicate the engine could not evaluate (compile/render/classify)
+// without matching on message text.
+type ConstraintStage string
+
+const (
+	// ConstraintStageValidate: the request violates a structural invariant BAML's
+	// own parser/validator guarantees — an unknown level, a check with no label,
+	// or a `{{ ... }}`-wrapped expression. BAML could never have produced it.
+	ConstraintStageValidate ConstraintStage = "validate"
+	// ConstraintStageProject: This is not a shape with a proven serde projection
+	// (undefined, media, a native container, an unrecognized host object).
+	ConstraintStageProject ConstraintStage = "project"
+	// ConstraintStageCompile: the synthesized `{{ <expr> }}` template did not
+	// parse. In BAML this is render_expression's `env.render_str(..)?`.
+	ConstraintStageCompile ConstraintStage = "compile"
+	// ConstraintStageRender: the template parsed but raised while rendering (an
+	// unknown attribute chain, a bad filter argument, ...). Also
+	// render_expression's `?`.
+	ConstraintStageRender ConstraintStage = "render"
+	// ConstraintStageClassify: the predicate rendered successfully but its text is
+	// neither "true" nor "false" — BAML's `Predicate did not evaluate to a
+	// boolean`. This is an evaluator error, NOT a failed predicate.
+	ConstraintStageClassify ConstraintStage = "classify"
+)
+
+// ConstraintError is the single error type EvaluateConstraints returns. It
+// carries the stage, the failing constraint, and its index, so a caller can
+// report which of a batch of predicates went wrong without parsing a string.
+//
+// Index is the position in ConstraintRequest.Constraints, or -1 when the failure
+// is not attributable to one constraint — which today means only
+// ConstraintStageProject, since `This` is projected once for the whole batch.
+// Constraint is the zero Constraint in that case.
+type ConstraintError struct {
+	Index      int
+	Constraint Constraint
+	Stage      ConstraintStage
+	Err        error
+}
+
+func (e *ConstraintError) Error() string {
+	if e.Index < 0 {
+		return fmt.Sprintf("bamlprofile: constraint %s: %v", e.Stage, e.Err)
+	}
+	return fmt.Sprintf("bamlprofile: constraint %d (%s %q) %s: %v",
+		e.Index, e.Constraint.Level, e.Constraint.Expression, e.Stage, e.Err)
+}
+
+func (e *ConstraintError) Unwrap() error { return e.Err }
+
+// constraintTemplateName is the name given to the one-off synthetic template a
+// predicate is compiled as. The fork does not store a template built with
+// TemplateFromNamedString in the environment (environment.go:498-501), so the
+// same name is reused for every predicate without any of them colliding. It is
+// observable only in a compile/render error message; the environment forces
+// AutoEscapeNone (env.go), so unlike stock MiniJinja's name-driven autoescape it
+// cannot change what a predicate renders.
+const constraintTemplateName = "bamlprofile_constraint"
+
+// EvaluateConstraints evaluates every constraint in req against req.This and
+// reports the results in input order.
+//
+// It reproduces BAML v0.223's run_user_checks + evaluate_predicate exactly:
+//
+//   - a bare get_env() environment with NO prompt globals;
+//   - `this` bound to the SERDE projection of the host value, and nothing else
+//     bound;
+//   - each stored expression wrapped verbatim as `{{ <expr> }}` and rendered;
+//   - the rendered text classified as literally "true" or "false";
+//   - the batch ABORTING on the first evaluator error, with no partial report,
+//     mirroring `collect::<Result<Vec<_>>>()`.
+//
+// The two structural preflights run BEFORE any evaluation, so a malformed
+// request can never produce a half-evaluated report:
+//
+//   - every constraint is validated (validateConstraint);
+//   - req.This is projected once (projectConstraintThis).
+//
+// The projection runs even when there are no constraints. BAML would skip the
+// evaluator entirely in that case (field_type.rs:180), so this errors where BAML
+// is silent — the conservative direction. It never does the reverse: an
+// unsupported value is refused, never bound and rendered against.
+//
+// A false assert is NOT an error: it is a successful evaluation whose report has
+// AssertFailed set. A false check is likewise a normal result. Only an
+// unsupported projection, a compile failure, a render failure, or a
+// non-"true"/"false" rendering produce an error, and each returns a
+// *ConstraintError naming its stage.
+func EvaluateConstraints(req ConstraintRequest) (ConstraintReport, error) {
+	// PREFLIGHT 1: structural invariants, over the WHOLE batch, before anything is
+	// evaluated. These are conditions BAML's parser and type validator already
+	// guarantee, so a request that trips one describes something stock BAML could
+	// not have produced; failing loud beats evaluating a predicate whose meaning we
+	// would have had to guess at.
+	//
+	// The constraints are cloned here, once, and everything downstream (including
+	// the returned Results) uses the COPIES — so a caller mutating its slice or a
+	// label pointee after the call cannot change the report it was handed.
+	constraints := make([]Constraint, len(req.Constraints))
+	for i, c := range req.Constraints {
+		if err := validateConstraint(c); err != nil {
+			return ConstraintReport{}, &ConstraintError{Index: i, Constraint: c.clone(), Stage: ConstraintStageValidate, Err: err}
+		}
+		constraints[i] = c.clone()
+	}
+
+	// PREFLIGHT 2: the serde projection of `this`, done ONCE for the batch exactly
+	// as BAML builds one `Value::from_serialize(this)` per evaluate_predicate call
+	// over the same value.
+	this, err := projectConstraintThis(req.This)
+	if err != nil {
+		return ConstraintReport{}, &ConstraintError{Index: -1, Stage: ConstraintStageProject, Err: err}
+	}
+
+	// The context has exactly ONE key, matching evaluate_predicate's single-entry
+	// HashMap. Its map ordering is therefore unobservable; the ordering that IS
+	// observable lives inside a projected class, which uses the fork's ordered map.
+	// The fork passes an already-built value.Value through unchanged
+	// (value.FromAny, value/value.go:699-721), so the projected host value reaches
+	// the predicate as itself.
+	ctx := value.FromMap(map[string]value.Value{"this": this})
+
+	// One environment for the batch. BAML calls get_env() per predicate, but the
+	// environment is pure configuration — formatter, flags, filters, unknown-method
+	// callback — with no per-render mutable state and no stored templates, so a
+	// shared instance renders identically to a fresh one. It carries NO globals:
+	// `_`, `ctx` and the enum namespaces must be undefined in a predicate.
+	env := newConstraintEnvironment()
+
+	results := make([]ConstraintResult, 0, len(constraints))
+	assertFailed := false
+	for i, c := range constraints {
+		// render_expression's `format!(r#"{{{{ {} }}}}"#, expression.0)`: the stored
+		// expression wrapped VERBATIM. No trimming, no normalization — whatever the
+		// resolved constraint holds is what BAML would have wrapped.
+		tmpl, err := env.TemplateFromNamedString(constraintTemplateName, "{{ "+c.Expression+" }}")
+		if err != nil {
+			return ConstraintReport{}, &ConstraintError{Index: i, Constraint: c, Stage: ConstraintStageCompile, Err: err}
+		}
+		text, err := tmpl.Render(ctx)
+		if err != nil {
+			return ConstraintReport{}, &ConstraintError{Index: i, Constraint: c, Stage: ConstraintStageRender, Err: err}
+		}
+		passed, ok := classifyRenderedBool(text)
+		if !ok {
+			return ConstraintReport{}, &ConstraintError{Index: i, Constraint: c, Stage: ConstraintStageClassify,
+				Err: fmt.Errorf("predicate did not evaluate to a boolean (rendered %q)", text)}
+		}
+		if !passed && c.Level == ConstraintAssert {
+			assertFailed = true
+		}
+		results = append(results, ConstraintResult{Constraint: c, Passed: passed})
+	}
+	return ConstraintReport{Results: results, AssertFailed: assertFailed}, nil
+}
+
+// classifyRenderedBool is BAML's rendered-TEXT boolean classifier
+// (jinja_helpers.rs:89-93). ok is false for every other successful rendering.
+//
+// The comparison is byte-exact on purpose. BAML matches the rendered string
+// against the literals "true" and "false"; it does not trim, lowercase, or
+// downcast the underlying value. So `{{ this }}` on the boolean true renders
+// "true" and passes, while a predicate rendering " true", "True", "1" or "" is
+// an EVALUATOR ERROR — not a failed predicate. Treating any of those as false
+// would silently pass an unevaluatable predicate off as a rejection.
+func classifyRenderedBool(text string) (passed, ok bool) {
+	switch text {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// validateConstraint rejects the resolved-constraint shapes stock BAML cannot
+// produce. Each one is a structural impossibility upstream, so rejecting it can
+// never lose parity — it can only refuse a request BAML never issues.
+func validateConstraint(c Constraint) error {
+	switch c.Level {
+	case ConstraintCheck:
+		// parser-database/src/attributes/constraint.rs:33-38 and the type validator
+		// (validations/types.rs:231-238) BOTH reject an unlabelled check.
+		if c.Label == nil {
+			return errors.New("a check constraint must have a label")
+		}
+	case ConstraintAssert:
+		// An assert's label is optional.
+	default:
+		return fmt.Errorf("unknown constraint level %d", uint8(c.Level))
+	}
+	// A PRESENT label is a BAML identifier, which cannot be empty. An empty one
+	// would become an empty ResponseCheck name at the serving layer — a silent
+	// collision magnet — so it is refused here instead.
+	if c.Label != nil && *c.Label == "" {
+		return errors.New("constraint label is present but empty")
+	}
+	if isBracketWrapped(c.Expression) {
+		return fmt.Errorf("expression %q is wrapped in {{ ... }}; a resolved constraint holds the BARE expression "+
+			"(the evaluator adds the brackets), so this leaf declines rather than stripping them", c.Expression)
+	}
+	return nil
+}
+
+// isBracketWrapped reports whether an expression was handed over still wrapped in
+// Jinja interpolation brackets.
+//
+// This is a DECLINE detector, not a parser: it recognizes the one mistake a
+// descriptor adapter actually makes — passing the source spelling
+// `{{ this > 0 }}` where BAML stores `this > 0`. A bare expression that happens
+// to both start with `{{` and end with `}}` (only reachable via string literals,
+// e.g. `"{{" ~ this ~ "}}"`) is refused too. That is deliberate: refusing is a
+// loud, recoverable decline, whereas silently evaluating `{{ {{ this > 0 }} }}`
+// or silently stripping the brackets would be a wrong answer. If such an
+// expression ever turns up in real resolved metadata, the fix is an explicit
+// differentially-proven carve-out, not a looser heuristic here.
+func isBracketWrapped(expr string) bool {
+	t := strings.TrimSpace(expr)
+	return len(t) >= 4 && strings.HasPrefix(t, "{{") && strings.HasSuffix(t, "}}")
+}
+
+// newConstraintEnvironment builds the environment BAML v0.223 evaluates a
+// PREDICATE in: get_env() and NOTHING else (jinja_helpers.rs:67-77, which calls
+// get_env() and then binds only `this`).
+//
+// It stops at newGetEnvBase on purpose. Adding `_`, `ctx`, or the per-enum
+// namespace globals here — the three things [New] adds for a prompt — would let
+// a predicate reference names stock BAML leaves undefined, which is an out-do:
+// `{{ Color.RED }}` inside a constraint must be an error on both legs, not a
+// value on ours. The profileoracle context-isolation rows prove that against
+// live CFFI.
+//
+// No fork change is implied by this split; it is entirely a baml-rest-owned
+// factory boundary (see newGetEnvBase).
+func newConstraintEnvironment() *minijinja.Environment {
+	return newGetEnvBase()
+}

--- a/internal/bamlprofile/constraints_test.go
+++ b/internal/bamlprofile/constraints_test.go
@@ -1,0 +1,809 @@
+package bamlprofile
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/invakid404/minijinja-go/v2/value"
+)
+
+// These are CFFI-free REGRESSION GUARDS for the constraint lowerer, not parity
+// claims. The authority for what stock BAML v0.223 does is the live-CFFI
+// constraint differential in ./profileoracle (build tag `integration`); these
+// pin the mechanics that differential cannot see from the outside — the typed
+// error stages, the projection's exact fork representation, input-order
+// preservation, and the ownership of caller-supplied pointers.
+
+func lbl(s string) *string { return &s }
+
+// evalOK runs a batch that is expected to succeed.
+func evalOK(t *testing.T, this value.Value, cs ...Constraint) ConstraintReport {
+	t.Helper()
+	rep, err := EvaluateConstraints(ConstraintRequest{Constraints: cs, This: this})
+	if err != nil {
+		t.Fatalf("EvaluateConstraints: unexpected error: %v", err)
+	}
+	return rep
+}
+
+// evalErr runs a batch that is expected to fail, and returns the typed error.
+func evalErr(t *testing.T, this value.Value, cs ...Constraint) *ConstraintError {
+	t.Helper()
+	rep, err := EvaluateConstraints(ConstraintRequest{Constraints: cs, This: this})
+	if err == nil {
+		t.Fatalf("EvaluateConstraints: expected an error, got report %+v", rep)
+	}
+	// A failed batch must yield NO partial report — BAML's collect::<Result<Vec>>
+	// discards everything when any predicate fails.
+	if rep.Results != nil || rep.AssertFailed {
+		t.Errorf("failed batch returned a partial report: %+v", rep)
+	}
+	var ce *ConstraintError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error %v is not a *ConstraintError", err)
+	}
+	return ce
+}
+
+func assertConstraint(expr string) Constraint {
+	return Constraint{Level: ConstraintAssert, Expression: expr}
+}
+
+func checkConstraint(label, expr string) Constraint {
+	return Constraint{Level: ConstraintCheck, Expression: expr, Label: lbl(label)}
+}
+
+// --- the core predicate + rendered-text classifier -------------------------
+
+// TestConstraintBareExpressionIsWrappedVerbatim pins the synthetic-template seam:
+// the stored expression is BARE and the evaluator supplies `{{ ... }}`, exactly
+// as render_expression's format!(r#"{{{{ {} }}}}"#, expression.0) does.
+func TestConstraintBareExpressionIsWrappedVerbatim(t *testing.T) {
+	rep := evalOK(t, value.FromInt(5), assertConstraint("this > 0"))
+	if len(rep.Results) != 1 || !rep.Results[0].Passed {
+		t.Fatalf("bare `this > 0` on 5 did not pass: %+v", rep)
+	}
+	// The wrapping is textual, so an expression carrying its own interior braces
+	// (a map literal) still composes.
+	rep = evalOK(t, value.FromString("k"), assertConstraint(`{"k": 1}[this] == 1`))
+	if !rep.Results[0].Passed {
+		t.Fatalf("map-literal predicate did not pass: %+v", rep)
+	}
+}
+
+// TestConstraintExactBooleanText pins BAML's rendered-TEXT classifier: exactly
+// "true" and exactly "false", and every other successful rendering is an
+// evaluator error rather than a false predicate.
+func TestConstraintExactBooleanText(t *testing.T) {
+	passing := []string{
+		"true",            // the literal
+		"1 == 1",          // a comparison
+		"this",            // a boolean `this` renders "true"
+		"'tru' ~ 'e'",     // built by concatenation — text, not a downcast
+		"[1]|length == 1", // through a filter
+		"true if this else false",
+	}
+	for _, expr := range passing {
+		t.Run("pass/"+expr, func(t *testing.T) {
+			rep := evalOK(t, value.True(), assertConstraint(expr))
+			if !rep.Results[0].Passed {
+				t.Errorf("%q classified as false, want true", expr)
+			}
+		})
+	}
+
+	rep := evalOK(t, value.False(), assertConstraint("this"))
+	if rep.Results[0].Passed {
+		t.Error("`this` on the boolean false classified as true")
+	}
+
+	// Anything else is an ERROR. " true" is the load-bearing case: a trimming
+	// classifier would accept it, and a boolean-downcast classifier would too.
+	nonBoolean := []struct{ name, expr string }{
+		{"leading_space", `" true"`},
+		{"trailing_space", `"true "`},
+		{"capitalized", `"True"`},
+		{"one", `1`},
+		{"empty", `""`},
+		{"none", `none`},
+		{"list_of_true", `[true]`},
+		{"true_true", `"true" ~ "true"`},
+	}
+	for _, tc := range nonBoolean {
+		t.Run("error/"+tc.name, func(t *testing.T) {
+			ce := evalErr(t, value.True(), assertConstraint(tc.expr))
+			if ce.Stage != ConstraintStageClassify {
+				t.Errorf("stage = %q, want %q (err: %v)", ce.Stage, ConstraintStageClassify, ce.Err)
+			}
+		})
+	}
+}
+
+// TestConstraintNonBooleanIsNeverFalse is the same rule stated as the property
+// that actually matters: a predicate the evaluator cannot classify must not
+// become a failed assert. Turning it into `false` would reject a value BAML
+// would have errored on — a different, quieter wrong answer.
+func TestConstraintNonBooleanIsNeverFalse(t *testing.T) {
+	rep, err := EvaluateConstraints(ConstraintRequest{
+		Constraints: []Constraint{assertConstraint(`"maybe"`)},
+		This:        value.FromInt(1),
+	})
+	if err == nil {
+		t.Fatalf("non-boolean predicate produced a report instead of an error: %+v", rep)
+	}
+	if rep.AssertFailed {
+		t.Error("non-boolean predicate was reported as a failed assert")
+	}
+}
+
+// --- error stages ----------------------------------------------------------
+
+func TestConstraintErrorStages(t *testing.T) {
+	cases := []struct {
+		name  string
+		this  value.Value
+		c     Constraint
+		stage ConstraintStage
+	}{
+		{"validate_unknown_level", value.FromInt(1),
+			Constraint{Level: ConstraintLevel(0), Expression: "true"}, ConstraintStageValidate},
+		{"validate_unknown_level_high", value.FromInt(1),
+			Constraint{Level: ConstraintLevel(9), Expression: "true"}, ConstraintStageValidate},
+		{"validate_check_without_label", value.FromInt(1),
+			Constraint{Level: ConstraintCheck, Expression: "true"}, ConstraintStageValidate},
+		{"validate_empty_label", value.FromInt(1),
+			Constraint{Level: ConstraintAssert, Expression: "true", Label: lbl("")}, ConstraintStageValidate},
+		{"validate_bracket_wrapped", value.FromInt(1),
+			assertConstraint("{{ this > 0 }}"), ConstraintStageValidate},
+		{"validate_bracket_wrapped_padded", value.FromInt(1),
+			assertConstraint("  {{ this > 0 }}  "), ConstraintStageValidate},
+		{"project_undefined", value.Undefined(),
+			assertConstraint("true"), ConstraintStageProject},
+		{"compile_syntax", value.FromInt(1),
+			assertConstraint("this >"), ConstraintStageCompile},
+		{"compile_unbalanced_brace", value.FromInt(1),
+			assertConstraint("}} bad {{"), ConstraintStageCompile},
+		{"render_unknown_filter", value.FromInt(1),
+			assertConstraint("this|no_such_filter"), ConstraintStageRender},
+		{"classify_non_boolean", value.FromInt(1),
+			assertConstraint("this"), ConstraintStageClassify},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ce := evalErr(t, tc.this, tc.c)
+			if ce.Stage != tc.stage {
+				t.Errorf("stage = %q, want %q (err: %v)", ce.Stage, tc.stage, ce.Err)
+			}
+		})
+	}
+}
+
+// TestConstraintErrorIndexIdentifiesTheFailingConstraint pins that the typed
+// error names WHICH predicate failed, and that a whole-request failure (the one
+// projection, shared by the batch) reports -1 rather than pointing at an
+// arbitrary constraint.
+func TestConstraintErrorIndexIdentifiesTheFailingConstraint(t *testing.T) {
+	ce := evalErr(t, value.FromInt(1),
+		assertConstraint("this > 0"),
+		assertConstraint("this > 1"),
+		assertConstraint("this|no_such_filter"),
+	)
+	if ce.Index != 2 {
+		t.Errorf("Index = %d, want 2", ce.Index)
+	}
+	if ce.Constraint.Expression != "this|no_such_filter" {
+		t.Errorf("Constraint.Expression = %q, want the failing one", ce.Constraint.Expression)
+	}
+
+	ce = evalErr(t, value.Undefined(), assertConstraint("true"))
+	if ce.Index != -1 {
+		t.Errorf("projection failure Index = %d, want -1", ce.Index)
+	}
+	if ce.Constraint != (Constraint{}) {
+		t.Errorf("projection failure carries a constraint %+v, want the zero Constraint", ce.Constraint)
+	}
+}
+
+// TestConstraintBatchAbortsWithoutPartialReport pins run_user_checks'
+// collect::<Result<Vec<_>>>(): an error anywhere discards the results that
+// already succeeded, rather than returning them alongside the failure.
+func TestConstraintBatchAbortsWithoutPartialReport(t *testing.T) {
+	rep, err := EvaluateConstraints(ConstraintRequest{
+		Constraints: []Constraint{
+			checkConstraint("ok", "this > 0"),       // would pass
+			assertConstraint("this > 100"),          // would fail (a normal result)
+			assertConstraint("this|no_such_filter"), // errors
+			checkConstraint("never", "true"),        // never reached
+		},
+		This: value.FromInt(5),
+	})
+	if err == nil {
+		t.Fatalf("expected an error, got %+v", rep)
+	}
+	if len(rep.Results) != 0 {
+		t.Errorf("aborted batch returned %d results, want none: %+v", len(rep.Results), rep.Results)
+	}
+	if rep.AssertFailed {
+		t.Error("aborted batch reported AssertFailed; a failed batch makes no assert claim at all")
+	}
+}
+
+// TestConstraintPreflightRunsBeforeAnyEvaluation pins that a structurally
+// impossible constraint LATER in the batch is caught before an earlier one is
+// evaluated — so a malformed request can never half-run.
+func TestConstraintPreflightRunsBeforeAnyEvaluation(t *testing.T) {
+	ce := evalErr(t, value.FromInt(1),
+		assertConstraint("this|no_such_filter"),                // would fail at render
+		Constraint{Level: ConstraintCheck, Expression: "true"}, // unlabelled check
+	)
+	if ce.Stage != ConstraintStageValidate || ce.Index != 1 {
+		t.Errorf("got stage %q index %d, want the validate failure at index 1", ce.Stage, ce.Index)
+	}
+}
+
+// --- levels, labels, order, ownership --------------------------------------
+
+// TestConstraintFalseAssertVersusFalseCheck is the assert/check split: a false
+// assert sets AssertFailed (terminal at the serving layer), a false check is
+// retained as an ordinary result and makes no rejection claim.
+func TestConstraintFalseAssertVersusFalseCheck(t *testing.T) {
+	rep := evalOK(t, value.FromInt(5), checkConstraint("big", "this > 100"))
+	if rep.AssertFailed {
+		t.Error("a false CHECK set AssertFailed")
+	}
+	if len(rep.Results) != 1 || rep.Results[0].Passed {
+		t.Fatalf("false check not retained as a result: %+v", rep.Results)
+	}
+
+	rep = evalOK(t, value.FromInt(5), assertConstraint("this > 100"))
+	if !rep.AssertFailed {
+		t.Error("a false ASSERT did not set AssertFailed")
+	}
+	if len(rep.Results) != 1 || rep.Results[0].Passed {
+		t.Fatalf("false assert not retained as a result: %+v", rep.Results)
+	}
+
+	// A PASSING assert alongside a failing check must not set AssertFailed.
+	rep = evalOK(t, value.FromInt(5),
+		assertConstraint("this > 0"),
+		checkConstraint("big", "this > 100"),
+	)
+	if rep.AssertFailed {
+		t.Error("AssertFailed set although every assert passed")
+	}
+}
+
+// TestConstraintResultsAreInInputOrder pins the ordering contract PR-3 owns:
+// results come back in declared input order, with each constraint's level, label
+// and expression intact, so Slice 7.2 has a stable source order to build a
+// Checked<T> from.
+func TestConstraintResultsAreInInputOrder(t *testing.T) {
+	cs := []Constraint{
+		checkConstraint("c1", "this > 0"),
+		assertConstraint("this > 1"),
+		checkConstraint("c2", "this > 100"),
+		{Level: ConstraintAssert, Expression: "this > 200", Label: lbl("a2")},
+	}
+	rep := evalOK(t, value.FromInt(5), cs...)
+	if len(rep.Results) != len(cs) {
+		t.Fatalf("got %d results, want %d", len(rep.Results), len(cs))
+	}
+	wantPassed := []bool{true, true, false, false}
+	for i, r := range rep.Results {
+		if r.Constraint.Expression != cs[i].Expression || r.Constraint.Level != cs[i].Level {
+			t.Errorf("result %d = %+v, want the constraint at input index %d", i, r.Constraint, i)
+		}
+		if r.Passed != wantPassed[i] {
+			t.Errorf("result %d Passed = %v, want %v", i, r.Passed, wantPassed[i])
+		}
+	}
+	if !rep.AssertFailed {
+		t.Error("AssertFailed not set although `this > 200` failed on 5")
+	}
+
+	// A caller filtering to checks sees label/expression/pass state intact.
+	var checks []ConstraintResult
+	for _, r := range rep.Results {
+		if r.Constraint.Level == ConstraintCheck {
+			checks = append(checks, r)
+		}
+	}
+	if len(checks) != 2 || *checks[0].Constraint.Label != "c1" || *checks[1].Constraint.Label != "c2" {
+		t.Errorf("check filter = %+v, want c1 then c2", checks)
+	}
+}
+
+// TestConstraintReportOwnsItsLabels pins that the report does not alias the
+// caller's *string labels. Without the copy, writing through a label pointer
+// after the call would retroactively rename a check in a report already handed
+// out — the same ownership rule enum members apply to a resolved alias.
+func TestConstraintReportOwnsItsLabels(t *testing.T) {
+	label := "original"
+	cs := []Constraint{{Level: ConstraintCheck, Expression: "true", Label: &label}}
+	rep := evalOK(t, value.FromInt(1), cs...)
+
+	label = "mutated"
+	cs[0].Expression = "false"
+
+	if got := *rep.Results[0].Constraint.Label; got != "original" {
+		t.Errorf("label = %q after the caller mutated its pointee, want %q", got, "original")
+	}
+	if got := rep.Results[0].Constraint.Expression; got != "true" {
+		t.Errorf("expression = %q after the caller mutated its slice, want %q", got, "true")
+	}
+}
+
+// TestConstraintEmptyBatch pins that no constraints is a successful, empty
+// report — matching run_user_checks over an empty constraint list — while the
+// projection preflight still runs (an unsupported `this` is refused rather than
+// silently accepted because nothing would have looked at it).
+func TestConstraintEmptyBatch(t *testing.T) {
+	rep := evalOK(t, value.FromInt(1))
+	if len(rep.Results) != 0 || rep.AssertFailed {
+		t.Errorf("empty batch = %+v, want an empty report", rep)
+	}
+	if ce := evalErr(t, value.Undefined()); ce.Stage != ConstraintStageProject {
+		t.Errorf("empty batch with an unsupported This: stage %q, want %q", ce.Stage, ConstraintStageProject)
+	}
+}
+
+// TestConstraintBatchIsIndependentOfBatching guards the one optimization
+// EvaluateConstraints takes over the reference: BAML calls get_env() per
+// predicate, while this builds one environment per BATCH.
+//
+// The claim is that the environment carries no per-render state, so batching
+// cannot be observable. That is asserted directly — every constraint must give
+// the same answer alone as it does alongside the others, in either order, and a
+// repeated batch must be identical — rather than argued from the fork's
+// internals, which could change under us.
+func TestConstraintBatchIsIndependentOfBatching(t *testing.T) {
+	cs := []Constraint{
+		checkConstraint("ns", "namespace(x=1).x == 1"),
+		checkConstraint("leak", "x is undefined"),
+		checkConstraint("macro_free", "[1, 2]|map('string')|join(',') == '1,2'"),
+		checkConstraint("plain", "this > 0"),
+	}
+	this := value.FromInt(5)
+
+	batched := evalOK(t, this, cs...)
+	for i, c := range cs {
+		single := evalOK(t, this, c)
+		if single.Results[0].Passed != batched.Results[i].Passed {
+			t.Errorf("constraint %d (%s) = %v alone but %v in a batch; the shared environment is leaking state",
+				i, c.Expression, single.Results[0].Passed, batched.Results[i].Passed)
+		}
+	}
+
+	// Reversing the batch must not change any individual verdict either.
+	reversed := make([]Constraint, len(cs))
+	for i, c := range cs {
+		reversed[len(cs)-1-i] = c
+	}
+	revRep := evalOK(t, this, reversed...)
+	for i := range cs {
+		if revRep.Results[len(cs)-1-i].Passed != batched.Results[i].Passed {
+			t.Errorf("constraint %d (%s) changed verdict when the batch was reversed", i, cs[i].Expression)
+		}
+	}
+
+	// And a repeat of the same batch is identical.
+	again := evalOK(t, this, cs...)
+	if len(again.Results) != len(batched.Results) || again.AssertFailed != batched.AssertFailed {
+		t.Fatalf("repeated batch differs: %+v vs %+v", again, batched)
+	}
+	for i := range again.Results {
+		if again.Results[i].Passed != batched.Results[i].Passed {
+			t.Errorf("constraint %d changed verdict on a repeated batch", i)
+		}
+	}
+}
+
+// --- the constraint environment --------------------------------------------
+
+// TestConstraintEnvironmentHasNoPromptGlobals is the context-isolation guard:
+// BAML's evaluator binds `this` and nothing else, so the three globals New adds
+// for a PROMPT must be undefined in a predicate. The same names are asserted
+// present through New, so the test fails if the refactor ever drains the prompt
+// factory instead of the constraint one.
+func TestConstraintEnvironmentHasNoPromptGlobals(t *testing.T) {
+	names := []string{"_", "ctx", "Color"}
+	cfg := Config{Enums: []EnumDef{{Name: "Color", Values: []EnumValue{{Canonical: "RED"}}}}}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			rep := evalOK(t, value.FromInt(1), assertConstraint(name+" is undefined"))
+			if !rep.Results[0].Passed {
+				t.Errorf("%s is DEFINED inside a constraint; the constraint environment must add no prompt globals", name)
+			}
+			if got := render(t, cfg, "{{ "+name+" is undefined }}"); got != "false" {
+				t.Errorf("%s is undefined in a PROMPT render (%q); the refactor removed a prompt global", name, got)
+			}
+		})
+	}
+
+	// The enum NAMESPACE being undefined also makes member access an error rather
+	// than a value: `Color.RED` cannot quietly become something in a predicate.
+	if ce := evalErr(t, value.FromInt(1), assertConstraint("Color.RED == 'RED'")); ce.Stage != ConstraintStageRender {
+		t.Errorf("Color.RED in a constraint: stage %q, want %q", ce.Stage, ConstraintStageRender)
+	}
+}
+
+// TestConstraintEnvironmentKeepsGetEnvConfiguration pins the other half of the
+// split: dropping the globals must not drop get_env's ENGINE configuration.
+// Each row is a get_env delta or a registry entry a predicate can reach.
+func TestConstraintEnvironmentKeepsGetEnvConfiguration(t *testing.T) {
+	cases := []struct{ name, expr string }{
+		{"builtin_length", "[1, 2, 3]|length == 3"},
+		{"baml_sum_override", "[1, 2.5]|sum == 3.5"},
+		{"baml_sum_empty", "[]|sum == 0"},
+		{"regex_match", `"abc123"|regex_match("[0-9]+")`},
+		{"regex_match_bad_pattern_is_false", `"x"|regex_match("(") == false`},
+		{"pycompat_unknown_method", `"abc".upper() == "ABC"`},
+		{"builtin_function_range", "range(3)|list|length == 3"},
+		{"whitespace_flags_are_inert_here", "true"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := evalOK(t, value.None(), assertConstraint(tc.expr))
+			if !rep.Results[0].Passed {
+				t.Errorf("%q did not hold in a constraint environment", tc.expr)
+			}
+		})
+	}
+
+	// get_env's none -> "null" FORMATTER is installed here too, even though a
+	// constraint can never end up depending on it: the formatter runs on the final
+	// output, and the classifier only accepts "true"/"false", so a predicate that
+	// renders a none is an error either way. What the formatter changes is WHICH
+	// text the error reports — "null" rather than the engine default "". Pinning
+	// that keeps the constraint environment on the same get_env base as the prompt
+	// one instead of quietly drifting to a bare NewEnvironment.
+	ce := evalErr(t, value.None(), assertConstraint("this"))
+	if ce.Stage != ConstraintStageClassify || !strings.Contains(ce.Err.Error(), `"null"`) {
+		t.Errorf("a none-rendering predicate reported %v; want a classify error over the get_env %q text", ce.Err, "null")
+	}
+}
+
+// --- the serde projection ---------------------------------------------------
+
+func mustEnum(t *testing.T, enumName, canonical string, alias *string) value.Value {
+	t.Helper()
+	v, err := EnumMember(enumName, canonical, alias)
+	if err != nil {
+		t.Fatalf("EnumMember: %v", err)
+	}
+	return v
+}
+
+func mustClass(t *testing.T, fields ...ClassField) value.Value {
+	t.Helper()
+	v, err := ClassValue(fields)
+	if err != nil {
+		t.Fatalf("ClassValue: %v", err)
+	}
+	return v
+}
+
+func mustList(t *testing.T, items ...value.Value) value.Value {
+	t.Helper()
+	v, err := ListValue(items)
+	if err != nil {
+		t.Fatalf("ListValue: %v", err)
+	}
+	return v
+}
+
+// TestProjectionEnumIsCanonicalString pins BamlValue::Enum's serde arm: the
+// canonical variant, never the prompt display alias. This is THE divergence
+// between the two host lowerings, so both directions are asserted.
+func TestProjectionEnumIsCanonicalString(t *testing.T) {
+	red := mustEnum(t, "Color", "RED", lbl("rouge"))
+	cases := []struct {
+		expr string
+		want bool
+	}{
+		{`this == "RED"`, true},
+		{`this == "rouge"`, false},
+		{`this is string`, true},
+		{`this|upper == "RED"`, true},
+		{`this|string == "RED"`, true},
+		// `.value` is the PROMPT object's only attribute; the projected string has
+		// no attributes at all.
+		{`this.value is undefined`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.expr, func(t *testing.T) {
+			rep := evalOK(t, red, assertConstraint(tc.expr))
+			if rep.Results[0].Passed != tc.want {
+				t.Errorf("%q = %v, want %v", tc.expr, rep.Results[0].Passed, tc.want)
+			}
+		})
+	}
+}
+
+// TestProjectionClassIsCanonicalKeyOrderedMap pins BamlValue::Class's serde arm:
+// a plain mapping keyed by CANONICAL names, in declared order, with no alias key
+// and no host debug rendering.
+func TestProjectionClassIsCanonicalKeyOrderedMap(t *testing.T) {
+	c := mustClass(t,
+		ClassField{Canonical: "zeta", Alias: lbl("zwire"), Value: value.FromInt(1)},
+		ClassField{Canonical: "alpha", Alias: lbl("awire"), Value: value.FromString("v")},
+	)
+	cases := []struct {
+		expr string
+		want bool
+	}{
+		{`this.zeta == 1`, true},
+		{`this.alpha == "v"`, true},
+		{`this.zwire is undefined`, true},
+		{`this.awire is undefined`, true},
+		{`this is mapping`, true},
+		{`this|length == 2`, true},
+		// DECLARED order, not sorted: a Go map would have yielded alpha first.
+		{`this|list|join(",") == "zeta,alpha"`, true},
+		{`this|list|join(",") == "alpha,zeta"`, false},
+		// The prompt class's pretty `{map:#?}` render must not leak in.
+		{`this|string == "{\"zeta\": 1, \"alpha\": \"v\"}"`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.expr, func(t *testing.T) {
+			rep := evalOK(t, c, assertConstraint(tc.expr))
+			if rep.Results[0].Passed != tc.want {
+				t.Errorf("%q = %v, want %v", tc.expr, rep.Results[0].Passed, tc.want)
+			}
+		})
+	}
+}
+
+// TestProjectionListIsPlainSequence pins BamlValue::List's serde arm.
+func TestProjectionListIsPlainSequence(t *testing.T) {
+	l := mustList(t, value.FromString("a"), value.FromString("b"))
+	cases := []struct {
+		expr string
+		want bool
+	}{
+		{`this|length == 2`, true},
+		{`this[0] == "a"`, true},
+		{`"b" in this`, true},
+		{`this is sequence`, true},
+		{`this|join(",") == "a,b"`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.expr, func(t *testing.T) {
+			rep := evalOK(t, l, assertConstraint(tc.expr))
+			if rep.Results[0].Passed != tc.want {
+				t.Errorf("%q = %v, want %v", tc.expr, rep.Results[0].Passed, tc.want)
+			}
+		})
+	}
+}
+
+// TestProjectionRecurses pins that the projection walks nested host values —
+// an aliased enum buried in a list inside a class must still be its canonical
+// string, and a nested none must still be none.
+func TestProjectionRecurses(t *testing.T) {
+	nested := mustClass(t,
+		ClassField{Canonical: "inner", Alias: lbl("nest"), Value: mustList(t,
+			mustEnum(t, "Color", "RED", lbl("rouge")),
+			mustClass(t, ClassField{Canonical: "deep", Value: value.None()}),
+		)},
+	)
+	cases := []struct {
+		expr string
+		want bool
+	}{
+		{`this.inner[0] == "RED"`, true},
+		{`this.inner[0] == "rouge"`, false},
+		{`this.inner[1].deep is none`, true},
+		{`this.inner[1].deep is undefined`, false},
+		{`this.nest is undefined`, true},
+		{`this.inner|length == 2`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.expr, func(t *testing.T) {
+			rep := evalOK(t, nested, assertConstraint(tc.expr))
+			if rep.Results[0].Passed != tc.want {
+				t.Errorf("%q = %v, want %v", tc.expr, rep.Results[0].Passed, tc.want)
+			}
+		})
+	}
+}
+
+// TestProjectionScalarsAndNone pins the scalar/none arms are passed through
+// unchanged.
+func TestProjectionScalarsAndNone(t *testing.T) {
+	cases := []struct {
+		name string
+		this value.Value
+		expr string
+	}{
+		{"string", value.FromString("hi"), `this == "hi"`},
+		{"int", value.FromInt(7), `this == 7`},
+		{"float", value.FromFloat(1.5), `this == 1.5`},
+		{"bool", value.True(), `this == true`},
+		{"none", value.None(), `this is none`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := evalOK(t, tc.this, assertConstraint(tc.expr))
+			if !rep.Results[0].Passed {
+				t.Errorf("%s: %q did not hold", tc.name, tc.expr)
+			}
+		})
+	}
+}
+
+// TestProjectionAlternateDebugIsNotThePromptRenderer pins the |pprint / debug()
+// path, which is a DIFFERENT fork code path from |string (v2.16.0-baml.6 PATCHES
+// #106-#108 scope the object-render dispatch to the map arm, and the list arm
+// respects the ambient alternate flag). A green |string assertion therefore does
+// not cover it.
+//
+// It is the path where PR-2's hand-written Rust-debug renderer would leak into a
+// predicate if the prompt host object were ever bound to `this` — alias keys for
+// a class, bare enum aliases for a list. Both the projected bytes and the prompt
+// bytes are spelled out, so the test records exactly what the wrong answer looks
+// like rather than only asserting the right one.
+//
+// The live-CFFI half is class_pprint_is_serde_map / list_pprint_is_serde_seq in
+// ./profileoracle; this is the CGO-free regression guard for the same bytes.
+func TestProjectionAlternateDebugIsNotThePromptRenderer(t *testing.T) {
+	promptClass := mustClass(t,
+		ClassField{Canonical: "zeta", Alias: lbl("z"), Value: value.FromInt(1)},
+		ClassField{Canonical: "alpha", Alias: lbl("a"), Value: value.FromString("v")},
+	)
+	promptList := mustList(t,
+		mustEnum(t, "Color", "RED", lbl("rouge")),
+		mustEnum(t, "Color", "GREEN", nil),
+	)
+
+	cases := []struct {
+		name string
+		this value.Value
+		// wantProjected is what a predicate must see: the serde projection's
+		// alternate-debug bytes (canonical keys, quoted canonical enum strings).
+		wantProjected string
+		// wantPrompt is PR-2's prompt-lowering rendering of the SAME value — the
+		// bytes that must never reach a predicate.
+		wantPrompt string
+	}{
+		{
+			name:          "class",
+			this:          promptClass,
+			wantProjected: "{\n    \"zeta\": 1,\n    \"alpha\": \"v\",\n}",
+			wantPrompt:    "{\n    \"z\": 1,\n    \"a\": \"v\",\n}",
+		},
+		{
+			name:          "list",
+			this:          promptList,
+			wantProjected: "[\n    \"RED\",\n    \"GREEN\",\n]",
+			wantPrompt:    "[\n    rouge,\n    GREEN,\n]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantProjected == tc.wantPrompt {
+				t.Fatal("the two spellings are identical, so this row cannot discriminate")
+			}
+			// The prompt object really does render the leaking spelling — without
+			// this the test could pass because the renderer changed rather than
+			// because the projection is right.
+			if got := renderPromptPprint(t, tc.this); got != tc.wantPrompt {
+				t.Fatalf("PR-2 prompt |pprint = %q, want %q; the counter-value this row records is stale", got, tc.wantPrompt)
+			}
+			// Both alternate-debug entry points on the PROJECTED value.
+			for _, expr := range []string{"this|pprint", "debug(this)"} {
+				got := renderConstraintText(t, tc.this, expr)
+				if got != tc.wantProjected {
+					t.Errorf("%s = %q, want %q", expr, got, tc.wantProjected)
+				}
+				if got == tc.wantPrompt {
+					t.Errorf("%s leaked the PR-2 prompt rendering into a predicate", expr)
+				}
+			}
+		})
+	}
+}
+
+// renderConstraintText renders a bare expression through the constraint seam —
+// the projection, the constraint environment and the `{{ ... }}` wrapping — and
+// returns the raw text, bypassing the "true"/"false" classifier so a rendering
+// can be inspected directly.
+func renderConstraintText(t *testing.T, this value.Value, expr string) string {
+	t.Helper()
+	projected, err := projectConstraintThis(this)
+	if err != nil {
+		t.Fatalf("projectConstraintThis: %v", err)
+	}
+	tmpl, err := newConstraintEnvironment().TemplateFromNamedString(constraintTemplateName, "{{ "+expr+" }}")
+	if err != nil {
+		t.Fatalf("compile %q: %v", expr, err)
+	}
+	out, err := tmpl.Render(value.FromMap(map[string]value.Value{"this": projected}))
+	if err != nil {
+		t.Fatalf("render %q: %v", expr, err)
+	}
+	return out
+}
+
+// renderPromptPprint renders |pprint of a value bound WITHOUT the projection, as
+// the prompt factory would — the leak this package must prevent.
+func renderPromptPprint(t *testing.T, this value.Value) string {
+	t.Helper()
+	env, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tmpl, err := env.TemplateFromNamedString("prompt", "{{ this|pprint }}")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	out, err := tmpl.Render(map[string]any{"this": this})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	return out
+}
+
+// TestProjectionFailsClosed pins the decline-by-default rule. Every one of these
+// is a value BAML's `this` can never be, and each must be REFUSED rather than
+// bound — binding a prompt host object, or a native container the caller built
+// itself, is exactly the out-do the parity-decline rule forbids.
+func TestProjectionFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		this value.Value
+	}{
+		{"undefined", value.Undefined()},
+		{"native_slice", value.FromSlice([]value.Value{value.FromInt(1)})},
+		{"native_map", value.FromMap(map[string]value.Value{"a": value.FromInt(1)})},
+		{"ordered_map", value.FromOrderedMap(value.NewOrderedMap(0))},
+		{"bytes", value.FromBytes([]byte("x"))},
+		{"foreign_object", value.FromObject(foreignHostObject{})},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ce := evalErr(t, tc.this, assertConstraint("true"))
+			if ce.Stage != ConstraintStageProject {
+				t.Errorf("stage = %q, want %q (err: %v)", ce.Stage, ConstraintStageProject, ce.Err)
+			}
+		})
+	}
+}
+
+// TestProjectionFailsClosedInsideAContainer pins that the decline survives
+// nesting: an unsupported value buried in a host class or list is refused too,
+// naming the path so a caller can find it.
+func TestProjectionFailsClosedInsideAContainer(t *testing.T) {
+	// ClassValue/ListValue reject a foreign object at construction, so the nested
+	// case is reached through the projector directly — which is exactly the guard
+	// that keeps a future host type from silently flowing through.
+	bad := &classObject{
+		fields: []classField{{canonical: "f", aliasKey: "f", value: value.FromObject(foreignHostObject{})}},
+		byName: map[string]value.Value{"f": value.FromObject(foreignHostObject{})},
+	}
+	_, err := projectConstraintThis(value.FromObject(bad))
+	if err == nil {
+		t.Fatal("a foreign object nested in a class projected successfully")
+	}
+	if !strings.Contains(err.Error(), `field "f"`) {
+		t.Errorf("error %q does not name the offending field", err)
+	}
+
+	badList := &listObject{items: []value.Value{value.FromObject(foreignHostObject{})}}
+	_, err = projectConstraintThis(value.FromObject(badList))
+	if err == nil {
+		t.Fatal("a foreign object nested in a list projected successfully")
+	}
+	if !strings.Contains(err.Error(), "item 0") {
+		t.Errorf("error %q does not name the offending item", err)
+	}
+}
+
+// foreignHostObject stands in for a fork object this package did not build — a
+// media value, or any host type whose constraint ingress is not yet proven.
+type foreignHostObject struct{}
+
+func (foreignHostObject) GetAttr(string) value.Value { return value.Undefined() }

--- a/internal/bamlprofile/doc.go
+++ b/internal/bamlprofile/doc.go
@@ -64,6 +64,44 @@
 // each type). Byte-exactness is proven by the stock-CFFI differential in
 // ./profileoracle.
 //
+// PR-3 — the constraint lowerer & typed façade (constraints.go, project.go):
+//   - EvaluateConstraints over resolved Constraint/ConstraintRequest values,
+//     reproducing run_user_checks + evaluate_predicate: a bare get_env()
+//     environment, the stored expression wrapped verbatim as `{{ <expr> }}`,
+//     exactly one bound name (`this`), and the rendered-TEXT "true"/"false"
+//     classifier — a non-boolean rendering is an ERROR, never a failed predicate;
+//   - the batch aborting on the first evaluator error with NO partial report,
+//     mirroring `collect::<Result<Vec<_>>>()`, and a false ASSERT surfacing as
+//     ConstraintReport.AssertFailed while a false CHECK is retained as a result;
+//   - the CONSTRAINT-side serde projection of `this` (project.go), which is a
+//     different lowering from PR-2's prompt host model: an enum is its CANONICAL
+//     string (no alias), a class is an ordered map of CANONICAL keys (no alias
+//     key, no `{map:#?}` render), a list is a plain sequence, and every
+//     unsupported shape fails closed;
+//   - the environment split: newGetEnvBase carries get_env's engine
+//     configuration, New adds the prompt globals, newConstraintEnvironment does
+//     not — so `_`, `ctx` and the enum namespaces are undefined in a predicate,
+//     as they are in stock BAML. No fork change was needed for any of it.
+//
+// Authority: jinja_helpers.rs:67-93, jsonish coercer mod.rs:322-338 and
+// field_type.rs:180-294, baml_value.rs:41-57 (cited at each declaration). Parity
+// is proven by the stock-CFFI CallFunctionParse differential in ./profileoracle,
+// which runs BAML's real coercer rather than merely rendering a prompt.
+//
+// Two stock behaviors PR-3 MEASURED and did not reproduce, both owned by the
+// serving slice and ledgered on #583:
+//
+//   - stock BAML evaluates NO constraints on a bare `string` return type —
+//     jsonish::from_str short-circuits before coercion (jsonish/src/lib.rs:
+//     233-237). EvaluateConstraints has no return type and evaluates whatever it
+//     is given, so Slice 7.2 must reproduce the skip; evaluating there would
+//     REJECT responses stock accepts. Pinned by
+//     TestStockSkipsConstraintsOnBareStringReturn.
+//   - duplicate check LABELS collapse in the response representation (last
+//     wins), while PR-3 returns both results in declared order. The stable
+//     policy is 7.2's; the collapse is measured by
+//     TestConstraintDuplicateLabelCollapse.
+//
 // # What is DEFERRED / DECLINED (explicitly NOT built here)
 //
 //   - Media host values (Image/Audio/Pdf/Video, URL/Base64/File): BAML's serde
@@ -74,7 +112,19 @@
 //     override: the get_env-level `format` is the fork's printf filter, so a
 //     class|format(type=...) ERRORS rather than silently emitting a
 //     serialization (proven in host_test.go). Tracked on #602.
-//   - The prompt lowerer and the constraint lowerer / predicate façade, and the
-//     descriptor/parser layer that would supply resolved enum/class aliases and
-//     ordered fields in production (PR-2 consumes them as explicit typed inputs).
+//   - The prompt lowerer, and the descriptor/parser layer that would supply
+//     resolved enum/class aliases, ordered fields and BARE constraint
+//     expressions in production (PR-2 and PR-3 consume them as explicit typed
+//     inputs). In particular this leaf does NOT parse BAML source, strip
+//     `{{ ... }}` from a constraint expression, typecheck a Jinja expression, or
+//     import BAML IR/descriptors — a bracket-wrapped expression is REJECTED, not
+//     normalized.
+//   - Constraint ingress for media values and BamlValue::Map: PR-2 provides no
+//     host constructor for either, so projectConstraintThis declines them rather
+//     than guessing a projection. Tracked on #602/#572.
+//   - The serving side of constraints: translating descriptors into resolved
+//     Constraints, running them during native response parsing, the public
+//     `Checked<T>`/JSON envelope and its stable ordering, assert-rejection
+//     message wording and first-five presentation, duplicate-label policy,
+//     streaming/partial semantics, and fallback routing. All Slice 7.2.
 package bamlprofile

--- a/internal/bamlprofile/env.go
+++ b/internal/bamlprofile/env.go
@@ -37,8 +37,12 @@ type Config struct {
 	Enums []EnumDef
 }
 
-// New constructs a fork *minijinja.Environment configured exactly like BAML
-// v0.223's get_env(), for the parts that do not need the host value model yet.
+// New constructs the fork *minijinja.Environment BAML v0.223 renders a PROMPT
+// with: get_env()'s engine configuration (newGetEnvBase) plus the globals BAML's
+// prompt renderer supplies — `_`, `ctx`, and one namespace per declared enum.
+//
+// The engine-configuration half is shared with newConstraintEnvironment; the
+// globals below are exactly what a constraint must NOT see.
 //
 // Authority (byte-for-byte): BAML v0.223
 // engine/baml-lib/baml-core/src/ir/jinja_helpers.rs:7-36
@@ -56,8 +60,8 @@ type Config struct {
 //	env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
 //
 // minijinja::Environment::new() (fork NewEnvironment) already installs the
-// BAML-exact builtin filter/test/function registry, so New only layers get_env's
-// deltas on top of it.
+// BAML-exact builtin filter/test/function registry, so newGetEnvBase only layers
+// get_env's deltas on top of it.
 //
 // get_env() does NOT set an auto-escape mode: BAML renders prompts through
 // render_str, whose template name has no html/xml extension, so the engine
@@ -77,54 +81,17 @@ type Config struct {
 // is a resolved-metadata contract violation, so it fails loud here rather than
 // installing a global that renders or compares wrong.
 func New(cfg Config) (*minijinja.Environment, error) {
-	env := minijinja.NewEnvironment()
-
-	// BAML's custom formatter: a top-level none renders as the literal "null"
-	// (not minijinja's default empty string); everything else renders through the
-	// engine's escaping path. Under AutoEscapeNone the escape func is the
-	// identity, so this is none -> "null", else the value's display string.
-	//
-	// Nested none inside a host class/list is handled by the host debug walker
-	// (debugValue in class.go); this top-level rule is the none -> "null" that
-	// BAML's jinja_helpers formatter applies before rendering.
-	//
-	// Object rendering is NOT this formatter's business. The fork's Value.String
-	// dispatches value.ObjectWithString itself (v2.16.0-baml.4, PATCHES #104),
-	// which is BAML's escape_formatter reaching an object's own render/Display —
-	// and, being at the fork's primitive, it composes through native containers,
-	// |join, filter coercions and `~` as well, which a formatter-only branch here
-	// never could. The top-level none -> "null" rule is the only get_env delta.
-	env.SetFormatter(func(_ *minijinja.State, val value.Value, escape func(string) string) string {
-		if val.IsNone() {
-			return escape("null")
-		}
-		return escape(val.String())
-	})
-
-	// env.set_debug(true).
-	env.SetDebug(true)
-
-	// env.set_trim_blocks(true); env.set_lstrip_blocks(true). Start from the
-	// engine defaults so no unrelated whitespace knob is disturbed, then set the
-	// two BAML sets, exactly as the fork's own oracle harness does.
-	ws := syntax.DefaultWhitespace()
-	ws.TrimBlocks = true
-	ws.LstripBlocks = true
-	env.SetWhitespace(ws)
-
-	// See the doc comment: BAML relies on the engine default (none) for its
-	// html-less prompt templates; we make it explicit.
-	env.SetAutoEscapeFunc(func(string) minijinja.AutoEscape { return minijinja.AutoEscapeNone })
-
-	// get_env additions/overrides.
-	env.AddFilter("regex_match", regexMatchFilter)
-	env.AddFilter("sum", sumFilter) // overrides the engine builtin sum
-	env.SetUnknownMethodCallback(pycompat.UnknownMethodCallback)
+	env := newGetEnvBase()
 
 	// The get_env simple globals, matching internal/nativeprompt/env.go. Declared
 	// ONCE so the reserved-name preflight below derives its set from this same
 	// list: a future third get_env global is then automatically protected against
 	// an enum-name collision, with no second place to keep in sync.
+	//
+	// These are PROMPT-ONLY. BAML injects them as render context when it renders a
+	// prompt; its CONSTRAINT evaluator creates a bare get_env() and binds `this`
+	// alone (jinja_helpers.rs:67-93), so newConstraintEnvironment deliberately
+	// stops at newGetEnvBase and never reaches this block.
 	simpleGlobals := []struct {
 		name  string
 		value value.Value
@@ -180,4 +147,73 @@ func New(cfg Config) (*minijinja.Environment, error) {
 	}
 
 	return env, nil
+}
+
+// newGetEnvBase builds the part of BAML v0.223's get_env() that is pure ENGINE
+// CONFIGURATION: the formatter, debug/whitespace flags, autoescape, the
+// regex_match/sum filter deltas, and the pycompat unknown-method callback
+// (jinja_helpers.rs:7-36). It installs NO globals.
+//
+// This is the shared base of the leaf's two environment factories, and the split
+// is load-bearing rather than cosmetic. get_env() itself adds no globals at all;
+// `_` and `ctx` are things BAML's PROMPT renderer supplies as render context, and
+// the per-enum namespaces are things its prompt renderer injects (lib.rs:316-327).
+// BAML's CONSTRAINT evaluator calls the same get_env() and then binds exactly one
+// name, `this` (jinja_helpers.rs:83-89) — so in a predicate, `_`, `ctx` and
+// `Color` are undefined. Reproducing that means the two factories must diverge
+// exactly here: [New] continues on to install the prompt globals,
+// [newConstraintEnvironment] stops.
+//
+// Every call returns a FRESH environment. [New] needs that because its ctx global
+// carries a per-render OutputFormat (as nativeprompt.buildEnv does); the
+// constraint factory does not, but sharing one would make the two factories'
+// lifetimes entangled for no gain.
+func newGetEnvBase() *minijinja.Environment {
+	env := minijinja.NewEnvironment()
+
+	// BAML's custom formatter: a top-level none renders as the literal "null"
+	// (not minijinja's default empty string); everything else renders through the
+	// engine's escaping path. Under AutoEscapeNone the escape func is the
+	// identity, so this is none -> "null", else the value's display string.
+	//
+	// Nested none inside a host class/list is handled by the host debug walker
+	// (debugValue in class.go); this top-level rule is the none -> "null" that
+	// BAML's jinja_helpers formatter applies before rendering.
+	//
+	// Object rendering is NOT this formatter's business. The fork's Value.String
+	// dispatches value.ObjectWithString itself (v2.16.0-baml.4, PATCHES #104),
+	// which is BAML's escape_formatter reaching an object's own render/Display —
+	// and, being at the fork's primitive, it composes through native containers,
+	// |join, filter coercions and `~` as well, which a formatter-only branch here
+	// never could. The top-level none -> "null" rule is the only get_env delta.
+	env.SetFormatter(func(_ *minijinja.State, val value.Value, escape func(string) string) string {
+		if val.IsNone() {
+			return escape("null")
+		}
+		return escape(val.String())
+	})
+
+	// env.set_debug(true).
+	env.SetDebug(true)
+
+	// env.set_trim_blocks(true); env.set_lstrip_blocks(true). Start from the
+	// engine defaults so no unrelated whitespace knob is disturbed, then set the
+	// two BAML sets, exactly as the fork's own oracle harness does.
+	ws := syntax.DefaultWhitespace()
+	ws.TrimBlocks = true
+	ws.LstripBlocks = true
+	env.SetWhitespace(ws)
+
+	// See New's doc comment: BAML relies on the engine default (none) for its
+	// html-less prompt templates, and its constraint evaluator renders a template
+	// named "<string>" for the same reason; we make it explicit so neither
+	// factory's behavior depends on a template name.
+	env.SetAutoEscapeFunc(func(string) minijinja.AutoEscape { return minijinja.AutoEscapeNone })
+
+	// get_env additions/overrides.
+	env.AddFilter("regex_match", regexMatchFilter)
+	env.AddFilter("sum", sumFilter) // overrides the engine builtin sum
+	env.SetUnknownMethodCallback(pycompat.UnknownMethodCallback)
+
+	return env
 }

--- a/internal/bamlprofile/profileoracle/constraint_integration_test.go
+++ b/internal/bamlprofile/profileoracle/constraint_integration_test.go
@@ -1,0 +1,524 @@
+//go:build integration
+
+package profileoracle
+
+// Stock BAML v0.223.0 differential for internal/bamlprofile's CONSTRAINT lowerer.
+//
+// It links the UNTOUCHED github.com/boundaryml/baml@v0.223.0 runtime via CFFI and
+// runs every constraint row through BamlRuntime.CallFunctionParse — the CFFI
+// response-parse path (language_client_go/pkg/runtime.go:178-213). That path runs
+// BAML's real coercer, so the constraints on the function's return type go
+// through run_user_checks -> evaluate_predicate -> validate_asserts. Rendering a
+// prompt would exercise none of it.
+//
+// Run:
+//
+//	CGO_ENABLED=1 go test -tags integration ./internal/bamlprofile/profileoracle
+//
+// Regenerate the recorded version/source-map fixture after an intended corpus
+// change:
+//
+//	WRITE_CONSTRAINT_ORACLE_FIXTURE=1 CGO_ENABLED=1 go test -tags integration \
+//	  ./internal/bamlprofile/profileoracle -run TestConstraintOracleFixture
+
+import (
+	"context"
+	stdjson "encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	baml_go "github.com/boundaryml/baml/engine/language_client_go/baml_go"
+	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+)
+
+const constraintFixturePath = "testdata/constraint_oracle.json"
+
+// constraintParseTimeout bounds a single CallFunctionParse.
+//
+// A healthy parse answers in milliseconds. The deadline exists because a Rust
+// panic inside BAML's parse path unwinds the tokio worker that owns the request,
+// so the CFFI call never delivers a result and the Go side would block FOREVER —
+// the same failure mode fault_integration_test.go documents for BuildRequest. A
+// timeout is NEVER converted into a verdict here: it is a loud harness failure
+// pointing at the subprocess leg, because "it hung" is not evidence of any
+// particular outcome class.
+const constraintParseTimeout = 60 * time.Second
+
+// --- the stock decode type map ---------------------------------------------
+
+// checkedTypeBinding maps a corpus return type to the CFFI checked-type NAME the
+// stock client will look up, and the Go type it must find there.
+//
+// When a return type declares any @check, the CFFI wraps the value in a
+// CffiValueChecked whose name is `CHECKED_TYPES.<inner type's union name>`
+// (language_client_cffi/src/ctypes/baml_value_with_meta_encode.rs:69-101, with
+// the checks popped from the inner type). The stock Go client resolves that name
+// through a package-global type map and PANICS if it is missing
+// (baml_go/serde/decode.go:290-312) — inside a cgo callback, which would abort
+// the test binary. So the bindings are declared here and
+// TestConstraintCheckedTypesAreRegistered proves the corpus never needs one that
+// is absent.
+//
+// The union names come from ToUnionName (baml-types/src/ir_type/mod.rs:935-1002):
+// a primitive is its own spelling, a class/enum is its declared name, and a list
+// is `List__<element>`. The Go side of a class/enum decodes to the client's
+// DYNAMIC fallback (serde/decode.go:186-220) because this harness registers no
+// generated struct for the corpus types — which is fine: the differential
+// compares CHECKS, not the decoded value's Go shape.
+//
+// "string" is registered although NO corpus row uses it: it is needed by
+// TestStockSkipsConstraintsOnBareStringReturn, which parses a checked bare-string
+// return precisely to prove stock reports no checks for it.
+type checkedTypeBinding struct {
+	name string
+	typ  reflect.Type
+}
+
+func checkedTypeBindings() map[string]checkedTypeBinding {
+	return map[string]checkedTypeBinding{
+		"int":      {"int", reflect.TypeOf(baml.Checked[int64]{})},
+		"string":   {"string", reflect.TypeOf(baml.Checked[string]{})},
+		"Color":    {"Color", reflect.TypeOf(baml.Checked[baml.DynamicEnum]{})},
+		"C":        {"C", reflect.TypeOf(baml.Checked[baml.DynamicClass]{})},
+		"string[]": {"List__string", reflect.TypeOf(baml.Checked[[]string]{})},
+	}
+}
+
+var constraintTypeMapOnce sync.Once
+
+// ensureConstraintTypeMap installs the checked-type map on the stock client.
+//
+// baml.SetTypeMap is a package GLOBAL, so it is installed once per test binary.
+// It cannot disturb the prompt differential: BuildRequest returns an object
+// handle and never runs serde.Decode (pkg/callbacks.go:184-190,220-226).
+func ensureConstraintTypeMap() {
+	constraintTypeMapOnce.Do(func() {
+		m := map[string]reflect.Type{}
+		for _, b := range checkedTypeBindings() {
+			m["CHECKED_TYPES."+b.name] = b.typ
+		}
+		baml.SetTypeMap(m)
+	})
+}
+
+// TestConstraintCheckedTypesAreRegistered proves the corpus can never ask the
+// stock client for a checked type the harness did not register.
+//
+// The failure it prevents is not a red test: decode.go panics inside a cgo
+// callback, which ABORTS the test binary with a Rust-ish stack and no row name.
+// Catching it here, in a CFFI-free assertion that runs before any parse, turns
+// that into a one-line message naming the row and the missing binding.
+func TestConstraintCheckedTypesAreRegistered(t *testing.T) {
+	bindings := checkedTypeBindings()
+	used := map[string]bool{}
+	for _, r := range ConstraintCorpus() {
+		if !r.DeclaresCheck() {
+			continue
+		}
+		b, ok := bindings[r.ReturnType]
+		if !ok {
+			t.Errorf("row %q declares a @check on return type %q, but no CHECKED_TYPES binding is registered for it; "+
+				"add one to checkedTypeBindings or the stock client's decode will panic inside a cgo callback",
+				r.ID, r.ReturnType)
+			continue
+		}
+		used[r.ReturnType] = true
+		if b.typ.Kind() != reflect.Struct {
+			t.Errorf("binding for %q is not a struct type", r.ReturnType)
+			continue
+		}
+		if _, ok := b.typ.FieldByName("Value"); !ok {
+			t.Errorf("binding for %q has no Value field; decodeCheckedValue sets one", r.ReturnType)
+		}
+		if _, ok := b.typ.FieldByName("Checks"); !ok {
+			t.Errorf("binding for %q has no Checks field; decodeCheckedValue sets one", r.ReturnType)
+		}
+	}
+	if len(used) == 0 {
+		t.Fatal("no corpus row declares a @check; the Checked<T> half of the differential would prove nothing")
+	}
+	t.Logf("checked-type bindings exercised by the corpus: %d of %d registered", len(used), len(bindings))
+}
+
+// --- the stock leg ----------------------------------------------------------
+
+// stockConstraintOutcome parses one row through stock BAML and classifies the
+// result into the same normalized outcome the profile leg produces.
+func stockConstraintOutcome(t *testing.T, rt *baml.BamlRuntime, r ConstraintRow, env map[string]string) ConstraintOutcome {
+	t.Helper()
+
+	// CallFunctionParse's kwargs are not the function's parameters: the CFFI reads
+	// `text` (the raw response to parse) and `stream`
+	// (language_client_cffi/src/ffi/functions.rs:163-183). Every corpus function is
+	// parameterless, so these two are the whole argument set.
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"text": r.Raw, "stream": false},
+		Env:    env,
+	}
+	encoded, err := args.Encode()
+	if err != nil {
+		// Encoding is HARNESS work, never an engine outcome.
+		t.Fatalf("row %q: encode parse args: %v", r.ID, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), constraintParseTimeout)
+	defer cancel()
+	result, err := rt.CallFunctionParse(ctx, r.FuncName(), encoded)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			// A hang, not a verdict. Stock's parse path can block forever when the
+			// Rust engine panics (see fault_integration_test.go); calling that an
+			// outcome would let a row match on a crash.
+			t.Fatalf("row %q: stock CallFunctionParse did not return within %s.\n"+
+				"That is the signature of a Rust panic unwinding the tokio worker, not a classifiable outcome. "+
+				"Prove it through a subprocess leg (as fault_integration_test.go does for BuildRequest) "+
+				"before declaring any class for this row.", r.ID, constraintParseTimeout)
+		}
+		kind, ok := classifyStockConstraintError(err)
+		if !ok {
+			t.Fatalf("row %q: stock BAML failed with an error this harness cannot classify as a constraint outcome: %v\n"+
+				"Refusing to guess: an unrecognized parse failure (a coercion failure, a runtime setup problem) "+
+				"is not evidence that the CONSTRAINT behaved any particular way.", r.ID, err)
+		}
+		return ConstraintOutcome{Kind: kind, Detail: err.Error()}
+	}
+	// The row's own declaration selects the legal result shape, so an undecodable
+	// Checked[T] is reported AS one instead of surfacing later as a generic check
+	// mismatch against the profile leg.
+	checks, err := stockChecksOf(result, r.DeclaresCheck())
+	if err != nil {
+		t.Fatalf("row %q: stock BAML parsed but its result shape is not one this harness understands: %v (result %T: %+v)",
+			r.ID, err, result, result)
+	}
+	return ConstraintOutcome{Kind: ConstraintParsed, Checks: checks}
+}
+
+// stock error needles. They are matched, not compared: the differential's
+// contract is the outcome CLASS, and these are only how the class is READ off
+// stock's message.
+//
+// Both come straight from BAML v0.223's source and are the two distinct ways a
+// constrained parse can fail:
+//
+//   - validate_asserts builds "Assertions failed." and carries the BAML comment
+//     "IMPORTANT: DO NOT CHANGE THIS MESSAGE"
+//     (jsonish/src/deserializer/coercer/field_type.rs:272-287);
+//   - a predicate that could not be evaluated is wrapped as
+//     "Failed to evaluate constraints: {e:?}" BEFORE validate_asserts is reached
+//     (field_type.rs:191-199), which is why an evaluator error beats a failing
+//     assert in the same batch.
+//
+// Anything else is deliberately NOT classified — see the caller.
+const (
+	stockAssertNeedle    = "Assertions failed"
+	stockEvalErrorNeedle = "Failed to evaluate constraints"
+)
+
+func classifyStockConstraintError(err error) (ConstraintOutcomeKind, bool) {
+	msg := err.Error()
+	// The evaluator-error needle is checked FIRST. run_user_checks aborts before
+	// validate_asserts runs, so the two can never both be genuine — but stock
+	// nests the inner error's Debug rendering into the outer message, and an
+	// evaluator error raised on a value that ALSO has failing asserts must still
+	// read as an evaluator error.
+	if strings.Contains(msg, stockEvalErrorNeedle) {
+		return ConstraintEvalError, true
+	}
+	if strings.Contains(msg, stockAssertNeedle) {
+		return ConstraintAssertFailed, true
+	}
+	return "", false
+}
+
+// --- the differential -------------------------------------------------------
+
+// TestConstraintDifferential is the constraint proof: every corpus row parsed
+// through stock BAML v0.223 lands in the same outcome class as the pure-Go leaf,
+// with the same evaluated checks.
+//
+// Both halves of every row are asserted, in this order:
+//
+//  1. stock BAML really produces the row's DECLARED class (so a declaration
+//     cannot rot into a fiction, exactly as TestProfileFaultDifferential does);
+//  2. the profile produces the same class stock did — never a conservative parse
+//     where stock failed, and never a decline where stock succeeded;
+//  3. for a parsed row, the evaluated CHECK sets match exactly: label,
+//     BARE expression, and pass state.
+//
+// (3) is stronger than it looks. Stock's ResponseCheck.expression is the bare
+// `expression.0` BAML's parser stored, so comparing it to the profile's
+// Constraint.Expression proves the corpus's bare spelling really is what BAML
+// records — the round trip behind the "Expression is already bare" contract.
+func TestConstraintDifferential(t *testing.T) {
+	assertBAMLAuthority(t)
+	ensureConstraintTypeMap()
+
+	rows := ConstraintCorpus()
+	env := envVars()
+	rt, err := baml.CreateRuntime("./baml_src", GenerateConstraintBAMLSource(rows), env)
+	if err != nil {
+		t.Fatalf("CreateRuntime from the in-memory constraint corpus: %v\n"+
+			"Every predicate must survive BAML's jinja PARSER (a parse error is a hard CreateRuntime error, "+
+			"while a type error is only a warning), so a malformed expression takes the whole project down.", err)
+	}
+
+	for _, r := range rows {
+		t.Run(r.ID, func(t *testing.T) {
+			if r.Expect == ConstraintPanic {
+				t.Fatalf("row declares Expect=%s, but this harness has no subprocess stock leg. "+
+					"A panic hangs CallFunctionParse forever in-process; wire the child-process machinery from "+
+					"fault_integration_test.go before declaring the panic class here.", r.Expect)
+			}
+
+			stock := stockConstraintOutcome(t, &rt, r, env)
+
+			want := r.Expect
+			if want == "" {
+				want = ConstraintParsed
+			}
+			if stock.Kind != want {
+				t.Fatalf("row declares stock BAML %s, but stock BAML actually produced %s.\n"+
+					"The declaration is stale — fix the row, not this assertion.", want, stock)
+			}
+
+			prof := ConstraintOutcomeProfile(r)
+			if prof.Kind != stock.Kind {
+				t.Fatalf("outcome-class mismatch\nstock BAML: %s\nprofile:    %s\n"+
+					"A row is green ONLY when the profile lands in stock's class; parsing where stock fails "+
+					"(or declining where stock parses) is the parity-decline rule's out-do.", stock, prof)
+			}
+			if stock.Kind != ConstraintParsed {
+				t.Logf("both legs %s — stock: %s | profile: %s", stock.Kind, stock.Detail, prof.Detail)
+				return
+			}
+			if !equalChecks(prof.Checks, stock.Checks) {
+				t.Errorf("check mismatch\nstock BAML: %#v\nprofile:    %#v", stock.Checks, prof.Checks)
+			}
+		})
+	}
+}
+
+func equalChecks(a, b []CheckOutcome) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestConstraintDuplicateLabelCollapse is scope open question #2, measured rather
+// than assumed.
+//
+// BAML evaluates duplicate-labelled checks in order and the CFFI carries them as
+// an ordered list, but its Go client folds that list into a map keyed by label
+// (serde/decode.go:297-303), so only one survives the response representation.
+// This records WHICH, so Slice 7.2 can document a stable policy instead of
+// inheriting an accident. It asserts the collapse is real (two declared checks,
+// one reported) and that the profile's identically-collapsed view agrees; it
+// deliberately does NOT assert a policy, because PR-3 does not own one.
+func TestConstraintDuplicateLabelCollapse(t *testing.T) {
+	assertBAMLAuthority(t)
+	ensureConstraintTypeMap()
+
+	const probeID = "levels_duplicate_label_probe"
+	var probe ConstraintRow
+	for _, r := range ConstraintCorpus() {
+		if r.ID == probeID {
+			probe = r
+		}
+	}
+	if probe.ID == "" {
+		t.Fatalf("the duplicate-label probe row %q is gone; scope open question #2 would go unmeasured", probeID)
+	}
+	declared := 0
+	labels := map[string]int{}
+	for _, c := range probe.Constraints {
+		if c.IsCheck() && c.Label != nil {
+			declared++
+			labels[*c.Label]++
+		}
+	}
+	if declared < 2 || len(labels) != 1 {
+		t.Fatalf("the probe row no longer declares two checks under ONE label (%d checks, %d labels)", declared, len(labels))
+	}
+
+	env := envVars()
+	rt, err := baml.CreateRuntime("./baml_src", GenerateConstraintBAMLSource(ConstraintCorpus()), env)
+	if err != nil {
+		t.Fatalf("CreateRuntime: %v", err)
+	}
+	stock := stockConstraintOutcome(t, &rt, probe, env)
+	if stock.Kind != ConstraintParsed {
+		t.Fatalf("the probe row did not parse on stock BAML: %s", stock)
+	}
+	if len(stock.Checks) != 1 {
+		t.Fatalf("stock reported %d checks for %d duplicate-labelled declarations; "+
+			"the collapse this probe exists to measure did not happen: %#v", len(stock.Checks), declared, stock.Checks)
+	}
+	prof := ConstraintOutcomeProfile(probe)
+	if !equalChecks(prof.Checks, stock.Checks) {
+		t.Errorf("duplicate-label collapse differs\nstock BAML: %#v\nprofile:    %#v", stock.Checks, prof.Checks)
+	}
+	t.Logf("MEASURED (scope open question #2): %d checks declared under label %q collapse to ONE in the response "+
+		"representation, retaining {expression=%q passed=%v}. PR-3 still returns both, in declared order; "+
+		"Slice 7.2 owns the documented policy.",
+		declared, stock.Checks[0].Label, stock.Checks[0].Expression, stock.Checks[0].Passed)
+}
+
+// TestStockSkipsConstraintsOnBareStringReturn pins a MEASURED stock-BAML v0.223
+// asymmetry that the corpus cannot express as an ordinary differential row,
+// because the profile has no way to reproduce it and must not try.
+//
+// jsonish::from_str short-circuits a bare string target before any coercion runs:
+//
+//	if matches!(target, TypeIR::Primitive(TypeValue::String, _)) {
+//	    return Ok(BamlValueWithFlags::String((raw_string.to_string(), target).into()));
+//	}
+//	// jsonish/src/lib.rs:233-237
+//
+// The match ignores the type's metadata, so `-> string @assert(...) @check(...)`
+// never reaches TypeCoercer::coerce, never reaches run_user_checks, and its
+// constraints are NEVER EVALUATED. This test proves both halves of that against
+// the live runtime: a check reports no result at all, and an assert that is
+// plainly false does not reject the parse.
+//
+// Why it matters beyond curiosity: at Slice 7.2 a lowerer that faithfully
+// evaluates the constraints it was given would REJECT responses stock BAML
+// accepts — an out-do in the most damaging direction, since it turns a working
+// call into a parse failure. 7.2 must reproduce the skip for a bare `string`
+// return (or decline the shape); PR-3 records the fact and the leaf stays
+// deliberately unwired. Ledgered as PR-3 parity debt on #583.
+//
+// It is a live measurement, not a golden: if a future stock version starts
+// evaluating these, this test fails and the 7.2 rule has to be revisited.
+func TestStockSkipsConstraintsOnBareStringReturn(t *testing.T) {
+	assertBAMLAuthority(t)
+	ensureConstraintTypeMap()
+
+	const (
+		checkFn  = "CStr_check_is_dropped"
+		assertFn = "CStr_false_assert_is_ignored"
+	)
+	files := map[string]string{
+		"clients.baml": clientSource(),
+		"types.baml":   typesBAMLSource(),
+		"strskip.baml": "function " + checkFn + "() -> string @check(never_reported, {{ this|length > 2 }}) {\n" +
+			"  client " + clientName + "\n  prompt #\"\n" + constraintPromptBody + "\n\"#\n}\n\n" +
+			"function " + assertFn + "() -> string @assert({{ false }}) {\n" +
+			"  client " + clientName + "\n  prompt #\"\n" + constraintPromptBody + "\n\"#\n}\n",
+	}
+	env := envVars()
+	rt, err := baml.CreateRuntime("./baml_src", files, env)
+	if err != nil {
+		t.Fatalf("CreateRuntime: %v", err)
+	}
+
+	parse := func(fn string) (any, error) {
+		args := baml.BamlFunctionArguments{Kwargs: map[string]any{"text": "hello", "stream": false}, Env: env}
+		encoded, err := args.Encode()
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), constraintParseTimeout)
+		defer cancel()
+		return rt.CallFunctionParse(ctx, fn, encoded)
+	}
+
+	result, err := parse(checkFn)
+	if err != nil {
+		t.Fatalf("%s: stock BAML failed to parse a bare string return: %v", checkFn, err)
+	}
+	// declaresCheck is TRUE: the function DOES carry a @check, so the CFFI still
+	// wraps the value in a Checked[string] — it is the CHECK LIST inside that is
+	// empty, because the predicate was never evaluated. Passing true keeps the
+	// shape contract enforced here too, so a future stock that stopped wrapping
+	// would fail loudly rather than read as "zero checks, as expected".
+	checks, err := stockChecksOf(result, true)
+	if err != nil {
+		t.Fatalf("%s: unexpected result shape: %v.\n"+
+			"Stock no longer returns a Checked[string] for a checked bare-string return; "+
+			"the measured skip below must be re-derived from what it does now.", checkFn, err)
+	}
+	if len(checks) != 0 {
+		t.Fatalf("%s: stock reported %d check(s) on a bare `string` return: %#v.\n"+
+			"The jsonish::from_str string short-circuit no longer skips coercion — "+
+			"re-derive the Slice 7.2 rule from this behavior instead of the old one.", checkFn, len(checks), checks)
+	}
+
+	if _, err := parse(assertFn); err != nil {
+		t.Fatalf("%s: an @assert({{ false }}) on a bare `string` return REJECTED the parse (%v).\n"+
+			"Stock v0.223 skips it entirely; if that changed, the Slice 7.2 rule must change with it.", assertFn, err)
+	}
+
+	t.Logf("MEASURED: stock BAML v0.223 evaluates NO constraints on a bare `string` return type " +
+		"(jsonish/src/lib.rs:233-237 returns before coercion). A @check reports nothing and an " +
+		"@assert({{ false }}) does not reject. Slice 7.2 must reproduce the skip rather than evaluate; " +
+		"evaluating would fail calls stock accepts. Ledgered on #583.")
+}
+
+// --- the fixture ------------------------------------------------------------
+
+// TestConstraintOracleFixture is the constraint corpus's version + source-map
+// drift guard, a SIBLING of profile_oracle.json rather than extra fields in it:
+// the two corpora generate two different .baml projects through two different
+// runtime entry points, and one file per project keeps a prompt-corpus edit from
+// invalidating the constraint record and vice versa.
+func TestConstraintOracleFixture(t *testing.T) {
+	// Guard the authority FIRST — before either branch — so a regen in a bad
+	// environment (wrong CFFI runtime, replaced/mispinned module) fails fast
+	// instead of baking bad values into the fixture.
+	assertBAMLAuthority(t)
+
+	observedModule, _, _ := bamlPinFromGoMod(t, rootGoModPath)
+	files := GenerateConstraintBAMLSource(ConstraintCorpus())
+	live := guardFixture{
+		BAMLRuntimeVersion: baml_go.BamlVersion(),
+		BAMLModuleVersion:  observedModule,
+		SourceSHA256:       sourceSHA256(files),
+		RowCount:           len(ConstraintCorpus()),
+		Note:               "stock BAML v0.223.0 CallFunctionParse constraint differential for internal/bamlprofile (Slice 2 PR-3)",
+	}
+
+	if os.Getenv("WRITE_CONSTRAINT_ORACLE_FIXTURE") == "1" {
+		if err := os.MkdirAll(filepath.Dir(constraintFixturePath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		b, err := stdjson.MarshalIndent(live, "", "  ")
+		if err != nil {
+			t.Fatalf("marshal fixture: %v", err)
+		}
+		if err := os.WriteFile(constraintFixturePath, append(b, '\n'), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("wrote %s", constraintFixturePath)
+		return
+	}
+
+	data, err := os.ReadFile(constraintFixturePath)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v (regenerate with WRITE_CONSTRAINT_ORACLE_FIXTURE=1)", constraintFixturePath, err)
+	}
+	var want guardFixture
+	if err := stdjson.Unmarshal(data, &want); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	if live.BAMLRuntimeVersion != want.BAMLRuntimeVersion || live.BAMLModuleVersion != want.BAMLModuleVersion {
+		t.Fatalf("version drift: live %+v, fixture %+v", live, want)
+	}
+	if live.SourceSHA256 != want.SourceSHA256 || live.RowCount != want.RowCount {
+		t.Fatalf("constraint corpus source drift: live sha=%s rows=%d, fixture sha=%s rows=%d.\n"+
+			"If the corpus change is intended, regenerate:\n"+
+			"  WRITE_CONSTRAINT_ORACLE_FIXTURE=1 CGO_ENABLED=1 go test -tags integration ./internal/bamlprofile/profileoracle -run TestConstraintOracleFixture",
+			live.SourceSHA256, live.RowCount, want.SourceSHA256, want.RowCount)
+	}
+}

--- a/internal/bamlprofile/profileoracle/constraintcorpus.go
+++ b/internal/bamlprofile/profileoracle/constraintcorpus.go
@@ -1,0 +1,566 @@
+package profileoracle
+
+// The CONSTRAINT differential corpus and its profile leg.
+//
+// The prompt corpus (rows.go) proves the profile RENDERS like stock BAML. This
+// one proves the profile EVALUATES CONSTRAINTS like stock BAML, which is a
+// different code path on both legs:
+//
+//   - stock leg: BamlRuntime.CallFunctionParse — the CFFI response-parse entry
+//     point (language_client_go/pkg/runtime.go:178-213). Given an unambiguous raw
+//     response text and a function whose RETURN TYPE carries @check/@assert
+//     attributes, it runs BAML's real coercer, which calls run_user_checks ->
+//     evaluate_predicate and then validate_asserts
+//     (jsonish/src/deserializer/coercer/{mod.rs:322-338,field_type.rs:180-294}).
+//     Merely rendering a prompt would exercise none of that.
+//   - profile leg: bamlprofile.EvaluateConstraints over the SAME resolved
+//     constraints and the same resolved host value, built by types.go's hostValue
+//     from the row's plain-Go This exactly as the prompt corpus builds a render
+//     argument.
+//
+// The two legs are compared by a normalized OUTCOME (parsed / assert-failed /
+// evaluator error) plus, for a parsed row, the evaluated CHECK set. Stock's check
+// representation is a map keyed by label, so the comparison normalizes both sides
+// into the same label-keyed form rather than pretending stock exposes an order —
+// PR-3 owns the ordered results, Slice 7.2 owns the serialized order.
+//
+// This file is CFFI-free and carries no build tag, so `go build ./...` and the
+// default `go test` stay CGO-free; the stock leg lives in
+// constraint_integration_test.go behind `//go:build integration`.
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/invakid404/baml-rest/internal/bamlprofile"
+	"github.com/invakid404/minijinja-go/v2/value"
+)
+
+// constraintPromptBody is the inert prompt every constraint function carries.
+// CallFunctionParse never renders it — it parses a supplied response text — but a
+// BAML function must declare one. It is deliberately literal (no interpolation)
+// so it cannot fail for a reason unrelated to constraints.
+const constraintPromptBody = "constraint oracle"
+
+// ConstraintDecl is one resolved constraint as it is BOTH declared in the
+// generated .baml source and handed to the profile.
+//
+// Expression is the BARE expression, exactly as baml_types::Constraint stores it;
+// the generator wraps it in `{{ ... }}` for the SOURCE spelling and the profile
+// evaluator wraps it for the RUNTIME spelling. Keeping one bare string for both
+// is what makes the differential able to compare stock's ResponseCheck.expression
+// (which is the bare `expression.0`) against the profile's Constraint.Expression.
+//
+// Label is a *string because BAML distinguishes an unlabelled assert (None) from
+// a labelled one, and requires a label on every check.
+type ConstraintDecl struct {
+	Level      bamlprofile.ConstraintLevel
+	Label      *string
+	Expression string
+}
+
+// IsCheck reports whether this declaration is a CHECK. It is the one predicate
+// both the CFFI-free tests and the integration leg need — a row with any check is
+// a row whose stock result arrives wrapped in a Checked<T>.
+func (c ConstraintDecl) IsCheck() bool { return c.Level == bamlprofile.ConstraintCheck }
+
+// ConstraintRow is one constraint differential case.
+type ConstraintRow struct {
+	// ID is the stable identifier (also the basis of the BAML function name).
+	ID string
+	// Surface groups rows for readability (core, levels, get_env, enum, ...).
+	Surface string
+	// ReturnType is the BAML return type the constraints hang off, e.g. "string",
+	// "int", "Color", "C", "string[]". It must be a type types.go's hostValue can
+	// lower, because the profile leg builds `this` from it.
+	ReturnType string
+	// Constraints are the resolved constraints in DECLARED order. The generator
+	// emits them in this order and the profile evaluates them in this order.
+	Constraints []ConstraintDecl
+	// Raw is the raw "LLM response" text handed to CallFunctionParse. It must
+	// coerce to ReturnType UNAMBIGUOUSLY: the differential is about constraints,
+	// so a row whose value is in question proves nothing.
+	Raw string
+	// This is the plain-Go value the profile leg lowers (via hostValue) into the
+	// same resolved host value BAML's coercer produces from Raw. Use
+	// int64/float64/string/bool/nil and []any/map[string]any, as in Row.Args.
+	This any
+	// Expect, when non-empty, declares that stock BAML does NOT parse this row
+	// successfully, and WHICH class it produces. Like Row.Fault it is asserted
+	// against the live stock leg so it cannot rot into a fiction, and it is what
+	// keeps a profile that quietly succeeded where stock failed from being green.
+	// Empty means both legs must parse successfully.
+	Expect ConstraintOutcomeKind
+}
+
+// ConstraintOutcomeKind classifies how a constrained parse ended. It is the
+// comparison unit for every constraint row; a parsed row additionally compares
+// its evaluated checks.
+type ConstraintOutcomeKind string
+
+const (
+	// ConstraintParsed: every predicate evaluated and no assert failed. Stock
+	// returned a value (a Checked<T> when the type declares checks); the profile
+	// returned a report with AssertFailed false.
+	ConstraintParsed ConstraintOutcomeKind = "parsed"
+	// ConstraintAssertFailed: every predicate evaluated, and at least one ASSERT
+	// was false. Stock rejects the parse (validate_asserts); the profile sets
+	// ConstraintReport.AssertFailed. This is NOT an evaluator error on either leg.
+	ConstraintAssertFailed ConstraintOutcomeKind = "assert_failed"
+	// ConstraintEvalError: a predicate could not be evaluated — it failed to
+	// compile, raised while rendering, or rendered text that is neither "true" nor
+	// "false". Stock reports it as a constraint-evaluation failure; the profile
+	// returns a *bamlprofile.ConstraintError at the compile/render/classify stage.
+	ConstraintEvalError ConstraintOutcomeKind = "eval_error"
+	// ConstraintUnsupported is PROFILE-ONLY: the leaf declined the request before
+	// evaluating anything (a malformed constraint, or a `this` shape with no
+	// proven serde projection). Stock BAML has no counterpart, so this kind can
+	// never match a stock outcome — which is the point. A corpus row that produces
+	// it is a real gap, reported with its detail rather than absorbed into
+	// ConstraintEvalError where it would look like ordinary parity.
+	ConstraintUnsupported ConstraintOutcomeKind = "unsupported"
+	// ConstraintPanic: an INTERNAL invariant failure rather than a recoverable
+	// error — stock Rust's `unreachable!()` or the fork's value.UnorderableMaps.
+	// Handled exactly as the prompt corpus handles OutcomePanic (see types.go),
+	// including the subprocess stock leg, so a hang can never be reported as a
+	// value.
+	ConstraintPanic ConstraintOutcomeKind = "panic"
+)
+
+// CheckOutcome is one evaluated CHECK, normalized to the shape both legs can
+// produce: stock's ResponseCheck {name, expression, status} and the profile's
+// ConstraintResult over a ConstraintCheck constraint.
+type CheckOutcome struct {
+	Label      string
+	Expression string
+	Passed     bool
+}
+
+// ConstraintOutcome is a classified constrained-parse result from one leg.
+//
+// Kind is always compared. Checks is compared only for ConstraintParsed, and is
+// sorted by Label so the two legs' different natural orders (stock's map, the
+// profile's declared order) do not make an equal result look unequal. Detail is
+// DIAGNOSTIC ONLY: stock's Rust error text and the profile's Go error text
+// describe the same failure in different words, and comparing them would pin a
+// message rather than a behavior.
+type ConstraintOutcome struct {
+	Kind   ConstraintOutcomeKind
+	Checks []CheckOutcome
+	Detail string
+}
+
+// String renders a ConstraintOutcome for a failure message.
+func (o ConstraintOutcome) String() string {
+	if o.Kind == ConstraintParsed {
+		return fmt.Sprintf("%s(checks=%v)", o.Kind, o.Checks)
+	}
+	return fmt.Sprintf("%s(%s)", o.Kind, o.Detail)
+}
+
+// FuncName is the BAML function name generated for a constraint row. The CRow_
+// prefix keeps it distinct from the prompt corpus's Row_ names, so the two
+// generated projects can never collide if they are ever merged.
+func (r ConstraintRow) FuncName() string {
+	var b strings.Builder
+	b.WriteString("CRow_")
+	for _, c := range r.ID {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+			b.WriteRune(c)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// DeclaresCheck reports whether a row's constraints include a CHECK.
+//
+// It is the row-level predicate the stock leg turns on: the CFFI wraps a parsed
+// value in a CffiValueChecked only when the return type carries at least one
+// check (baml_value_with_meta_encode.rs:69-101), so this decides both which
+// checked-type binding the row needs and which result SHAPE the stock reader must
+// insist on (see stockChecksOf).
+func (r ConstraintRow) DeclaresCheck() bool {
+	for _, c := range r.Constraints {
+		if c.IsCheck() {
+			return true
+		}
+	}
+	return false
+}
+
+// profileConstraints converts a row's declarations into the leaf's resolved
+// contract, preserving order and the presence/absence of each label.
+func (r ConstraintRow) profileConstraints() []bamlprofile.Constraint {
+	out := make([]bamlprofile.Constraint, len(r.Constraints))
+	for i, c := range r.Constraints {
+		out[i] = bamlprofile.Constraint{Level: c.Level, Expression: c.Expression, Label: c.Label}
+	}
+	return out
+}
+
+// EvaluateConstraintRow runs a row through the PROFILE leg and returns its
+// classified outcome.
+//
+// Lowering `this` is the HARNESS's job and a failure there is wrapped as
+// *harnessError, exactly as RenderProfile does: only bamlprofile's own verdict is
+// an engine outcome. [ConstraintOutcomeProfile] re-raises a harness failure
+// loudly rather than classifying it, so a row declaring a failure class cannot
+// pass because the harness broke.
+func EvaluateConstraintRow(r ConstraintRow) (ConstraintOutcome, error) {
+	this, err := hostValue(r.ReturnType, r.This)
+	if err != nil {
+		return ConstraintOutcome{}, &harnessError{
+			fmt.Errorf("profileoracle: row %q This (%s): %w", r.ID, r.ReturnType, err)}
+	}
+
+	report, err := bamlprofile.EvaluateConstraints(bamlprofile.ConstraintRequest{
+		Constraints: r.profileConstraints(),
+		This:        this,
+	})
+	if err != nil {
+		var ce *bamlprofile.ConstraintError
+		if !errors.As(err, &ce) {
+			// EvaluateConstraints documents *ConstraintError as its only error type.
+			// An untyped error means the leaf's contract changed under the oracle;
+			// that is a harness-visible defect, not a classifiable engine outcome.
+			return ConstraintOutcome{}, &harnessError{
+				fmt.Errorf("profileoracle: row %q: EvaluateConstraints returned a non-*ConstraintError: %w", r.ID, err)}
+		}
+		switch ce.Stage {
+		case bamlprofile.ConstraintStageValidate, bamlprofile.ConstraintStageProject:
+			// A leaf-side DECLINE, not an evaluation. Kept distinct so it can never
+			// be mistaken for stock's evaluator error.
+			return ConstraintOutcome{Kind: ConstraintUnsupported, Detail: ce.Error()}, nil
+		default:
+			return ConstraintOutcome{Kind: ConstraintEvalError, Detail: ce.Error()}, nil
+		}
+	}
+	if report.AssertFailed {
+		return ConstraintOutcome{Kind: ConstraintAssertFailed, Detail: assertFailureDetail(report)}, nil
+	}
+	return ConstraintOutcome{Kind: ConstraintParsed, Checks: checksOfReport(report)}, nil
+}
+
+// assertFailureDetail summarizes which asserts failed. Diagnostic only — the
+// differential compares the CLASS, never this text, because stock's wording
+// ("Assertions failed." plus up to five causes) is the serving layer's contract,
+// not PR-3's.
+func assertFailureDetail(report bamlprofile.ConstraintReport) string {
+	var failed []string
+	for _, res := range report.Results {
+		if res.Constraint.Level == bamlprofile.ConstraintAssert && !res.Passed {
+			label := "<unlabelled>"
+			if res.Constraint.Label != nil {
+				label = *res.Constraint.Label
+			}
+			failed = append(failed, fmt.Sprintf("%s: %s", label, res.Constraint.Expression))
+		}
+	}
+	return "failed asserts: " + strings.Join(failed, "; ")
+}
+
+// checksOfReport projects the profile's ordered results into the normalized,
+// label-keyed check set stock can also produce.
+//
+// The projection is deliberately the SAME collapse stock's Go client applies when
+// it builds `map[string]Check` from the ordered CFFI check list: a repeated label
+// keeps the LAST occurrence. Doing it identically on both legs is what makes the
+// duplicate-label probe row a measurement rather than an accident — the row
+// asserts the collapse explicitly, and Slice 7.2 owns the policy.
+func checksOfReport(report bamlprofile.ConstraintReport) []CheckOutcome {
+	byLabel := map[string]CheckOutcome{}
+	for _, res := range report.Results {
+		if res.Constraint.Level != bamlprofile.ConstraintCheck {
+			continue
+		}
+		label := ""
+		if res.Constraint.Label != nil {
+			label = *res.Constraint.Label
+		}
+		byLabel[label] = CheckOutcome{Label: label, Expression: res.Constraint.Expression, Passed: res.Passed}
+	}
+	return sortedChecks(byLabel)
+}
+
+// sortedChecks flattens a label-keyed check set into the canonical comparison
+// order (by label), which both legs produce independently.
+func sortedChecks(byLabel map[string]CheckOutcome) []CheckOutcome {
+	out := make([]CheckOutcome, 0, len(byLabel))
+	for _, c := range byLabel {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Label < out[j].Label })
+	return out
+}
+
+// stockChecksOf reads the evaluated checks off a STOCK parse result and
+// normalizes them into the same label-keyed set checksOfReport produces for the
+// profile leg.
+//
+// declaresCheck is the row's [ConstraintRow.DeclaresCheck], and it selects which
+// result SHAPE is legal — the reader is fail-loud in BOTH directions rather than
+// tolerant in one:
+//
+//   - declaresCheck: the CFFI must have wrapped the value, so the result MUST be
+//     a Checked[T] — a non-nil struct with a map-kind `Checks` field
+//     (baml_go/shared/checked.go:12-15). nil, a plain decoded value, or a struct
+//     without `Checks` is an ERROR naming the undecodable result. An EMPTY map is
+//     fine and is not an error: stock legitimately reports zero checks for a bare
+//     `string` return type, whose constraints it never evaluates (see
+//     TestStockSkipsConstraintsOnBareStringReturn).
+//   - !declaresCheck: nothing was wrapped, so there is nothing to read and a
+//     plain value/nil/struct-without-`Checks` yields no checks. A result that
+//     DOES carry `Checks` is an ERROR: the CFFI only wraps a checked type, so it
+//     contradicts the row's own declaration.
+//
+// Returning an empty set for a shape the harness failed to understand would make
+// the check comparison vacuously green for that row, or — once the profile leg
+// disagrees — report a generic check mismatch that hides an undecodable stock
+// result behind what looks like a parity failure.
+//
+// The read is reflective rather than a type switch so that adding a checked
+// return type to the corpus needs a binding and nothing else. It touches no CFFI
+// type, which is what keeps it here (and unit-testable) rather than behind the
+// integration tag.
+func stockChecksOf(result any, declaresCheck bool) ([]CheckOutcome, error) {
+	checksField, err := checksFieldOf(result, declaresCheck)
+	if err != nil || !checksField.IsValid() {
+		return nil, err
+	}
+	byLabel := map[string]CheckOutcome{}
+	iter := checksField.MapRange()
+	for iter.Next() {
+		entry := iter.Value()
+		name, err := stringField(entry, "Name")
+		if err != nil {
+			return nil, err
+		}
+		expr, err := stringField(entry, "Expression")
+		if err != nil {
+			return nil, err
+		}
+		status, err := stringField(entry, "Status")
+		if err != nil {
+			return nil, err
+		}
+		var passed bool
+		switch status {
+		case "succeeded":
+			passed = true
+		case "failed":
+			passed = false
+		default:
+			// ResponseCheck::from_check_result emits exactly these two
+			// (baml-types/src/constraint.rs:66-72). A third would mean the contract
+			// moved; refusing to map it keeps a new status from silently becoming
+			// "failed".
+			return nil, fmt.Errorf("check %q has status %q, want %q or %q", name, status, "succeeded", "failed")
+		}
+		byLabel[name] = CheckOutcome{Label: name, Expression: expr, Passed: passed}
+	}
+	return sortedChecks(byLabel), nil
+}
+
+// checksFieldOf locates a stock result's `Checks` map and enforces the
+// shape contract described on stockChecksOf. It returns the zero reflect.Value
+// when there is legitimately nothing to read.
+func checksFieldOf(result any, declaresCheck bool) (reflect.Value, error) {
+	missing := func(what string) (reflect.Value, error) {
+		if declaresCheck {
+			return reflect.Value{}, fmt.Errorf(
+				"the row declares a @check, so stock must return a Checked[T], but %s; "+
+					"the result is undecodable rather than check-free", what)
+		}
+		return reflect.Value{}, nil
+	}
+	if result == nil {
+		return missing("the result is nil")
+	}
+	rv := reflect.ValueOf(result)
+	if rv.Kind() != reflect.Struct {
+		// A plain decoded value: string, int64, a slice, ...
+		return missing(fmt.Sprintf("the result is a %s, not a struct", rv.Kind()))
+	}
+	checksField := rv.FieldByName("Checks")
+	if !checksField.IsValid() {
+		// A decoded struct that is not a Checked[T] — DynamicClass, DynamicEnum, ...
+		return missing(fmt.Sprintf("the %s result has no Checks field", rv.Type()))
+	}
+	if !declaresCheck {
+		return reflect.Value{}, fmt.Errorf(
+			"the row declares NO @check, yet stock returned a %s carrying a Checks field; "+
+				"the CFFI wraps only a checked type, so the row and the generated source disagree", rv.Type())
+	}
+	if checksField.Kind() != reflect.Map {
+		return reflect.Value{}, fmt.Errorf("Checks field is a %s, want a map", checksField.Kind())
+	}
+	return checksField, nil
+}
+
+func stringField(v reflect.Value, name string) (string, error) {
+	f := v.FieldByName(name)
+	if !f.IsValid() || f.Kind() != reflect.String {
+		return "", fmt.Errorf("check entry has no string field %q", name)
+	}
+	return f.String(), nil
+}
+
+// ConstraintOutcomeProfile runs a row through the profile leg and CLASSIFIES the
+// result, re-raising a harness failure instead of turning it into an outcome.
+//
+// It recovers exactly one panic type — value.UnorderableMaps, the fork's
+// recoverable spelling of stock MiniJinja's `unreachable!()` (v2.16.0-baml.4,
+// PATCHES #103) — mirroring RenderProfileOutcome. Any other panic is re-raised:
+// it would be a genuine defect here, and swallowing it would let a stock panic
+// row match a quietly-classified crash.
+func ConstraintOutcomeProfile(r ConstraintRow) (o ConstraintOutcome) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			u, ok := rec.(value.UnorderableMaps)
+			if !ok {
+				panic(rec)
+			}
+			o = ConstraintOutcome{Kind: ConstraintPanic, Detail: u.Error()}
+		}
+	}()
+	out, err := EvaluateConstraintRow(r)
+	if err != nil {
+		var he *harnessError
+		if errors.As(err, &he) {
+			panic(fmt.Sprintf("profileoracle: row %q: profile harness failed before the leaf evaluated (not an engine outcome): %v", r.ID, err))
+		}
+		panic(fmt.Sprintf("profileoracle: row %q: unexpected non-harness error from EvaluateConstraintRow: %v", r.ID, err))
+	}
+	return out
+}
+
+// GenerateConstraintBAMLSource builds the deterministic in-memory .baml project
+// for the constraint corpus: the shared client, the SHARED types.baml (so
+// hostValue's enum aliases and class field order describe the same declarations
+// stock parses into), and one function per row.
+//
+// It is a separate project from the prompt corpus's, not extra rows in it: the
+// two exercise different runtime entry points, and keeping them apart means the
+// prompt corpus's checked-in source hash is untouched by constraint work.
+func GenerateConstraintBAMLSource(rows []ConstraintRow) map[string]string {
+	sorted := append([]ConstraintRow(nil), rows...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+
+	var fns strings.Builder
+	for _, r := range sorted {
+		fns.WriteString(constraintFunctionSource(r))
+		fns.WriteString("\n")
+	}
+
+	return map[string]string{
+		"clients.baml":     clientSource(),
+		"types.baml":       typesBAMLSource(),
+		"constraints.baml": fns.String(),
+	}
+}
+
+// constraintFunctionSource emits one constrained function.
+//
+// The constraint attributes hang off the RETURN TYPE, which is the position
+// BAML's coercer runs run_user_checks for (field_type.rs:180-194) and the
+// position its own test corpus uses:
+//
+//	function FooToInt(...) -> int @check(small_int, {{ this < 10 }})
+//
+// The expression is emitted back inside `{{ ... }}` because that is the SOURCE
+// spelling; BAML's parser strips the brackets and stores the bare expression,
+// which is what ConstraintDecl.Expression already holds. That round trip is
+// itself part of the proof: stock's ResponseCheck.expression comes back as the
+// bare string, and the differential compares it to ours.
+func constraintFunctionSource(r ConstraintRow) string {
+	var b strings.Builder
+	b.WriteString("function ")
+	b.WriteString(r.FuncName())
+	b.WriteString("() -> ")
+	b.WriteString(r.ReturnType)
+	for _, c := range r.Constraints {
+		b.WriteString(constraintAttributeSource(c))
+	}
+	b.WriteString(" {\n  client ")
+	b.WriteString(clientName)
+	b.WriteString("\n  prompt #\"\n")
+	b.WriteString(constraintPromptBody)
+	b.WriteString("\n\"#\n}\n")
+	return b.String()
+}
+
+// constraintAttributeSource spells one constraint as its BAML attribute.
+//
+// A malformed declaration panics rather than emitting source stock BAML would
+// reject with an opaque CreateRuntime parse error a hundred rows away from its
+// cause. These are AUTHOR-CONTROLLED corpus constants, so a panic here is a
+// corpus bug caught at generation time; TestConstraintCorpusIsWellFormed checks
+// the same invariants without CFFI.
+func constraintAttributeSource(c ConstraintDecl) string {
+	var name string
+	switch c.Level {
+	case bamlprofile.ConstraintCheck:
+		name = "check"
+		if c.Label == nil {
+			panic(fmt.Sprintf("profileoracle: check constraint %q has no label; BAML rejects an unlabelled check", c.Expression))
+		}
+	case bamlprofile.ConstraintAssert:
+		name = "assert"
+	default:
+		panic(fmt.Sprintf("profileoracle: constraint %q has level %v, which is not a BAML level", c.Expression, c.Level))
+	}
+	if strings.Contains(c.Expression, "{{") || strings.Contains(c.Expression, "}}") {
+		panic(fmt.Sprintf("profileoracle: constraint expression %q contains a jinja bracket pair; "+
+			"a resolved expression is BARE and the generator would emit unparseable BAML", c.Expression))
+	}
+	if c.Label != nil {
+		// The label is emitted verbatim as a BAML IDENTIFIER (the grammar's
+		// `Expression::Identifier` arm, constraint.rs:44-49). Anything that is not
+		// one — a space, a quote, a closing paren — would silently reshape the
+		// attribute into a form BAML rejects a hundred rows away from its cause.
+		if !isBAMLIdentifier(*c.Label) {
+			panic(fmt.Sprintf("profileoracle: constraint label %q is not a BAML identifier; "+
+				"the generator would emit an attribute stock BAML cannot parse", *c.Label))
+		}
+		return " @" + name + "(" + *c.Label + ", {{ " + c.Expression + " }})"
+	}
+	return " @" + name + "({{ " + c.Expression + " }})"
+}
+
+// isBAMLIdentifier reports whether s is a plain ASCII identifier, the shape a
+// constraint label must have.
+func isBAMLIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r == '_':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// ck builds a labelled check declaration.
+func ck(label, expr string) ConstraintDecl {
+	return ConstraintDecl{Level: bamlprofile.ConstraintCheck, Label: &label, Expression: expr}
+}
+
+// as_ builds an UNLABELLED assert declaration (`@assert({{ expr }})`).
+func as_(expr string) ConstraintDecl {
+	return ConstraintDecl{Level: bamlprofile.ConstraintAssert, Expression: expr}
+}
+
+// asl builds a LABELLED assert declaration (`@assert(label, {{ expr }})`).
+func asl(label, expr string) ConstraintDecl {
+	return ConstraintDecl{Level: bamlprofile.ConstraintAssert, Label: &label, Expression: expr}
+}

--- a/internal/bamlprofile/profileoracle/constraintcorpus_test.go
+++ b/internal/bamlprofile/profileoracle/constraintcorpus_test.go
@@ -1,0 +1,394 @@
+package profileoracle
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/internal/bamlprofile"
+)
+
+// These are structural (no build tag, CFFI-free): they assert the constraint
+// corpus is well-formed and that the profile leg classifies every row. They
+// assert NO expected outcome VALUES beyond each row's own declaration — the
+// authority is the stock-BAML differential in constraint_integration_test.go.
+
+func TestConstraintCorpusRowIDsUnique(t *testing.T) {
+	seen := map[string]bool{}
+	fns := map[string]bool{}
+	for _, r := range ConstraintCorpus() {
+		if r.ID == "" {
+			t.Fatal("a constraint row has an empty ID")
+		}
+		if seen[r.ID] {
+			t.Fatalf("duplicate constraint row ID %q", r.ID)
+		}
+		seen[r.ID] = true
+		fn := r.FuncName()
+		if fns[fn] {
+			t.Fatalf("two constraint rows map to the same BAML function name %q", fn)
+		}
+		fns[fn] = true
+	}
+}
+
+// TestConstraintCorpusIsWellFormed pins the invariants the generated .baml
+// source depends on. A violation would otherwise surface as an opaque
+// CreateRuntime parse error naming neither the row nor the reason.
+func TestConstraintCorpusIsWellFormed(t *testing.T) {
+	for _, r := range ConstraintCorpus() {
+		t.Run(r.ID, func(t *testing.T) {
+			if r.ReturnType == "" {
+				t.Error("empty ReturnType")
+			}
+			if len(r.Constraints) == 0 {
+				t.Error("no constraints; the row would prove nothing about the evaluator")
+			}
+			for i, c := range r.Constraints {
+				switch c.Level {
+				case bamlprofile.ConstraintCheck:
+					if c.Label == nil {
+						t.Errorf("constraint %d is an unlabelled check; BAML rejects it at CreateRuntime", i)
+					}
+				case bamlprofile.ConstraintAssert:
+				default:
+					t.Errorf("constraint %d has level %v, which is not a BAML level", i, c.Level)
+				}
+				if c.Label != nil && !isBAMLIdentifier(*c.Label) {
+					t.Errorf("constraint %d label %q is not a BAML identifier", i, *c.Label)
+				}
+				if strings.Contains(c.Expression, "{{") || strings.Contains(c.Expression, "}}") {
+					t.Errorf("constraint %d expression %q carries jinja brackets; it must be the BARE expression", i, c.Expression)
+				}
+				if strings.TrimSpace(c.Expression) == "" {
+					t.Errorf("constraint %d has an empty expression", i)
+				}
+			}
+			// The row's This must lower through the same path the profile leg uses,
+			// with the row's declared return type.
+			if _, err := hostValue(r.ReturnType, r.This); err != nil {
+				t.Errorf("This does not lower as %s: %v", r.ReturnType, err)
+			}
+			// The generator must be able to emit the row.
+			src := constraintFunctionSource(r)
+			if !strings.Contains(src, "-> "+r.ReturnType) {
+				t.Errorf("generated source does not declare the return type:\n%s", src)
+			}
+		})
+	}
+}
+
+// TestConstraintExpectDeclarationsAreOutcomeClasses guards the one way a row
+// could silently escape the differential.
+//
+// ConstraintRow.Expect routes a row: empty means both legs must PARSE, non-empty
+// declares a failure class asserted on both legs. `Expect: ConstraintParsed`
+// would compile, look like a declaration, and be trivially satisfied — so only a
+// genuine failure class may appear. ConstraintUnsupported is a PROFILE-ONLY
+// decline with no stock counterpart, so it may never be declared either.
+func TestConstraintExpectDeclarationsAreOutcomeClasses(t *testing.T) {
+	parsed, declared := 0, 0
+	for _, r := range ConstraintCorpus() {
+		switch r.Expect {
+		case "":
+			parsed++
+		case ConstraintAssertFailed, ConstraintEvalError, ConstraintPanic:
+			declared++
+		default:
+			t.Errorf("row %q declares Expect=%q, which is not a stock failure class; "+
+				"only %q, %q and %q route a row to the failure comparison",
+				r.ID, r.Expect, ConstraintAssertFailed, ConstraintEvalError, ConstraintPanic)
+		}
+	}
+	if declared == 0 {
+		t.Fatal("no rows declare a failure class; the failure contract must not silently cover nothing")
+	}
+	t.Logf("constraint corpus: %d rows — %d expected to parse, %d declared failures",
+		len(ConstraintCorpus()), parsed, declared)
+}
+
+// TestConstraintCorpusCoversEverySurface pins that the minimum discriminating
+// surface list from the settled scope is actually populated. Without it a future
+// edit could delete every enum-projection row and still leave a green suite.
+func TestConstraintCorpusCoversEverySurface(t *testing.T) {
+	want := []string{"core", "levels", "get_env", "enum", "class", "list", "isolation", "fault"}
+	have := map[string]int{}
+	for _, r := range ConstraintCorpus() {
+		have[r.Surface]++
+	}
+	for _, s := range want {
+		if have[s] == 0 {
+			t.Errorf("no constraint rows for the required surface %q", s)
+		}
+	}
+	for s := range have {
+		if !slicesContains(want, s) {
+			t.Errorf("row surface %q is not in the declared surface list; add it there so its coverage is guarded", s)
+		}
+	}
+}
+
+func slicesContains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestProfileLegClassifiesEveryConstraintRow is the CGO-free half of the
+// constraint contract: every row must reach a CLASSIFIED profile outcome, and a
+// row that declares a failure class must produce that class on the profile leg.
+// Parsing where stock fails is the parity-decline rule's out-do, and this catches
+// it without CFFI; the stock half (that BAML really produces the declared class)
+// needs the live runtime and lives in TestConstraintDifferential.
+//
+// ConstraintUnsupported is failed explicitly rather than compared: it is a
+// profile-side decline with no stock counterpart, so a row producing it is a real
+// gap in the projection, not a parity result.
+func TestProfileLegClassifiesEveryConstraintRow(t *testing.T) {
+	for _, r := range ConstraintCorpus() {
+		t.Run(r.ID, func(t *testing.T) {
+			got := ConstraintOutcomeProfile(r)
+			if got.Kind == ConstraintUnsupported {
+				t.Fatalf("the profile DECLINED this row (%s); a corpus row must exercise the evaluator, "+
+					"not the projection's fail-closed path", got.Detail)
+			}
+			want := r.Expect
+			if want == "" {
+				want = ConstraintParsed
+			}
+			if got.Kind != want {
+				t.Errorf("profile outcome = %s, want class %s", got, want)
+			}
+		})
+	}
+}
+
+// TestConstraintOutcomeProfileFailsLoudOnHarnessError proves the constraint
+// contract cannot be satisfied by a broken HARNESS. A row whose This does not
+// match its declared return type fails during lowering — a *harnessError, not the
+// leaf's verdict. Classifying that as an evaluator error would let a row
+// declaring ConstraintEvalError pass because the harness failed to set it up.
+func TestConstraintOutcomeProfileFailsLoudOnHarnessError(t *testing.T) {
+	r := ConstraintRow{
+		ID:          "constraint_harness_failure_probe",
+		ReturnType:  "C",
+		Raw:         `{"prop1": "value"}`,
+		This:        "not a class map",
+		Constraints: []ConstraintDecl{as_("true")},
+		Expect:      ConstraintEvalError,
+	}
+	defer func() {
+		if rec := recover(); rec == nil {
+			t.Fatal("ConstraintOutcomeProfile classified a harness lowering failure as an outcome instead of failing loudly")
+		}
+	}()
+	o := ConstraintOutcomeProfile(r)
+	t.Fatalf("ConstraintOutcomeProfile returned %v instead of re-raising the harness failure", o)
+}
+
+// fakeCheck mirrors baml_go/shared.Check's field set (Name/Expression/Status),
+// and fakeChecked mirrors shared.Checked[T] (Value + Checks). The stock reader is
+// reflective by design — so that adding a checked return type needs only a
+// binding — which is exactly what lets these stand in for the real decoded types
+// without linking the CFFI.
+type fakeCheck struct {
+	Name       string
+	Expression string
+	Status     string
+}
+
+type fakeChecked struct {
+	Value  any
+	Checks map[string]fakeCheck
+}
+
+// TestStockChecksOfShapeContract pins the stock reader's fail-loud contract in
+// BOTH directions.
+//
+// The rule it enforces: a row's own declaration decides which result SHAPE is
+// legal. Returning an empty check set for a shape the harness could not decode
+// would either make that row's check comparison vacuously green, or surface later
+// as a generic "check mismatch" against the profile leg that hides an undecodable
+// stock result behind what looks like a parity failure.
+func TestStockChecksOfShapeContract(t *testing.T) {
+	checked := fakeChecked{Value: "v", Checks: map[string]fakeCheck{
+		"b": {Name: "b", Expression: "this > 1", Status: "failed"},
+		"a": {Name: "a", Expression: "this > 0", Status: "succeeded"},
+	}}
+
+	t.Run("declared_check_reads_and_sorts", func(t *testing.T) {
+		got, err := stockChecksOf(checked, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []CheckOutcome{
+			{Label: "a", Expression: "this > 0", Passed: true},
+			{Label: "b", Expression: "this > 1", Passed: false},
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %d checks, want %d: %#v", len(got), len(want), got)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("check %d = %#v, want %#v", i, got[i], want[i])
+			}
+		}
+	})
+
+	// An EMPTY check list on a wrapped value is legitimate, not a shape failure:
+	// stock returns exactly that for a bare `string` return type, whose
+	// constraints it never evaluates.
+	t.Run("declared_check_empty_map_is_not_an_error", func(t *testing.T) {
+		got, err := stockChecksOf(fakeChecked{Value: "v", Checks: map[string]fakeCheck{}}, true)
+		if err != nil {
+			t.Fatalf("an empty Checks map must not be a shape error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %#v, want no checks", got)
+		}
+	})
+
+	// THE FINDING: a declared-check row whose result is not a Checked[T] must be
+	// reported as an undecodable result, not silently as "no checks".
+	t.Run("declared_check_undecodable_results_fail_loud", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			result any
+		}{
+			{"nil", nil},
+			{"plain_string", "hello"},
+			{"plain_slice", []string{"a"}},
+			{"struct_without_checks", struct{ Name, Value string }{"C", "v"}},
+			{"checks_not_a_map", struct{ Checks string }{"nope"}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := stockChecksOf(tc.result, true)
+				if err == nil {
+					t.Fatalf("a declared-check row decoded %T as %#v checks instead of failing loud", tc.result, got)
+				}
+				if got != nil {
+					t.Errorf("an errored read returned %#v, want no checks", got)
+				}
+			})
+		}
+	})
+
+	// An UNCHECKED row legitimately decodes to a plain value, and reads as no
+	// checks rather than as a failure.
+	t.Run("undeclared_check_plain_results_read_as_none", func(t *testing.T) {
+		for _, result := range []any{nil, "hello", int64(5), []string{"a"}, struct{ Name, Value string }{"C", "v"}} {
+			got, err := stockChecksOf(result, false)
+			if err != nil {
+				t.Errorf("%T: unexpected error: %v", result, err)
+			}
+			if len(got) != 0 {
+				t.Errorf("%T: got %#v, want no checks", result, got)
+			}
+		}
+	})
+
+	// The other direction: the CFFI wraps only a checked type, so a wrapped result
+	// for a row that declares no check means the row and the generated source
+	// disagree — a corpus bug, reported rather than absorbed.
+	t.Run("undeclared_check_wrapped_result_fails_loud", func(t *testing.T) {
+		if got, err := stockChecksOf(checked, false); err == nil {
+			t.Fatalf("a wrapped result for an unchecked row read as %#v instead of failing loud", got)
+		}
+	})
+
+	// A status outside stock's two spellings must not silently become "failed".
+	t.Run("unknown_status_fails_loud", func(t *testing.T) {
+		bad := fakeChecked{Checks: map[string]fakeCheck{"a": {Name: "a", Expression: "x", Status: "pending"}}}
+		if got, err := stockChecksOf(bad, true); err == nil {
+			t.Fatalf("status %q read as %#v instead of failing loud", "pending", got)
+		}
+	})
+
+	// A check entry missing one of the three strings is a shape failure too.
+	t.Run("incomplete_check_entry_fails_loud", func(t *testing.T) {
+		bad := struct {
+			Checks map[string]struct{ Name string }
+		}{
+			Checks: map[string]struct{ Name string }{"a": {Name: "a"}},
+		}
+		if got, err := stockChecksOf(bad, true); err == nil {
+			t.Fatalf("a check entry without Expression/Status read as %#v instead of failing loud", got)
+		}
+	})
+}
+
+// TestConstraintRowDeclaresCheck pins the predicate that selects the stock result
+// shape, since getting it backwards would silently relax the reader's contract
+// for every checked row.
+func TestConstraintRowDeclaresCheck(t *testing.T) {
+	if (ConstraintRow{Constraints: []ConstraintDecl{as_("true"), asl("l", "true")}}).DeclaresCheck() {
+		t.Error("assert-only row reported as declaring a check")
+	}
+	if !(ConstraintRow{Constraints: []ConstraintDecl{as_("true"), ck("c", "true")}}).DeclaresCheck() {
+		t.Error("row with a check reported as declaring none")
+	}
+	if (ConstraintRow{}).DeclaresCheck() {
+		t.Error("constraint-free row reported as declaring a check")
+	}
+
+	// Every corpus row's answer must match its generated source, which is the
+	// property the stock reader relies on.
+	for _, r := range ConstraintCorpus() {
+		src := constraintFunctionSource(r)
+		if got, want := r.DeclaresCheck(), strings.Contains(src, " @check("); got != want {
+			t.Errorf("row %q: DeclaresCheck()=%v but the generated source %s a @check", r.ID, got,
+				map[bool]string{true: "carries", false: "does not carry"}[want])
+		}
+	}
+}
+
+// TestConstraintSourceIsDeterministic pins that the generated project does not
+// depend on row order or Go map iteration — the source hash in the checked-in
+// fixture would otherwise drift between runs and the guard would be worthless.
+func TestConstraintSourceIsDeterministic(t *testing.T) {
+	rows := ConstraintCorpus()
+	reversed := make([]ConstraintRow, len(rows))
+	for i, r := range rows {
+		reversed[len(rows)-1-i] = r
+	}
+	a, b := GenerateConstraintBAMLSource(rows), GenerateConstraintBAMLSource(reversed)
+	if len(a) != len(b) {
+		t.Fatalf("file sets differ: %d vs %d", len(a), len(b))
+	}
+	for name, content := range a {
+		if b[name] != content {
+			t.Errorf("%s differs between row orders", name)
+		}
+	}
+}
+
+// TestConstraintFunctionSourcePanicsOnMalformedDeclaration pins the fail-loud
+// generator guards: an unlabelled check and a bracket-wrapped expression must
+// panic at generation time rather than emit .baml stock BAML rejects with an
+// error that names neither.
+func TestConstraintFunctionSourcePanicsOnMalformedDeclaration(t *testing.T) {
+	cases := []struct {
+		name string
+		decl ConstraintDecl
+	}{
+		{"unlabelled_check", ConstraintDecl{Level: bamlprofile.ConstraintCheck, Expression: "true"}},
+		{"bracket_wrapped", as_("{{ true }}")},
+		{"unknown_level", ConstraintDecl{Level: bamlprofile.ConstraintLevel(0), Expression: "true"}},
+		{"label_with_space", ck("not an identifier", "true")},
+		{"label_with_paren", ck("bad)label", "true")},
+		{"label_leading_digit", ck("1bad", "true")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected constraintAttributeSource to panic")
+				}
+			}()
+			_ = constraintAttributeSource(tc.decl)
+		})
+	}
+}

--- a/internal/bamlprofile/profileoracle/constraintrows.go
+++ b/internal/bamlprofile/profileoracle/constraintrows.go
@@ -1,0 +1,469 @@
+package profileoracle
+
+// newlineExpr is a jinja expression evaluating to a single "\n", derived from the
+// ENGINE's own alternate-debug renderer rather than written as a literal.
+//
+// It exists because BAML's constraint-attribute jinja parser does not honour a
+// `\n` escape inside a string literal (measured: `'a\nb'` compares as the literal
+// four characters, so an exact-bytes comparison written that way silently fails
+// on BOTH legs and proves nothing). `[1]|pprint` renders "[\n    1,\n]" on both
+// engines, so index 1 of it IS the newline.
+//
+// The pprint rows below use it as `|replace(newlineExpr, '|')`, which makes their
+// comparison an EXACT byte pin under a documented 1:1 substitution — every byte
+// of the rendering is spelled out, with only the newline glyph written as `|`.
+// Each such row also pins `|pprint|length`, so the substitution cannot be hiding
+// a different number of newlines, and asserts `newlineExpr|length == 1` so the
+// derivation itself is checked rather than assumed.
+const newlineExpr = `([1]|pprint)[1]`
+
+// ConstraintCorpus is the constraint differential corpus: the rows that must be
+// proven against LIVE stock BAML v0.223 CFFI, not against hand-written Go
+// goldens.
+//
+// Every row declares a RETURN TYPE carrying @check/@assert attributes, an
+// unambiguous raw response text, and the plain-Go value that text coerces to.
+// The stock leg parses the text through BamlRuntime.CallFunctionParse (which runs
+// BAML's real coercer -> run_user_checks -> evaluate_predicate -> validate_asserts);
+// the profile leg lowers the same value through hostValue and calls
+// bamlprofile.EvaluateConstraints. The two outcomes are compared by class, and a
+// parsed row additionally compares its evaluated checks.
+//
+// # Raw text uses ALIASES; `this` uses CANONICAL names
+//
+// This is not incidental — it is what makes the projection rows discriminating,
+// and it was MEASURED, not assumed:
+//
+//   - an enum variant coerces from its resolved ALIAS. `Color.RED` is
+//     @alias("rouge"), so the raw response must say `rouge`; the raw text `RED`
+//     is a coercion ERROR ("Expected Color ... enum value, got String(\"RED\")").
+//   - a class field coerces from its ALIAS KEY. `C.prop1` is @alias("key1"), so
+//     the raw JSON must say `{"key1": ...}`; the canonical spelling produces a
+//     different, nonsensical value.
+//
+// So the wire says `rouge`/`key1` and the constraint's `this` says `RED`/`prop1`.
+// A row like enum_canonical_equal therefore cannot pass by accident: the string
+// it asserts appears NOWHERE in the input.
+//
+// SCOPE OF THE PROOF — read before treating a green run as full constraint parity:
+//
+//   - A bare `string` return type is NOT here, and cannot be. Stock BAML's
+//     jsonish::from_str short-circuits `TypeIR::Primitive(TypeValue::String, _)`
+//     before any coercion (jsonish/src/lib.rs:233-237), so its constraints are
+//     never evaluated at all. That measured asymmetry is pinned by
+//     TestStockSkipsConstraintsOnBareStringReturn and ledgered for Slice 7.2;
+//     string-valued predicates are exercised here through a class FIELD instead.
+//   - The expression SURFACE is earned row by row. The fork is a BAML-exact
+//     engine, but this corpus only claims the constructs it actually exercises.
+//     Anything else stays unclaimed rather than assumed (see doc.go's declines).
+//   - Media values and BamlValue::Map have no proven constraint ingress, because
+//     PR-2's host model provides no constructor for them. They are declined by
+//     the projection and are deliberately absent here; the gap is ledgered on
+//     #583/#602/#572 as applicable.
+//   - Duplicate check LABELS are probed, not policed. Stock's Go client collapses
+//     the ordered CFFI check list into a map, so the observable collapse is
+//     measured here and the stable policy is Slice 7.2's to define.
+//   - Error TEXT is diagnostic. A fault row compares the outcome CLASS, exactly
+//     as the prompt corpus's fault rows do, because Rust's and Go's messages for
+//     the same failure are different strings.
+//
+// The shared enum/class declarations come from types.go (the same types.baml the
+// prompt corpus generates), so an enum's resolved alias and a class's declared
+// field order describe one set of declarations on both legs.
+func ConstraintCorpus() []ConstraintRow {
+	return []ConstraintRow{
+		// ===================== core predicate =====================
+		// The evaluator itself: a true/false predicate over `this`, the literal
+		// true/false forms, and the rendered-TEXT classifier — including the
+		// string-looking "true"/"false" that a boolean DOWNCAST would reject and the
+		// near-miss texts that a TRIMMING classifier would wrongly accept.
+		{ID: "core_assert_pass", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("this > 0")}},
+		{ID: "core_assert_fail", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("this > 100")}, Expect: ConstraintAssertFailed},
+		{ID: "core_check_pass", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{ck("gt_zero", "this > 0")}},
+		{ID: "core_check_fail", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{ck("gt_hundred", "this > 100")}},
+		{ID: "core_literal_true", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("true")}},
+		{ID: "core_literal_false", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("false")}, Expect: ConstraintAssertFailed},
+		// A real boolean `this` renders the text "true" — the case where
+		// rendered-text and boolean-downcast semantics agree, and the control for
+		// the two rows below where they do not.
+		{ID: "core_bool_this_true", Surface: "core", ReturnType: "bool", Raw: "true", This: true,
+			Constraints: []ConstraintDecl{as_("this")}},
+		{ID: "core_bool_this_false", Surface: "core", ReturnType: "bool", Raw: "false", This: false,
+			Constraints: []ConstraintDecl{as_("this")}, Expect: ConstraintAssertFailed},
+		// STRING-looking booleans: the predicate never produces a bool at all, yet
+		// its rendered text is exactly "true"/"false". BAML accepts both, because it
+		// matches the rendered string.
+		{ID: "core_string_true_passes", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_(`"true"`)}},
+		{ID: "core_string_false_fails", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_(`"false"`)}, Expect: ConstraintAssertFailed},
+		// NON-BOOLEAN output: an evaluator error, never a failed predicate. The
+		// whitespace and capitalization rows are the ones that separate exact
+		// matching from a trimming/case-folding classifier.
+		{ID: "core_nonboolean_number", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("this")}, Expect: ConstraintEvalError},
+		{ID: "core_nonboolean_string_field", Surface: "core", ReturnType: "C", Raw: `{"key1": "value"}`,
+			This:        map[string]any{"prop1": "value"},
+			Constraints: []ConstraintDecl{as_("this.prop1")}, Expect: ConstraintEvalError},
+		{ID: "core_nonboolean_leading_space", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_(`" true"`)}, Expect: ConstraintEvalError},
+		{ID: "core_nonboolean_trailing_space", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_(`"true "`)}, Expect: ConstraintEvalError},
+		{ID: "core_nonboolean_capitalized", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_(`"True"`)}, Expect: ConstraintEvalError},
+		{ID: "core_nonboolean_empty", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_(`""`)}, Expect: ConstraintEvalError},
+		{ID: "core_nonboolean_none", Surface: "core", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("none")}, Expect: ConstraintEvalError},
+
+		// ===================== levels & labels =====================
+		// A check must carry a label; an assert may or may not. A false ASSERT is
+		// terminal; a false CHECK survives as metadata on a successfully parsed
+		// value. Order and level are both preserved across a mixed batch.
+		{ID: "levels_assert_unlabelled_pass", Surface: "levels", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("this > 0")}},
+		{ID: "levels_assert_labelled_pass", Surface: "levels", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{asl("positive", "this > 0")}},
+		{ID: "levels_assert_labelled_fail", Surface: "levels", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{asl("too_small", "this > 100")}, Expect: ConstraintAssertFailed},
+		// THE assert/check split, both halves, each with the OTHER level present so
+		// neither row can pass by accident:
+		//   - a false CHECK next to a passing assert -> the value parses and the
+		//     failed check comes back as metadata;
+		//   - a false ASSERT next to a passing check -> the parse is rejected and no
+		//     check metadata survives at all.
+		{ID: "levels_false_check_survives", Surface: "levels", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{asl("positive", "this > 0"), ck("big", "this > 100")}},
+		{ID: "levels_false_assert_rejects", Surface: "levels", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{ck("positive", "this > 0"), as_("this > 100")},
+			Expect:      ConstraintAssertFailed},
+		// A mixed multi-constraint batch: two checks with different outcomes and two
+		// asserts, all passing at the assert level so the row parses and every check
+		// is observable.
+		{ID: "levels_mixed_multi", Surface: "levels", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{
+				ck("c_first", "this > 0"),
+				as_("this > 1"),
+				ck("c_second", "this > 100"),
+				asl("a_last", "this > 2"),
+			}},
+		// DUPLICATE-LABEL PROBE (scope open question #2). BAML evaluates both in
+		// order, but the Go client folds the ordered CFFI check list into a map, so
+		// only one label survives the response representation. The differential
+		// measures which; Slice 7.2 owns the documented policy. The two predicates
+		// have OPPOSITE outcomes so the collapse is visible rather than idempotent.
+		{ID: "levels_duplicate_label_probe", Surface: "levels", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{ck("dup", "this > 0"), ck("dup", "this > 100")}},
+
+		// ===================== get_env inside a predicate =====================
+		// The predicate environment is BAML's get_env(): the builtin registry plus
+		// BAML's regex_match and sum overrides and the pycompat unknown-method
+		// callback. Each row reaches one of them from inside a constraint.
+		//
+		// The string-valued rows go through a class FIELD rather than a `string`
+		// return type, because stock never evaluates constraints on the latter (see
+		// the file doc).
+		{ID: "getenv_length", Surface: "get_env", ReturnType: "string[]", Raw: `["a", "b", "c"]`,
+			This:        []any{"a", "b", "c"},
+			Constraints: []ConstraintDecl{as_("this|length == 3")}},
+		{ID: "getenv_sum_ints", Surface: "get_env", ReturnType: "int[]", Raw: "[1, 2, 3]",
+			This:        []any{int64(1), int64(2), int64(3)},
+			Constraints: []ConstraintDecl{as_("this|sum == 6")}},
+		// BAML's sum OVERRIDE returns 0 for an empty list rather than the builtin's
+		// behavior — the discriminating arm of the override.
+		{ID: "getenv_sum_empty", Surface: "get_env", ReturnType: "int[]", Raw: "[]",
+			This:        []any{},
+			Constraints: []ConstraintDecl{as_("this|sum == 0")}},
+		{ID: "getenv_regex_match_true", Surface: "get_env", ReturnType: "C", Raw: `{"key1": "abc123"}`,
+			This:        map[string]any{"prop1": "abc123"},
+			Constraints: []ConstraintDecl{as_(`this.prop1|regex_match("[0-9]+")`)}},
+		{ID: "getenv_regex_match_false", Surface: "get_env", ReturnType: "C", Raw: `{"key1": "abcdef"}`,
+			This:        map[string]any{"prop1": "abcdef"},
+			Constraints: []ConstraintDecl{as_(`this.prop1|regex_match("[0-9]+")`)}, Expect: ConstraintAssertFailed},
+		{ID: "getenv_pycompat_upper", Surface: "get_env", ReturnType: "C", Raw: `{"key1": "abc"}`,
+			This:        map[string]any{"prop1": "abc"},
+			Constraints: []ConstraintDecl{as_(`this.prop1.upper() == "ABC"`)}},
+		{ID: "getenv_pycompat_startswith", Surface: "get_env", ReturnType: "C", Raw: `{"key1": "hello"}`,
+			This:        map[string]any{"prop1": "hello"},
+			Constraints: []ConstraintDecl{as_(`this.prop1.startswith("he")`)}},
+
+		// ===================== enum serde projection =====================
+		// THE host-model split. BAML's PROMPT lowering makes an enum a host object
+		// whose display is the alias and whose `.value` is the canonical name; its
+		// CONSTRAINT lowering makes it the canonical STRING and nothing else.
+		//
+		// Color.RED is @alias("rouge"), and the raw response says `rouge` because
+		// that is what stock's coercer accepts — so "RED" appears nowhere in the
+		// input and every passing row below is proving the canonical projection.
+		{ID: "enum_canonical_equal", Surface: "enum", ReturnType: "Color", Raw: "rouge", This: "RED",
+			Constraints: []ConstraintDecl{as_(`this == "RED"`)}},
+		{ID: "enum_alias_not_equal", Surface: "enum", ReturnType: "Color", Raw: "rouge", This: "RED",
+			Constraints: []ConstraintDecl{as_(`this == "rouge"`)}, Expect: ConstraintAssertFailed},
+		{ID: "enum_is_string", Surface: "enum", ReturnType: "Color", Raw: "rouge", This: "RED",
+			Constraints: []ConstraintDecl{as_("this is string")}},
+		// The prompt host object answers `.value`; the projected string has no
+		// attributes. This is the display-sensitive probe that fails loudly if the
+		// PR-2 object is ever bound directly.
+		{ID: "enum_no_value_attribute", Surface: "enum", ReturnType: "Color", Raw: "rouge", This: "RED",
+			Constraints: []ConstraintDecl{as_("this.value is undefined")}},
+		// Under the prompt lowering this would be "ROUGE".
+		{ID: "enum_upper_is_canonical", Surface: "enum", ReturnType: "Color", Raw: "rouge", This: "RED",
+			Constraints: []ConstraintDecl{as_(`this|upper == "RED"`)}},
+		// An UNALIASED variant, where the wire and canonical spellings coincide —
+		// the control that keeps the aliased rows from being read as "the projection
+		// always differs from the wire".
+		{ID: "enum_unaliased_variant", Surface: "enum", ReturnType: "Color", Raw: "GREEN", This: "GREEN",
+			Constraints: []ConstraintDecl{as_(`this == "GREEN"`)}},
+		{ID: "enum_check_canonical", Surface: "enum", ReturnType: "Color", Raw: "rouge", This: "RED",
+			Constraints: []ConstraintDecl{ck("is_red", `this == "RED"`)}},
+		{ID: "enum_check_alias_fails", Surface: "enum", ReturnType: "Color", Raw: "rouge", This: "RED",
+			Constraints: []ConstraintDecl{ck("is_rouge", `this == "rouge"`)}},
+
+		// ===================== class serde projection =====================
+		// A class is a plain mapping keyed by CANONICAL field names. C.prop1 is
+		// @alias("key1"), and the wire uses `key1`, so the canonical key is a
+		// property of the PROJECTION and not an echo of the input.
+		{ID: "class_canonical_field", Surface: "class", ReturnType: "C", Raw: `{"key1": "value"}`,
+			This:        map[string]any{"prop1": "value"},
+			Constraints: []ConstraintDecl{as_(`this.prop1 == "value"`)}},
+		{ID: "class_alias_absent", Surface: "class", ReturnType: "C", Raw: `{"key1": "value"}`,
+			This:        map[string]any{"prop1": "value"},
+			Constraints: []ConstraintDecl{as_("this.key1 is undefined")}},
+		{ID: "class_is_mapping", Surface: "class", ReturnType: "C", Raw: `{"key1": "value"}`,
+			This:        map[string]any{"prop1": "value"},
+			Constraints: []ConstraintDecl{as_("this is mapping"), as_(`this|list|join(",") == "prop1"`)}},
+		{ID: "class_length", Surface: "class", ReturnType: "WithColor", Raw: `{"colour": "rouge", "n": 4}`,
+			This:        map[string]any{"color": "RED", "n": int64(4)},
+			Constraints: []ConstraintDecl{as_("this|length == 2")}},
+		// ORDER-SENSITIVE probes. They use Ow, whose DECLARED order (zeta, alpha) is
+		// the reverse of both its sorted order (alpha, zeta) and its alias order
+		// (a, z) — so a passing row can only be explained by BAML's insertion-ordered
+		// BamlMap, reproduced by the fork's ordered map in the projection. Every
+		// other multi-field class in the corpus is declared in sorted order, where a
+		// plain Go map would look identical.
+		{ID: "class_order_declared_not_sorted", Surface: "class", ReturnType: "Ow", Raw: `{"z": 1, "a": "v"}`,
+			This: map[string]any{"zeta": int64(1), "alpha": "v"},
+			Constraints: []ConstraintDecl{
+				as_(`this|list|join(",") == "zeta,alpha"`),
+				as_(`this|list|join(",") != "alpha,zeta"`),
+			}},
+		// The raw JSON deliberately presents the fields in the OPPOSITE order to the
+		// declaration, and in sorted-alias order at that. Stock still yields DECLARED
+		// order, so this is the row that separates "declared" from "wire" while the
+		// row above separates "declared" from "sorted".
+		{ID: "class_order_wire_reversed", Surface: "class", ReturnType: "Ow", Raw: `{"a": "v", "z": 1}`,
+			This:        map[string]any{"zeta": int64(1), "alpha": "v"},
+			Constraints: []ConstraintDecl{as_(`this|list|join(",") == "zeta,alpha"`)}},
+		// Order-sensitive probes that do NOT go through |list, so the ordering claim
+		// does not rest on one filter's implementation. `|first` and `|items` follow
+		// the mapping's own iteration order (zeta first), while `|dictsort` sorts by
+		// key (alpha first) — the pair shows the natural order is genuinely
+		// insertion order rather than sorted order that happens to agree.
+		{ID: "class_order_iteration", Surface: "class", ReturnType: "Ow", Raw: `{"z": 1, "a": "v"}`,
+			This: map[string]any{"zeta": int64(1), "alpha": "v"},
+			Constraints: []ConstraintDecl{
+				as_(`this|first == "zeta"`),
+				as_(`this|items|first|first == "zeta"`),
+				as_(`this|dictsort|first|first == "alpha"`),
+			}},
+		// The projected class's STRING rendering is the ordinary fork mapping
+		// render, in insertion order — NOT the PR-2 prompt class's forced-alternate
+		// Rust `{map:#?}` debug bytes with alias keys. This is the class analogue of
+		// enum_no_value_attribute: it fails loudly if the prompt host object is ever
+		// bound to `this`.
+		// The ALTERNATE-DEBUG renderers, |pprint and debug(), pinned byte-exactly.
+		//
+		// This is a separate fork code path from |string (fork v2.16.0-baml.6
+		// PATCHES #106-#108 scope the object-render dispatch to the MAP arm, and the
+		// list arm respects the ambient alternate flag), so a green |string row does
+		// not cover it. It is exactly where PR-2's classObject would leak its
+		// ALIAS-keyed `{map:#?}` rendering into a predicate if the prompt object were
+		// ever bound to `this`: the prompt lowering renders
+		// `{|    "z": 1,|    "a": "v",|}` where the serde projection renders
+		// `{|    "zeta": 1,|    "alpha": "v",|}` (newlines shown as `|`; see
+		// newlineExpr). Ow's aliases are one character long, so the two spellings
+		// even differ in LENGTH, which the |length assertion pins independently.
+		{ID: "class_pprint_is_serde_map", Surface: "class", ReturnType: "Ow", Raw: `{"z": 1, "a": "v"}`,
+			This: map[string]any{"zeta": int64(1), "alpha": "v"},
+			Constraints: []ConstraintDecl{
+				// The newline derivation itself, checked rather than assumed.
+				as_(newlineExpr + `|length == 1`),
+				// Exact byte count of the rendering — pins the newline count too.
+				as_(`this|pprint|length == 36`),
+				// Exact bytes, newline written as `|`.
+				as_(`this|pprint|replace(` + newlineExpr + `, '|') == '{|    "zeta": 1,|    "alpha": "v",|}'`),
+				// The recorded counter-value: the PROMPT lowering's exact bytes, which
+				// must NOT be what a predicate sees.
+				as_(`this|pprint|replace(` + newlineExpr + `, '|') != '{|    "z": 1,|    "a": "v",|}'`),
+				// debug() is the same `{:#?}` call through a different entry point.
+				as_(`debug(this)|replace(` + newlineExpr + `, '|') == '{|    "zeta": 1,|    "alpha": "v",|}'`),
+			}},
+		{ID: "class_string_render_is_not_prompt_debug", Surface: "class", ReturnType: "Ow", Raw: `{"z": 1, "a": "v"}`,
+			This: map[string]any{"zeta": int64(1), "alpha": "v"},
+			// Single-quoted on purpose: BAML's jinja expression parser rejects a
+			// backslash-escaped quote inside a constraint attribute ("unexpected input
+			// after expression"), so the double quotes have to be the literal's
+			// contents rather than its delimiters.
+			Constraints: []ConstraintDecl{as_(`this|string == '{"zeta": 1, "alpha": "v"}'`)}},
+		{ID: "class_enum_field_canonical", Surface: "class", ReturnType: "Ecw", Raw: `{"colour": "rouge"}`,
+			This:        map[string]any{"color": "RED"},
+			Constraints: []ConstraintDecl{as_(`this.color == "RED"`), as_("this.colour is undefined")}},
+		{ID: "class_enum_field_alias_fails", Surface: "class", ReturnType: "Ecw", Raw: `{"colour": "rouge"}`,
+			This:        map[string]any{"color": "RED"},
+			Constraints: []ConstraintDecl{as_(`this.color == "rouge"`)}, Expect: ConstraintAssertFailed},
+		// The RENDER of a class holding an enum. Attribute-access rows cannot tell
+		// the two lowerings apart — PR-2's classObject also answers `.color` by the
+		// canonical name, and its enum member's comparator also equals the canonical
+		// string — so this is the row that does: the prompt lowering would render
+		// "{\n    \"colour\": rouge,\n}" (alias key, bare alias value, forced
+		// alternate debug) where the serde projection renders {"color": "RED"}.
+		{ID: "class_enum_render_is_not_prompt_debug", Surface: "class", ReturnType: "Ecw", Raw: `{"colour": "rouge"}`,
+			This:        map[string]any{"color": "RED"},
+			Constraints: []ConstraintDecl{as_(`this|string == '{"color": "RED"}'`)}},
+		// Nested class -> class -> list recursion, with both alias keys absent at
+		// both depths.
+		{ID: "class_nested_recursion", Surface: "class", ReturnType: "Cw",
+			Raw:  `{"nested": {"data": ["a", "b"]}}`,
+			This: map[string]any{"inner": map[string]any{"items": []any{"a", "b"}}},
+			Constraints: []ConstraintDecl{
+				as_(`this.inner.items[1] == "b"`),
+				as_("this.nested is undefined"),
+				as_("this.inner.data is undefined"),
+				as_("this.inner.items|length == 2"),
+			}},
+		// A null optional field is PRESENT as none, not absent: length is 1 and the
+		// key iterates. That distinction is invisible to `is none` alone (undefined
+		// is not none, but an absent key would also make the length 0), so both are
+		// asserted.
+		{ID: "class_nested_none", Surface: "class", ReturnType: "Nw", Raw: `{"perhaps": null}`,
+			This:        map[string]any{"maybe": nil},
+			Constraints: []ConstraintDecl{as_("this.maybe is none"), as_("this|length == 1"), as_(`this|list|join(",") == "maybe"`)}},
+		// The same, with the optional field OMITTED from the wire entirely — stock
+		// still materializes it as a present none.
+		{ID: "class_omitted_optional_is_none", Surface: "class", ReturnType: "Nw", Raw: `{}`,
+			This:        map[string]any{},
+			Constraints: []ConstraintDecl{as_("this.maybe is none"), as_("this|length == 1")}},
+		{ID: "class_nested_present_optional", Surface: "class", ReturnType: "Nw", Raw: `{"perhaps": "here"}`,
+			This:        map[string]any{"maybe": "here"},
+			Constraints: []ConstraintDecl{as_(`this.maybe == "here"`)}},
+		{ID: "class_check_field", Surface: "class", ReturnType: "C", Raw: `{"key1": "value"}`,
+			This:        map[string]any{"prop1": "value"},
+			Constraints: []ConstraintDecl{ck("has_value", `this.prop1 == "value"`)}},
+
+		// ===================== list serde projection =====================
+		// A list is an ordinary sequence: length, index, membership, iteration. The
+		// PR-2 host list's compact/alternate debug rendering is prompt-only and must
+		// not be reachable.
+		{ID: "list_length", Surface: "list", ReturnType: "string[]", Raw: `["a", "b"]`,
+			This:        []any{"a", "b"},
+			Constraints: []ConstraintDecl{as_("this|length == 2")}},
+		{ID: "list_index", Surface: "list", ReturnType: "string[]", Raw: `["a", "b"]`,
+			This:        []any{"a", "b"},
+			Constraints: []ConstraintDecl{as_(`this[0] == "a"`)}},
+		{ID: "list_membership", Surface: "list", ReturnType: "string[]", Raw: `["a", "b"]`,
+			This:        []any{"a", "b"},
+			Constraints: []ConstraintDecl{as_(`"b" in this`)}},
+		{ID: "list_is_sequence", Surface: "list", ReturnType: "string[]", Raw: `["a", "b"]`,
+			This:        []any{"a", "b"},
+			Constraints: []ConstraintDecl{as_("this is sequence")}},
+		{ID: "list_join", Surface: "list", ReturnType: "string[]", Raw: `["a", "b"]`,
+			This:        []any{"a", "b"},
+			Constraints: []ConstraintDecl{as_(`this|join(",") == "a,b"`)}},
+		// Enum items inside a list project to their canonical strings too, so the
+		// recursion is proven at the list level and not just the class level.
+		{ID: "list_enum_items_canonical", Surface: "list", ReturnType: "Color[]", Raw: `["rouge", "GREEN"]`,
+			This:        []any{"RED", "GREEN"},
+			Constraints: []ConstraintDecl{as_(`this[0] == "RED"`), as_(`this[1] == "GREEN"`), as_("this|length == 2")}},
+		// The RENDER of a list of enums — the list analogue of
+		// class_enum_render_is_not_prompt_debug, and the only list row that is
+		// discriminating. Length, index, membership, `is sequence` and |join all
+		// answer identically for PR-2's listObject (it is an ObjectReprSeq with
+		// SeqLen/SeqItem) and for a plain projected slice, and its enum items even
+		// compare EQUAL to the canonical string through the PR-2 comparator. The
+		// rendering is where they part: the prompt lowering is "[rouge, GREEN]"
+		// (bare aliases, Rust debug_list) and the projection is ["RED", "GREEN"].
+		{ID: "list_enum_render_is_not_prompt_debug", Surface: "list", ReturnType: "Color[]", Raw: `["rouge", "GREEN"]`,
+			This:        []any{"RED", "GREEN"},
+			Constraints: []ConstraintDecl{as_(`this|string == '["RED", "GREEN"]'`)}},
+		// The list half of the alternate-debug pin (see class_pprint_is_serde_map).
+		// A host list's |pprint is NOT its |string: the fork's list arm respects the
+		// ambient alternate flag, so the compact top-level render and the multi-line
+		// debug_list are different code paths, and only this row covers the second.
+		// PR-2's listObject would render its items as BARE aliases —
+		// `[|    rouge,|    GREEN,|]` — where the serde projection renders quoted
+		// canonical strings.
+		{ID: "list_pprint_is_serde_seq", Surface: "list", ReturnType: "Color[]", Raw: `["rouge", "GREEN"]`,
+			This: []any{"RED", "GREEN"},
+			Constraints: []ConstraintDecl{
+				as_(newlineExpr + `|length == 1`),
+				as_(`this|pprint|length == 27`),
+				as_(`this|pprint|replace(` + newlineExpr + `, '|') == '[|    "RED",|    "GREEN",|]'`),
+				// The recorded counter-value: PR-2's prompt-list debug spelling.
+				as_(`this|pprint|replace(` + newlineExpr + `, '|') != '[|    rouge,|    GREEN,|]'`),
+				as_(`debug(this)|replace(` + newlineExpr + `, '|') == '[|    "RED",|    "GREEN",|]'`),
+			}},
+		{ID: "list_enum_items_alias_fails", Surface: "list", ReturnType: "Color[]", Raw: `["rouge"]`,
+			This:        []any{"RED"},
+			Constraints: []ConstraintDecl{as_(`this[0] == "rouge"`)}, Expect: ConstraintAssertFailed},
+		{ID: "list_check", Surface: "list", ReturnType: "string[]", Raw: `["a", "b"]`,
+			This:        []any{"a", "b"},
+			Constraints: []ConstraintDecl{ck("nonempty", "this|length > 0")}},
+
+		// ===================== context isolation =====================
+		// MEASURED rows proving the constraint environment is a bare get_env(): the
+		// three globals BAML's PROMPT renderer injects are undefined here. Adding
+		// any of them would be an out-do — the profile would answer where stock
+		// BAML has nothing.
+		{ID: "iso_ctx_undefined", Surface: "isolation", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("ctx is undefined")}},
+		{ID: "iso_role_helper_undefined", Surface: "isolation", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("_ is undefined")}},
+		{ID: "iso_enum_namespace_undefined", Surface: "isolation", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("Color is undefined")}},
+		// Reaching THROUGH an absent global is an evaluator error rather than a
+		// quietly-undefined value, on both legs.
+		{ID: "iso_enum_member_access_errors", Surface: "isolation", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_(`Color.RED == "RED"`)}, Expect: ConstraintEvalError},
+		{ID: "iso_ctx_output_format_errors", Surface: "isolation", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_(`ctx.output_format == ""`)}, Expect: ConstraintEvalError},
+
+		// ===================== faults =====================
+		// Predicates stock BAML actually FAILS on. Each is compared by outcome
+		// class through the same discipline the prompt corpus's fault rows use: the
+		// declaration is asserted against the live stock leg, so it cannot rot, and
+		// a profile that renders a conservative `false` where stock errors is NOT
+		// green.
+		{ID: "fault_unknown_filter", Surface: "fault", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("this|no_such_filter")}, Expect: ConstraintEvalError},
+		{ID: "fault_length_of_int", Surface: "fault", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("this|length > 0")}, Expect: ConstraintEvalError},
+		{ID: "fault_attribute_chain_through_undefined", Surface: "fault", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("this.a.b == 1")}, Expect: ConstraintEvalError},
+		{ID: "fault_floordiv_by_zero", Surface: "fault", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("this // 0 > 0")}, Expect: ConstraintEvalError},
+		{ID: "fault_mod_by_zero", Surface: "fault", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("this % 0 > 0")}, Expect: ConstraintEvalError},
+		// TRUE division by zero is NOT an error in either engine — it is f64
+		// infinity, so the comparison succeeds. The row is here precisely because it
+		// looks like a fault and is not: without it, the two `... by zero` rows above
+		// would read as a general rule the engines do not actually have.
+		{ID: "fault_truediv_by_zero_is_infinity", Surface: "fault", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("this / 0 > 0")}},
+		// An error in a LATER constraint aborts the batch: the earlier passing check
+		// must not come back as a partial report on either leg.
+		{ID: "fault_aborts_batch", Surface: "fault", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{ck("ok", "this > 0"), as_("this|no_such_filter")},
+			Expect:      ConstraintEvalError},
+		// An error alongside a FAILING assert: the evaluator error wins, because
+		// run_user_checks aborts before validate_asserts ever runs.
+		{ID: "fault_beats_failing_assert", Surface: "fault", ReturnType: "int", Raw: "5", This: int64(5),
+			Constraints: []ConstraintDecl{as_("this > 100"), as_("this|no_such_filter")},
+			Expect:      ConstraintEvalError},
+	}
+}

--- a/internal/bamlprofile/profileoracle/rows.go
+++ b/internal/bamlprofile/profileoracle/rows.go
@@ -312,6 +312,15 @@ func Corpus() []Row {
 		{ID: "class_int_compare", Surface: "class",
 			Params: []Param{{Name: "c", BamlType: "WithColor"}}, Args: map[string]any{"c": map[string]any{"color": "GREEN", "n": int64(4)}},
 			Template: `{% if c.n < 40 %}true{% else %}false{% endif %}`}, // true (mirrors render_number_comparison_with_alias)
+		// Ow exists for the CONSTRAINT corpus's order probes (its declared order is
+		// the reverse of its sorted order); this row keeps it referenced on the
+		// prompt leg too, so the generated project has no dead type. It is
+		// deliberately ORDER-INDEPENDENT — attribute access only — because a class
+		// argument's field order comes from the Go client's random map iteration
+		// (see classDecls) and could not be byte-pinned here.
+		{ID: "class_ow_access", Surface: "class",
+			Params: []Param{{Name: "c", BamlType: "Ow"}}, Args: map[string]any{"c": map[string]any{"zeta": int64(1), "alpha": "v"}},
+			Template: `{{ c.zeta }}/{{ c.alpha }}/{{ c.z is undefined }}/{{ c|length }}`}, // 1/v/true/2
 
 		// --- class: direct pretty/debug rendering ({map:#?} bytes) ---
 		// Aliased keys, four-space nesting, trailing commas, nested class/list,

--- a/internal/bamlprofile/profileoracle/testdata/constraint_oracle.json
+++ b/internal/bamlprofile/profileoracle/testdata/constraint_oracle.json
@@ -1,0 +1,7 @@
+{
+  "baml_runtime_version": "0.223.0",
+  "baml_module_version": "v0.223.0",
+  "baml_source_sha256": "d4a2745e78926ea4b97f4138556a666ac1301580b9d981278b061819a42dbcd0",
+  "row_count": 79,
+  "note": "stock BAML v0.223.0 CallFunctionParse constraint differential for internal/bamlprofile (Slice 2 PR-3)"
+}

--- a/internal/bamlprofile/profileoracle/testdata/profile_oracle.json
+++ b/internal/bamlprofile/profileoracle/testdata/profile_oracle.json
@@ -1,7 +1,7 @@
 {
   "baml_runtime_version": "0.223.0",
   "baml_module_version": "v0.223.0",
-  "baml_source_sha256": "2554332d6cd0aaeede522da7dde5c648a0cf51b55a246968c4c14da86daed51b",
-  "row_count": 150,
+  "baml_source_sha256": "354ae942c3333731eec2f317156e5da341bba6765fa212a2877c357933bfe463",
+  "row_count": 151,
   "note": "stock BAML v0.223.0 get_env + enum/class host-value-model differential for internal/bamlprofile (Slice 2 PR-1 + PR-2)"
 }

--- a/internal/bamlprofile/profileoracle/types.go
+++ b/internal/bamlprofile/profileoracle/types.go
@@ -122,6 +122,22 @@ func classDecls() []classDecl {
 		{"Ew", []classFieldDecl{{"raw", al("escaped"), "string"}}},
 		// Ecw: a single enum field, rendered as the BARE alias inside the map.
 		{"Ecw", []classFieldDecl{{"color", al("colour"), "Color"}}},
+		// Ow is the ORDER-DISCRIMINATING class: its declared order (zeta, alpha) is
+		// the REVERSE of its sorted order, and of its alias order (z, a). Every other
+		// multi-field class here happens to be declared in sorted order, so a probe
+		// over one of them cannot tell BAML's insertion-ordered BamlMap apart from a
+		// Go map's sorted iteration — the constraint corpus's class_order_* rows need
+		// a class where the two genuinely disagree.
+		//
+		// It is used ORDER-INDEPENDENTLY on the prompt leg (attribute access only, as
+		// classDecls' doc requires, since a class ARGUMENT's field order comes from
+		// the Go client's random map iteration) and ORDER-SENSITIVELY on the
+		// constraint leg, where the value comes from PARSING and stock yields declared
+		// order regardless of wire order.
+		{"Ow", []classFieldDecl{
+			{"zeta", al("z"), "int"},
+			{"alpha", al("a"), "string"},
+		}},
 		// Empty: a FIELDLESS class. It is a KNOWN-empty map — falsey, length 0,
 		// rendering as `{}` — which is exactly what a non-enumerable enum object is
 		// NOT, so it is the live-CFFI control for the opaque-map rows.

--- a/internal/bamlprofile/project.go
+++ b/internal/bamlprofile/project.go
@@ -1,0 +1,122 @@
+package bamlprofile
+
+import (
+	"fmt"
+
+	"github.com/invakid404/minijinja-go/v2/value"
+)
+
+// This file is the CONSTRAINT-side lowering of a BAML value — the half of BAML's
+// host model that is NOT the prompt host model in enum.go/class.go/list.go.
+//
+// BAML has two different lowerings of the same BamlValue and uses each in exactly
+// one place:
+//
+//   - the PROMPT renderer lowers Enum/Class/List into custom MiniJinja host
+//     objects carrying aliases and Rust-debug rendering
+//     (jinja-runtime/src/baml_value_to_jinja_value.rs:19-80). That is PR-2's
+//     enumMember / classObject / listObject.
+//   - the CONSTRAINT evaluator does NOT. evaluate_predicate binds
+//     `Value::from_serialize(this)` (baml-core/src/ir/jinja_helpers.rs:83-89),
+//     which goes through BamlValue's serde impl
+//     (baml-types/src/baml_value.rs:41-57):
+//
+//     BamlValue::Enum(_, v)  => serialize_str(v)   // CANONICAL variant, no alias
+//     BamlValue::Class(_, m) => m.serialize(..)    // canonical-key ordered map
+//     BamlValue::List(l)     => l.serialize(..)    // ordinary sequence
+//     BamlValue::Null        => serialize_none()
+//     scalars                => themselves
+//
+// So in a predicate an enum IS its canonical string, a class IS a plain mapping
+// keyed by canonical field names, and neither carries a prompt alias or the
+// hand-written debug rendering. `this|string`, `this|pprint`, `this == "RED"` and
+// `this.aliasKey` all answer differently under the two lowerings, which is why
+// the projection exists rather than binding the PR-2 object directly.
+//
+// PR-3 accepts the PR-2 host values at its public boundary (they are the resolved
+// values a later slice already knows how to build) and projects them here, once,
+// before binding `this`.
+
+// projectConstraintThis lowers a bamlprofile host value into the shape BAML's
+// serde projection produces, for binding as a constraint's `this`.
+//
+// It is deliberately DECLINE-BY-DEFAULT. Only the shapes PR-2 proved and BAML's
+// serde impl covers are accepted:
+//
+//   - none stays none (serialize_none);
+//   - a string/number/bool scalar is retained verbatim;
+//   - an enumMember becomes its CANONICAL variant string — never the alias;
+//   - a classObject becomes a fork ORDERED map keyed by canonical field names,
+//     with recursively projected values. The ordered map (not a Go map) is what
+//     preserves BAML's insertion-ordered BamlMap, which an iteration-sensitive
+//     predicate (`this|list`, `this|dictsort`, `for k in this`) observes;
+//   - a listObject becomes an ordinary fork slice of recursively projected items.
+//
+// Everything else FAILS CLOSED with an error: an undefined value, a media value,
+// a native fork container passed as `This`, and any unrecognized object. Binding
+// a prompt host object directly would be the exact out-do the parity-decline rule
+// forbids — the predicate would see an alias, an alternate key, or the pretty
+// debug rendering that BAML's constraint evaluator never shows it.
+func projectConstraintThis(v value.Value) (value.Value, error) {
+	if v.IsUndefined() {
+		// Undefined is not a BamlValue at all; BAML's `this` is always a real
+		// value. There is no serde projection to reproduce, so decline.
+		return value.Undefined(), fmt.Errorf("value is undefined")
+	}
+	if v.IsNone() {
+		return v, nil
+	}
+	if obj, ok := v.AsObject(); ok {
+		switch o := obj.(type) {
+		case *enumMember:
+			// BamlValue::Enum(_, v) => serializer.serialize_str(v): the CANONICAL
+			// variant name. The prompt display alias (o.display()) is deliberately
+			// NOT used — `this == "rouge"` must be false where `this == "RED"` is
+			// true, even for an @alias("rouge") variant.
+			return value.FromString(o.canonical), nil
+		case *classObject:
+			// BamlValue::Class(_, m) => m.serialize(..) over a BamlMap keyed by
+			// CANONICAL field names. The alias projection classObject carries for
+			// rendering has no counterpart here: `this.key1` is undefined where
+			// `this.prop1` is the value.
+			m := value.NewOrderedMap(len(o.fields))
+			for _, f := range o.fields {
+				pv, err := projectConstraintThis(f.value)
+				if err != nil {
+					return value.Undefined(), fmt.Errorf("field %q: %w", f.canonical, err)
+				}
+				m.Set(f.canonical, pv)
+			}
+			return value.FromOrderedMap(m), nil
+		case *listObject:
+			// BamlValue::List(l) => l.serialize(..): an ordinary sequence. The host
+			// list's compact/alternate debug rendering is prompt-only.
+			items := make([]value.Value, len(o.items))
+			for i, it := range o.items {
+				pv, err := projectConstraintThis(it)
+				if err != nil {
+					return value.Undefined(), fmt.Errorf("item %d: %w", i, err)
+				}
+				items[i] = pv
+			}
+			return value.FromSlice(items), nil
+		default:
+			// A media value, an external fork object, or any future host type whose
+			// constraint ingress has not been differentially proven. Decline rather
+			// than bind the object and hope its render happens to match.
+			return value.Undefined(), fmt.Errorf("unsupported host object type %T", obj)
+		}
+	}
+	switch v.Kind() {
+	case value.KindString, value.KindNumber, value.KindBool:
+		// BamlValue::String/Int/Float/Bool serialize as themselves. This is the same
+		// accepted scalar set assertHostRenderable admits into a host class/list, so
+		// a value that PR-2 can hold is a value PR-3 can project.
+		return v, nil
+	default:
+		// A native fork sequence/mapping/bytes/callable reaching `This` means the
+		// caller bypassed the host constructors; BAML's `this` is always a lowered
+		// BamlValue, so there is nothing faithful to project.
+		return value.Undefined(), fmt.Errorf("value must be a scalar, none, or a bamlprofile host value, got kind %v", v.Kind())
+	}
+}


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

de-BAML Slice 2 **PR-3**: the pure-Go **constraint lowerer** and its narrow **typed façade** in `internal/bamlprofile`, on top of PR-2 (`fb283b35`) and the pinned fork `github.com/invakid404/minijinja-go/v2@v2.16.0-baml.6`. Test-only, unwired, pure-Go/CGO-free. **No fork change. No parsing/serving wiring.**

## What it builds

**1. The evaluator (`constraints.go`)** — BAML v0.223's `run_user_checks` + `evaluate_predicate`, copied rather than improved (`jinja_helpers.rs:67-93`, `jsonish/.../mod.rs:322-338`, `field_type.rs:180-294`):

- a **bare `get_env()`** environment with **no prompt globals**;
- the stored **bare** expression wrapped verbatim as `{{ <expr> }}` via a one-off synthetic template (`TemplateFromNamedString`, which the fork does not store in the environment);
- exactly **one** bound name, `this`;
- **rendered-TEXT** classification: exactly `"true"`/`"false"`. `" true"`, `"True"`, `"1"`, `""` are a typed **error**, never a failed predicate — this is not a boolean downcast;
- the batch **aborts** on the first evaluator error with **no partial report** (`collect::<Result<Vec<_>>>()`);
- a false **assert** sets `ConstraintReport.AssertFailed`; a false **check** is retained as an ordinary result.

**2. The serde projection (`project.go`)** — the half of BAML's host model that is *not* PR-2's prompt lowering. `evaluate_predicate` binds `Value::from_serialize(this)` (`baml_value.rs:41-57`), so in a predicate:

| BamlValue | prompt lowering (PR-2) | constraint lowering (PR-3) |
| --- | --- | --- |
| `Enum` | host object, display = alias, `.value` = canonical | the **canonical string**, no attributes |
| `Class` | host object, canonical attrs + alias-keyed `{map:#?}` render | ordered map of **canonical keys**, ordinary render |
| `List` | host object, Rust `debug_list` render | plain sequence |

Media, undefined, native containers and unrecognized host objects **fail closed** — the prompt object is never bound.

**3. The environment split (`env.go`)** — `newGetEnvBase` carries get_env's engine configuration; `New` continues on to add `_`/`ctx`/enum namespaces; `newConstraintEnvironment` stops. Prompt behavior is unchanged. No fork patch is implied.

**4. The façade** — `ConstraintLevel` / `Constraint` / `ConstraintRequest` / `ConstraintResult` / `ConstraintReport` / `ConstraintError` / `EvaluateConstraints`. Results come back in **declared input order**; PR-3 deliberately emits **no** `Checked<T>` envelope (that and its stable ordering are Slice 7.2).

Structural impossibilities are **preflighted loudly, never reinterpreted**: unknown level, unlabelled check, empty label, and a `{{ ... }}`-wrapped expression (**rejected, not stripped** — a resolved constraint holds the bare expression).

## Differential proof

A new `profileoracle` constraint corpus — **79 rows** — driving stock BAML v0.223 **`CallFunctionParse`**, the CFFI response-parse path that runs BAML's *real* coercer (`run_user_checks` → `evaluate_predicate` → `validate_asserts`). Rendering a prompt would exercise none of it. Compared against **live CFFI**, never Go-only goldens, reusing the existing `assertBAMLAuthority` / source-hash fixture / harness-failure-is-loud discipline.

Surfaces: core predicate & the exact-text classifier · levels/labels & the assert-rejects/check-survives split · `length`/`sum`/`regex_match`/pycompat inside a predicate · enum, class and list serde projection with nesting and an order-sensitive probe · context isolation · faults.

**The rows are discriminating by construction.** Stock coerces an aliased enum from its **alias** and a class field from its **alias key**, so the wire says `rouge`/`key1` while the constraint's `this` says `RED`/`prop1` — the asserted string appears *nowhere* in the input. Where attribute access alone could not tell the two lowerings apart (PR-2's `classObject` also answers canonical attributes, and its enum comparator also equals the canonical string), the **render** rows do — on *both* renderer paths. `this|string` is `{"color": "RED"}` / `["RED", "GREEN"]`, not the prompt lowering's `{\n    "colour": rouge,\n}` / `[rouge, GREEN]`; and the separate alternate-debug path (`this|pprint`, `debug(this)` — fork PATCHES #106-#108) is pinned **byte-exactly**, recording the prompt spelling that must not appear. Since BAML's constraint-attribute jinja parser does not honour `\n` escapes (an exact-bytes row written that way is false on *both* legs and proves nothing), those rows derive the newline from the engine itself via `([1]|pprint)[1]` and additionally pin `|pprint|length`, so the normalization cannot hide a differing newline count. A new `Ow` class whose declared order is the *reverse* of its sorted order makes the ordered-map claim real rather than a coincidence.

Sibling fixture `testdata/constraint_oracle.json` records the v0.223.0 runtime/module authority plus the generated source hash and row count; regeneration is integration-only and rejects a replaced/mispinned module.

## Review round 1 — P2 fixed: live-CFFI `this|pprint` discriminator

`|pprint` / `debug()` is a **separate fork renderer path** from `|string` (v2.16.0-baml.6 PATCHES #106-#108 scope object-render dispatch to the MAP arm; the list arm respects the ambient alternate flag), so the green `|string` rows did not prove the PR-2 prompt debug renderer cannot leak through `this|pprint`. Two new live rows close it: `class_pprint_is_serde_map` (`Ow`) and `list_pprint_is_serde_seq` (`Color[]`), both in `TestConstraintDifferential`.

Writing them surfaced a trap worth recording: **BAML's constraint-attribute jinja parser does not honour a `\n` escape**, so an exact-bytes comparison spelled `'{\n    "zeta": 1,…}'` is false on *both* legs — a row that looks green while proving nothing (measured: the projected *and* the prompt spelling both `failed`). The rows therefore derive the newline from the engine itself — `([1]|pprint)[1]`, asserted to be one character — and pin:

- `this|pprint|length == 36` / `== 27` — exact byte count, so the substitution cannot hide a different newline count;
- `this|pprint|replace(nl, '|') == '…'` — **every byte**, newline written as `|`;
- `… != '…'` — the **recorded counter-value**: PR-2's exact prompt spelling (`{|    "z": 1,|    "a": "v",|}` / `[|    rouge,|    GREEN,|]`);
- `debug(this)|replace(nl, '|') == '…'` — the other alternate-debug entry point.

Both were verified **false for the PR-2 prompt objects** before being written, so they genuinely fail if `this` is bound to `classObject`/`listObject`. `TestProjectionAlternateDebugIsNotThePromptRenderer` is the CGO-free half, and it first asserts the prompt object *really* renders the leaking spelling — so the guard cannot pass because the renderer drifted rather than because the projection is right.

## Two stock behaviors MEASURED and deliberately not reproduced

Both are ledgered on **#583** for Slice 7.2:

1. **A bare `string` return type never evaluates its constraints.** `jsonish::from_str` short-circuits `TypeIR::Primitive(TypeValue::String, _)` before any coercion (`jsonish/src/lib.rs:233-237`), ignoring the type's metadata. A `@check` reports nothing and an `@assert({{ false }})` does not reject. Pinned live by `TestStockSkipsConstraintsOnBareStringReturn`. **7.2 must reproduce the skip** — evaluating there would fail calls stock accepts, an out-do in the most damaging direction.
2. **Duplicate check labels collapse** in the response representation (last wins), while PR-3 returns both in declared order. Measured by `TestConstraintDuplicateLabelCollapse`; the stable policy is 7.2's (scope open question #2).

## Bot triage round — P3 fixed: fail-loud stock check decoding

`stockChecksOf` returned an **empty check set** for a nil / non-struct / no-`Checks` stock result, contradicting its own documented "every unrecognized shape is an ERROR" contract. A declared-check row still failed eventually — but as a *generic check mismatch* against the profile leg, hiding an undecodable `Checked[T]` behind what reads like a parity failure.

The reader now takes the row's own declaration (`ConstraintRow.DeclaresCheck()`) and is fail-loud in **both** directions: a declared-check row's result must be a `Checked[T]`, and an *un*checked row's result must **not** carry `Checks` (the CFFI wraps only a checked type, so that would mean the row and the generated source disagree). An **empty** `Checks` map stays a success — load-bearing for the bare-string probe, where stock *does* wrap the value and it is the check list inside that is empty.

The reader (pure `reflect`, no CFFI type) moved out of the `//go:build integration` file, which made a CFFI-free test practical: `TestStockChecksOfShapeContract` drives it with local structs mirroring `shared.Checked[T]`/`shared.Check` across nine shapes, and `TestConstraintRowDeclaresCheck` cross-checks every corpus row's predicate against whether its generated source actually carries ` @check(`. No production semantics changed.

## Validation

- `gofmt` clean on every changed file
- `CGO_ENABLED=0 go build ./...` · `go test ./...` green (the single `cmd/hacks/hacks` failure is pre-existing on `master` under `CGO_ENABLED=0` — that test shells out `go build` on a cgo-only BAML client; it passes with `CGO_ENABLED=1`)
- `CGO_ENABLED=1 go test -tags integration ./internal/bamlprofile/profileoracle` — **604 assertions green**, including the untouched PR-1/PR-2 prompt differential
- `go vet ./...` and `go vet -tags integration ./...` clean
- dependency purity: the leaf imports the fork + stdlib only; **zero** BAML CFFI references outside `//go:build integration`
- `.embedignore:77` still excludes `internal/bamlprofile`

## Explicitly out of scope

BAML source parsing, interpolation stripping, Jinja typechecking, BAML IR/descriptors; prompt-only globals and render-layer concerns; media and `BamlValue::Map` constraint ingress (#602/#572); and the whole serving side — descriptor→constraint translation, running constraints during native parsing, the public `Checked<T>`/JSON envelope, assert-message wording, duplicate-label policy, stream semantics and fallback routing (all Slice 7.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
