### PR TITLE
ci(unit-tests): raise timeout-minutes 35→50 (interim; #656)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,11 +22,12 @@ jobs:
     # adapters/common/codegen/internal/testharness/stress.go.
     env:
       BAML_HEAVY_TEST_RUNS: "5"
-    # -race -count=100 across every module has grown past the 10-minute
-    # cap as suites expanded (bamlutils/buildrequest ~4 min,
-    # pool ~4 min on their own). 25 leaves headroom for further growth
-    # without masking a real stuck-test regression.
-    timeout-minutes: 35
+    # The -race -count=100 all-module suite runs ~33-34 min on master
+    # (bamlutils/llmhttp alone ~15 min, ~43% of the budget), so 35 left
+    # near-zero headroom and any substantial PR tipped it over. 50 is an
+    # INTERIM stopgap, not a target: the durable fix is sharding this job
+    # into a balanced parallel matrix, tracked in #656.
+    timeout-minutes: 50
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

Interim CI unblock: the `unit-tests` job's `-race -count=100` all-module suite runs **~33–34 min** on master against a 35-minute cap — effectively zero headroom, so any substantial PR tips it over and fails on timeout rather than on a real regression.

`bamlutils/llmhttp` alone accounts for **~15 min (~43% of the budget)**, which is why the wall-clock is so lopsided.

This raises `timeout-minutes` 35 → 50 for that job only, and rewrites the comment above it (it still described a "10-minute cap" and a value of 25, neither of which matched the file or reality).

**This is a stopgap, not a target.** The durable fix is sharding the job into a balanced parallel matrix, tracked in #656.

`standalone-modules` (`timeout-minutes: 15`) is unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

