### PR TITLE
fix(debaml): decline target-level constraint bundles (close pre-existing checkSupported b.Target over-claim)

### DIFF
--- a/.github/workflows/constraint-oracle.yml
+++ b/.github/workflows/constraint-oracle.yml
@@ -1,24 +1,32 @@
 name: Constraint Evaluator Oracle
 
-# Runs the de-BAML constraint-evaluator differential against a STOCK BAML
-# v0.223.0 generated client (internal/debaml/constraintoracle).
+# Runs the de-BAML STOCK-BAML-v0.223.0 CFFI differentials that live behind
+# //go:build integration under internal/: the constraint evaluator oracle
+# (internal/debaml/constraintoracle), the guard-removal ledger harness
+# (internal/debaml/guardledger), and the bamlprofile oracle
+# (internal/bamlprofile/profileoracle).
 #
-# Why its own workflow. The oracle lives behind //go:build integration in a
-# package under internal/, so neither of the existing lanes reaches it:
+# Why its own workflow. Every one of those packages is integration-tagged and
+# under internal/, so neither of the existing lanes reaches it:
 # `go build -tags integration ./...` skips _test.go files and testdata
 # directories, and the integration matrix runs `go test -tags=integration
 # ./integration/...` only. Without this job the fail-closed claim the evaluator
 # makes — never a boolean stock did not produce — would be unenforced on PRs,
 # which is exactly the gap this file closes.
 #
-# It is cheap: no Docker, no mock LLM, no container build. It links the stock
-# BAML CFFI (auto-downloaded on first use and cached here) and drives
-# Parse.<Method> over fixed assistant text — no network calls to a provider.
+# It is cheap: no Docker, no mock LLM, no container build. Each lane links the
+# stock BAML CFFI (auto-downloaded on first use and cached here) and drives
+# Parse.<Method> / CallFunctionParse over fixed assistant text — no network
+# calls to a provider, and no secrets.
 
 on:
   pull_request:
     paths:
       - "internal/debaml/**"
+      # The profile oracle's CFFI differentials and their recorded fixtures live
+      # under profileoracle/; the constraint façade they measure lives one level
+      # up in the same tree, so the whole package is a trigger.
+      - "internal/bamlprofile/**"
       - ".github/workflows/constraint-oracle.yml"
       - "go.mod"
       - "go.sum"
@@ -26,6 +34,7 @@ on:
     branches: [master]
     paths:
       - "internal/debaml/**"
+      - "internal/bamlprofile/**"
       - ".github/workflows/constraint-oracle.yml"
       - "go.mod"
       - "go.sum"
@@ -46,14 +55,21 @@ jobs:
     # round-10 integral-float `2.0 ** 63` promotion are only observable here.
     # A macOS/arm64 developer run is a weaker check, not an equivalent one.
     runs-on: ubuntu-latest
-    # The two integration steps below each carry their own 15-minute `go test`
+    # The THREE integration steps below each carry their own 15-minute `go test`
     # timeout, and a Go timeout is worth more than a job cancellation here: it
     # dumps every goroutine, which is the only diagnosis available for the CFFI
     # HANG cases this lane deliberately isolates (`is divisibleby(0)` takes the
-    # stock process down rather than returning). A 20-minute job budget could
-    # pre-empt the second step's timeout and throw that dump away, so the job
-    # gets room for both plus setup.
-    timeout-minutes: 45
+    # stock process down rather than returning). An Actions cancellation throws
+    # that dump away.
+    #
+    # THE BUDGET MUST EXCEED THE SUM OF THE INNER GO TIMEOUTS, so the inner
+    # timeout always fires first and the dump always survives. 3 x 15m = 45m of
+    # inner budget, plus ~15m of headroom for checkout/setup/vet/the unit step
+    # and for the dump itself to be written and uploaded. At exactly 45 a hung
+    # first or second lane would starve the third of its own diagnostic timeout —
+    # which is how this number went from 45 to 60 when the profileoracle lane was
+    # added. Any future step with its own `-timeout` must raise this too.
+    timeout-minutes: 60
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7.0.0
@@ -73,9 +89,9 @@ jobs:
           key: baml-cffi-0.223.0-${{ runner.os }}
 
       - name: Compile the integration-tagged tree
-        # Cheap guard that the oracle's own sources still build under the tag,
-        # independent of whether the run below gets that far.
-        run: go vet -tags integration ./internal/debaml/...
+        # Cheap guard that the oracles' own sources still build under the tag,
+        # independent of whether the runs below get that far.
+        run: go vet -tags integration ./internal/debaml/... ./internal/bamlprofile/...
 
       - name: Constraint evaluator differential vs stock BAML v0.223.0
         # The load-bearing assertion is TestConstraintProfileIsFailClosed: for
@@ -102,6 +118,26 @@ jobs:
         env:
           CGO_ENABLED: "1"
         run: go test -tags integration -count=1 -v -timeout 15m ./internal/debaml/guardledger/
+
+      - name: bamlprofile oracle vs stock BAML v0.223.0
+        # The third CFFI differential, and the one that makes the de-BAML
+        # TARGET-LEVEL constraint gate an enforced claim rather than an opt-in
+        # one. TestStockTargetLevelConstraintDispositionAndNativeDecline builds
+        # each constrained return type as real BAML source, parses it through the
+        # untouched v0.223 runtime (CallFunctionParse -> run_user_checks ->
+        # validate_asserts), and asserts internal/debaml DECLINES the equivalent
+        # bundle beside it — so "native no longer serves where stock raises" is
+        # measured on every PR instead of asserted in a report. Without this step
+        # the test is integration-tagged under internal/ and no lane reaches it:
+        # unit-tests runs untagged, the integration matrix runs ./integration/...
+        # only, and the two steps above name their packages explicitly.
+        #
+        # The whole package runs, not just that test: the prompt/fault/constraint
+        # differentials beside it are the same shape of stock-CFFI claim and were
+        # equally unenforced.
+        env:
+          CGO_ENABLED: "1"
+        run: go test -tags=integration -count=1 -v -timeout 15m ./internal/bamlprofile/profileoracle/
 
       - name: Constraint evaluator unit lane
         # The CGO-free half of the same claim, so a guard cannot be removed

--- a/internal/bamlprofile/profileoracle/target_constraint_integration_test.go
+++ b/internal/bamlprofile/profileoracle/target_constraint_integration_test.go
@@ -1,0 +1,798 @@
+//go:build integration
+
+package profileoracle
+
+// Stock BAML v0.223.0 differential for the de-BAML TARGET-LEVEL constraint gate.
+//
+// WHAT IT PROVES, and why it lives here rather than in internal/debaml.
+// internal/debaml's support gate now declines any bundle carrying a constraint on
+// `b.Target` (checkSupportedFields -> checkTypeNoConstraints). That gate closed a
+// real over-claim, but "over-claim" is a statement about what STOCK does, and no
+// unit test in internal/debaml can make it: the native constraint evaluator's
+// verdict is not stock's parse verdict. This package already links the untouched
+// v0.223 runtime through CFFI and parses through CallFunctionParse — BAML's real
+// coercer, run_user_checks -> evaluate_predicate -> validate_asserts — so the
+// stock half is MEASURED here and the native half is asserted beside it.
+//
+// THE MEASUREMENT CAME FIRST, AND IT CORRECTED THE STORY. A target-level
+// constraint does not have one stock behaviour, it has three, and only the first
+// is an out-claim of the kind "native served where BAML raises":
+//
+//   - RAISES — a bare `int` return and a LIST-LEVEL constraint both reject the
+//     parse with "Assertions failed.". Native served the value. That is the
+//     out-claim the gate removes.
+//   - SERVES A DIFFERENT VALUE — a constrained list ELEMENT does NOT reject.
+//     coerce_array DROPS each element that fails, so stock returns `[]` where
+//     native returned `[1,2]`. Still an out-claim, in value rather than in
+//     outcome.
+//   - SERVES THE SAME VALUE — a bare `string` return skips constraints entirely
+//     (measured by [TestStockSkipsConstraintsOnBareStringReturn]), so native's
+//     served value MATCHED stock's. Declining it is NOT an out-claim fix; it is
+//     plain over-decline, which the parity principle permits and which this test
+//     records as such rather than dressing up.
+//
+// Writing the bare-string row as "stock would have raised" would contradict this
+// package's own measurement, so each row states its measured disposition and the
+// assertions follow from it.
+
+import (
+	"bytes"
+	"context"
+	stdjson "encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"testing"
+
+	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/debaml"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// stockTargetDisposition is what stock v0.223 does with a target-level
+// constraint, as measured by this test.
+type stockTargetDisposition string
+
+const (
+	// stockRaises: the parse is rejected — "Assertions failed."
+	stockRaises stockTargetDisposition = "raises"
+	// stockServes: the parse succeeds; wantServed is the document it yields.
+	stockServes stockTargetDisposition = "serves"
+)
+
+// targetConstraintCase pairs ONE .baml return type carrying a target-level
+// constraint with the internal/schema Bundle that lowers to the same shape, so
+// the stock leg and the native leg are talking about the same schema.
+//
+// bundle is hand-built rather than lowered from the source: BAML source ->
+// Bundle is the introspection pipeline, not something a differential should
+// depend on. The correspondence is instead held by the SHAPE assertions below
+// (each case pins its target Kind and the exact constraints the Bundle declares)
+// plus the served-value comparison for the stockServes rows — where native's own
+// coercion of the same raw is compared against the bytes stock actually returned.
+type targetConstraintCase struct {
+	name string
+	// returnType is spliced into `function <fn>() -> <returnType>`.
+	returnType string
+	// bareReturnType is the SAME shape with the constraint removed. It gives the
+	// stock leg a constraint-free CONTROL for the same raw, which is what lets a
+	// divergence be ATTRIBUTED to the constraint instead of merely observed —
+	// see the three-way rule in [classifyTargetConstraintRow].
+	bareReturnType string
+	// decls is extra BAML declared before the function (a type alias, when the
+	// constraint sits on a list ELEMENT — BAML has no inline spelling for that).
+	decls string
+	// raw is the response text handed to CallFunctionParse and to native.
+	raw string
+
+	disposition stockTargetDisposition
+	// wantServedJSON is stock's parsed value, JSON-encoded, for a stockServes
+	// row. JSON and not fmt %v: %v is a lossy Go rendering that cannot be
+	// compared with native's JSON without discarding delimiters, and discarding
+	// them is what would let `[1 2]` and `[12]` collapse into each other.
+	wantServedJSON string
+	// wantBareServedJSON is the constraint-free control's value, JSON-encoded.
+	wantBareServedJSON string
+
+	// bundle is the native-side equivalent, and wantTargetKind pins that it is
+	// the shape the return type spells.
+	bundle         func() *schema.Bundle
+	wantTargetKind schema.TypeKind
+	// wantNativeWouldServe is what native's coercer produces for raw — the value
+	// native served while the gate admitted this bundle. It is not trusted: the
+	// test DERIVES it by running ParseStaticBundle over the constraint-stripped
+	// twin of bundle (native's coercer never reads Meta.Constraints, so the twin
+	// coerces identically to what the constrained bundle served while admitted)
+	// and requires the two to agree.
+	wantNativeWouldServe string
+	// outClaim records whether native's admitted behaviour diverged from stock
+	// BECAUSE OF THE CONSTRAINT. Re-derived at runtime from the three measured
+	// values, so a row cannot claim an out-claim its own numbers do not show.
+	outClaim bool
+}
+
+func targetConstraintCases() []targetConstraintCase {
+	strT := func() schema.Type {
+		return schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveString}
+	}
+	intT := func() schema.Type {
+		return schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt}
+	}
+	assert := func(t schema.Type, label, expr string) schema.Type {
+		t.Meta.Constraints = append(append([]schema.Constraint(nil), t.Meta.Constraints...),
+			schema.Constraint{Level: schema.ConstraintAssert, Expression: expr, Label: &label})
+		return t
+	}
+	ptr := func(t schema.Type) *schema.Type { return &t }
+	bundle := func(target schema.Type) func() *schema.Bundle {
+		return func() *schema.Bundle { return &schema.Bundle{Target: target} }
+	}
+
+	return []targetConstraintCase{
+		{
+			// The headline row: a top-level @assert stock genuinely FAILS. Native
+			// served `5`; stock rejects the parse. Declining restores the BAML
+			// fallback that raises.
+			name:                 "bare-int-return-assert",
+			returnType:           "int @assert(f, {{ false }})",
+			bareReturnType:       "int",
+			raw:                  "5",
+			disposition:          stockRaises,
+			wantBareServedJSON:   "5",
+			bundle:               bundle(assert(intT(), "f", "false")),
+			wantTargetKind:       schema.TypePrimitive,
+			wantNativeWouldServe: "5",
+			outClaim:             true,
+		},
+		{
+			// The constraint on the LIST ITSELF, not its element. Also raises.
+			name:                 "target-list-level-assert",
+			returnType:           "int[] @assert(f, {{ false }})",
+			bareReturnType:       "int[]",
+			raw:                  "[1,2]",
+			disposition:          stockRaises,
+			wantBareServedJSON:   "[1,2]",
+			bundle:               bundle(assert(schema.Type{Kind: schema.TypeList, Elem: ptr(intT())}, "f", "false")),
+			wantTargetKind:       schema.TypeList,
+			wantNativeWouldServe: "[1,2]",
+			outClaim:             true,
+		},
+		{
+			// The constrained list ELEMENT. It does NOT raise: coerce_array drops
+			// every element whose coercion fails, so stock serves the EMPTY list
+			// where native served both. An out-claim in value — and attributable,
+			// because the constraint-free control serves both elements too.
+			name:                 "target-list-element-assert",
+			returnType:           "TCBigNum[]",
+			bareReturnType:       "int[]",
+			decls:                "type TCBigNum = int @assert(big, {{ this > 100 }})\n",
+			raw:                  "[1,2]",
+			disposition:          stockServes,
+			wantServedJSON:       "[]",
+			wantBareServedJSON:   "[1,2]",
+			bundle:               bundle(schema.Type{Kind: schema.TypeList, Elem: ptr(assert(intT(), "big", "this > 100"))}),
+			wantTargetKind:       schema.TypeList,
+			wantNativeWouldServe: "[1,2]",
+			outClaim:             true,
+		},
+		{
+			// The bare-`string` return, and the reason this test exists in this
+			// shape. Stock SKIPS constraints on that route
+			// ([TestStockSkipsConstraintsOnBareStringReturn]), so the constraint
+			// changes NOTHING about what it serves — the control below returns the
+			// identical document. NOT an out-claim: declining it is over-decline,
+			// safe under the parity principle but not a fix for anything the
+			// constraint caused.
+			//
+			// The raw is QUOTED. Stock's jsonish accepts a bare `hello`, but
+			// native's static extractor requires a cleanly-claimable JSON candidate
+			// and declines an unquoted token — which would make the twin decline for
+			// a reason that has nothing to do with constraints.
+			//
+			// Stock's string short-circuit then hands that raw text back VERBATIM,
+			// quotes included, so its value is the 7-character string `"hello"`
+			// while native's JSON decodes to the 5-character `hello`. That is a real
+			// representation difference on the bare-string route, and it is present
+			// WITH AND WITHOUT the constraint — which is precisely why the
+			// classification consults the control instead of comparing native
+			// against the constrained leg alone. An earlier comparator papered over
+			// it by stripping quotes before comparing, which is the lossiness this
+			// row now documents rather than hides.
+			name:                 "bare-string-return-assert",
+			returnType:           `string @assert(f, {{ false }})`,
+			bareReturnType:       "string",
+			raw:                  `"hello"`,
+			disposition:          stockServes,
+			wantServedJSON:       `"\"hello\""`,
+			wantBareServedJSON:   `"\"hello\""`,
+			bundle:               bundle(assert(strT(), "f", "false")),
+			wantTargetKind:       schema.TypePrimitive,
+			wantNativeWouldServe: `"hello"`,
+			outClaim:             false,
+		},
+	}
+}
+
+// classifyTargetConstraintRow decides, from three MEASURED values, whether
+// native's admitted behaviour diverged from stock BECAUSE OF THE CONSTRAINT.
+//
+// A raise is unambiguous: stock produced no value at all, so anything native
+// served is an out-claim.
+//
+// For a serving row the question is attribution, and one comparison cannot
+// answer it. Native and stock can differ for reasons the constraint did not
+// cause — the bare-string route hands back the raw text verbatim, quotes
+// included, where native's JSON decodes them away, with or without any
+// constraint. Charging that to the constraint gate would be a false claim of
+// exactly the kind rounds 2-4 removed. So the CONTROL decides:
+//
+//   - native == stock(constrained)                  -> agreement, no out-claim;
+//   - native != stock(constrained) and
+//     native == stock(unconstrained)                -> the constraint caused the
+//     divergence: native served what BAML serves WITHOUT it. OUT-CLAIM;
+//   - native != stock(constrained) and
+//     native != stock(unconstrained)                -> native differs from BAML
+//     on this route regardless of the constraint. Not attributable to this gate,
+//     so not an out-claim it removed.
+//
+// It is the same test the optional-target shape was dropped under: a difference
+// that survives removing the constraint was never part of the gap.
+func classifyTargetConstraintRow(disposition stockTargetDisposition, nativeJSON, stockJSON, bareJSON []byte) (bool, string, error) {
+	if disposition == stockRaises {
+		return true, "stock produced no value at all", nil
+	}
+	agreesWithStock, err := sameServedDocument(nativeJSON, stockJSON)
+	if err != nil {
+		return false, "", err
+	}
+	if agreesWithStock {
+		return false, "native served exactly what stock served", nil
+	}
+	agreesWithControl, err := sameServedDocument(nativeJSON, bareJSON)
+	if err != nil {
+		return false, "", err
+	}
+	if agreesWithControl {
+		return true, "native served what stock serves WITHOUT the constraint", nil
+	}
+	return false, "native differs from stock with AND without the constraint — a route-level " +
+		"difference this gate does not cause", nil
+}
+
+// TestStockTargetLevelConstraintDispositionAndNativeDecline is the two-leg proof
+// behind the target-level gate.
+//
+// PER ROW, in order:
+//
+//  1. STOCK, LIVE. Parse the row's raw through the untouched v0.223 runtime and
+//     require the measured disposition — a classified "Assertions failed."
+//     rejection, or a parse whose value equals the pinned document. This is a
+//     measurement, not a golden: a stock version that changed any of these turns
+//     this red rather than letting the narrative rot.
+//  2. NATIVE DECLINES. The equivalent Bundle is refused by
+//     SupportsNativeFinalBundle AND ParseStaticBundle with the
+//     ErrDeBAMLParseUnsupported fallback sentinel, so the call routes to BAML —
+//     which is the engine that produced leg 1.
+//  3. THE CLASSIFICATION IS DERIVED. Whether the row was an out-claim is
+//     recomputed from stock's own outcome versus what native served, and checked
+//     against the row's claim. A row cannot assert "native out-claimed" unless
+//     stock either rejected or returned different bytes.
+//
+// Step 3 is what keeps this honest about the bare-string row: it is carried here
+// as a decline whose stock counterpart AGREES with what native served, i.e. an
+// over-decline, and the test fails if anyone relabels it an out-claim.
+func TestStockTargetLevelConstraintDispositionAndNativeDecline(t *testing.T) {
+	assertBAMLAuthority(t)
+	ensureConstraintTypeMap()
+
+	cases := targetConstraintCases()
+	if len(cases) != 4 {
+		t.Fatalf("target-level cases = %d, want 4", len(cases))
+	}
+	// At least one row of each disposition, so neither arm of the switch below is
+	// vacuous, and at least one genuine out-claim — without which the test would
+	// prove the gate removed nothing.
+	var raises, serves, outClaims int
+	for _, c := range cases {
+		switch c.disposition {
+		case stockRaises:
+			raises++
+		case stockServes:
+			serves++
+		}
+		if c.outClaim {
+			outClaims++
+		}
+	}
+	if raises == 0 || serves == 0 {
+		t.Fatalf("cases cover raises=%d serves=%d; both dispositions must be exercised", raises, serves)
+	}
+	if outClaims == 0 {
+		t.Fatal("no case claims an out-claim; the gate would be removing nothing")
+	}
+	if outClaims == len(cases) {
+		t.Fatal("every case claims an out-claim; the safe-over-decline arm of the taxonomy would be " +
+			"unrepresented and a misattribution could not be caught")
+	}
+
+	files := map[string]string{
+		"clients.baml": clientSource(),
+		"types.baml":   typesBAMLSource(),
+	}
+	fnName := func(c targetConstraintCase) string { return "TC_" + sanitizeTargetCaseName(c.name) }
+	bareFnName := func(c targetConstraintCase) string { return "TCbare_" + sanitizeTargetCaseName(c.name) }
+	fnSource := func(name, returnType string) string {
+		return "function " + name + "() -> " + returnType + " {\n" +
+			"  client " + clientName + "\n  prompt #\"\n" + constraintPromptBody + "\n\"#\n}\n"
+	}
+	for _, c := range cases {
+		// Each row contributes TWO functions: the constrained subject and the
+		// constraint-free CONTROL of the same shape. The control is what makes a
+		// divergence attributable rather than merely observed.
+		files["tc_"+sanitizeTargetCaseName(c.name)+".baml"] = c.decls +
+			fnSource(fnName(c), c.returnType) + "\n" +
+			fnSource(bareFnName(c), c.bareReturnType)
+	}
+	env := envVars()
+	rt, err := baml.CreateRuntime("./baml_src", files, env)
+	if err != nil {
+		t.Fatalf("CreateRuntime over the target-level cases: %v\n"+
+			"Every predicate must survive BAML's jinja parser, so a malformed one takes the whole project down.", err)
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			parse := func(fn string) (any, error) {
+				args := baml.BamlFunctionArguments{Kwargs: map[string]any{"text": c.raw, "stream": false}, Env: env}
+				encoded, encErr := args.Encode()
+				if encErr != nil {
+					t.Fatalf("encode parse args: %v", encErr)
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), constraintParseTimeout)
+				defer cancel()
+				return rt.CallFunctionParse(ctx, fn, encoded)
+			}
+
+			// --- leg 1: stock, live, WITH the constraint ----------------------
+			result, stockErr := parse(fnName(c))
+
+			var stockJSON []byte
+			switch c.disposition {
+			case stockRaises:
+				if stockErr == nil {
+					t.Fatalf("stock v0.223 PARSED %v; this row is pinned as an assert REJECTION.\n"+
+						"The measurement is stale — the gate's out-claim story for this shape must be re-derived.", result)
+				}
+				if errors.Is(stockErr, context.DeadlineExceeded) {
+					t.Fatalf("stock CallFunctionParse did not return within %s; that is a Rust panic unwinding "+
+						"the tokio worker, not a classifiable outcome", constraintParseTimeout)
+				}
+				kind, ok := classifyStockConstraintError(stockErr)
+				if !ok {
+					t.Fatalf("stock failed with an error this harness cannot classify as a constraint outcome: %v\n"+
+						"An unrecognized parse failure is not evidence the CONSTRAINT rejected anything.", stockErr)
+				}
+				if kind != ConstraintAssertFailed {
+					t.Fatalf("stock failed as %s, want %s (%v)", kind, ConstraintAssertFailed, stockErr)
+				}
+			case stockServes:
+				if stockErr != nil {
+					t.Fatalf("stock v0.223 REJECTED the parse (%v); this row is pinned as serving %s.\n"+
+						"The measurement is stale.", stockErr, c.wantServedJSON)
+				}
+				var jerr error
+				stockJSON, jerr = stockServedJSON(result)
+				if jerr != nil {
+					t.Fatalf("%v", jerr)
+				}
+				if got := string(stockJSON); got != c.wantServedJSON {
+					t.Fatalf("stock served %s, want %s; the row's classification is derived from "+
+						"this value, so it must be re-measured", got, c.wantServedJSON)
+				}
+			}
+
+			// --- leg 1b: stock, live, WITHOUT the constraint (the control) ----
+			// The control must always PARSE: it is the same shape minus the
+			// predicate, so a rejection here means the fixture — not the
+			// constraint — is what stock is objecting to, and no attribution the
+			// classifier makes below would mean anything.
+			bareResult, bareErr := parse(bareFnName(c))
+			if bareErr != nil {
+				t.Fatalf("the constraint-FREE control `-> %s` was REJECTED by stock (%v); the row cannot "+
+					"attribute anything to its constraint", c.bareReturnType, bareErr)
+			}
+			bareJSON, jerr := stockServedJSON(bareResult)
+			if jerr != nil {
+				t.Fatalf("%v", jerr)
+			}
+			if got := string(bareJSON); got != c.wantBareServedJSON {
+				t.Fatalf("the constraint-free control served %s, want %s; attribution is derived from "+
+					"this value, so it must be re-measured", got, c.wantBareServedJSON)
+			}
+
+			// --- leg 2: native declines ---------------------------------------
+			b := c.bundle()
+			if got := b.Target.Kind; got != c.wantTargetKind {
+				t.Fatalf("the native Bundle's target kind is %q, want %q; it no longer mirrors the "+
+					"return type %q the stock leg parsed", got, c.wantTargetKind, c.returnType)
+			}
+			if err := debaml.SupportsNativeFinalBundle(b); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Errorf("SupportsNativeFinalBundle = %v; want the ErrDeBAMLParseUnsupported fallback sentinel — "+
+					"a target-level constraint must route this call to BAML", err)
+			}
+			res, perr := debaml.ParseStaticBundle(context.Background(), b, c.raw)
+			if !errors.Is(perr, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Errorf("ParseStaticBundle = (%s, %v); want the fallback sentinel", res.JSON, perr)
+			}
+			if len(res.JSON) != 0 {
+				t.Errorf("a declining ParseStaticBundle still returned %s", res.JSON)
+			}
+
+			// --- leg 3: the classification, derived ---------------------------
+			// WHAT NATIVE SERVED, run rather than quoted. Native's coercer never
+			// reads Meta.Constraints, so the constraint-stripped twin coerces raw
+			// exactly as the constrained bundle did while the gate admitted it.
+			// Deriving it closes the hole a literal would leave: the row cannot
+			// claim native produced something it did not.
+			twin, removed := withoutTargetConstraints(b)
+			if removed == 0 {
+				t.Fatalf("the case declares no target constraint; it cannot be about the target gate")
+			}
+			twinRes, twinErr := debaml.ParseStaticBundle(context.Background(), twin, c.raw)
+			if twinErr != nil {
+				t.Fatalf("the constraint-stripped twin DECLINED (%v); it must serve, both as the "+
+					"no-over-decline control and as the source of what native served", twinErr)
+			}
+			if got := string(twinRes.JSON); got != c.wantNativeWouldServe {
+				t.Fatalf("native serves %s for %s, not the pinned %s; the classification "+
+					"is derived from this value", got, c.raw, c.wantNativeWouldServe)
+			}
+			nativeWouldServe := twinRes.JSON
+
+			derived, why, cerr := classifyTargetConstraintRow(c.disposition, nativeWouldServe, stockJSON, bareJSON)
+			if cerr != nil {
+				t.Fatalf("classifying the row: %v", cerr)
+			}
+			if derived != c.outClaim {
+				t.Fatalf("the row claims outClaim=%v, but the measurements derive %v: %s.\n"+
+					"  stock(constrained) = %s\n  stock(control)     = %s\n  native served      = %s",
+					c.outClaim, derived, why, stockOrRaised(c.disposition, stockJSON), bareJSON, nativeWouldServe)
+			}
+			if c.outClaim {
+				t.Logf("OUT-CLAIM REMOVED (%s): stock %s for `-> %s` on %s; native served %s while the gate "+
+					"admitted it, and now declines to BAML.", why, c.disposition, c.returnType, c.raw, nativeWouldServe)
+			} else {
+				t.Logf("OVER-DECLINE (safe, not an out-claim fix) (%s): stock serves %s for `-> %s` on %s, "+
+					"control serves %s; the gate declines it anyway.",
+					why, stockJSON, c.returnType, c.raw, bareJSON)
+			}
+		})
+	}
+}
+
+// stockOrRaised renders the constrained leg's outcome for a failure message: a
+// raising row has no served document, and printing an empty one would read as
+// "it served nothing" rather than "it errored".
+func stockOrRaised(d stockTargetDisposition, stockJSON []byte) string {
+	if d == stockRaises {
+		return "<raised>"
+	}
+	return string(stockJSON)
+}
+
+// withoutTargetConstraints returns a copy of b whose target type tree carries no
+// constraints, plus the number removed. Only the target is walked: these bundles
+// have no classes or enums, and the target is the whole subject.
+func withoutTargetConstraints(b *schema.Bundle) (*schema.Bundle, int) {
+	removed := 0
+	var strip func(schema.Type) schema.Type
+	strip = func(t schema.Type) schema.Type {
+		removed += len(t.Meta.Constraints)
+		t.Meta.Constraints = nil
+		if t.Elem != nil {
+			e := strip(*t.Elem)
+			t.Elem = &e
+		}
+		if t.Key != nil {
+			k := strip(*t.Key)
+			t.Key = &k
+		}
+		if t.Value != nil {
+			v := strip(*t.Value)
+			t.Value = &v
+		}
+		if t.Union != nil {
+			u := *t.Union
+			u.Variants = make([]schema.Type, len(t.Union.Variants))
+			for i := range t.Union.Variants {
+				u.Variants[i] = strip(t.Union.Variants[i])
+			}
+			t.Union = &u
+		}
+		return t
+	}
+	return &schema.Bundle{Target: strip(b.Target)}, removed
+}
+
+// sameServedDocument compares two served documents STRUCTURALLY and with EXACT
+// numeric semantics.
+//
+// Both sides are decoded into `any` trees and walked by [equalServedValue], so
+// the comparison is over JSON structure and values rather than over spelling: a
+// list is a list, a string is a string, whitespace and object-key order do not
+// matter, and `5` equals `5.0`.
+//
+// IT REPLACES TWO WEAKER COMPARATORS, and both failures pointed the same way —
+// two genuinely different served documents reading as agreement, in the one
+// place the taxonomy claims to be DERIVED:
+//
+//   - the first version deleted quotes, commas and spaces from each side to
+//     reconcile stock's Go `%v` rendering with native's JSON, which cannot tell
+//     `[1 2]` from `[12]`;
+//   - the second decoded both sides but compared with reflect.DeepEqual over
+//     plain `encoding/json` output. That stores EVERY JSON number as float64, so
+//     `9007199254740992` and `9007199254740993` — distinct integers either side
+//     of 2^53, and native's int path carries exact int64 — collapsed into one
+//     float64 and compared equal.
+//
+// So decoding alone was not enough: the decode must PRESERVE the number, which
+// is why [decodeServedDocument] uses json.Decoder.UseNumber and the walk
+// compares json.Number values as exact rationals. Raw json.Number STRING
+// equality would not do either — it would make `5` differ from `5.0` and break
+// the spelling-freedom contract this comparator deliberately keeps.
+//
+// A decode failure is returned, never swallowed. "It did not parse" is not
+// evidence of agreement.
+func sameServedDocument(a, b []byte) (bool, error) {
+	av, err := decodeServedDocument(a)
+	if err != nil {
+		return false, err
+	}
+	bv, err := decodeServedDocument(b)
+	if err != nil {
+		return false, err
+	}
+	return equalServedValue(av, bv)
+}
+
+// decodeServedDocument decodes one served document into an `any` tree whose
+// numbers are json.Number — the exact source text — rather than float64.
+//
+// It also rejects TRAILING DATA. `5 6` decoding to `5` and comparing equal to a
+// document that really is `5` would be the same kind of quiet agreement this
+// comparator exists to prevent.
+func decodeServedDocument(b []byte) (any, error) {
+	dec := stdjson.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", b, err)
+	}
+	if err := dec.Decode(new(any)); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("decode %s: trailing data after the document (%v)", b, err)
+	}
+	return v, nil
+}
+
+// equalServedValue walks two decoded trees. It is a hand-written walk rather
+// than reflect.DeepEqual because numbers need value equality, not
+// representation equality: json.Number is a string, so DeepEqual over it would
+// report `5` != `5.0`.
+//
+// An unexpected dynamic type is an ERROR, not `false`. UseNumber decoding can
+// only produce nil, bool, string, json.Number, []any and map[string]any, so
+// anything else means the input did not come from where this function assumes —
+// and answering "not equal" would be a guess.
+func equalServedValue(a, b any) (bool, error) {
+	switch av := a.(type) {
+	case nil:
+		return b == nil, nil
+	case bool:
+		bv, ok := b.(bool)
+		return ok && av == bv, nil
+	case string:
+		bv, ok := b.(string)
+		return ok && av == bv, nil
+	case stdjson.Number:
+		bv, ok := b.(stdjson.Number)
+		if !ok {
+			return false, nil
+		}
+		return equalJSONNumber(av, bv)
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			return false, nil
+		}
+		for i := range av {
+			eq, err := equalServedValue(av[i], bv[i])
+			if err != nil || !eq {
+				return false, err
+			}
+		}
+		return true, nil
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok || len(av) != len(bv) {
+			return false, nil
+		}
+		for k, v := range av {
+			w, present := bv[k]
+			if !present {
+				return false, nil
+			}
+			eq, err := equalServedValue(v, w)
+			if err != nil || !eq {
+				return false, err
+			}
+		}
+		return true, nil
+	default:
+		return false, fmt.Errorf("decoded tree holds %T, which UseNumber decoding cannot produce", a)
+	}
+}
+
+// equalJSONNumber compares two JSON numbers by EXACT value.
+//
+// big.Rat parses the literal decimal (including an exponent) with no precision
+// loss at any magnitude, so `5` == `5.0` and `1e2` == `100` while
+// `9007199254740992` != `9007199254740993`. float64 would lose the second pair
+// and int64 would reject the first.
+func equalJSONNumber(a, b stdjson.Number) (bool, error) {
+	ar, ok := new(big.Rat).SetString(a.String())
+	if !ok {
+		return false, fmt.Errorf("JSON number %q is not an exact rational", a.String())
+	}
+	br, ok := new(big.Rat).SetString(b.String())
+	if !ok {
+		return false, fmt.Errorf("JSON number %q is not an exact rational", b.String())
+	}
+	return ar.Cmp(br) == 0, nil
+}
+
+// TestSameServedDocumentIsNotLossy pins the comparator against the failure modes
+// its two predecessors had. Both lost information in the same DIRECTION —
+// distinct documents reading as agreement — which is the direction that would
+// let [classifyTargetConstraintRow] miss a real value divergence.
+//
+//   - The string normalizer deleted quotes, commas and spaces, so `[1 2]` and
+//     `[12]` were both `[12]` and a two-element list equalled a one-element one.
+//   - The decode-then-reflect.DeepEqual version stored every number as float64,
+//     so `9007199254740992` and `9007199254740993` — either side of 2^53, and
+//     native's int path carries exact int64 — collapsed into one value.
+//
+// Both pairs are cases here, and both must be UNEQUAL.
+//
+// The equal cases are the other half of the claim, and they are what rules out
+// the cheap over-corrections: comparing raw json.Number strings would make `5`
+// differ from `5.0`, and comparing bytes would make whitespace and key order
+// significant. The comparator must see through JSON's spelling freedom while
+// still preserving value, so trading false agreement for false divergence fails
+// here just as loudly.
+func TestSameServedDocumentIsNotLossy(t *testing.T) {
+	cases := []struct {
+		name  string
+		a, b  string
+		equal bool
+	}{
+		// THE FIRST REGRESSION. Two genuinely different documents the string
+		// normalizer collapsed into one.
+		{"two-element list vs one-element list", `[1,2]`, `[12]`, false},
+		{"list vs concatenated string", `[1,2]`, `"12"`, false},
+		// A string whose CONTENT is a quoted string is not the same document as
+		// that string — exactly the bare-string route's stock-vs-native
+		// difference, which the old comparator erased.
+		{"quoted content vs bare content", `"\"hello\""`, `"hello"`, false},
+		{"empty list vs two-element list", `[]`, `[1,2]`, false},
+		{"empty list vs empty string", `[]`, `""`, false},
+		{"nested depth differs", `[[1]]`, `[1]`, false},
+		// THE SECOND REGRESSION. Adjacent integers just past 2^53: the same
+		// float64 once decoded, distinct as written, and distinct in native's
+		// int64 path. In a list, bare, and under an object key, because the walk
+		// reaches the number by a different route in each.
+		{"adjacent integers past 2^53 in a list", `[9007199254740992]`, `[9007199254740993]`, false},
+		{"adjacent integers past 2^53, bare", `9007199254740992`, `9007199254740993`, false},
+		{"adjacent integers past 2^53 under a key", `{"n":9007199254740993}`, `{"n":9007199254740992}`, false},
+		// Spelling freedom that must NOT read as divergence. These are what a raw
+		// json.Number string comparison would get wrong.
+		{"whitespace is not structure", `[1, 2]`, `[1,2]`, true},
+		{"int and float spelling of one number", `5`, `5.0`, true},
+		{"exponent spelling of one number", `1e2`, `100`, true},
+		// Value equality holds at large magnitude too — the exact-rational
+		// comparison is not a special case bolted onto small numbers.
+		{"large integer and its decimal spelling", `9007199254740993`, `9007199254740993.0`, true},
+		{"object key order", `{"a":1,"b":2}`, `{"b":2,"a":1}`, true},
+		{"identical strings", `"hello"`, `"hello"`, true},
+	}
+	if len(cases) != 15 {
+		t.Fatalf("comparator cases = %d, want 15", len(cases))
+	}
+	var equalCases, unequalCases int
+	for _, c := range cases {
+		if c.equal {
+			equalCases++
+		} else {
+			unequalCases++
+		}
+		t.Run(c.name, func(t *testing.T) {
+			got, err := sameServedDocument([]byte(c.a), []byte(c.b))
+			if err != nil {
+				t.Fatalf("sameServedDocument(%s, %s): %v", c.a, c.b, err)
+			}
+			if got != c.equal {
+				t.Errorf("sameServedDocument(%s, %s) = %v, want %v", c.a, c.b, got, c.equal)
+			}
+			// The comparison must not depend on argument order.
+			rev, err := sameServedDocument([]byte(c.b), []byte(c.a))
+			if err != nil {
+				t.Fatalf("sameServedDocument(%s, %s): %v", c.b, c.a, err)
+			}
+			if rev != got {
+				t.Errorf("sameServedDocument is not symmetric for %s / %s: %v then %v", c.a, c.b, got, rev)
+			}
+		})
+	}
+	if equalCases == 0 || unequalCases == 0 {
+		t.Fatalf("cases cover equal=%d unequal=%d; a comparator test that only exercises one "+
+			"answer cannot distinguish a correct comparator from a constant", equalCases, unequalCases)
+	}
+
+	// A decode failure is an ERROR, never a silent "not equal" — "it did not
+	// parse" is not evidence about the documents.
+	if _, err := sameServedDocument([]byte(`{`), []byte(`{}`)); err == nil {
+		t.Error("sameServedDocument accepted undecodable input; a decode failure must surface")
+	}
+	// So is trailing data: decoding only the prefix and calling it equal to a
+	// document that really is that prefix would be the same quiet agreement.
+	if _, err := sameServedDocument([]byte(`5 6`), []byte(`5`)); err == nil {
+		t.Error("sameServedDocument accepted trailing data; the prefix must not stand in for the document")
+	}
+
+	// The exact-value claim, checked at the seam rather than only through the
+	// document API: adjacent integers past 2^53 must not be one number, and the
+	// spelling-freedom pair must be.
+	distinct, err := equalJSONNumber(stdjson.Number("9007199254740992"), stdjson.Number("9007199254740993"))
+	if err != nil {
+		t.Fatalf("equalJSONNumber on adjacent 2^53 integers: %v", err)
+	}
+	if distinct {
+		t.Error("equalJSONNumber says 9007199254740992 == 9007199254740993; the comparison went " +
+			"through float64 instead of an exact rational")
+	}
+	same, err := equalJSONNumber(stdjson.Number("5"), stdjson.Number("5.0"))
+	if err != nil {
+		t.Fatalf("equalJSONNumber on 5 vs 5.0: %v", err)
+	}
+	if !same {
+		t.Error("equalJSONNumber says 5 != 5.0; the comparison is over the literal text, which breaks " +
+			"the spelling-freedom contract")
+	}
+}
+
+// stockServedJSON re-encodes a stock parse result as JSON so it can be compared
+// with native's bytes on equal terms. The stock client decodes into Go values
+// (string, []int64, ...); JSON is the common ground both legs already speak, and
+// encoding rather than fmt-rendering is what keeps the comparison lossless.
+func stockServedJSON(v any) ([]byte, error) {
+	out, err := stdjson.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("re-encode stock result %T: %w", v, err)
+	}
+	return out, nil
+}
+
+// sanitizeTargetCaseName turns a case name into a BAML identifier fragment.
+func sanitizeTargetCaseName(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r == '-' {
+			out = append(out, '_')
+			continue
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}

--- a/internal/debaml/boundary_decline_test.go
+++ b/internal/debaml/boundary_decline_test.go
@@ -72,6 +72,10 @@ func stringType() schema.Type {
 	return schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveString}
 }
 
+func intType() schema.Type {
+	return schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt}
+}
+
 func constrained(t schema.Type, level schema.ConstraintLevel, expr string) schema.Type {
 	t.Meta.Constraints = append(t.Meta.Constraints, schema.Constraint{Level: level, Expression: expr})
 	return t
@@ -81,9 +85,37 @@ func constrained(t schema.Type, level schema.ConstraintLevel, expr string) schem
 // constraint forces native fallback — native never evaluates constraints, so it
 // declines regardless of level (check vs assert) or whether the predicate would
 // pass or fail. Covers the scope's constraint sub-cases at the decline gate:
-// scalar field, list (and list element), class-level, and enum-level.
+// scalar field, list (and list element), class-level, enum-level, and — since the
+// b.Target walk landed — the RETURN TYPE itself and its list element.
 func TestNativeDeclines_Constraints(t *testing.T) {
 	label := func(s string) *string { return &s }
+
+	// TARGET-LEVEL. `function F() -> T @assert(...)` declares its predicate on
+	// b.Target, which no class or enum entry can report; before checkSupportedFields
+	// walked the target these bundles were ADMITTED and native served a value BAML
+	// would not. What BAML does instead varies by shape — a bare `int` return
+	// rejects the parse, a bare `string` return skips the constraint entirely — and
+	// that taxonomy is measured live against stock v0.223 by
+	// [TestTargetLevelConstraintDeclineClassification] and profileoracle's
+	// TestStockTargetLevelConstraintDispositionAndNativeDecline. The GATE does not
+	// care which: it declines on the constraint alone, at either level.
+	requireCheckSupportedDeclines(t, &schema.Bundle{
+		Target: constrained(intType(), schema.ConstraintAssert, "false"),
+	}, "@assert on the target type")
+	requireCheckSupportedDeclines(t, &schema.Bundle{
+		Target: constrained(stringType(), schema.ConstraintAssert, `this == "expected"`),
+	}, "@assert on a bare-string target type")
+
+	targetCheckType := stringType()
+	targetCheckType.Meta.Constraints = []schema.Constraint{{Level: schema.ConstraintCheck, Expression: `this == "expected"`, Label: label("expected")}}
+	requireCheckSupportedDeclines(t, &schema.Bundle{Target: targetCheckType}, "@check on the target type")
+
+	// A constrained ELEMENT of a target LIST — the same gap one structural step in,
+	// so the walk is pinned as a tree walk rather than a single-node check.
+	requireCheckSupportedDeclines(t, &schema.Bundle{Target: schema.Type{
+		Kind: schema.TypeList,
+		Elem: ptr(constrained(intType(), schema.ConstraintAssert, "this > 100")),
+	}}, "@assert on a target list element")
 
 	// @assert on a scalar field.
 	requireCheckSupportedDeclines(t, declineBundle(schema.ClassDef{
@@ -137,6 +169,36 @@ func TestNativeDeclines_Constraints(t *testing.T) {
 		Fields: []schema.ClassField{scalarField("s", stringType()), scalarField("xs", schema.Type{Kind: schema.TypeList, Elem: ptr(stringType())})},
 	})); err != nil {
 		t.Fatalf("constraint-free control: checkSupported unexpectedly declined: %v", err)
+	}
+
+	// TARGET-LEVEL CONTROL, and the reason the target walk is a decline-MORE change
+	// rather than a blanket target reject. Each of these is the SAME target shape as
+	// a decline above with the constraint REMOVED, plus the two target shapes the
+	// static corpus actually serves (a bare string return, a class return). All must
+	// still ADMIT — the target walk looks at Meta.Constraints and nothing else, so it
+	// must not import checkSupportedType's coercion-scope declines into a position
+	// that was never subject to them.
+	unconstrained := []struct {
+		name   string
+		target schema.Type
+	}{
+		{"bare string return", stringType()},
+		{"class return", schema.Type{Kind: schema.TypeClass, Name: "Root", Mode: schema.NonStreaming}},
+		{"list of string return", schema.Type{Kind: schema.TypeList, Elem: ptr(stringType())}},
+		{"list of int return", schema.Type{Kind: schema.TypeList, Elem: ptr(intType())}},
+		{"map return", schema.Type{Kind: schema.TypeMap, Key: ptr(stringType()), Value: ptr(intType())}},
+		{"optional string return", schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{stringType()}, Nullable: true}}},
+	}
+	if len(unconstrained) != 6 {
+		t.Fatalf("unconstrained target controls = %d, want 6", len(unconstrained))
+	}
+	for _, u := range unconstrained {
+		b := declineBundle(schema.ClassDef{Fields: []schema.ClassField{scalarField("s", stringType())}})
+		b.Target = u.target
+		if err := checkSupported(b); err != nil {
+			t.Errorf("unconstrained target %q: checkSupported DECLINED (%v); the target walk must "+
+				"reject constraints only, never a shape", u.name, err)
+		}
 	}
 }
 

--- a/internal/debaml/constraint_state_collect_test.go
+++ b/internal/debaml/constraint_state_collect_test.go
@@ -21,17 +21,16 @@ package debaml
 // constraint_state_seam_test.go proves that with a go/ast walk over the whole
 // repo rather than a source-text grep: it re-derives this file's declared names
 // from the AST and fails if any non-test .go file so much as mentions one.
-// Production internal/debaml is byte-identical to the base revision; nothing in
-// this slice changes coerce's return, checkSupported, Parse, ParseStaticBundle,
-// admission, or any public surface. Constraint-bearing bundles still decline —
-// [constraintCoercionRun.ProductionSupport] records that verdict on every run so
-// a fixture cannot quietly become admitted — with ONE documented exception: a
-// constraint declared on `b.Target` itself is currently ADMITTED, because
-// checkSupported never walks the target type. That is a pre-existing over-claim
-// at the base revision, granted an explicit temporary authority exception and
-// scheduled as its own separate "decline-more" production slice (#583); it is
-// asserted as a known-gap tripwire in constraint_state_test.go rather than
-// papered over, and the invariant is narrowed nowhere else.
+// Nothing in this collector changes coerce's return, checkSupported, Parse,
+// ParseStaticBundle, admission, or any public surface. Constraint-bearing bundles
+// decline — [constraintCoercionRun.ProductionSupport] records that verdict on
+// every run so a fixture cannot quietly become admitted — and that now holds with
+// NO exception. It briefly did not: a constraint declared on `b.Target` itself
+// was admitted, because checkSupported did not walk the target type. That
+// pre-existing over-claim was carried as a documented temporary exception and an
+// asserted known-gap tripwire while this TEST-ONLY collector landed; the
+// decline-more fix has since walked b.Target in checkSupportedFields, and
+// constraint_state_test.go asserts the whole invariant with nothing carved out.
 //
 // HOW IT STAYS HONEST ABOUT "THE SAME COERCION". The collector never
 // re-implements a canonicalization decision it could delegate. At every node it

--- a/internal/debaml/constraint_state_test.go
+++ b/internal/debaml/constraint_state_test.go
@@ -24,24 +24,25 @@ package debaml
 //     only, that checkSupported still refuses its bundle, so no state result can
 //     be misread as admission moving.
 //
-// THE ONE NARROWED INVARIANT, and it is narrowed NOWHERE ELSE. "Constraint-
-// bearing bundles still decline" holds for every shape in this file except one:
-// a constraint declared on `b.Target` ITSELF (a bare-string return type, or a
-// constrained element/value of a target list/map) is currently ADMITTED, because
-// checkSupported -> checkSupportedFields walks b.Enums and b.Classes and never
-// walks b.Target. That is a PRE-EXISTING over-claim at the base revision
-// 707b2419, not something this TEST-ONLY slice introduces or may fix; the
-// repository owner granted an explicit, documented, TEMPORARY authority
-// exception for it and scheduled the fix as its own separate "decline-more"
-// production slice. Tracked on #583.
-//
-// The exception is stated as an ASSERTED TRIPWIRE, not a silent log:
-// [TestKnownGap_TargetLevelConstraintAdmission] asserts the wrong behaviour on
-// purpose — including that native SERVES a value failing its own @assert — and
-// fails the moment the gate starts declining, so it is a canary for the fix.
-// [TestConstraintStateConstrainedBundlesAreStillRefused] hard-asserts the
-// unchanged invariant for every other shape, through checkSupported,
-// SupportsNativeFinalBundle AND ParseStaticBundle.
+// THE INVARIANT IS NOW UNNARROWED. "Constraint-bearing bundles still decline"
+// holds for EVERY shape in this file, with no exception. It did not always: a
+// constraint declared on `b.Target` ITSELF (a bare-string return type, or a
+// constrained element/value of a target list/map) used to be ADMITTED, because
+// checkSupported -> checkSupportedFields walked b.Enums and b.Classes and never
+// walked b.Target. That pre-existing over-claim was carried here as a documented,
+// temporary exception and an asserted tripwire while the collector slice (which
+// was TEST-ONLY and could not touch a gate) landed. The decline-more fix has since
+// walked the target in checkSupportedFields, the tripwire tripped as designed, and
+// its fixtures now live in the ordinary declining set:
+// [TestConstraintStateConstrainedBundlesAreStillRefused] hard-asserts EVERY
+// constrained shape — target-level included — through checkSupported,
+// SupportsNativeFinalBundle AND ParseStaticBundle, and
+// [TestTargetLevelConstraintDeclineClassification] keeps the closed gap's own
+// evidence: per shape, the exact value native WOULD have served, and which of
+// stock v0.223's three dispositions that value met — an out-claim removed, or
+// plain over-decline. The stock half of that is measured live through CFFI by
+// TestStockTargetLevelConstraintDispositionAndNativeDecline in
+// internal/bamlprofile/profileoracle, never inferred from the native evaluator.
 
 import (
 	"context"
@@ -246,12 +247,9 @@ func requireConstraintStateSkipped(t *testing.T, st *constraintCoercionState, wa
 //
 // IT IS DELIBERATELY ONE-DIRECTIONAL. No fixture that runs through this helper
 // may assert that a bundle is ACCEPTED; the safe direction is the only one it
-// checks. The single shape the gate does not reach — a constraint on `b.Target`
-// itself — is deliberately NOT routed through here. It is handled by
-// [TestKnownGap_TargetLevelConstraintAdmission], which asserts that wrong
-// behaviour on purpose as a documented, temporary exception (#583) and FAILS the
-// moment the gate starts declining, so the gap is a canary for its fix rather
-// than a silent log or a permanent lock.
+// checks. EVERY fixture in this file routes through it, including the
+// target-level ones: checkSupportedFields walks b.Target for constraints, so
+// there is no longer a constrained shape the gate fails to reach.
 func requireConstraintStateStillDeclines(t *testing.T, run *constraintCoercionRun) {
 	t.Helper()
 	got := run.ProductionSupport
@@ -272,25 +270,6 @@ func collectConstraintStateFixture(t *testing.T, b *schema.Bundle, raw string) *
 		t.Fatalf("collect(%s): %v", raw, err)
 	}
 	requireConstraintStateStillDeclines(t, run)
-	return run
-}
-
-// collectConstraintStateTargetLevelFixture is the collector entry for the ONE
-// fixture family whose constrained node cannot be nested: a bare-string RETURN
-// TYPE (that IS the route under test). It makes no assertion about
-// checkSupported here, because a target-level constraint falls under the single
-// documented exception to the non-admission invariant — the pre-existing
-// b.Target gap at 707b2419, tracked on #583 and scheduled as its own
-// decline-more slice. The gap is asserted, in full and on purpose, by
-// [TestKnownGap_TargetLevelConstraintAdmission]; duplicating a weaker version of
-// that assertion in this helper would spread the exception instead of confining
-// it to one named test.
-func collectConstraintStateTargetLevelFixture(t *testing.T, b *schema.Bundle, raw string) *constraintCoercionRun {
-	t.Helper()
-	run, err := collectConstraintCoercionState(b, raw)
-	if err != nil {
-		t.Fatalf("collect(%s): %v", raw, err)
-	}
 	return run
 }
 
@@ -708,10 +687,11 @@ func TestConstraintStateBareStringReturnSkipsBothLevels(t *testing.T) {
 		"shape", `this == "also_expected"`,
 	)
 	b := constraintStateBundle(t, target, nil, nil)
-	// The gate does not walk the TARGET type, so this bundle is not declined
-	// today; that shape and its consequences are pinned by
-	// TestKnownGap_TargetLevelConstraintAdmission (#583).
-	run := collectConstraintStateTargetLevelFixture(t, b, `"actual"`)
+	// Production refuses this bundle like any other constrained one — the gate walks
+	// b.Target. The collector runs anyway: it is not gated, and the skip it records
+	// here is a STOCK BAML behaviour (the bare-string return route), which the
+	// evaluator slice models whether or not native is allowed to serve the shape.
+	run := collectConstraintStateFixture(t, b, `"actual"`)
 
 	root := run.Root
 	if got, want := root.Disposition, constraintDispositionSkipBareStringReturn; got != want {
@@ -1802,20 +1782,21 @@ func TestConstraintStateDuplicateMapKeysNeverReachTheBuilder(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestConstraintStateConstrainedBundlesAreStillRefused is the boundary lock: the
-// unchanged half of the non-admission invariant.
+// WHOLE non-admission invariant, with nothing carved out of it.
 //
 // It asserts, HARD, through the three gates that actually decide serving —
 // `checkSupported` (the Parse gate), `SupportsNativeFinalBundle` (the admission
 // predicate) and `ParseStaticBundle` (the static-final entry point) — that every
-// constrained shape reachable from a class field, a class declaration or an enum
-// declaration is REFUSED with the ErrDeBAMLParseUnsupported fallback sentinel.
-// That is the invariant Slice 7.2a must not move, and a state result must never
-// be readable as admission changing.
+// constrained shape reachable from the RETURN TYPE, a class field, a class
+// declaration or an enum declaration is REFUSED with the
+// ErrDeBAMLParseUnsupported fallback sentinel. A state result must never be
+// readable as admission changing.
 //
-// The single exception — a constraint on `b.Target` itself — is NOT quietly
-// omitted here. It is asserted in full, as the wrong behaviour it is, by
-// [TestKnownGap_TargetLevelConstraintAdmission], which also re-proves that the
-// exception stays confined to the target-level position.
+// The three target-level rows arrived from the retired #662 tripwire: they were
+// the one family the gate did not reach, and the decline-more fix that walks
+// b.Target moved them here. Each row carries its OWN raw, chosen so the DECLINE is
+// a gate decision rather than a coercion failure — the unconstrained-twin
+// assertion below proves that by serving the very same bytes.
 func TestConstraintStateConstrainedBundlesAreStillRefused(t *testing.T) {
 	suit := schema.EnumDef{
 		Name: schema.Name{Name: "Suit"},
@@ -1851,42 +1832,185 @@ func TestConstraintStateConstrainedBundlesAreStillRefused(t *testing.T) {
 	optionalField := constraintStateClass("Wrapper",
 		constraintStateField("note", "", constraintStateCheck(constraintStateOptional(constraintStateStringType()), "c", `this == "x"`)))
 
+	// The raw the CLASS-rooted rows are driven with: one object carrying every
+	// field any of them reads, so each row's stripped twin below coerces it
+	// cleanly.
+	const classRaw = `{"note":"x","suit":"Hearts","lvl":"Low","amount":3,"qty":3,"nums":[1],"scores":{"a":1}}`
+
 	gated := []struct {
 		name   string
 		bundle *schema.Bundle
+		raw    string
+		// twinServed is the EXACT document the constraint-stripped twin serves for
+		// raw, or "" when that twin still declines for a reason unrelated to
+		// constraints — in which case twinDeclines names that reason and the row
+		// asserts it instead. Exactly one of the two is set.
+		twinServed   string
+		twinDeclines string
 	}{
-		{"scalar-class-field", constraintStateBundle(t, constraintStateClassType("Wrapper"), []schema.ClassDef{scalarField}, nil)},
-		{"optional-class-field", constraintStateBundle(t, constraintStateClassType("Wrapper"), []schema.ClassDef{optionalField}, nil)},
-		{"enum-field", constraintStateBundle(t, constraintStateClassType("Hand"), []schema.ClassDef{hand}, []schema.EnumDef{suit})},
-		{"enum-declaration", constraintStateBundle(t, constraintStateClassType("Hand"), []schema.ClassDef{constraintStateClass("Hand", constraintStateField("lvl", "", schema.Type{Kind: schema.TypeEnum, Name: "Level"}))}, []schema.EnumDef{constrainedEnum})},
-		{"class-declaration", constraintStateBundle(t, constraintStateClassType("Order"), []schema.ClassDef{order}, nil)},
-		{"list-element", constraintStateBundle(t, constraintStateClassType("Bag"), []schema.ClassDef{bag}, nil)},
-		{"map-value", constraintStateBundle(t, constraintStateClassType("Board"), []schema.ClassDef{boardValue}, nil)},
-		{"map-key", constraintStateBundle(t, constraintStateClassType("Board"), []schema.ClassDef{boardKey}, nil)},
+		{"scalar-class-field", constraintStateBundle(t, constraintStateClassType("Wrapper"), []schema.ClassDef{scalarField}, nil), classRaw,
+			"", "single string-absorbing-field root class"},
+		{"optional-class-field", constraintStateBundle(t, constraintStateClassType("Wrapper"), []schema.ClassDef{optionalField}, nil), classRaw,
+			"", "single string-absorbing-field root class"},
+		{"enum-field", constraintStateBundle(t, constraintStateClassType("Hand"), []schema.ClassDef{hand}, []schema.EnumDef{suit}), classRaw,
+			"", `required field "suit" provably fails to coerce`},
+		{"enum-declaration", constraintStateBundle(t, constraintStateClassType("Hand"), []schema.ClassDef{constraintStateClass("Hand", constraintStateField("lvl", "", schema.Type{Kind: schema.TypeEnum, Name: "Level"}))}, []schema.EnumDef{constrainedEnum}), classRaw,
+			`{"lvl":"Low"}`, ""},
+		{"class-declaration", constraintStateBundle(t, constraintStateClassType("Order"), []schema.ClassDef{order}, nil), classRaw,
+			`{"amount":3}`, ""},
+		{"list-element", constraintStateBundle(t, constraintStateClassType("Bag"), []schema.ClassDef{bag}, nil), classRaw,
+			`{"nums":[1]}`, ""},
+		{"map-value", constraintStateBundle(t, constraintStateClassType("Board"), []schema.ClassDef{boardValue}, nil), classRaw,
+			"", "non-last unquoted-scalar class field or scalar map value"},
+		{"map-key", constraintStateBundle(t, constraintStateClassType("Board"), []schema.ClassDef{boardKey}, nil), classRaw,
+			"", "non-last unquoted-scalar class field or scalar map value"},
+		// The three rows the b.Target walk added — the retired #662 tripwire's own
+		// fixtures, now ordinary members of the declining set. Their twins SERVE, so
+		// they are also this change's no-over-decline regression fixtures: the exact
+		// bytes native used to serve WITH the constraint are still served without it.
+		{"target-assert", constraintStateBundle(t, constraintStateAssert(constraintStateStringType(), "shape", `this == "expected"`), nil, nil), `"actual"`,
+			`"actual"`, ""},
+		{"target-check", constraintStateBundle(t, constraintStateCheck(constraintStateStringType(), "shape", `this == "expected"`), nil, nil), `"actual"`,
+			`"actual"`, ""},
+		{"target-list-element", constraintStateBundle(t, schema.Type{
+			Kind: schema.TypeList,
+			Elem: ptrConstraintStateType(constraintStateAssert(constraintStateIntType(), "big", "this > 100")),
+		}, nil, nil), `[1,2]`,
+			`[1,2]`, ""},
 	}
-	requireConstraintStateCount(t, len(gated), 8, "gated constrained shapes")
+	requireConstraintStateCount(t, len(gated), 11, "gated constrained shapes")
+	served := 0
 	for _, g := range gated {
+		if g.twinServed != "" {
+			served++
+		}
 		t.Run(g.name, func(t *testing.T) {
+			if (g.twinServed == "") == (g.twinDeclines == "") {
+				t.Fatalf("the row sets neither or both of twinServed/twinDeclines; one outcome must be stated")
+			}
 			if err := checkSupported(g.bundle); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
 				t.Errorf("checkSupported = %v; want the ErrDeBAMLParseUnsupported fallback sentinel", err)
 			}
 			if err := SupportsNativeFinalBundle(g.bundle); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
 				t.Errorf("SupportsNativeFinalBundle = %v; want the fallback sentinel", err)
 			}
-			// The static-final entry point must refuse too, on a raw that would
-			// otherwise coerce cleanly — so this is a gate decision, not a parse
-			// failure.
-			_, err := ParseStaticBundle(context.Background(), g.bundle, `{"note":"x","suit":"Hearts","lvl":"Low","amount":3,"qty":3,"nums":[1],"scores":{"a":1}}`)
+			// The static-final entry point must refuse too.
+			_, err := ParseStaticBundle(context.Background(), g.bundle, g.raw)
 			if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
 				t.Errorf("ParseStaticBundle = %v; want the fallback sentinel", err)
 			}
+
+			// NO OVER-DECLINE, and the reason the declines above are attributable to
+			// the constraint at all. The twin is DERIVED from this very bundle by
+			// deleting its constraints and nothing else, so the pair differs in
+			// exactly that attribute: whatever the twin admits, the constraint alone
+			// caused the gate to refuse it.
+			twin, removed := constraintStateWithoutConstraints(t, g.bundle)
+			if removed == 0 {
+				t.Fatalf("the fixture declares no constraint; its decline proves nothing about constraints")
+			}
+			// checkSupported is the gate the b.Target walk changed, so every twin —
+			// including the three target-level ones — must pass it.
+			if err := checkSupported(twin); err != nil {
+				t.Fatalf("stripped twin: checkSupported DECLINED (%v); removing the constraint must restore admission", err)
+			}
+			res, terr := ParseStaticBundle(context.Background(), twin, g.raw)
+			if g.twinServed != "" {
+				if terr != nil {
+					t.Fatalf("stripped twin: ParseStaticBundle = %v; want it to SERVE %s", terr, g.twinServed)
+				}
+				if got := string(res.JSON); got != g.twinServed {
+					t.Errorf("stripped twin served %s, want %s", got, g.twinServed)
+				}
+				return
+			}
+			// The twin passes the CONSTRAINT gate but still declines downstream, for
+			// a reason this row names. Pinning it is what stops the arm from being a
+			// silent "it declined, close enough": the reason must be the stated
+			// non-constraint one, so nothing here can be read as the constraint gate
+			// still firing.
+			if terr == nil {
+				t.Fatalf("stripped twin SERVED %s; the row claims it declines for %q", res.JSON, g.twinDeclines)
+			}
+			if !strings.Contains(terr.Error(), g.twinDeclines) {
+				t.Errorf("stripped twin declined with %v; want the non-constraint reason %q", terr, g.twinDeclines)
+			}
+			if strings.Contains(terr.Error(), "constraint") {
+				t.Errorf("stripped twin declined for a CONSTRAINT reason (%v) after every constraint was removed", terr)
+			}
 		})
 	}
+	requireConstraintStateCount(t, served, 6, "rows whose stripped twin serves")
+}
 
+// constraintStateWithoutConstraints returns a DEEP COPY of b with every declared
+// @assert/@check removed — from the target's whole type tree, from each enum and
+// class declaration, and from every field type — plus the number it removed.
+//
+// It is DERIVED rather than hand-written on purpose. A second, hand-built
+// "unconstrained version" of a fixture can drift into a different shape, and then
+// its admission says nothing about why the constrained one declined. Copying the
+// subject and deleting exactly one attribute makes the pair differ in exactly that
+// attribute, so the twin's admission isolates the constraint as the cause. The
+// count is returned so a caller can refuse a vacuous comparison against a fixture
+// that declared nothing.
+func constraintStateWithoutConstraints(t *testing.T, b *schema.Bundle) (*schema.Bundle, int) {
+	t.Helper()
+	removed := 0
+	var stripType func(schema.Type) schema.Type
+	stripType = func(x schema.Type) schema.Type {
+		removed += len(x.Meta.Constraints)
+		x.Meta.Constraints = nil
+		if x.Elem != nil {
+			x.Elem = ptrConstraintStateType(stripType(*x.Elem))
+		}
+		if x.Key != nil {
+			x.Key = ptrConstraintStateType(stripType(*x.Key))
+		}
+		if x.Value != nil {
+			x.Value = ptrConstraintStateType(stripType(*x.Value))
+		}
+		if len(x.Items) > 0 {
+			items := make([]schema.Type, len(x.Items))
+			for i := range x.Items {
+				items[i] = stripType(x.Items[i])
+			}
+			x.Items = items
+		}
+		if x.Union != nil {
+			u := *x.Union
+			u.Variants = make([]schema.Type, len(x.Union.Variants))
+			for i := range x.Union.Variants {
+				u.Variants[i] = stripType(x.Union.Variants[i])
+			}
+			x.Union = &u
+		}
+		return x
+	}
+
+	enums := make([]schema.EnumDef, len(b.Enums))
+	for i := range b.Enums {
+		enums[i] = b.Enums[i]
+		removed += len(enums[i].Constraints)
+		enums[i].Constraints = nil
+	}
+	classes := make([]schema.ClassDef, len(b.Classes))
+	for i := range b.Classes {
+		classes[i] = b.Classes[i]
+		removed += len(classes[i].Constraints)
+		classes[i].Constraints = nil
+		fields := make([]schema.ClassField, len(b.Classes[i].Fields))
+		for j := range b.Classes[i].Fields {
+			fields[j] = b.Classes[i].Fields[j]
+			fields[j].Type = stripType(fields[j].Type)
+		}
+		classes[i].Fields = fields
+	}
+	return constraintStateBundle(t, stripType(b.Target), classes, enums), removed
 }
 
 // ---------------------------------------------------------------------------
-// The ONE narrowed-invariant exception — an asserted known-gap tripwire
+// The closed target-level gap — what declining actually bought
 // ---------------------------------------------------------------------------
 
 // constraintStateDeclaredConstraints renders a schema node's DECLARED
@@ -1906,156 +2030,153 @@ func constraintStateDeclaredConstraints(t schema.Type) []string {
 	return out
 }
 
-// TestKnownGap_TargetLevelConstraintAdmission is a KNOWN-GAP TRIPWIRE. It
-// asserts a WRONG production behaviour on purpose, and it is expected to FAIL
-// the day that behaviour is fixed.
+// TestTargetLevelConstraintDeclineClassification is what the retired #662
+// known-gap tripwire turned into once the gap closed.
 //
-// THE GAP, exactly. `checkSupported` -> `checkSupportedFields`
-// (internal/debaml/parse.go) iterates `b.Enums` and `b.Classes` and never walks
-// `b.Target`. A constraint declared on the RETURN TYPE itself — `function F() ->
-// string @assert(...)`, or a constrained element/value of a target list/map — is
-// therefore never examined, so `checkSupported`, `SupportsNativeFinalBundle` and
-// `ParseStaticBundle` all ADMIT it. The observable consequence, asserted below,
-// is that native SERVES a value whose own `@assert` is FALSE — which is an
-// over-claim, not merely a coverage gap.
+// THE GAP THAT WAS. `checkSupported` -> `checkSupportedFields` iterated `b.Enums`
+// and `b.Classes` and never walked `b.Target`, so a constraint declared on the
+// RETURN TYPE itself — `function F() -> int @assert(...)`, or a constrained
+// element of a target list — was never examined and all three gates ADMITTED it.
+// The tripwire asserted that wrong behaviour on purpose and failed the moment
+// [checkTypeNoConstraints] landed.
 //
-// THIS IS PRE-EXISTING AT THE BASE REVISION 707b2419. Slice 7.2a-2 is
-// TEST-ONLY: it adds no production code and changes no gate, so it neither
-// introduced this nor may fix it. The repository owner granted an EXPLICIT,
-// DOCUMENTED, TEMPORARY authority exception narrowing the slice's
-// "constraint-bearing bundles still decline" invariant to exclude exactly this
-// target-level shape, and scheduled the fix as its own separate "decline-more"
-// production slice. Tracked on #583, which records the measured envelope, the
-// static-final reachability, and what the fix slice must do.
+// WHAT THIS TEST IS FOR. The decline itself is pinned alongside every other
+// constrained shape by [TestConstraintStateConstrainedBundlesAreStillRefused].
+// What is pinned HERE is the other half of the differential: for each
+// target-level shape, the exact value native SERVED while the gate admitted it.
+// That value is the native leg of the out-claim question, and it is derived
+// rather than quoted — from the constraint-stripped twin, which coerces
+// identically because native's coercer never reads Meta.Constraints.
 //
-// WHY ASSERTED RATHER THAN LOGGED. An earlier revision only `t.Log`ged the
-// verdict so that closing the gap would not turn the suite red. That is a
-// false-green: a silent log is indistinguishable from a test that checks
-// nothing, and nothing would notice if the over-claim widened. A tripwire is the
-// honest shape — it states the wrong behaviour as a fact, so
+// WHERE THE STOCK LEG LIVES, AND WHY NOT HERE. Whether declining a shape REMOVED
+// an out-claim depends on what stock BAML v0.223 does with it, and no unit test
+// in this package can answer that: [EvaluateConstraint] is the native evaluator,
+// and its verdict on a predicate is NOT stock's verdict on a parse. Stock is
+// measured live, through CFFI, by
+// TestStockTargetLevelConstraintDispositionAndNativeDecline in
+// internal/bamlprofile/profileoracle, which parses these same shapes through the
+// untouched v0.223 runtime and asserts the native decline beside each one. Its
+// measurement is a THREE-way taxonomy, and every row below carries the class it
+// landed in:
 //
-//   - while the gap is open, the exception is impossible to overlook: this test
-//     is named for it and describes it in full;
-//   - the moment the decline-more slice lands, EVERY gate assertion here fails
-//     with a message saying so, and the fix's author deletes the tripwire and
-//     moves the bare-string collector fixture from
-//     [collectConstraintStateTargetLevelFixture] to
-//     [collectConstraintStateFixture].
+//   - RAISES — a bare `int` return and a LIST-LEVEL constraint reject the parse
+//     with "Assertions failed.". Native served a value; BAML errors. A genuine
+//     out-claim, and declining restores the erroring fallback.
+//   - SERVES A DIFFERENT VALUE — a constrained list ELEMENT does not reject.
+//     coerce_array DROPS each failing element, so stock returns `[]` where native
+//     returned `[1,2]`. An out-claim in value rather than in outcome.
+//   - SERVES THE SAME VALUE — a bare `string` return skips constraint evaluation
+//     entirely, so native's served value MATCHED stock's. Declining it is NOT an
+//     out-claim fix; it is plain over-decline, safe under the parity principle.
+//     [TestConstraintStateBareStringReturnSkipsBothLevels] pins that skip on the
+//     collector side and profileoracle's TestStockSkipsConstraintsOnBareStringReturn
+//     measures it against stock. Calling this row a removed out-claim would
+//     contradict both, so it is labelled for what it is.
 //
-// WHY THE PROOF IS ATTACHED TO THE SCHEMA, and not to a literal. A previous cut
-// demonstrated the over-claim by calling EvaluateConstraint on a hand-written
-// expression over a hand-built value. That was DETACHED: deleting the @assert
-// from the probes left the test green, because nothing tied the predicate it
-// evaluated to the predicate the bundle actually declares. It now
-//
-//  1. pins each probe's EXACT declared constraints on its schema node — count,
-//     level, label and expression ([constraintStateDeclaredConstraints]);
-//  2. requires at least one of them to be an @assert;
-//  3. takes the expression FROM that schema node and evaluates it against the
-//     canonical value the collector built for the served document, after
-//     requiring that value's serialization to equal the bytes ParseStaticBundle
-//     ACTUALLY returned; and
-//  4. cross-checks that verdict against the collector's own recorded outcome for
-//     the same node.
-//
-// So deleting or changing either probe's constraint fails this test, and the
-// sentence "native served a value failing its own @assert" is backed by the
-// bundle's own predicate over the bundle's own served value.
-//
-// It is a canary, not a lock. Nothing else in this slice narrows the
-// non-admission invariant: every OTHER constrained shape is hard-asserted to
-// decline through all three gates by
-// [TestConstraintStateConstrainedBundlesAreStillRefused], and the contrast block
-// at the end of this test re-proves that the exception is confined to the
-// target-level position.
-func TestKnownGap_TargetLevelConstraintAdmission(t *testing.T) {
-	const gapClosed = "GAP CLOSED — this is the expected fix, not a regression. " +
-		"Delete TestKnownGap_TargetLevelConstraintAdmission, move the bare-string fixture from " +
-		"collectConstraintStateTargetLevelFixture to collectConstraintStateFixture, and drop the " +
-		"narrowed-invariant note from this file's header and the PR body. Detail: "
-
-	// The subject: a bare-string RETURN TYPE carrying a FALSE @assert.
-	bareString := constraintStateBundle(t,
-		constraintStateAssert(constraintStateStringType(), "shape", `this == "expected"`), nil, nil)
-	// And a constrained ELEMENT of a target list, so the gap is recorded as the
-	// shape it is (anything hanging off b.Target) rather than as one special case.
-	targetList := constraintStateBundle(t, schema.Type{
-		Kind: schema.TypeList,
-		Elem: ptrConstraintStateType(constraintStateAssert(constraintStateIntType(), "big", "this > 100")),
-	}, nil, nil)
-
+// The taxonomy is asserted, not just described: the row set must contain at least
+// one genuine out-claim and at least one over-decline, so it cannot quietly
+// collapse into "they all decline, therefore they were all bugs".
+func TestTargetLevelConstraintDeclineClassification(t *testing.T) {
 	probes := []struct {
-		name     string
-		bundle   *schema.Bundle
-		raw      string
-		wantJSON string
-		// constrained returns the schema node the predicate is DECLARED on. The
-		// expression evaluated below is read from here, never from a literal.
-		constrained func(*schema.Bundle) schema.Type
+		name   string
+		bundle *schema.Bundle
+		raw    string
+		// wouldHaveServed is what ParseStaticBundle returned for raw BEFORE the
+		// gate walked b.Target. Asserted against the constraint-stripped twin, so
+		// it is measured here rather than remembered.
+		wouldHaveServed string
+		// constrained returns the schema node the predicate is DECLARED on, and
 		// wantDeclared is that node's complete constraint list, in order.
+		constrained  func(*schema.Bundle) schema.Type
 		wantDeclared []string
-		// wantEvalPaths are the collector paths whose canonical value the declared
-		// predicate must evaluate FALSE against — the values native actually served.
-		//
-		// It is an EXPECTATION, not a loop driver: the set actually evaluated is
-		// DERIVED from the served state below, so emptying this field makes the
-		// coverage assertion FAIL rather than silently skipping links 3-4.
-		wantEvalPaths []string
-		// skipRoute selects how the collector records the verdict: the bare-string
-		// RETURN route skips evaluation and records a COUNTERFACTUAL, every other
-		// node records an EVENT. The expected rendering itself is DERIVED from the
-		// schema node below, never hard-coded, so there is no second literal that
-		// could drift away from what the bundle declares.
-		skipRoute bool
+		// stockDoes and outClaim record profileoracle's LIVE measurement for this
+		// shape. They are documentation of another test's result, which is why the
+		// row set's composition is asserted below rather than these values being
+		// re-derived from a native evaluator call.
+		stockDoes string
+		outClaim  bool
 	}{
 		{
-			name:          "bare-string-return",
-			bundle:        bareString,
-			raw:           `"actual"`,
-			wantJSON:      `"actual"`,
-			constrained:   func(b *schema.Bundle) schema.Type { return b.Target },
-			wantDeclared:  []string{`assert/"shape"/this == "expected"`},
-			wantEvalPaths: []string{"$"},
-			// The bare-string RETURN route skips evaluation, so the collector records
-			// the predicate as a COUNTERFACTUAL rather than an event — which is the
-			// same false verdict, reached the other way.
-			skipRoute: true,
+			// The genuine out-claim: stock REJECTS the parse, native served 5.
+			name:            "bare-int-return",
+			bundle:          constraintStateBundle(t, constraintStateAssert(constraintStateIntType(), "f", "false"), nil, nil),
+			raw:             `5`,
+			wouldHaveServed: `5`,
+			constrained:     func(b *schema.Bundle) schema.Type { return b.Target },
+			wantDeclared:    []string{`assert/"f"/false`},
+			stockDoes:       "raises (Assertions failed.)",
+			outClaim:        true,
 		},
 		{
-			name:         "target-list-element",
-			bundle:       targetList,
-			raw:          `[1,2]`,
-			wantJSON:     `[1,2]`,
-			constrained:  func(b *schema.Bundle) schema.Type { return *b.Target.Elem },
-			wantDeclared: []string{`assert/"big"/this > 100`},
-			// BOTH served elements fail the element's own @assert.
-			wantEvalPaths: []string{"$[0]", "$[1]"},
+			// The constraint on the LIST ITSELF. Stock rejects this one too.
+			name: "target-list-level",
+			bundle: constraintStateBundle(t, constraintStateAssert(schema.Type{
+				Kind: schema.TypeList, Elem: ptrConstraintStateType(constraintStateIntType()),
+			}, "f", "false"), nil, nil),
+			raw:             `[1,2]`,
+			wouldHaveServed: `[1,2]`,
+			constrained:     func(b *schema.Bundle) schema.Type { return b.Target },
+			wantDeclared:    []string{`assert/"f"/false`},
+			stockDoes:       "raises (Assertions failed.)",
+			outClaim:        true,
+		},
+		{
+			// The constrained ELEMENT of a target list — one of the two retired
+			// tripwire fixtures. Stock does NOT reject, so this is not the
+			// "native serves where BAML raises" shape; it is still an out-claim,
+			// in VALUE: coerce_array drops both failing elements and stock serves
+			// `[]` where native served both.
+			name: "target-list-element",
+			bundle: constraintStateBundle(t, schema.Type{
+				Kind: schema.TypeList,
+				Elem: ptrConstraintStateType(constraintStateAssert(constraintStateIntType(), "big", "this > 100")),
+			}, nil, nil),
+			raw:             `[1,2]`,
+			wouldHaveServed: `[1,2]`,
+			constrained:     func(b *schema.Bundle) schema.Type { return *b.Target.Elem },
+			wantDeclared:    []string{`assert/"big"/this > 100`},
+			stockDoes:       "serves [] (coerce_array drops the failing elements)",
+			outClaim:        true,
+		},
+		{
+			// The other retired tripwire fixture, and the row that keeps this test
+			// honest. Stock SKIPS constraints on a bare-string return, so it serves
+			// exactly what native served. Over-decline, not a removed out-claim.
+			name:            "bare-string-return",
+			bundle:          constraintStateBundle(t, constraintStateAssert(constraintStateStringType(), "shape", `this == "expected"`), nil, nil),
+			raw:             `"actual"`,
+			wouldHaveServed: `"actual"`,
+			constrained:     func(b *schema.Bundle) schema.Type { return b.Target },
+			wantDeclared:    []string{`assert/"shape"/this == "expected"`},
+			stockDoes:       "serves the same value (bare-string return skips constraints)",
+			outClaim:        false,
 		},
 	}
-	requireConstraintStateCount(t, len(probes), 2, "known-gap probes")
+	requireConstraintStateCount(t, len(probes), 4, "target-level probes")
+
+	// THE TAXONOMY IS NOT ALLOWED TO COLLAPSE. Without a genuine out-claim the
+	// gate would be removing nothing; without an over-decline row the bare-string
+	// contradiction this test exists to reconcile would have quietly vanished.
+	outClaims, overDeclines := 0, 0
+	for _, p := range probes {
+		if p.outClaim {
+			outClaims++
+		} else {
+			overDeclines++
+		}
+	}
+	if outClaims == 0 {
+		t.Fatal("no probe is a genuine out-claim; the gate would be removing nothing")
+	}
+	if overDeclines == 0 {
+		t.Fatal("no probe is an over-decline; the bare-string route's stock SKIP must stay represented")
+	}
+
 	for _, p := range probes {
 		t.Run(p.name, func(t *testing.T) {
-			// 1. The Parse gate admits it.
-			if err := checkSupported(p.bundle); err != nil {
-				t.Fatalf("%scheckSupported now DECLINES a target-level constraint: %v", gapClosed, err)
-			}
-			// 2. The admission predicate admits it.
-			if err := SupportsNativeFinalBundle(p.bundle); err != nil {
-				t.Fatalf("%sSupportsNativeFinalBundle now DECLINES a target-level constraint: %v", gapClosed, err)
-			}
-			// 3. The static-final entry point serves it.
-			res, err := ParseStaticBundle(context.Background(), p.bundle, p.raw)
-			if err != nil {
-				t.Fatalf("%sParseStaticBundle now DECLINES a target-level constraint: %v", gapClosed, err)
-			}
-			if got := string(res.JSON); got != p.wantJSON {
-				t.Fatalf("ParseStaticBundle served %s, want %s; the gap's shape changed and this "+
-					"tripwire needs re-deriving", got, p.wantJSON)
-			}
-
-			// 4. THE ATTACHED PREDICATE. Pin exactly what the probe declares, so the
-			// evaluation below cannot drift from the fixture — a deleted, relabelled,
-			// downgraded or reworded constraint fails right here.
+			// 1. Pin exactly what the probe declares, so nothing below can drift
+			// from the fixture — a deleted, relabelled, downgraded or reworded
+			// constraint fails right here.
 			node := p.constrained(p.bundle)
 			declared := constraintStateDeclaredConstraints(node)
 			requireConstraintStateCount(t, len(declared), len(p.wantDeclared), "declared constraints on the probe's schema node")
@@ -2064,127 +2185,95 @@ func TestKnownGap_TargetLevelConstraintAdmission(t *testing.T) {
 					t.Fatalf("declared constraint %d = %s, want %s", i, declared[i], p.wantDeclared[i])
 				}
 			}
-			asserts := 0
-			for i := range node.Meta.Constraints {
-				if node.Meta.Constraints[i].Level == schema.ConstraintAssert {
-					asserts++
-				}
+
+			// 2. NATIVE DECLINES, through all three gates, with the fallback
+			// sentinel — so the call routes to BAML and native serves nothing.
+			if err := checkSupported(p.bundle); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Errorf("checkSupported = %v; want the ErrDeBAMLParseUnsupported fallback sentinel", err)
 			}
-			if asserts == 0 {
-				t.Fatalf("the probe declares no @assert; it cannot demonstrate that native serves a " +
-					"value failing its own assertion")
+			if err := SupportsNativeFinalBundle(p.bundle); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Errorf("SupportsNativeFinalBundle = %v; want the fallback sentinel", err)
+			}
+			res, serr := ParseStaticBundle(context.Background(), p.bundle, p.raw)
+			if !errors.Is(serr, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Errorf("ParseStaticBundle = (%s, %v); want the fallback sentinel", res.JSON, serr)
+			}
+			if len(res.JSON) != 0 {
+				t.Errorf("a declining ParseStaticBundle still returned %s; a decline must serve nothing", res.JSON)
 			}
 
-			// 5. THE SERVED VALUE. The collector rebuilds the canonical value for the
-			// same bundle and raw; requiring its serialization to equal the bytes
-			// ParseStaticBundle ACTUALLY returned is what makes the evaluation below a
-			// statement about the served result rather than about a value this test
-			// invented.
-			run, err := collectConstraintCoercionState(p.bundle, p.raw)
-			if err != nil {
-				t.Fatalf("collect: %v", err)
+			// 3. WHAT NATIVE SERVED WHILE THE GATE ADMITTED THIS, measured. The
+			// constraint-stripped twin differs from the probe in exactly one
+			// attribute and native's coercer never reads that attribute, so the
+			// twin's output IS what the constrained bundle used to serve. This is
+			// also the row's no-over-decline control: removing the constraint must
+			// restore both admission and the byte-identical served document.
+			twin, removed := constraintStateWithoutConstraints(t, p.bundle)
+			if removed == 0 {
+				t.Fatalf("the probe declares no constraint; it cannot be about the target gate")
 			}
-			if got, want := string(run.Root.CanonicalJSON), string(res.JSON); got != want {
-				t.Fatalf("the collector's canonical document %s is not what ParseStaticBundle served (%s); "+
-					"the over-claim proof would be about a different value", got, want)
+			if err := checkSupported(twin); err != nil {
+				t.Fatalf("stripped twin: checkSupported DECLINED (%v); removing the constraint must restore admission", err)
 			}
-
-			// The expected recorded rendering, DERIVED from the schema node — so a
-			// changed level, label or expression moves both the pin above and the
-			// expectation below together, and neither can be satisfied by a stale
-			// literal.
-			wantRecorded := make([]string, 0, len(node.Meta.Constraints))
-			for i := range node.Meta.Constraints {
-				c := &node.Meta.Constraints[i]
-				label := "-"
-				if c.Label != nil {
-					label = strconv.Quote(*c.Label)
-				}
-				verdict := "=false"
-				if p.skipRoute {
-					verdict = "~would-be-false"
-				}
-				wantRecorded = append(wantRecorded, fmt.Sprintf("%s/%s/%s/%s%s",
-					constraintOriginTypeMeta, c.Level, label, c.Expression, verdict))
+			twinRes, terr := ParseStaticBundle(context.Background(), twin, p.raw)
+			if terr != nil {
+				t.Fatalf("stripped twin: ParseStaticBundle = %v; want it to SERVE %s", terr, p.wouldHaveServed)
+			}
+			if got := string(twinRes.JSON); got != p.wouldHaveServed {
+				t.Fatalf("native serves %s for %s, not the recorded %s; the out-claim classification in "+
+					"profileoracle's TestStockTargetLevelConstraintDispositionAndNativeDecline is derived "+
+					"from this value and must be re-measured", got, p.raw, p.wouldHaveServed)
 			}
 
-			// 6. THE EVALUATED SET, DERIVED FROM THE SERVED STATE. Every collected
-			// node whose schema type declares exactly the constraints pinned in link 1
-			// is a node the predicate must be false over. Deriving it — rather than
-			// iterating a fixture field — is what stops the over-claim proof from
-			// being skippable: emptying wantEvalPaths now makes the coverage
-			// assertion FAIL, where a fixture-driven loop would simply run zero times
-			// and report nothing.
-			var evalNodes []*constraintCoercionState
-			var evalPaths []string
-			run.Root.walk(func(n *constraintCoercionState) {
-				if !n.HasCanonical {
-					return
-				}
-				if !constraintStateStringsEqual(constraintStateDeclaredConstraints(n.Type), declared) {
-					return
-				}
-				evalNodes = append(evalNodes, n)
-				evalPaths = append(evalPaths, n.Path.String())
-			})
-			if len(evalNodes) == 0 {
-				t.Fatalf("no served node carries the probe's declared constraints %v; there is nothing "+
-					"to demonstrate the over-claim on", declared)
-			}
-			requireConstraintStateCount(t, len(evalPaths), len(p.wantEvalPaths), "constrained nodes in the served state")
-			for i := range p.wantEvalPaths {
-				if evalPaths[i] != p.wantEvalPaths[i] {
-					t.Fatalf("constrained node %d is at %s, want %s", i, evalPaths[i], p.wantEvalPaths[i])
-				}
-			}
-
-			// 7. THE OVER-CLAIM ITSELF: the bundle's OWN predicate, read from the
-			// schema node above, is FALSE over every value native served.
-			for _, st := range evalNodes {
-				path := st.Path.String()
-				for i := range node.Meta.Constraints {
-					c := &node.Meta.Constraints[i]
-					ok, err := EvaluateConstraint(st.Canonical, c.Expression)
-					if err != nil {
-						t.Fatalf("%s: the evaluator could not decide the served value's own %s %q (%v); "+
-							"the tripwire can no longer demonstrate the over-claim", path, c.Level, c.Expression, err)
-					}
-					if ok {
-						t.Fatalf("%s: the served value %s SATISFIES its own %s %q, so this probe "+
-							"demonstrates no over-claim", path, constraintStateDescribe(st.Canonical), c.Level, c.Expression)
-					}
-				}
-				// 8. Cross-check: the collector reached the same verdict by its own
-				// route — an event for an ordinary node, a counterfactual for the
-				// bare-string RETURN route that skips evaluation. Both renderings are
-				// derived from the schema node, so this also re-proves that what the
-				// collector evaluated is what the bundle declares.
-				if p.skipRoute {
-					requireConstraintStateEvents(t, st, nil)
-					requireConstraintStateSkipped(t, st, wantRecorded)
-				} else {
-					requireConstraintStateSkipped(t, st, nil)
-					requireConstraintStateEvents(t, st, wantRecorded)
-					if !st.AssertFailed {
-						t.Errorf("%s: a false @assert did not set AssertFailed; native served a value the "+
-							"collector does not even record as failing", path)
-					}
-				}
+			if p.outClaim {
+				t.Logf("OUT-CLAIM REMOVED: native served %s; stock %s. The decline routes the call to BAML.",
+					p.wouldHaveServed, p.stockDoes)
+			} else {
+				t.Logf("OVER-DECLINE (safe, not an out-claim fix): native served %s; stock %s.",
+					p.wouldHaveServed, p.stockDoes)
 			}
 		})
 	}
 
-	// CONTRAST — this must hold in EVERY world, gap open or closed, and it is
-	// what confines the exception to the target-level position. The SAME
-	// constrained string one level down inside a class field is refused by all
-	// three gates.
+	// CONTRAST — the decline is about the CONSTRAINT, not about the target
+	// position. The same target shapes with no constraint still admit and serve,
+	// and the same constrained string one level down inside a class field declines
+	// exactly as it always did.
+	unconstrained := []struct {
+		name       string
+		bundle     *schema.Bundle
+		raw        string
+		wantServed string
+	}{
+		{"bare string target", constraintStateBundle(t, constraintStateStringType(), nil, nil), `"actual"`, `"actual"`},
+		{"bare int target", constraintStateBundle(t, constraintStateIntType(), nil, nil), `5`, `5`},
+		{"int list target", constraintStateBundle(t, schema.Type{
+			Kind: schema.TypeList, Elem: ptrConstraintStateType(constraintStateIntType()),
+		}, nil, nil), `[1,2]`, `[1,2]`},
+	}
+	requireConstraintStateCount(t, len(unconstrained), 3, "unconstrained target controls")
+	for _, u := range unconstrained {
+		t.Run("still-served/"+u.name, func(t *testing.T) {
+			if err := SupportsNativeFinalBundle(u.bundle); err != nil {
+				t.Fatalf("SupportsNativeFinalBundle DECLINED an unconstrained target: %v", err)
+			}
+			res, err := ParseStaticBundle(context.Background(), u.bundle, u.raw)
+			if err != nil {
+				t.Fatalf("ParseStaticBundle = %v; an unconstrained target must still be served", err)
+			}
+			if got := string(res.JSON); got != u.wantServed {
+				t.Errorf("served %s, want %s", got, u.wantServed)
+			}
+		})
+	}
+
 	nested := constraintStateBundle(t, constraintStateClassType("Wrapper"), []schema.ClassDef{
 		constraintStateClass("Wrapper", constraintStateField("note", "",
 			constraintStateAssert(constraintStateStringType(), "shape", `this == "expected"`))),
 	}, nil)
 	if err := checkSupported(nested); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
 		t.Errorf("checkSupported on a constrained CLASS FIELD = %v; want the fallback sentinel — "+
-			"the exception must stay confined to the target-level position", err)
+			"the target walk must not have moved the field-level decline", err)
 	}
 	if err := SupportsNativeFinalBundle(nested); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
 		t.Errorf("SupportsNativeFinalBundle on a constrained CLASS FIELD = %v; want the fallback sentinel", err)
@@ -2199,13 +2288,10 @@ func TestKnownGap_TargetLevelConstraintAdmission(t *testing.T) {
 // are all still refused by production, so no state result in this file can be
 // read as admission moving.
 //
-// The bare-string RETURN family is deliberately absent: its constrained node
-// cannot be nested (that IS the route under test), and a target-level constraint
-// falls under the single documented exception to the non-admission invariant
-// (#583). It is covered by [TestKnownGap_TargetLevelConstraintAdmission], which
-// asserts the current admitted behaviour in full — including that the bundle's
-// own @assert is FALSE over the value ParseStaticBundle served — and fails when
-// the decline-more fix slice lands.
+// The bare-string RETURN family is included. It used to be the one family left
+// out, because its constrained node cannot be nested (that IS the route under
+// test) and the gate did not walk b.Target; now checkSupportedFields does, so the
+// family is refused like every other and belongs in this list.
 func TestConstraintStateEveryCollectorFixtureFamilyIsRefused(t *testing.T) {
 	suit := schema.EnumDef{
 		Name: schema.Name{Name: "Suit"},
@@ -2267,8 +2353,14 @@ func TestConstraintStateEveryCollectorFixtureFamilyIsRefused(t *testing.T) {
 		{"default-filled-required-field", constraintStateBundle(t, constraintStateClassType("Sack"), []schema.ClassDef{defaulted}, nil), `{"name":"x"}`},
 		{"single-field-implied-key", constraintStateBundle(t, constraintStateClassType("Note"), []schema.ClassDef{note}, nil), `{"other":"x"}`},
 		{"map-default-fill", constraintStateBundle(t, constraintStateClassType("Ledger"), []schema.ClassDef{ledger}, nil), `{"name":"x","tally":3}`},
+		// The bare-string RETURN family, the fixture of
+		// [TestConstraintStateBareStringReturnSkipsBothLevels] — declined since the
+		// gate started walking b.Target.
+		{"bare-string-return", constraintStateBundle(t, constraintStateAssert(
+			constraintStateCheck(constraintStateStringType(), "nonempty", `this == "expected"`),
+			"shape", `this == "also_expected"`), nil, nil), `"actual"`},
 	}
-	requireConstraintStateCount(t, len(fixtures), 9, "collector fixture families")
+	requireConstraintStateCount(t, len(fixtures), 10, "collector fixture families")
 	for _, f := range fixtures {
 		t.Run(f.name, func(t *testing.T) {
 			run, err := collectConstraintCoercionState(f.bundle, f.raw)

--- a/internal/debaml/parse.go
+++ b/internal/debaml/parse.go
@@ -480,8 +480,8 @@ func checkTypeNoStream(t schema.Type) error {
 }
 
 // checkSupported reports whether every type reachable from the lowered
-// bundle is inside the M1 coercion cut-line. It walks the synthetic
-// target's class and every other reachable class (TypeClass/TypeEnum
+// bundle is inside the M1 coercion cut-line. It walks the target type, the
+// synthetic target's class and every other reachable class (TypeClass/TypeEnum
 // references are leaves here because the bundle lists each reachable
 // definition as its own entry), returning a wrapped
 // bamlutils.ErrDeBAMLParseUnsupported for the first out-of-scope feature.
@@ -502,15 +502,36 @@ func checkSupported(b *schema.Bundle) error {
 	return checkSupportedFields(b)
 }
 
-// checkSupportedFields runs the per-enum / per-class / per-field cut-line that is
-// IDENTICAL for the non-recursive and the admitted-recursive-class final paths. It
-// is the body of [checkSupported] after the blanket structural-alias/recursive-class
-// rejects; the recursion-aware final profile (checkSupportedRecursive) reuses it so
-// the two paths share one field cut-line and only the top-level recursion admission
-// differs. It does NOT re-reject recursion — a recursive class's nullable-class edge
-// is a nullable union, which checkSupportedType already lets through its null fast
-// path, and the class definitions themselves are validated as ordinary class entries.
+// checkSupportedFields runs the per-target / per-enum / per-class / per-field
+// cut-line that is IDENTICAL for the non-recursive and the admitted-recursive-class
+// final paths. It is the body of [checkSupported] after the blanket
+// structural-alias/recursive-class rejects; the recursion-aware final profile
+// (checkSupportedRecursive) reuses it so the two paths share one field cut-line and
+// only the top-level recursion admission differs. It does NOT re-reject recursion —
+// a recursive class's nullable-class edge is a nullable union, which
+// checkSupportedType already lets through its null fast path, and the class
+// definitions themselves are validated as ordinary class entries.
+//
+// b.Target is walked FIRST, for constraints only ([checkTypeNoConstraints]). The
+// enum/class loops below cannot see a constraint declared on the RETURN TYPE
+// itself — `-> string @assert(...)`, or a constrained element/key/value/variant of
+// a target list/map/union — because those live on the target Type node, not on any
+// bundle entry. Admitting one is an OVER-CLAIM rather than a coverage gap: native
+// does not evaluate constraints, so it serves a value BAML would not. Measured
+// live against stock v0.223 (profileoracle's
+// TestStockTargetLevelConstraintDispositionAndNativeDecline): a bare `int` return
+// and a list-LEVEL constraint make stock REJECT the parse, and a constrained list
+// ELEMENT makes coerce_array drop the failing elements — where native served the
+// value and the whole list respectively. (A bare `string` return is the one shape
+// stock skips constraints on, so declining that one is safe over-decline rather
+// than a fix; the walk does not special-case it, because over-decline is allowed
+// and a carve-out would not be.) checkNoStreamAnnotations already pairs a target
+// walk with its per-class walk for the same reason; this is that pairing for
+// constraints.
 func checkSupportedFields(b *schema.Bundle) error {
+	if err := checkTypeNoConstraints(b.Target); err != nil {
+		return err
+	}
 	for i := range b.Enums {
 		if len(b.Enums[i].Constraints) > 0 {
 			return unsupported("enum constraints")
@@ -523,6 +544,59 @@ func checkSupportedFields(b *schema.Bundle) error {
 		}
 		for j := range c.Fields {
 			if err := checkSupportedType(b, c.Fields[j].Type); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// checkTypeNoConstraints walks one type tree rejecting any type-level
+// @assert/@check (Type.Meta.Constraints), and NOTHING else. Named class/enum
+// refs are leaves — their definitions are validated as bundle entries in
+// [checkSupportedFields] — exactly as in checkTypeNoStream, whose shape this
+// mirrors.
+//
+// IT IS DELIBERATELY NOT [checkSupportedType]. That function opens with the same
+// constraint reject but continues into the COERCION cut-line — the multi-arm-union
+// list element, the M2c safe-union families, the map key/value surface — declines
+// that the target position has never been subject to. Running the whole cut-line
+// over b.Target would decline bundles that admit (and, for the observe lane,
+// measure) today; the target gap is a constraint over-claim, so closing it removes
+// exactly one wrong admission and adds none.
+//
+// The descent into a list element / map key+value / union variant / tuple item is
+// what makes that removal complete: a constraint on any of them is declared on the
+// target's own type tree, so no class or enum entry reports it either.
+func checkTypeNoConstraints(t schema.Type) error {
+	if len(t.Meta.Constraints) > 0 {
+		return unsupported("target type constraints")
+	}
+	switch t.Kind {
+	case schema.TypeList:
+		if t.Elem != nil {
+			return checkTypeNoConstraints(*t.Elem)
+		}
+	case schema.TypeMap:
+		if t.Key != nil {
+			if err := checkTypeNoConstraints(*t.Key); err != nil {
+				return err
+			}
+		}
+		if t.Value != nil {
+			return checkTypeNoConstraints(*t.Value)
+		}
+	case schema.TypeUnion:
+		if t.Union != nil {
+			for i := range t.Union.Variants {
+				if err := checkTypeNoConstraints(t.Union.Variants[i]); err != nil {
+					return err
+				}
+			}
+		}
+	case schema.TypeTuple:
+		for i := range t.Items {
+			if err := checkTypeNoConstraints(t.Items[i]); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

## The bug — a pre-existing over-claim, surfaced by #662's tripwire

`checkSupported → checkSupportedFields` (`internal/debaml/parse.go`) walked `b.Enums` and `b.Classes` and **never `b.Target`**. A constraint declared on the RETURN TYPE itself — `function F() -> int @assert(...)`, or a constrained element of a target list — therefore lived on a node no bundle entry reports, and all three gates (`checkSupported`, `SupportsNativeFinalBundle`, `ParseStaticBundle`) **ADMITTED** it.

Native does not evaluate constraints, so it served a value BAML would not. For a bare `int` return and a list-level constraint, stock v0.223 **rejects the parse outright** while native returned the value — an over-claim, not merely a coverage gap.

## The fix — decline-more, nothing else

`checkSupportedFields` now walks `b.Target` first, through a new `checkTypeNoConstraints`: a constraint-only tree walk over the target and its list element / map key+value / union variant / tuple item. `checkSupportedRecursive` shares the same body, and `SupportsNativeFinalBundle` + `ParseStaticBundle` inherit the corrected gate automatically.

**It is deliberately NOT `checkSupportedType`.** That function opens with the same constraint reject but continues into the COERCION cut-line — the multi-arm-union list element, the M2c safe-union families, the map key/value surface — declines the target position has never been subject to. Running the whole cut-line over `b.Target` would remove admissions the static observe lane measures today. The gap is a *constraint* over-claim, so closing it **removes wrong admissions and adds none**.

The precedent for the shape is in the same file: `checkNoStreamAnnotations` already pairs `checkTypeNoStream(b.Target)` with its per-class walk.

## What stock v0.223 actually does — measured, and it corrected the story

The first cut of this PR argued "stock would have raised" from a decided-false *native evaluator* verdict. That was wrong for the bare-string fixture, and it contradicted this repo's own `TestStockSkipsConstraintsOnBareStringReturn`. Review caught it (P1).

The stock leg is now **measured live through CFFI**, not inferred. A new differential — `TestStockTargetLevelConstraintDispositionAndNativeDecline` in `internal/bamlprofile/profileoracle` — builds each target-level shape as real BAML source, parses it through the untouched v0.223 runtime via `CallFunctionParse` (BAML's real coercer: `run_user_checks` → `evaluate_predicate` → `validate_asserts`), and asserts the native decline beside it. The measurement is a **three-way taxonomy**:

| `-> T` | raw | stock v0.223 | native served | verdict |
|---|---|---|---|---|
| `int @assert(false)` | `5` | **raises** "Assertions failed." | `5` | **out-claim removed** |
| `int[] @assert(false)` | `[1,2]` | **raises** | `[1,2]` | **out-claim removed** |
| `TCBigNum[]` (element `@assert(this>100)`) | `[1,2]` | **serves `[]`** — `coerce_array` drops failing elements | `[1,2]` | **out-claim removed** (in value) |
| `string @assert(false)` | `"hello"` | **serves the same value** — bare-string return skips constraints | `"hello"` | **over-decline** (safe, not a fix) |

The requested proof is met by the first two rows: **where stock v0.223 fails the assert, native now declines instead of serving the value**, restoring the BAML fallback that raises. The third is an out-claim in value rather than outcome. The fourth is labelled for what it is — over-decline, permitted by the parity principle — and is *not* described as a rejection.

Three things keep this from being narrative:

- **"What native served" is run, not quoted.** Both legs derive it by executing `ParseStaticBundle` over the constraint-stripped twin (native's coercer never reads `Meta.Constraints`, so the twin coerces identically to what the constrained bundle served while admitted) and require it to match the pinned value.
- **The comparison is structural and numerically exact.** Stock's Go value is re-encoded as JSON; both sides are decoded with `json.Decoder.UseNumber` (trailing data rejected) and walked by a numeric-aware deep-equal that compares `json.Number` as exact `big.Rat` rationals. Two earlier comparators lost information the same way — distinct documents reading as agreement: a string normalizer that stripped quotes/commas/spaces couldn't tell `[1 2]` from `[12]`, and plain `json.Unmarshal` + `reflect.DeepEqual` stored every number as `float64`, collapsing `9007199254740992` and `9007199254740993` (either side of 2^53 — and native's int path carries exact `int64`). Exact rationals keep `5 == 5.0` and `1e2 == 100`, which raw `json.Number` string equality would break. `TestSameServedDocumentIsNotLossy` pins both directions across 15 cases, plus symmetry, decode errors and trailing data.
- **Attribution is derived from a stock control.** Each row also runs a constraint-FREE BAML function of the same shape. A divergence counts as an out-claim only if it disappears when the constraint does: native ≠ stock(constrained) **and** native = stock(control). If native differs from stock both with *and* without the constraint, that is a route-level difference this gate does not cause — which is exactly the bare-string case, where stock's string short-circuit returns the raw text verbatim (quotes included) with or without any constraint. A row cannot label itself, and mislabelling either way fails the test.

A constrained **optional** target was probed and deliberately dropped: `int?` is already declined by `checkStreamRootSupported` (mixed-union streaming deferral) with or without the constraint, so it was never part of the gap and claiming it as a removed out-claim would be false. The union descent in `checkTypeNoConstraints` stays as a defensive arm, covered by a plain decline assertion.

## The proof is enforced by CI, not opt-in

That CFFI test is `//go:build integration` under `internal/`, and no PR lane reached it: `unit-tests.yml` runs untagged tests, `integration-tests.yml` runs `./integration/...` only, and the `constraint-oracle` job named its two debaml CFFI packages explicitly. `internal/bamlprofile/profileoracle` was in fact run by **no** workflow at all, so its pre-existing prompt/fault/constraint differentials were equally unenforced.

`.github/workflows/constraint-oracle.yml` now:

- runs `CGO_ENABLED=1 go test -tags=integration -count=1 -v -timeout 15m ./internal/bamlprofile/profileoracle/` as a step in the `constraint-oracle` job — its natural home, already carrying the CGO/CFFI toolchain and the cached v0.223 runtime;
- lists `internal/bamlprofile/**` in its `pull_request` and `push` path triggers (a superset of `profileoracle/**`: it also covers the constraint façade one level up that the oracle measures against stock);
- extends the integration-tag compile guard to `./internal/debaml/... ./internal/bamlprofile/...`;
- raises the job's `timeout-minutes` 45 → 60. The budget must **exceed** the sum of the inner `go test -timeout 15m` values (3 × 15 = 45) so the inner Go timeout always fires first and its goroutine dump — the only diagnosis this lane has for the CFFI hang cases it isolates — survives instead of being thrown away by an Actions cancellation. The rationale comment now states that invariant, so the next lane added has to raise it too.

**Green run: [31185206308](https://github.com/invakid404/baml-rest/actions/runs/31185206308)** — "Constraint Evaluator Oracle", `completed success` on `8a0c74fc`, step `bamlprofile oracle vs stock BAML v0.223.0`:

```
OUT-CLAIM REMOVED (stock produced no value at all): `-> int @assert(false)` on 5; native served 5
OUT-CLAIM REMOVED (stock produced no value at all): `-> int[] @assert(false)` on [1,2]; native served [1,2]
OUT-CLAIM REMOVED (native served what stock serves WITHOUT the constraint): `-> TCBigNum[]` on [1,2]
OVER-DECLINE (native differs from stock with AND without the constraint — a route-level
              difference this gate does not cause): `-> string @assert(false)`
--- PASS: TestStockTargetLevelConstraintDispositionAndNativeDecline (0.00s)
    --- PASS: .../bare-int-return-assert · target-list-level-assert · target-list-element-assert · bare-string-return-assert
--- PASS: TestSameServedDocumentIsNotLossy (0.00s)
--- PASS: TestSameServedDocumentIsNotLossy (15 cases, incl. the 2^53 pairs)
ok  	github.com/invakid404/baml-rest/internal/bamlprofile/profileoracle	0.589s
```

The taxonomy measured on CI's linux/amd64 runner is identical to the local darwin/arm64 measurement. The same run re-verified the 719-case differential: 719 `--- PASS: TestConstraintExpressionDifferential/<case>` lines, plus `TestConstraintProfileIsFailClosed` and `TestConstraintProfileCost` PASS.

## No over-decline — the key risk, proven

- **Derived twins.** Every row of `TestConstraintStateConstrainedBundlesAreStillRefused` (8 pre-existing + 3 new target-level) builds a twin by deep-copying the subject bundle and deleting *only* its constraints. The pair differs in exactly that attribute, so the twin's admission isolates the constraint as the cause of the decline. Every twin must pass `checkSupported` — the gate this PR changed. Six twins also **serve**, pinned to the exact document; the five that still decline downstream (string-absorbing root class, greedy-read cascade, a field that provably fails to coerce) assert that exact non-constraint reason *and* assert the reason does not mention constraints.
- **Unconstrained target controls.** `TestNativeDeclines_Constraints` covers 6 target shapes (bare string, class, `string[]`, `int[]`, `map<string,int>`, `string?`) that must all still admit; `TestTargetLevelConstraintDeclineClassification` re-serves bare-string, bare-int and int-list targets byte-for-byte.
- **Whole-corpus regression.** Full root `go test ./...` and `go test -tags=integration ./internal/...` green with no other test touched: the static-serving corpora (`internal/nativeprompt/staticservefixture`, `staticoracle`), the recursive-class/alias families, and `nativeserve/admission` (the runtime static admission lane) all still admit and serve exactly as before.
- **Mutation check, both legs.** Reverting just the three-line gate call turns red exactly the target-level assertions — 5 unit tests and all 4 CFFI rows — and nothing else. The coverage is load-bearing.

## The #662 tripwire is retired, and the exception is gone

`TestKnownGap_TargetLevelConstraintAdmission` tripped with its GAP CLOSED message on the first build, as designed. Following its own instruction:

- Its two fixtures (bare-string return, target-list element) — plus a top-level `@check` — moved into the **normal constrained-decline set**, asserted through all three gates like every other family.
- `collectConstraintStateTargetLevelFixture` is deleted; the bare-string collector fixture now routes through `collectConstraintStateFixture`, which asserts production declines.
- The bare-string RETURN family joins `TestConstraintStateEveryCollectorFixtureFamilyIsRefused` (9 → 10 families).
- All documented-exception sites are reconciled: the `constraint_state_test.go` header, `requireConstraintStateStillDeclines`, `TestConstraintStateConstrainedBundlesAreStillRefused`, `TestConstraintStateEveryCollectorFixtureFamilyIsRefused`, and the `constraint_state_collect_test.go` header. **The invariant now holds fully, with nothing carved out.**

The tripwire's *evidence* is kept rather than discarded, re-aimed as `TestTargetLevelConstraintDeclineClassification` (renamed from the first cut's misleading name). Per shape it pins the exact declared constraints on the schema node, asserts all three gates decline and serve nothing, measures what native served via the stripped twin, and records which of stock's three dispositions that met. It derives **no** stock claim from `EvaluateConstraint`, and it asserts the row set contains at least one genuine out-claim *and* at least one over-decline so the taxonomy cannot collapse into "they all decline, therefore they were all bugs".

## Differential / gates

| gate | result |
|---|---|
| `gofmt -l` on changed files | clean (`internal/debaml/fix.go` is dirty at base `394ea753` too — untouched here) |
| `CGO_ENABLED=0 go build ./...` | green |
| `go vet ./...` / `go vet -tags=integration ./...` | green |
| `go test ./...` (root module) | green |
| `go test -tags=integration ./internal/...` | green (16 packages) |
| **719-case constraint differential** | **719 subtests / 0 divergences — unchanged.** `TestConstraintExpressionDifferential` 719 PASS, `TestConstraintProfileIsFailClosed` green, `TestConstraintProfileCost` pins 265 agree / 454 unsupported unmoved. It is evaluation, not admission; no oracle source changed. |
| **stock-CFFI target differential** (`profileoracle`) | **green locally and ON CI** — 4 rows, live v0.223, 3 out-claims + 1 over-decline, plus the 15-case comparator self-test; run [31185206308](https://github.com/invakid404/baml-rest/actions/runs/31185206308) |
| `boundary_decline_test` / `TestNativeDeclines_Constraints` | green, now covering target-level `@assert` (int and string), `@check`, and a target-list element |
| #649 evaluator seam (`constraint_state_seam_test.go`) | green |
| #661 guard-ledger + CFFI harness | green |
| #662 collector | green **with the tripwire retired** |
| `nativeserve` module (`GOWORK=off go build ./... && go test ./...`) | green, incl. `admission` |
| `internal/nativebody/nanollmprepare` | builds green |

`integration/` (Docker-backed) could not run locally — no Docker daemon in this environment. CI covers it; the in-process static-serving path is covered by `staticservefixture` + `nativeserve/admission` above.

## Pin / tar / embed

- **No pin or tar movement.** No new exported symbol: the change is one unexported function plus a three-line call inside `internal/debaml`; the CI change is workflow YAML, which touches neither (and is not in the `//go:embed` set). `nativeserve/go.mod`, `internal/nativebody/nanollmprepare/go.mod` and `cmd/build/nativeworker_module.tar` are untouched (the tar contains only `nanollmprepare/**` + `nativeserve/**` sources, no `internal/debaml`). The `nativeserve-goget` external-consumer lane resolves an unchanged module graph.
- **Embed freshness.** `internal/debaml/parse.go` *is* in the root `//go:embed` set, but the set embeds live source — no checked-in artifact is derived from it, and the directive list is unchanged (no file added or removed; the new test file is a `_test.go` in a package the directive does not list). `internal/debaml/guard_ledger.md` and every other embedded data file are byte-identical. `embed.go`, `go.mod`, `go.sum` untouched.

## Flag

Behind `BAML_REST_USE_DEBAML`. Flag-on, these target-level bundles now decline → BAML fallback. Flag-off, the native parse/serve seams are never installed (`StageFlag` decline in `nativeserve/admission`, nil `deBAMLParser` in dynclient), so it is full BAML, unchanged.

## Diff

6 files, 1 production:

- `internal/debaml/parse.go` — the gate
- `internal/bamlprofile/profileoracle/target_constraint_integration_test.go` — the stock-CFFI differential (new)
- `.github/workflows/constraint-oracle.yml` — CI wiring so that differential is enforced
- `internal/debaml/boundary_decline_test.go`, `internal/debaml/constraint_state_test.go`, `internal/debaml/constraint_state_collect_test.go` — tests

No `go.mod`, `go.sum`, `nativeserve/`, `nanollmprepare/`, `cmd/build/nativeworker_module.tar` or `embed.go` path changed.
