### PR TITLE
feat(debaml): Slice 7.2a-3 — serving-shaped differential oracle + boundary lock (TEST-ONLY)

### DIFF
--- a/.embedignore
+++ b/.embedignore
@@ -106,6 +106,18 @@ internal/debaml/testdata/constraint_oracle
 # markdown manifest itself.
 internal/debaml/testdata/guard_ledger
 
+# de-BAML Slice 7.2a-3 SERVING-SHAPED DIFFERENTIAL ORACLE proof material: the
+# rendered in-memory .baml fixture project the stock BAML v0.223.0 CFFI compiles at
+# test time, and the byte-compared JSON export of the 719-case constraintoracle
+# corpus the serving oracle consumes as a regression source. Both are read FROM
+# DISK by the //go:build integration tests in internal/debaml (os.ReadFile), never
+# through the embedded FS, and neither is a customer-build input — they are
+# test-only proof material like constraint_oracle and guard_ledger above. Excluded
+# here (cmd/embed includes testdata dirs by default) so the root embed manifest and
+# the server binary's bundle stay unchanged; embedding them would add ~132 KB of
+# oracle fixtures to every shipped binary for no runtime purpose.
+internal/debaml/testdata/serving_oracle
+
 # de-BAML Phase 4b + 5.1 gated nanollm Prepare validation: a SEPARATE, test-only
 # Go module (github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare)
 # excluded from go.work so the PUBLIC github.com/viktordanov/nanollm-ffi/go

--- a/.github/workflows/constraint-oracle.yml
+++ b/.github/workflows/constraint-oracle.yml
@@ -68,8 +68,9 @@ jobs:
     # and for the dump itself to be written and uploaded. At exactly 45 a hung
     # first or second lane would starve the third of its own diagnostic timeout —
     # which is how this number went from 45 to 60 when the profileoracle lane was
-    # added. Any future step with its own `-timeout` must raise this too.
-    timeout-minutes: 60
+    # added, and from 60 to 75 when the serving-oracle lane was. Any future step
+    # with its own `-timeout` must raise this too.
+    timeout-minutes: 75
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7.0.0
@@ -139,7 +140,37 @@ jobs:
           CGO_ENABLED: "1"
         run: go test -tags=integration -count=1 -v -timeout 15m ./internal/bamlprofile/profileoracle/
 
+      - name: Serving-shaped differential oracle vs stock BAML v0.223.0
+        # Slice 7.2a-3. Builds an IN-MEMORY .baml project from each corpus row's
+        # schema.Bundle, drives it through the stock CFFI's CallFunctionParse —
+        # the same entry point the generated Parse.<Method> wrappers call — and
+        # compares the recorded stock envelope against the native coercion-state
+        # collector + evaluator. TestServingOracleFailClosed is the load-bearing
+        # assertion (native reproduces stock or refuses; never a boolean stock did
+        # not produce) and TestServingOracleBoundaryLock is the invariant that
+        # every constraint-bearing bundle still DECLINES through checkSupported,
+        # SupportsNativeFinalBundle and ParseStaticBundle, target-level included.
+        #
+        # It also RE-DRIVES the 719-case constraint corpus serving-shaped
+        # (TestServingOracleBridgeCorpus), through the checked-in artifact
+        # constraintoracle's TestConstraintCorpusBridgeExport re-renders and
+        # byte-compares in the step above — so the two lanes are ordered: a corpus
+        # change fails the export step first, and the consumer picks it up here.
+        #
+        # It carries one SUBPROCESS row — `is divisibleby(0)` again, isolated so a
+        # CFFI abort cannot take the corpus down — whose child is killed at a 45s
+        # deadline, so the step budget allows for that.
+        env:
+          CGO_ENABLED: "1"
+        run: go test -tags=integration -count=1 -v -timeout 15m -run 'TestServingOracle' ./internal/debaml/
+
       - name: Constraint evaluator unit lane
         # The CGO-free half of the same claim, so a guard cannot be removed
         # without a red lane even if the oracle job is skipped by paths.
-        run: go test -count=1 -run 'Constraint|JinjaHelpers|Evaluator|Withdrawn|GuardLedger|RemovedGuard|RemovedLength|RemovedLast' ./internal/debaml/
+        #
+        # ServingOracle is in the list because the serving oracle's BOUNDARY half
+        # is deliberately untagged (serving_oracle_gate_test.go): it drives
+        # checkSupported / checkSupportedFields / checkSupportedType by name and
+        # proves the oracle is unreachable from production, neither of which needs
+        # CGO or the CFFI.
+        run: go test -count=1 -run 'Constraint|JinjaHelpers|Evaluator|Withdrawn|GuardLedger|RemovedGuard|RemovedLength|RemovedLast|ServingOracle' ./internal/debaml/

--- a/internal/debaml/constraintoracle/servingbridge_export_test.go
+++ b/internal/debaml/constraintoracle/servingbridge_export_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+
+package constraintoracle
+
+// The TEST-ONLY BRIDGE that hands this package's 719-case corpus to the Slice
+// 7.2a-3 serving-shaped oracle.
+//
+// WHY A FILE AND NOT AN IMPORT. Both corpora live in _test.go files — this one in
+// package constraintoracle, the serving oracle's in package debaml — and Go cannot
+// import test code across packages. Promoting either into a non-test package would
+// add shared production-visible code, which the TEST-ONLY invariant forbids and
+// which would make the production diff non-empty. A checked-in JSON artifact is the
+// one carrier that crosses the boundary without either cost.
+//
+// WHY IT CANNOT GO STALE. The file is a pure function of the live corpus:
+// TestConstraintCorpusBridgeExport re-renders it on every run and byte-compares.
+// A case added, removed, re-expressed or re-pinned here fails this test until the
+// artifact is regenerated, and the serving oracle then consumes the new content.
+// So the 719 cases are a REGRESSION SOURCE for the serving oracle rather than a
+// separate suite that merely happens to be green.
+//
+// Regenerate with:
+//
+//	BAML_CONSTRAINT_BRIDGE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//	  ./internal/debaml/constraintoracle -run TestConstraintCorpusBridgeExport
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	// bridgeExportPath is the artifact the serving oracle reads. It deliberately
+	// lives under the SERVING oracle's testdata: it is that oracle's input, and
+	// keeping it there makes the direction of the dependency obvious.
+	bridgeExportPath = "../testdata/serving_oracle/constraint_corpus.json"
+	// bridgeWriteEnv rewrites the artifact instead of comparing.
+	bridgeWriteEnv = "BAML_CONSTRAINT_BRIDGE_WRITE"
+	// bridgeVersion is bumped when the artifact's SHAPE changes. The consumer
+	// pins it, so a shape change cannot be read as a content change.
+	bridgeVersion = 1
+)
+
+// bridgeExport is the artifact's top level.
+//
+// Field names are explicit and the consumer decodes with DisallowUnknownFields, so
+// a field added here without teaching the consumer about it is a hard failure on
+// the other side rather than a silently ignored half-migration.
+type bridgeExport struct {
+	Version int           `json:"version"`
+	Prelude string        `json:"prelude"`
+	Groups  []bridgeGroup `json:"groups"`
+	Cases   []bridgeCase  `json:"cases"`
+}
+
+// bridgeGroup is one `this` value: the BAML field type that carries the
+// attributes and the assistant text that produces the value.
+type bridgeGroup struct {
+	Name     string `json:"name"`
+	BAMLType string `json:"baml_type"`
+	Input    string `json:"input"`
+}
+
+// bridgeCase is one (expression, `this`) observation with both pinned outcomes.
+type bridgeCase struct {
+	Label string `json:"label"`
+	Group string `json:"group"`
+	Expr  string `json:"expr"`
+	// Retained is the JinjaExpression BAML evaluates, when it differs from Expr
+	// (the attribute lexer doubles backslashes). Empty means identical.
+	Retained string `json:"retained,omitempty"`
+	Stock    string `json:"stock"`
+	Native   string `json:"native"`
+}
+
+// renderBridgeExport builds the artifact from the LIVE corpus.
+func renderBridgeExport() ([]byte, error) {
+	out := bridgeExport{Version: bridgeVersion, Prelude: bamlPrelude}
+	for _, g := range constraintGroups {
+		out.Groups = append(out.Groups, bridgeGroup{Name: g.Name, BAMLType: g.BAMLType, Input: g.Input})
+	}
+	for _, c := range constraintCases {
+		out.Cases = append(out.Cases, bridgeCase{
+			Label: c.Label, Group: c.Group, Expr: c.Expr, Retained: c.Retained,
+			Stock: string(c.Stock), Native: string(c.Native),
+		})
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	// HTML escaping OFF: the corpus is full of `<`, `>` and `&` inside expressions,
+	// and escaping them would make the artifact unreadable in review for no benefit
+	// — the consumer decodes it as JSON either way.
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(out); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// TestConstraintCorpusBridgeExport pins the bridge artifact as a pure function of
+// this package's corpus.
+//
+// Without it the serving oracle would consume a snapshot that could drift away from
+// the 719 cases it claims to be a regression source for.
+func TestConstraintCorpusBridgeExport(t *testing.T) {
+	want, err := renderBridgeExport()
+	if err != nil {
+		t.Fatalf("render the bridge export: %v", err)
+	}
+	if os.Getenv(bridgeWriteEnv) != "" {
+		if err := os.MkdirAll(filepath.Dir(bridgeExportPath), 0o755); err != nil {
+			t.Fatalf("create %s: %v", filepath.Dir(bridgeExportPath), err)
+		}
+		if err := os.WriteFile(bridgeExportPath, want, 0o644); err != nil {
+			t.Fatalf("write %s: %v", bridgeExportPath, err)
+		}
+		t.Logf("%s rewritten from the live corpus (%d groups, %d cases)",
+			bridgeExportPath, len(constraintGroups), len(constraintCases))
+		return
+	}
+	got, err := os.ReadFile(bridgeExportPath)
+	if err != nil {
+		t.Fatalf("read %s: %v (regenerate with %s=1)", bridgeExportPath, err, bridgeWriteEnv)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("%s is stale: it no longer matches the live corpus. The Slice 7.2a-3 serving oracle "+
+			"consumes it as a regression source, so it must be regenerated with %s=1 whenever a case "+
+			"changes.\n  on disk %d bytes, rendered %d bytes",
+			bridgeExportPath, bridgeWriteEnv, len(got), len(want))
+	}
+	// Non-vacuity: the artifact must actually carry the corpus.
+	if len(constraintCases) == 0 || len(constraintGroups) == 0 {
+		t.Fatal("the corpus is empty; the exported artifact would carry nothing")
+	}
+	t.Logf("bridge export current: %d groups, %d cases", len(constraintGroups), len(constraintCases))
+}

--- a/internal/debaml/serving_oracle_bridge_test.go
+++ b/internal/debaml/serving_oracle_bridge_test.go
@@ -1,0 +1,1407 @@
+//go:build integration
+
+package debaml
+
+// COMPOSING THE 719-CASE CONSTRAINT CORPUS AS A REGRESSION SOURCE.
+//
+// internal/debaml/constraintoracle enumerates 719 (expression, `this`) cases and
+// pins both legs' outcomes. Those cases are EVALUATOR-shaped: the native leg there
+// is handed a hand-written ConstraintValue and the expression, with no coercion in
+// between. This file re-drives every one of them SERVING-shaped instead: the
+// group's assistant text is coerced by each engine from raw bytes, and the
+// predicate runs over whatever that coercion produced.
+//
+// That is what makes them a regression source here rather than a separate suite —
+// a case whose outcome depends on the coerced value, not just on the expression,
+// is now covered end to end, and any case that stops reproducing its pinned outcome
+// through the serving path fails here.
+//
+// HOW THE CORPUS CROSSES THE PACKAGE BOUNDARY. Both corpora live in _test.go files
+// in different packages, and Go cannot import test code across packages; promoting
+// either into a non-test package would add shared production-visible code, which
+// this slice forbids. The carrier is a checked-in JSON artifact written by
+// constraintoracle's TestConstraintCorpusBridgeExport, which re-renders and
+// byte-compares it on every run, so it cannot drift from the live 719 cases.
+//
+// STRICT DECODING. The artifact is the oracle's one encoded-evidence boundary, and
+// it is decoded with DisallowUnknownFields and an explicit duplicate-key rejection:
+// a field the producer added but the consumer does not understand, or a case object
+// carrying the same key twice, is a hard failure rather than a silently dropped
+// half of the evidence.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+const (
+	// soBridgePath is the artifact constraintoracle exports.
+	soBridgePath = "testdata/serving_oracle/constraint_corpus.json"
+	// soBridgeVersion is the artifact SHAPE this consumer understands. A producer
+	// that bumps it without this being updated fails loudly.
+	soBridgeVersion = 1
+	// soBridgePrefix namespaces the bridge's generated declarations and functions so
+	// they cannot collide with the serving corpus's own.
+	soBridgePrefix = "CO_"
+)
+
+// ---------------------------------------------------------------------------
+// The artifact
+// ---------------------------------------------------------------------------
+
+type soBridgeExport struct {
+	Version int             `json:"version"`
+	Prelude string          `json:"prelude"`
+	Groups  []soBridgeGroup `json:"groups"`
+	Cases   []soBridgeCase  `json:"cases"`
+}
+
+type soBridgeGroup struct {
+	Name     string `json:"name"`
+	BAMLType string `json:"baml_type"`
+	Input    string `json:"input"`
+}
+
+type soBridgeCase struct {
+	Label    string `json:"label"`
+	Group    string `json:"group"`
+	Expr     string `json:"expr"`
+	Retained string `json:"retained,omitempty"`
+	Stock    string `json:"stock"`
+	Native   string `json:"native"`
+}
+
+// retainedExpr is the source the engines actually evaluate: BAML's attribute lexer
+// doubles backslashes, so a row that carries a Retained spelling is compared as the
+// bytes stock reports back rather than as the bytes the .baml was written with.
+func (c soBridgeCase) retainedExpr() string {
+	if c.Retained != "" {
+		return c.Retained
+	}
+	return c.Expr
+}
+
+// isolated mirrors constraintoracle's batching rule: a case whose stock outcome is
+// not a real check status gets its own function, because an evaluator error rejects
+// the WHOLE node and would take every other case in its batch down with it.
+func (c soBridgeCase) isolated() bool { return c.Stock == "error" || c.Stock == "no-checks" }
+
+// soLoadBridgeExport reads the artifact with a STRICT decoder.
+func soLoadBridgeExport(path string) (soBridgeExport, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return soBridgeExport{}, err
+	}
+	if err := soRejectDuplicateJSONKeys(raw); err != nil {
+		return soBridgeExport{}, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	// A field the producer added that this consumer does not model would otherwise
+	// be silently dropped, and half the evidence would go unnoticed.
+	dec.DisallowUnknownFields()
+	var out soBridgeExport
+	if err := dec.Decode(&out); err != nil {
+		return soBridgeExport{}, fmt.Errorf("decode %s: %w", path, err)
+	}
+	// Exactly one document: trailing content would mean the artifact is not what it
+	// claims to be.
+	if _, err := dec.Token(); err != io.EOF {
+		return soBridgeExport{}, fmt.Errorf("decode %s: trailing content after the document (%v)", path, err)
+	}
+	if out.Version != soBridgeVersion {
+		return soBridgeExport{}, fmt.Errorf("%s carries version %d, this consumer understands %d",
+			path, out.Version, soBridgeVersion)
+	}
+	return out, nil
+}
+
+// soRejectDuplicateJSONKeys walks the raw document and refuses any object that
+// declares the same key twice.
+//
+// encoding/json keeps the LAST occurrence silently, so a duplicated key would drop
+// evidence without any decoder error. DisallowUnknownFields does not catch it.
+func soRejectDuplicateJSONKeys(raw []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var walk func(path string) error
+	walk = func(path string) error {
+		tok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		delim, ok := tok.(json.Delim)
+		if !ok {
+			return nil
+		}
+		switch delim {
+		case '{':
+			seen := map[string]bool{}
+			for dec.More() {
+				keyTok, err := dec.Token()
+				if err != nil {
+					return err
+				}
+				key, ok := keyTok.(string)
+				if !ok {
+					return fmt.Errorf("%s: non-string object key %v", path, keyTok)
+				}
+				if seen[key] {
+					return fmt.Errorf("%s: duplicate object key %q; encoding/json would silently keep the "+
+						"last one and drop the evidence in the first", path, key)
+				}
+				seen[key] = true
+				if err := walk(path + "." + key); err != nil {
+					return err
+				}
+			}
+		case '[':
+			for i := 0; dec.More(); i++ {
+				if err := walk(fmt.Sprintf("%s[%d]", path, i)); err != nil {
+					return err
+				}
+			}
+		}
+		// Consume the closing delimiter.
+		_, err = dec.Token()
+		return err
+	}
+	if err := walk("$"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// The bridge project
+// ---------------------------------------------------------------------------
+
+// soBridgePrelude is the schema form of constraintoracle's shared declarations.
+//
+// It is hand-written here and then PROVEN equivalent: TestServingOracleBridgeCorpus
+// renders it back with the oracle's own renderer and byte-compares against the
+// prelude text the artifact carries, so a change on the producer's side cannot pass
+// unnoticed.
+func soBridgePrelude() ([]schema.ClassDef, []schema.EnumDef) {
+	rouge := "rouge"
+	classes := []schema.ClassDef{
+		soClassOf("Probe", []schema.ClassField{
+			soField("b", intType()),
+			soField("a", stringType()),
+			soField("c", soListOf(intType())),
+		}),
+		soClassOf("NestInner", []schema.ClassField{
+			soField("name", intType()),
+			soField("tags", soListOf(stringType())),
+		}),
+		soClassOf("Nest", []schema.ClassField{
+			soField("a", soClassType("NestInner")),
+			soField("name", stringType()),
+			soField("rows", soListOf(soClassType("NestInner"))),
+		}),
+	}
+	enums := []schema.EnumDef{{
+		Name: schema.Name{Name: "Hue"},
+		Values: []schema.EnumValue{
+			{Name: schema.Name{Name: "RED", Alias: &rouge}},
+			{Name: schema.Name{Name: "GREEN"}},
+		},
+	}}
+	return classes, enums
+}
+
+// soBridgePreludeOrder is the order the producer declares the prelude in, so the
+// equivalence render can be compared verbatim.
+var soBridgePreludeOrder = []string{"Probe", "Hue", "NestInner", "Nest"}
+
+// soParseBAMLType turns one of the corpus's BAML type expressions into a
+// schema.Type.
+//
+// It is deliberately small and total: an expression it does not understand is an
+// error, never a guess. Every parse is checked by rendering it back and requiring
+// the original spelling, so a mis-parse cannot silently change what a case is
+// driven against.
+func soParseBAMLType(expr string) (schema.Type, error) {
+	e := strings.TrimSpace(expr)
+	switch {
+	case e == "":
+		return schema.Type{}, fmt.Errorf("empty type expression")
+	case strings.HasSuffix(e, "?"):
+		inner, err := soParseBAMLType(strings.TrimSuffix(e, "?"))
+		if err != nil {
+			return schema.Type{}, err
+		}
+		return soOptional(inner), nil
+	case strings.HasSuffix(e, "[]"):
+		inner, err := soParseBAMLType(strings.TrimSuffix(e, "[]"))
+		if err != nil {
+			return schema.Type{}, err
+		}
+		return soListOf(inner), nil
+	case strings.HasPrefix(e, "map<") && strings.HasSuffix(e, ">"):
+		body := e[len("map<") : len(e)-1]
+		comma := strings.Index(body, ",")
+		if comma < 0 {
+			return schema.Type{}, fmt.Errorf("map type %q has no key/value separator", expr)
+		}
+		key, err := soParseBAMLType(body[:comma])
+		if err != nil {
+			return schema.Type{}, err
+		}
+		val, err := soParseBAMLType(body[comma+1:])
+		if err != nil {
+			return schema.Type{}, err
+		}
+		return soMapOf(key, val), nil
+	case e == "int":
+		return intType(), nil
+	case e == "float":
+		return soFloatType(), nil
+	case e == "string":
+		return stringType(), nil
+	case e == "bool":
+		return soBoolType(), nil
+	case e == "Hue":
+		return soEnumType("Hue"), nil
+	case e == "Probe", e == "Nest", e == "NestInner":
+		return soClassType(e), nil
+	}
+	return schema.Type{}, fmt.Errorf("unmodelled BAML type expression %q; the bridge refuses to guess", expr)
+}
+
+// soBridgeUnit is one driveable unit: a generated class carrying one or more of the
+// corpus's checks over a group's value.
+//
+// TWO BUNDLES, and the difference is load-bearing. BAML's attribute lexer REWRITES
+// the expression text for five of the 719 cases (it doubles backslashes, so a BAML
+// constraint cannot express a regex escape at all). The .baml project must be
+// rendered from the SOURCE spelling — that is what the lexer consumes — while the
+// native evaluator must be given the spelling stock actually evaluates and reports
+// back in Check.Expression, or the differential would be comparing BAML's attribute
+// lexer against Go's string literals rather than two engines over one expression.
+//
+// The original constraint oracle makes the same distinction (it feeds native
+// c.retainedExpr()); the bridge previously did not, and ran its native leg on the
+// pre-lexer spelling for those five rows.
+type soBridgeUnit struct {
+	// Method is the BAML function name.
+	Method string
+	Group  soBridgeGroup
+	Cases  []soBridgeCase
+	// Bundle carries the SOURCE spelling and is what the .baml project is rendered
+	// from, and what the stock readback is interpreted against.
+	Bundle *schema.Bundle
+	// NativeBundle carries the STOCK-RETAINED spelling and is what the native leg
+	// coerces and evaluates. For a case whose spelling survives the lexer unchanged
+	// the two are identical.
+	NativeBundle *schema.Bundle
+}
+
+// usesRetainedSpelling reports whether any of this unit's cases is one the BAML
+// attribute lexer rewrote.
+func (u soBridgeUnit) usesRetainedSpelling() bool {
+	for _, c := range u.Cases {
+		if c.Retained != "" && c.Retained != c.Expr {
+			return true
+		}
+	}
+	return false
+}
+
+// soBuildBridgeUnits turns the artifact into driveable units, batching exactly as
+// constraintoracle does.
+func soBuildBridgeUnits(exp soBridgeExport) ([]soBridgeUnit, error) {
+	classes, enums := soBridgePrelude()
+	byName := map[string]soBridgeGroup{}
+	for _, g := range exp.Groups {
+		if _, dup := byName[g.Name]; dup {
+			return nil, fmt.Errorf("duplicate group %q in the bridge artifact", g.Name)
+		}
+		byName[g.Name] = g
+	}
+	// DUPLICATE CASE LABELS ARE REJECTED HERE, at the artifact boundary.
+	//
+	// Rejecting duplicate JSON keys is not enough: two distinct case OBJECTS may
+	// reuse the same Label, and the label is what four downstream operations select
+	// by — the @check attribute in the generated .baml, the per-site assertion, the
+	// stock outcome lookup, and the native outcome lookup. All 719 cases would still
+	// be counted while one case's evidence was read for another, which is a silent
+	// mis-attribution rather than a loud failure.
+	seenLabel := map[string]string{}
+	for _, c := range exp.Cases {
+		if prev, dup := seenLabel[c.Label]; dup {
+			return nil, fmt.Errorf("duplicate case label %q in the bridge artifact (groups %q and %q); the "+
+				"label is what the .baml attribute, the per-site assertion and both outcome lookups select "+
+				"by, so one case's evidence would be read for another while the count still came to %d",
+				c.Label, prev, c.Group, len(exp.Cases))
+		}
+		seenLabel[c.Label] = c.Group
+	}
+
+	unit := func(name string, g soBridgeGroup, cases []soBridgeCase) (soBridgeUnit, error) {
+		base, err := soParseBAMLType(g.BAMLType)
+		if err != nil {
+			return soBridgeUnit{}, fmt.Errorf("group %q: %w", g.Name, err)
+		}
+		if got := soBaseTypeExpr(base); got != g.BAMLType {
+			return soBridgeUnit{}, fmt.Errorf("group %q: the parsed type renders as %q but the corpus "+
+				"declares %q; the bridge would drive a DIFFERENT shape", g.Name, got, g.BAMLType)
+		}
+		// Two field types from the same base: the SOURCE spelling for the .baml, the
+		// STOCK-RETAINED spelling for the native evaluator. See soBridgeUnit.
+		sourceType, nativeType := base, base
+		for _, c := range cases {
+			sourceType = soWith(sourceType, soCheck(c.Label, c.Expr))
+			nativeType = soWith(nativeType, soCheck(c.Label, c.retainedExpr()))
+		}
+		build := func(t schema.Type) (*schema.Bundle, error) {
+			cls := soClassOf(name, []schema.ClassField{soField("v", t)})
+			b := &schema.Bundle{
+				Target:  soClassType(name),
+				Classes: append(append([]schema.ClassDef(nil), classes...), cls),
+				Enums:   enums,
+			}
+			if err := b.RebuildIndexes(); err != nil {
+				return nil, fmt.Errorf("group %q: %w", g.Name, err)
+			}
+			return b, nil
+		}
+		src, err := build(sourceType)
+		if err != nil {
+			return soBridgeUnit{}, err
+		}
+		nat, err := build(nativeType)
+		if err != nil {
+			return soBridgeUnit{}, err
+		}
+		return soBridgeUnit{Method: soFunctionName(name), Group: g, Cases: cases,
+			Bundle: src, NativeBundle: nat}, nil
+	}
+
+	var out []soBridgeUnit
+	for _, g := range exp.Groups {
+		var batched []soBridgeCase
+		for _, c := range exp.Cases {
+			if c.Group == g.Name && !c.isolated() {
+				batched = append(batched, c)
+			}
+		}
+		if len(batched) == 0 {
+			continue
+		}
+		u, err := unit(soBridgePrefix+"B_"+g.Name, g, batched)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	for _, c := range exp.Cases {
+		if !c.isolated() {
+			continue
+		}
+		g, ok := byName[c.Group]
+		if !ok {
+			return nil, fmt.Errorf("case %q references unknown group %q", c.Label, c.Group)
+		}
+		u, err := unit(soBridgePrefix+"I_"+c.Label, g, []soBridgeCase{c})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	return out, nil
+}
+
+// soRenderBridgeProject renders the bridge's own in-memory project.
+func soRenderBridgeProject(units []soBridgeUnit) string {
+	var b strings.Builder
+	b.WriteString(soPrelude)
+	classes, enums := soBridgePrelude()
+	for _, name := range soBridgePreludeOrder {
+		for _, e := range enums {
+			if e.Name.Name == name {
+				b.WriteString("\n")
+				b.WriteString(soRenderEnum(e))
+			}
+		}
+		for _, c := range classes {
+			if c.Name.Name == name {
+				b.WriteString("\n")
+				b.WriteString(soRenderClass(c))
+			}
+		}
+	}
+	for _, u := range units {
+		cls := u.Bundle.Classes[len(u.Bundle.Classes)-1]
+		b.WriteString("\n")
+		b.WriteString(soRenderClass(cls))
+		b.WriteString("\n")
+		b.WriteString(soRenderFunction(strings.TrimPrefix(u.Method, soFunctionPrefix), u.Bundle.Target))
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// The test
+// ---------------------------------------------------------------------------
+
+// soWantBridgeCases pins how many of the 719 cases the serving-shaped harness
+// drives, and how they land. A case moving between buckets has to be acknowledged.
+const (
+	soWantBridgeCases = 719
+	// soWantBridgeGroups is the number of `this` values behind them.
+	soWantBridgeGroups = 28
+)
+
+// soBridgeCollectorRefusals are the cases the serving-shaped harness cannot carry
+// all the way to the evaluator, because the TEST-ONLY #662 collector refuses the
+// COERCION first.
+//
+// Every one of them is the same limitation, and it is a limitation of the witness
+// rather than of either engine: the collector re-serializes a float leaf as its
+// shortest round-trip decimal (9223372036854776000) while production coerce keeps
+// the source token (9223372036854775808.0), and the exact big.Rat divergence check
+// compares those two DECIMALS rather than the float64 they both denote. The same
+// finding is recorded by the guard_float_2p63 fixture.
+//
+// This is a PINNED SET, not a skip. Every label here must be observed refusing, and
+// every observed refusal must be listed — so a 13th case joining them, or one of
+// these starting to work, fails until it is acknowledged. And each one's pinned
+// NATIVE outcome must already be "unsupported", which is what makes the refusal
+// safe: the collector can only be hiding a decline native was going to make anyway,
+// never an answer.
+var soBridgeCollectorRefusals = map[string]string{
+	"asint_float_abs":         "2^63 float leaf: collector decimal round-trip",
+	"asint_float_compare":     "2^63 float leaf: collector decimal round-trip",
+	"asint_float_divisibleby": "2^63 float leaf: collector decimal round-trip",
+	"asint_float_even":        "2^63 float leaf: collector decimal round-trip",
+	"asint_float_int":         "2^63 float leaf: collector decimal round-trip",
+	"asint_float_integer":     "2^63 float leaf: collector decimal round-trip",
+	"asint_float_odd":         "2^63 float leaf: collector decimal round-trip",
+	"asint_float_string":      "2^63 float leaf: collector decimal round-trip",
+	"asint_list_elem_even":    "2^63 float element: collector decimal round-trip",
+	"asint_list_sum":          "2^63 float element: collector decimal round-trip",
+	"asint_reject_odd":        "2^63 float element: collector decimal round-trip",
+	"asint_select_even":       "2^63 float element: collector decimal round-trip",
+}
+
+// TestServingOracleBridgeCorpus drives every case of the 719-case constraint
+// corpus through the SERVING-shaped harness and requires the fail-closed contract
+// to hold over all of them.
+//
+// Three things are asserted per case, and none of them is an aggregate:
+//
+//  1. the STOCK outcome the serving path observes reproduces the outcome
+//     constraintoracle pinned for it — so the two harnesses agree about BAML;
+//  2. the NATIVE outcome, evaluated over the value THIS harness coerced (rather
+//     than a hand-written ConstraintValue), reproduces the pinned native outcome;
+//     and
+//  3. native never produces a boolean stock did not, nor a different one.
+func TestServingOracleBridgeCorpus(t *testing.T) {
+	soEnsureRuntime(t)
+	exp := soBridgeCorpus(t)
+
+	// The prelude this file models must be the prelude the producer declares.
+	var rendered strings.Builder
+	classes, enums := soBridgePrelude()
+	for _, name := range soBridgePreludeOrder {
+		for _, e := range enums {
+			if e.Name.Name == name {
+				rendered.WriteString("\n" + soRenderEnum(e))
+			}
+		}
+		for _, c := range classes {
+			if c.Name.Name == name {
+				rendered.WriteString("\n" + soRenderClass(c))
+			}
+		}
+	}
+	if got, want := soNormaliseBAML(rendered.String()), soNormaliseBAML(exp.Prelude); got != want {
+		t.Fatalf("the bridge's schema model of the shared prelude is not what constraintoracle declares, so "+
+			"every case would be driven against a different shape:\n  modelled %q\n  declared %q", got, want)
+	}
+
+	if len(exp.Cases) != soWantBridgeCases || len(exp.Groups) != soWantBridgeGroups {
+		t.Fatalf("the bridge artifact carries %d cases over %d groups, want %d over %d. The serving oracle "+
+			"consumes the constraint corpus as a regression source, so a change in its size has to be "+
+			"acknowledged here.", len(exp.Cases), len(exp.Groups), soWantBridgeCases, soWantBridgeGroups)
+	}
+
+	units := soBridgeUnits
+	if len(units) == 0 {
+		t.Fatal("the bridge built no units; every case below would be silently skipped")
+	}
+	rt, env, err := soBridgeRuntime(units)
+	if err != nil {
+		t.Fatalf("create the bridge runtime: %v", err)
+	}
+
+	driven, violations := 0, []string{}
+	stockAgree, nativeAgree := 0, 0
+	refused := map[string]bool{}
+	for _, u := range units {
+		stock, serr := soBridgeDriveStock(rt, env, u)
+		violations = append(violations, soBridgeAssertSites(u, stock, serr)...)
+		for _, c := range u.Cases {
+			driven++
+			gotStock := soBridgeStockOutcome(stock, serr, c.Label)
+			if gotStock != c.Stock {
+				violations = append(violations, fmt.Sprintf(
+					"%s: the SERVING path observes stock %q where constraintoracle pinned %q "+
+						"(method %s, raw %q, expr %q)",
+					c.Label, gotStock, c.Stock, u.Method, u.Group.Input, c.retainedExpr()))
+				continue
+			}
+			stockAgree++
+
+			gotNative, nerr := soBridgeNativeOutcome(u, c)
+			if strings.HasPrefix(gotNative, "coercion:") {
+				// The collector refused the coercion, so the evaluator was never
+				// reached. Allowed ONLY for the pinned set, and only where native was
+				// already declining — a refusal that hid an ANSWER would be a
+				// fail-closed hole.
+				refused[c.Label] = true
+				if why := soBridgeRefusalViolation(c.Label, c.Native); why != "" {
+					violations = append(violations, fmt.Sprintf("%s: %s (%s: %v)",
+						c.Label, why, gotNative, nerr))
+				}
+				continue
+			}
+			if gotNative != c.Native {
+				violations = append(violations, fmt.Sprintf(
+					"%s: the SERVING path observes native %q where constraintoracle pinned %q "+
+						"(raw %q, expr %q, err %v)",
+					c.Label, gotNative, c.Native, u.Group.Input, c.retainedExpr(), nerr))
+				continue
+			}
+			nativeAgree++
+
+			// The contract itself, over the LIVE outcomes.
+			if gotNative == "unsupported" {
+				continue
+			}
+			if gotStock != gotNative {
+				violations = append(violations, fmt.Sprintf(
+					"%s: native answered %q where stock produced %q — expr %q",
+					c.Label, gotNative, gotStock, c.retainedExpr()))
+			}
+		}
+	}
+	if driven != soWantBridgeCases {
+		t.Fatalf("drove %d cases, want %d; a silently skipped case is a silently dropped regression source",
+			driven, soWantBridgeCases)
+	}
+	// The pinned refusal set must be exact in BOTH directions.
+	for label := range soBridgeCollectorRefusals {
+		if !refused[label] {
+			violations = append(violations, fmt.Sprintf(
+				"%s is pinned as a collector refusal but the serving harness drove it successfully; the "+
+					"#662 limitation it records has been fixed and the entry must be removed", label))
+		}
+	}
+	if len(soBridgeCollectorRefusals) == 0 && len(refused) > 0 {
+		violations = append(violations, "the refusal set is empty but refusals were observed")
+	}
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		shown := violations
+		if len(shown) > 20 {
+			shown = shown[:20]
+		}
+		t.Fatalf("the serving-shaped harness does not reproduce the 719-case corpus; %d disagreement(s):\n  %s",
+			len(violations), strings.Join(shown, "\n  "))
+	}
+	t.Logf("719-case corpus re-driven serving-shaped: %d cases over %d units; stock reproduced %d/%d, "+
+		"native reproduced %d/%d, %d blocked by the #662 collector's float divergence check (all of them "+
+		"already pinned native=unsupported)", driven, len(units), stockAgree, driven, nativeAgree, driven,
+		len(refused))
+}
+
+// soBridgeRefusalViolation decides whether a collector refusal is ACCEPTABLE for a
+// case, returning the reason it is not.
+//
+// It is a function rather than inline code so both of its refusal reasons can be
+// driven directly (TestServingOracleBridgeRefusalPolicy): in a normal run every
+// observed refusal is listed and already declining, so neither branch would ever
+// execute and neither could be shown to work.
+func soBridgeRefusalViolation(label, pinnedNative string) string {
+	if _, listed := soBridgeCollectorRefusals[label]; !listed {
+		return "the collector refused the coercion and the case is not in soBridgeCollectorRefusals; a " +
+			"case cannot drop out of the regression source without being acknowledged"
+	}
+	if pinnedNative != "unsupported" {
+		return fmt.Sprintf("the collector refused the coercion, but constraintoracle pins native=%q for it "+
+			"— the refusal would be HIDING an answer rather than a decline", pinnedNative)
+	}
+	return ""
+}
+
+// soBridgeCorpus loads and strictly decodes the artifact.
+func soBridgeCorpus(t *testing.T) soBridgeExport {
+	t.Helper()
+	exp, err := soLoadBridgeExport(soBridgePath)
+	if err != nil {
+		t.Fatalf("load %s: %v\nRegenerate it with BAML_CONSTRAINT_BRIDGE_WRITE=1 go test -tags integration "+
+			"./internal/debaml/constraintoracle -run TestConstraintCorpusBridgeExport", soBridgePath, err)
+	}
+	return exp
+}
+
+// soNormaliseBAML collapses blank lines and trailing space so two renderings of the
+// same declarations compare equal without pinning whitespace conventions.
+func soNormaliseBAML(s string) string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimRight(line, " \t")
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+// soBridgeUnits is the bridge's driveable units, built once during runtime setup
+// so their declarations can be registered in the process-global type map.
+var soBridgeUnits []soBridgeUnit
+
+// soBridgeUnitsFromArtifact loads the artifact and builds the units.
+func soBridgeUnitsFromArtifact() ([]soBridgeUnit, error) {
+	exp, err := soLoadBridgeExport(soBridgePath)
+	if err != nil {
+		return nil, fmt.Errorf("load the 719-case bridge artifact: %w (regenerate it with "+
+			"BAML_CONSTRAINT_BRIDGE_WRITE=1 go test -tags integration ./internal/debaml/constraintoracle "+
+			"-run TestConstraintCorpusBridgeExport)", err)
+	}
+	return soBuildBridgeUnits(exp)
+}
+
+// soBridgeRuntimeState memoizes the bridge runtime: one project, one compile.
+var (
+	soBridgeRT      baml.BamlRuntime
+	soBridgeEnv     map[string]string
+	soBridgeErr     error
+	soBridgeStarted bool
+)
+
+// soBridgeRuntime compiles the bridge project once.
+func soBridgeRuntime(units []soBridgeUnit) (baml.BamlRuntime, map[string]string, error) {
+	if soBridgeStarted {
+		return soBridgeRT, soBridgeEnv, soBridgeErr
+	}
+	soBridgeStarted = true
+	src := soRenderBridgeProject(units)
+	soBridgeEnv = soEnvSnapshot()
+	soBridgeRT, soBridgeErr = baml.CreateRuntime("./baml_src",
+		map[string]string{"constraint_bridge.baml": src}, soBridgeEnv)
+	return soBridgeRT, soBridgeEnv, soBridgeErr
+}
+
+// soBridgeDriveStock parses one unit through the stock CFFI.
+func soBridgeDriveStock(rt baml.BamlRuntime, env map[string]string, u soBridgeUnit) (soStockEnvelope, error) {
+	fmt.Fprintf(os.Stderr, "serving-oracle: bridge BEGIN %s\n", u.Method)
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"text": u.Group.Input, "stream": false},
+		Env:    env,
+	}
+	encoded, err := args.Encode()
+	if err != nil {
+		return soStockEnvelope{}, err
+	}
+	res, callErr := rt.CallFunctionParse(context.Background(), u.Method, encoded)
+	fmt.Fprintf(os.Stderr, "serving-oracle: bridge END   %s\n", u.Method)
+	if callErr != nil {
+		return soClassifyStockError(callErr), callErr
+	}
+	var sites []soStockSite
+	identity, doc, rerr := soReadStockResult(u.Bundle, res, "$", &sites)
+	if rerr != nil {
+		return soStockEnvelope{}, rerr
+	}
+	return soStockEnvelope{Kind: soStockValue, Identity: identity, JSON: doc, Sites: sites}, nil
+}
+
+// soBridgeAssertSites checks the WHOLE observed check collection of one unit
+// against the artifact: cardinality, declaration ORDER, label, the exact
+// CFFI-retained EXPRESSION text, and the node each check ran at.
+//
+// Checking only the status of a label-selected site (which is what this did) leaves
+// the expression contract unasserted: the five rows whose spelling the attribute
+// lexer rewrites would stay green if the retained spelling changed while their
+// boolean did not. All five currently decline natively, which masks the gap rather
+// than closing it.
+func soBridgeAssertSites(u soBridgeUnit, env soStockEnvelope, callErr error) []string {
+	return soBridgeAssertSitesWith(u, env, callErr, soAllBridgeSiteChecks)
+}
+
+// soBridgeSiteChecks names the individual comparisons soBridgeAssertSitesWith
+// makes.
+//
+// Every real caller uses [soAllBridgeSiteChecks]; the set exists so
+// TestServingOracleBridgeRetainedExpressionGuardBites can turn exactly ONE
+// comparison off and show that it, and nothing else, is what catches a drifted
+// retained expression. That test also asserts every field of the default set is
+// true, so a comparison cannot be quietly disabled for the real path.
+type soBridgeSiteChecks struct {
+	Cardinality bool
+	Order       bool
+	Expression  bool
+	Path        bool
+	Certified   bool
+}
+
+// soAllBridgeSiteChecks is the set every production caller of the bridge uses.
+var soAllBridgeSiteChecks = soBridgeSiteChecks{
+	Cardinality: true, Order: true, Expression: true, Path: true, Certified: true,
+}
+
+// soBridgeAssertSitesWith is soBridgeAssertSites with the comparison set made
+// explicit. Only the counterfactual test passes anything but the full set.
+func soBridgeAssertSitesWith(u soBridgeUnit, env soStockEnvelope, callErr error,
+	checks soBridgeSiteChecks) []string {
+	if callErr != nil {
+		// Stock rejected the node, so there is no collection to compare. The per-case
+		// outcome check covers the rejection itself.
+		return nil
+	}
+	// Every case whose pinned stock outcome is a real check status must appear, in
+	// declaration order. A "no-checks" case is emitted with no entry at all.
+	var want []soBridgeCase
+	for _, c := range u.Cases {
+		if c.Stock != "no-checks" {
+			want = append(want, c)
+		}
+	}
+	var out []string
+	if checks.Cardinality && len(env.Sites) != len(want) {
+		return []string{fmt.Sprintf(
+			"%s: stock reported %d check(s) where the artifact declares %d:\n      observed %s",
+			u.Method, len(env.Sites), len(want), soRenderStockSites(env.Sites))}
+	}
+	if len(env.Sites) != len(want) {
+		// Cardinality checking is off and the lengths differ: compare what overlaps
+		// rather than indexing past the end.
+		return out
+	}
+	for i, c := range want {
+		got := env.Sites[i]
+		if checks.Order && got.Label != c.Label {
+			out = append(out, fmt.Sprintf("%s: check %d is labelled %q, the artifact declares %q at that "+
+				"position — the collection is not in declaration order", u.Method, i, got.Label, c.Label))
+			continue
+		}
+		if checks.Expression && got.Expression != c.retainedExpr() {
+			out = append(out, fmt.Sprintf("%s: check %d (%s) — stock RETAINED the expression\n"+
+				"      observed %q\n      artifact %q\n"+
+				"    The retained spelling is what the native evaluator is fed, so a change here means the "+
+				"two engines are being compared over different source.",
+				u.Method, i, c.Label, got.Expression, c.retainedExpr()))
+		}
+		if checks.Path && got.Path != "$.v" {
+			out = append(out, fmt.Sprintf("%s: check %d (%s) ran at %s, want $.v",
+				u.Method, i, c.Label, got.Path))
+		}
+		if checks.Certified && !got.Certified {
+			out = append(out, fmt.Sprintf("%s: check %d (%s) is an UNCERTIFIED root site; every bridge check "+
+				"is a nested field and must come from the raw CFFI tree", u.Method, i, c.Label))
+		}
+	}
+	return out
+}
+
+// soBridgeStockOutcome maps one case's stock observation onto constraintoracle's
+// vocabulary, so the two harnesses are compared in the same terms.
+func soBridgeStockOutcome(env soStockEnvelope, callErr error, label string) string {
+	if callErr != nil {
+		return "error"
+	}
+	for _, s := range env.Sites {
+		if s.Label != label {
+			continue
+		}
+		switch s.Status {
+		case "succeeded":
+			return "true"
+		case "failed":
+			return "false"
+		default:
+			return s.Status
+		}
+	}
+	return "no-checks"
+}
+
+// soBridgeNativeOutcome evaluates one case through the SERVING path: the group's
+// raw text is extracted and coerced by production, and the predicate then runs over
+// the value that coercion produced.
+//
+// That is the difference from constraintoracle's own native leg, which is handed a
+// hand-written ConstraintValue: here the value is derived, so a case whose outcome
+// depends on coercion is covered end to end.
+func soBridgeNativeOutcome(u soBridgeUnit, c soBridgeCase) (string, error) {
+	// The NATIVE bundle: the spelling stock reports back, not the spelling the .baml
+	// was written with.
+	f := servingOracleFixture{Name: c.Label, Bundle: u.NativeBundle, Raw: u.Group.Input}
+	env := soRunNative(f)
+	switch env.Kind {
+	case soNativeCoercionError, soNativeNoCandidate, soNativeUnmodelled, soNativeCollectorDiverged:
+		return "coercion:" + string(env.Kind), fmt.Errorf("%s", env.Message)
+	}
+	for _, s := range env.Sites {
+		if s.Label != c.Label {
+			continue
+		}
+		switch s.Outcome {
+		case constraintOutcomeTrue:
+			return "true", nil
+		case constraintOutcomeFalse:
+			return "false", nil
+		case constraintOutcomeUnsupported:
+			return "unsupported", nil
+		}
+	}
+	return "no-checks", nil
+}
+
+// TestServingOracleBridgeStrictDecoding proves the artifact boundary is STRICT, in
+// every direction that could silently drop evidence.
+//
+// The bridge is the oracle's only encoded-evidence boundary. A decoder that ignored
+// an unknown field, kept the last of two duplicate keys, or accepted a second
+// document would let half the corpus go missing with no error at all.
+func TestServingOracleBridgeStrictDecoding(t *testing.T) {
+	// The REAL artifact must load, or every negative below would pass trivially.
+	if _, err := soLoadBridgeExport(soBridgePath); err != nil {
+		t.Fatalf("the checked-in artifact does not load: %v", err)
+	}
+	base := `{"version":1,"prelude":"","groups":[{"name":"g","baml_type":"int","input":"{}"}],` +
+		`"cases":[{"label":"l","group":"g","expr":"this","stock":"true","native":"true"}]}`
+	if err := soWriteTemp(t, base); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{"unknown field at the top level",
+			`{"version":1,"prelude":"","groups":[],"cases":[],"surprise":1}`, "surprise"},
+		{"unknown field inside a case",
+			`{"version":1,"prelude":"","groups":[],"cases":[{"label":"l","group":"g","expr":"e",` +
+				`"stock":"true","native":"true","weight":3}]}`, "weight"},
+		{"duplicate key inside a case",
+			`{"version":1,"prelude":"","groups":[],"cases":[{"label":"a","label":"b","group":"g",` +
+				`"expr":"e","stock":"true","native":"true"}]}`, "duplicate object key"},
+		{"duplicate key at the top level",
+			`{"version":1,"version":2,"prelude":"","groups":[],"cases":[]}`, "duplicate object key"},
+		{"trailing content after the document",
+			`{"version":1,"prelude":"","groups":[],"cases":[]} {"version":1}`, "trailing content"},
+		{"a version this consumer does not understand",
+			`{"version":99,"prelude":"","groups":[],"cases":[]}`, "version"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "corpus.json")
+			if err := os.WriteFile(path, []byte(tc.doc), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			_, err := soLoadBridgeExport(path)
+			if err == nil {
+				t.Fatal("the strict decoder ACCEPTED a document that drops or contradicts evidence")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("the refusal does not name the problem (%q): %v", tc.want, err)
+			}
+		})
+	}
+	// CONTROL: the well-formed document loads, so the refusals above are about the
+	// defects rather than about the decoder rejecting everything.
+	path := filepath.Join(t.TempDir(), "corpus.json")
+	if err := os.WriteFile(path, []byte(base), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := soLoadBridgeExport(path)
+	if err != nil {
+		t.Fatalf("the well-formed control does not load: %v", err)
+	}
+	if len(got.Cases) != 1 || got.Cases[0].Label != "l" {
+		t.Fatalf("the control decoded to %+v", got)
+	}
+}
+
+// soWriteTemp is a sanity check that the base document used above is itself valid,
+// so a typo in it cannot make every negative case pass for the wrong reason.
+func soWriteTemp(t *testing.T, doc string) error {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "base.json")
+	if err := os.WriteFile(path, []byte(doc), 0o644); err != nil {
+		return err
+	}
+	if _, err := soLoadBridgeExport(path); err != nil {
+		return fmt.Errorf("the base document for the strict-decoding table is itself invalid: %w", err)
+	}
+	return nil
+}
+
+// TestServingOracleBridgeTypeParserRoundTrips proves the bridge drives each group
+// against the type the corpus DECLARES.
+//
+// The parser is small on purpose, and it is not trusted: every group's expression
+// is parsed and rendered back, and an expression the parser does not model is an
+// error rather than a guess.
+func TestServingOracleBridgeTypeParserRoundTrips(t *testing.T) {
+	exp := soBridgeCorpus(t)
+	if len(exp.Groups) == 0 {
+		t.Fatal("no groups; the round-trip claim would be vacuous")
+	}
+	seen := map[string]bool{}
+	for _, g := range exp.Groups {
+		parsed, err := soParseBAMLType(g.BAMLType)
+		if err != nil {
+			t.Errorf("group %q: %v", g.Name, err)
+			continue
+		}
+		if got := soBaseTypeExpr(parsed); got != g.BAMLType {
+			t.Errorf("group %q: %q parsed and rendered back as %q", g.Name, g.BAMLType, got)
+		}
+		seen[g.BAMLType] = true
+	}
+	// The corpus must exercise more than one shape, or the round trip proves nothing
+	// about the parser.
+	if len(seen) < 5 {
+		t.Errorf("the groups cover only %d distinct type expressions: %v", len(seen), seen)
+	}
+	// An unmodelled expression is refused rather than guessed at.
+	for _, bad := range []string{"", "Widget", "map<int>", "tuple<int, int>"} {
+		if _, err := soParseBAMLType(bad); err == nil {
+			t.Errorf("the parser accepted the unmodelled expression %q; it must refuse rather than guess", bad)
+		}
+	}
+}
+
+// TestServingOracleBridgeRefusalPolicy drives the refusal policy directly, because
+// a normal run never reaches either of its rejecting branches.
+func TestServingOracleBridgeRefusalPolicy(t *testing.T) {
+	if len(soBridgeCollectorRefusals) == 0 {
+		t.Fatal("the pinned refusal set is empty; the policy would accept nothing and prove nothing")
+	}
+	var listed string
+	for label := range soBridgeCollectorRefusals {
+		listed = label
+		break
+	}
+	if why := soBridgeRefusalViolation(listed, "unsupported"); why != "" {
+		t.Errorf("a LISTED refusal whose case already declines must be accepted; got %q", why)
+	}
+	if why := soBridgeRefusalViolation(listed, "true"); why == "" {
+		t.Error("a listed refusal whose case is pinned native=true must be REJECTED: the refusal would be " +
+			"hiding an answer rather than a decline")
+	}
+	if why := soBridgeRefusalViolation("a_case_that_is_not_listed", "unsupported"); why == "" {
+		t.Error("an UNLISTED refusal must be rejected, or a case could drop out of the regression source " +
+			"unnoticed")
+	}
+}
+
+// soWantRetainedRewrites is how many of the 719 cases BAML's attribute lexer
+// rewrites. Pinned, because everything below is a claim about them: if the count
+// went to zero the retained-spelling machinery would be exercising nothing.
+const soWantRetainedRewrites = 5
+
+// TestServingOracleBridgeRetainedSpellingIsWired proves the two spellings go to the
+// two places they belong, for the cases where they actually differ.
+//
+// BAML's attribute lexer DOUBLES backslashes, so for five of the 719 expressions the
+// text stock evaluates is not the text the .baml was written with. The project must
+// be rendered from the SOURCE spelling (that is what the lexer consumes) and the
+// native evaluator must be fed the RETAINED spelling (that is what stock evaluated),
+// or the differential compares BAML's lexer against Go's string literals.
+//
+// All five currently decline natively, so a boolean comparison alone cannot see the
+// difference — which is exactly why the wiring is asserted structurally here and the
+// observed expression is asserted per site by soBridgeAssertSites.
+func TestServingOracleBridgeRetainedSpellingIsWired(t *testing.T) {
+	soEnsureRuntime(t)
+	exp := soBridgeCorpus(t)
+
+	rewritten := map[string]soBridgeCase{}
+	for _, c := range exp.Cases {
+		if c.Retained != "" && c.Retained != c.Expr {
+			rewritten[c.Label] = c
+		}
+	}
+	if len(rewritten) != soWantRetainedRewrites {
+		t.Fatalf("the artifact carries %d lexer-rewritten expressions, want %d. Every claim below is about "+
+			"them, so a change in that population has to be acknowledged.", len(rewritten), soWantRetainedRewrites)
+	}
+
+	// The rendered PROJECT must carry the source spelling, and never the retained one.
+	project := soRenderBridgeProject(soBridgeUnits)
+	for label, c := range rewritten {
+		if !strings.Contains(project, c.Expr) {
+			t.Errorf("%s: the .baml project does not carry the SOURCE spelling %q, which is what the "+
+				"attribute lexer consumes", label, c.Expr)
+		}
+		if strings.Contains(project, c.Retained) {
+			t.Errorf("%s: the .baml project carries the RETAINED spelling %q; that is stock's OUTPUT, not "+
+				"its input, and writing it back would double the backslashes again", label, c.Retained)
+		}
+	}
+
+	// The NATIVE bundle must carry the retained spelling, and the source bundle the
+	// source spelling — checked on the unit that actually holds them.
+	found := map[string]bool{}
+	for _, u := range soBridgeUnits {
+		if !u.usesRetainedSpelling() {
+			continue
+		}
+		src := soBridgeConstraintsOf(t, u.Bundle)
+		nat := soBridgeConstraintsOf(t, u.NativeBundle)
+		for label, c := range rewritten {
+			gotSrc, okSrc := src[label]
+			gotNat, okNat := nat[label]
+			if !okSrc || !okNat {
+				continue
+			}
+			found[label] = true
+			if gotSrc != c.Expr {
+				t.Errorf("%s: the project bundle carries %q, want the SOURCE spelling %q", label, gotSrc, c.Expr)
+			}
+			if gotNat != c.Retained {
+				t.Errorf("%s: the NATIVE bundle carries %q, want the STOCK-RETAINED spelling %q",
+					label, gotNat, c.Retained)
+			}
+		}
+	}
+	if len(found) != len(rewritten) {
+		t.Fatalf("only %d of %d rewritten cases were located in a unit; the wiring claim would cover less "+
+			"than it says", len(found), len(rewritten))
+	}
+
+	// And the LIVE observation: stock reports the retained spelling back for each of
+	// them. This is what soBridgeAssertSites compares per site on every run; asserting
+	// it here as well names the five rows the contract exists for.
+	rt, env, err := soBridgeRuntime(soBridgeUnits)
+	if err != nil {
+		t.Fatalf("bridge runtime: %v", err)
+	}
+	seen := 0
+	for _, u := range soBridgeUnits {
+		if !u.usesRetainedSpelling() {
+			continue
+		}
+		stock, callErr := soBridgeDriveStock(rt, env, u)
+		if callErr != nil {
+			t.Fatalf("%s: stock rejected the unit carrying the rewritten expressions: %v", u.Method, callErr)
+		}
+		for _, s := range stock.Sites {
+			c, ok := rewritten[s.Label]
+			if !ok {
+				continue
+			}
+			seen++
+			if s.Expression != c.Retained {
+				t.Errorf("%s: stock retained %q, the artifact records %q", s.Label, s.Expression, c.Retained)
+			}
+			if s.Expression == c.Expr {
+				t.Errorf("%s: stock retained the SOURCE spelling unchanged, so this case no longer witnesses "+
+					"the lexer rewrite and must be re-derived", s.Label)
+			}
+		}
+	}
+	if seen != len(rewritten) {
+		t.Fatalf("observed %d of %d rewritten expressions live; the rest were never driven", seen, len(rewritten))
+	}
+	t.Logf("retained spelling wired for %d lexer-rewritten expressions: project=source, native=retained, "+
+		"stock observed to report the retained form", seen)
+}
+
+// soBridgeConstraintsOf maps label -> expression for the `v` field of a unit's
+// generated class.
+func soBridgeConstraintsOf(t *testing.T, b *schema.Bundle) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	cls := b.Classes[len(b.Classes)-1]
+	for _, f := range cls.Fields {
+		for _, c := range f.Type.Meta.Constraints {
+			if c.Label == nil {
+				continue
+			}
+			if _, dup := out[*c.Label]; dup {
+				t.Fatalf("class %s declares the label %q twice; the lookup would hide one", cls.Name.Name, *c.Label)
+			}
+			out[*c.Label] = c.Expression
+		}
+	}
+	return out
+}
+
+// soRetainedGuardWitness is the row the counterfactual below drifts. It is one of
+// the five expressions BAML's attribute lexer rewrites, so its retained spelling is
+// genuinely different from its source spelling — which is the whole point.
+const soRetainedGuardWitness = "f_lines"
+
+// soWantRetainedWitnessSites is the EXACT size of the check collection the witness
+// unit reports: every non-isolated case of the `const` group, which is where
+// f_lines rides.
+//
+// Pinned exactly rather than bounded, and that is the point. A lower bound would
+// leave the counterfactual technically satisfied after a batching or corpus change
+// that shrank this witness to a two-site collection: the drift would still be
+// caught, but no longer against a collection large enough for "order and
+// cardinality were held stable while only the expression moved" to mean anything —
+// the whole-collection half of the proof would have retired silently while the
+// 719-wide bridge stayed green.
+//
+// IF THE CORPUS REALLY CHANGES this constant must be updated DELIBERATELY, as a
+// conscious edit alongside the regenerated artifact, not adjusted to whatever the
+// run happened to produce.
+const soWantRetainedWitnessSites = 410
+
+// TestServingOracleBridgeRetainedExpressionGuardBites proves the per-site
+// EXPRESSION comparison is the UNIQUE catcher of a drifted retained spelling.
+//
+// The five lexer-rewritten rows all decline natively, so no boolean comparison can
+// see their expression change; and the whole-collection assertion has four other
+// comparisons that could mask which one fired. This holds label, `$.v` path,
+// declaration order, cardinality and boolean status STABLE, changes ONLY the
+// retained expression text, and shows the pair the proof needs:
+//
+//	drifted + every comparison enabled          -> FAILS   (the guard catches it)
+//	drifted + only the expression check disabled -> PASSES  (nothing else catches it)
+//
+// It is hermetic and deterministic: it reads the checked-in artifact and builds both
+// envelopes in memory, with no CFFI call and no file mutation. The LIVE half — that
+// stock really does report the retained spelling back — is
+// TestServingOracleBridgeRetainedSpellingIsWired.
+func TestServingOracleBridgeRetainedExpressionGuardBites(t *testing.T) {
+	units, err := soBridgeUnitsFromArtifact()
+	if err != nil {
+		t.Fatalf("build the bridge units: %v", err)
+	}
+	// Every comparison must be on for the real path, or the counterfactual below
+	// would be turning off something already off.
+	all := reflect.ValueOf(soAllBridgeSiteChecks)
+	for i := 0; i < all.NumField(); i++ {
+		if !all.Field(i).Bool() {
+			t.Fatalf("soAllBridgeSiteChecks.%s is false; the bridge's real path is not running every "+
+				"comparison", all.Type().Field(i).Name)
+		}
+	}
+
+	unit, witness, ok := soFindRetainedWitness(units, soRetainedGuardWitness)
+	if !ok {
+		t.Fatalf("no bridge unit carries the retained-expression row %q; the counterfactual would drift "+
+			"nothing", soRetainedGuardWitness)
+	}
+	if witness.Retained == "" || witness.Retained == witness.Expr {
+		t.Fatalf("%s no longer carries a retained spelling that differs from its source spelling "+
+			"(expr %q, retained %q); pick another of the lexer-rewritten rows",
+			witness.Label, witness.Expr, witness.Retained)
+	}
+
+	faithful := soBridgeFaithfulSites(t, unit)
+	if len(faithful) != soWantRetainedWitnessSites {
+		t.Fatalf("the %s witness unit reports %d check(s), want exactly %d.\n"+
+			"The counterfactual below holds ORDER and CARDINALITY stable across the WHOLE collection while "+
+			"moving one expression, so the collection's size is part of what it proves — a shrunk witness "+
+			"would still catch the drift but would no longer demonstrate that. If the corpus or the "+
+			"batching genuinely changed, update soWantRetainedWitnessSites deliberately.",
+			witness.Label, len(faithful), soWantRetainedWitnessSites)
+	}
+	env := func(sites []soStockSite) soStockEnvelope {
+		return soStockEnvelope{Kind: soStockValue, Identity: "class:x{}", JSON: "{}", Sites: sites}
+	}
+
+	// BASELINE. The faithful collection must be accepted, or "the drifted one fails"
+	// would say nothing about the drift.
+	if got := soBridgeAssertSites(unit, env(faithful), nil); len(got) > 0 {
+		t.Fatalf("the FAITHFUL collection was rejected, so the counterfactual below would prove nothing:\n  %s",
+			strings.Join(got, "\n  "))
+	}
+
+	// DRIFT: one character of one retained expression, and nothing else.
+	drifted := append([]soStockSite(nil), faithful...)
+	idx := -1
+	for i := range drifted {
+		if drifted[i].Label == witness.Label {
+			idx = i
+		}
+	}
+	if idx < 0 {
+		t.Fatalf("%s is not in the witness unit's reported collection", witness.Label)
+	}
+	drifted[idx].Expression = witness.Retained + " "
+
+	// Everything else is held stable, asserted rather than assumed.
+	if len(drifted) != len(faithful) {
+		t.Fatal("the drift changed the cardinality")
+	}
+	for i := range faithful {
+		if drifted[i].Label != faithful[i].Label {
+			t.Fatalf("the drift changed the label at position %d", i)
+		}
+		if drifted[i].Path != faithful[i].Path {
+			t.Fatalf("the drift changed the path at position %d", i)
+		}
+		if drifted[i].Status != faithful[i].Status {
+			t.Fatalf("the drift changed the boolean status at position %d", i)
+		}
+		if drifted[i].Certified != faithful[i].Certified {
+			t.Fatalf("the drift changed the certification at position %d", i)
+		}
+		changed := drifted[i].Expression != faithful[i].Expression
+		switch {
+		case i == idx && !changed:
+			t.Fatalf("the drift did NOT change the expression at position %d, so the counterfactual would "+
+				"be comparing a collection against itself", i)
+		case i != idx && changed:
+			t.Fatalf("the drift also changed the expression at position %d; only %d may move", i, idx)
+		}
+	}
+
+	// V7: the guard catches it.
+	withGuard := soBridgeAssertSites(unit, env(drifted), nil)
+	if len(withGuard) == 0 {
+		t.Fatal("a drifted RETAINED expression was accepted with every comparison enabled; the native leg " +
+			"would be evaluating a spelling stock never reported")
+	}
+	joined := strings.Join(withGuard, "\n  ")
+	if !strings.Contains(joined, "RETAINED the expression") {
+		t.Fatalf("the failure does not name the retained expression:\n  %s", joined)
+	}
+
+	// V8: nothing ELSE catches it. Exactly one comparison is turned off.
+	noExpr := soAllBridgeSiteChecks
+	noExpr.Expression = false
+	if diff := soBridgeChecksDiff(soAllBridgeSiteChecks, noExpr); diff != []string{"Expression"}[0] {
+		t.Fatalf("the counterfactual disables %q, want only Expression", diff)
+	}
+	if got := soBridgeAssertSitesWith(unit, env(drifted), nil, noExpr); len(got) > 0 {
+		t.Fatalf("with ONLY the expression comparison disabled the drift was still caught, so the "+
+			"expression assertion is not the unique catcher and this proof is not the one it claims:\n  %s",
+			strings.Join(got, "\n  "))
+	}
+	t.Logf("retained-expression guard is the unique catcher: drift caught with every comparison enabled, "+
+		"accepted with only the expression comparison disabled (witness %s, %d sites held stable)",
+		witness.Label, len(faithful))
+}
+
+// soFindRetainedWitness locates the unit carrying a named case.
+func soFindRetainedWitness(units []soBridgeUnit, label string) (soBridgeUnit, soBridgeCase, bool) {
+	for _, u := range units {
+		for _, c := range u.Cases {
+			if c.Label == label {
+				return u, c, true
+			}
+		}
+	}
+	return soBridgeUnit{}, soBridgeCase{}, false
+}
+
+// soBridgeFaithfulSites builds the check collection stock reports for a unit, from
+// the artifact alone.
+//
+// It is deterministic and needs no CFFI: the artifact pins each case's outcome, and
+// the retained spelling is what stock echoes back in Check.Expression. That stock
+// really behaves this way is asserted live elsewhere
+// (TestServingOracleBridgeRetainedSpellingIsWired and every bridge run); here the
+// point is only that the two envelopes differ in exactly one field.
+func soBridgeFaithfulSites(t *testing.T, u soBridgeUnit) []soStockSite {
+	t.Helper()
+	var out []soStockSite
+	for _, c := range u.Cases {
+		var status string
+		switch c.Stock {
+		case "true":
+			status = "succeeded"
+		case "false":
+			status = "failed"
+		case "no-checks":
+			continue
+		default:
+			t.Fatalf("%s: the witness unit carries the outcome %q, which stock does not report as a check "+
+				"status; pick a unit whose cases are all real statuses", c.Label, c.Stock)
+		}
+		out = append(out, soStockSite{
+			Path: "$.v", Label: c.Label, Expression: c.retainedExpr(), Status: status, Certified: true,
+		})
+	}
+	return out
+}
+
+// soBridgeChecksDiff names the fields that differ between two comparison sets, so
+// the counterfactual can prove it disabled exactly one.
+func soBridgeChecksDiff(a, b soBridgeSiteChecks) string {
+	av, bv := reflect.ValueOf(a), reflect.ValueOf(b)
+	var diff []string
+	for i := 0; i < av.NumField(); i++ {
+		if av.Field(i).Bool() != bv.Field(i).Bool() {
+			diff = append(diff, av.Type().Field(i).Name)
+		}
+	}
+	return strings.Join(diff, ",")
+}
+
+// TestServingOracleBridgeRejectsDuplicateCaseLabels pins the artifact-boundary
+// check that duplicate JSON-key rejection cannot make.
+//
+// Two distinct case objects may reuse a Label without repeating any JSON key. The
+// label is what the generated @check attribute, the per-site assertion and both
+// outcome lookups select by, so a duplicate silently reads one case's evidence for
+// another while the total still comes to 719.
+func TestServingOracleBridgeRejectsDuplicateCaseLabels(t *testing.T) {
+	base := soBridgeExport{
+		Version: soBridgeVersion,
+		Groups:  []soBridgeGroup{{Name: "g", BAMLType: "int", Input: `{"v":1}`}},
+		Cases: []soBridgeCase{
+			{Label: "dup", Group: "g", Expr: "this > 0", Stock: "true", Native: "true"},
+			{Label: "other", Group: "g", Expr: "this > 1", Stock: "false", Native: "false"},
+		},
+	}
+	// CONTROL first: unique labels build, so the rejection below is about the
+	// duplication rather than about the fixture being malformed.
+	if _, err := soBuildBridgeUnits(base); err != nil {
+		t.Fatalf("the unique-label control does not build: %v", err)
+	}
+
+	dup := base
+	dup.Cases = append([]soBridgeCase(nil), base.Cases...)
+	// A DIFFERENT case object reusing the label: no JSON key is repeated, so the
+	// strict decoder cannot see it.
+	dup.Cases[1].Label = "dup"
+	_, err := soBuildBridgeUnits(dup)
+	if err == nil {
+		t.Fatal("two case objects sharing a Label were ACCEPTED; all 719 cases would still be counted while " +
+			"one case's evidence was read for another")
+	}
+	if !strings.Contains(err.Error(), "duplicate case label") {
+		t.Fatalf("the refusal does not name the duplicate label: %v", err)
+	}
+
+	// And the live artifact is clean, so the check is not merely latent.
+	exp := soBridgeCorpus(t)
+	seen := map[string]bool{}
+	for _, c := range exp.Cases {
+		if seen[c.Label] {
+			t.Fatalf("the checked-in artifact carries the duplicate label %q", c.Label)
+		}
+		seen[c.Label] = true
+	}
+	if len(seen) != len(exp.Cases) {
+		t.Fatalf("the artifact has %d cases under %d distinct labels", len(exp.Cases), len(seen))
+	}
+}

--- a/internal/debaml/serving_oracle_compare_test.go
+++ b/internal/debaml/serving_oracle_compare_test.go
@@ -1,0 +1,908 @@
+//go:build integration
+
+package debaml
+
+// The CONTRACT: how a stock envelope and a native envelope are allowed to relate.
+//
+// There is one rule and it is fail-closed:
+//
+//	native may reproduce stock exactly, or refuse to decide. It may never produce
+//	a boolean stock did not produce, and it may never produce a DIFFERENT one.
+//
+// Everything below is that rule made discriminating. Each row lands in exactly one
+// agreement bucket, the buckets are tallied and pinned, and a row that would land
+// in none is a failure rather than a silently defaulted "other". Every bucket that
+// is not an agreement requires the fixture to carry a one-sentence Divergence note,
+// so a measured cost can neither appear nor disappear without being written down.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// soAgreement is how one row's two envelopes relate.
+type soAgreement string
+
+const (
+	// soAgreeValue: stock emitted a value, native canonicalized the same document
+	// with the same identity, and every check site agreed.
+	soAgreeValue soAgreement = "agree-value"
+	// soAgreeAssertFailure: stock REJECTED the node on a false @assert and native's
+	// state records the same assertion, at the same level, evaluating false.
+	soAgreeAssertFailure soAgreement = "agree-assert-failure"
+	// soAgreeRefusal: neither engine produced a boolean — stock's evaluator or
+	// coercion failed and native refused too. They agree in substance.
+	soAgreeRefusal soAgreement = "agree-refusal"
+	// soNativeDeclinesPredicate: stock DECIDED and native refused the PREDICATE with
+	// ErrConstraintUnsupported. Safe, and the measured cost of the native profile.
+	soNativeDeclinesPredicate soAgreement = "native-declines-predicate"
+	// soNativeDeclinesCoercion: native's production coerce refused the VALUE with the
+	// ErrDeBAMLParseUnsupported sentinel, so no state exists to compare. Fail-closed
+	// by construction: the same sentinel is what makes the serving path fall back.
+	soNativeDeclinesCoercion soAgreement = "native-declines-coercion"
+	// soNativeDeclinesExtraction: native's extraction stage found no cleanly-claimable
+	// candidate in the assistant text, so it never reached coercion. Stock's
+	// recovery is broader. Also a decline, also fail-closed.
+	soNativeDeclinesExtraction soAgreement = "native-declines-extraction"
+	// soCollectorRefuses: the TEST-ONLY collector could not mirror production's
+	// coercion (an unmodelled shape, or a traversal that did not serialize to
+	// production's bytes) and refused to report a state. It is a limitation of the
+	// witness rather than of either engine, and it is recorded as such.
+	soCollectorRefuses soAgreement = "collector-refuses"
+	// soStateDiverges: the two legs canonicalized the same raw text into different
+	// values. Never served, because the row is constraint-bearing.
+	soStateDiverges soAgreement = "state-divergence"
+	// soEventShapeDiverges: the two legs agree on every boolean but not on the SHAPE
+	// of the check collection — stock repeated a check, or reported none where
+	// native ran one and declined it.
+	soEventShapeDiverges soAgreement = "event-shape-divergence"
+	// soStockUnobservable: stock aborts or hangs, so there is no envelope to agree
+	// with and no boolean may be fabricated.
+	soStockUnobservable soAgreement = "stock-unobservable"
+)
+
+// soIsAgreement reports whether a bucket is an AGREEMENT, i.e. one that requires
+// no Divergence note.
+func soIsAgreement(a soAgreement) bool {
+	return a == soAgreeValue || a == soAgreeAssertFailure || a == soAgreeRefusal
+}
+
+// soMismatchKind names WHERE two envelopes parted company, so a failure report
+// says what kind of disagreement it is rather than only that there was one.
+type soMismatchKind string
+
+const (
+	soMismatchState    soMismatchKind = "state"
+	soMismatchEvent    soMismatchKind = "event"
+	soMismatchBoundary soMismatchKind = "boundary"
+)
+
+// soMismatch is one way the two envelopes parted company.
+//
+// Violation says whether it BREAKS the contract. A documented state or
+// check-collection-shape difference does not: it defines the row's bucket, is
+// pinned byte-for-byte by the recorded envelopes, and is required to carry a
+// Divergence note. A boolean disagreement, an admitted constraint-bearing bundle,
+// or a native answer where stock produced none always does.
+type soMismatch struct {
+	Kind      soMismatchKind
+	Violation bool
+	Detail    string
+}
+
+func (m soMismatch) String() string {
+	tag := "RECORDED"
+	if m.Violation {
+		tag = "VIOLATION"
+	}
+	return tag + " " + string(m.Kind) + ": " + m.Detail
+}
+
+// soViolations filters a mismatch list down to the contract-breaking entries.
+func soViolations(ms []soMismatch) []soMismatch {
+	var out []soMismatch
+	for _, m := range ms {
+		if m.Violation {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// soCheckSites returns native's CHECK-level sites — the ones stock can report back
+// inside a value. @assert sites are handled separately, because stock never
+// carries a holding assertion in the value and reports a failing one as a
+// rejection.
+func soCheckSites(env soNativeEnvelope) []soNativeSite {
+	var out []soNativeSite
+	for _, s := range env.Sites {
+		if s.Level == schema.ConstraintCheck {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// soCollapseRepeats folds CONSECUTIVE IDENTICAL stock sites into one.
+//
+// Stock repeats a check when the value reached its node more than once — a
+// single-value-into-list wrap, or a list re-coerced after an element was dropped —
+// and reports the same (path, label, expression, status) twice. That is a fact
+// about the check COLLECTION's shape, not about the predicate: the result is
+// identical, so folding cannot hide a differing boolean.
+//
+// It is deliberately narrow. Two checks sharing a label with DIFFERENT expressions
+// (the duplicate-label asymmetry) are not consecutive-identical and survive; so
+// does the same expression with a different status. TestServingOracleDuplicateLabel
+// is the control that proves the fold does not swallow that case.
+func soCollapseRepeats(sites []soStockSite) []soStockSite {
+	var out []soStockSite
+	for _, s := range sites {
+		if n := len(out); n > 0 && out[n-1] == s {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// soDecidedSites are the native sites that produced a boolean.
+func soDecidedSites(sites []soNativeSite) []soNativeSite {
+	var out []soNativeSite
+	for _, s := range sites {
+		if s.Outcome == constraintOutcomeTrue || s.Outcome == constraintOutcomeFalse {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// soCompare applies the contract and returns every way the two legs disagree,
+// together with the agreement bucket the row lands in.
+func soCompare(f servingOracleFixture, stock soStockEnvelope, native soNativeEnvelope) (soAgreement, []soMismatch) {
+	var out []soMismatch
+	add := func(k soMismatchKind, format string, args ...any) {
+		out = append(out, soMismatch{Kind: k, Violation: true, Detail: fmt.Sprintf(format, args...)})
+	}
+	record := func(k soMismatchKind, format string, args ...any) {
+		out = append(out, soMismatch{Kind: k, Detail: fmt.Sprintf(format, args...)})
+	}
+
+	// ---- boundary -------------------------------------------------------
+	//
+	// Recorded for EVERY row, on every run: the support verdict the collector read
+	// off production's own checkSupported. A constraint-bearing row that became
+	// admitted is a boundary mismatch here as well as a failure of the dedicated
+	// boundary test, so the differential cannot go green on an admitted fixture.
+	if f.Unconstrained {
+		if native.Support != nil {
+			add(soMismatchBoundary, "the UNCONSTRAINED control was DECLINED by checkSupported (%v); the "+
+				"decline must be caused by constraints, not by the shape", native.Support)
+		}
+	} else {
+		switch {
+		case native.Support == nil:
+			add(soMismatchBoundary, "checkSupported ADMITTED a constraint-bearing bundle; native would serve a "+
+				"value BAML computes differently")
+		case !errors.Is(native.Support, bamlutils.ErrDeBAMLParseUnsupported):
+			add(soMismatchBoundary, "checkSupported declined with an error that does not wrap "+
+				"ErrDeBAMLParseUnsupported: %v", native.Support)
+		}
+	}
+
+	if f.Fatal {
+		// Stock is unobservable. The only claim available is that native refuses,
+		// asserted here and again, with the live subprocess evidence, by
+		// TestServingOracleFatalRowIsUnobservable.
+		for _, s := range native.Sites {
+			if s.Outcome != constraintOutcomeUnsupported {
+				add(soMismatchEvent, "stock is process-fatal for this row, but native DECIDED %s for %s — "+
+					"no boolean may be produced where the oracle cannot be observed", s.Outcome, s.render())
+			}
+		}
+		return soStockUnobservable, out
+	}
+
+	// ---- native produced no state at all --------------------------------
+	//
+	// Three different reasons, kept apart. Two are production DECLINES and are
+	// fail-closed by construction; the third is the test-only collector refusing,
+	// which is a limitation of the witness and is recorded as one.
+	switch native.Kind {
+	case soNativeNoCandidate:
+		return soNativeDeclinesExtraction, out
+	case soNativeUnmodelled, soNativeCollectorDiverged:
+		return soCollectorRefuses, out
+	case soNativeCoercionError:
+		if stock.Kind == soStockUnrecognisedError {
+			add(soMismatchState, "stock returned an unrecognised error shape: %s",
+				strings.Join(stock.Reasons, " | "))
+			return soAgreement("unrecognised-stock-error"), out
+		}
+		// The two axes are independent and both matter: did native fall back with the
+		// supported sentinel or fail outright, and did stock DECIDE something or refuse
+		// the value too.
+		//
+		// A stock assertion-failure is a DECISION — stock named an assertion and
+		// rejected the node on it — so it can never be a shared refusal. Folding it into
+		// agree-refusal was calling a real difference an agreement.
+		sentinel := errors.Is(native.Err, bamlutils.ErrDeBAMLParseUnsupported)
+		switch {
+		case sentinel && stock.Kind == soStockValue:
+			return soNativeDeclinesCoercion, out
+		case sentinel && stock.Kind == soStockAssertFailed:
+			// Stock decided; native declined to coerce at all. Safe (the caller falls
+			// back to BAML) but a measured cost, not an agreement.
+			return soNativeDeclinesCoercion, out
+		case sentinel:
+			// Stock refused the value too, so neither engine produced anything.
+			return soAgreeRefusal, out
+		case stock.Kind == soStockValue:
+			add(soMismatchState, "stock produced a value (%s) but native's coercion FAILED without the "+
+				"unsupported sentinel: %v", stock.Identity, native.Err)
+			return soStateDiverges, out
+		case stock.Kind == soStockAssertFailed:
+			add(soMismatchState, "stock REJECTED the node on a named assertion (%s) but native's coercion "+
+				"FAILED without the unsupported sentinel (%v); that is a claimed native parse failure, not a "+
+				"fall back to BAML, and the two legs do not agree",
+				strings.Join(soFailedAssert(stock.Reasons), " | "), native.Err)
+			return soStateDiverges, out
+		default:
+			// Stock's evaluator or coercion failed and native failed too.
+			return soAgreeRefusal, out
+		}
+	}
+
+	// ---- state ----------------------------------------------------------
+	stateDiverged := false
+	if stock.Kind == soStockValue {
+		if stock.Identity != native.Identity {
+			record(soMismatchState, "canonical identity differs:\n      stock  %s\n      native %s",
+				stock.Identity, native.Identity)
+			stateDiverged = true
+		} else if diff, ok := constraintStateJSONEquivalent([]byte(native.JSON), []byte(stock.JSON)); !ok {
+			// Exact, order-sensitive, big.Rat over numbers — never float64.
+			record(soMismatchState, "canonical document differs at %s:\n      stock  %s\n      native %s",
+				diff, stock.JSON, native.JSON)
+			stateDiverged = true
+		}
+	}
+
+	// ---- events ---------------------------------------------------------
+	drops := soDropsByPrefix(native)
+	nativeChecks := soCheckSites(native)
+	stockSites := soCollapseRepeats(stock.Sites)
+	eventShapeDiverged := len(stockSites) != len(stock.Sites)
+	if eventShapeDiverged {
+		record(soMismatchEvent, "stock REPEATED a check: %d entries collapse to %d distinct ones:\n      %s",
+			len(stock.Sites), len(stockSites), soRenderStockSites(stock.Sites))
+	}
+
+	switch stock.Kind {
+	case soStockValue:
+		// ORDER IS ONLY CLAIMED WHERE IT WAS OBSERVED. A site read from the raw CFFI
+		// tree carries stock's own order; one recovered from a folded ROOT collection
+		// does not (see soFoldedSites), so those are compared as an unordered multiset
+		// per path and the unavailability is recorded on the row rather than papered
+		// over with the schema's order.
+		certified, uncertified := 0, 0
+		for _, ss := range stockSites {
+			if ss.Certified {
+				certified++
+			} else {
+				uncertified++
+			}
+		}
+		if certified > 0 && uncertified > 0 {
+			add(soMismatchEvent, "the row mixes %d CERTIFIED and %d UNCERTIFIED check site(s); the comparator "+
+				"models one or the other, not both, so this shape is unmodelled rather than silently compared "+
+				"at the weaker standard", certified, uncertified)
+			break
+		}
+		if uncertified > 0 {
+			record(soMismatchEvent, "root-envelope certification is UNAVAILABLE for %d site(s): baml_go folds "+
+				"a root Checked's collection into a map before this oracle can see it, so stock's ORDER and "+
+				"MULTIPLICITY there are unobservable. Label, expression, path and result ARE compared; order "+
+				"is not claimed.", uncertified)
+			out = append(out, soCompareUncertifiedSites(stockSites, nativeChecks)...)
+			break
+		}
+		if len(stockSites) != len(nativeChecks) {
+			// The ONE tolerated shape difference: stock reported nothing (its optional
+			// coercion swallowed the failure) and native decided nothing either.
+			// Anything else is a real disagreement.
+			if len(stockSites) == 0 && len(soDecidedSites(nativeChecks)) == 0 {
+				record(soMismatchEvent, "stock reported NO check (its optional coercion swallowed the "+
+					"failure) where native ran %d and decided none of them: %s",
+					len(nativeChecks), soRenderNativeSites(nativeChecks))
+				eventShapeDiverged = true
+				break
+			}
+			add(soMismatchEvent, "stock ran %d check(s) and native ran %d:\n      stock  %s\n      native %s",
+				len(stockSites), len(nativeChecks), soRenderStockSites(stockSites), soRenderNativeSites(nativeChecks))
+			// The differential fails on the violation above, but the BUCKET must move too:
+			// leaving it at agree-value would let the tally and the note contract call a
+			// check-collection mismatch an agreement.
+			eventShapeDiverged = true
+			break
+		}
+		for i, ss := range stockSites {
+			ns := nativeChecks[i]
+			if ss.Expression != ns.Expression {
+				add(soMismatchEvent, "check %d: stock evaluated %q and native evaluated %q",
+					i, ss.Expression, ns.Expression)
+				continue
+			}
+			if ss.Label != ns.Label {
+				add(soMismatchEvent, "check %d (%q): stock labelled it %q and native %q",
+					i, ss.Expression, ss.Label, ns.Label)
+			}
+			// EVERY site's path is compared, root ones included. A root Checked's
+			// collection reaches this code folded (see soChecked), but its path and
+			// order are re-derived from the schema and its contents verified exactly,
+			// so there is nothing to exempt.
+			if want := soAlignNativePath(ns.Path, drops); want != ss.Path {
+				add(soMismatchEvent, "check %d (%q): stock ran it at %s, native at %s (aligned %s)",
+					i, ss.Expression, ss.Path, ns.Path, want)
+			}
+			switch ns.Outcome {
+			case constraintOutcomeUnsupported:
+				// Native declined this predicate: safe, and counted as a cost below.
+			case constraintOutcomeTrue:
+				if ss.Status != "succeeded" {
+					add(soMismatchEvent, "check %d (%q): native answered TRUE where stock reported %q",
+						i, ss.Expression, ss.Status)
+				}
+			case constraintOutcomeFalse:
+				if ss.Status != "failed" {
+					add(soMismatchEvent, "check %d (%q): native answered FALSE where stock reported %q",
+						i, ss.Expression, ss.Status)
+				}
+			default:
+				add(soMismatchEvent, "check %d (%q): native produced the unrecognised outcome %q",
+					i, ss.Expression, ns.Outcome)
+			}
+		}
+		// A holding @assert leaves no trace in stock's value, so every native assert
+		// site must have held (or been declined). One that evaluated FALSE would mean
+		// native rejects a node stock served.
+		for _, s := range native.Sites {
+			if s.Level == schema.ConstraintAssert && s.Outcome == constraintOutcomeFalse {
+				add(soMismatchEvent, "stock SERVED the value, but native's @assert %s evaluated false", s.render())
+			}
+		}
+
+	case soStockAssertFailed:
+		// Stock named the assertion that rejected the node. Native must have found
+		// the same one false — or have declined it.
+		failed := soFailedAssert(stock.Reasons)
+		if len(failed) == 0 {
+			add(soMismatchEvent, "stock reported an assertion failure but named no assertion: %v", stock.Reasons)
+			break
+		}
+		for _, want := range failed {
+			matched, declined := false, false
+			for _, s := range native.Sites {
+				if s.Level != schema.ConstraintAssert {
+					continue
+				}
+				// Stock renders the pair as "<label> <expression>".
+				if want != strings.TrimSpace(s.Label+" "+s.Expression) {
+					continue
+				}
+				switch s.Outcome {
+				case constraintOutcomeFalse:
+					matched = true
+				case constraintOutcomeUnsupported:
+					declined = true
+				case constraintOutcomeTrue:
+					add(soMismatchEvent, "stock REJECTED the node on %q, but native evaluated that assertion TRUE",
+						want)
+				}
+			}
+			if !matched && !declined {
+				add(soMismatchEvent, "stock rejected the node on the assertion %q, which native's state does not "+
+					"record as false or declined:\n      native %s", want, soRenderNativeSites(native.Sites))
+			}
+		}
+		// Stock rejected the node, so it emitted no value and reported no check. The
+		// ONLY predicates native may have decided are the assertions stock itself
+		// named; anything else is a boolean stock did not produce.
+		for _, s := range soDecidedSites(native.Sites) {
+			named := false
+			for _, want := range failed {
+				if want == strings.TrimSpace(s.Label+" "+s.Expression) {
+					named = true
+				}
+			}
+			if !named {
+				add(soMismatchEvent, "stock REJECTED the node on %v and reported no check, but native decided "+
+					"%s for %s, which stock never named", failed, s.Outcome, s.render())
+			}
+		}
+
+	case soStockEvaluatorError, soStockCoercionError:
+		// Stock produced NO VALUE at all, so it produced no boolean either. Native
+		// deciding ANY predicate here is a boolean stock did not produce — the exact
+		// thing the fail-closed rule forbids — and it is a violation whether stock's
+		// message happens to name that predicate or not.
+		//
+		// This used to be guarded only for soStockEvaluatorError, and only for
+		// predicates stock's message named. That accepted the counterexample
+		// "stock returned a coercion error while native returned a canonical value
+		// and a true/false check", which is what
+		// TestServingOracleContractRejectsNativeDecisionWithoutStock now pins.
+		for _, s := range soDecidedSites(native.Sites) {
+			add(soMismatchEvent, "stock produced NO value (%s: %s) but native DECIDED %s for %s; native may "+
+				"never produce a boolean stock did not produce",
+				stock.Kind, strings.Join(stock.Reasons, " | "), s.Outcome, s.render())
+		}
+		// Native canonicalizing a value where stock produced none is a STATE
+		// difference. It is not by itself a contract violation — native serves
+		// nothing, because the bundle declines — but it must be recorded and noted
+		// rather than silently read as agreement.
+		if native.Identity != "" {
+			record(soMismatchState, "stock produced no value (%s) but native canonicalized %s",
+				stock.Kind, native.Identity)
+			stateDiverged = true
+		}
+
+	case soStockUnrecognisedError:
+		add(soMismatchState, "stock returned an error shape the envelope vocabulary does not recognise, so "+
+			"there is nothing to compare against: %s", strings.Join(stock.Reasons, " | "))
+	}
+
+	// ---- bucket ---------------------------------------------------------
+	//
+	// Priority order, most specific first. A row lands in exactly one bucket and the
+	// tally pins the population of each.
+	// Gate on the actual UNDECIDED population, at any level. Gating on nativeChecks
+	// missed a value whose only native site is a declined @assert: it has no
+	// check-level site, so the row landed in agree-value with no divergence note even
+	// though native refused to decide something.
+	declinedPredicate := len(soDecidedSites(native.Sites)) < len(native.Sites)
+	switch {
+	case stateDiverged:
+		return soStateDiverges, out
+	case eventShapeDiverged:
+		return soEventShapeDiverges, out
+	case declinedPredicate && stock.Kind == soStockValue:
+		return soNativeDeclinesPredicate, out
+	case stock.Kind == soStockValue:
+		return soAgreeValue, out
+	case stock.Kind == soStockAssertFailed:
+		return soAgreeAssertFailure, out
+	case stock.Kind == soStockEvaluatorError, stock.Kind == soStockCoercionError:
+		return soAgreeRefusal, out
+	case stock.Kind == soStockUnrecognisedError:
+		return soAgreement("unrecognised-stock-error"), out
+	}
+	out = append(out, soMismatch{Kind: soMismatchEvent,
+		Detail: "the row landed in no agreement bucket; stock kind " + string(stock.Kind)})
+	return soAgreement("unbucketed"), out
+}
+
+// soStockNamesExpression reports whether stock's reason chain mentions this
+// expression, i.e. whether the evaluator failure was about THIS predicate.
+//
+// Without it, a class whose evaluator failed on one predicate would forbid native
+// from deciding a DIFFERENT, unrelated predicate on the same node — which stock
+// never claimed anything about.
+func soStockNamesExpression(reasons []string, expr string) bool {
+	for _, r := range reasons {
+		if strings.Contains(r, expr) {
+			return true
+		}
+	}
+	return false
+}
+
+func soRenderStockSites(sites []soStockSite) string {
+	parts := make([]string, len(sites))
+	for i, s := range sites {
+		parts[i] = s.render()
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
+func soRenderNativeSites(sites []soNativeSite) string {
+	parts := make([]string, len(sites))
+	for i, s := range sites {
+		parts[i] = s.render()
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
+// soReport is the PER-CASE report. Every failure in this package carries one, so no
+// assertion is ever satisfied by an aggregate: the row names its own .baml source
+// and method, the raw text both legs were given, the schema in play, and both
+// envelopes in full.
+func soReport(f servingOracleFixture, stock soStockEnvelope, native soNativeEnvelope, problems []soMismatch) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n  fixture   %s (family %s)", f.Name, f.Family)
+	fmt.Fprintf(&b, "\n  purpose   %s", f.Doc)
+	fmt.Fprintf(&b, "\n  source    %s", f.source())
+	fmt.Fprintf(&b, "\n  raw       %q", f.Raw)
+	fmt.Fprintf(&b, "\n  schema    %s", soTypeExpr(f.Bundle.Target))
+	fmt.Fprintf(&b, "\n  stock     %s", stock.render())
+	fmt.Fprintf(&b, "\n  native    %s", native.render())
+	fmt.Fprintf(&b, "\n  support   %v", native.Support)
+	if f.Divergence != "" {
+		fmt.Fprintf(&b, "\n  divergence %s", f.Divergence)
+	}
+	for _, p := range problems {
+		fmt.Fprintf(&b, "\n  MISMATCH  %s", p)
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// The contract, driven directly.
+// ---------------------------------------------------------------------------
+
+// soContractFixture is a minimal constraint-bearing fixture for the direct
+// contract tests. It is a real bundle, so the boundary arm of the contract sees
+// the same decline it sees for a corpus row.
+func soContractFixture() servingOracleFixture {
+	return servingOracleFixture{
+		Name: "contract-probe", Family: "scalar", Doc: "direct contract test",
+		Bundle: soOneFieldBundle("SoContractProbe", soWith(intType(), soCheck("gt", "this > 0"))),
+		Raw:    `{"v":5}`,
+	}
+}
+
+// TestServingOracleContractRejectsNativeDecisionWithoutStock is the direct proof
+// of the fail-closed rule's hardest edge: stock produced NO value, so it produced
+// no boolean, and native must not produce one either.
+//
+// It is driven over SYNTHETIC envelopes rather than through the CFFI, because the
+// point is the comparator's behaviour on a combination the current corpus does not
+// contain — a combination that was silently ACCEPTED before this test existed.
+func TestServingOracleContractRejectsNativeDecisionWithoutStock(t *testing.T) {
+	f := soContractFixture()
+	decided := func(outcome constraintStateOutcome) soNativeEnvelope {
+		return soNativeEnvelope{
+			Kind: soNativeValue, Identity: "class:SoContractProbe{v=int:5}", JSON: `{"v":5}`,
+			Support: checkSupported(f.Bundle),
+			Sites: []soNativeSite{{
+				Path: "$.v", Origin: constraintOriginTypeMeta, Level: schema.ConstraintCheck,
+				Labeled: true, Label: "gt", Expression: "this > 0", Outcome: outcome,
+			}},
+		}
+	}
+
+	cases := []struct {
+		name  string
+		stock soStockEnvelope
+		// wantViolation is whether the contract must REJECT the pair.
+		wantViolation bool
+		// declineIsClean says whether the SAME pair with native DECLINING must carry
+		// no violation at all. It is false only for the assertion row, where stock
+		// names an assertion native's state does not record — a separate, legitimate
+		// violation that has nothing to do with the decided predicate under test, and
+		// one TestServingOracleContractAcceptsStockNamedAssertion covers directly.
+		declineIsClean bool
+	}{
+		{
+			name: "stock coercion error, native decides TRUE",
+			stock: soStockEnvelope{Kind: soStockCoercionError,
+				Reasons: []string{"Failed while parsing required fields: missing=0, unparsed=1"}},
+			wantViolation: true, declineIsClean: true,
+		},
+		{
+			name: "stock evaluator error, native decides TRUE",
+			stock: soStockEnvelope{Kind: soStockEvaluatorError,
+				Reasons: []string{"Failed to evaluate constraints: unknown filter: filter nope is unknown"}},
+			wantViolation: true, declineIsClean: true,
+		},
+		{
+			name: "stock evaluator error naming a DIFFERENT expression, native still decides",
+			stock: soStockEnvelope{Kind: soStockEvaluatorError,
+				Reasons: []string{"Failed to evaluate constraints: unknown filter: something else entirely"}},
+			wantViolation: true, declineIsClean: true,
+		},
+		{
+			name: "stock assertion failure, native decides an assertion stock did NOT name",
+			stock: soStockEnvelope{Kind: soStockAssertFailed,
+				Reasons: []string{"Assertions failed.", "Failed: other this > 100"}},
+			wantViolation: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, outcome := range []constraintStateOutcome{constraintOutcomeTrue, constraintOutcomeFalse} {
+				_, problems := soCompare(f, tc.stock, decided(outcome))
+				got := len(soViolations(problems)) > 0
+				if got != tc.wantViolation {
+					t.Fatalf("native decided %s where stock produced no value: violation=%v, want %v\n  %v",
+						outcome, got, tc.wantViolation, problems)
+				}
+			}
+			// The DECLINED variant of the very same pair must be accepted: refusing to
+			// decide is exactly what native is allowed to do.
+			if !tc.declineIsClean {
+				return
+			}
+			_, problems := soCompare(f, tc.stock, decided(constraintOutcomeUnsupported))
+			for _, v := range soViolations(problems) {
+				if v.Kind == soMismatchEvent {
+					t.Fatalf("native DECLINING the predicate must not be a violation; got %v", v)
+				}
+			}
+		})
+	}
+}
+
+// TestServingOracleContractRejectsUnnamedDecisionBesideANamedAssertion is the
+// narrow case only the "stock never named it" guard can catch.
+//
+// Stock rejects the node on an assertion native DOES record as false — so the
+// matching arm is satisfied — and native ALSO decides an unrelated @check. Stock
+// emitted no value and reported no check, so that second boolean is one stock never
+// produced.
+func TestServingOracleContractRejectsUnnamedDecisionBesideANamedAssertion(t *testing.T) {
+	ty := soWith(intType(), soAssert("gt", "this > 100"), soCheck("pos", "this > 0"))
+	f := servingOracleFixture{
+		Name: "contract-mixed-probe", Family: "scalar", Doc: "direct contract test",
+		Bundle: soOneFieldBundle("SoContractMixed", ty), Raw: `{"v":5}`,
+	}
+	stock := soStockEnvelope{Kind: soStockAssertFailed,
+		Reasons: []string{"Assertions failed.", "Failed: gt this > 100"}}
+	site := func(level schema.ConstraintLevel, label, expr string, o constraintStateOutcome) soNativeSite {
+		return soNativeSite{Path: "$.v", Origin: constraintOriginTypeMeta, Level: level,
+			Labeled: true, Label: label, Expression: expr, Outcome: o}
+	}
+	native := soNativeEnvelope{
+		Kind: soNativeAssertFailed, Identity: "class:SoContractMixed{v=int:5}", JSON: `{"v":5}`,
+		Support: checkSupported(f.Bundle),
+		Sites: []soNativeSite{
+			site(schema.ConstraintAssert, "gt", "this > 100", constraintOutcomeFalse),
+			site(schema.ConstraintCheck, "pos", "this > 0", constraintOutcomeTrue),
+		},
+	}
+	if _, problems := soCompare(f, stock, native); len(soViolations(problems)) == 0 {
+		t.Fatal("native decided a @check stock never reported, beside an assertion stock DID name; the " +
+			"unnamed decision is a boolean stock did not produce and must be a violation")
+	}
+	// CONTROL: the same pair with the unrelated check DECLINED is accepted, so the
+	// guard is about deciding rather than about having a second constraint at all.
+	native.Sites[1].Outcome = constraintOutcomeUnsupported
+	if _, problems := soCompare(f, stock, native); len(soViolations(problems)) > 0 {
+		t.Fatalf("declining the unrelated predicate must be accepted; got %v", soViolations(problems))
+	}
+}
+
+// TestServingOracleContractAcceptsStockNamedAssertion is the other direction: the
+// one decided predicate a stock no-value outcome DOES evidence is the assertion
+// stock's own message names.
+//
+// Without it the rule above would be a blanket ban, and every assertion-failure
+// row in the corpus would be a violation — a test that forbids everything proves
+// nothing about what is allowed.
+func TestServingOracleContractAcceptsStockNamedAssertion(t *testing.T) {
+	f := servingOracleFixture{
+		Name: "contract-assert-probe", Family: "scalar", Doc: "direct contract test",
+		Bundle: soOneFieldBundle("SoContractAssert", soWith(intType(), soAssert("gt", "this > 100"))),
+		Raw:    `{"v":5}`,
+	}
+	stock := soStockEnvelope{Kind: soStockAssertFailed,
+		Reasons: []string{"Assertions failed.", "Failed: gt this > 100"}}
+	native := soNativeEnvelope{
+		Kind: soNativeAssertFailed, Identity: "class:SoContractAssert{v=int:5}", JSON: `{"v":5}`,
+		Support: checkSupported(f.Bundle),
+		Sites: []soNativeSite{{
+			Path: "$.v", Origin: constraintOriginTypeMeta, Level: schema.ConstraintAssert,
+			Labeled: true, Label: "gt", Expression: "this > 100", Outcome: constraintOutcomeFalse,
+		}},
+	}
+	bucket, problems := soCompare(f, stock, native)
+	if v := soViolations(problems); len(v) > 0 {
+		t.Fatalf("the assertion stock itself named must be allowed to be decided false: %v", v)
+	}
+	if bucket != soAgreeAssertFailure {
+		t.Fatalf("bucket = %s, want %s", bucket, soAgreeAssertFailure)
+	}
+	// And the same envelope with the assertion evaluating TRUE is a violation: stock
+	// rejected the node on it.
+	native.Sites[0].Outcome = constraintOutcomeTrue
+	if _, problems := soCompare(f, stock, native); len(soViolations(problems)) == 0 {
+		t.Fatal("native evaluating stock's REJECTING assertion true must be a violation")
+	}
+}
+
+// TestServingOracleContractRejectsUnrecognisedStockError proves the vocabulary has
+// no default bucket: an error shape it does not know is a harness failure, never
+// an agreement.
+func TestServingOracleContractRejectsUnrecognisedStockError(t *testing.T) {
+	f := soContractFixture()
+	stock := soClassifyStockError(errors.New(`ParsingError { scope: [], reason: "a brand new BAML failure mode", causes: [] }`))
+	if stock.Kind != soStockUnrecognisedError {
+		t.Fatalf("an unknown reason chain classified as %s; it must be %s", stock.Kind, soStockUnrecognisedError)
+	}
+	if len(stock.Reasons) != 1 || stock.Reasons[0] != "a brand new BAML failure mode" {
+		t.Fatalf("the unknown reason was not retained verbatim: %v", stock.Reasons)
+	}
+	bucket, problems := soCompare(f, stock, soNativeEnvelope{
+		Kind: soNativeValue, Identity: "class:SoContractProbe{v=int:5}", JSON: `{"v":5}`,
+		Support: checkSupported(f.Bundle),
+	})
+	if len(soViolations(problems)) == 0 {
+		t.Fatal("an unrecognised stock error must be a violation, not a silently accepted refusal")
+	}
+	if soIsAgreement(bucket) {
+		t.Fatalf("an unrecognised stock error landed in the agreeing bucket %s", bucket)
+	}
+	// CONTROL: each known shape still classifies, so the vocabulary is not simply
+	// rejecting everything.
+	if len(soKnownStockErrorShapes) == 0 {
+		t.Fatal("soKnownStockErrorShapes is empty; the classifier would reject every error")
+	}
+	for _, shape := range soKnownStockErrorShapes {
+		got := soClassifyStockError(errors.New(`ParsingError { scope: [], reason: "` + shape.Fragment + ` x", causes: [] }`))
+		if got.Kind != shape.Kind {
+			t.Errorf("the reason fragment %q classified as %s, want %s", shape.Fragment, got.Kind, shape.Kind)
+		}
+	}
+}
+
+// soCompareUncertifiedSites compares a root check collection whose ORDER stock no
+// longer carries.
+//
+// It matches by (path, label, expression) as a MULTISET and compares the result of
+// each matched pair. Everything the folded map genuinely evidences is still checked
+// exactly — which labels ran, at which node, over which expression text, and with
+// which result — and the one thing it cannot evidence, their relative order, is not
+// asserted. A native site with no stock counterpart, or a stock site with no native
+// one, is a violation either way.
+func soCompareUncertifiedSites(stock []soStockSite, native []soNativeSite) []soMismatch {
+	type key struct{ path, label, expr string }
+	remaining := map[key][]soNativeSite{}
+	for _, ns := range native {
+		k := key{soUnionArmRe.ReplaceAllString(ns.Path, ""), ns.Label, ns.Expression}
+		remaining[k] = append(remaining[k], ns)
+	}
+	var out []soMismatch
+	violation := func(format string, args ...any) {
+		out = append(out, soMismatch{Kind: soMismatchEvent, Violation: true,
+			Detail: fmt.Sprintf(format, args...)})
+	}
+	for _, ss := range stock {
+		k := key{ss.Path, ss.Label, ss.Expression}
+		pool := remaining[k]
+		if len(pool) == 0 {
+			violation("stock ran %s but native records no such predicate at that node:\n      native %s",
+				ss.render(), soRenderNativeSites(native))
+			continue
+		}
+		ns := pool[0]
+		remaining[k] = pool[1:]
+		switch ns.Outcome {
+		case constraintOutcomeUnsupported:
+			// Declined: safe, and counted as a cost by the bucket logic.
+		case constraintOutcomeTrue:
+			if ss.Status != "succeeded" {
+				violation("%s: native answered TRUE where stock reported %q", ss.render(), ss.Status)
+			}
+		case constraintOutcomeFalse:
+			if ss.Status != "failed" {
+				violation("%s: native answered FALSE where stock reported %q", ss.render(), ss.Status)
+			}
+		default:
+			violation("%s: native produced the unrecognised outcome %q", ss.render(), ns.Outcome)
+		}
+	}
+	for k, pool := range remaining {
+		for _, ns := range pool {
+			if ns.Outcome == constraintOutcomeUnsupported {
+				continue
+			}
+			violation("native DECIDED %s at %s, which stock's root collection does not contain",
+				ns.render(), k.path)
+		}
+	}
+	return out
+}
+
+// TestServingOracleBucketsDoNotCallDifferencesAgreement drives the three
+// classification holes CodeRabbit found, over synthetic envelopes.
+//
+// Each was independently real: a row that genuinely differed could land in an
+// AGREEING bucket, where the note contract requires no explanation and the tally
+// records it as parity. None of them was reachable from the current corpus, which
+// is exactly why they needed direct tests rather than a re-pinned count.
+func TestServingOracleBucketsDoNotCallDifferencesAgreement(t *testing.T) {
+	fixture := func(ty schema.Type) servingOracleFixture {
+		return servingOracleFixture{
+			Name: "bucket-probe", Family: "scalar", Doc: "direct bucket test",
+			Bundle: soOneFieldBundle("SoBucketProbe", ty), Raw: `{"v":5}`,
+		}
+	}
+	site := func(level schema.ConstraintLevel, label, expr string, o constraintStateOutcome) soNativeSite {
+		return soNativeSite{Path: "$.v", Origin: constraintOriginTypeMeta, Level: level,
+			Labeled: true, Label: label, Expression: expr, Outcome: o}
+	}
+
+	t.Run("stock decided an assertion, native could not coerce at all", func(t *testing.T) {
+		f := fixture(soWith(intType(), soAssert("gt", "this > 100")))
+		stock := soStockEnvelope{Kind: soStockAssertFailed,
+			Reasons: []string{"Assertions failed.", "Failed: gt this > 100"}}
+
+		// The SUPPORTED fallback: native declined to coerce. Stock still decided, so
+		// this is a measured cost, never a shared refusal.
+		declined := soNativeEnvelope{Kind: soNativeCoercionError, Support: checkSupported(f.Bundle),
+			Err: unsupported("probe"), Message: "declined"}
+		if bucket, _ := soCompare(f, stock, declined); bucket != soNativeDeclinesCoercion {
+			t.Errorf("a sentinel decline against a stock ASSERTION FAILURE landed in %s; stock decided a "+
+				"named assertion false, so the two legs did not agree", bucket)
+		}
+		// A NON-sentinel coercion failure is a claimed native parse failure, not a
+		// fall back — a different thing again, and also not an agreement.
+		failed := soNativeEnvelope{Kind: soNativeCoercionError, Support: checkSupported(f.Bundle),
+			Err: errors.New("native blew up"), Message: "boom"}
+		bucket, problems := soCompare(f, stock, failed)
+		if soIsAgreement(bucket) {
+			t.Errorf("a NON-sentinel coercion failure against a stock assertion failure landed in the "+
+				"agreeing bucket %s", bucket)
+		}
+		if len(soViolations(problems)) == 0 {
+			t.Error("a claimed native parse failure where stock produced a definite verdict must be a violation")
+		}
+		// CONTROL: where stock ALSO refused the value, a sentinel decline IS an
+		// agreement — so the rule above is about stock having decided, not about
+		// declines in general.
+		refused := soStockEnvelope{Kind: soStockEvaluatorError,
+			Reasons: []string{"Failed to evaluate constraints: unknown filter: nope"}}
+		if bucket, _ := soCompare(f, refused, declined); bucket != soAgreeRefusal {
+			t.Errorf("both legs refusing the value must agree; got %s", bucket)
+		}
+	})
+
+	t.Run("the only declined native site is an @assert", func(t *testing.T) {
+		f := fixture(soWith(intType(), soAssert("gt", "this > 0")))
+		stock := soStockEnvelope{Kind: soStockValue, Identity: "class:SoBucketProbe{v=int:5}",
+			JSON: `{"v":5}`}
+		native := soNativeEnvelope{Kind: soNativeUnsupported, Identity: "class:SoBucketProbe{v=int:5}",
+			JSON: `{"v":5}`, Support: checkSupported(f.Bundle),
+			Sites: []soNativeSite{site(schema.ConstraintAssert, "gt", "this > 0", constraintOutcomeUnsupported)},
+		}
+		bucket, _ := soCompare(f, stock, native)
+		if bucket != soNativeDeclinesPredicate {
+			t.Errorf("native REFUSED to decide the only predicate on the row and it landed in %s; a declined "+
+				"@assert has no check-level site, which is how this reached an agreeing bucket with no "+
+				"divergence note", bucket)
+		}
+		// CONTROL: the same row with the assertion DECIDED is a genuine agreement.
+		native.Kind = soNativeValue
+		native.Sites[0].Outcome = constraintOutcomeTrue
+		if bucket, _ := soCompare(f, stock, native); bucket != soAgreeValue {
+			t.Errorf("a decided assertion that holds must agree; got %s", bucket)
+		}
+	})
+
+	t.Run("a check-count mismatch is not an agreement", func(t *testing.T) {
+		f := fixture(soWith(intType(), soCheck("a", "this > 0")))
+		stock := soStockEnvelope{Kind: soStockValue, Identity: "class:SoBucketProbe{v=int:5}", JSON: `{"v":5}`,
+			Sites: []soStockSite{
+				{Path: "$.v", Label: "a", Expression: "this > 0", Status: "succeeded", Certified: true},
+				{Path: "$.v", Label: "b", Expression: "this > 1", Status: "succeeded", Certified: true},
+			}}
+		native := soNativeEnvelope{Kind: soNativeValue, Identity: "class:SoBucketProbe{v=int:5}",
+			JSON: `{"v":5}`, Support: checkSupported(f.Bundle),
+			Sites: []soNativeSite{site(schema.ConstraintCheck, "a", "this > 0", constraintOutcomeTrue)},
+		}
+		bucket, problems := soCompare(f, stock, native)
+		if soIsAgreement(bucket) {
+			t.Errorf("stock ran 2 checks and native ran 1, and the row landed in the agreeing bucket %s; the "+
+				"differential fails it separately, but the tally and the note contract would call it parity",
+				bucket)
+		}
+		if len(soViolations(problems)) == 0 {
+			t.Error("a check-count mismatch must be a violation")
+		}
+	})
+}

--- a/internal/debaml/serving_oracle_corpus_test.go
+++ b/internal/debaml/serving_oracle_corpus_test.go
@@ -1,0 +1,754 @@
+//go:build integration
+
+package debaml
+
+// The serving-shaped CORPUS.
+//
+// Every row is a complete serving unit: a schema.Bundle, the .baml function
+// rendered from it, and the exact raw assistant text. Both legs are driven over
+// the SAME two inputs, so the differential compares two engines rather than two
+// descriptions of a fixture.
+//
+// The bundles reuse the helpers boundary_decline_test.go already declares
+// (stringType, intType, scalarField, constrained, ptr) so the shapes the oracle
+// drives and the shapes the unit-level decline guards pin are built the same way.
+
+import (
+	"fmt"
+
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// ---------------------------------------------------------------------------
+// Bundle helpers
+// ---------------------------------------------------------------------------
+
+func soFloatType() schema.Type {
+	return schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveFloat}
+}
+
+func soBoolType() schema.Type {
+	return schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveBool}
+}
+
+func soClassType(name string) schema.Type {
+	return schema.Type{Kind: schema.TypeClass, Name: name, Mode: schema.NonStreaming}
+}
+
+func soEnumType(name string) schema.Type {
+	return schema.Type{Kind: schema.TypeEnum, Name: name}
+}
+
+func soListOf(elem schema.Type) schema.Type {
+	return schema.Type{Kind: schema.TypeList, Elem: ptr(elem)}
+}
+
+func soMapOf(key, value schema.Type) schema.Type {
+	return schema.Type{Kind: schema.TypeMap, Key: ptr(key), Value: ptr(value)}
+}
+
+func soOptional(v schema.Type) schema.Type {
+	return schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: []schema.Type{v}, Nullable: true}}
+}
+
+func soUnionOf(variants ...schema.Type) schema.Type {
+	return schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{Variants: variants}}
+}
+
+// soCheck / soAssert build the two constraint levels. A @check MUST carry a label
+// (BAML's grammar requires it); an @assert may, and the corpus uses labelled
+// asserts throughout because stock names the label in its rejection message and
+// the differential matches on it.
+func soCheck(label, expr string) schema.Constraint {
+	l := label
+	return schema.Constraint{Level: schema.ConstraintCheck, Expression: expr, Label: &l}
+}
+
+func soAssert(label, expr string) schema.Constraint {
+	l := label
+	return schema.Constraint{Level: schema.ConstraintAssert, Expression: expr, Label: &l}
+}
+
+// soWith attaches constraints to a type node.
+func soWith(t schema.Type, cs ...schema.Constraint) schema.Type {
+	t.Meta.Constraints = append(append([]schema.Constraint(nil), t.Meta.Constraints...), cs...)
+	return t
+}
+
+// soField builds a class field, optionally aliased.
+func soField(name string, t schema.Type) schema.ClassField {
+	return schema.ClassField{Name: schema.Name{Name: name}, Type: t}
+}
+
+func soAliasedField(name, alias string, t schema.Type) schema.ClassField {
+	a := alias
+	return schema.ClassField{Name: schema.Name{Name: name, Alias: &a}, Type: t}
+}
+
+// soBundle assembles a bundle and builds its indexes. A hand-built Bundle whose
+// indexes were never built silently fails every FindClass/FindEnum lookup inside
+// coerce, so this is not optional bookkeeping.
+func soBundle(target schema.Type, classes []schema.ClassDef, enums []schema.EnumDef) *schema.Bundle {
+	b := &schema.Bundle{Target: target, Classes: classes, Enums: enums}
+	if err := b.RebuildIndexes(); err != nil {
+		panic(fmt.Sprintf("serving oracle: corpus bundle indexes: %v", err))
+	}
+	return b
+}
+
+// soClassOf builds a class definition.
+func soClassOf(name string, fields []schema.ClassField, constraints ...schema.Constraint) schema.ClassDef {
+	return schema.ClassDef{
+		Name: schema.Name{Name: name}, Mode: schema.NonStreaming,
+		Fields: fields, Constraints: constraints,
+	}
+}
+
+// soOneFieldBundle is the shape most rows use: a single class with one field `v`,
+// returned by the function.
+func soOneFieldBundle(class string, fieldType schema.Type, classConstraints ...schema.Constraint) *schema.Bundle {
+	return soBundle(soClassType(class),
+		[]schema.ClassDef{soClassOf(class, []schema.ClassField{soField("v", fieldType)}, classConstraints...)},
+		nil)
+}
+
+// soSuitEnum is the aliased enum every enum row uses. The alias is on the VARIANT,
+// which is the ingress the model writes and the canonical name the predicate must
+// observe.
+func soSuitEnum(name string, constraints ...schema.Constraint) schema.EnumDef {
+	alias := "hearts_alias"
+	return schema.EnumDef{
+		Name: schema.Name{Name: name},
+		Values: []schema.EnumValue{
+			{Name: schema.Name{Name: "Hearts", Alias: &alias}},
+			{Name: schema.Name{Name: "Spades"}},
+		},
+		Constraints: constraints,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The corpus
+// ---------------------------------------------------------------------------
+
+// servingOracleFixtures is the corpus. Stock and Native are RECORDINGS; see
+// [TestServingOracleDifferential] for the recording mode that produces them.
+var servingOracleFixtures = []servingOracleFixture{
+	// -- scalars ------------------------------------------------------------
+	{
+		Name: "scalar_int_check_pass", Family: "scalar",
+		Doc:    "an int @check whose predicate holds: stock emits the value carrying a succeeded check",
+		Bundle: soOneFieldBundle("SoIntPass", soWith(intType(), soCheck("gt", "this > 0"))),
+		Raw:    `{"v":5}`,
+		Stock:  "value class:SoIntPass{v=int:5} checks=[$.v|\"gt\"|this > 0=succeeded]",
+		Native: "value class:SoIntPass{v=int:5} events=[$.v|type_meta/check/\"gt\"/this > 0=true]",
+	},
+	{
+		Name: "scalar_int_check_fail", Family: "scalar",
+		Doc:    "a FALSE @check is DATA: stock still emits the value, with status failed",
+		Bundle: soOneFieldBundle("SoIntFail", soWith(intType(), soCheck("gt", "this > 100"))),
+		Raw:    `{"v":5}`,
+		Stock:  "value class:SoIntFail{v=int:5} checks=[$.v|\"gt\"|this > 100=failed]",
+		Native: "value class:SoIntFail{v=int:5} events=[$.v|type_meta/check/\"gt\"/this > 100=false]",
+	},
+	{
+		Name: "scalar_int_assert_pass", Family: "scalar",
+		Doc:    "a holding @assert leaves no trace in the value: no check entry is emitted",
+		Bundle: soOneFieldBundle("SoIntAssertPass", soWith(intType(), soAssert("gt", "this > 0"))),
+		Raw:    `{"v":5}`,
+		Stock:  "value class:SoIntAssertPass{v=int:5} checks=[]",
+		Native: "value class:SoIntAssertPass{v=int:5} events=[$.v|type_meta/assert/\"gt\"/this > 0=true]",
+	},
+	{
+		Name: "scalar_int_assert_fail", Family: "scalar",
+		Doc:    "a FALSE @assert REJECTS the node — a different outcome class from a false check",
+		Bundle: soOneFieldBundle("SoIntAssertFail", soWith(intType(), soAssert("gt", "this > 100"))),
+		Raw:    `{"v":5}`,
+		Stock:  "assertion-failure Failed while parsing required fields: missing=0, unparsed=1 | Failed to parse field v: <root>: Assertions failed. / - <root>: Failed: gt this > 100 | Assertions failed. | Failed: gt this > 100",
+		Native: "assertion-failure class:SoIntAssertFail{v=int:5} events=[$.v|type_meta/assert/\"gt\"/this > 100=false]",
+	},
+	{
+		Name: "scalar_float_check", Family: "scalar",
+		Doc:    "float leaf: the value domain is the SCHEMA's, so 1.5 is a float on both legs",
+		Bundle: soOneFieldBundle("SoFloat", soWith(soFloatType(), soCheck("gt", "this > 1.0"))),
+		Raw:    `{"v":1.5}`,
+		Stock:  "value class:SoFloat{v=float:1.5} checks=[$.v|\"gt\"|this > 1.0=succeeded]",
+		Native: "value class:SoFloat{v=float:1.5} events=[$.v|type_meta/check/\"gt\"/this > 1.0=true]",
+	},
+	{
+		Name: "scalar_bool_check", Family: "scalar",
+		Doc:    "bool leaf, and a predicate that IS the value rather than a comparison",
+		Bundle: soOneFieldBundle("SoBool", soWith(soBoolType(), soCheck("istrue", "this"))),
+		Raw:    `{"v":true}`,
+		Stock:  "value class:SoBool{v=bool:true} checks=[$.v|\"istrue\"|this=succeeded]",
+		Native: "value class:SoBool{v=bool:true} events=[$.v|type_meta/check/\"istrue\"/this=true]",
+	},
+	{
+		Name: "scalar_string_check_fail", Family: "scalar",
+		Doc:    "CONTROL for the bare-string skip: the same false predicate on a string FIELD does run",
+		Bundle: soOneFieldBundle("SoStrField", soWith(stringType(), soCheck("eq", `this == "expected"`))),
+		Raw:    `{"v":"actual"}`,
+		Stock:  "value class:SoStrField{v=string:\"actual\"} checks=[$.v|\"eq\"|this == \"expected\"=failed]",
+		Native: "value class:SoStrField{v=string:\"actual\"} events=[$.v|type_meta/check/\"eq\"/this == \"expected\"=false]",
+	},
+	{
+		Name: "scalar_optional_null", Family: "scalar",
+		Doc:    "an optional field given null: the null arm wins and the predicate runs against null",
+		Bundle: soOneFieldBundle("SoOptNull", soWith(soOptional(intType()), soCheck("isnull", "this == none"))),
+		Raw:    `{"v":null}`,
+		Divergence: "native refuses `none`: the closed predicate grammar has no null literal, so the " +
+			"comparison is declined rather than decided",
+		Stock:  "value class:SoOptNull{v=null} checks=[$.v|\"isnull\"|this == none=succeeded]",
+		Native: "evaluator-unsupported class:SoOptNull{v=null} events=[$.v|type_meta/check/\"isnull\"/this == none=unsupported]",
+	},
+	{
+		Name: "scalar_multi_check_order", Family: "scalar",
+		Doc: "three checks in DECLARATION order with mixed results — order is part of the envelope",
+		Bundle: soOneFieldBundle("SoMulti", soWith(intType(),
+			soCheck("a", "this > 0"), soCheck("b", "this > 3"), soCheck("c", "this > 100"))),
+		Raw:    `{"v":5}`,
+		Stock:  "value class:SoMulti{v=int:5} checks=[$.v|\"a\"|this > 0=succeeded $.v|\"b\"|this > 3=succeeded $.v|\"c\"|this > 100=failed]",
+		Native: "value class:SoMulti{v=int:5} events=[$.v|type_meta/check/\"a\"/this > 0=true $.v|type_meta/check/\"b\"/this > 3=true $.v|type_meta/check/\"c\"/this > 100=false]",
+	},
+
+	// -- enums --------------------------------------------------------------
+	{
+		Name: "enum_canonical", Family: "enum",
+		Doc: "the model writes an UNALIASED variant; the predicate observes the canonical name",
+		Bundle: soBundle(soClassType("SoEnumCanon"),
+			[]schema.ClassDef{soClassOf("SoEnumCanon", []schema.ClassField{
+				soField("v", soWith(soEnumType("SoSuit"), soCheck("spades", `this == "Spades"`))),
+			})},
+			[]schema.EnumDef{soSuitEnum("SoSuit")}),
+		Raw:    `{"v":"Spades"}`,
+		Stock:  "value class:SoEnumCanon{v=enum:SoSuit=Spades} checks=[$.v|\"spades\"|this == \"Spades\"=succeeded]",
+		Native: "value class:SoEnumCanon{v=enum:SoSuit=Spades} events=[$.v|type_meta/check/\"spades\"/this == \"Spades\"=true]",
+	},
+	{
+		Name: "enum_alias_shadows_canonical", Family: "enum",
+		Doc: "an @alias on a variant REPLACES its ingress spelling rather than adding one: the model " +
+			"writing the CANONICAL name no longer matches, and BOTH legs refuse the value",
+		Bundle: soBundle(soClassType("SoEnumShadow"),
+			[]schema.ClassDef{soClassOf("SoEnumShadow", []schema.ClassField{
+				soField("v", soWith(soEnumType("SoSuit"), soCheck("hearts", `this == "Hearts"`))),
+			})},
+			[]schema.EnumDef{soSuitEnum("SoSuit")}),
+		Raw:    `{"v":"Hearts"}`,
+		Stock:  "coercion-error Failed while parsing required fields: missing=0, unparsed=1 | Failed to parse field v: v: Expected SoSuit @check(hearts, {{..}} ) enum value, got String(\"Hearts\", Complete). | Expected SoSuit @check(hearts, {{..}} ) enum value, got String(\"Hearts\", Complete).",
+		Native: "coercion-error debaml: constraint-state collector: $: production coercion did not succeed (the collector models a SUCCESSFUL canonical coercion only): bamlutils: de-BAML parser unsupported: class \"SoEnumShadow\": required field \"v\" provably fails to coerce (BAML errors the class)",
+	},
+	{
+		Name: "enum_alias_ingress", Family: "asymmetry",
+		Doc: "ASYMMETRY 3: the model writes the ALIAS, the predicate sees the CANONICAL variant — " +
+			"`this == \"Hearts\"` holds and `this == \"hearts_alias\"` does not",
+		Bundle: soBundle(soClassType("SoEnumAlias"),
+			[]schema.ClassDef{soClassOf("SoEnumAlias", []schema.ClassField{
+				soField("v", soWith(soEnumType("SoSuit"),
+					soCheck("canonical", `this == "Hearts"`), soCheck("alias", `this == "hearts_alias"`))),
+			})},
+			[]schema.EnumDef{soSuitEnum("SoSuit")}),
+		Raw:    `{"v":"hearts_alias"}`,
+		Stock:  "value class:SoEnumAlias{v=enum:SoSuit=Hearts} checks=[$.v|\"canonical\"|this == \"Hearts\"=succeeded $.v|\"alias\"|this == \"hearts_alias\"=failed]",
+		Native: "value class:SoEnumAlias{v=enum:SoSuit=Hearts} events=[$.v|type_meta/check/\"canonical\"/this == \"Hearts\"=true $.v|type_meta/check/\"alias\"/this == \"hearts_alias\"=false]",
+	},
+
+	// -- classes ------------------------------------------------------------
+	{
+		Name: "class_level_check", Family: "class",
+		Doc: "a class-level @@check: the predicate sees the whole class value",
+		Bundle: soBundle(soClassType("SoClsLevel"),
+			[]schema.ClassDef{soClassOf("SoClsLevel",
+				[]schema.ClassField{soField("s", stringType()), soField("n", intType())},
+				soCheck("hass", "this.s|length > 0"))},
+			nil),
+		Raw:    `{"s":"hi","n":2}`,
+		Stock:  "value class:SoClsLevel{s=string:\"hi\",n=int:2} checks=[$|\"hass\"|this.s|length > 0=succeeded~uncertified-order]",
+		Native: "value class:SoClsLevel{s=string:\"hi\",n=int:2} events=[$|declaration/check/\"hass\"/this.s|length > 0=true]",
+	},
+	{
+		Name: "class_level_assert_fail", Family: "class",
+		Doc: "a class-level @assert that fails rejects the whole class",
+		Bundle: soBundle(soClassType("SoClsAssert"),
+			[]schema.ClassDef{soClassOf("SoClsAssert",
+				[]schema.ClassField{soField("s", stringType())},
+				soAssert("long", "this.s|length > 10"))},
+			nil),
+		Raw:    `{"s":"hi"}`,
+		Stock:  "assertion-failure Assertions failed. | Failed: long this.s|length > 10 | Failed: long this.s|length > 10",
+		Native: "assertion-failure class:SoClsAssert{s=string:\"hi\"} events=[$|declaration/assert/\"long\"/this.s|length > 10=false]",
+	},
+	{
+		Name: "class_schema_order", Family: "class",
+		Doc: "fields declared b,a — NOT alphabetical — so an observation that reports a,b is reporting " +
+			"a sorted enumeration rather than the schema order",
+		Bundle: soBundle(soClassType("SoOrder"),
+			[]schema.ClassDef{soClassOf("SoOrder",
+				[]schema.ClassField{
+					soField("b", soWith(intType(), soCheck("bpos", "this > 0"))),
+					soField("a", soWith(stringType(), soCheck("astr", `this == "x"`))),
+				})},
+			nil),
+		Raw:    `{"a":"x","b":2}`,
+		Stock:  "value class:SoOrder{b=int:2,a=string:\"x\"} checks=[$.b|\"bpos\"|this > 0=succeeded $.a|\"astr\"|this == \"x\"=succeeded]",
+		Native: "value class:SoOrder{b=int:2,a=string:\"x\"} events=[$.b|type_meta/check/\"bpos\"/this > 0=true $.a|type_meta/check/\"astr\"/this == \"x\"=true]",
+	},
+	{
+		Name: "class_field_alias", Family: "alias",
+		Doc: "ASYMMETRY 3, class form: the model writes the field ALIAS `qty`, the canonical entry is " +
+			"`amount`, and the class-level predicate reads the canonical name",
+		Bundle: soBundle(soClassType("SoAliasCls"),
+			[]schema.ClassDef{soClassOf("SoAliasCls",
+				[]schema.ClassField{soAliasedField("amount", "qty", intType())},
+				soCheck("amount", "this.amount == 3"))},
+			nil),
+		Raw:    `{"qty":3}`,
+		Stock:  "value class:SoAliasCls{amount=int:3} checks=[$|\"amount\"|this.amount == 3=succeeded~uncertified-order]",
+		Native: "value class:SoAliasCls{amount=int:3} events=[$|declaration/check/\"amount\"/this.amount == 3=true]",
+	},
+	{
+		Name: "class_nested", Family: "class",
+		Doc: "a nested class member with a constraint on the OUTER field and one INSIDE the inner class",
+		Bundle: soBundle(soClassType("SoOuter"),
+			[]schema.ClassDef{
+				soClassOf("SoOuter", []schema.ClassField{
+					soField("i", soWith(soClassType("SoInner"), soCheck("innerb", "this.b > 0"))),
+				}),
+				soClassOf("SoInner", []schema.ClassField{
+					soField("b", soWith(intType(), soCheck("bpos", "this > 1"))),
+					soField("a", stringType()),
+				}),
+			}, nil),
+		Raw:    `{"i":{"a":"x","b":2}}`,
+		Stock:  "value class:SoOuter{i=class:SoInner{b=int:2,a=string:\"x\"}} checks=[$.i|\"innerb\"|this.b > 0=succeeded $.i.b|\"bpos\"|this > 1=succeeded]",
+		Native: "value class:SoOuter{i=class:SoInner{b=int:2,a=string:\"x\"}} events=[$.i|type_meta/check/\"innerb\"/this.b > 0=true $.i.b|type_meta/check/\"bpos\"/this > 1=true]",
+	},
+
+	// -- lists --------------------------------------------------------------
+	{
+		Name: "list_type_check", Family: "list",
+		Doc:    "a constraint on the LIST type sees the whole list",
+		Bundle: soOneFieldBundle("SoListType", soWith(soListOf(intType()), soCheck("len", "this|length == 3"))),
+		Raw:    `{"v":[1,2,3]}`,
+		Stock:  "value class:SoListType{v=list[int:1,int:2,int:3]} checks=[$.v|\"len\"|this|length == 3=succeeded]",
+		Native: "value class:SoListType{v=list[int:1,int:2,int:3]} events=[$.v|type_meta/check/\"len\"/this|length == 3=true]",
+	},
+	{
+		Name: "list_elem_check", Family: "list",
+		Doc:    "a constraint on the ELEMENT runs once per element, in order, with per-element results",
+		Bundle: soOneFieldBundle("SoListElem", soListOf(soWith(intType(), soCheck("pos", "this > 0")))),
+		Raw:    `{"v":[1,-2,3]}`,
+		Stock:  "value class:SoListElem{v=list[int:1,int:-2,int:3]} checks=[$.v[0]|\"pos\"|this > 0=succeeded $.v[1]|\"pos\"|this > 0=failed $.v[2]|\"pos\"|this > 0=succeeded]",
+		Native: "value class:SoListElem{v=list[int:1,int:-2,int:3]} events=[$.v[0]|type_meta/check/\"pos\"/this > 0=true $.v[1]|type_meta/check/\"pos\"/this > 0=false $.v[2]|type_meta/check/\"pos\"/this > 0=true]",
+	},
+	{
+		Name: "list_dropped_elem", Family: "list",
+		Doc: "an element BAML cannot parse is dropped from the emitted list; the surviving elements' " +
+			"constraints still run, and the native input index no longer equals the emitted index",
+		Bundle: soOneFieldBundle("SoListDrop", soListOf(soWith(intType(), soCheck("pos", "this > 0")))),
+		Raw:    `{"v":[1,{"nope":true},3]}`,
+		Divergence: "stock reports each surviving element's check TWICE — the list is coerced again after " +
+			"the ArrayItemParseError skip — where native records one event per element",
+		Stock:  "value class:SoListDrop{v=list[int:1,int:3]} checks=[$.v[0]|\"pos\"|this > 0=succeeded $.v[0]|\"pos\"|this > 0=succeeded $.v[1]|\"pos\"|this > 0=succeeded $.v[1]|\"pos\"|this > 0=succeeded]",
+		Native: "value class:SoListDrop{v=list[int:1,int:3]} events=[$.v[0]|type_meta/check/\"pos\"/this > 0=true $.v[2]|type_meta/check/\"pos\"/this > 0=true] skipped=[$.v[1]|type_meta/check/\"pos\"/this > 0~would-be-not-evaluated $.v[1]|node:skipped_child_or_union_path:element dropped by BAML's ArrayItemParseError partial-array skip]",
+	},
+	{
+		Name: "list_nested_dropped_elem", Family: "list",
+		Doc: "a dropped element inside a NESTED list: the constraint sites after it run at input " +
+			"coordinates the emitted list no longer uses, and the drop is recorded under an owning-list " +
+			"path that is itself indexed ($.v[1].w). It is the row that drives the nested input-vs-emitted " +
+			"alignment end to end, producer through consumer",
+		Bundle: soBundle(soClassType("SoNestDrop"),
+			[]schema.ClassDef{
+				soClassOf("SoNestDrop", []schema.ClassField{
+					soField("v", soListOf(soClassType("SoNestDropInner"))),
+				}),
+				soClassOf("SoNestDropInner", []schema.ClassField{
+					soField("w", soListOf(soWith(intType(), soCheck("pos", "this > 0")))),
+				}),
+			}, nil),
+		Raw: `{"v":[{"w":[9]},{"w":[1,{"bad":true},3]}]}`,
+		Divergence: "stock reports each surviving inner element's check TWICE — the inner list is coerced " +
+			"again after the ArrayItemParseError skip — where native records one event per element",
+		Stock:  "value class:SoNestDrop{v=list[class:SoNestDropInner{w=list[int:9]},class:SoNestDropInner{w=list[int:1,int:3]}]} checks=[$.v[0].w[0]|\"pos\"|this > 0=succeeded $.v[1].w[0]|\"pos\"|this > 0=succeeded $.v[1].w[0]|\"pos\"|this > 0=succeeded $.v[1].w[1]|\"pos\"|this > 0=succeeded $.v[1].w[1]|\"pos\"|this > 0=succeeded]",
+		Native: "value class:SoNestDrop{v=list[class:SoNestDropInner{w=list[int:9]},class:SoNestDropInner{w=list[int:1,int:3]}]} events=[$.v[0].w[0]|type_meta/check/\"pos\"/this > 0=true $.v[1].w[0]|type_meta/check/\"pos\"/this > 0=true $.v[1].w[2]|type_meta/check/\"pos\"/this > 0=true] skipped=[$.v[1].w[1]|type_meta/check/\"pos\"/this > 0~would-be-not-evaluated $.v[1].w[1]|node:skipped_child_or_union_path:element dropped by BAML's ArrayItemParseError partial-array skip]",
+	},
+	{
+		Name: "list_single_to_array", Family: "list",
+		Doc:    "a non-array value is wrapped into a one-element list, and the element constraint runs on it",
+		Bundle: soOneFieldBundle("SoListWrap", soListOf(soWith(intType(), soCheck("pos", "this > 0")))),
+		Raw:    `{"v":7}`,
+		Divergence: "stock reports the wrapped element's check TWICE — the value is coerced once bare and " +
+			"once inside the synthesized list — where native records one event",
+		Stock:  "value class:SoListWrap{v=list[int:7]} checks=[$.v[0]|\"pos\"|this > 0=succeeded $.v[0]|\"pos\"|this > 0=succeeded]",
+		Native: "value class:SoListWrap{v=list[int:7]} events=[$.v[0]|type_meta/check/\"pos\"/this > 0=true]",
+	},
+
+	// -- maps ---------------------------------------------------------------
+	{
+		Name: "map_value_check", Family: "map",
+		Doc: "constrained map VALUES, with the model's key order preserved (b before a) — a sorted " +
+			"readback would be a different envelope",
+		Bundle: soOneFieldBundle("SoMapVal", soMapOf(stringType(), soWith(intType(), soCheck("pos", "this > 0")))),
+		Raw:    `{"v":{"b":1,"a":-2}}`,
+		Stock:  "value class:SoMapVal{v=map{b=int:1,a=int:-2}} checks=[$.v[\"b\"]|\"pos\"|this > 0=succeeded $.v[\"a\"]|\"pos\"|this > 0=failed]",
+		Native: "value class:SoMapVal{v=map{b=int:1,a=int:-2}} events=[$.v[\"b\"]|type_meta/check/\"pos\"/this > 0=true $.v[\"a\"]|type_meta/check/\"pos\"/this > 0=false]",
+	},
+	{
+		Name: "map_key_check", Family: "map",
+		Doc: "a constraint on the map KEY type: stock evaluates NOTHING for it (no check reaches the " +
+			"value) and native records the key node as a policy-declined shape — the negative-admission fixture",
+		Bundle: soOneFieldBundle("SoMapKey", soMapOf(soWith(stringType(), soCheck("k", "this|length > 0")), intType())),
+		Raw:    `{"v":{"b":1}}`,
+		Stock:  "value class:SoMapKey{v=map{b=int:1}} checks=[]",
+		Native: "value class:SoMapKey{v=map{b=int:1}} events=[] skipped=[$.v.<key>|type_meta/check/\"k\"/this|length > 0~would-be-not-evaluated $.v.<key>|node:policy_declined_constrained_shape:map-key constraints stay a negative-admission fixture in Slice 7.2a]",
+	},
+
+	// -- unions -------------------------------------------------------------
+	{
+		Name: "union_constrained_arm_wins", Family: "union",
+		Doc:    "the constrained arm wins, so its predicate runs",
+		Bundle: soOneFieldBundle("SoUnionInt", soUnionOf(soWith(intType(), soCheck("pos", "this > 0")), stringType())),
+		Raw:    `{"v":7}`,
+		Divergence: "native's production coerce DECLINES a constrained union arm with the " +
+			"ErrDeBAMLParseUnsupported sentinel, so no state exists to compare — fail-closed by construction",
+		Stock:  "value class:SoUnionInt{v=int:7} checks=[$.v|\"pos\"|this > 0=succeeded]",
+		Native: "coercion-error debaml: constraint-state collector: $: production coercion did not succeed (the collector models a SUCCESSFUL canonical coercion only): bamlutils: de-BAML parser unsupported: class \"SoUnionInt\": a field could not be resolved to BAML's value (deferred lenient success/default/scoring)",
+	},
+	{
+		Name: "union_constrained_arm_loses", Family: "union",
+		Doc:    "the UNCONSTRAINED arm wins, so the losing arm's predicate never runs on either leg",
+		Bundle: soOneFieldBundle("SoUnionStr", soUnionOf(soWith(intType(), soCheck("pos", "this > 0")), stringType())),
+		Raw:    `{"v":"seven"}`,
+		Divergence: "same decline as the winning-arm row: the constrained union is refused by production " +
+			"coerce whichever arm wins",
+		Stock:  "value class:SoUnionStr{v=string:\"seven\"} checks=[]",
+		Native: "coercion-error debaml: constraint-state collector: $: production coercion did not succeed (the collector models a SUCCESSFUL canonical coercion only): bamlutils: de-BAML parser unsupported: class \"SoUnionStr\": a field could not be resolved to BAML's value (deferred lenient success/default/scoring)",
+	},
+
+	{
+		Name: "union_target_level", Family: "union",
+		Doc: "a constrained arm of a union RETURN TYPE — the one union position production coerce reaches, " +
+			"so the winning-arm path is observable rather than declined at the class field",
+		Bundle: soBundle(soUnionOf(soWith(intType(), soCheck("pos", "this > 0")), stringType()), nil, nil),
+		Raw:    `7`,
+		Divergence: "production coerce DECLINES a constrained union arm at the RETURN TYPE too, so no union " +
+			"arm is coerced anywhere in the corpus — see TestServingOracleNoUnionArmIsCoerced",
+		Stock:  "value int:7 checks=[$|\"pos\"|this > 0=succeeded~uncertified-order]",
+		Native: "coercion-error debaml: constraint-state collector: $: production coercion did not succeed (the collector models a SUCCESSFUL canonical coercion only): bamlutils: de-BAML parser unsupported: union variant kind \"primitive\": not a scalar/literal/enum leaf, a required-flat-leaf class, a list, or a string-keyed map",
+	},
+
+	// -- target-level -------------------------------------------------------
+	{
+		Name: "target_int_check_fail", Family: "target",
+		Doc:    "a @check on the RETURN TYPE itself: stock evaluates it and reports it in a root Checked",
+		Bundle: soBundle(soWith(intType(), soCheck("gt", "this > 100")), nil, nil),
+		Raw:    `5`,
+		Stock:  "value int:5 checks=[$|\"gt\"|this > 100=failed~uncertified-order]",
+		Native: "value int:5 events=[$|type_meta/check/\"gt\"/this > 100=false]",
+	},
+	{
+		Name: "target_int_assert_fail", Family: "target",
+		Doc:    "a failing @assert on the return type rejects the whole parse",
+		Bundle: soBundle(soWith(intType(), soAssert("gt", "this > 100")), nil, nil),
+		Raw:    `5`,
+		Stock:  "assertion-failure Assertions failed. | Failed: gt this > 100",
+		Native: "assertion-failure int:5 events=[$|type_meta/assert/\"gt\"/this > 100=false]",
+	},
+	{
+		Name: "target_string_check_skipped", Family: "asymmetry",
+		Doc: "ASYMMETRY 1: a BARE STRING return skips constraint evaluation entirely — stock emits the " +
+			"value with an EMPTY check collection even though the predicate is false",
+		Bundle: soBundle(soWith(stringType(), soCheck("eq", `this == "expected"`)), nil, nil),
+		Raw:    `"actual"`,
+		Divergence: "both legs SKIP the predicate (the asymmetry), and they canonicalize the quoted text " +
+			"differently: a bare-string return makes stock take the assistant text VERBATIM, quotes and all, " +
+			"while native extracts the JSON string it denotes",
+		Stock:  "value string:\"\\\"actual\\\"\" checks=[]",
+		Native: "value string:\"actual\" events=[] skipped=[$|type_meta/check/\"eq\"/this == \"expected\"~would-be-false]",
+	},
+	{
+		Name: "target_string_assert_skipped", Family: "asymmetry",
+		Doc: "ASYMMETRY 1 at @assert level: a false assertion on a bare-string return does NOT reject — " +
+			"the value is served unchanged",
+		Bundle: soBundle(soWith(stringType(), soAssert("eq", `this == "expected"`)), nil, nil),
+		Raw:    `"actual"`,
+		Divergence: "as the @check row: both legs skip the predicate, and the quoted assistant text is " +
+			"canonicalized verbatim by stock and as a JSON string by native",
+		Stock:  "value string:\"\\\"actual\\\"\" checks=[]",
+		Native: "value string:\"actual\" events=[] skipped=[$|type_meta/assert/\"eq\"/this == \"expected\"~would-be-false]",
+	},
+	{
+		Name: "target_string_bare_word", Family: "target",
+		Doc: "the assistant text is a BARE WORD rather than JSON: stock recovers it as the string return, " +
+			"native's extraction finds no cleanly-claimable candidate and declines before coercion",
+		Bundle: soBundle(soWith(stringType(), soCheck("eq", `this == "expected"`)), nil, nil),
+		Raw:    `actual`,
+		Divergence: "native's extraction stage declines a bare word; stock's recovery is broader. The " +
+			"decline is the serving path's own (no cleanly-claimable JSON candidate)",
+		Stock:  "value string:\"actual\" checks=[]",
+		Native: "no-candidate no cleanly-claimable JSON candidate",
+	},
+	{
+		Name: "target_list_elem_check", Family: "target",
+		Doc:    "a constrained ELEMENT of a target list — the target walk one structural step in",
+		Bundle: soBundle(soListOf(soWith(intType(), soCheck("pos", "this > 0"))), nil, nil),
+		Raw:    `[1,-2]`,
+		Stock:  "value list[int:1,int:-2] checks=[$[0]|\"pos\"|this > 0=succeeded~uncertified-order $[1]|\"pos\"|this > 0=failed~uncertified-order]",
+		Native: "value list[int:1,int:-2] events=[$[0]|type_meta/check/\"pos\"/this > 0=true $[1]|type_meta/check/\"pos\"/this > 0=false]",
+	},
+
+	// -- the duplicate-label asymmetry --------------------------------------
+	{
+		Name: "duplicate_label", Family: "asymmetry",
+		Doc: "ASYMMETRY 2: two @check attributes under ONE label are two ordered results with different " +
+			"outcomes; folding them by label would silently drop one",
+		Bundle: soOneFieldBundle("SoDup", soWith(intType(),
+			soCheck("dup", "this > 0"), soCheck("dup", "this > 100"))),
+		Raw:    `{"v":5}`,
+		Stock:  "value class:SoDup{v=int:5} checks=[$.v|\"dup\"|this > 0=succeeded $.v|\"dup\"|this > 100=failed]",
+		Native: "value class:SoDup{v=int:5} events=[$.v|type_meta/check/\"dup\"/this > 0=true $.v|type_meta/check/\"dup\"/this > 100=false]",
+	},
+
+	{
+		Name: "duplicate_identical_nonadjacent", Family: "asymmetry",
+		Doc: "the SAME check declared twice with a third between them: stock reports three entries, two of " +
+			"which are byte-identical but NOT adjacent — the case that makes the repeat-collapse's " +
+			"consecutive-only restriction load-bearing rather than decorative",
+		Bundle: soOneFieldBundle("SoDupSame", soWith(intType(),
+			soCheck("a", "this > 0"), soCheck("b", "this > 3"), soCheck("a", "this > 0"))),
+		Raw:    `{"v":5}`,
+		Stock:  "value class:SoDupSame{v=int:5} checks=[$.v|\"a\"|this > 0=succeeded $.v|\"b\"|this > 3=succeeded $.v|\"a\"|this > 0=succeeded]",
+		Native: "value class:SoDupSame{v=int:5} events=[$.v|type_meta/check/\"a\"/this > 0=true $.v|type_meta/check/\"b\"/this > 3=true $.v|type_meta/check/\"a\"/this > 0=true]",
+	},
+
+	// -- evaluator errors ---------------------------------------------------
+	{
+		Name: "err_unknown_filter", Family: "error",
+		Doc:        "an unknown filter is an EVALUATOR error: stock rejects the node rather than failing a check",
+		Bundle:     soOneFieldBundle("SoErrFilter", soWith(intType(), soCheck("uf", "this|nosuchfilter"))),
+		Raw:        `{"v":5}`,
+		Divergence: "stock REJECTS the whole node when a predicate fails to evaluate, so it emits no value; native's coercion is constraint-blind and canonicalizes int:5 while declining the predicate itself",
+		Stock:      "evaluator-error Failed while parsing required fields: missing=0, unparsed=1 | Failed to parse field v: v: Failed to evaluate constraints: unknown filter: filter nosuchfilter is unknown (in <string>:1) | Failed to evaluate constraints: unknown filter: filter nosuchfilter is unknown (in <string>:1)",
+		Native:     "evaluator-unsupported class:SoErrFilter{v=int:5} events=[$.v|type_meta/check/\"uf\"/this|nosuchfilter=unsupported]",
+	},
+	{
+		Name: "err_non_boolean", Family: "error",
+		Doc:        "a predicate that renders a non-boolean is an evaluator error, NOT a failed check",
+		Bundle:     soOneFieldBundle("SoErrNonBool", soWith(intType(), soCheck("nb", "this + 1"))),
+		Raw:        `{"v":5}`,
+		Divergence: "as the unknown-filter row: stock rejects the node and emits nothing, native canonicalizes the value and declines the predicate",
+		Stock:      "evaluator-error Failed while parsing required fields: missing=0, unparsed=1 | Failed to parse field v: v: Failed to evaluate constraints: Predicate did not evaluate to a boolean | Failed to evaluate constraints: Predicate did not evaluate to a boolean",
+		Native:     "evaluator-unsupported class:SoErrNonBool{v=int:5} events=[$.v|type_meta/check/\"nb\"/this + 1=unsupported]",
+	},
+	{
+		Name: "err_unknown_method", Family: "error",
+		Doc:        "an unknown method on the value is an evaluator error",
+		Bundle:     soOneFieldBundle("SoErrMethod", soWith(stringType(), soCheck("um", "this.nosuchmethod()"))),
+		Raw:        `{"v":"x"}`,
+		Divergence: "as the unknown-filter row: stock rejects the node and emits nothing, native canonicalizes the value and declines the predicate",
+		Stock:      "evaluator-error Failed while parsing required fields: missing=0, unparsed=1 | Failed to parse field v: v: Failed to evaluate constraints: unknown method: string has no method named nosuchmethod (in <string>:1) | Failed to evaluate constraints: unknown method: string has no method named nosuchmethod (in <string>:1)",
+		Native:     "evaluator-unsupported class:SoErrMethod{v=string:\"x\"} events=[$.v|type_meta/check/\"um\"/this.nosuchmethod()=unsupported]",
+	},
+	{
+		Name: "err_optional_swallows", Family: "error",
+		Doc: "an OPTIONAL field whose predicate errors: the optional coercion swallows the failure and " +
+			"yields null with NO check entry — neither a pass nor a fail",
+		Bundle: soOneFieldBundle("SoErrOpt", soWith(soOptional(intType()), soCheck("uf", "this|nosuchfilter"))),
+		Raw:    `{"v":5}`,
+		Divergence: "stock's OPTIONAL coercion is constraint-aware — the evaluator failure nulls the field " +
+			"and emits no check — while native's coercion is constraint-blind and keeps int:5. Native " +
+			"decides nothing (the predicate is declined), and the bundle declines at the gate",
+		Stock:  "value class:SoErrOpt{v=null} checks=[]",
+		Native: "evaluator-unsupported class:SoErrOpt{v=int:5} events=[$.v|type_meta/check/\"uf\"/this|nosuchfilter=unsupported]",
+	},
+
+	// -- guard-ledger rows --------------------------------------------------
+	{
+		Name: "guard_int_above_2p53", Family: "guard",
+		Doc: "the exact i64 a float64 core cannot tell from its neighbour: 2^53+1 must survive coercion " +
+			"and be compared exactly",
+		Bundle:     soOneFieldBundle("SoBigInt", soWith(intType(), soCheck("gt", "this > 9007199254740992"))),
+		Raw:        `{"v":9007199254740993}`,
+		Divergence: "native's numeric whitelist refuses a comparison against an integer literal above 2^53",
+		Stock:      "value class:SoBigInt{v=int:9007199254740993} checks=[$.v|\"gt\"|this > 9007199254740992=succeeded]",
+		Native:     "evaluator-unsupported class:SoBigInt{v=int:9007199254740993} events=[$.v|type_meta/check/\"gt\"/this > 9007199254740992=unsupported]",
+	},
+	{
+		Name: "guard_float_2p63", Family: "guard",
+		Doc:    "2^63 as a float — the AsInt hazard where Go's conversion is implementation-defined",
+		Bundle: soOneFieldBundle("SoBigFloat", soWith(soFloatType(), soCheck("gt", "this > 1.0"))),
+		Raw:    `{"v":9223372036854775808.0}`,
+		Divergence: "the #662 collector REFUSES this row: its float leaf is re-serialized as the shortest " +
+			"round-trip decimal (9223372036854776000) while production coerce keeps the source token " +
+			"(9223372036854775808.0), and the exact big.Rat divergence check compares the two DECIMALS " +
+			"rather than the float64 they both denote. A limitation of the witness, not of either engine",
+		Stock:  "value class:SoBigFloat{v=float:9.223372036854776e+18} checks=[$.v|\"gt\"|this > 1.0=succeeded]",
+		Native: "collector-diverged debaml: constraint-state traversal diverged from production coercion at $.v: $: number 9223372036854776000 vs 9223372036854775808.0 (state 9223372036854776000 vs production 9223372036854775808.0)",
+	},
+	{
+		Name: "guard_string_number", Family: "guard",
+		Doc:        "a NUMERIC STRING stays a string: the schema chooses the domain, not the token",
+		Bundle:     soOneFieldBundle("SoStrNum", soWith(stringType(), soCheck("eq", `this == "9007199254740993"`))),
+		Raw:        `{"v":"9007199254740993"}`,
+		Divergence: "native's numeric whitelist refuses the predicate: the string literal carries a numeric run outside the proven range",
+		Stock:      "value class:SoStrNum{v=string:\"9007199254740993\"} checks=[$.v|\"eq\"|this == \"9007199254740993\"=succeeded]",
+		Native:     "evaluator-unsupported class:SoStrNum{v=string:\"9007199254740993\"} events=[$.v|type_meta/check/\"eq\"/this == \"9007199254740993\"=unsupported]",
+	},
+	{
+		Name: "guard_arithmetic", Family: "guard",
+		Doc:        "arithmetic inside a predicate, which the native operator gate treats as a proven shape",
+		Bundle:     soOneFieldBundle("SoArith", soWith(intType(), soCheck("ar", "(this + 1) * 2 == 12"))),
+		Raw:        `{"v":5}`,
+		Divergence: "native's operator gate refuses arithmetic inside a predicate",
+		Stock:      "value class:SoArith{v=int:5} checks=[$.v|\"ar\"|(this + 1) * 2 == 12=succeeded]",
+		Native:     "evaluator-unsupported class:SoArith{v=int:5} events=[$.v|type_meta/check/\"ar\"/(this + 1) * 2 == 12=unsupported]",
+	},
+	{
+		Name: "guard_length_filter", Family: "guard",
+		Doc:    "the length filter over a unicode string",
+		Bundle: soOneFieldBundle("SoLen", soWith(stringType(), soCheck("len", "this|length == 5"))),
+		Raw:    `{"v":"héllo"}`,
+		Stock:  "value class:SoLen{v=string:\"h\u00e9llo\"} checks=[$.v|\"len\"|this|length == 5=succeeded]",
+		Native: "value class:SoLen{v=string:\"h\u00e9llo\"} events=[$.v|type_meta/check/\"len\"/this|length == 5=true]",
+	},
+
+	// -- native-decline controls -------------------------------------------
+	{
+		Name: "decline_pycompat_format", Family: "decline",
+		Doc: "stock DECIDES a Python-style str.format predicate; native has no pycompat hook and must " +
+			"refuse rather than answer",
+		Bundle: soOneFieldBundle("SoPyFmt", soWith(stringType(),
+			soCheck("fmt", `"{:,}".format(1234567) == "1,234,567"`))),
+		Raw:        `{"v":"x"}`,
+		Divergence: "pycompat str.format: minijinja-Go v2.16.0 has no unknown-method callback",
+		Stock:      "value class:SoPyFmt{v=string:\"x\"} checks=[$.v|\"fmt\"|\"{:,}\".format(1234567) == \"1,234,567\"=succeeded]",
+		Native:     "evaluator-unsupported class:SoPyFmt{v=string:\"x\"} events=[$.v|type_meta/check/\"fmt\"/\"{:,}\".format(1234567) == \"1,234,567\"=unsupported]",
+	},
+	{
+		Name: "decline_regex_match", Family: "decline",
+		Doc: "stock DECIDES a regex_match predicate; native withdrew regex_match (RE2 and Rust's regex " +
+			"crate are different engines) and must refuse",
+		Bundle: soOneFieldBundle("SoRegex", soWith(stringType(),
+			soCheck("rx", `this|regex_match("abc")`))),
+		Raw:        `{"v":"abcdef"}`,
+		Divergence: "regex_match is withdrawn: Go RE2 vs Rust regex are not proven identical",
+		Stock:      "value class:SoRegex{v=string:\"abcdef\"} checks=[$.v|\"rx\"|this|regex_match(\"abc\")=succeeded]",
+		Native:     "evaluator-unsupported class:SoRegex{v=string:\"abcdef\"} events=[$.v|type_meta/check/\"rx\"/this|regex_match(\"abc\")=unsupported]",
+	},
+	{
+		Name: "decline_divisible_by_zero", Family: "decline",
+		Doc: "stock cannot be OBSERVED at all: BAML v0.223 evaluates the test in Rust and panics on the " +
+			"CFFI callback thread, so the row is driven from an isolated subprocess and no boolean is fabricated",
+		Bundle:     soOneFieldBundle("SoDivZero", soWith(intType(), soCheck("dz", "this is divisibleby(0)"))),
+		Raw:        `{"v":4}`,
+		Fatal:      true,
+		Divergence: "divisibleby(0) aborts or hangs the stock process; native refuses structurally",
+	},
+
+	// -- serving-shaped extraction -----------------------------------------
+	{
+		Name: "serving_markdown_fence", Family: "class",
+		Doc: "the assistant text is a fenced markdown block, so both legs exercise their EXTRACTION " +
+			"stage before any coercion or constraint runs",
+		Bundle: soOneFieldBundle("SoFenced", soWith(intType(), soCheck("gt", "this > 0"))),
+		Raw:    "Here you go:\n```json\n{\"v\": 5}\n```\n",
+		Stock:  "value class:SoFenced{v=int:5} checks=[$.v|\"gt\"|this > 0=succeeded]",
+		Native: "value class:SoFenced{v=int:5} events=[$.v|type_meta/check/\"gt\"/this > 0=true]",
+	},
+	{
+		Name: "serving_jsonish_comments", Family: "class",
+		Doc:    "JSONish comments in the assistant text, stripped by both legs before extraction",
+		Bundle: soOneFieldBundle("SoCommented", soWith(intType(), soCheck("gt", "this > 0"))),
+		Raw:    "{\n  // the answer\n  \"v\": 5\n}",
+		Stock:  "value class:SoCommented{v=int:5} checks=[$.v|\"gt\"|this > 0=succeeded]",
+		Native: "value class:SoCommented{v=int:5} events=[$.v|type_meta/check/\"gt\"/this > 0=true]",
+	},
+
+	// -- unconstrained controls --------------------------------------------
+	//
+	// These carry NO constraint anywhere. The boundary lock requires them to be
+	// ADMITTED, which is what makes every other row's decline constraint-specific
+	// rather than a blanket refusal of the corpus shape.
+	{
+		Name: "control_class_unconstrained", Family: "control",
+		Doc: "CONTROL: the class/field shape of the constrained rows, with the constraints removed",
+		Bundle: soBundle(soClassType("SoCtlCls"),
+			[]schema.ClassDef{soClassOf("SoCtlCls", []schema.ClassField{
+				soField("b", intType()), soField("a", stringType()),
+			})}, nil),
+		Raw:           `{"a":"x","b":2}`,
+		Unconstrained: true,
+		Stock:         "value class:SoCtlCls{b=int:2,a=string:\"x\"} checks=[]",
+		Native:        "value class:SoCtlCls{b=int:2,a=string:\"x\"} events=[]",
+	},
+	{
+		Name: "control_list_unconstrained", Family: "control",
+		Doc:           "CONTROL: the list shape without the element constraint",
+		Bundle:        soOneFieldBundle("SoCtlList", soListOf(intType())),
+		Raw:           `{"v":[1,2,3]}`,
+		Unconstrained: true,
+		Stock:         "value class:SoCtlList{v=list[int:1,int:2,int:3]} checks=[]",
+		Native:        "value class:SoCtlList{v=list[int:1,int:2,int:3]} events=[]",
+	},
+	{
+		Name: "control_map_unconstrained", Family: "control",
+		Doc:           "CONTROL: the map shape without the value constraint",
+		Bundle:        soOneFieldBundle("SoCtlMap", soMapOf(stringType(), intType())),
+		Raw:           `{"v":{"b":1,"a":2}}`,
+		Unconstrained: true,
+		Stock:         "value class:SoCtlMap{v=map{b=int:1,a=int:2}} checks=[]",
+		Native:        "value class:SoCtlMap{v=map{b=int:1,a=int:2}} events=[]",
+	},
+	{
+		Name: "control_target_string", Family: "control",
+		Doc:           "CONTROL: a bare-string return with no constraint — the shape the static corpus serves",
+		Bundle:        soBundle(stringType(), nil, nil),
+		Raw:           `actual`,
+		Unconstrained: true,
+		Divergence: "native's extraction declines a bare word, so this control proves ADMISSION rather " +
+			"than serving; the serving direction is covered by the controls that do emit bytes",
+		Stock:  "value string:\"actual\" checks=[]",
+		Native: "no-candidate no cleanly-claimable JSON candidate",
+	},
+	{
+		Name: "bare_string_quoted_text", Family: "control",
+		Doc: "KNOWN GAP, and UNCONSTRAINED: a bare-string return given QUOTED assistant text. Stock takes " +
+			"the text verbatim, quotes included; native's static serving path extracts the JSON string it " +
+			"denotes and serves a different value. Nothing in this slice causes it and nothing here fixes " +
+			"it — see TestServingOracleKnownGap_BareStringQuotedText",
+		Bundle:        soBundle(stringType(), nil, nil),
+		Raw:           `"actual"`,
+		Unconstrained: true,
+		Divergence: "stock serves the verbatim text (quotes included) where native serves the string it " +
+			"denotes — a PRE-EXISTING divergence in the admitted bare-string-target lane, unrelated to " +
+			"constraints",
+		Stock:  "value string:\"\\\"actual\\\"\" checks=[]",
+		Native: "value string:\"actual\" events=[]",
+	},
+}
+
+// servingOracleProbes are project functions that are NOT corpus rows.
+//
+// A probe exists so a named test can drive a shape the differential must not
+// contain. The root duplicate-label probe is the only one: its folded readback is
+// deliberately lossy, so it cannot be compared like a fixture — but the loss has to
+// be MEASURED against the real baml_go decode rather than described, which is what
+// TestServingOracleRootCheckFoldIsLossy does with it.
+var servingOracleProbes = []servingOracleProbe{
+	{
+		Name: "probe_root_duplicate_label",
+		Doc: "two @check attributes under ONE label on the RETURN TYPE. Stock evaluates both; baml_go's " +
+			"root readback folds them into one map entry. Driven only by TestServingOracleRootCheckFoldIsLossy",
+		Bundle: soBundle(soWith(intType(),
+			soCheck("dup", "this > 0"), soCheck("dup", "this > 100")), nil, nil),
+		Raw: `5`,
+	},
+	{
+		Name: "probe_nested_duplicate_label",
+		Doc: "the SAME two checks one level down, where the raw CFFI tree keeps both — the control that " +
+			"makes the root fold a measurable LOSS rather than an absence",
+		Bundle: soOneFieldBundle("SoProbeNestedDup", soWith(intType(),
+			soCheck("dup", "this > 0"), soCheck("dup", "this > 100"))),
+		Raw: `{"v":5}`,
+	},
+}

--- a/internal/debaml/serving_oracle_fatal_test.go
+++ b/internal/debaml/serving_oracle_fatal_test.go
@@ -1,0 +1,326 @@
+//go:build integration
+
+package debaml
+
+// The row stock cannot be ASKED in-process.
+//
+// Every other row is driven in-process because stock either answers or returns an
+// error. `this is divisibleby(0)` does neither: BAML v0.223 evaluates the test in
+// Rust and panics with "attempt to calculate the remainder with a divisor of zero"
+// on the CFFI callback thread, which a Go `recover` in the caller cannot
+// intercept, so the process either aborts or is left waiting for a result that
+// never arrives. Driving it in the main binary would take the rest of the corpus
+// down with it.
+//
+// It is therefore driven from an ISOLATED SUBPROCESS under a deadline, and what
+// the parent records is decided by the child's OWN report rather than by its exit
+// status:
+//
+//	the deadline expired, or the child died on a SIGNAL   -> process-fatal
+//	the child printed a structured "returned an error"    -> FAIL; that is an
+//	                                                         evaluator-error
+//	                                                         envelope, and the row
+//	                                                         and the native guard
+//	                                                         behind it have to be
+//	                                                         re-derived
+//	the child printed a structured "returned a value"     -> FAIL; the premise is
+//	                                                         gone
+//	anything else                                          -> FAIL, as a harness
+//	                                                         failure
+//
+// A NON-RETURN ONLY COUNTS AFTER THE REACHED MARKER. Without it, any stall
+// satisfies the process-fatal arm: a cold BAML cache making the CFFI load exceed
+// the deadline, a stall while the project compiles, a future deadlock with nothing
+// to do with the predicate. Each would confirm the claim without measuring it —
+// absence of a result standing in for evidence about the expression. The child
+// announces that it reached the parse BEFORE calling it, on unbuffered stdout, so
+// a hang before that point is a harness failure and only a hang after it says
+// anything about stock.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	// soFatalChildEnv gates the child body so it is inert during a normal run.
+	soFatalChildEnv = "BAML_SERVING_ORACLE_FATAL_CHILD"
+	// soChildDeadline bounds the subprocess: generous enough that a loaded machine
+	// cannot produce a false "hang", short enough to keep the suite usable.
+	soChildDeadline = 45 * time.Second
+
+	// The child's structured report. A prefix rather than an exit code, because an
+	// exit code cannot distinguish "stock returned an error" from "the fixture is
+	// stale" or "the project failed to compile". The payload is escaped onto one
+	// line because a BAML coercion error is routinely multi-line.
+	soChildErrorPrefix = "SERVING_ORACLE_CHILD returned-error: "
+	soChildValuePrefix = "SERVING_ORACLE_CHILD returned-value: "
+	// soChildReachedMarker is announced BEFORE the parse and is what turns a hang
+	// into an observation.
+	soChildReachedMarker = "SERVING_ORACLE_CHILD reached-parse"
+)
+
+// soChildOutcome is a subprocess run, classified. The kind is never inferred from
+// the exit code alone.
+type soChildOutcome struct {
+	Kind    string // timeout | signal | returned-error | returned-value | unreported
+	Reached bool
+	Detail  string
+	Output  string
+}
+
+// soClassifyChildRun is the classification itself, kept pure so it can be tested
+// without spawning anything.
+//
+// ORDER MATTERS, and it is report-first. A structured report means the child
+// REACHED the CFFI and came back with an answer; that observation is already made
+// and cannot be un-made by what the deadline did afterwards. Checking the deadline
+// first would let a returned stock error be recorded as a timeout — a false green
+// in exactly the proof this row exists for.
+func soClassifyChildRun(out string, runErr error, deadlineExpired bool) soChildOutcome {
+	reached := strings.Contains(out, soChildReachedMarker)
+	if line, ok := soReportedLine(out, soChildErrorPrefix); ok {
+		return soChildOutcome{Kind: "returned-error", Reached: reached, Detail: line, Output: out}
+	}
+	if line, ok := soReportedLine(out, soChildValuePrefix); ok {
+		return soChildOutcome{Kind: "returned-value", Reached: reached, Detail: line, Output: out}
+	}
+	if deadlineExpired {
+		return soChildOutcome{Kind: "timeout", Reached: reached,
+			Detail: "deadline exceeded before the child reported", Output: out}
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) && !exitErr.Exited() {
+		return soChildOutcome{Kind: "signal", Reached: reached, Detail: exitErr.String(), Output: out}
+	}
+	return soChildOutcome{Kind: "unreported", Reached: reached, Detail: fmt.Sprint(runErr), Output: out}
+}
+
+// soProvesUnobservable reports whether a run that never returned says anything
+// about the EXPRESSION: it must have failed to return AND have announced that it
+// reached the parse.
+func soProvesUnobservable(c soChildOutcome) bool {
+	return c.Reached && (c.Kind == "timeout" || c.Kind == "signal")
+}
+
+// soReportedLine finds the child's structured report and unescapes the payload.
+func soReportedLine(out, prefix string) (string, bool) {
+	for _, line := range strings.Split(out, "\n") {
+		if i := strings.Index(line, prefix); i >= 0 {
+			return soUnescapeChildPayload(strings.TrimSuffix(line[i+len(prefix):], "\r")), true
+		}
+	}
+	return "", false
+}
+
+// soEscapeChildPayload / soUnescapeChildPayload carry an arbitrary message over a
+// line-oriented channel without losing any of it: only the bytes that would break
+// the framing are touched.
+func soEscapeChildPayload(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	return strings.ReplaceAll(s, "\n", `\n`)
+}
+
+func soUnescapeChildPayload(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] != '\\' || i+1 >= len(s) {
+			b.WriteByte(s[i])
+			continue
+		}
+		i++
+		switch s[i] {
+		case 'n':
+			b.WriteByte('\n')
+		case 'r':
+			b.WriteByte('\r')
+		case '\\':
+			b.WriteByte('\\')
+		default:
+			b.WriteByte('\\')
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}
+
+// TestServingOracleFatalRowIsUnobservable drives every Fatal row in a subprocess
+// and requires stock to be UNOBSERVABLE there.
+func TestServingOracleFatalRowIsUnobservable(t *testing.T) {
+	if os.Getenv(soFatalChildEnv) != "" {
+		t.Skip("child process: driven by the parent")
+	}
+	rows := 0
+	for _, f := range servingOracleFixtures {
+		if !f.Fatal {
+			continue
+		}
+		rows++
+		t.Run(f.Name, func(t *testing.T) {
+			c := soRunFatalChild(t, f.Name)
+			if (c.Kind == "timeout" || c.Kind == "signal") && !soProvesUnobservable(c) {
+				t.Fatalf("the child did not return (%s: %s) but never announced that it REACHED the parse, so "+
+					"this says nothing about %s — it is a harness failure (a cold CFFI cache, a stall while the "+
+					"in-memory project compiled, or an unrelated deadlock):\n%s", c.Kind, c.Detail, f.Name, c.Output)
+			}
+			switch c.Kind {
+			case "timeout":
+				t.Logf("recorded envelope %s: stock BAML v0.223 HANGS on this row — the child reached the parse "+
+					"and never came back (killed after %s)", soStockProcessFatal, soChildDeadline)
+			case "signal":
+				if !strings.Contains(c.Output, "divisor of zero") && !strings.Contains(c.Output, "remainder") {
+					t.Fatalf("the child died on a signal, but not with the expected divisor-of-zero abort (%s):\n%s",
+						c.Detail, c.Output)
+				}
+				t.Logf("recorded envelope %s: stock BAML v0.223 aborts the process on this row (%s)",
+					soStockProcessFatal, c.Detail)
+			case "returned-error":
+				t.Fatalf("stock RETURNED an error for %s instead of aborting: %q.\nThat is an %s envelope, not "+
+					"%s — the row's classification and the native guard that rests on unobservability must be "+
+					"re-derived.", f.Name, c.Detail, soStockEvaluatorError, soStockProcessFatal)
+			case "returned-value":
+				t.Fatalf("stock ANSWERED %s: %q; the native guard is no longer justified.", f.Name, c.Detail)
+			default:
+				t.Fatalf("the child neither reported nor died on a signal (%s: %s); this is a harness or fixture "+
+					"failure, not an observation about stock:\n%s", c.Kind, c.Detail, c.Output)
+			}
+
+			// Native's side, pinned next to the evidence: a refusal, never an answer.
+			native := soRunNative(f)
+			if len(native.Sites) == 0 {
+				t.Fatalf("native evaluated no predicate for %s, so its refusal is not observable: %s",
+					f.Name, native.render())
+			}
+			for _, s := range native.Sites {
+				if s.Outcome != constraintOutcomeUnsupported {
+					t.Fatalf("native DECIDED %s for %s where stock cannot be observed at all; no boolean may be "+
+						"fabricated there", s.Outcome, s.render())
+				}
+			}
+		})
+	}
+	if rows == 0 {
+		t.Fatal("no Fatal row in the corpus; this test would assert nothing")
+	}
+}
+
+// soRunFatalChild re-executes this test binary against the child body under a
+// deadline and classifies what happened.
+func soRunFatalChild(t *testing.T, fixture string) soChildOutcome {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("locate test binary: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), soChildDeadline)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, exe, "-test.run", "^TestServingOracleFatalChild$", "-test.v")
+	cmd.Env = append(os.Environ(), soFatalChildEnv+"="+fixture)
+	raw, runErr := cmd.CombinedOutput()
+	return soClassifyChildRun(string(raw), runErr, ctx.Err() != nil)
+}
+
+// TestServingOracleFatalChild is the subprocess body. It is inert unless the
+// parent names a fixture, so `go test` never trips it by accident.
+func TestServingOracleFatalChild(t *testing.T) {
+	name := os.Getenv(soFatalChildEnv)
+	if name == "" {
+		t.Skip("helper for TestServingOracleFatalRowIsUnobservable")
+	}
+	var target servingOracleFixture
+	for _, f := range servingOracleFixtures {
+		if f.Name == name {
+			target = f
+		}
+	}
+	if target.Name == "" {
+		t.Fatalf("no fixture named %q", name)
+	}
+	soEnsureRuntime(t)
+
+	// ANNOUNCED FIRST, deliberately after the project has compiled and before
+	// anything that can block. os.Stdout is unbuffered here, so the marker is in the
+	// pipe before the parse starts; if the process is killed mid-parse the parent
+	// still reads it, which is what distinguishes a hang INSIDE stock from a hang on
+	// the way to it.
+	fmt.Println(soChildReachedMarker)
+	env, err := soDriveStock(target)
+	if err != nil {
+		fmt.Printf("%s%s\n", soChildErrorPrefix, soEscapeChildPayload(err.Error()))
+		return
+	}
+	if env.Kind != soStockValue {
+		fmt.Printf("%s%s\n", soChildErrorPrefix, soEscapeChildPayload(env.render()))
+		return
+	}
+	fmt.Printf("%s%s\n", soChildValuePrefix, soEscapeChildPayload(env.render()))
+}
+
+// TestServingOracleChildClassification proves the classifier CLASSIFIES, over
+// synthetic transcripts, so the live arms above rest on a function whose behaviour
+// is pinned rather than on one that has only ever been exercised one way.
+func TestServingOracleChildClassification(t *testing.T) {
+	// A REAL signal death rather than a hand-built ExitError: the classifier reads
+	// ProcessState, so a zero value would test a shape that cannot occur.
+	fatalErr := soSignalDeathError(t)
+	cases := []struct {
+		name       string
+		out        string
+		runErr     error
+		deadline   bool
+		wantKind   string
+		wantProves bool
+	}{
+		{"reached then killed", soChildReachedMarker + "\n", nil, true, "timeout", true},
+		{"killed before reaching", "loading\n", nil, true, "timeout", false},
+		{"reported an error even though the deadline expired",
+			soChildReachedMarker + "\n" + soChildErrorPrefix + "boom\n", nil, true, "returned-error", false},
+		{"reported a value", soChildReachedMarker + "\n" + soChildValuePrefix + "v\n", nil, false,
+			"returned-value", false},
+		{"nothing reported and no signal", "", errors.New("exit status 1"), false, "unreported", false},
+		{"signal death after reaching", soChildReachedMarker + "\n", fatalErr, false, "signal", true},
+		{"signal death before reaching", "loading\n", fatalErr, false, "signal", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := soClassifyChildRun(tc.out, tc.runErr, tc.deadline)
+			if got.Kind != tc.wantKind {
+				t.Fatalf("kind = %q, want %q", got.Kind, tc.wantKind)
+			}
+			if soProvesUnobservable(got) != tc.wantProves {
+				t.Fatalf("provesUnobservable = %v, want %v (reached=%v kind=%q)",
+					soProvesUnobservable(got), tc.wantProves, got.Reached, got.Kind)
+			}
+		})
+	}
+	// The escaping round-trips a payload that contains both framing bytes, so a
+	// multi-line stock error is compared as the bytes stock produced.
+	const payload = "a\nb\\c\rd"
+	if got := soUnescapeChildPayload(soEscapeChildPayload(payload)); got != payload {
+		t.Fatalf("payload round-trip = %q, want %q", got, payload)
+	}
+}
+
+// soSignalDeathError produces a genuine *exec.ExitError for a process killed by a
+// signal, so the classifier's signal arm is exercised against the real thing.
+func soSignalDeathError(t *testing.T) error {
+	t.Helper()
+	err := exec.Command("/bin/sh", "-c", "kill -9 $$").Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected an *exec.ExitError from a signal death, got %v", err)
+	}
+	if exitErr.Exited() {
+		t.Fatalf("the helper process exited normally (%v); it must die on a signal for this control to "+
+			"mean anything", exitErr)
+	}
+	return err
+}

--- a/internal/debaml/serving_oracle_gate_test.go
+++ b/internal/debaml/serving_oracle_gate_test.go
@@ -1,0 +1,1675 @@
+package debaml
+
+// The BOUNDARY LOCK at the gate functions themselves, and the structural proof
+// that the serving oracle is test-only.
+//
+// This file carries NO build tag on purpose. The integration oracle needs CGO and
+// the stock BAML CFFI; the invariant it rests on must not. Everything here runs in
+// the ordinary `go test ./internal/debaml/...` gate, so a change that widened
+// admission would fail before anyone reached for a tagged run.
+//
+// It drives checkSupported, checkSupportedFields and checkSupportedType BY NAME,
+// which the integration oracle cannot do as directly: those are unexported and the
+// oracle reaches them through Parse / SupportsNativeFinalBundle / ParseStaticBundle.
+// Both directions matter — the exported entry points are what production actually
+// calls, and the three internal functions are where the decision is made — so the
+// invariant is asserted at both.
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// servingOracleGateFamilies is the shared vocabulary of shape families.
+//
+// It is declared HERE, in the untagged half, and consumed by the integration
+// corpus: TestServingOracleCorpusIsWellFormed requires every family below to have
+// at least one oracle fixture AND every fixture's family to appear below. Neither
+// list can drift away from the other without a failure.
+var servingOracleGateFamilies = []string{
+	"scalar", "enum", "class", "list", "map", "union",
+	"alias", "target", "asymmetry", "guard", "decline", "error", "control",
+}
+
+// servingOracleGateRow is one shape the three gate functions are driven over.
+type servingOracleGateRow struct {
+	Family string
+	What   string
+	Bundle *schema.Bundle
+	// TypeNode is the type node checkSupportedType must decline on its own, when
+	// the constraint lives on a TYPE rather than on a class/enum declaration. Nil
+	// where the constraint is declared on a ClassDef/EnumDef, because
+	// checkSupportedType never sees those — claiming otherwise would be asserting a
+	// decline the function is not responsible for.
+	TypeNode *schema.Type
+}
+
+// servingOracleGateRows covers every family in servingOracleGateFamilies.
+func servingOracleGateRows() []servingOracleGateRow {
+	label := func(s string) *string { return &s }
+	check := func(t schema.Type, l, expr string) schema.Type {
+		t.Meta.Constraints = append(t.Meta.Constraints,
+			schema.Constraint{Level: schema.ConstraintCheck, Expression: expr, Label: label(l)})
+		return t
+	}
+	field := func(name string, t schema.Type) schema.ClassField {
+		return schema.ClassField{Name: schema.Name{Name: name}, Type: t}
+	}
+	aliased := func(name, alias string, t schema.Type) schema.ClassField {
+		a := alias
+		return schema.ClassField{Name: schema.Name{Name: name, Alias: &a}, Type: t}
+	}
+	indexed := func(b *schema.Bundle) *schema.Bundle {
+		if err := b.RebuildIndexes(); err != nil {
+			panic("serving oracle gate: " + err.Error())
+		}
+		return b
+	}
+	cls := func(name string, fields []schema.ClassField, cs ...schema.Constraint) schema.ClassDef {
+		return schema.ClassDef{Name: schema.Name{Name: name}, Mode: schema.NonStreaming,
+			Fields: fields, Constraints: cs}
+	}
+	rootOf := func(name string) schema.Type {
+		return schema.Type{Kind: schema.TypeClass, Name: name, Mode: schema.NonStreaming}
+	}
+	oneField := func(name string, t schema.Type, cs ...schema.Constraint) *schema.Bundle {
+		return indexed(&schema.Bundle{Target: rootOf(name),
+			Classes: []schema.ClassDef{cls(name, []schema.ClassField{field("v", t)}, cs...)}})
+	}
+
+	scalarT := check(intType(), "gt", "this > 0")
+	listElemT := schema.Type{Kind: schema.TypeList, Elem: ptr(check(intType(), "pos", "this > 0"))}
+	mapValT := schema.Type{Kind: schema.TypeMap, Key: ptr(stringType()),
+		Value: ptr(check(intType(), "pos", "this > 0"))}
+	mapKeyT := schema.Type{Kind: schema.TypeMap, Key: ptr(check(stringType(), "k", "this|length > 0")),
+		Value: ptr(intType())}
+	unionT := schema.Type{Kind: schema.TypeUnion, Union: &schema.UnionType{
+		Variants: []schema.Type{check(intType(), "pos", "this > 0"), stringType()}}}
+	guardT := check(intType(), "big", "this > 9007199254740992")
+	declineT := check(stringType(), "fmt", `"{:,}".format(1) == "1"`)
+	errT := check(intType(), "uf", "this|nosuchfilter")
+	dupT := intType()
+	dupT.Meta.Constraints = []schema.Constraint{
+		{Level: schema.ConstraintCheck, Expression: "this > 0", Label: label("dup")},
+		{Level: schema.ConstraintCheck, Expression: "this > 100", Label: label("dup")},
+	}
+	targetT := check(stringType(), "eq", `this == "expected"`)
+	targetListT := schema.Type{Kind: schema.TypeList, Elem: ptr(check(intType(), "pos", "this > 0"))}
+
+	enumBundle := indexed(&schema.Bundle{
+		Target:  rootOf("GateEnumCls"),
+		Classes: []schema.ClassDef{cls("GateEnumCls", []schema.ClassField{field("c", schema.Type{Kind: schema.TypeEnum, Name: "GateSuit"})})},
+		Enums: []schema.EnumDef{{
+			Name:   schema.Name{Name: "GateSuit"},
+			Values: []schema.EnumValue{{Name: schema.Name{Name: "Hearts"}}, {Name: schema.Name{Name: "Spades"}}},
+			Constraints: []schema.Constraint{{Level: schema.ConstraintCheck,
+				Expression: `this != "Hearts"`, Label: label("not_hearts")}},
+		}},
+	})
+	aliasBundle := indexed(&schema.Bundle{
+		Target: rootOf("GateAliasCls"),
+		Classes: []schema.ClassDef{cls("GateAliasCls",
+			[]schema.ClassField{aliased("amount", "qty", intType())},
+			schema.Constraint{Level: schema.ConstraintCheck, Expression: "this.amount == 3", Label: label("amt")})},
+	})
+	classLevelBundle := indexed(&schema.Bundle{
+		Target: rootOf("GateClsLevel"),
+		Classes: []schema.ClassDef{cls("GateClsLevel",
+			[]schema.ClassField{field("s", stringType())},
+			schema.Constraint{Level: schema.ConstraintCheck, Expression: "this.s|length > 0", Label: label("has_s")})},
+	})
+
+	return []servingOracleGateRow{
+		{"scalar", "@check on a scalar field", oneField("GateScalar", scalarT), &scalarT},
+		{"enum", "enum-level @check", enumBundle, nil},
+		{"class", "class-level @check", classLevelBundle, nil},
+		{"list", "@check on a list ELEMENT", oneField("GateList", listElemT), &listElemT},
+		{"map", "@check on a map VALUE", oneField("GateMapVal", mapValT), &mapValT},
+		{"map", "@check on a map KEY", oneField("GateMapKey", mapKeyT), &mapKeyT},
+		{"union", "@check on a union ARM", oneField("GateUnion", unionT), &unionT},
+		{"alias", "class-level @check over an ALIASED field", aliasBundle, nil},
+		{"target", "@check on the RETURN TYPE itself", indexed(&schema.Bundle{Target: targetT}), &targetT},
+		{"target", "@check on a target LIST ELEMENT", indexed(&schema.Bundle{Target: targetListT}), &targetListT},
+		{"asymmetry", "two @check attributes under ONE label", oneField("GateDup", dupT), &dupT},
+		{"guard", "a large-number predicate", oneField("GateGuard", guardT), &guardT},
+		{"decline", "a predicate native refuses to evaluate", oneField("GateDecline", declineT), &declineT},
+		{"error", "a predicate whose evaluation fails", oneField("GateError", errT), &errT},
+	}
+}
+
+// TestServingOracleGateDeclinesEveryFamily drives the three gate functions by name
+// over every constraint-bearing family.
+//
+// It is the UNNARROWED invariant: nothing is carved out, target-level included.
+func TestServingOracleGateDeclinesEveryFamily(t *testing.T) {
+	rows := servingOracleGateRows()
+	if len(rows) == 0 {
+		t.Fatal("no gate rows; the boundary lock would be vacuous")
+	}
+	covered := map[string]int{}
+	typeChecked := 0
+	for _, r := range rows {
+		covered[r.Family]++
+		t.Run(r.Family+"/"+r.What, func(t *testing.T) {
+			if err := checkSupported(r.Bundle); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Fatalf("checkSupported returned %v, want ErrDeBAMLParseUnsupported for %s", err, r.What)
+			}
+			if err := checkSupportedFields(r.Bundle); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Fatalf("checkSupportedFields returned %v, want ErrDeBAMLParseUnsupported for %s", err, r.What)
+			}
+			if err := SupportsNativeFinalBundle(r.Bundle); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Fatalf("SupportsNativeFinalBundle returned %v, want ErrDeBAMLParseUnsupported for %s", err, r.What)
+			}
+			if r.TypeNode == nil {
+				return
+			}
+			typeChecked++
+			if err := checkSupportedType(r.Bundle, *r.TypeNode); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Fatalf("checkSupportedType returned %v, want ErrDeBAMLParseUnsupported for %s", err, r.What)
+			}
+		})
+	}
+	if typeChecked == 0 {
+		t.Fatal("no row drove checkSupportedType; that function would be unasserted")
+	}
+	// Every family except the control must be represented, and the control family is
+	// asserted in the opposite direction by TestServingOracleGateAdmitsUnconstrained.
+	for _, fam := range servingOracleGateFamilies {
+		if fam == "control" {
+			continue
+		}
+		if covered[fam] == 0 {
+			t.Errorf("family %q has no gate row", fam)
+		}
+	}
+}
+
+// TestServingOracleGateAdmitsUnconstrained is the control direction: the SAME
+// shapes without constraints are admitted by all three functions.
+//
+// Without it, every assertion above would be satisfied by a gate that declined
+// everything, which is not the invariant — the invariant is that CONSTRAINTS cause
+// the decline.
+func TestServingOracleGateAdmitsUnconstrained(t *testing.T) {
+	rows := servingOracleGateRows()
+	admitted := 0
+	for _, r := range rows {
+		stripped := servingOracleGateStrip(r.Bundle)
+		t.Run(r.Family+"/"+r.What, func(t *testing.T) {
+			if err := checkSupported(stripped); err != nil {
+				t.Fatalf("the constraint-stripped twin of %s was DECLINED by checkSupported: %v", r.What, err)
+			}
+			if err := checkSupportedFields(stripped); err != nil {
+				t.Fatalf("the constraint-stripped twin of %s was DECLINED by checkSupportedFields: %v", r.What, err)
+			}
+			if r.TypeNode != nil {
+				if err := checkSupportedType(stripped, servingOracleGateStripType(*r.TypeNode)); err != nil {
+					t.Fatalf("the constraint-stripped node of %s was DECLINED by checkSupportedType: %v",
+						r.What, err)
+				}
+			}
+			// SupportsNativeFinalBundle adds a STREAM cut-line on top of the constraint
+			// cut-line, and it legitimately declines some unconstrained shapes (a single
+			// string-absorbing-field root class, a scalar map value). Those are allowed
+			// here — but only after their reason is checked NOT to be a constraint, so
+			// the allowance cannot absorb a constraint decline.
+			if err := SupportsNativeFinalBundle(stripped); err != nil {
+				if strings.Contains(err.Error(), "constraint") {
+					t.Fatalf("the constraint-stripped twin of %s was declined by SupportsNativeFinalBundle for "+
+						"a CONSTRAINT reason (%v), but it carries none", r.What, err)
+				}
+				t.Logf("%s: the stripped twin is declined by the stream cut-line (%v); admission is still "+
+					"proven by checkSupported and checkSupportedFields", r.What, err)
+			}
+		})
+		admitted++
+	}
+	if admitted == 0 {
+		t.Fatal("no control was checked; the constraint-specificity claim would be vacuous")
+	}
+}
+
+// servingOracleGateStrip removes every constraint from a bundle.
+//
+// It PRESERVES every non-constraint fact, RecursiveClasses and the structural
+// recursive aliases included. Rebuilding without them made the stripped twin a
+// different bundle rather than a constraint-free clone: a fixture whose recursion
+// independently causes a decline would have had that fact erased, and its
+// "constraints caused the decline" attribution would have been about a shape the
+// gate never saw.
+func servingOracleGateStrip(b *schema.Bundle) *schema.Bundle {
+	out := &schema.Bundle{
+		Target:           servingOracleGateStripType(b.Target),
+		RecursiveClasses: append([]string(nil), b.RecursiveClasses...),
+	}
+	for _, a := range b.StructuralRecursiveAliases {
+		out.StructuralRecursiveAliases = append(out.StructuralRecursiveAliases,
+			schema.RecursiveAliasDef{Name: a.Name, Target: servingOracleGateStripType(a.Target)})
+	}
+	for _, c := range b.Classes {
+		nc := c
+		nc.Constraints = nil
+		nc.Fields = nil
+		for _, f := range c.Fields {
+			nf := f
+			nf.Type = servingOracleGateStripType(f.Type)
+			nc.Fields = append(nc.Fields, nf)
+		}
+		out.Classes = append(out.Classes, nc)
+	}
+	for _, e := range b.Enums {
+		ne := e
+		ne.Constraints = nil
+		out.Enums = append(out.Enums, ne)
+	}
+	if err := out.RebuildIndexes(); err != nil {
+		panic("serving oracle gate strip: " + err.Error())
+	}
+	return out
+}
+
+// servingOracleGateStripType removes the constraints from a type and EVERY type
+// nested inside it — Items included, which was previously skipped, leaving a tuple
+// element's constraint in the "stripped" twin.
+func servingOracleGateStripType(t schema.Type) schema.Type {
+	out := t
+	out.Meta.Constraints = nil
+	if t.Elem != nil {
+		out.Elem = ptr(servingOracleGateStripType(*t.Elem))
+	}
+	if t.Key != nil {
+		out.Key = ptr(servingOracleGateStripType(*t.Key))
+	}
+	if t.Value != nil {
+		out.Value = ptr(servingOracleGateStripType(*t.Value))
+	}
+	if len(t.Items) > 0 {
+		out.Items = nil
+		for _, it := range t.Items {
+			out.Items = append(out.Items, servingOracleGateStripType(it))
+		}
+	}
+	if t.Arrow != nil {
+		a := *t.Arrow
+		a.Return = servingOracleGateStripType(t.Arrow.Return)
+		a.Params = nil
+		for _, p := range t.Arrow.Params {
+			a.Params = append(a.Params, servingOracleGateStripType(p))
+		}
+		out.Arrow = &a
+	}
+	if t.Union != nil {
+		u := *t.Union
+		u.Variants = nil
+		for _, v := range t.Union.Variants {
+			u.Variants = append(u.Variants, servingOracleGateStripType(v))
+		}
+		out.Union = &u
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Structural proofs
+// ---------------------------------------------------------------------------
+
+// servingOracleSourceGlob matches the oracle's own files.
+const servingOracleSourceGlob = "serving_oracle_*.go"
+
+// servingOracleAnchors must EXIST, and may only be declared in a _test.go file.
+//
+// Named anchors rather than a filename check: renaming a file must not be able to
+// disable the guard, and a missing anchor means the oracle was gutted rather than
+// that the rule passed.
+var servingOracleAnchors = []string{
+	"servingOracleFixtures", "servingOracleFixture", "servingOracleGateRows",
+	"soRenderProject", "soRunNative", "soCompare", "soDriveStock", "soReadStockValue",
+	"soClassObserver", "soChecked", "soStockEnvelope", "soNativeEnvelope",
+	"soAlignNativePath", "soBuildTypeMap", "soEnsureRuntime", "soStripConstraints",
+}
+
+// servingOracleReservedPrefixes is the namespace the oracle declares into. Every
+// identifier the oracle declares must match one, and no production file may
+// declare or reference one of the oracle's identifiers.
+var servingOracleReservedPrefixes = []string{"so", "servingOracle", "TestServingOracle"}
+
+// TestServingOracleIsTestOnly is the STRUCTURAL proof — a go/ast walk, not a
+// source-text grep — that nothing in this slice can be linked into a production
+// binary.
+//
+// Three rules, each with a direction that can fail:
+//
+//  1. every anchor exists, and only in _test.go files;
+//  2. every identifier the oracle declares is inside the reserved namespace, so
+//     rule 3's scan cannot be evaded by naming something outside it;
+//  3. no non-test .go file anywhere in the repository declares or references any
+//     identifier the oracle declares.
+func TestServingOracleIsTestOnly(t *testing.T) {
+	repo := servingOracleRepoRoot(t)
+	declaredHere, err := servingOracleOwnDeclarations(repo)
+	if err != nil {
+		t.Fatalf("index the oracle's own declarations: %v", err)
+	}
+	if len(declaredHere) == 0 {
+		t.Fatal("the oracle declares no identifiers; the scan below would be vacuous")
+	}
+
+	// Rule 1: anchors exist, in _test.go only.
+	if len(servingOracleAnchors) == 0 {
+		t.Fatal("servingOracleAnchors is empty; rule 1 would be satisfied trivially")
+	}
+	index, err := servingOracleDeclarationIndex(repo)
+	if err != nil {
+		t.Fatalf("index repository declarations: %v", err)
+	}
+	for _, a := range servingOracleAnchors {
+		files := index[a]
+		if len(files) == 0 {
+			t.Errorf("anchor %q is declared nowhere; the oracle was renamed or removed and this guard no "+
+				"longer describes it", a)
+			continue
+		}
+		for _, rel := range files {
+			if !strings.HasSuffix(rel, "_test.go") {
+				t.Errorf("anchor %q is declared in the PRODUCTION file %s; the serving oracle must be "+
+					"test-only", a, rel)
+			}
+		}
+	}
+
+	// Rule 2: the oracle's own namespace is real.
+	if len(servingOracleReservedPrefixes) == 0 {
+		t.Fatal("servingOracleReservedPrefixes is empty; rule 2 would be satisfied trivially")
+	}
+	for name := range declaredHere {
+		if !servingOracleHasReservedPrefix(name) {
+			t.Errorf("the oracle declares %q, which is outside its reserved namespace %v; move it inside so "+
+				"the no-production-caller scan cannot be evaded", name, servingOracleReservedPrefixes)
+		}
+	}
+
+	// Rule 3: no production file declares or references any of them.
+	hits, err := servingOracleProductionReferences(repo, declaredHere)
+	if err != nil {
+		t.Fatalf("scan for production references: %v", err)
+	}
+	if len(hits) > 0 {
+		sort.Strings(hits)
+		t.Fatalf("the serving oracle is reachable from PRODUCTION code:\n  %s", strings.Join(hits, "\n  "))
+	}
+	t.Logf("test-only: %d oracle identifiers, %d anchors, no production declaration or reference",
+		len(declaredHere), len(servingOracleAnchors))
+}
+
+// TestServingOracleTestOnlyGuardBites is the guard's own bite check.
+//
+// It proves the scan CLASSIFIES rather than merely returns nothing: a synthetic
+// production file that references an anchor is detected, and a real production
+// identifier is not mistaken for one of the oracle's.
+func TestServingOracleTestOnlyGuardBites(t *testing.T) {
+	dir := t.TempDir()
+	synthetic := filepath.Join(dir, "fake_production.go")
+	src := "package fake\n\nfunc use() { _ = servingOracleFixtures }\n"
+	if err := os.WriteFile(synthetic, []byte(src), 0o644); err != nil {
+		t.Fatalf("write synthetic production file: %v", err)
+	}
+	hits, err := servingOracleProductionReferences(dir, map[string]struct{}{"servingOracleFixtures": {}})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("the scan did not detect a production file referencing servingOracleFixtures; it cannot be " +
+			"relied on to detect a real one")
+	}
+	// NEGATIVE control: a production identifier that is genuinely production must
+	// not be swallowed by the reserved namespace.
+	for _, name := range []string{"EvaluateConstraint", "SupportsNativeFinalBundle", "ParseStaticBundle"} {
+		if servingOracleHasReservedPrefix(name) {
+			t.Errorf("the reserved namespace swallows the PRODUCTION identifier %q", name)
+		}
+		repo := servingOracleRepoRoot(t)
+		index, err := servingOracleDeclarationIndex(repo)
+		if err != nil {
+			t.Fatalf("index: %v", err)
+		}
+		if !servingOracleDeclaredByProduction(index, name) {
+			t.Errorf("%q has no PRODUCTION declaration; the negative control is stale", name)
+		}
+	}
+}
+
+// TestServingOracleGateReadsNoEnvironment is the STRUCTURAL half of "the flag does
+// not alter the decision".
+//
+// The integration boundary lock sets BAML_REST_USE_DEBAML both ways around every
+// gate call, which shows the outcome does not change. This shows WHY it cannot: no
+// production file under internal/debaml or internal/schema reads the process
+// environment at all, so no gate decision can be conditioned on any flag.
+//
+// It walks RECURSIVELY and resolves the import, because the earlier version could
+// have stayed green through a real regression: it globbed only each directory root
+// (missing nested production packages such as bamlunicode and outputformat), it
+// matched an identifier literally spelled `os` rather than whatever name the file
+// imports "os" under, and it knew only three of the environment-read APIs.
+func TestServingOracleGateReadsNoEnvironment(t *testing.T) {
+	pkgs := servingOracleProductionPackages(t, ".", "../schema")
+	if len(pkgs) < 3 {
+		t.Fatalf("the scan covered %d package director(ies) %v; it is meant to reach NESTED production "+
+			"packages (internal/debaml/bamlunicode, internal/schema/outputformat) and not only the two roots",
+			len(pkgs), servingOraclePackageDirs(pkgs))
+	}
+	if len(servingOracleEnvAPIs) == 0 {
+		t.Fatal("servingOracleEnvAPIs is empty; the scan would look for nothing")
+	}
+	for pkg, api := range servingOracleEnvAPIs {
+		if len(api) == 0 {
+			t.Fatalf("the environment API set for %q is empty; that package would be watched for nothing", pkg)
+		}
+	}
+
+	scanned := 0
+	var hits []string
+	for dir, pkg := range pkgs {
+		uses := servingOracleProductionBindings(t, pkg, dir)
+		for path, file := range pkg.Files {
+			scanned++
+			hits = append(hits, servingOracleEnvHits(path, file, uses)...)
+		}
+	}
+	if scanned == 0 {
+		t.Fatal("no production file was scanned; the claim would be vacuous")
+	}
+	if len(hits) > 0 {
+		sort.Strings(hits)
+		t.Fatalf("production code behind the native gate reads the environment, so a flag COULD alter the "+
+			"admission decision:\n  %s", strings.Join(hits, "\n  "))
+	}
+	t.Logf("no environment read in %d production files across %d packages under internal/debaml and "+
+		"internal/schema (bindings resolved with go/types)", scanned, len(pkgs))
+}
+
+// servingOraclePackage is one production package's parsed non-test files.
+type servingOraclePackage struct {
+	Fset  *token.FileSet
+	Files map[string]*ast.File
+}
+
+// ---------------------------------------------------------------------------
+// Memoized fixtures
+//
+// Parsing 49 production files, type-checking six packages, and walking every .go
+// file in the repository are the three expensive things this file does — and all
+// three are functions of the SOURCE TREE, which does not change while a test binary
+// runs. Recomputing them per iteration made `go test -race -count=100` dominate the
+// unit-tests lane's per-package budget (see the diagnosis in the Slice 7.2a-3
+// report).
+//
+// They are therefore computed ONCE per process and shared. Nothing is weakened: the
+// assertions still run in full on every iteration, over the same trees; only the
+// derived, read-only inputs are reused. Every consumer treats them as immutable —
+// ast.Inspect and types.Info lookups are reads — and the package's tests do not run
+// in parallel.
+// ---------------------------------------------------------------------------
+
+var (
+	servingOracleFixtureMu sync.Mutex
+
+	// Keyed by the ROOTS scanned, not a single flag. A second caller naming
+	// different roots would otherwise be handed the first caller's packages and its
+	// scan would prove nothing about the trees it asked for — the same cache-key
+	// unsoundness that made a re-parsed probe read a stale binding map.
+	servingOracleProdPkgsCache = map[string]servingOracleProdPkgsEntry{}
+
+	// Bindings are keyed by *ast.Ident POINTERS, so a binding map is only meaningful
+	// for the exact AST it was computed from. Both caches below therefore hold the
+	// PARSED FILES together with their bindings; caching bindings alone against a
+	// name that gets re-parsed would hand the detector a map none of the new
+	// identifiers appear in, and it would (correctly, but uselessly) fail closed on
+	// every selector.
+	//
+	// For production packages that means keying on the PARSE ITSELF rather than on the
+	// directory: now that the parse cache above is keyed by roots, one directory can
+	// legitimately have several distinct *servingOraclePackage values live at once
+	// (`.` parsed under {"."} is a different AST from `.` parsed under {".",
+	// "../schema"}). A directory-keyed binding cache would hand the second one the
+	// first one's map, in which none of its identifiers appear.
+	servingOracleProdBindings = map[servingOracleBindKey]servingOracleBindings{}
+	servingOracleProbeCache   = map[string]*servingOracleProbeFixture{}
+
+	servingOracleTreeCache = map[string][]servingOracleParsedFile{}
+	servingOracleTreeErr   = map[string]error{}
+)
+
+// servingOracleProdPkgsEntry is one memoized production-package parse.
+type servingOracleProdPkgsEntry struct {
+	Pkgs map[string]*servingOraclePackage
+	Err  error
+}
+
+// servingOracleBindKey identifies the bindings of one PARSE of one package.
+//
+// Pkg is the identity that matters — a binding map's keys are identifiers inside
+// that exact AST — and it alone makes the key sound. Dir rides along because it is
+// the package path go/types was configured with, so a hypothetical caller checking
+// one AST under two package paths also gets its own entry rather than the other's.
+type servingOracleBindKey struct {
+	Pkg *servingOraclePackage
+	Dir string
+}
+
+// servingOracleBindings is one memoized type-check result: the resolved uses and
+// whether go/types produced any bindings at all.
+type servingOracleBindings struct {
+	Uses map[*ast.Ident]types.Object
+	OK   bool
+}
+
+// servingOracleParsedFile is one parsed file of a scanned tree.
+type servingOracleParsedFile struct {
+	// Rel is the slash-separated path relative to the scanned root.
+	Rel  string
+	File *ast.File
+}
+
+// servingOracleProbeFixture is one synthetic probe: the AST and the bindings that
+// belong to it, kept together for the reason above.
+type servingOracleProbeFixture struct {
+	File *ast.File
+	Uses map[*ast.Ident]types.Object
+	OK   bool
+}
+
+// servingOracleProductionPackages parses every production .go file under the given
+// roots, grouped by directory so each package can be type-checked as a unit.
+//
+// testdata is skipped: it is never built, and a generated oracle client under it is
+// not production code.
+func servingOracleProductionPackages(t *testing.T, roots ...string) map[string]*servingOraclePackage {
+	t.Helper()
+	servingOracleFixtureMu.Lock()
+	defer servingOracleFixtureMu.Unlock()
+	key := strings.Join(roots, "\x00")
+	if entry, done := servingOracleProdPkgsCache[key]; done {
+		if entry.Err != nil {
+			t.Fatalf("parse the production packages %v: %v", roots, entry.Err)
+		}
+		return entry.Pkgs
+	}
+	out, err := servingOracleParseProductionPackages(roots...)
+	servingOracleProdPkgsCache[key] = servingOracleProdPkgsEntry{Pkgs: out, Err: err}
+	if err != nil {
+		t.Fatalf("parse the production packages %v: %v", roots, err)
+	}
+	return out
+}
+
+// servingOracleParseProductionPackages does the parsing itself.
+func servingOracleParseProductionPackages(roots ...string) (map[string]*servingOraclePackage, error) {
+	out := map[string]*servingOraclePackage{}
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if d.Name() == "testdata" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			dir := filepath.Dir(path)
+			pkg := out[dir]
+			if pkg == nil {
+				pkg = &servingOraclePackage{Fset: token.NewFileSet(), Files: map[string]*ast.File{}}
+				out[dir] = pkg
+			}
+			file, perr := parser.ParseFile(pkg.Fset, path, nil, 0)
+			if perr != nil {
+				// Fail closed: an unreadable file is not evidence that it reads nothing.
+				return fmt.Errorf("parse %s: %w", path, perr)
+			}
+			pkg.Files[path] = file
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("scan %s: %w", root, err)
+		}
+	}
+	return out, nil
+}
+
+func servingOraclePackageDirs(pkgs map[string]*servingOraclePackage) []string {
+	out := make([]string, 0, len(pkgs))
+	for dir := range pkgs {
+		out = append(out, dir)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// servingOracleResolveBindings type-checks one package and returns the resolved
+// identifier bindings.
+//
+// WHY TYPE-CHECKING RATHER THAN SPELLING. The question the scan has to answer is
+// whether the `X` in `X.Getenv(...)` still DENOTES the imported os package at that
+// point in the source. Comparing X's spelling to the import's name gets that wrong
+// for ordinary, compilable Go:
+//
+//	import env "os"
+//	var _ = env.Args                       // genuinely the import
+//	func f() string { var env local; return env.Getenv("X") }   // NOT the import
+//
+// go/types answers it exactly: the shadowed use resolves to a *types.Var, the real
+// one to a *types.PkgName whose imported path is "os".
+//
+// WHAT THE IMPORTER DOES, AND WHY A STUB IS ENOUGH. Every import resolves to a
+// STUB package carrying the real import PATH — this module's own dependencies
+// cannot be loaded by the stdlib importers in module mode, and they do not need to
+// be. The question is only which OBJECT a qualifier denotes: go/types creates the
+// *types.PkgName from the import declaration itself, so `os` (or an alias of it)
+// binds to a PkgName whose Imported().Path() is "os" whether or not that package's
+// contents were loaded, while a shadowing local binds to a *types.Var. Selector
+// lookups INTO a stub fail, and those errors are irrelevant here — but the detector
+// never relies on them, and it FAILS CLOSED on any selector whose binding it could
+// not resolve.
+//
+// The returned bool is false when type-checking produced no bindings at all, which
+// the caller must treat as a hard failure rather than a clean package.
+func servingOracleResolveBindings(pkg *servingOraclePackage, dir string) (map[*ast.Ident]types.Object, bool) {
+	files := make([]*ast.File, 0, len(pkg.Files))
+	for _, f := range pkg.Files {
+		files = append(files, f)
+	}
+	info := &types.Info{Uses: map[*ast.Ident]types.Object{}, Defs: map[*ast.Ident]types.Object{}}
+	cfg := &types.Config{
+		Importer: servingOracleImporter{},
+		// Errors are collected rather than fatal: a stubbed dependency makes every
+		// selector into it undefined, and none of that bears on identifier binding.
+		Error: func(error) {},
+	}
+	_, _ = cfg.Check(dir, pkg.Fset, files, info)
+	return info.Uses, len(info.Uses) > 0
+}
+
+// servingOracleProductionBindings memoizes the bindings of a PRODUCTION package
+// against the exact parse they were computed from, so the pointers always match:
+// the map returned for a package is always the one go/types produced for THAT
+// package's files. See servingOracleBindKey.
+func servingOracleProductionBindings(t *testing.T, pkg *servingOraclePackage, dir string) map[*ast.Ident]types.Object {
+	t.Helper()
+	key := servingOracleBindKey{Pkg: pkg, Dir: dir}
+	servingOracleFixtureMu.Lock()
+	entry, done := servingOracleProdBindings[key]
+	servingOracleFixtureMu.Unlock()
+	uses, ok := entry.Uses, entry.OK
+	if !done {
+		uses, ok = servingOracleResolveBindings(pkg, dir)
+		servingOracleFixtureMu.Lock()
+		servingOracleProdBindings[key] = servingOracleBindings{Uses: uses, OK: ok}
+		servingOracleFixtureMu.Unlock()
+	}
+	if !ok {
+		t.Fatalf("go/types resolved no identifier bindings for %s (%d file(s)); the environment guard "+
+			"cannot answer what any selector denotes and must not report the package clean",
+			dir, len(pkg.Files))
+	}
+	return uses
+}
+
+// servingOracleImporter resolves every import to a complete, empty stub carrying
+// the real path. See servingOracleResolveBindings for why the contents are not
+// needed.
+type servingOracleImporter struct{}
+
+func (servingOracleImporter) Import(path string) (*types.Package, error) {
+	seg := path
+	if idx := strings.LastIndex(seg, "/"); idx >= 0 {
+		seg = seg[idx+1:]
+	}
+	p := types.NewPackage(path, seg)
+	p.MarkComplete()
+	return p, nil
+}
+
+// servingOracleEnvAPIs is the COMPLETE set of standard-library entry points, per
+// package, through which code can reach the process environment.
+//
+// TWO PACKAGES, because one is not enough: `os`'s environment functions are thin
+// wrappers over `syscall`'s, and a gate that called syscall.Getenv directly would
+// read the very same environment while an os-only proof stayed green. That is a
+// false green, not an alternate spelling.
+//
+// MUTATION IS INCLUDED alongside reading. A gate that WRITES the environment is
+// conditioning behaviour on it just as surely, and including Setenv/Unsetenv/
+// Clearenv costs nothing here — no production file behind the gate touches either.
+//
+// The sets are pinned by TestServingOracleEnvAPISetIsPinned, so a stdlib addition
+// is a conscious edit rather than a silent gap.
+// A SET, NOT A BOOLEAN MAP, and that is a proof property rather than a style
+// choice. While the detector decided from a stored `bool`, flipping one entry to
+// false silently disabled that API — and a key-only pin stayed green, because the
+// name was still there. Membership has no value to flip.
+var servingOracleEnvAPIs = map[string]map[string]struct{}{
+	"os": {
+		"Getenv": {}, "LookupEnv": {}, "Environ": {}, "ExpandEnv": {},
+		"Setenv": {}, "Unsetenv": {}, "Clearenv": {},
+	},
+	"syscall": {
+		"Getenv": {}, "Environ": {},
+		"Setenv": {}, "Unsetenv": {}, "Clearenv": {},
+	},
+}
+
+// servingOracleExpectedEnvAPIs is the INDEPENDENT expectation the pin compares
+// against, and the source the per-entry positive probes are generated from.
+//
+// It is written out by hand on purpose. Generating the probes from the live
+// allowlist would be self-referential — deleting an entry would delete its own
+// probe and stay green — so both the exactness check and the "every entry is
+// detectable" check are driven from here instead.
+var servingOracleExpectedEnvAPIs = map[string][]string{
+	"os":      {"Clearenv", "Environ", "ExpandEnv", "Getenv", "LookupEnv", "Setenv", "Unsetenv"},
+	"syscall": {"Clearenv", "Environ", "Getenv", "Setenv", "Unsetenv"},
+}
+
+// servingOracleEnvPkgName is the identifier a DEFAULT import of path is qualified
+// by: its last segment.
+//
+// It is the single source of truth for that derivation. The detector and the
+// per-entry probe generator both call it, so they cannot disagree about how a
+// watched package is spelled at a call site — they did, before this existed.
+func servingOracleEnvPkgName(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+// servingOracleIsEnvAPI reports whether fn is an environment entry point of pkg.
+func servingOracleIsEnvAPI(pkgPath, fn string) bool {
+	_, ok := servingOracleEnvAPIs[pkgPath][fn]
+	return ok
+}
+
+// servingOracleEnvImports resolves how a file imports each ENVIRONMENT package: the
+// local names it may be qualified by, and which of them are DOT-imported.
+//
+// A dot import is reported separately because it cannot be scanned the same way —
+// `Getenv("X")` is then a bare identifier indistinguishable from a call to any
+// local function of that name, so the caller fails closed on it rather than
+// concluding the file reads nothing. A blank import cannot be called at all.
+func servingOracleEnvImports(file *ast.File) (names map[string]struct{}, dotImported []string) {
+	names = map[string]struct{}{}
+	for _, imp := range file.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			continue
+		}
+		if _, watched := servingOracleEnvAPIs[path]; !watched {
+			continue
+		}
+		switch {
+		case imp.Name == nil:
+			// The package's own name qualifies it, and that is the LAST path segment
+			// rather than the whole path. Registering the full path worked only
+			// because "os" and "syscall" contain no slash; a watched multi-segment
+			// path would never have matched its default-imported selectors while the
+			// pin stayed green — the exact false-green shape this file exists to
+			// prevent.
+			names[servingOracleEnvPkgName(path)] = struct{}{}
+		case imp.Name.Name == ".":
+			dotImported = append(dotImported, path)
+		case imp.Name.Name == "_":
+			// Imported for its side effects only; it cannot be called.
+		default:
+			names[imp.Name.Name] = struct{}{}
+		}
+	}
+	sort.Strings(dotImported)
+	return names, dotImported
+}
+
+// servingOracleEnvHits reports every environment read this scan can see in one
+// file, and every construct it CANNOT see through.
+//
+// It is the single detector the live scan and TestServingOracleEnvironmentScanBites
+// both drive, so the bite test exercises the real code path rather than a copy that
+// can drift away from it.
+//
+// A qualified selector is a hit only when its qualifier's RESOLVED BINDING is the
+// imported os package — not when it merely shares the import's spelling. `uses` is
+// go/types' Uses map for the file's package; a selector whose qualifier is missing
+// from it cannot be judged, so it fails closed.
+func servingOracleEnvHits(path string, file *ast.File, uses map[*ast.Ident]types.Object) []string {
+	var hits []string
+	qualifiers, dotImported := servingOracleEnvImports(file)
+	if len(qualifiers) > 0 {
+		ast.Inspect(file, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			qualifier, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			// Only identifiers spelled like an environment-package import can BE one;
+			// anything else is some other package or value and is not this guard's
+			// business. The binding check below is what decides whether it actually is.
+			if _, isEnvQualifier := qualifiers[qualifier.Name]; !isEnvQualifier {
+				return true
+			}
+			obj, resolved := uses[qualifier]
+			if !resolved {
+				if !servingOracleAnyEnvAPI(sel.Sel.Name) {
+					return true
+				}
+				hits = append(hits, fmt.Sprintf("%s: %s.%s — the qualifier's binding could not be "+
+					"resolved, so this guard fails closed rather than assume it is not an environment "+
+					"package", path, qualifier.Name, sel.Sel.Name))
+				return true
+			}
+			pkgName, isPkg := obj.(*types.PkgName)
+			if !isPkg {
+				// SHADOWED: the identifier denotes a local value, not the import. This
+				// is ordinary, compilable Go and must not be reported.
+				return true
+			}
+			imported := pkgName.Imported().Path()
+			if !servingOracleIsEnvAPI(imported, sel.Sel.Name) {
+				return true
+			}
+			hits = append(hits, fmt.Sprintf("%s: %s.%s (package %q imported as %q)",
+				path, qualifier.Name, sel.Sel.Name, imported, qualifier.Name))
+			return true
+		})
+	}
+	if len(dotImported) == 0 {
+		return hits
+	}
+	// FAIL CLOSED on a dot import. An unqualified Getenv(...) is syntactically
+	// identical to a call to any local function of that name, and there is no
+	// qualifier whose binding could settle it, so this scan cannot prove the file
+	// reads no environment — and "cannot prove" must not read as "proved it does
+	// not". The bare call is named when one is present, so the report says what was
+	// found rather than only that the shape is unscannable.
+	detail := ""
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok || !servingOracleAnyEnvAPI(id.Name) {
+			return true
+		}
+		detail = fmt.Sprintf(" — it calls %s(...) unqualified", id.Name)
+		return false
+	})
+	hits = append(hits, fmt.Sprintf("%s: DOT-IMPORTS %v%s. An unqualified environment call is "+
+		"indistinguishable from a call to any local function of the same name, so this guard fails "+
+		"closed rather than claim the file reads nothing.", path, dotImported, detail))
+	return hits
+}
+
+// servingOracleAnyEnvAPI reports whether a bare function name matches an
+// environment entry point of ANY watched package. It is used only where the
+// package cannot be established — a dot import, or an unresolvable qualifier —
+// which is precisely where this guard fails closed.
+func servingOracleAnyEnvAPI(fn string) bool {
+	for _, api := range servingOracleEnvAPIs {
+		if _, ok := api[fn]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// TestServingOracleEnvironmentScanBites proves the scan CLASSIFIES, in BOTH
+// directions, over the shapes that distinguish a resolved binding from a spelling
+// match — and over BOTH environment packages.
+//
+// It drives servingOracleEnvHits through the same type-checking path the live scan
+// uses, so the two cannot drift apart.
+func TestServingOracleEnvironmentScanBites(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		// -- os, positive ---------------------------------------------------
+		{"a plain os.Getenv", "package p\n\nimport \"os\"\n\nfunc f() string { return os.Getenv(\"X\") }\n", true},
+		{"os.LookupEnv", "package p\n\nimport \"os\"\n\nfunc f() bool { _, ok := os.LookupEnv(\"X\"); return ok }\n", true},
+		{"os.Environ", "package p\n\nimport \"os\"\n\nfunc f() []string { return os.Environ() }\n", true},
+		{"os.ExpandEnv", "package p\n\nimport \"os\"\n\nfunc f() string { return os.ExpandEnv(\"$X\") }\n", true},
+		{"os.Setenv (mutation counts too)", "package p\n\nimport \"os\"\n\nfunc f() error { return os.Setenv(\"X\", \"1\") }\n", true},
+		{"an ALIASED os import that really calls Getenv", "package p\n\nimport env \"os\"\n\nfunc f() string { return env.Getenv(\"X\") }\n", true},
+
+		// -- syscall, positive: the package an os-only proof missed entirely --
+		{"syscall.Getenv", "package p\n\nimport \"syscall\"\n\nfunc f() string { v, _ := syscall.Getenv(\"X\"); return v }\n", true},
+		{"syscall.Environ", "package p\n\nimport \"syscall\"\n\nfunc f() []string { return syscall.Environ() }\n", true},
+		{"syscall.Setenv", "package p\n\nimport \"syscall\"\n\nfunc f() error { return syscall.Setenv(\"X\", \"1\") }\n", true},
+		{"an ALIASED syscall import that really calls Getenv", "package p\n\nimport sc \"syscall\"\n\nfunc f() string { v, _ := sc.Getenv(\"X\"); return v }\n", true},
+
+		// -- dot imports of either package: unscannable, so fail closed ------
+		{"a DOT import of os with a bare Getenv", "package p\n\nimport . \"os\"\n\nfunc f() string { return Getenv(\"BAML_REST_USE_DEBAML\") }\n", true},
+		{"a DOT import of os with no visible env call", "package p\n\nimport . \"os\"\n\nfunc f() error { _, err := Open(\"x\"); return err }\n", true},
+		{"a DOT import of syscall", "package p\n\nimport . \"syscall\"\n\nfunc f() []string { return Environ() }\n", true},
+
+		// -- shadows: ordinary compilable Go that must NOT be reported -------
+		{"a DEFAULT os import shadowed by a local value", "package p\n\nimport \"os\"\n\n" +
+			"var _ = os.Args\n\ntype local struct{}\n\nfunc (local) Getenv(string) string { return \"x\" }\n\n" +
+			"func f() string { var os local; return os.Getenv(\"X\") }\n", false},
+		{"an ALIASED os import shadowed by a local value", "package p\n\nimport env \"os\"\n\n" +
+			"var _ = env.Args\n\ntype local struct{}\n\nfunc (local) Getenv(string) string { return \"x\" }\n\n" +
+			"func f() string { var env local; return env.Getenv(\"X\") }\n", false},
+		{"a DEFAULT syscall import shadowed by a local value", "package p\n\nimport \"syscall\"\n\n" +
+			"var _ = syscall.Stdin\n\ntype local struct{}\n\nfunc (local) Environ() []string { return nil }\n\n" +
+			"func f() []string { var syscall local; return syscall.Environ() }\n", false},
+		{"an ALIASED syscall import shadowed by a local value", "package p\n\nimport sc \"syscall\"\n\n" +
+			"var _ = sc.Stdin\n\ntype local struct{}\n\nfunc (local) Getenv(string) (string, bool) { return \"\", false }\n\n" +
+			"func f() string { var sc local; v, _ := sc.Getenv(\"X\"); return v }\n", false},
+
+		// -- non-environment calls into the same packages --------------------
+		{"os.Open is not an environment read", "package p\n\nimport \"os\"\n\nfunc f() error { _, err := os.Open(\"x\"); return err }\n", false},
+		{"syscall.Kill is not an environment read", "package p\n\nimport \"syscall\"\n\nfunc f() error { return syscall.Kill(1, 0) }\n", false},
+
+		{"a local value called os in a file with NO os import", "package p\n\ntype t struct{ Getenv func(string) string }\n\nfunc f() string { var os t; return os.Getenv(\"X\") }\n", false},
+		{"a BLANK import cannot be called", "package p\n\nimport _ \"os\"\n\nfunc f() string { return \"\" }\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hits := servingOracleProbeEnvHits(t, tc.src)
+			if (len(hits) > 0) != tc.want {
+				t.Fatalf("detected=%v (%v), want %v", len(hits) > 0, hits, tc.want)
+			}
+		})
+	}
+	// The dot-import report must NAME the bare call when there is one, so the failure
+	// tells its reader what was found rather than only that the shape is unscannable.
+	hits := servingOracleProbeEnvHits(t,
+		"package p\n\nimport . \"os\"\n\nfunc f() string { return Getenv(\"X\") }\n")
+	if len(hits) != 1 || !strings.Contains(hits[0], "Getenv(...) unqualified") {
+		t.Fatalf("the dot-import report does not name the bare call: %v", hits)
+	}
+	// And an UNRESOLVABLE qualifier fails closed rather than being read as "not the
+	// import": the detector is handed an empty binding map for a file that really
+	// does call the import.
+	for _, src := range []string{
+		"package p\n\nimport \"os\"\n\nfunc f() string { return os.Getenv(\"X\") }\n",
+		"package p\n\nimport \"syscall\"\n\nfunc f() []string { return syscall.Environ() }\n",
+	} {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "probe.go", src, 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		unresolved := servingOracleEnvHits("probe.go", file, map[*ast.Ident]types.Object{})
+		if len(unresolved) != 1 || !strings.Contains(unresolved[0], "could not be resolved") {
+			t.Fatalf("an unresolvable qualifier must FAIL CLOSED; got %v", unresolved)
+		}
+	}
+}
+
+// TestServingOracleEnvAPISetIsPinned pins the watched surface exactly, so a
+// standard-library addition — or a quiet deletion — is a conscious edit.
+//
+// It compares against [servingOracleExpectedEnvAPIs], which is written out
+// independently of the live set, and it checks both directions: a package or a
+// function present in one and not the other fails.
+func TestServingOracleEnvAPISetIsPinned(t *testing.T) {
+	if len(servingOracleExpectedEnvAPIs) != len(servingOracleEnvAPIs) {
+		t.Fatalf("the scan watches %d package(s), the pin names %d",
+			len(servingOracleEnvAPIs), len(servingOracleExpectedEnvAPIs))
+	}
+	for pkg, names := range servingOracleExpectedEnvAPIs {
+		api, ok := servingOracleEnvAPIs[pkg]
+		if !ok {
+			t.Errorf("package %q is pinned but not watched", pkg)
+			continue
+		}
+		got := make([]string, 0, len(api))
+		for name := range api {
+			got = append(got, name)
+		}
+		sort.Strings(got)
+		if strings.Join(got, ",") != strings.Join(names, ",") {
+			t.Errorf("the %q environment API set is %v, want %v", pkg, got, names)
+		}
+	}
+	for pkg := range servingOracleEnvAPIs {
+		if _, ok := servingOracleExpectedEnvAPIs[pkg]; !ok {
+			t.Errorf("package %q is watched but not pinned", pkg)
+		}
+	}
+	// The membership helper must agree with the set in both directions, so the
+	// detector's own predicate cannot drift from the table the pin checks.
+	for pkg, names := range servingOracleExpectedEnvAPIs {
+		for _, fn := range names {
+			if !servingOracleIsEnvAPI(pkg, fn) {
+				t.Errorf("servingOracleIsEnvAPI(%q, %q) is false for a pinned entry", pkg, fn)
+			}
+		}
+	}
+	for _, fn := range []string{"Open", "Kill", "Getpid", "Exit"} {
+		for pkg := range servingOracleExpectedEnvAPIs {
+			if servingOracleIsEnvAPI(pkg, fn) {
+				t.Errorf("servingOracleIsEnvAPI(%q, %q) is true for a NON-environment function", pkg, fn)
+			}
+		}
+	}
+}
+
+// TestServingOracleEveryEnvAPIEntryIsDetected proves EVERY pinned entry is
+// load-bearing: each one is driven through the real go/types resolver and
+// servingOracleEnvHits, and each must be a HIT.
+//
+// Before this, four of the twelve (os.Unsetenv/Clearenv, syscall.Unsetenv/Clearenv)
+// were exercised by nothing at all, so disabling them was invisible to the whole
+// suite. The probes are generated from the INDEPENDENT expectation rather than from
+// the live allowlist: generating them from the allowlist would delete a deleted
+// entry's own probe and stay green.
+func TestServingOracleEveryEnvAPIEntryIsDetected(t *testing.T) {
+	total := 0
+	for pkg, names := range servingOracleExpectedEnvAPIs {
+		if len(names) == 0 {
+			t.Fatalf("package %q has no pinned entries; this test would prove nothing about it", pkg)
+		}
+		// The SAME derivation the detector uses, so the probe and the thing it
+		// probes cannot disagree about the qualifier.
+		qualifier := servingOracleEnvPkgName(pkg)
+		for _, fn := range names {
+			total++
+			t.Run(pkg+"."+fn, func(t *testing.T) {
+				// A bare selector rather than a call: the stub importer means the
+				// function's signature is unknown either way, and the detector matches
+				// the selector, so this is uniform across all twelve entries.
+				src := fmt.Sprintf("package p\n\nimport %q\n\nvar _ = %s.%s\n", pkg, qualifier, fn)
+				hits := servingOracleProbeEnvHits(t, src)
+				if len(hits) != 1 {
+					t.Fatalf("%s.%s produced %d hit(s) %v, want exactly 1; the allowlist entry is not "+
+						"load-bearing and could be removed or disabled unnoticed", qualifier, fn, len(hits), hits)
+				}
+				if !strings.Contains(hits[0], qualifier+"."+fn) || !strings.Contains(hits[0], pkg) {
+					t.Fatalf("the hit does not name %s.%s from package %q: %s", qualifier, fn, pkg, hits[0])
+				}
+			})
+		}
+	}
+	if total != 12 {
+		t.Fatalf("drove %d allowlist entries, want 12; the pinned surface changed without this count "+
+			"being acknowledged", total)
+	}
+	// CONTROL: a NON-environment selector from the same packages is not a hit, so
+	// the probes above discriminate rather than flagging every selector.
+	for _, tc := range []struct{ pkg, fn string }{{"os", "Open"}, {"syscall", "Kill"}} {
+		src := fmt.Sprintf("package p\n\nimport %q\n\nvar _ = %s.%s\n", tc.pkg, tc.pkg, tc.fn)
+		if hits := servingOracleProbeEnvHits(t, src); len(hits) != 0 {
+			t.Errorf("%s.%s was reported as an environment read: %v", tc.pkg, tc.fn, hits)
+		}
+	}
+}
+
+// servingOracleProbeEnvHits type-checks one synthetic source file exactly as the
+// live scan type-checks a production package, then runs the detector over it.
+//
+// Going through the real binding resolution is the point: a probe scanned without
+// it would prove nothing about the shadowing cases.
+func servingOracleProbeEnvHits(t *testing.T, src string) []string {
+	t.Helper()
+	servingOracleFixtureMu.Lock()
+	fixture, done := servingOracleProbeCache[src]
+	servingOracleFixtureMu.Unlock()
+	if !done {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "probe.go", src, 0)
+		if err != nil {
+			t.Fatalf("parse the probe: %v", err)
+		}
+		pkg := &servingOraclePackage{Fset: fset, Files: map[string]*ast.File{"probe.go": file}}
+		// The package path is the probe's own SOURCE, so two different probes can
+		// never be type-checked as one another.
+		uses, ok := servingOracleResolveBindings(pkg, "probe:"+src)
+		fixture = &servingOracleProbeFixture{File: file, Uses: uses, OK: ok}
+		servingOracleFixtureMu.Lock()
+		servingOracleProbeCache[src] = fixture
+		servingOracleFixtureMu.Unlock()
+	}
+	if !fixture.OK {
+		t.Fatalf("go/types resolved no identifier bindings for the probe; the detector could not judge a "+
+			"single selector:\n%s", src)
+	}
+	// The CACHED file, not a fresh parse: the binding map is keyed by that AST's
+	// identifier pointers.
+	return servingOracleEnvHits("probe.go", fixture.File, fixture.Uses)
+}
+
+// ---------------------------------------------------------------------------
+// AST helpers
+// ---------------------------------------------------------------------------
+
+func servingOracleRepoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	return root
+}
+
+func servingOracleHasReservedPrefix(name string) bool {
+	for _, p := range servingOracleReservedPrefixes {
+		if !strings.HasPrefix(name, p) {
+			continue
+		}
+		rest := name[len(p):]
+		// A prefix match only counts when the next rune starts a new word, so `sort`
+		// is not read as the `so` namespace while `soRenderProject` is.
+		if rest == "" {
+			continue
+		}
+		if p == "so" && !(rest[0] >= 'A' && rest[0] <= 'Z') {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// servingOracleOwnDeclarations returns every top-level identifier the oracle's own
+// files declare.
+func servingOracleOwnDeclarations(repo string) (map[string]struct{}, error) {
+	paths, err := filepath.Glob(filepath.Join(repo, "internal", "debaml", servingOracleSourceGlob))
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]struct{}{}
+	for _, path := range paths {
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			return nil, perr
+		}
+		for _, name := range servingOracleTopLevelNames(file) {
+			out[name] = struct{}{}
+		}
+	}
+	return out, nil
+}
+
+// servingOracleTopLevelNames lists the top-level declarations of one file,
+// including methods (whose receiver type is what matters for the scan).
+func servingOracleTopLevelNames(file *ast.File) []string {
+	var out []string
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Recv == nil {
+				out = append(out, d.Name.Name)
+			}
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				switch s := spec.(type) {
+				case *ast.TypeSpec:
+					out = append(out, s.Name.Name)
+				case *ast.ValueSpec:
+					for _, n := range s.Names {
+						if n.Name != "_" {
+							out = append(out, n.Name)
+						}
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// servingOracleDeclarationIndex maps every top-level identifier in the repository
+// to the files declaring it, relative to repo. Test files are INCLUDED: rule 1
+// needs both, because that is how a test-only anchor is distinguished from one
+// that leaked into production.
+func servingOracleDeclarationIndex(repo string) (map[string][]string, error) {
+	out := map[string][]string{}
+	err := servingOracleWalkGo(repo, func(path, rel string, file *ast.File) {
+		for _, name := range servingOracleTopLevelNames(file) {
+			out[name] = append(out[name], rel)
+		}
+	})
+	return out, err
+}
+
+// servingOracleDeclaredByProduction reports whether name has at least one
+// declaration in a NON-test file. A presence-only check would keep the negative
+// control green after the name moved into test-only code, at which point it would
+// no longer name a production seam at all.
+func servingOracleDeclaredByProduction(index map[string][]string, name string) bool {
+	for _, rel := range index[name] {
+		if !strings.HasSuffix(rel, "_test.go") {
+			return true
+		}
+	}
+	return false
+}
+
+// servingOracleProductionReferences finds every non-test .go file that declares or
+// mentions one of the given identifiers.
+func servingOracleProductionReferences(repo string, names map[string]struct{}) ([]string, error) {
+	var hits []string
+	err := servingOracleWalkGo(repo, func(path, rel string, file *ast.File) {
+		if strings.HasSuffix(rel, "_test.go") {
+			return
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			id, ok := n.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if _, watched := names[id.Name]; !watched {
+				return true
+			}
+			hits = append(hits, rel+": "+id.Name)
+			return true
+		})
+	})
+	return hits, err
+}
+
+// servingOracleWalkGo yields every .go file under repo, parsed.
+//
+// The parse is MEMOIZED per root (see the fixture block above): the tree does not
+// change while the binary runs, and re-parsing every file in the repository on each
+// of 100 iterations is what put this package over the unit-tests budget. The walk
+// itself still visits every file on every call, so no assertion is skipped.
+func servingOracleWalkGo(repo string, fn func(path, rel string, file *ast.File)) error {
+	files, err := servingOracleParsedTree(repo)
+	if err != nil {
+		return err
+	}
+	for _, f := range files {
+		fn(filepath.Join(repo, f.Rel), f.Rel, f.File)
+	}
+	return nil
+}
+
+// servingOracleParsedTree parses every .go file under repo, once per root.
+func servingOracleParsedTree(repo string) ([]servingOracleParsedFile, error) {
+	// ONLY the repository root is memoized. It is fixed for the life of the binary,
+	// which is what makes reuse sound. A temp directory is not: the AST-error bite
+	// test deliberately rewrites one between two scans, and serving it a cached tree
+	// would make that test pass by looking at the wrong bytes.
+	cacheable := repo == servingOracleRepoRootPath()
+	if cacheable {
+		servingOracleFixtureMu.Lock()
+		if files, done := servingOracleTreeCache[repo]; done {
+			err := servingOracleTreeErr[repo]
+			servingOracleFixtureMu.Unlock()
+			return files, err
+		}
+		servingOracleFixtureMu.Unlock()
+	}
+
+	var out []servingOracleParsedFile
+	err := filepath.WalkDir(repo, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", ".jj", "node_modules", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		rel, rerr := filepath.Rel(repo, path)
+		if rerr != nil {
+			return rerr
+		}
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			// A file the parser cannot read is NOT evidence of absence. Swallowing it
+			// would make an unparseable production .go read as "no oracle reference",
+			// which is the one answer this scan must never give by accident.
+			return fmt.Errorf("parse %s: %w", rel, perr)
+		}
+		out = append(out, servingOracleParsedFile{Rel: filepath.ToSlash(rel), File: file})
+		return nil
+	})
+
+	if cacheable {
+		servingOracleFixtureMu.Lock()
+		servingOracleTreeCache[repo], servingOracleTreeErr[repo] = out, err
+		servingOracleFixtureMu.Unlock()
+	}
+	return out, err
+}
+
+// servingOracleRepoRootPath resolves the repository root once, for the cache
+// predicate above. It deliberately does not take a *testing.T: an unresolvable root
+// simply makes nothing cacheable rather than failing a test that is not about it.
+var servingOracleRepoRootOnce sync.Once
+var servingOracleRepoRootAbs string
+
+func servingOracleRepoRootPath() string {
+	servingOracleRepoRootOnce.Do(func() {
+		if abs, err := filepath.Abs("../.."); err == nil {
+			servingOracleRepoRootAbs = abs
+		}
+	})
+	return servingOracleRepoRootAbs
+}
+
+// TestServingOracleASTWalkPropagatesParseErrors proves the repo scan FAILS CLOSED
+// on a file it cannot parse.
+//
+// Returning nil there would make an unparseable production .go read as "no oracle
+// reference" — absence of evidence standing in for evidence, in the one scan whose
+// whole job is to find a reference.
+func TestServingOracleASTWalkPropagatesParseErrors(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.go")
+	if err := os.WriteFile(good, []byte("package fake\n\nfunc ok() {}\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// CONTROL first: a parseable tree scans cleanly, so the failure below is about
+	// the broken file rather than about the walk refusing everything.
+	if _, err := servingOracleProductionReferences(dir, map[string]struct{}{"servingOracleFixtures": {}}); err != nil {
+		t.Fatalf("a parseable tree must scan without error; got %v", err)
+	}
+	broken := filepath.Join(dir, "broken.go")
+	if err := os.WriteFile(broken, []byte("package fake\n\nfunc ( ... this is not Go\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := servingOracleProductionReferences(dir, map[string]struct{}{"servingOracleFixtures": {}})
+	if err == nil {
+		t.Fatal("an UNPARSEABLE .go file was silently skipped; the scan would report 'no production " +
+			"reference' for a file it never read")
+	}
+	if !strings.Contains(err.Error(), "broken.go") {
+		t.Fatalf("the error does not name the file it could not read: %v", err)
+	}
+}
+
+// TestServingOracleBindingResolutionRefusesAnEmptyResult witnesses the guard that
+// stops a package whose bindings could not be resolved from being reported clean.
+//
+// Every real package and every probe resolves bindings, so the guard is satisfied
+// in normal operation and its removal cannot be seen from those runs. Driving a
+// package that genuinely produces none is what makes it load-bearing.
+func TestServingOracleBindingResolutionRefusesAnEmptyResult(t *testing.T) {
+	fset := token.NewFileSet()
+	empty, err := parser.ParseFile(fset, "empty.go", "package p\n", 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, ok := servingOracleResolveBindings(
+		&servingOraclePackage{Fset: fset, Files: map[string]*ast.File{"empty.go": empty}},
+		"probe:binding-resolution/empty"); ok {
+		t.Fatal("a package that resolves NO identifier bindings was reported usable; the scan would then " +
+			"report it clean without having been able to judge a single selector")
+	}
+	// CONTROL: a package that DOES resolve bindings is usable, so the guard is about
+	// the empty result rather than about refusing everything.
+	fset2 := token.NewFileSet()
+	real, err := parser.ParseFile(fset2, "real.go", "package p\n\nimport \"os\"\n\nvar _ = os.Args\n", 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	uses, ok := servingOracleResolveBindings(
+		&servingOraclePackage{Fset: fset2, Files: map[string]*ast.File{"real.go": real}},
+		"probe:binding-resolution/real")
+	if !ok || len(uses) == 0 {
+		t.Fatalf("the control package resolved no bindings (ok=%v, uses=%d)", ok, len(uses))
+	}
+}
+
+// TestServingOracleEnvHitsRequiresTheOsPackage witnesses the last predicate in the
+// binding check: a qualifier that resolves to a PACKAGE must resolve to `os`
+// specifically.
+//
+// Within a single file that check cannot fire — an identifier cannot be both an os
+// import name and a binding to some other package — so it is unreachable from the
+// live scan and from the source-level bite table. It is asserted directly rather
+// than left as an unexercised branch: the detector is handed a file that imports os
+// as `env`, and a binding map in which `env` denotes a DIFFERENT package.
+func TestServingOracleEnvHitsRequiresTheOsPackage(t *testing.T) {
+	const src = "package p\n\nimport env \"os\"\n\nfunc f() string { return env.Getenv(\"X\") }\n"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "probe.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var qualifier *ast.Ident
+	ast.Inspect(file, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "Getenv" {
+			qualifier, _ = sel.X.(*ast.Ident)
+		}
+		return true
+	})
+	if qualifier == nil {
+		t.Fatal("the probe has no env.Getenv selector")
+	}
+	self := types.NewPackage("probe", "p")
+
+	// Bound to a package that is NOT os: not a hit.
+	other := types.NewPkgName(token.NoPos, self, "env", types.NewPackage("example.com/other", "env"))
+	if hits := servingOracleEnvHits("probe.go", file,
+		map[*ast.Ident]types.Object{qualifier: other}); len(hits) > 0 {
+		t.Errorf("a qualifier bound to %q was reported as an os read: %v",
+			other.Imported().Path(), hits)
+	}
+	// CONTROL: bound to os, it IS a hit — so the check discriminates rather than
+	// rejecting every package binding.
+	osPkg := types.NewPkgName(token.NoPos, self, "env", types.NewPackage("os", "os"))
+	hits := servingOracleEnvHits("probe.go", file, map[*ast.Ident]types.Object{qualifier: osPkg})
+	if len(hits) != 1 || !strings.Contains(hits[0], "env.Getenv") {
+		t.Errorf("a qualifier bound to os was not reported: %v", hits)
+	}
+}
+
+// TestServingOracleEnvPkgNameIsTheSharedDerivation pins the qualifier derivation a
+// default import gets, including the multi-segment case no watched package
+// currently has.
+//
+// The detector and the per-entry probe generator both call this helper. They used
+// to derive it independently — the detector registered the WHOLE import path — which
+// agreed only because "os" and "syscall" contain no slash. A watched multi-segment
+// path would then never have matched its default-imported selectors while the pinned
+// set stayed green, which is the false-green shape this file exists to prevent.
+func TestServingOracleEnvPkgNameIsTheSharedDerivation(t *testing.T) {
+	for path, want := range map[string]string{
+		"os":                    "os",
+		"syscall":               "syscall",
+		"example.com/x/env":     "env",
+		"golang.org/x/sys/unix": "unix",
+	} {
+		if got := servingOracleEnvPkgName(path); got != want {
+			t.Errorf("servingOracleEnvPkgName(%q) = %q, want %q", path, got, want)
+		}
+	}
+	// And the detector really uses it: a file DEFAULT-importing a multi-segment
+	// watched path must register the last segment as a qualifier. The path is
+	// injected into the watched set for the length of this test so the case can be
+	// driven without moving the pinned production surface.
+	//
+	// The injection SWAPS A WHOLE MAP rather than writing into the live one. Every
+	// reader of servingOracleEnvAPIs (servingOracleIsEnvAPI, servingOracleEnvImports,
+	// servingOracleAnyEnvAPI) reads it WITHOUT the mutex, because a pinned lookup
+	// table is otherwise immutable for the life of the process — so an in-place write
+	// under a write-side-only lock buys nothing, and the moment any test in this file
+	// grows a t.Parallel it becomes a concurrent map read/write. Copy-on-write keeps
+	// every map value immutable once published: a reader holds a complete, consistent
+	// table either way, and the restore below hands back the ORIGINAL map untouched.
+	const multi = "example.com/x/env"
+	servingOracleFixtureMu.Lock()
+	pinned := servingOracleEnvAPIs
+	widened := make(map[string]map[string]struct{}, len(pinned)+1)
+	for path, api := range pinned {
+		widened[path] = api
+	}
+	widened[multi] = map[string]struct{}{"Getenv": {}}
+	servingOracleEnvAPIs = widened
+	servingOracleFixtureMu.Unlock()
+	defer func() {
+		servingOracleFixtureMu.Lock()
+		servingOracleEnvAPIs = pinned
+		servingOracleFixtureMu.Unlock()
+	}()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "probe.go",
+		"package p\n\nimport \""+multi+"\"\n\nvar _ = env.Getenv\n", 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	names, dot := servingOracleEnvImports(file)
+	if dot != nil {
+		t.Fatalf("a default import was read as a dot import: %v", dot)
+	}
+	if _, ok := names["env"]; !ok {
+		t.Fatalf("a default import of %q registered %v; the qualifier must be its last segment %q, or the "+
+			"detector would never match its selectors", multi, names, "env")
+	}
+	if _, ok := names[multi]; ok {
+		t.Fatalf("a default import of %q registered the whole PATH as a qualifier; no selector is ever "+
+			"spelled that way", multi)
+	}
+}
+
+// TestServingOracleProductionPackageCacheIsKeyedByRoots proves the memoized
+// package parse is keyed by the roots it scanned.
+//
+// The live scan is the only caller today and always names the same two roots, so a
+// cache that ignored the argument would be correct by accident and unobservable —
+// and the next caller to name different roots would silently receive the first
+// call's packages and prove nothing about the trees it asked for. Two calls with
+// DIFFERENT root sets must return different results.
+//
+// It costs one extra parse of one root per process: the result is memoized like
+// every other fixture here, so -count re-runs are free.
+func TestServingOracleProductionPackageCacheIsKeyedByRoots(t *testing.T) {
+	oneRoot := servingOracleProductionPackages(t, ".")
+	twoRoots := servingOracleProductionPackages(t, ".", "../schema")
+	if len(oneRoot) == 0 || len(twoRoots) == 0 {
+		t.Fatalf("a root scan returned nothing (%d, %d); the comparison would be vacuous",
+			len(oneRoot), len(twoRoots))
+	}
+	if len(twoRoots) <= len(oneRoot) {
+		t.Fatalf("scanning %d root(s) returned %d package(s) and scanning 1 returned %d; the cache is "+
+			"serving one caller's result to another that named different roots", 2, len(twoRoots), len(oneRoot))
+	}
+	// The narrower scan must not contain a package from the root it did not name.
+	for dir := range oneRoot {
+		if strings.Contains(filepath.ToSlash(dir), "schema") {
+			t.Errorf("the single-root scan of %q returned the package %q, which is under a root it never "+
+				"named", ".", dir)
+		}
+	}
+	// …and the wider one must, so the difference is the second root rather than noise.
+	found := false
+	for dir := range twoRoots {
+		if strings.Contains(filepath.ToSlash(dir), "schema") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the two-root scan returned no package under ../schema; the roots argument had no effect")
+	}
+}
+
+// TestServingOracleProductionBindingsBelongToTheirOwnParse proves the memoized
+// go/types bindings are associated with the AST they were computed from, and not
+// merely with the directory that AST came from.
+//
+// This is the second half of the roots-keyed cache above, and the reason it is
+// needed: once one directory can have several distinct parses live at once, a
+// binding cache keyed by directory alone hands the second parse the first parse's
+// map. Nothing about that fails loudly — the map is a valid map, and lookups into
+// it simply miss — so the environment detector would fail closed on every selector
+// of a package it believes it scanned. Binding maps are keyed by *ast.Ident
+// POINTERS, so "the wrong package's map" and "an empty map" are the same thing.
+//
+// The assertion is exact rather than statistical: every identifier the returned map
+// binds must be an identifier of the AST that was asked about, and there must be at
+// least one. Serving the other root set's map makes the overlap ZERO while the map
+// itself stays non-empty, which trips both halves.
+func TestServingOracleProductionBindingsBelongToTheirOwnParse(t *testing.T) {
+	const dir = "."
+	oneRoot := servingOracleProductionPackages(t, dir)
+	twoRoots := servingOracleProductionPackages(t, dir, "../schema")
+
+	// Precondition: the SAME directory, parsed under two root sets, is two distinct
+	// ASTs. Without this the test would pass by comparing a parse to itself.
+	narrow, wide := oneRoot[dir], twoRoots[dir]
+	if narrow == nil || wide == nil {
+		t.Fatalf("directory %q is missing from a root scan (1-root: %v, 2-root: %v); the comparison "+
+			"would be vacuous", dir, narrow != nil, wide != nil)
+	}
+	if narrow == wide {
+		t.Fatalf("both root scans returned the SAME *servingOraclePackage for %q; the binding cache is "+
+			"never asked to distinguish two parses of one directory and this witness proves nothing", dir)
+	}
+	if len(narrow.Files) == 0 || len(wide.Files) == 0 {
+		t.Fatalf("a parse of %q has no files (1-root: %d, 2-root: %d)", dir, len(narrow.Files), len(wide.Files))
+	}
+
+	// Both directions, because either parse may reach the cache first: whichever one
+	// a directory-keyed cache stored, the OTHER one is served a foreign map.
+	for _, parse := range []struct {
+		what string
+		pkg  *servingOraclePackage
+	}{
+		{"the 1-root parse", narrow},
+		{"the 2-root parse", wide},
+	} {
+		own := map[*ast.Ident]struct{}{}
+		for _, file := range parse.pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				if id, isIdent := n.(*ast.Ident); isIdent {
+					own[id] = struct{}{}
+				}
+				return true
+			})
+		}
+
+		uses := servingOracleProductionBindings(t, parse.pkg, dir)
+		matched := 0
+		for id := range uses {
+			if _, mine := own[id]; mine {
+				matched++
+			}
+		}
+		switch {
+		case matched == 0:
+			t.Errorf("the bindings returned for %s of %q contain ZERO of its %d identifiers (the map "+
+				"binds %d identifier(s), all of them from some OTHER parse); the binding cache is keyed "+
+				"by directory rather than by the parse it belongs to, so the environment scan would "+
+				"resolve nothing in this package", parse.what, dir, len(own), len(uses))
+		case matched != len(uses):
+			t.Errorf("the bindings returned for %s of %q bind %d identifier(s) but only %d belong to "+
+				"that parse; the map is a mixture of parses", parse.what, dir, len(uses), matched)
+		}
+	}
+}

--- a/internal/debaml/serving_oracle_model_test.go
+++ b/internal/debaml/serving_oracle_model_test.go
@@ -1,0 +1,737 @@
+//go:build integration
+
+package debaml
+
+// The comparison ENVELOPE both legs are rendered into.
+//
+// The oracle compares far more than JSON value equality. Per fixture it records,
+// from each leg independently:
+//
+//	identity   the canonical value in ONE shared vocabulary — class and enum
+//	           NAMES, field/entry ORDER, and every leaf typed
+//	           (class:Hand{suit=enum:Suit=Hearts,bid=int:2}). Two documents that
+//	           marshal to the same JSON but disagree about which class they are,
+//	           or in which order the fields sit, are NOT equal here.
+//	json       the serialized document, compared with the EXACT big.Rat
+//	           comparator (constraintStateValueDiff), never float64.
+//	sites      every constraint that RAN, in traversal-then-declaration order,
+//	           with its path, level, label and exact expression text, and its
+//	           result. Labels are never folded, so a duplicate label is two
+//	           ordered sites rather than one.
+//	kind       value / assertion-failure / evaluator-error / coercion-error /
+//	           process-fatal. These are distinct outcomes and are never collapsed:
+//	           a false @check is DATA in an emitted value, a false @assert REJECTS
+//	           the node, and a predicate that could not be evaluated is neither.
+//
+// The stock envelope is read from the raw CFFI value tree rather than from a
+// generated client's decoded structs, because the generated readback is LOSSY in
+// exactly the place this slice has to measure: baml_go's decodeCheckedValue folds
+// Checked.Checks into a map[string]Check, so two @check attributes sharing a label
+// collapse to one and their order is gone. Reading the protobuf directly keeps the
+// ordered []CFFICheckValue stock actually produced. TestServingOracleDuplicateLabel
+// pins BOTH observations — the ordered pair and the fold — so the lossiness is a
+// recorded property of stock's Go binding rather than a limitation this oracle
+// papers over.
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/boundaryml/baml/engine/language_client_go/pkg/cffi"
+
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+// servingOracleFixture is one serving-shaped row: an in-memory .baml function,
+// the raw assistant text, and the RECORDED envelope of each leg.
+//
+// Both pins are recordings read off the live legs (see the recording mode in
+// [TestServingOracleDifferential]), not predictions, and both are re-verified on
+// every run — so a change on either side has to be acknowledged rather than
+// absorbed, and the corpus cannot be edited into agreement with itself.
+type servingOracleFixture struct {
+	// Name is unique and is the BAML function name once prefixed.
+	Name string
+	// Family is the shape family this fixture belongs to. Every family in
+	// [servingOracleGateFamilies] must have at least one fixture, and every
+	// fixture's family must be in that list — the two directions are what keep the
+	// non-integration gate test (serving_oracle_gate_test.go, which drives
+	// checkSupported/checkSupportedFields/checkSupportedType by name) covering the
+	// same shapes the oracle drives.
+	Family string
+	// Doc says what this row is evidence FOR. Required.
+	Doc string
+	// Bundle is the native schema. The .baml is rendered from it.
+	Bundle *schema.Bundle
+	// Raw is the assistant text handed to BOTH legs.
+	Raw string
+	// Stock is the RECORDED stock envelope, rendered by soStockEnvelope.render.
+	Stock string
+	// Native is the RECORDED native envelope, rendered by soNativeEnvelope.render.
+	Native string
+	// Fatal marks a row stock cannot be asked in-process (it aborts or hangs the
+	// CFFI). Such a row is driven ONLY from an isolated subprocess and never
+	// contributes a fabricated boolean. See serving_oracle_fatal_test.go.
+	Fatal bool
+	// Unconstrained marks a CONTROL fixture that carries no constraint anywhere.
+	// The boundary lock requires it to be ADMITTED, which is what makes the
+	// decline of every other fixture constraint-specific rather than a blanket
+	// refusal of the corpus.
+	Unconstrained bool
+	// Divergence explains, in one sentence, why this row does NOT land in an
+	// agreement bucket: a predicate native refuses to evaluate, a coercion native
+	// declines outright, a value the two legs canonicalize differently, or a check
+	// collection whose SHAPE differs. It is required for every non-agreeing bucket
+	// and forbidden for an agreeing one (TestServingOracleAgreementTally asserts
+	// both directions), so a cost can neither appear nor disappear silently.
+	//
+	// It is never an allowance to SERVE. Every such row is constraint-bearing, so
+	// the production gate declines the bundle and native's value never reaches a
+	// caller — which TestServingOracleBoundaryLock asserts for every row
+	// independently of this field.
+	Divergence string
+}
+
+// method is the generated BAML function this fixture is driven through.
+func (f servingOracleFixture) method() string { return soFunctionName(f.Name) }
+
+// source names the .baml the method lives in, for the per-case report.
+func (f servingOracleFixture) source() string { return soProjectFile + ":" + f.method() }
+
+// ---------------------------------------------------------------------------
+// Stock envelope
+// ---------------------------------------------------------------------------
+
+// soStockKind is what the stock leg DID, as the caller observes it.
+type soStockKind string
+
+const (
+	// soStockValue: stock emitted a value. Any @check results ride inside it as
+	// data; a false @check does NOT prevent this.
+	soStockValue soStockKind = "value"
+	// soStockAssertFailed: an @assert predicate rendered false, so stock REJECTED
+	// the node ("Assertions failed."). There is no value.
+	soStockAssertFailed soStockKind = "assertion-failure"
+	// soStockEvaluatorError: a predicate failed to compile/evaluate, or did not
+	// render exactly true/false. Stock rejects the node. It is NOT a failed check
+	// and must never be mapped onto one.
+	soStockEvaluatorError soStockKind = "evaluator-error"
+	// soStockCoercionError: stock could not coerce the text into the target type at
+	// all — a parse/coercion failure with no constraint involved.
+	soStockCoercionError soStockKind = "coercion-error"
+	// soStockProcessFatal: stock cannot be observed in-process (it aborts or
+	// hangs). Recorded from a subprocess and NEVER converted into a boolean.
+	soStockProcessFatal soStockKind = "process-fatal"
+	// soStockUnrecognisedError: stock returned an error whose reason chain matches
+	// NO known shape. It is a HARNESS FAILURE, not a bucket: reading a new error
+	// class as an ordinary coercion failure would quietly fold an unknown stock
+	// behaviour into a known one, which is the opposite of what the envelope
+	// vocabulary is for. Every test treats it as fatal.
+	soStockUnrecognisedError soStockKind = "unrecognised-stock-error"
+)
+
+// soKnownStockErrorShapes are the reason fragments that classify a stock error.
+// The list is asserted non-empty and each entry is required to be matched by at
+// least one corpus row, so a shape can neither be added without a witness nor
+// removed while a row still depends on it.
+var soKnownStockErrorShapes = []struct {
+	Fragment string
+	Kind     soStockKind
+}{
+	{"Failed to evaluate constraints:", soStockEvaluatorError},
+	{"Assertions failed.", soStockAssertFailed},
+	{"Failed while parsing required fields:", soStockCoercionError},
+	{"Expected ", soStockCoercionError},
+}
+
+// soStockSite is one constraint stock evaluated, at the position it ran.
+type soStockSite struct {
+	Path       string
+	Label      string
+	Expression string
+	// Status is stock's own word: "succeeded" or "failed". It is kept verbatim
+	// rather than mapped to a bool so an unrecognised third status cannot be
+	// silently read as one of the two.
+	Status string
+	// Certified says whether this site was READ FROM THE RAW CFFI TREE.
+	//
+	// A certified site carries stock's own order and multiplicity. An UNCERTIFIED one
+	// was recovered from a root check collection baml_go had already folded into a
+	// map[string]shared.Check, where order and multiplicity no longer exist — see
+	// soChecked. The distinction is carried all the way into the rendered envelope
+	// and into the comparator, which does not claim an ordering it cannot observe.
+	Certified bool
+}
+
+func (s soStockSite) render() string {
+	out := fmt.Sprintf("%s|%s|%s=%s", s.Path, strconv.Quote(s.Label), s.Expression, s.Status)
+	if !s.Certified {
+		// The marker is part of the PINNED envelope, so a row whose root evidence is
+		// uncertified says so in the corpus rather than only in a comment.
+		out += "~uncertified-order"
+	}
+	return out
+}
+
+// soStockEnvelope is one stock observation.
+type soStockEnvelope struct {
+	Kind     soStockKind
+	Identity string
+	JSON     string
+	Sites    []soStockSite
+	// Reasons is the ordered `reason:` chain of stock's ParsingError, unquoted.
+	// It is what turns "an error" into an exact observation.
+	Reasons []string
+}
+
+func (e soStockEnvelope) render() string {
+	switch e.Kind {
+	case soStockValue:
+		parts := make([]string, len(e.Sites))
+		for i, s := range e.Sites {
+			parts[i] = s.render()
+		}
+		return fmt.Sprintf("value %s checks=[%s]", e.Identity, strings.Join(parts, " "))
+	case soStockProcessFatal:
+		return "process-fatal " + strings.Join(e.Reasons, " | ")
+	default:
+		return string(e.Kind) + " " + strings.Join(e.Reasons, " | ")
+	}
+}
+
+// soReasonRe matches the `reason: "..."` fields of BAML's ParsingError Debug
+// rendering, which is what the CFFI hands back as the error string.
+var soReasonRe = regexp.MustCompile(`reason: ("(?:[^"\\]|\\.)*")`)
+
+// soClassifyStockError turns a stock error into a kind plus its exact reason
+// chain.
+//
+// The classification is driven by stock's OWN words and has no default bucket: an
+// error whose reasons match none of the known shapes is a coercion error, which is
+// the conservative reading (it claims nothing about constraints), and the reasons
+// are pinned either way so a re-classified error cannot pass unnoticed.
+func soClassifyStockError(err error) soStockEnvelope {
+	msg := err.Error()
+	var reasons []string
+	for _, m := range soReasonRe.FindAllStringSubmatch(msg, -1) {
+		unq, uerr := strconv.Unquote(m[1])
+		if uerr != nil {
+			// Keep the raw form rather than dropping it: a reason we cannot unquote
+			// is still evidence, and silently skipping it would shorten the chain the
+			// pin compares.
+			unq = m[1]
+		}
+		reasons = append(reasons, unq)
+	}
+	if len(reasons) == 0 {
+		reasons = []string{soCollapse(msg)}
+	}
+	// NO DEFAULT BUCKET, and that is load-bearing. An error shape this vocabulary
+	// does not recognise is reported as [soStockUnrecognisedError], which every
+	// caller treats as a harness failure; defaulting it to a coercion error would
+	// silently absorb a new stock behaviour into a known one.
+	kind := soStockUnrecognisedError
+	for _, r := range reasons {
+		for _, shape := range soKnownStockErrorShapes {
+			if !strings.Contains(r, shape.Fragment) {
+				continue
+			}
+			// Precedence: an evaluator failure outranks the assertion/parse wrappers
+			// BAML nests it inside, and an assertion failure outranks the generic
+			// required-fields wrapper. Without it the outermost wrapper would win and
+			// every nested failure would read as a plain coercion error.
+			if kind == soStockUnrecognisedError ||
+				soStockKindRank(shape.Kind) > soStockKindRank(kind) {
+				kind = shape.Kind
+			}
+		}
+	}
+	out := make([]string, len(reasons))
+	for i, r := range reasons {
+		out[i] = soCollapse(r)
+	}
+	return soStockEnvelope{Kind: kind, Reasons: out}
+}
+
+// soStockKindRank orders the error kinds by specificity, so the innermost
+// (most specific) reason decides the classification rather than the outermost
+// wrapper BAML happens to nest it in.
+func soStockKindRank(k soStockKind) int {
+	switch k {
+	case soStockEvaluatorError:
+		return 3
+	case soStockAssertFailed:
+		return 2
+	case soStockCoercionError:
+		return 1
+	}
+	return 0
+}
+
+// soCollapse folds a multi-line message onto one line so a pinned envelope stays
+// comparable for EQUALITY. Only the framing is touched.
+func soCollapse(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\n", " / ")
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// soFailedAssert extracts the (label, expression) pairs stock names in a
+// "Failed: <label> <expression>" reason, which is how it reports WHICH assertion
+// rejected the node.
+func soFailedAssert(reasons []string) []string {
+	var out []string
+	for _, r := range reasons {
+		if rest, ok := strings.CutPrefix(r, "Failed: "); ok {
+			out = append(out, rest)
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Reading the raw CFFI value
+// ---------------------------------------------------------------------------
+
+// soReadStockValue walks the raw CFFI value tree, producing the shared-vocabulary
+// identity, the serialized document and every constraint site in traversal order.
+//
+// It walks the PROTOBUF rather than a decoded struct on purpose (see the file
+// comment): the ordered []CFFICheckValue is only available here.
+func soReadStockValue(h *cffi.CFFIValueHolder, path string, sites *[]soStockSite) (identity string, doc json.RawMessage, err error) {
+	if h == nil {
+		return "", nil, fmt.Errorf("%s: nil value holder", path)
+	}
+	switch v := h.GetValue().(type) {
+	case *cffi.CFFIValueHolder_CheckedValue:
+		c := v.CheckedValue
+		if c == nil {
+			return "", nil, fmt.Errorf("%s: nil checked value", path)
+		}
+		for _, chk := range c.Checks {
+			if chk == nil {
+				return "", nil, fmt.Errorf("%s: nil check entry", path)
+			}
+			*sites = append(*sites, soStockSite{
+				Path: path, Label: chk.Name, Expression: chk.Expression, Status: chk.Status,
+				// Read from the raw protobuf: stock's own order and multiplicity.
+				Certified: true,
+			})
+		}
+		// The Checked wrapper is transparent to the VALUE: its checks are recorded
+		// above and the identity is the value they ran against.
+		return soReadStockValue(c.Value, path, sites)
+
+	case *cffi.CFFIValueHolder_UnionVariantValue:
+		u := v.UnionVariantValue
+		if u == nil {
+			return "", nil, fmt.Errorf("%s: nil union variant", path)
+		}
+		// Transparent as well. Which ARM won is observable in the identity of the
+		// value itself (an int arm renders int:…, a string arm string:…), and the
+		// native side records the arm index separately.
+		return soReadStockValue(u.Value, path, sites)
+
+	case *cffi.CFFIValueHolder_NullValue:
+		return "null", json.RawMessage("null"), nil
+
+	case *cffi.CFFIValueHolder_BoolValue:
+		return "bool:" + strconv.FormatBool(v.BoolValue), json.RawMessage(strconv.FormatBool(v.BoolValue)), nil
+
+	case *cffi.CFFIValueHolder_IntValue:
+		s := strconv.FormatInt(v.IntValue, 10)
+		return "int:" + s, json.RawMessage(s), nil
+
+	case *cffi.CFFIValueHolder_FloatValue:
+		s := strconv.FormatFloat(v.FloatValue, 'g', -1, 64)
+		return "float:" + s, json.RawMessage(s), nil
+
+	case *cffi.CFFIValueHolder_StringValue:
+		q := strconv.Quote(v.StringValue)
+		enc, merr := json.Marshal(v.StringValue)
+		if merr != nil {
+			return "", nil, fmt.Errorf("%s: marshal string: %w", path, merr)
+		}
+		return "string:" + q, enc, nil
+
+	case *cffi.CFFIValueHolder_EnumValue:
+		e := v.EnumValue
+		if e == nil || e.Name == nil {
+			return "", nil, fmt.Errorf("%s: nil enum value", path)
+		}
+		enc, merr := json.Marshal(e.Value)
+		if merr != nil {
+			return "", nil, fmt.Errorf("%s: marshal enum: %w", path, merr)
+		}
+		return "enum:" + e.Name.Name + "=" + e.Value, enc, nil
+
+	case *cffi.CFFIValueHolder_ListValue:
+		l := v.ListValue
+		if l == nil {
+			return "", nil, fmt.Errorf("%s: nil list value", path)
+		}
+		ids := make([]string, len(l.Items))
+		docs := make([]string, len(l.Items))
+		for i, it := range l.Items {
+			id, d, ierr := soReadStockValue(it, fmt.Sprintf("%s[%d]", path, i), sites)
+			if ierr != nil {
+				return "", nil, ierr
+			}
+			ids[i], docs[i] = id, string(d)
+		}
+		return "list[" + strings.Join(ids, ",") + "]", json.RawMessage("[" + strings.Join(docs, ",") + "]"), nil
+
+	case *cffi.CFFIValueHolder_MapValue:
+		m := v.MapValue
+		if m == nil {
+			return "", nil, fmt.Errorf("%s: nil map value", path)
+		}
+		ids := make([]string, len(m.Entries))
+		docs := make([]string, len(m.Entries))
+		seen := map[string]bool{}
+		for i, e := range m.Entries {
+			if e == nil {
+				return "", nil, fmt.Errorf("%s: nil map entry", path)
+			}
+			if seen[e.Key] {
+				// A duplicate key would make the document depend on which entry a
+				// decoder kept. Refuse rather than record one of them.
+				return "", nil, fmt.Errorf("%s: duplicate map key %q in stock readback", path, e.Key)
+			}
+			seen[e.Key] = true
+			id, d, ierr := soReadStockValue(e.Value, fmt.Sprintf("%s[%q]", path, e.Key), sites)
+			if ierr != nil {
+				return "", nil, ierr
+			}
+			kq, merr := json.Marshal(e.Key)
+			if merr != nil {
+				return "", nil, fmt.Errorf("%s: marshal map key: %w", path, merr)
+			}
+			ids[i] = e.Key + "=" + id
+			docs[i] = string(kq) + ":" + string(d)
+		}
+		return "map{" + strings.Join(ids, ",") + "}", json.RawMessage("{" + strings.Join(docs, ",") + "}"), nil
+
+	case *cffi.CFFIValueHolder_ClassValue:
+		c := v.ClassValue
+		if c == nil || c.Name == nil {
+			return "", nil, fmt.Errorf("%s: nil class value", path)
+		}
+		ids := make([]string, len(c.Fields))
+		docs := make([]string, len(c.Fields))
+		seen := map[string]bool{}
+		for i, f := range c.Fields {
+			if f == nil {
+				return "", nil, fmt.Errorf("%s: nil class field", path)
+			}
+			if seen[f.Key] {
+				return "", nil, fmt.Errorf("%s: duplicate field %q in stock readback", path, f.Key)
+			}
+			seen[f.Key] = true
+			id, d, ierr := soReadStockValue(f.Value, path+"."+f.Key, sites)
+			if ierr != nil {
+				return "", nil, ierr
+			}
+			kq, merr := json.Marshal(f.Key)
+			if merr != nil {
+				return "", nil, fmt.Errorf("%s: marshal field key: %w", path, merr)
+			}
+			ids[i] = f.Key + "=" + id
+			docs[i] = string(kq) + ":" + string(d)
+		}
+		return "class:" + c.Name.Name + "{" + strings.Join(ids, ",") + "}",
+			json.RawMessage("{" + strings.Join(docs, ",") + "}"), nil
+	}
+	// Every remaining CFFI variant (literal, media/raw object, streaming state) is
+	// outside what a non-streaming constraint fixture can produce. Refusing is the
+	// point: a silently rendered "unknown" would let an unmodelled shape compare
+	// equal to itself.
+	return "", nil, fmt.Errorf("%s: unmodelled CFFI value %T", path, h.GetValue())
+}
+
+// ---------------------------------------------------------------------------
+// Native envelope
+// ---------------------------------------------------------------------------
+
+// soNativeKind is what the NATIVE leg did.
+type soNativeKind string
+
+const (
+	// soNativeValue: coercion produced a canonical value and every attached
+	// predicate that ran produced a boolean.
+	soNativeValue soNativeKind = "value"
+	// soNativeAssertFailed: an @assert-level event evaluated FALSE. Native does not
+	// act on it (it declines the whole bundle at admission), but the state records
+	// it, and it is what stock's "Assertions failed." must line up with.
+	soNativeAssertFailed soNativeKind = "assertion-failure"
+	// soNativeUnsupported: at least one predicate was refused with
+	// ErrConstraintUnsupported. Native declined to decide.
+	soNativeUnsupported soNativeKind = "evaluator-unsupported"
+	// soNativeCoercionError: production coerce refused the value.
+	soNativeCoercionError soNativeKind = "coercion-error"
+	// soNativeNoCandidate: extraction found no cleanly-claimable candidate, which
+	// is a DECLINE in the serving path rather than a parse result.
+	soNativeNoCandidate soNativeKind = "no-candidate"
+	// soNativeUnmodelled: the collector refuses to model this coercion shape.
+	soNativeUnmodelled soNativeKind = "collector-unmodelled"
+	// soNativeCollectorDiverged: the collector's traversal did not serialize to the
+	// document production coerce produced, so it REFUSED to report a state. It is
+	// distinct from a coercion error: production coerced the value fine, and it is
+	// the test-only collector that could not mirror it.
+	soNativeCollectorDiverged soNativeKind = "collector-diverged"
+)
+
+// soNativeSite is one predicate the native collector ran, at the node it ran on.
+type soNativeSite struct {
+	Path       string
+	Origin     constraintStateOrigin
+	Level      schema.ConstraintLevel
+	Labeled    bool
+	Label      string
+	Expression string
+	Outcome    constraintStateOutcome
+}
+
+func (s soNativeSite) render() string {
+	label := "-"
+	if s.Labeled {
+		label = strconv.Quote(s.Label)
+	}
+	return fmt.Sprintf("%s|%s/%s/%s/%s=%s", s.Path, s.Origin, s.Level, label, s.Expression, s.Outcome)
+}
+
+// soNativeSkip is one predicate that did NOT run, with the counterfactual the
+// collector recorded — positive evidence that the predicate was reached rather
+// than merely absent.
+type soNativeSkip struct {
+	Path   string
+	Detail string
+}
+
+func (s soNativeSkip) render() string { return s.Path + "|" + s.Detail }
+
+// soNativeEnvelope is one native observation.
+type soNativeEnvelope struct {
+	Kind     soNativeKind
+	Identity string
+	JSON     string
+	Sites    []soNativeSite
+	Skips    []soNativeSkip
+	// Support is checkSupported(bundle) VERBATIM — recorded on every row, never
+	// acted on, so a fixture cannot quietly become admitted.
+	Support error
+	// Err is the coercion/collector error itself, retained so the contract can tell
+	// a production DECLINE (the ErrDeBAMLParseUnsupported sentinel — fail-closed by
+	// construction) from a collector refusal or a real failure, rather than reading
+	// all three off one message string.
+	Err     error
+	Message string
+}
+
+func (e soNativeEnvelope) render() string {
+	switch e.Kind {
+	case soNativeCoercionError, soNativeNoCandidate, soNativeUnmodelled, soNativeCollectorDiverged:
+		return string(e.Kind) + " " + e.Message
+	}
+	sites := make([]string, len(e.Sites))
+	for i, s := range e.Sites {
+		sites[i] = s.render()
+	}
+	skips := make([]string, len(e.Skips))
+	for i, s := range e.Skips {
+		skips[i] = s.render()
+	}
+	out := fmt.Sprintf("%s %s events=[%s]", e.Kind, e.Identity, strings.Join(sites, " "))
+	if len(skips) > 0 {
+		out += " skipped=[" + strings.Join(skips, " ") + "]"
+	}
+	return out
+}
+
+// soRunNative drives the NATIVE leg end to end, exactly as the static serving path
+// does: strip JSONish comments, extract the cleanly-claimable candidate, then
+// coerce and evaluate through the test-only coercion-state collector.
+//
+// The extraction half is production's own (stripJSONComments +
+// extractCandidateMode + bundleNumMode — the same three calls ParseStaticBundle
+// makes), so a fixture whose raw text is fenced or commented exercises the real
+// front half rather than a decoded shortcut.
+func soRunNative(f servingOracleFixture) soNativeEnvelope {
+	support := checkSupported(f.Bundle)
+	in, ok := extractCandidateMode(stripJSONComments(f.Raw), bundleNumMode(f.Bundle))
+	if !ok {
+		return soNativeEnvelope{Kind: soNativeNoCandidate, Support: support,
+			Message: "no cleanly-claimable JSON candidate"}
+	}
+	c := &constraintStateCollector{bundle: f.Bundle}
+	root, err := c.node(f.Bundle.Target, in, nil, constraintStatePath{{Kind: constraintPathRoot}}, false, true)
+	if err != nil {
+		kind := soNativeCoercionError
+		switch {
+		case soIsUnmodelled(err):
+			kind = soNativeUnmodelled
+		case strings.Contains(err.Error(), errConstraintStateDiverged.Error()):
+			kind = soNativeCollectorDiverged
+		}
+		return soNativeEnvelope{Kind: kind, Support: support, Err: err, Message: soCollapse(err.Error())}
+	}
+
+	env := soNativeEnvelope{Kind: soNativeValue, Support: support,
+		Identity: constraintStateDescribe(root.Canonical), JSON: string(root.CanonicalJSON)}
+	root.walk(func(n *constraintCoercionState) {
+		p := n.Path.String()
+		for _, ev := range n.Events {
+			env.Sites = append(env.Sites, soNativeSite{
+				Path: p, Origin: ev.Origin, Level: ev.Level, Labeled: ev.Labeled,
+				Label: ev.Label, Expression: ev.Expression, Outcome: ev.Outcome,
+			})
+		}
+		for _, sk := range n.Skipped {
+			env.Skips = append(env.Skips, soNativeSkip{Path: p, Detail: sk.describe()})
+		}
+		if n.Disposition == constraintDispositionSkippedPath || n.Disposition == constraintDispositionPolicyDeclined {
+			env.Skips = append(env.Skips, soNativeSkip{Path: p, Detail: "node:" + string(n.Disposition) + ":" + n.SkipReason})
+		}
+	})
+	for _, s := range env.Sites {
+		if s.Outcome == constraintOutcomeUnsupported {
+			env.Kind = soNativeUnsupported
+		}
+	}
+	if env.Kind == soNativeValue {
+		for _, s := range env.Sites {
+			if s.Level == schema.ConstraintAssert && s.Outcome == constraintOutcomeFalse {
+				env.Kind = soNativeAssertFailed
+			}
+		}
+	}
+	return env
+}
+
+// soIsUnmodelled keeps the collector's "I refuse to model this shape" refusal
+// distinguishable from a real coercion failure. Folding the two would let an
+// unmodelled shape be reported as stock-disagreement, or worse, as agreement.
+func soIsUnmodelled(err error) bool {
+	return strings.Contains(err.Error(), errConstraintStateUnmodelled.Error())
+}
+
+// ---------------------------------------------------------------------------
+// Path alignment between the two legs
+// ---------------------------------------------------------------------------
+
+// soUnionArmRe matches the collector's union-arm path segment.
+var soUnionArmRe = regexp.MustCompile(`\|arm[0-9]+`)
+
+// soAlignNativePath maps a native constraint-state path onto the path the STOCK
+// readback reports for the same node.
+//
+// ONE normalisation, and it is derived rather than assumed. The collector indexes
+// list elements by their INPUT position, so an element BAML dropped keeps the index
+// it arrived at while stock's emitted list has closed the gap. The shift is computed
+// from the collector's OWN skipped-path records, so it comes from the same run.
+//
+// There is deliberately NO union-arm normalisation. The collector renders a winning
+// union arm as `|armN`, which stock's tree does not carry — but production coerce
+// declines every constrained union in this corpus (at a class field AND at the
+// return type), so no such path is ever produced and a normalisation for it would
+// be dead code that silently loosened the comparison.
+// TestServingOracleNoUnionArmIsCoerced asserts that absence positively, with the
+// decline as its evidence, so a future change that admits constrained unions fails
+// here and forces the alignment to be re-derived with a fixture behind it.
+func soAlignNativePath(path string, dropsByPrefix map[string][]int) string {
+	return soShiftDroppedIndexes(path, dropsByPrefix)
+}
+
+// soIndexRe matches the FIRST list index segment of a path, splitting it into the
+// prefix, the index and the remaining tail. soShiftDroppedIndexes walks a path
+// left to right with it.
+var soIndexRe = regexp.MustCompile(`^(.*?)\[([0-9]+)\](.*)$`)
+
+// soLastIndexRe matches a path that ENDS in a list index, splitting it into the
+// owning list's full path and that index.
+//
+// The producer keys drops by the owning list, which for a NESTED element is
+// `$.v[2].w` rather than `$.v` — the greedy prefix and the end anchor are what
+// make that so. Matching the first index instead (and discarding anything with a
+// remaining suffix, as this did) meant a skip at `$.v[2].w[1]` produced no key at
+// all, so the consumer's nested support could only ever be exercised by a
+// hand-built map.
+var soLastIndexRe = regexp.MustCompile(`^(.*)\[([0-9]+)\]$`)
+
+// soShiftDroppedIndexes rewrites every `[i]` segment of path into the index the
+// element has in stock's EMITTED list, given the input indexes dropped under each
+// list prefix.
+//
+// TWO COORDINATE SYSTEMS, tracked separately. The collector's paths — and therefore
+// the keys of dropsByPrefix — are in INPUT coordinates; the rendered result is in
+// stock's EMITTED coordinates. Once an outer index has been shifted, the emitted
+// rendering is no longer a valid key: a nested list under an outer element whose
+// earlier sibling was dropped would look up `$.v[1].w` when the collector recorded
+// its drops under `$.v[2].w`, miss, and leave the inner index unshifted.
+//
+// So the input-coordinate prefix is carried alongside the emitted one and is what
+// the map is queried with.
+func soShiftDroppedIndexes(path string, dropsByPrefix map[string][]int) string {
+	if len(dropsByPrefix) == 0 {
+		return path
+	}
+	var emitted strings.Builder // what is returned: stock's coordinates
+	var input strings.Builder   // what the drop map is keyed by: the collector's
+	rest := path
+	for {
+		m := soIndexRe.FindStringSubmatch(rest)
+		if m == nil {
+			emitted.WriteString(rest)
+			return emitted.String()
+		}
+		prefix, idxText, tail := m[1], m[2], m[3]
+		idx, err := strconv.Atoi(idxText)
+		if err != nil {
+			// Unreachable: the regexp only matches digits.
+			emitted.WriteString(rest)
+			return emitted.String()
+		}
+		shift := 0
+		for _, d := range dropsByPrefix[input.String()+prefix] {
+			if d < idx {
+				shift++
+			}
+		}
+		fmt.Fprintf(&emitted, "%s[%d]", prefix, idx-shift)
+		fmt.Fprintf(&input, "%s[%d]", prefix, idx)
+		rest = tail
+	}
+}
+
+// soDropsByPrefix reads the collector's skipped LIST ELEMENT paths out of a native
+// envelope, keyed by the owning list's path. Only node-level skips are counted: a
+// per-predicate skip (a bare-string return, say) does not remove an element from
+// the emitted list.
+func soDropsByPrefix(env soNativeEnvelope) map[string][]int {
+	out := map[string][]int{}
+	for _, s := range env.Skips {
+		if !strings.HasPrefix(s.Detail, "node:") {
+			continue
+		}
+		// Key by the OWNING LIST, which is everything up to the final index. A
+		// nested element's owner is itself an indexed path, and that is exactly the
+		// key soShiftDroppedIndexes builds as it walks.
+		m := soLastIndexRe.FindStringSubmatch(s.Path)
+		if m == nil {
+			continue
+		}
+		idx, err := strconv.Atoi(m[2])
+		if err != nil {
+			continue
+		}
+		out[m[1]] = append(out[m[1]], idx)
+	}
+	return out
+}

--- a/internal/debaml/serving_oracle_project_test.go
+++ b/internal/debaml/serving_oracle_project_test.go
@@ -1,0 +1,504 @@
+//go:build integration
+
+package debaml
+
+// The in-memory .baml PROJECT the stock leg is driven against.
+//
+// Unlike internal/debaml/constraintoracle and internal/debaml/guardledger, this
+// oracle checks in NO generated BAML client. The project is a map[string]string
+// handed to baml.CreateRuntime at test time and driven through
+// BamlRuntime.CallFunctionParse — the same CFFI entry point the generated
+// Parse.<Method> wrappers call, one layer down.
+//
+// WHY THAT MATTERS FOR THE FIXTURE PROTECTIONS. A checked-in generated client can
+// go stale against the .baml it was generated from, which is why the sibling
+// oracles carry a source-map freshness test. Here the .baml the runtime compiles
+// is produced from the SAME schema.Bundle the native leg coerces against, in the
+// same process, on every run — there is no second artifact to drift. What replaces
+// the freshness check is therefore a stronger claim, not a weaker one:
+//
+//   - [TestServingOracleProjectDrift] byte-compares the rendered project against a
+//     checked-in golden so a corpus change is visible in review, and pins its
+//     SHA-256 so the golden cannot be regenerated silently;
+//   - [TestServingOracleProjectIsTheOneStockDrivesAndFixtureMethodsExist] proves the
+//     bytes the runtime was created from are the bytes the golden pins, and that
+//     every fixture's function is present in them and reachable.
+//
+// SINGLE SOURCE OF TRUTH. Each fixture owns a [schema.Bundle]. The .baml is
+// RENDERED from that bundle, so a fixture cannot describe one schema to stock and
+// another to native. The renderer is not trusted: if it lowered a type wrongly the
+// two legs would see different schemas, and the differential's canonical-value
+// comparison fails loudly rather than passing on a shared mistake.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/invakid404/baml-rest/bamlutils/schemadescriptor"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+const (
+	// soFunctionPrefix namespaces every generated function so a fixture name can
+	// never collide with a BAML keyword or a declaration name.
+	soFunctionPrefix = "SO_"
+
+	// soClient is the client every function names. It is never called — the oracle
+	// drives the PARSE entry point, not the LLM — but a BAML function must declare
+	// one.
+	soClient = "ServingOracleClient"
+
+	// soProjectFile is the single .baml file of the in-memory project, and
+	// soProjectGolden is the checked-in copy [TestServingOracleProjectDrift]
+	// byte-compares it against.
+	soProjectFile   = "serving_oracle.baml"
+	soProjectGolden = "testdata/serving_oracle/project.baml"
+
+	// soWriteEnv rewrites the golden instead of comparing (see the drift test).
+	soWriteEnv = "BAML_SERVING_ORACLE_FIXTURE_WRITE"
+)
+
+// soPrelude is the fixed head of the project: the unroutable client.
+const soPrelude = `// GENERATED at test time from the Slice 7.2a-3 serving-oracle corpus — do not edit.
+//
+// Every declaration below is rendered from the schema.Bundle of one corpus
+// fixture (serving_oracle_corpus_test.go) by soRenderProject, so the .baml the
+// stock BAML v0.223.0 CFFI compiles and the schema.Bundle the native collector
+// coerces against are the same description of the same shape.
+//
+// Regenerate with:
+//   BAML_SERVING_ORACLE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml -run TestServingOracleProjectDrift
+
+client<llm> ` + soClient + ` {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://serving-oracle.invalid/v1"
+  }
+}
+`
+
+// soFunctionName is the BAML function that carries one fixture.
+func soFunctionName(fixture string) string { return soFunctionPrefix + fixture }
+
+// ---------------------------------------------------------------------------
+// schema.Bundle -> .baml source
+// ---------------------------------------------------------------------------
+
+// soTypeExpr renders a type in a position where trailing attributes are legal:
+// the base type followed by its own @check/@assert attributes.
+func soTypeExpr(t schema.Type) string {
+	out := soBaseTypeExpr(t)
+	for _, c := range t.Meta.Constraints {
+		out += " " + soConstraintAttr(c)
+	}
+	return out
+}
+
+// soInnerTypeExpr renders a type in a NESTED position (list element, map key/value,
+// union variant), parenthesising exactly when the rendering is more than one type
+// token.
+//
+// BAML v0.223 rejects `map<string, int @check(...)>` outright — a constrained
+// nested type must be parenthesised — so this is a grammar requirement rather
+// than a style choice; the corpus's map-value and list-element fixtures are what
+// prove the parenthesised form is the one that compiles.
+func soInnerTypeExpr(t schema.Type) string {
+	s := soTypeExpr(t)
+	if len(t.Meta.Constraints) > 0 || soIsMultiVariantUnion(t) {
+		return "(" + s + ")"
+	}
+	return s
+}
+
+func soIsMultiVariantUnion(t schema.Type) bool {
+	return t.Kind == schema.TypeUnion && t.Union != nil && len(t.Union.Variants) > 1
+}
+
+func soBaseTypeExpr(t schema.Type) string {
+	switch t.Kind {
+	case schema.TypePrimitive:
+		switch t.Primitive {
+		case schema.PrimitiveString:
+			return "string"
+		case schema.PrimitiveInt:
+			return "int"
+		case schema.PrimitiveFloat:
+			return "float"
+		case schema.PrimitiveBool:
+			return "bool"
+		case schema.PrimitiveNull:
+			return "null"
+		case schema.PrimitiveMedia:
+			return string(t.Media)
+		}
+		panic("serving oracle: unrenderable primitive " + string(t.Primitive))
+	case schema.TypeEnum, schema.TypeClass:
+		return t.Name
+	case schema.TypeLiteral:
+		if t.Literal == nil {
+			panic("serving oracle: literal type with no value")
+		}
+		switch t.Literal.Kind {
+		case schema.LiteralString:
+			return strconv.Quote(t.Literal.String)
+		case schema.LiteralInt:
+			return strconv.FormatInt(t.Literal.Int, 10)
+		case schema.LiteralBool:
+			return strconv.FormatBool(t.Literal.Bool)
+		}
+		panic("serving oracle: unrenderable literal kind " + string(t.Literal.Kind))
+	case schema.TypeList:
+		if t.Elem == nil {
+			panic("serving oracle: list type with no element")
+		}
+		return soInnerTypeExpr(*t.Elem) + "[]"
+	case schema.TypeMap:
+		if t.Key == nil || t.Value == nil {
+			panic("serving oracle: map type with no key/value")
+		}
+		return "map<" + soInnerTypeExpr(*t.Key) + ", " + soInnerTypeExpr(*t.Value) + ">"
+	case schema.TypeUnion:
+		if t.Union == nil {
+			panic("serving oracle: union type with no payload")
+		}
+		parts := make([]string, len(t.Union.Variants))
+		for i, v := range t.Union.Variants {
+			parts[i] = soInnerTypeExpr(v)
+		}
+		joined := strings.Join(parts, " | ")
+		if !t.Union.Nullable {
+			return joined
+		}
+		if len(parts) == 1 {
+			return parts[0] + "?"
+		}
+		return "(" + joined + ")?"
+	}
+	panic("serving oracle: unrenderable type kind " + string(t.Kind))
+}
+
+// soConstraintAttr renders one constraint as its BAML attribute. An unlabelled
+// @check is not expressible in BAML (the grammar requires the label), so a corpus
+// fixture that declares one is a bug rather than a fact about BAML; it panics
+// here instead of rendering something the project would reject for an unrelated
+// reason.
+func soConstraintAttr(c schema.Constraint) string {
+	kind := "check"
+	if c.Level == schema.ConstraintAssert {
+		kind = "assert"
+	}
+	if c.Label == nil {
+		if c.Level == schema.ConstraintCheck {
+			panic("serving oracle: @check without a label is not expressible in BAML")
+		}
+		return fmt.Sprintf("@assert({{ %s }})", c.Expression)
+	}
+	return fmt.Sprintf("@%s(%s, {{ %s }})", kind, *c.Label, c.Expression)
+}
+
+// soRenderClass renders one class declaration.
+func soRenderClass(c schema.ClassDef) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "class %s {\n", c.Name.Name)
+	for _, f := range c.Fields {
+		fmt.Fprintf(&b, "  %s %s", f.Name.Name, soBaseTypeExpr(f.Type))
+		if f.Name.Alias != nil {
+			fmt.Fprintf(&b, " @alias(%s)", strconv.Quote(*f.Name.Alias))
+		}
+		for _, ct := range f.Type.Meta.Constraints {
+			b.WriteString(" " + soConstraintAttr(ct))
+		}
+		b.WriteString("\n")
+	}
+	for _, ct := range c.Constraints {
+		fmt.Fprintf(&b, "  @@%s\n", strings.TrimPrefix(soConstraintAttr(ct), "@"))
+	}
+	b.WriteString("}\n")
+	return b.String()
+}
+
+// soRenderEnum renders one enum declaration.
+func soRenderEnum(e schema.EnumDef) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "enum %s {\n", e.Name.Name)
+	for _, v := range e.Values {
+		fmt.Fprintf(&b, "  %s", v.Name.Name)
+		if v.Name.Alias != nil {
+			fmt.Fprintf(&b, " @alias(%s)", strconv.Quote(*v.Name.Alias))
+		}
+		b.WriteString("\n")
+	}
+	for _, ct := range e.Constraints {
+		fmt.Fprintf(&b, "  @@%s\n", strings.TrimPrefix(soConstraintAttr(ct), "@"))
+	}
+	b.WriteString("}\n")
+	return b.String()
+}
+
+// soRenderFunction renders the function that carries one fixture. The parameter is
+// never used — Parse takes the assistant text, not the function arguments — but a
+// BAML function must declare one, and the prompt must reference ctx.output_format
+// or the project does not describe the return type to the model.
+func soRenderFunction(fixture string, target schema.Type) string {
+	return fmt.Sprintf("function %s(topic: string) -> %s {\n  client %s\n  prompt #\"{{ topic }} {{ ctx.output_format }}\"#\n}\n",
+		soFunctionName(fixture), soTypeExpr(target), soClient)
+}
+
+// soDeclaration is one named class/enum declaration contributed by a fixture,
+// carried with its source so a collision between two fixtures is reported with
+// both renderings rather than silently resolved.
+type soDeclaration struct {
+	Name    string
+	Source  string
+	Fixture string
+}
+
+// soRenderProject renders the whole in-memory project from the corpus.
+//
+// Declarations are emitted in FIRST-CONTRIBUTION order, then functions in corpus
+// order, so the output is a pure function of the corpus and the drift test can
+// byte-compare it. Two fixtures may share a declaration name only if they render
+// it identically; anything else is a corpus bug and returns an error rather than
+// producing a project whose meaning depends on which fixture was rendered last.
+func soRenderProject(fixtures []servingOracleFixture) (string, error) {
+	var b strings.Builder
+	b.WriteString(soPrelude)
+
+	seen := map[string]soDeclaration{}
+	var order []string
+	add := func(d soDeclaration) error {
+		prev, ok := seen[d.Name]
+		if ok {
+			if prev.Source != d.Source {
+				return fmt.Errorf("declaration %q is rendered differently by fixtures %q and %q:\n--- %s\n%s--- %s\n%s",
+					d.Name, prev.Fixture, d.Fixture, prev.Fixture, prev.Source, d.Fixture, d.Source)
+			}
+			return nil
+		}
+		seen[d.Name] = d
+		order = append(order, d.Name)
+		return nil
+	}
+	for _, f := range fixtures {
+		if f.Bundle == nil {
+			return "", fmt.Errorf("fixture %q has no bundle", f.Name)
+		}
+		for _, e := range f.Bundle.Enums {
+			if err := add(soDeclaration{Name: e.Name.Name, Source: soRenderEnum(e), Fixture: f.Name}); err != nil {
+				return "", err
+			}
+		}
+		for _, c := range f.Bundle.Classes {
+			if err := add(soDeclaration{Name: c.Name.Name, Source: soRenderClass(c), Fixture: f.Name}); err != nil {
+				return "", err
+			}
+		}
+	}
+	for _, name := range order {
+		b.WriteString("\n")
+		b.WriteString(seen[name].Source)
+	}
+	for _, f := range fixtures {
+		b.WriteString("\n")
+		b.WriteString(soRenderFunction(f.Name, f.Bundle.Target))
+	}
+	// PROBES are rendered into the same project but are not corpus rows: they exist
+	// so a named test can drive a shape the differential must NOT contain (a root
+	// duplicate label, whose folded readback is deliberately lossy). Keeping them in
+	// the project means the drift golden covers them too.
+	for _, pr := range servingOracleProbes {
+		for _, c := range pr.Bundle.Classes {
+			if err := add(soDeclaration{Name: c.Name.Name, Source: soRenderClass(c), Fixture: "probe:" + pr.Name}); err != nil {
+				return "", err
+			}
+			b.WriteString("\n")
+			b.WriteString(seen[c.Name.Name].Source)
+		}
+		b.WriteString("\n")
+		b.WriteString(soRenderFunction(pr.Name, pr.Bundle.Target))
+	}
+	return b.String(), nil
+}
+
+// servingOracleProbe is a project function driven only by a named test.
+type servingOracleProbe struct {
+	Name   string
+	Doc    string
+	Bundle *schema.Bundle
+	Raw    string
+}
+
+// method is the generated BAML function for this probe.
+func (p servingOracleProbe) method() string { return soFunctionName(p.Name) }
+
+// soProjectFiles is the in-memory project handed to baml.CreateRuntime.
+func soProjectFiles(src string) map[string]string {
+	return map[string]string{soProjectFile: src}
+}
+
+// soProjectHash is the SHA-256 of the rendered project, in hex. The drift test
+// pins it next to the golden so regenerating the golden without acknowledging the
+// change is not possible.
+func soProjectHash(src string) string {
+	sum := sha256.Sum256([]byte(src))
+	return hex.EncodeToString(sum[:])
+}
+
+// soEnvSnapshot is the environment the runtime is created with, mirroring the
+// generated client's getEnvVars. The fixture project's client is unroutable and
+// no LLM call is ever made, so nothing here is read; it is passed for parity with
+// the real serving path rather than for effect.
+func soEnvSnapshot() map[string]string {
+	env := map[string]string{}
+	for _, kv := range os.Environ() {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || v == "" {
+			continue
+		}
+		env[k] = v
+	}
+	return env
+}
+
+// soSortedNames returns the fixture names, sorted, for a stable failure message.
+func soSortedNames(fixtures []servingOracleFixture) []string {
+	out := make([]string, 0, len(fixtures))
+	for _, f := range fixtures {
+		out = append(out, f.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// schema.Bundle -> schemadescriptor.Bundle
+// ---------------------------------------------------------------------------
+
+// soDescriptorFor converts a fixture bundle into the PUBLIC descriptor shape, so
+// the same schema can be handed to [Parse] through the static-descriptor lane —
+// the only request shape that can carry a constraint at all.
+//
+// It is a mechanical field-for-field mirror; it is NOT trusted. Every caller
+// lowers the result back with schema.FromStaticDescriptor and requires the round
+// trip to reproduce the original bundle exactly (soParseRequestFor), so a
+// conversion mistake fails loudly instead of quietly driving Parse over a
+// different schema.
+func soDescriptorFor(b *schema.Bundle) schemadescriptor.Bundle {
+	out := schemadescriptor.Bundle{
+		Version:          schemadescriptor.Version,
+		Method:           "SO",
+		Target:           soDescriptorType(b.Target),
+		RecursiveClasses: append([]string(nil), b.RecursiveClasses...),
+	}
+	for _, e := range b.Enums {
+		de := schemadescriptor.EnumDef{
+			Name:        schemadescriptor.Name{Name: e.Name.Name, Alias: e.Name.Alias},
+			Constraints: soDescriptorConstraints(e.Constraints),
+		}
+		for _, v := range e.Values {
+			de.Values = append(de.Values, schemadescriptor.EnumValue{
+				Name:        schemadescriptor.Name{Name: v.Name.Name, Alias: v.Name.Alias},
+				Description: v.Description,
+			})
+		}
+		out.Enums = append(out.Enums, de)
+	}
+	for _, c := range b.Classes {
+		dc := schemadescriptor.ClassDef{
+			Name:        schemadescriptor.Name{Name: c.Name.Name, Alias: c.Name.Alias},
+			Description: c.Description,
+			Mode:        schemadescriptor.StreamingMode(c.Mode),
+			Constraints: soDescriptorConstraints(c.Constraints),
+			Stream: schemadescriptor.StreamingBehavior{
+				Needed: c.Stream.Needed, Done: c.Stream.Done, State: c.Stream.State,
+			},
+		}
+		for _, f := range c.Fields {
+			dc.Fields = append(dc.Fields, schemadescriptor.ClassField{
+				Name:            schemadescriptor.Name{Name: f.Name.Name, Alias: f.Name.Alias},
+				Type:            soDescriptorType(f.Type),
+				Description:     f.Description,
+				StreamingNeeded: f.StreamingNeeded,
+			})
+		}
+		out.Classes = append(out.Classes, dc)
+	}
+	for _, a := range b.StructuralRecursiveAliases {
+		out.StructuralRecursiveAliases = append(out.StructuralRecursiveAliases,
+			schemadescriptor.RecursiveAliasDef{Name: a.Name, Target: soDescriptorType(a.Target)})
+	}
+	return out
+}
+
+func soDescriptorConstraints(cs []schema.Constraint) []schemadescriptor.Constraint {
+	var out []schemadescriptor.Constraint
+	for _, c := range cs {
+		out = append(out, schemadescriptor.Constraint{
+			Level:      schemadescriptor.ConstraintLevel(c.Level),
+			Expression: c.Expression,
+			Label:      c.Label,
+		})
+	}
+	return out
+}
+
+func soDescriptorType(t schema.Type) schemadescriptor.Type {
+	out := schemadescriptor.Type{
+		Kind: schemadescriptor.TypeKind(t.Kind),
+		Meta: schemadescriptor.TypeMeta{
+			Constraints: soDescriptorConstraints(t.Meta.Constraints),
+			Stream: schemadescriptor.StreamingBehavior{
+				Needed: t.Meta.Stream.Needed, Done: t.Meta.Stream.Done, State: t.Meta.Stream.State,
+			},
+		},
+		Primitive: schemadescriptor.PrimitiveKind(t.Primitive),
+		Media:     schemadescriptor.MediaKind(t.Media),
+		Name:      t.Name,
+		Mode:      schemadescriptor.StreamingMode(t.Mode),
+		Dynamic:   t.Dynamic,
+	}
+	if t.Literal != nil {
+		out.Literal = &schemadescriptor.LiteralValue{
+			Kind:   schemadescriptor.LiteralKind(t.Literal.Kind),
+			String: t.Literal.String, Int: t.Literal.Int, Bool: t.Literal.Bool,
+		}
+	}
+	if t.Elem != nil {
+		e := soDescriptorType(*t.Elem)
+		out.Elem = &e
+	}
+	if t.Key != nil {
+		k := soDescriptorType(*t.Key)
+		out.Key = &k
+	}
+	if t.Value != nil {
+		v := soDescriptorType(*t.Value)
+		out.Value = &v
+	}
+	for _, it := range t.Items {
+		out.Items = append(out.Items, soDescriptorType(it))
+	}
+	if t.Union != nil {
+		u := schemadescriptor.UnionType{Nullable: t.Union.Nullable}
+		for _, v := range t.Union.Variants {
+			u.Variants = append(u.Variants, soDescriptorType(v))
+		}
+		out.Union = &u
+	}
+	if t.Arrow != nil {
+		a := schemadescriptor.ArrowType{Return: soDescriptorType(t.Arrow.Return)}
+		for _, p := range t.Arrow.Params {
+			a.Params = append(a.Params, soDescriptorType(p))
+		}
+		out.Arrow = &a
+	}
+	return out
+}

--- a/internal/debaml/serving_oracle_stock_test.go
+++ b/internal/debaml/serving_oracle_stock_test.go
@@ -1,0 +1,740 @@
+//go:build integration
+
+package debaml
+
+// The STOCK leg: an in-memory .baml project compiled by the stock BAML v0.223.0
+// CFFI and driven through BamlRuntime.CallFunctionParse.
+//
+// WHY CallFunctionParse RATHER THAN A GENERATED Parse.<Method>. They are the same
+// call: every generated `func (*parse) FooFn(text string)` encodes
+// {"text": …, "stream": false} and calls exactly this runtime method. Going one
+// layer down buys two things this slice needs — the project can be built in
+// memory from the corpus instead of checked in and regenerated, and the RAW CFFI
+// value tree is reachable, which is where the ordered check collection lives.
+//
+// HOW THE RAW TREE IS REACHED. baml_go decodes the CFFI payload on the callback
+// thread using a process-global type map. Registering the corpus's class names to
+// [soClassObserver] — a type whose Decode does nothing but retain the protobuf
+// pointer — makes that decode hand back the tree itself. Nothing else is done on
+// the callback thread: a panic there is not recoverable by the caller (it is the
+// same property that makes `divisibleby(0)` process-fatal), so the observer is the
+// smallest possible body and every walk happens on the test goroutine.
+//
+// NATIVE OUTPUT IS NEVER FED BACK IN. The only bytes handed to the CFFI are a
+// fixture's Raw assistant text. The native leg's canonical JSON, its
+// ConstraintValue and its events are compared against what stock produced and are
+// never used to construct a stock call.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	baml_go "github.com/boundaryml/baml/engine/language_client_go/baml_go"
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/serde"
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/shared"
+	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+	"github.com/boundaryml/baml/engine/language_client_go/pkg/cffi"
+
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// soClassObserver is registered for every corpus class. Its Decode retains the
+// protobuf node and returns; see the file comment for why it does nothing else.
+type soClassObserver struct{ raw *cffi.CFFIValueClass }
+
+func (o *soClassObserver) Decode(h *cffi.CFFIValueClass, _ baml.TypeMap) { o.raw = h }
+
+// soEnumObserver is the same for enums.
+type soEnumObserver struct{ raw *cffi.CFFIValueEnum }
+
+func (o *soEnumObserver) Decode(h *cffi.CFFIValueEnum) { o.raw = h }
+
+// soChecked is the shape baml_go's decodeCheckedValue requires by REFLECTION: it
+// sets the fields named Value and Checks and nothing else, so the field names and
+// the Checks type are load-bearing.
+//
+// # The one place the raw tree is NOT reachable, and what is done about it
+//
+// It is reached only for a Checked value at the ROOT of the returned document (a
+// target-level constraint, a root class-level @@check, or a root list/map whose
+// elements carry one). Every NESTED Checked is captured as a raw holder by an
+// observer above it, ordered collection intact.
+//
+// At the root there is no hook: baml_go decodes the payload on the CFFI callback
+// thread and `decodeCheckedValue` has already folded `[]CFFICheckValue` into a
+// `map[string]shared.Check` before any registered type is touched — it only
+// reflect-Sets the fields named Value and Checks. The lower-level entry points
+// (baml_go.CallFunctionParseFromC + RegisterCallbacks) would hand back the raw
+// protobuf, but registering a callback needs `import "C"`, which Go does not allow
+// in a _test.go file. So the fold is a property of the binding, not a choice here.
+//
+// So at a ROOT position stock's ORDER and MULTIPLICITY are UNAVAILABLE to this
+// oracle. That is stated rather than worked around, and it is NOT reconstructed
+// from the schema and presented as observed:
+//
+//   - every site recovered from a folded root map is marked Certified=false and
+//     renders as `~uncertified-order`, which is part of the PINNED stock envelope,
+//     so the five affected corpus rows record the limitation in the corpus itself;
+//   - the comparator does not index-pair those sites. It matches them as an
+//     UNORDERED multiset per path (soCompareUncertifiedSites), so no ordering claim
+//     rests on evidence that no longer exists, and it records the unavailability on
+//     the row's report;
+//   - what the folded map DOES evidence is still checked exactly: for every entry
+//     stock REPORTED, its label must be declared at that node, its expression text
+//     must match the declaration, and the result of each matched pair is compared —
+//     so an entry stock reported that the schema does not declare is a hard failure,
+//     and so is native deciding a predicate stock's collection does not contain. A
+//     declared constraint the map does NOT report is deliberately PERMITTED and is
+//     not a refusal: that is what a losing union arm and a route that skips
+//     evaluation look like (see soFoldedSites, which continues past an absent
+//     entry); and
+//   - a node whose schema declares one label TWICE is refused UNCONDITIONALLY by
+//     soFoldedSites, whatever the map turned out to contain, because a map-keyed
+//     readback cannot represent that result at all.
+//
+// TestServingOracleRootCheckFoldIsLossy measures the loss rather than describing
+// it: it drives a root duplicate-label probe through the real CFFI and observes the
+// decoded map keep ONE entry where the .baml declares two, with the NESTED twin
+// keeping both, in declaration order, from the raw tree.
+// TestServingOracleRootEnvelopeCertificationIsUnavailable then asserts the
+// unavailability itself — that uncertified sites exist, that certified ones also
+// exist so the limitation is narrow, that only ROOT paths are ever uncertified, and
+// that every affected row's pinned envelope carries the marker.
+type soChecked struct {
+	Value  any
+	Checks map[string]shared.Check
+}
+
+// ---------------------------------------------------------------------------
+// The type map
+// ---------------------------------------------------------------------------
+
+// soFixedCheckedNames are the CHECKED_TYPES keys baml_go can ask for that are not
+// derived from a corpus declaration.
+//
+// Two different namings reach the same map, and both are registered because both
+// are live: baml_go's serde.typeToString (which renders a container as the bare
+// word "list"/"optional"/"union"/"class") is used when a LIST or MAP element type
+// is converted, while the Rust side sends compound value names ("List__int",
+// "Optional__int") on the value itself. A missing key is a panic on the callback
+// thread, i.e. a dead process, so this registration is deliberately generous —
+// over-registration costs nothing because every key maps to the same observer.
+var soFixedCheckedNames = []string{
+	"int", "string", "float", "bool", "null",
+	"class", "list", "map", "optional", "union", "checked", "stream_state",
+}
+
+// soCheckedValueName renders the compound CHECKED_TYPES name the Rust side sends
+// for a value of type t, mirroring the names observed in this repo's checked-in
+// stock client (List__int, Optional__int, Map__string_int).
+func soCheckedValueName(t schema.Type) string {
+	switch t.Kind {
+	case schema.TypePrimitive:
+		switch t.Primitive {
+		case schema.PrimitiveString:
+			return "string"
+		case schema.PrimitiveInt:
+			return "int"
+		case schema.PrimitiveFloat:
+			return "float"
+		case schema.PrimitiveBool:
+			return "bool"
+		case schema.PrimitiveNull:
+			return "null"
+		}
+		return string(t.Primitive)
+	case schema.TypeEnum, schema.TypeClass:
+		return t.Name
+	case schema.TypeList:
+		if t.Elem == nil {
+			return "List__unknown"
+		}
+		return "List__" + soCheckedValueName(*t.Elem)
+	case schema.TypeMap:
+		if t.Key == nil || t.Value == nil {
+			return "Map__unknown"
+		}
+		return "Map__" + soCheckedValueName(*t.Key) + "_" + soCheckedValueName(*t.Value)
+	case schema.TypeUnion:
+		if t.Union != nil && t.Union.Nullable && len(t.Union.Variants) == 1 {
+			return "Optional__" + soCheckedValueName(t.Union.Variants[0])
+		}
+		return "union"
+	}
+	return string(t.Kind)
+}
+
+// soWalkTypes yields t and every type nested inside it.
+func soWalkTypes(t schema.Type, fn func(schema.Type)) {
+	fn(t)
+	if t.Elem != nil {
+		soWalkTypes(*t.Elem, fn)
+	}
+	if t.Key != nil {
+		soWalkTypes(*t.Key, fn)
+	}
+	if t.Value != nil {
+		soWalkTypes(*t.Value, fn)
+	}
+	for _, it := range t.Items {
+		soWalkTypes(it, fn)
+	}
+	if t.Union != nil {
+		for _, v := range t.Union.Variants {
+			soWalkTypes(v, fn)
+		}
+	}
+	if t.Arrow != nil {
+		for _, p := range t.Arrow.Params {
+			soWalkTypes(p, fn)
+		}
+		soWalkTypes(t.Arrow.Return, fn)
+	}
+}
+
+// soBuildTypeMap derives the process-global BAML type map from the corpus.
+//
+// extra carries bundles that are driven through the CFFI but are not corpus rows —
+// today the 719-case bridge's generated units. They MUST be registered here: an
+// unregistered class decodes dynamically and its inner Checked then panics on the
+// CFFI callback thread, which kills the process rather than failing a test.
+func soBuildTypeMap(fixtures []servingOracleFixture, extra []*schema.Bundle) map[string]reflect.Type {
+	clsT := reflect.TypeOf(soClassObserver{})
+	enumT := reflect.TypeOf(soEnumObserver{})
+	chkT := reflect.TypeOf(soChecked{})
+
+	tm := map[string]reflect.Type{}
+	for _, n := range soFixedCheckedNames {
+		tm["CHECKED_TYPES."+n] = chkT
+	}
+	// The probes are rendered into the same project and driven through the same
+	// CFFI, so their declarations need the same registration; without it a probe's
+	// class decodes dynamically and its raw tree — the control the root-fold
+	// measurement rests on — is lost.
+	for _, pr := range servingOracleProbes {
+		for _, c := range pr.Bundle.Classes {
+			tm["TYPES."+c.Name.Name] = clsT
+			tm["CHECKED_TYPES."+c.Name.Name] = chkT
+			for _, fld := range c.Fields {
+				soWalkTypes(fld.Type, func(t schema.Type) {
+					tm["CHECKED_TYPES."+soCheckedValueName(t)] = chkT
+				})
+			}
+		}
+		soWalkTypes(pr.Bundle.Target, func(t schema.Type) {
+			tm["CHECKED_TYPES."+soCheckedValueName(t)] = chkT
+		})
+	}
+	for _, b := range extra {
+		if b == nil {
+			continue
+		}
+		for _, c := range b.Classes {
+			tm["TYPES."+c.Name.Name] = clsT
+			tm["CHECKED_TYPES."+c.Name.Name] = chkT
+			for _, fld := range c.Fields {
+				soWalkTypes(fld.Type, func(t schema.Type) {
+					tm["CHECKED_TYPES."+soCheckedValueName(t)] = chkT
+				})
+			}
+		}
+		for _, e := range b.Enums {
+			tm["TYPES."+e.Name.Name] = enumT
+			tm["CHECKED_TYPES."+e.Name.Name] = chkT
+		}
+		soWalkTypes(b.Target, func(t schema.Type) {
+			tm["CHECKED_TYPES."+soCheckedValueName(t)] = chkT
+		})
+	}
+	for _, f := range fixtures {
+		if f.Bundle == nil {
+			continue
+		}
+		for _, c := range f.Bundle.Classes {
+			tm["TYPES."+c.Name.Name] = clsT
+			tm["CHECKED_TYPES."+c.Name.Name] = chkT
+			for _, fld := range c.Fields {
+				soWalkTypes(fld.Type, func(t schema.Type) {
+					tm["CHECKED_TYPES."+soCheckedValueName(t)] = chkT
+				})
+			}
+		}
+		for _, e := range f.Bundle.Enums {
+			tm["TYPES."+e.Name.Name] = enumT
+			tm["CHECKED_TYPES."+e.Name.Name] = chkT
+		}
+		soWalkTypes(f.Bundle.Target, func(t schema.Type) {
+			tm["CHECKED_TYPES."+soCheckedValueName(t)] = chkT
+		})
+	}
+	return tm
+}
+
+// ---------------------------------------------------------------------------
+// The runtime
+// ---------------------------------------------------------------------------
+
+var (
+	soRuntimeOnce sync.Once
+	soRuntime     baml.BamlRuntime
+	soRuntimeErr  error
+	// soRuntimeSource is the EXACT project text the runtime was created from. The
+	// drift test compares this against the golden rather than re-rendering, so the
+	// bytes stock compiled are the bytes under review.
+	soRuntimeSource string
+	soRuntimeEnv    map[string]string
+	soRuntimeTypes  map[string]reflect.Type
+)
+
+// soEnsureRuntime renders the project, registers the type map and creates the
+// stock runtime exactly once per process.
+func soEnsureRuntime(t *testing.T) {
+	t.Helper()
+	soRuntimeOnce.Do(func() {
+		soRuntimeSource, soRuntimeErr = soRenderProject(servingOracleFixtures)
+		if soRuntimeErr != nil {
+			return
+		}
+		// The 719-case bridge shares this process's global type map, so its generated
+		// units are registered here even though they are driven through their own
+		// runtime. Loading the artifact up front also means a missing or malformed one
+		// is a loud failure at setup rather than a panic mid-run.
+		var extra []*schema.Bundle
+		soBridgeUnits, soRuntimeErr = soBridgeUnitsFromArtifact()
+		if soRuntimeErr != nil {
+			return
+		}
+		for _, u := range soBridgeUnits {
+			extra = append(extra, u.Bundle)
+		}
+		soRuntimeTypes = soBuildTypeMap(servingOracleFixtures, extra)
+		baml.SetTypeMap(soRuntimeTypes)
+		soRuntimeEnv = soEnvSnapshot()
+		soRuntime, soRuntimeErr = baml.CreateRuntime("./baml_src", soProjectFiles(soRuntimeSource), soRuntimeEnv)
+	})
+	if soRuntimeErr != nil {
+		t.Fatalf("stock runtime for the in-memory serving-oracle project could not be created: %v\n"+
+			"the project the corpus renders is not a valid BAML v0.223.0 project:\n%s", soRuntimeErr, soRuntimeSource)
+	}
+}
+
+// soDriveStock runs one fixture through the stock CFFI and returns its envelope.
+//
+// The progress marker goes to STDERR unbuffered before the call. If a row aborts
+// the process — the failure mode `divisibleby(0)` has — the last marker names the
+// row that did it, so an unpinned fatal cannot present as an unattributable crash.
+func soDriveStock(f servingOracleFixture) (soStockEnvelope, error) {
+	fmt.Fprintf(os.Stderr, "serving-oracle: stock BEGIN %s\n", f.method())
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"text": f.Raw, "stream": false},
+		Env:    soRuntimeEnv,
+	}
+	encoded, err := args.Encode()
+	if err != nil {
+		return soStockEnvelope{}, fmt.Errorf("encode arguments for %s: %w", f.method(), err)
+	}
+	res, callErr := soRuntime.CallFunctionParse(context.Background(), f.method(), encoded)
+	fmt.Fprintf(os.Stderr, "serving-oracle: stock END   %s\n", f.method())
+	if callErr != nil {
+		return soClassifyStockError(callErr), nil
+	}
+	return soStockEnvelopeFromResult(f, res)
+}
+
+// soStockEnvelopeFromResult turns a decoded CallFunctionParse result into the
+// comparison envelope.
+func soStockEnvelopeFromResult(f servingOracleFixture, res any) (soStockEnvelope, error) {
+	var sites []soStockSite
+	identity, doc, err := soReadStockResult(f.Bundle, res, "$", &sites)
+	if err != nil {
+		return soStockEnvelope{}, fmt.Errorf("%s: read stock value: %w", f.method(), err)
+	}
+	return soStockEnvelope{Kind: soStockValue, Identity: identity, JSON: doc, Sites: sites}, nil
+}
+
+// soReadStockResult bridges the DECODED root (which is whatever the global type
+// map produced) into the raw-tree walk.
+//
+// Only three root shapes can occur, and each is handled explicitly rather than
+// through a default: an observer (the raw tree is available), a root-level
+// Checked or a slice of them (baml_go decoded them before this code ran), and a
+// bare scalar for an unconstrained scalar return.
+func soReadStockResult(b *schema.Bundle, res any, path string, sites *[]soStockSite) (string, string, error) {
+	switch v := res.(type) {
+	case soClassObserver:
+		if v.raw == nil {
+			return "", "", fmt.Errorf("%s: class observer captured no value", path)
+		}
+		id, doc, err := soReadStockValue(&cffi.CFFIValueHolder{
+			Value: &cffi.CFFIValueHolder_ClassValue{ClassValue: v.raw},
+		}, path, sites)
+		return id, string(doc), err
+	case soEnumObserver:
+		if v.raw == nil {
+			return "", "", fmt.Errorf("%s: enum observer captured no value", path)
+		}
+		id, doc, err := soReadStockValue(&cffi.CFFIValueHolder{
+			Value: &cffi.CFFIValueHolder_EnumValue{EnumValue: v.raw},
+		}, path, sites)
+		return id, string(doc), err
+	case soChecked:
+		// A ROOT-level Checked. baml_go has already folded the check collection into
+		// a map here, so the sites are recovered from that map and the fold is
+		// recorded rather than hidden: soCheckedSites sorts by label so the ordering
+		// claim is never made from data that no longer carries order.
+		folded, err := soFoldedSites(b, path, v.Checks)
+		if err != nil {
+			return "", "", err
+		}
+		*sites = append(*sites, folded...)
+		return soReadStockResult(b, v.Value, path, sites)
+	case []soChecked:
+		ids := make([]string, len(v))
+		docs := make([]string, len(v))
+		for i, e := range v {
+			id, doc, err := soReadStockResult(b, e, fmt.Sprintf("%s[%d]", path, i), sites)
+			if err != nil {
+				return "", "", err
+			}
+			ids[i], docs[i] = id, doc
+		}
+		return "list[" + strings.Join(ids, ",") + "]", "[" + strings.Join(docs, ",") + "]", nil
+	case serde.DynamicUnion:
+		// A union at the ROOT. baml_go decodes it before this code runs and keeps the
+		// winning variant's NAME plus its value. The union wrapper is transparent to
+		// the identity — which arm won is visible in the value's own rendering — so
+		// only the inner value is walked.
+		return soReadStockResult(b, v.Value, path, sites)
+	case serde.DynamicClass:
+		return "", "", fmt.Errorf("%s: stock decoded the class %q DYNAMICALLY, so its raw tree (and its "+
+			"ordered check collection) was lost; register TYPES.%s in the oracle type map", path, v.Name, v.Name)
+	case serde.DynamicEnum:
+		return "", "", fmt.Errorf("%s: stock decoded the enum %q DYNAMICALLY; register TYPES.%s in the "+
+			"oracle type map", path, v.Name, v.Name)
+	case string:
+		return "string:" + fmt.Sprintf("%q", v), fmt.Sprintf("%q", v), nil
+	case int64:
+		return fmt.Sprintf("int:%d", v), fmt.Sprintf("%d", v), nil
+	case float64:
+		f := strconv.FormatFloat(v, 'g', -1, 64)
+		return "float:" + f, f, nil
+	case bool:
+		return fmt.Sprintf("bool:%v", v), fmt.Sprintf("%v", v), nil
+	case nil:
+		return "null", "null", nil
+	}
+	return "", "", fmt.Errorf("%s: unmodelled stock root %T", path, res)
+}
+
+// soFoldedSites recovers what CAN be recovered from a FOLDED root check map, and
+// marks it UNCERTIFIED.
+//
+// # Root-envelope certification is UNAVAILABLE, and is not simulated
+//
+// baml_go folds a root Checked's collection into map[string]shared.Check inside
+// serde.decodeCheckedValue, on the CFFI callback thread, before any registered type
+// is touched (see soChecked). Stock's ORDER and MULTIPLICITY at a root position are
+// therefore destroyed before this oracle can observe them, and no amount of
+// schema-side reasoning recovers them: the schema says what was DECLARED, not what
+// stock reported.
+//
+// So this does NOT present a certified root envelope. It emits sites with
+// Certified=false, which:
+//
+//   - renders as `~uncertified-order` inside the PINNED stock envelope, so a row
+//     whose root evidence is uncertified says so in the corpus; and
+//   - makes the comparator compare those sites as an unordered multiset per path
+//     rather than claiming an order it did not observe.
+//
+// What IS still verified exactly, because the folded map does carry it: every label
+// stock reported must be declared at that node with the SAME expression text, and
+// the counts must match, so a reported entry the schema does not declare, or a
+// declared-and-reported entry that went missing, is a hard failure.
+//
+// # A determinable duplicate is refused UNCONDITIONALLY
+//
+// If the schema declares one label more than once at this node, the fold cannot
+// represent the result whatever the map happens to contain — including when the map
+// is EMPTY, or when the repeated label is absent while another is present. The
+// refusal below is therefore driven by the DECLARATION alone and never by the map's
+// contents; making it conditional on the map is what let those two states through
+// before.
+func soFoldedSites(b *schema.Bundle, path string, checks map[string]shared.Check) ([]soStockSite, error) {
+	declared, err := soDeclaredConstraintsAt(b, path)
+	if err != nil {
+		return nil, err
+	}
+	// UNCONDITIONAL: a label declared more than once at this node cannot survive a
+	// map-keyed readback, whatever the map turned out to contain. Checking the map
+	// first would accept the two states where the loss is invisible — an empty map,
+	// and a map whose surviving entry is a DIFFERENT label.
+	byLabel := map[string]int{}
+	labelOrder := []string{}
+	for _, c := range declared {
+		if c.Label == nil {
+			continue
+		}
+		if byLabel[*c.Label] == 0 {
+			labelOrder = append(labelOrder, *c.Label)
+		}
+		byLabel[*c.Label]++
+	}
+	for _, label := range labelOrder {
+		if byLabel[label] < 2 {
+			continue
+		}
+		return nil, fmt.Errorf("%s: the schema declares %d constraints under the label %q, and baml_go's "+
+			"root readback folds the check collection into a map[string]Check — so at most one of them "+
+			"survives and the root envelope is LOST for this node, whatever the map happens to contain "+
+			"(it reported %d entry/entries: %v). A fixture cannot be compared here; drive the shape as a "+
+			"probe instead (see TestServingOracleRootCheckFoldIsLossy).",
+			path, byLabel[label], label, len(checks), checks)
+	}
+
+	var out []soStockSite
+	matched := 0
+	for _, c := range declared {
+		if c.Label == nil {
+			continue
+		}
+		got, ok := checks[*c.Label]
+		if !ok {
+			// Declared but not reported: legitimate for a union's losing arm, and for
+			// a route that skips evaluation. The count check below is what makes a
+			// LOSS visible.
+			continue
+		}
+		matched++
+		if got.Expression != c.Expression {
+			return nil, fmt.Errorf("%s: stock reported the label %q with the expression %q, but the schema "+
+				"declares %q at that node", path, *c.Label, got.Expression, c.Expression)
+		}
+		// UNCERTIFIED: the position is the node's real path, but the ORDER among
+		// sibling entries is the schema's rather than stock's, because the fold
+		// destroyed stock's.
+		out = append(out, soStockSite{Path: path, Label: got.Name, Expression: got.Expression,
+			Status: got.Status, Certified: false})
+	}
+	if matched != len(checks) {
+		return nil, fmt.Errorf("%s: stock reported %d folded check(s) but %d of the %d constraint(s) the "+
+			"schema declares there matched. baml_go's root readback folds the collection into a "+
+			"map[string]Check, so this is what a LOST entry (two @check attributes under one label) looks "+
+			"like — the root envelope is no longer exact and the fixture cannot be compared. Reported: %v",
+			path, len(checks), matched, len(declared), checks)
+	}
+	return out, nil
+}
+
+// soDeclaredConstraintsAt returns the constraints the SCHEMA declares at a root
+// path, in the order the collector attaches them (declaration site first, then the
+// type node).
+//
+// It handles only the three ROOT positions a folded readback can occur at. Every
+// nested site comes from the raw CFFI tree and never needs this, so an unexpected
+// path is an error rather than an empty list — an empty list would silently make
+// the count check above vacuous.
+func soDeclaredConstraintsAt(b *schema.Bundle, path string) ([]schema.Constraint, error) {
+	node := b.Target
+	switch {
+	case path == "$":
+	case strings.HasPrefix(path, "$[") && strings.HasSuffix(path, "]"):
+		inner := path[2 : len(path)-1]
+		if strings.HasPrefix(inner, `"`) {
+			if b.Target.Value == nil {
+				return nil, fmt.Errorf("%s: the target is not a map, so a map-entry path is impossible", path)
+			}
+			node = *b.Target.Value
+		} else {
+			if b.Target.Elem == nil {
+				return nil, fmt.Errorf("%s: the target is not a list, so an index path is impossible", path)
+			}
+			node = *b.Target.Elem
+		}
+	default:
+		return nil, fmt.Errorf("%s: a folded check collection can only occur at a ROOT position "+
+			"($, $[i] or $[\"k\"]); a nested one is read from the raw CFFI tree", path)
+	}
+
+	var out []schema.Constraint
+	// A UNION node carries its constraints on the winning arm; which arm won is not
+	// knowable from the schema alone, so every arm's constraints are offered and the
+	// label match above selects the winner's. The count check still makes a loss
+	// visible, because a lost entry lowers the match count.
+	if node.Kind == schema.TypeUnion && node.Union != nil {
+		for _, v := range node.Union.Variants {
+			out = append(out, soDeclaredAtNode(b, v)...)
+		}
+		out = append(out, node.Meta.Constraints...)
+		return out, nil
+	}
+	return soDeclaredAtNode(b, node), nil
+}
+
+// soDeclaredAtNode is the per-node half: the class/enum DECLARATION's constraints
+// first, then the TYPE node's own, mirroring the collector's attachment order.
+func soDeclaredAtNode(b *schema.Bundle, t schema.Type) []schema.Constraint {
+	var out []schema.Constraint
+	switch t.Kind {
+	case schema.TypeClass:
+		if cls, ok := b.FindClass(t.Name, t.Mode); ok {
+			out = append(out, cls.Constraints...)
+		}
+	case schema.TypeEnum:
+		if en, ok := b.FindEnum(t.Name); ok {
+			out = append(out, en.Constraints...)
+		}
+	}
+	return append(out, t.Meta.Constraints...)
+}
+
+// soBAMLRuntimeVersion is the CFFI version the whole oracle is only valid against.
+const soBAMLRuntimeVersion = "0.223.0"
+
+// soLoadedBAMLVersion reports the version of the native library actually loaded
+// into this process.
+func soLoadedBAMLVersion() string { return baml_go.BamlVersion() }
+
+// soCreateRuntimeForSource compiles a one-file project and returns the runtime.
+// It is used by the source-rejection test, which needs a project that must FAIL to
+// compile, so it deliberately does not go through the memoized corpus runtime.
+func soCreateRuntimeForSource(src string) (baml.BamlRuntime, error) {
+	return baml.CreateRuntime("./baml_src", map[string]string{soProjectFile: src}, soEnvSnapshot())
+}
+
+// TestServingOracleStockReadbackIsStrict proves the readback's own refusals BITE
+// rather than decorate.
+//
+// Neither shape can be produced by stock BAML today, which is exactly why they are
+// driven directly: a guard that no fixture can reach is indistinguishable from one
+// that is not there, and a duplicate key or field silently kept would make the
+// canonical document depend on which entry the walk happened to record last.
+func TestServingOracleStockReadbackIsStrict(t *testing.T) {
+	intHolder := func(n int64) *cffi.CFFIValueHolder {
+		return &cffi.CFFIValueHolder{Value: &cffi.CFFIValueHolder_IntValue{IntValue: n}}
+	}
+	dupMap := &cffi.CFFIValueHolder{Value: &cffi.CFFIValueHolder_MapValue{MapValue: &cffi.CFFIValueMap{
+		Entries: []*cffi.CFFIMapEntry{
+			{Key: "k", Value: intHolder(1)},
+			{Key: "k", Value: intHolder(2)},
+		},
+	}}}
+	var sites []soStockSite
+	if _, _, err := soReadStockValue(dupMap, "$", &sites); err == nil {
+		t.Error("a map with a DUPLICATE key was accepted; the emitted document would depend on which " +
+			"entry the walk recorded last")
+	}
+	dupField := &cffi.CFFIValueHolder{Value: &cffi.CFFIValueHolder_ClassValue{ClassValue: &cffi.CFFIValueClass{
+		Name: &cffi.CFFITypeName{Namespace: cffi.CFFITypeNamespace_TYPES, Name: "Dup"},
+		Fields: []*cffi.CFFIMapEntry{
+			{Key: "f", Value: intHolder(1)},
+			{Key: "f", Value: intHolder(2)},
+		},
+	}}}
+	if _, _, err := soReadStockValue(dupField, "$", &sites); err == nil {
+		t.Error("a class with a DUPLICATE field was accepted")
+	}
+	// CONTROL: the same shapes with distinct keys are read, so the refusals are
+	// about duplication rather than about maps and classes.
+	okMap := &cffi.CFFIValueHolder{Value: &cffi.CFFIValueHolder_MapValue{MapValue: &cffi.CFFIValueMap{
+		Entries: []*cffi.CFFIMapEntry{
+			{Key: "b", Value: intHolder(1)},
+			{Key: "a", Value: intHolder(2)},
+		},
+	}}}
+	id, doc, err := soReadStockValue(okMap, "$", &sites)
+	if err != nil {
+		t.Fatalf("the distinct-key control was refused: %v", err)
+	}
+	// And the INPUT order is kept, not sorted.
+	if id != "map{b=int:1,a=int:2}" || string(doc) != `{"b":1,"a":2}` {
+		t.Fatalf("the readback did not preserve entry order: %s / %s", id, doc)
+	}
+	// An unmodelled CFFI variant is refused rather than rendered as a placeholder
+	// that would compare equal to itself.
+	if _, _, err := soReadStockValue(&cffi.CFFIValueHolder{}, "$", &sites); err == nil {
+		t.Error("an empty/unmodelled value holder was accepted")
+	}
+}
+
+// TestServingOracleTypeMapCoversTheCorpus proves the registration derived from the
+// corpus reaches every name baml_go can ask for on the value side.
+//
+// A missing CHECKED_TYPES key is not a test failure but a PANIC on the CFFI
+// callback thread — a dead process with no attribution — so the coverage is
+// asserted up front rather than discovered by a crash.
+func TestServingOracleTypeMapCoversTheCorpus(t *testing.T) {
+	soEnsureRuntime(t)
+	if len(soRuntimeTypes) == 0 {
+		t.Fatal("the type map is empty; every registration claim below would be vacuous")
+	}
+	classes, checked := 0, 0
+	checkedSeen := map[string]bool{}
+	for name := range soRuntimeTypes {
+		switch {
+		case strings.HasPrefix(name, "TYPES."):
+			classes++
+		case strings.HasPrefix(name, "CHECKED_TYPES."):
+			checked++
+		default:
+			t.Errorf("the type map carries the unexpected namespace %q", name)
+		}
+	}
+	if classes == 0 || checked == 0 {
+		t.Fatalf("the type map has %d TYPES and %d CHECKED_TYPES entries; both must be non-empty",
+			classes, checked)
+	}
+	for _, f := range servingOracleFixtures {
+		for _, c := range f.Bundle.Classes {
+			if _, ok := soRuntimeTypes["TYPES."+c.Name.Name]; !ok {
+				t.Errorf("%s: class %q is not registered, so stock would decode it dynamically and its raw "+
+					"tree (with its ordered check collection) would be lost", f.Name, c.Name.Name)
+			}
+		}
+		for _, e := range f.Bundle.Enums {
+			if _, ok := soRuntimeTypes["TYPES."+e.Name.Name]; !ok {
+				t.Errorf("%s: enum %q is not registered", f.Name, e.Name.Name)
+			}
+		}
+		// EVERY constrained node needs its checked name, not only the ones at the
+		// root: a root list or map hands its elements to serde, and baml_go asks for
+		// the COMPOUND name there (List__int, Map__string_int, Optional__int), which
+		// only the per-declaration walk supplies.
+		want := func(ty schema.Type) {
+			if len(ty.Meta.Constraints) == 0 {
+				return
+			}
+			key := "CHECKED_TYPES." + soCheckedValueName(ty)
+			if _, ok := soRuntimeTypes[key]; !ok {
+				t.Errorf("%s: %q is not registered; baml_go PANICS on the callback thread for a missing "+
+					"checked type, which kills the process rather than failing a test", f.Name, key)
+			}
+			checkedSeen[key] = true
+		}
+		soWalkTypes(f.Bundle.Target, want)
+		for _, c := range f.Bundle.Classes {
+			for _, fld := range c.Fields {
+				soWalkTypes(fld.Type, want)
+			}
+		}
+	}
+	// The compound names are what the per-declaration walk exists for; requiring at
+	// least one keeps this from passing on the fixed scalar vocabulary alone.
+	compound := 0
+	for key := range checkedSeen {
+		if strings.Contains(key, "__") {
+			compound++
+		}
+	}
+	if compound == 0 {
+		t.Error("no constrained node needed a COMPOUND checked name (List__/Map__/Optional__), so the " +
+			"per-declaration registration walk is unexercised by the corpus")
+	}
+	t.Logf("type map: %d TYPES entries, %d CHECKED_TYPES entries; %d constrained nodes needed a name, "+
+		"%d of them compound", classes, checked, len(checkedSeen), compound)
+}

--- a/internal/debaml/serving_oracle_test.go
+++ b/internal/debaml/serving_oracle_test.go
@@ -1,0 +1,1957 @@
+//go:build integration
+
+package debaml
+
+// Slice 7.2a-3 — the SERVING-SHAPED differential oracle.
+//
+// # What it proves
+//
+// For every row of the corpus: build an in-memory .baml project from the row's
+// schema.Bundle, hand the SAME raw assistant text to stock BAML v0.223.0's CFFI
+// and to the native coercion-state collector + evaluator, and require the native
+// leg to reproduce stock exactly or refuse to decide. The stock envelope is the
+// authority; the native leg is compared against it and is NEVER fed back into the
+// CFFI.
+//
+// # What it does NOT do
+//
+// Nothing here changes admission. Every constraint-bearing fixture still declines
+// through checkSupported / SupportsNativeFinalBundle / Parse / ParseStaticBundle —
+// [TestServingOracleBoundaryLock] asserts exactly that, for every row, including
+// the target-level ones — and no Checked[T] carrier, wire shape or mapper change
+// is in this slice.
+//
+// # Running
+//
+//	CGO_ENABLED=1 go test -tags integration ./internal/debaml -run TestServingOracle
+//
+// Requires CGO and the stock BAML v0.223.0 CFFI (auto-located under the user BAML
+// cache dir), exactly like the #597/#603/#649 oracles.
+//
+// # Recording the pins
+//
+// Stock and Native are RECORDINGS. To re-record after a corpus change:
+//
+//	BAML_SERVING_ORACLE_RECORD=1 CGO_ENABLED=1 go test -tags integration \
+//	  ./internal/debaml -run TestServingOracleDifferential -v
+//
+// which prints one RECORD line per row per leg. The pins are then compared for
+// EQUALITY on every subsequent run, so neither leg can change shape unnoticed.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/shared"
+	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+	"golang.org/x/mod/modfile"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/promptdescriptor"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+const (
+	// soRecordEnv switches the differential into recording mode.
+	soRecordEnv = "BAML_SERVING_ORACLE_RECORD"
+	// soRootGoModPath is the root module's go.mod, from this package's directory.
+	soRootGoModPath = "../../go.mod"
+	soBAMLModule    = "github.com/boundaryml/baml"
+	soBAMLVersion   = "v0.223.0"
+)
+
+// soWantProjectHash pins the SHA-256 of the rendered project. It is compared only
+// after the golden byte-comparison succeeds, so it is not a second copy of the
+// same check: it is what makes regenerating the golden a deliberate, reviewable
+// act rather than a silent one.
+const soWantProjectHash = "537a585b81527fa9ab54c95fcc076bc126d10e4d1a175348dfc8719b1e2cc9c3"
+
+// soStockCache memoizes one stock parse per fixture. The CFFI runtime is
+// process-global and the suite deliberately does not parallelise over it, so no
+// mutex is needed.
+var soStockCache = map[string]soStockEnvelope{}
+
+// soStockFor drives (or replays) the stock leg for one fixture.
+func soStockFor(t *testing.T, f servingOracleFixture) soStockEnvelope {
+	t.Helper()
+	if f.Fatal {
+		t.Fatalf("%s is a process-fatal row and must never be driven in-process; "+
+			"it belongs to TestServingOracleFatalRowIsUnobservable", f.Name)
+	}
+	if e, ok := soStockCache[f.Name]; ok {
+		return e
+	}
+	soEnsureRuntime(t)
+	e, err := soDriveStock(f)
+	if err != nil {
+		t.Fatalf("%s: the stock leg could not be read: %v", f.Name, err)
+	}
+	soStockCache[f.Name] = e
+	return e
+}
+
+// ---------------------------------------------------------------------------
+// (1) The oracle really is stock BAML v0.223.0.
+// ---------------------------------------------------------------------------
+
+// TestServingOracleStockIsPinnedBAML requires the LOADED CFFI runtime and the root
+// go.mod pin to be exactly v0.223.0, so a green differential can never be
+// attributed to a different BAML. The runtime check is the load-bearing one: it
+// reads the native library that actually parsed every row in this binary.
+func TestServingOracleStockIsPinnedBAML(t *testing.T) {
+	if got := soLoadedBAMLVersion(); got != soBAMLRuntimeVersion {
+		t.Fatalf("loaded BAML CFFI runtime reports version %q, want exactly %q", got, soBAMLRuntimeVersion)
+	}
+	raw, err := os.ReadFile(soRootGoModPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", soRootGoModPath, err)
+	}
+	if err := soCheckStockModulePin(raw); err != nil {
+		t.Fatalf("%s: %v", soRootGoModPath, err)
+	}
+}
+
+// soCheckStockModulePin requires go.mod to REQUIRE the stock BAML module at the
+// pinned version and to REPLACE it with nothing.
+//
+// It parses rather than string-matches. The text check it replaces looked for
+// `=> github.com/boundaryml/baml`, which catches a replacement whose NEW path is
+// the stock module but not one whose OLD path is:
+//
+//	github.com/boundaryml/baml v0.223.0 => ./local-fork
+//
+// That form keeps the required-version text intact — so the version assertion still
+// passed — while the module actually linked is a fork, which is precisely the
+// substitution the pin exists to prevent.
+func soCheckStockModulePin(gomod []byte) error {
+	f, err := modfile.Parse("go.mod", gomod, nil)
+	if err != nil {
+		return fmt.Errorf("parse: %w", err)
+	}
+	required := false
+	for _, r := range f.Require {
+		if r.Mod.Path != soBAMLModule {
+			continue
+		}
+		if r.Mod.Version != soBAMLVersion {
+			return fmt.Errorf("requires %s %s, want exactly %s; the oracle would be comparing against a "+
+				"different BAML", soBAMLModule, r.Mod.Version, soBAMLVersion)
+		}
+		required = true
+	}
+	if !required {
+		return fmt.Errorf("does not require %s at all", soBAMLModule)
+	}
+	// EITHER SIDE of a replacement is disqualifying: the old path being the stock
+	// module means something else is linked in its place, and the new path being it
+	// means some other module resolves to it.
+	for _, r := range f.Replace {
+		if r.Old.Path == soBAMLModule {
+			return fmt.Errorf("REPLACES %s (%s %s => %s %s); the oracle must link the stock module, not a "+
+				"fork", soBAMLModule, r.Old.Path, r.Old.Version, r.New.Path, r.New.Version)
+		}
+		if r.New.Path == soBAMLModule {
+			return fmt.Errorf("replaces %s %s WITH %s; another module would resolve to the stock path",
+				r.Old.Path, r.Old.Version, soBAMLModule)
+		}
+	}
+	return nil
+}
+
+// TestServingOracleStockPinRejectsAFork drives the pin check over synthetic go.mod
+// content, because the live one is (correctly) clean and would exercise only the
+// accepting path.
+func TestServingOracleStockPinRejectsAFork(t *testing.T) {
+	const base = "module example.com/x\n\ngo 1.26.5\n\nrequire github.com/boundaryml/baml v0.223.0\n"
+	if err := soCheckStockModulePin([]byte(base)); err != nil {
+		t.Fatalf("the clean control was rejected: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		mod  string
+		want string
+	}{
+		{
+			// The case the text check missed entirely.
+			name: "a LEFT-HAND replacement onto a local fork",
+			mod:  base + "\nreplace github.com/boundaryml/baml v0.223.0 => ./local-fork\n",
+			want: "REPLACES",
+		},
+		{
+			name: "a left-hand replacement with no version",
+			mod:  base + "\nreplace github.com/boundaryml/baml => ./local-fork\n",
+			want: "REPLACES",
+		},
+		{
+			name: "a RIGHT-HAND replacement onto the stock module",
+			mod:  base + "\nreplace example.com/other v1.0.0 => github.com/boundaryml/baml v0.223.0\n",
+			want: "WITH",
+		},
+		{
+			name: "a different required version",
+			mod:  "module example.com/x\n\ngo 1.26.5\n\nrequire github.com/boundaryml/baml v0.222.0\n",
+			want: "want exactly",
+		},
+		{
+			name: "the module is not required at all",
+			mod:  "module example.com/x\n\ngo 1.26.5\n",
+			want: "does not require",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := soCheckStockModulePin([]byte(tc.mod))
+			if err == nil {
+				t.Fatal("accepted a go.mod that does not link the stock BAML module")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("the refusal does not name the problem (%q): %v", tc.want, err)
+			}
+		})
+	}
+	// CONTROL: an unrelated replacement is fine, so the check is about the stock
+	// module rather than about replacements in general.
+	if err := soCheckStockModulePin([]byte(base + "\nreplace example.com/other => ./other\n")); err != nil {
+		t.Fatalf("an unrelated replacement was rejected: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// (2) The corpus is well formed.
+// ---------------------------------------------------------------------------
+
+// TestServingOracleCorpusIsWellFormed pins the corpus's own invariants, so a row
+// cannot be added in a shape that would make a later assertion vacuous.
+func TestServingOracleCorpusIsWellFormed(t *testing.T) {
+	if len(servingOracleFixtures) == 0 {
+		t.Fatal("the corpus is empty; every claim this package makes would be vacuous")
+	}
+	seen := map[string]bool{}
+	families := map[string]int{}
+	fatal, unconstrained := 0, 0
+	for _, f := range servingOracleFixtures {
+		if seen[f.Name] {
+			t.Fatalf("duplicate fixture name %q", f.Name)
+		}
+		seen[f.Name] = true
+		if f.Doc == "" {
+			t.Errorf("%s: no Doc; a row must say what it is evidence for", f.Name)
+		}
+		if f.Bundle == nil {
+			t.Fatalf("%s: no bundle", f.Name)
+		}
+		if f.Raw == "" {
+			t.Errorf("%s: no raw assistant text", f.Name)
+		}
+		families[f.Family]++
+		if f.Fatal {
+			fatal++
+		}
+		if f.Unconstrained {
+			unconstrained++
+			if soBundleHasConstraint(f.Bundle) {
+				t.Errorf("%s is marked Unconstrained but its bundle carries a constraint; the control would "+
+					"assert nothing", f.Name)
+			}
+		} else if !soBundleHasConstraint(f.Bundle) {
+			t.Errorf("%s carries no constraint but is not marked Unconstrained; it would be counted as a "+
+				"constraint-bearing decline it cannot witness", f.Name)
+		}
+	}
+	// Every family the non-integration gate test covers must be exercised here, and
+	// every family exercised here must be one the gate test covers. Neither
+	// direction alone is enough: the first stops the gate test from covering a shape
+	// the oracle never drives, the second stops the oracle from drifting into a
+	// shape the gate test never drives.
+	for _, want := range servingOracleGateFamilies {
+		if families[want] == 0 {
+			t.Errorf("gate family %q has no corpus fixture; the gate test would assert over a shape the "+
+				"oracle never drives", want)
+		}
+	}
+	for fam := range families {
+		if !soContains(servingOracleGateFamilies, fam) {
+			t.Errorf("fixture family %q is not in servingOracleGateFamilies; add it there so "+
+				"checkSupported/checkSupportedFields/checkSupportedType are driven over it by name", fam)
+		}
+	}
+	if fatal == 0 {
+		t.Error("no fixture is marked Fatal; the subprocess-isolation arm would be vacuous")
+	}
+	if unconstrained == 0 {
+		t.Error("no unconstrained control; every decline would be indistinguishable from a blanket refusal")
+	}
+	t.Logf("corpus: %d fixtures across %d families (%d process-fatal, %d unconstrained controls)",
+		len(servingOracleFixtures), len(families), fatal, unconstrained)
+}
+
+// soBundleHasConstraint reports whether any node of the bundle carries a
+// constraint — the property the boundary lock is about.
+func soBundleHasConstraint(b *schema.Bundle) bool {
+	found := false
+	soWalkTypes(b.Target, func(t schema.Type) {
+		if len(t.Meta.Constraints) > 0 {
+			found = true
+		}
+	})
+	for _, c := range b.Classes {
+		if len(c.Constraints) > 0 {
+			found = true
+		}
+		for _, f := range c.Fields {
+			soWalkTypes(f.Type, func(t schema.Type) {
+				if len(t.Meta.Constraints) > 0 {
+					found = true
+				}
+			})
+		}
+	}
+	for _, e := range b.Enums {
+		if len(e.Constraints) > 0 {
+			found = true
+		}
+	}
+	// Structural-alias TARGETS are constraint carriers too. Missing them would
+	// misclassify a carrier as unconstrained, and an "unconstrained control" that
+	// actually carries a constraint asserts the opposite of what it claims.
+	for _, a := range b.StructuralRecursiveAliases {
+		soWalkTypes(a.Target, func(t schema.Type) {
+			if len(t.Meta.Constraints) > 0 {
+				found = true
+			}
+		})
+	}
+	return found
+}
+
+func soContains(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// (3) The project stock compiles is the project under review.
+// ---------------------------------------------------------------------------
+
+// TestServingOracleProjectDrift pins the rendered .baml as a pure function of the
+// corpus, and pins its hash so the golden cannot be regenerated silently.
+//
+// The bytes compared are the ones the RUNTIME was created from (soRuntimeSource),
+// not a fresh render, so this closes the loop the sibling oracles close with a
+// generated-client source-map check: corpus -> project -> the compiled artifact
+// the stock leg is actually driving.
+func TestServingOracleProjectDrift(t *testing.T) {
+	soEnsureRuntime(t)
+	if os.Getenv(soWriteEnv) != "" {
+		if err := os.MkdirAll(filepath.Dir(soProjectGolden), 0o755); err != nil {
+			t.Fatalf("create %s: %v", filepath.Dir(soProjectGolden), err)
+		}
+		if err := os.WriteFile(soProjectGolden, []byte(soRuntimeSource), 0o644); err != nil {
+			t.Fatalf("write %s: %v", soProjectGolden, err)
+		}
+		t.Logf("%s rewritten from the corpus; its SHA-256 is %s — update soWantProjectHash",
+			soProjectGolden, soProjectHash(soRuntimeSource))
+		return
+	}
+	golden, err := os.ReadFile(soProjectGolden)
+	if err != nil {
+		t.Fatalf("read %s: %v (regenerate with %s=1)", soProjectGolden, err, soWriteEnv)
+	}
+	if string(golden) != soRuntimeSource {
+		t.Fatalf("%s is stale: it is not what the corpus renders and not what the stock runtime compiled.\n"+
+			"Regenerate with %s=1 and update soWantProjectHash.\n  golden %d bytes, rendered %d bytes",
+			soProjectGolden, soWriteEnv, len(golden), len(soRuntimeSource))
+	}
+	if got := soProjectHash(soRuntimeSource); got != soWantProjectHash {
+		t.Fatalf("the rendered project's SHA-256 is %s, want %s.\n"+
+			"The golden and the corpus agree, so this is a deliberate change that has to be acknowledged here.",
+			got, soWantProjectHash)
+	}
+	// Every fixture's function must be present in the compiled text. A row whose
+	// method is missing would fail its parse with "function not found", which is a
+	// harness failure, not an observation.
+	for _, f := range servingOracleFixtures {
+		if !strings.Contains(soRuntimeSource, "function "+f.method()+"(") {
+			t.Errorf("%s declares no function %s in the compiled project", f.Name, f.method())
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// (4) The differential.
+// ---------------------------------------------------------------------------
+
+// TestServingOracleDifferential drives both legs over every non-fatal row and
+// requires each to reproduce its RECORDED envelope exactly, then applies the
+// contract live.
+//
+// Pinning both legs makes this a regression pin as well as a differential: a row
+// where the two currently AGREE cannot silently start diverging, and one where
+// they currently diverge cannot silently change shape.
+func TestServingOracleDifferential(t *testing.T) {
+	soEnsureRuntime(t)
+	recording := os.Getenv(soRecordEnv) != ""
+	for _, f := range servingOracleFixtures {
+		if f.Fatal {
+			continue
+		}
+		t.Run(f.Name, func(t *testing.T) {
+			stock := soStockFor(t, f)
+			native := soRunNative(f)
+			_, problems := soCompare(f, stock, native)
+
+			if recording {
+				fmt.Printf("RECORD\t%s\tSTOCK\t%s\n", f.Name, stock.render())
+				fmt.Printf("RECORD\t%s\tNATIVE\t%s\n", f.Name, native.render())
+			} else {
+				if got := stock.render(); got != f.Stock {
+					t.Errorf("the STOCK envelope changed:\n  got  %s\n  want %s%s",
+						got, f.Stock, soReport(f, stock, native, problems))
+				}
+				if got := native.render(); got != f.Native {
+					t.Errorf("the NATIVE envelope changed:\n  got  %s\n  want %s%s",
+						got, f.Native, soReport(f, stock, native, problems))
+				}
+			}
+			if v := soViolations(problems); len(v) > 0 {
+				t.Errorf("the two legs disagree in a way the contract forbids:%s",
+					soReport(f, stock, native, problems))
+			}
+		})
+	}
+}
+
+// TestServingOracleFailClosed is the load-bearing assertion of this package.
+//
+// It runs over the LIVE legs rather than the pinned columns, so it cannot pass
+// because the corpus was edited to match, and there is no bucket for a known
+// difference: a native answer stock did not produce fails here.
+func TestServingOracleFailClosed(t *testing.T) {
+	soEnsureRuntime(t)
+	var violations []string
+	driven := 0
+	for _, f := range servingOracleFixtures {
+		if f.Fatal {
+			continue
+		}
+		driven++
+		stock := soStockFor(t, f)
+		native := soRunNative(f)
+		_, problems := soCompare(f, stock, native)
+		for _, p := range soViolations(problems) {
+			violations = append(violations, soReport(f, stock, native, []soMismatch{p}))
+		}
+	}
+	if driven == 0 {
+		t.Fatal("no row was driven; the fail-closed claim would be vacuous")
+	}
+	if len(violations) > 0 {
+		t.Fatalf("the serving-shaped differential is NOT fail-closed; %d disagreement(s) over %d rows:%s",
+			len(violations), driven, strings.Join(violations, "\n"))
+	}
+	t.Logf("fail-closed over %d driven rows", driven)
+}
+
+// soWantAgreement pins the population of each agreement bucket, so a change that
+// quietly turned a decline into an answer — or an answer into a decline — has to
+// be acknowledged.
+var soWantAgreement = map[soAgreement]int{
+	soAgreeValue:               27,
+	soAgreeAssertFailure:       3,
+	soAgreeRefusal:             1,
+	soNativeDeclinesPredicate:  6,
+	soNativeDeclinesCoercion:   3,
+	soNativeDeclinesExtraction: 2,
+	soCollectorRefuses:         1,
+	soStateDiverges:            7,
+	soEventShapeDiverges:       3,
+	soStockUnobservable:        1,
+}
+
+// TestServingOracleAgreementTally pins the measured shape of the corpus.
+//
+// The tally is LABELLED: every bucket means exactly what its name says, and a row
+// that lands in none is a failure rather than an unlabelled remainder.
+func TestServingOracleAgreementTally(t *testing.T) {
+	soEnsureRuntime(t)
+	got := map[soAgreement]int{}
+	for _, f := range servingOracleFixtures {
+		if f.Fatal {
+			got[soStockUnobservable]++
+			soRequireDivergenceNote(t, f, soStockUnobservable)
+			continue
+		}
+		stock := soStockFor(t, f)
+		native := soRunNative(f)
+		bucket, _ := soCompare(f, stock, native)
+		got[bucket]++
+		soRequireDivergenceNote(t, f, bucket)
+	}
+	if len(soWantAgreement) == 0 {
+		keys := make([]string, 0, len(got))
+		for k := range got {
+			keys = append(keys, string(k))
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			t.Logf("RECORD-TALLY %s: %d", k, got[soAgreement(k)])
+		}
+		t.Fatal("soWantAgreement is empty; pin the measured buckets logged above")
+	}
+	total := 0
+	for bucket, want := range soWantAgreement {
+		if got[bucket] != want {
+			t.Errorf("agreement bucket %s: got %d rows, want %d", bucket, got[bucket], want)
+		}
+		total += want
+	}
+	for bucket, n := range got {
+		if _, ok := soWantAgreement[bucket]; !ok {
+			t.Errorf("agreement bucket %s appeared with %d rows and is not pinned", bucket, n)
+		}
+	}
+	if total != len(servingOracleFixtures) {
+		t.Errorf("the pinned buckets cover %d rows, the corpus has %d", total, len(servingOracleFixtures))
+	}
+}
+
+// soRequireDivergenceNote enforces the note contract in BOTH directions: every
+// non-agreeing bucket must carry a one-sentence Divergence, and an agreeing bucket
+// must carry none. A note that survives its cause is as misleading as a cost with
+// no note.
+func soRequireDivergenceNote(t *testing.T, f servingOracleFixture, bucket soAgreement) {
+	t.Helper()
+	if soIsAgreement(bucket) {
+		if f.Divergence != "" {
+			t.Errorf("%s: carries a Divergence note but the two legs AGREE (%s); the note is stale",
+				f.Name, bucket)
+		}
+		return
+	}
+	if f.Divergence == "" {
+		t.Errorf("%s: landed in %s but carries no Divergence note saying what the two legs do differently",
+			f.Name, bucket)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// (5) The boundary lock.
+// ---------------------------------------------------------------------------
+
+// TestServingOracleBoundaryLock is the UNNARROWED invariant, over every fixture:
+// a constraint-bearing bundle is refused by every production entry point, and the
+// refusal is caused by the constraint rather than by the shape.
+//
+// Four gates are driven, not one:
+//
+//	checkSupported            the gate Parse runs
+//	SupportsNativeFinalBundle the admission predicate
+//	ParseStaticBundle         the static-final serving entry point
+//	Parse                     the dynamic entry point, reached through the same gate
+//
+// Target-level rows (@check/@assert on the return type, and on a target list
+// element) are included with nothing carved out: since #664 walked b.Target there
+// is no exception left, and this test fails if one reappears.
+func TestServingOracleBoundaryLock(t *testing.T) {
+	constrained, controls, servedControls, attributed, namedConstraint := 0, 0, 0, 0, 0
+	for _, f := range servingOracleFixtures {
+		t.Run(f.Name, func(t *testing.T) {
+			if f.Unconstrained {
+				controls++
+				if soRequireAdmitted(t, f) {
+					servedControls++
+				}
+				return
+			}
+			constrained++
+			attributedHere, namedHere := soRequireDeclined(t, f)
+			if attributedHere {
+				attributed++
+			}
+			if namedHere {
+				namedConstraint++
+			}
+		})
+	}
+	if constrained == 0 {
+		t.Fatal("no constraint-bearing fixture; the boundary lock would be vacuous")
+	}
+	if controls == 0 {
+		t.Fatal("no unconstrained control; the decline could not be shown to be constraint-specific")
+	}
+	if servedControls == 0 {
+		t.Fatal("no unconstrained control actually SERVED through ParseStaticBundle; the suite would only " +
+			"have proven that nothing is ever emitted")
+	}
+	if attributed != constrained {
+		t.Fatalf("only %d of %d constraint-bearing rows had their decline ATTRIBUTED to their constraints "+
+			"(stripped twin admitted); the lock would prove only that something refuses", attributed, constrained)
+	}
+	if namedConstraint == 0 {
+		t.Fatal("no row's decline message NAMED a constraint; the constraint cut-line itself would be " +
+			"unwitnessed even though every stripped twin is admitted")
+	}
+	t.Logf("boundary lock: %d constraint-bearing bundles declined by all gates, all %d attributed to their "+
+		"constraints (the stripped twin is admitted), %d of them named a constraint in the message; "+
+		"%d unconstrained controls admitted (%d of them served bytes)",
+		constrained, attributed, namedConstraint, controls, servedControls)
+}
+
+// soRequireDeclined drives every gate and requires the fallback sentinel from each.
+func soRequireDeclined(t *testing.T, f servingOracleFixture) (attributedToConstraint, declineNamesConstraint bool) {
+	t.Helper()
+	attributed, namedConstraint := false, false
+	// EVERY named seam, over EVERY constraint-bearing fixture — not a representative
+	// subset. checkSupportedFields and checkSupportedType are the two the gate test's
+	// hand-written rows cover; driving them here as well is what makes the
+	// un-narrowed claim ("every constraint-bearing fixture, aliases and target-level
+	// included, declines through all of them") a per-fixture fact.
+	//
+	// BAML_REST_USE_DEBAML is the serve-level umbrella switch. It is set BOTH ways
+	// around every gate call — Parse included — so the decision is shown to be
+	// independent of it. The structural half of that claim, that nothing in
+	// internal/debaml reads the environment at all, is
+	// TestServingOracleGateReadsNoEnvironment.
+	for _, flag := range []string{"true", "false", ""} {
+		soWithDeBAMLFlag(t, flag, func() {
+			err := checkSupported(f.Bundle)
+			if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Fatalf("BAML_REST_USE_DEBAML=%q: checkSupported returned %v, want ErrDeBAMLParseUnsupported "+
+					"for the constraint-bearing bundle %s", flag, err, soTypeExpr(f.Bundle.Target))
+			}
+			// ATTRIBUTION, in both directions. A decline only WITNESSES the constraint
+			// gate if the constraint caused it, which is proven by stripping the
+			// constraints and finding the twin admitted. A row whose SHAPE the gate
+			// refuses anyway must say so, and is then excluded from the attribution
+			// count rather than counted as evidence it cannot give.
+			if strippedErr := checkSupported(soStripConstraints(f.Bundle)); strippedErr != nil {
+				t.Fatalf("BAML_REST_USE_DEBAML=%q: the constraint-stripped twin of %s is ALSO declined (%v), "+
+					"so this row's decline is not attributable to its constraints", flag, f.Name, strippedErr)
+			}
+			// The CAUSAL attribution is the stripped twin above: constraints removed ->
+			// admitted, constraints present -> declined. The MESSAGE is a weaker signal
+			// and deliberately not required: adding a constraint to a union variant
+			// changes how checkSupportedUnionShape classifies it, so the gate refuses
+			// with a shape message for a decline the constraint caused. Both are
+			// counted, and the message-named population is required to be non-empty so
+			// the constraint cut-line itself stays witnessed.
+			attributed = true
+			if strings.Contains(err.Error(), "constraint") {
+				namedConstraint = true
+			}
+			fieldsErr := checkSupportedFields(f.Bundle)
+			if !errors.Is(fieldsErr, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Fatalf("BAML_REST_USE_DEBAML=%q: checkSupportedFields returned %v, want "+
+					"ErrDeBAMLParseUnsupported", flag, fieldsErr)
+			}
+			// The two are pinned to agree. checkSupported's body is checkSupportedFields
+			// after two blanket recursion rejects, and no corpus bundle is recursive, so
+			// a constraint decline that lived in one and not the other would mean the
+			// gate the ROUTE runs and the gate this test drives had parted company —
+			// which is exactly what a same-outcome assertion catches and what driving
+			// checkSupportedFields alongside checkSupported is for.
+			if fieldsErr.Error() != err.Error() {
+				t.Fatalf("BAML_REST_USE_DEBAML=%q: checkSupported and checkSupportedFields disagree about "+
+					"%s:\n  checkSupported       %v\n  checkSupportedFields %v",
+					flag, f.Name, err, fieldsErr)
+			}
+			// checkSupportedType is driven on EVERY constrained type node of the
+			// fixture, which for a target-level row is the return type itself and for a
+			// list/map/union row is the nested node the constraint sits on.
+			nodes := soConstrainedTypeNodes(f.Bundle)
+			if len(nodes) == 0 && !soBundleHasDeclarationConstraint(f.Bundle) {
+				t.Fatalf("%s carries no constrained TYPE node and no class/enum declaration constraint; "+
+					"checkSupportedType would be unasserted for it", f.Name)
+			}
+			for _, n := range nodes {
+				if err := checkSupportedType(f.Bundle, n); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+					t.Fatalf("BAML_REST_USE_DEBAML=%q: checkSupportedType(%s) returned %v, want "+
+						"ErrDeBAMLParseUnsupported", flag, soTypeExpr(n), err)
+				}
+			}
+			if err := SupportsNativeFinalBundle(f.Bundle); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Fatalf("BAML_REST_USE_DEBAML=%q: SupportsNativeFinalBundle returned %v, want "+
+					"ErrDeBAMLParseUnsupported", flag, err)
+			}
+			res, err := ParseStaticBundle(context.Background(), f.Bundle, f.Raw)
+			if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Fatalf("BAML_REST_USE_DEBAML=%q: ParseStaticBundle returned (%v, %v); a constraint-bearing "+
+					"bundle must decline rather than serve", flag, res, err)
+			}
+			if len(res.JSON) != 0 {
+				t.Fatalf("BAML_REST_USE_DEBAML=%q: ParseStaticBundle declined but still produced %s bytes",
+					flag, res.JSON)
+			}
+
+			// Parse — the ROOT entry point the worker calls. The constrained bundle is
+			// carried in through the STATIC descriptor lane, which is the only request
+			// shape that can express a constraint at all: DynamicOutputSchema has no
+			// constraint channel (the #572 dynamic-schema ceiling), so the dynamic lane
+			// could never present one to the gate. soParseRequestFor proves the
+			// descriptor lowers back to this exact bundle before driving it, so Parse is
+			// declining THIS fixture rather than something adjacent.
+			req := soParseRequestFor(t, f.Bundle, f.Raw)
+			pres, perr := Parse(context.Background(), req)
+			if !errors.Is(perr, bamlutils.ErrDeBAMLParseUnsupported) {
+				t.Fatalf("BAML_REST_USE_DEBAML=%q: Parse returned (%v, %v); a constraint-bearing bundle must "+
+					"decline at the root entry point too", flag, pres, perr)
+			}
+			if len(pres.JSON) != 0 {
+				t.Fatalf("BAML_REST_USE_DEBAML=%q: Parse declined but still produced %s bytes", flag, pres.JSON)
+			}
+		})
+	}
+	return attributed, namedConstraint
+}
+
+// soConstrainedTypeNodes returns every TYPE node of a bundle that carries a
+// constraint — the target, its nested nodes, and every class field's type tree.
+//
+// These are exactly the nodes checkSupportedType is responsible for. A class-level
+// or enum-level constraint is NOT one of them (it lives on the definition, which
+// checkSupportedType never sees), so claiming a decline for it would be asserting
+// something that function does not do.
+func soConstrainedTypeNodes(b *schema.Bundle) []schema.Type {
+	var out []schema.Type
+	collect := func(t schema.Type) {
+		soWalkTypes(t, func(n schema.Type) {
+			if len(n.Meta.Constraints) > 0 {
+				out = append(out, n)
+			}
+		})
+	}
+	collect(b.Target)
+	for _, c := range b.Classes {
+		for _, f := range c.Fields {
+			collect(f.Type)
+		}
+	}
+	return out
+}
+
+// soBundleHasDeclarationConstraint reports a constraint on a class or enum
+// DEFINITION, which checkSupportedFields owns and checkSupportedType does not.
+func soBundleHasDeclarationConstraint(b *schema.Bundle) bool {
+	for _, c := range b.Classes {
+		if len(c.Constraints) > 0 {
+			return true
+		}
+	}
+	for _, e := range b.Enums {
+		if len(e.Constraints) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// soParseRequestFor builds the Parse request that carries a constrained bundle.
+//
+// Parse's dynamic lane lowers a DynamicOutputSchema, which has NO constraint
+// channel, so a constraint can only reach Parse through the STATIC descriptor lane
+// (req.StaticStreamDescriptor with neither Stream nor StreamFinal set, which
+// Parse lowers with schema.FromStaticDescriptor and routes to ParseStaticBundle).
+//
+// The descriptor is derived from the bundle and then lowered BACK, and the round
+// trip is required to reproduce the bundle exactly. Without that, Parse could be
+// declining a bundle that merely resembles the fixture's.
+func soParseRequestFor(t *testing.T, b *schema.Bundle, raw string) bamlutils.DeBAMLParseRequest {
+	t.Helper()
+	desc := soDescriptorFor(b)
+	lowered, err := schema.FromStaticDescriptor(desc)
+	if err != nil {
+		t.Fatalf("the descriptor derived from the fixture does not lower: %v", err)
+	}
+	if a, bb := soBundleJSON(t, lowered), soBundleJSON(t, b); a != bb {
+		t.Fatalf("the descriptor round trip changed the bundle, so Parse would be driven over a DIFFERENT "+
+			"schema than the rest of the oracle:\n  lowered %s\n  fixture %s", a, bb)
+	}
+	return bamlutils.DeBAMLParseRequest{
+		Raw:                    raw,
+		StaticStreamDescriptor: &promptdescriptor.Function{Method: "SO", Return: desc},
+	}
+}
+
+// soBundleJSON renders a bundle's exported shape for comparison. The unexported
+// index maps carry `json:"-"`, so this compares the declarative content and not
+// the rebuilt lookup tables.
+func soBundleJSON(t *testing.T, b *schema.Bundle) string {
+	t.Helper()
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	return string(raw)
+}
+
+// soRequireAdmitted is the control direction: the same shapes WITHOUT constraints
+// must be admitted by the CONSTRAINT gate, so a decline elsewhere is attributable.
+//
+// checkSupported and checkSupportedFields are the constraint cut-line and must
+// admit outright. SupportsNativeFinalBundle adds a further STREAM cut-line that
+// legitimately declines some unconstrained shapes for reasons that have nothing to
+// do with constraints (a single string-absorbing-field root class, a scalar map
+// value). Those are allowed here — but only after their reason is checked NOT to be
+// a constraint, so the allowance cannot absorb a constraint decline.
+//
+// It reports whether the control actually SERVED, because at least one must, or the
+// suite would only ever have proven that nothing is emitted.
+func soRequireAdmitted(t *testing.T, f servingOracleFixture) (served bool) {
+	t.Helper()
+	if err := checkSupported(f.Bundle); err != nil {
+		t.Fatalf("the unconstrained control %s was DECLINED by checkSupported: %v", f.Name, err)
+	}
+	if err := checkSupportedFields(f.Bundle); err != nil {
+		t.Fatalf("the unconstrained control %s was DECLINED by checkSupportedFields: %v", f.Name, err)
+	}
+	if err := SupportsNativeFinalBundle(f.Bundle); err != nil {
+		soRequireNotAConstraintDecline(t, f.Name, "SupportsNativeFinalBundle", err)
+		return false
+	}
+	res, err := ParseStaticBundle(context.Background(), f.Bundle, f.Raw)
+	if err != nil {
+		soRequireNotAConstraintDecline(t, f.Name, "ParseStaticBundle", err)
+		return false
+	}
+	if len(res.JSON) == 0 {
+		t.Fatalf("the unconstrained control %s was admitted but served nothing", f.Name)
+	}
+	// The ROOT entry point must agree with the one below it: a control that serves
+	// through ParseStaticBundle must serve the SAME bytes through Parse, or the two
+	// lanes disagree about an admitted shape.
+	pres, perr := Parse(context.Background(), soParseRequestFor(t, f.Bundle, f.Raw))
+	if perr != nil {
+		t.Fatalf("the unconstrained control %s serves through ParseStaticBundle but Parse declined it: %v",
+			f.Name, perr)
+	}
+	if string(pres.JSON) != string(res.JSON) {
+		t.Fatalf("the unconstrained control %s serves different bytes through Parse and ParseStaticBundle:"+
+			"\n  Parse            %s\n  ParseStaticBundle %s", f.Name, pres.JSON, res.JSON)
+	}
+	return true
+}
+
+// soRequireNotAConstraintDecline pins the ATTRIBUTION of a decline: every
+// constraint decline in internal/debaml names "constraints" in its message
+// (unsupported("type constraints"), "class constraints", "enum constraints",
+// "target type constraints", "map key constraints", …), so a decline that names one
+// on a bundle carrying none would mean the gate is refusing for the wrong reason.
+func soRequireNotAConstraintDecline(t *testing.T, fixture, gate string, err error) {
+	t.Helper()
+	if strings.Contains(err.Error(), "constraint") {
+		t.Fatalf("the unconstrained control %s was declined by %s for a CONSTRAINT reason (%v), but it "+
+			"carries no constraint", fixture, gate, err)
+	}
+	t.Logf("%s: %s declines for a non-constraint reason (%v); admission is still proven by checkSupported",
+		fixture, gate, err)
+}
+
+// soWithDeBAMLFlag runs fn with BAML_REST_USE_DEBAML set to v (or unset for ""),
+// restoring the previous state afterwards.
+func soWithDeBAMLFlag(t *testing.T, v string, fn func()) {
+	t.Helper()
+	const key = "BAML_REST_USE_DEBAML"
+	prev, had := os.LookupEnv(key)
+	defer func() {
+		if had {
+			_ = os.Setenv(key, prev)
+			return
+		}
+		_ = os.Unsetenv(key)
+	}()
+	if v == "" {
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("unset %s: %v", key, err)
+		}
+	} else if err := os.Setenv(key, v); err != nil {
+		t.Fatalf("set %s: %v", key, err)
+	}
+	fn()
+}
+
+// TestServingOracleCanonicalMatchesProductionServing proves the decline is the
+// ONLY thing the constraints change.
+//
+// For every constraint-bearing row it strips the constraints from the bundle,
+// requires the stripped twin to be ADMITTED, and requires ParseStaticBundle — the
+// real static serving entry point — to emit EXACTLY the canonical bytes the
+// collector recorded for the constrained bundle.
+//
+// That makes the collector's CanonicalJSON an artifact of production serving
+// rather than of the collector: if the two ever parted, one of them would be
+// describing a value the serving path does not produce.
+func TestServingOracleCanonicalMatchesProductionServing(t *testing.T) {
+	compared, notServable := 0, 0
+	for _, f := range servingOracleFixtures {
+		if f.Fatal || f.Unconstrained {
+			continue
+		}
+		t.Run(f.Name, func(t *testing.T) {
+			native := soRunNative(f)
+			if native.Kind == soNativeCoercionError || native.Kind == soNativeNoCandidate ||
+				native.Kind == soNativeUnmodelled {
+				t.Skipf("no canonical value to compare: %s %s", native.Kind, native.Message)
+			}
+			stripped := soStripConstraints(f.Bundle)
+			if err := checkSupported(stripped); err != nil {
+				t.Fatalf("the constraint-stripped twin was still declined (%v); the decline is then NOT "+
+					"constraint-specific for this shape", err)
+			}
+			res, err := ParseStaticBundle(context.Background(), stripped, f.Raw)
+			if err != nil {
+				// The stream cut-line inside SupportsNativeFinalBundle declines some
+				// shapes for reasons that have nothing to do with constraints. Those are
+				// reported, and their reason is checked NOT to be a constraint, so the
+				// allowance cannot absorb a constraint decline.
+				soRequireNotAConstraintDecline(t, f.Name, "ParseStaticBundle (stripped twin)", err)
+				notServable++
+				t.Skipf("the stripped twin is not servable for a non-constraint reason: %v", err)
+			}
+			if diff, ok := constraintStateJSONEquivalent([]byte(native.JSON), res.JSON); !ok {
+				t.Fatalf("the collector's canonical document is not what production serving emits for the same "+
+					"raw text — %s\n  collector %s\n  serving   %s", diff, native.JSON, res.JSON)
+			}
+			compared++
+		})
+	}
+	if compared == 0 {
+		t.Fatal("no row was compared against production serving; the claim would be vacuous")
+	}
+	if compared+notServable != soWantServingComparable+soWantServingNotComparable {
+		t.Errorf("the serving comparison covered %d rows (%d compared, %d not servable) but the corpus "+
+			"pins %d + %d", compared+notServable, compared, notServable,
+			soWantServingComparable, soWantServingNotComparable)
+	}
+	if compared != soWantServingComparable || notServable != soWantServingNotComparable {
+		t.Errorf("serving comparability changed: compared=%d (want %d), not-servable=%d (want %d). Both are "+
+			"pinned so a shape moving between them has to be acknowledged.",
+			compared, soWantServingComparable, notServable, soWantServingNotComparable)
+	}
+	t.Logf("collector canonical == ParseStaticBundle output for %d rows; %d rows are not servable for "+
+		"non-constraint reasons", compared, notServable)
+}
+
+// soWantServingComparable / soWantServingNotComparable pin how much of the corpus
+// can be compared against production serving, and how much cannot because the
+// stream cut-line declines the shape for a NON-constraint reason. Both are pinned
+// so a shape moving between them is acknowledged rather than absorbed.
+const (
+	soWantServingComparable    = 26
+	soWantServingNotComparable = 17
+)
+
+// soStripConstraints returns a deep copy of b with every constraint removed.
+func soStripConstraints(b *schema.Bundle) *schema.Bundle {
+	out := &schema.Bundle{
+		Target:           soStripType(b.Target),
+		RecursiveClasses: append([]string(nil), b.RecursiveClasses...),
+	}
+	// The alias TARGETS are types and can carry constraints of their own; copying the
+	// slice shallowly left them in the "stripped" twin.
+	for _, a := range b.StructuralRecursiveAliases {
+		out.StructuralRecursiveAliases = append(out.StructuralRecursiveAliases,
+			schema.RecursiveAliasDef{Name: a.Name, Target: soStripType(a.Target)})
+	}
+	for _, c := range b.Classes {
+		nc := c
+		nc.Constraints = nil
+		nc.Fields = nil
+		for _, f := range c.Fields {
+			nf := f
+			nf.Type = soStripType(f.Type)
+			nc.Fields = append(nc.Fields, nf)
+		}
+		out.Classes = append(out.Classes, nc)
+	}
+	for _, e := range b.Enums {
+		ne := e
+		ne.Constraints = nil
+		out.Enums = append(out.Enums, ne)
+	}
+	if err := out.RebuildIndexes(); err != nil {
+		panic("serving oracle: stripped bundle indexes: " + err.Error())
+	}
+	return out
+}
+
+// soStripType removes the constraints from a type and every type nested inside it.
+// It must cover the same carriers as soBundleHasConstraint and
+// servingOracleGateStripType, or a stripped twin and the detector would disagree
+// about what a constraint-free clone is.
+func soStripType(t schema.Type) schema.Type {
+	out := t
+	out.Meta.Constraints = nil
+	if t.Elem != nil {
+		out.Elem = ptr(soStripType(*t.Elem))
+	}
+	if t.Key != nil {
+		out.Key = ptr(soStripType(*t.Key))
+	}
+	if t.Value != nil {
+		out.Value = ptr(soStripType(*t.Value))
+	}
+	if len(t.Items) > 0 {
+		out.Items = nil
+		for _, it := range t.Items {
+			out.Items = append(out.Items, soStripType(it))
+		}
+	}
+	if t.Union != nil {
+		u := *t.Union
+		u.Variants = nil
+		for _, v := range t.Union.Variants {
+			u.Variants = append(u.Variants, soStripType(v))
+		}
+		out.Union = &u
+	}
+	if t.Arrow != nil {
+		a := *t.Arrow
+		a.Return = soStripType(t.Arrow.Return)
+		a.Params = nil
+		for _, p := range t.Arrow.Params {
+			a.Params = append(a.Params, soStripType(p))
+		}
+		out.Arrow = &a
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// (6) The three asymmetries, asserted directly.
+// ---------------------------------------------------------------------------
+
+// TestServingOracleDuplicateLabel pins ASYMMETRY 2 from BOTH readbacks.
+//
+// From the raw CFFI tree, two @check attributes sharing one label are two ORDERED
+// results with different outcomes. Through baml_go's own decoded readback they
+// FOLD into a single map entry. Both are recorded: the ordered pair is the fact
+// about BAML, the fold is a fact about its Go binding, and 7.2b owns the wire
+// question with both on the table.
+func TestServingOracleDuplicateLabel(t *testing.T) {
+	f := soFixture(t, "duplicate_label")
+	stock := soStockFor(t, f)
+	if stock.Kind != soStockValue {
+		t.Fatalf("expected a value, got %s", stock.render())
+	}
+	if len(stock.Sites) != 2 {
+		t.Fatalf("the raw CFFI check collection has %d entries, want 2 — the duplicate-label observation "+
+			"depends on both being present:\n  %s", len(stock.Sites), stock.render())
+	}
+	a, b := stock.Sites[0], stock.Sites[1]
+	if a.Label != "dup" || b.Label != "dup" {
+		t.Fatalf("both checks must carry the label %q; got %q and %q", "dup", a.Label, b.Label)
+	}
+	if a.Expression == b.Expression {
+		t.Fatalf("the two checks must carry DIFFERENT expressions or the ordering claim is untestable; "+
+			"both are %q", a.Expression)
+	}
+	if a.Status != "succeeded" || b.Status != "failed" {
+		t.Fatalf("the two checks must have DIFFERENT results or a fold would be undetectable; got %q then %q",
+			a.Status, b.Status)
+	}
+
+	// The FOLD itself is not reconstructed here — reconstructing it would prove
+	// nothing about baml_go. It is measured against the real decode by
+	// TestServingOracleRootCheckFoldIsLossy, which drives a root duplicate-label
+	// probe through the CFFI and observes the decoded map keep one entry where this
+	// nested pair keeps two.
+
+	// Native keeps both, in declaration order.
+	native := soRunNative(f)
+	checks := soCheckSites(native)
+	if len(checks) != 2 {
+		t.Fatalf("native folded or dropped a duplicate label: %s", native.render())
+	}
+	if checks[0].Expression != a.Expression || checks[1].Expression != b.Expression {
+		t.Fatalf("native's events are not in stock's declaration order:\n  stock  %s\n  native %s",
+			soRenderStockSites(stock.Sites), soRenderNativeSites(checks))
+	}
+	// The field's kind is pinned structurally so a future refactor cannot quietly
+	// turn the ordered slice into a map.
+	if k := reflect.TypeOf(constraintCoercionState{}).Field(soFieldIndex(t, "Events")).Type.Kind(); k != reflect.Slice {
+		t.Fatalf("constraintCoercionState.Events is a %s; it must stay a slice or duplicate labels fold", k)
+	}
+}
+
+// soFieldIndex returns the index of a named field of constraintCoercionState.
+func soFieldIndex(t *testing.T, name string) int {
+	t.Helper()
+	rt := reflect.TypeOf(constraintCoercionState{})
+	for i := 0; i < rt.NumField(); i++ {
+		if rt.Field(i).Name == name {
+			return i
+		}
+	}
+	t.Fatalf("constraintCoercionState has no field %q", name)
+	return -1
+}
+
+// TestServingOracleBareStringReturnSkips pins ASYMMETRY 1 from the stock side and
+// the native side at once, with the CONTROL that makes it a property of the ROUTE
+// rather than of strings.
+func TestServingOracleBareStringReturnSkips(t *testing.T) {
+	for _, name := range []string{"target_string_check_skipped", "target_string_assert_skipped"} {
+		f := soFixture(t, name)
+		stock := soStockFor(t, f)
+		if stock.Kind != soStockValue {
+			t.Fatalf("%s: a bare-string return must still SERVE the value; got %s", name, stock.render())
+		}
+		// Stock takes the assistant text VERBATIM for a bare-string return, so the
+		// quotes are part of the value. Pinned exactly, because it is also what makes
+		// this row a state divergence.
+		if stock.Identity != `string:"\"actual\""` {
+			t.Fatalf("%s: stock served %s, want the raw text verbatim", name, stock.Identity)
+		}
+		if len(stock.Sites) != 0 {
+			t.Fatalf("%s: stock evaluated %d constraint(s) on a bare-string return; the skip is the "+
+				"observation:\n  %s", name, len(stock.Sites), stock.render())
+		}
+		native := soRunNative(f)
+		if native.Identity != `string:"actual"` {
+			t.Fatalf("%s: native canonicalized %s, want the JSON string the text denotes", name, native.Identity)
+		}
+		if len(soCheckSites(native)) != 0 || len(native.Sites) != 0 {
+			t.Fatalf("%s: native EVALUATED a predicate stock skipped: %s", name, native.render())
+		}
+		// Positive evidence, not absence: the collector records the counterfactual,
+		// so the predicate is known to have been reached and to have decided false.
+		if len(native.Skips) == 0 {
+			t.Fatalf("%s: native recorded no skipped predicate; a skip proven only by absence is not "+
+				"evidence: %s", name, native.render())
+		}
+		if !strings.Contains(native.render(), "~would-be-false") {
+			t.Fatalf("%s: the skipped predicate carries no false counterfactual, so nothing shows it was "+
+				"reached: %s", name, native.render())
+		}
+	}
+	// CONTROL: the same false predicate one level down, on a string FIELD, DOES run
+	// on both legs — so the skip is a property of the bare-string return route.
+	ctl := soFixture(t, "scalar_string_check_fail")
+	stock := soStockFor(t, ctl)
+	if len(stock.Sites) != 1 || stock.Sites[0].Status != "failed" {
+		t.Fatalf("control: the same predicate on a string FIELD must run and fail; got %s", stock.render())
+	}
+}
+
+// TestServingOracleAliasCanonicalization pins ASYMMETRY 3 live: the model writes
+// the alias, the predicate observes the canonical name, and the two spellings
+// produce OPPOSITE results.
+func TestServingOracleAliasCanonicalization(t *testing.T) {
+	f := soFixture(t, "enum_alias_ingress")
+	stock := soStockFor(t, f)
+	if stock.Identity != "class:SoEnumAlias{v=enum:SoSuit=Hearts}" {
+		t.Fatalf("stock did not canonicalize the alias: %s", stock.render())
+	}
+	if len(stock.Sites) != 2 {
+		t.Fatalf("expected the canonical and alias predicates, got %s", stock.render())
+	}
+	if stock.Sites[0].Status != "succeeded" || stock.Sites[1].Status != "failed" {
+		t.Fatalf("the canonical spelling must hold and the alias spelling must not; got %q then %q:\n  %s",
+			stock.Sites[0].Status, stock.Sites[1].Status, stock.render())
+	}
+	native := soRunNative(f)
+	if native.Identity != stock.Identity {
+		t.Fatalf("native canonicalized differently:\n  stock  %s\n  native %s", stock.Identity, native.Identity)
+	}
+	checks := soCheckSites(native)
+	if len(checks) != 2 || checks[0].Outcome != constraintOutcomeTrue || checks[1].Outcome != constraintOutcomeFalse {
+		t.Fatalf("native did not reproduce the alias asymmetry: %s", native.render())
+	}
+}
+
+// soFixture looks a fixture up by name, failing loudly on a rename so a test that
+// names a row cannot silently start testing nothing.
+func soFixture(t *testing.T, name string) servingOracleFixture {
+	t.Helper()
+	for _, f := range servingOracleFixtures {
+		if f.Name == name {
+			return f
+		}
+	}
+	t.Fatalf("no fixture named %q; the corpus has %v", name, soSortedNames(servingOracleFixtures))
+	return servingOracleFixture{}
+}
+
+// ---------------------------------------------------------------------------
+// (7) The path alignment is exercised, not merely defined.
+// ---------------------------------------------------------------------------
+
+// TestServingOracleAlignmentIsExercised proves the path normalisation is live.
+//
+// A normalisation that no row exercises makes the comparison looser than it reads,
+// and its removal would not be noticed. It therefore requires a row that actually
+// produces a dropped element, and asserts the mapping's effect on it in both
+// directions.
+func TestServingOracleAlignmentIsExercised(t *testing.T) {
+	// dropped list element — the one normalisation, and it must bite.
+	dn := soRunNative(soFixture(t, "list_dropped_elem"))
+	drops := soDropsByPrefix(dn)
+	if len(drops) == 0 {
+		t.Fatalf("the dropped-element row produced no skipped element, so the index shift is dead code: %s",
+			dn.render())
+	}
+	shifted := 0
+	for _, s := range soCheckSites(dn) {
+		if got := soAlignNativePath(s.Path, drops); got != s.Path {
+			shifted++
+		}
+	}
+	if shifted == 0 {
+		t.Fatalf("no site's index was shifted by the drop, so the normalisation changes nothing here: %s",
+			dn.render())
+	}
+	// And the mapping itself, in both directions, so a no-op implementation fails.
+	if got := soShiftDroppedIndexes("$.v[2]", map[string][]int{"$.v": {1}}); got != "$.v[1]" {
+		t.Fatalf("soShiftDroppedIndexes($.v[2], drop 1) = %q, want $.v[1]", got)
+	}
+	if got := soShiftDroppedIndexes("$.v[0]", map[string][]int{"$.v": {1}}); got != "$.v[0]" {
+		t.Fatalf("soShiftDroppedIndexes must not shift an index BEFORE the drop; got %q", got)
+	}
+
+	// The PRODUCER half, on a REAL fixture rather than a hand-built map. A drop
+	// inside a NESTED list must be recorded under its owning list's own indexed path
+	// ($.v[1].w), which is the key the consumer looks up. Keying by the FIRST index
+	// and discarding anything with a remaining suffix — which is what this did —
+	// produced no key at all for a nested drop, so the nested support below could
+	// only ever be exercised by a map no producer could emit.
+	nested := soRunNative(soFixture(t, "list_nested_dropped_elem"))
+	nestedDrops := soDropsByPrefix(nested)
+	const nestedOwner = "$.v[1].w"
+	if got, ok := nestedDrops[nestedOwner]; !ok || len(got) != 1 || got[0] != 1 {
+		t.Fatalf("soDropsByPrefix produced %v; the nested drop must be keyed by its owning list %q with "+
+			"input index 1, or the consumer's nested lookup can never match anything a producer emits",
+			nestedDrops, nestedOwner)
+	}
+	// …and the CONSUMER half over the same run: the site after the dropped element
+	// sits at input index 2 and must align onto stock's emitted index 1.
+	alignedNested := 0
+	for _, site := range soCheckSites(nested) {
+		if site.Path != nestedOwner+"[2]" {
+			continue
+		}
+		alignedNested++
+		if got := soAlignNativePath(site.Path, nestedDrops); got != nestedOwner+"[1]" {
+			t.Fatalf("nested producer->consumer: %s aligned to %q, want %q", site.Path, got, nestedOwner+"[1]")
+		}
+	}
+	if alignedNested != 1 {
+		t.Fatalf("the nested fixture produced %d site(s) after the dropped element, want 1: %s",
+			alignedNested, nested.render())
+	}
+
+	// NESTED (hand-built): an inner list under an outer element whose earlier sibling was dropped.
+	// The drop map is keyed in the collector's INPUT coordinates, so the inner lookup
+	// must use the unshifted outer index even though the rendered path carries the
+	// shifted one. Building the key from the emitted rendering — which is what this
+	// did — misses, and the inner index is silently left unshifted.
+	handBuilt := map[string][]int{
+		"$.v":      {0}, // outer element 0 dropped: input [1] becomes emitted [0]
+		"$.v[1].w": {0}, // inner element 0 of the SURVIVING outer element dropped
+		"$.v[0].w": {3}, // a decoy under the emitted coordinate: must never be used
+	}
+	if got := soShiftDroppedIndexes("$.v[1].w[1]", handBuilt); got != "$.v[0].w[0]" {
+		t.Fatalf("nested alignment: soShiftDroppedIndexes($.v[1].w[1]) = %q, want $.v[0].w[0]. The inner "+
+			"index must be shifted using the INPUT-coordinate prefix $.v[1].w, not the emitted $.v[0].w.", got)
+	}
+	// The decoy proves the lookup is not merely succeeding by coincidence: keyed by
+	// the emitted prefix it would shift the inner index by a different amount.
+	if got := soShiftDroppedIndexes("$.v[1].w[4]", handBuilt); got != "$.v[0].w[3]" {
+		t.Fatalf("nested alignment used the wrong coordinate system: got %q, want $.v[0].w[3]", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// (8) A shape BAML will not even compile.
+// ---------------------------------------------------------------------------
+
+// TestServingOracleForeignMapKeyIsSourceRejected records the foreign non-string
+// map key as what it actually is: not a divergence between two engines, but a
+// shape the BAML PROJECT LANGUAGE refuses, so no stock leg can exist for it.
+//
+// It is asserted rather than assumed — a runtime is created from a project
+// carrying exactly that declaration and the creation must FAIL — and native's
+// decline of the same shape is pinned beside it.
+func TestServingOracleForeignMapKeyIsSourceRejected(t *testing.T) {
+	src := soPrelude + `
+class SoForeignKey {
+  m map<int, string>
+}
+
+function SoForeignKeyFn(topic: string) -> SoForeignKey {
+  client ` + soClient + `
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+`
+	_, err := soCreateRuntimeForSource(src)
+	if err == nil {
+		t.Fatal("stock BAML v0.223.0 now compiles a map with a non-string key; the source-rejected " +
+			"classification has to be re-derived")
+	}
+	// The CFFI reports only "failed to create BAML runtime" through the error value
+	// (the diagnostic goes to its own log), so the discrimination is a CONTROL rather
+	// than a message match: the identical project with a STRING key must compile. The
+	// only difference between the two sources is the key type, so a compile failure
+	// on one and a success on the other attributes the rejection to it.
+	ctlSrc := strings.Replace(src, "map<int, string>", "map<string, string>", 1)
+	if ctlSrc == src {
+		t.Fatal("the control source is identical to the rejected one; the substitution did not apply")
+	}
+	if _, ctlErr := soCreateRuntimeForSource(ctlSrc); ctlErr != nil {
+		t.Fatalf("the string-keyed CONTROL project does not compile either (%v), so the rejection above "+
+			"is not attributable to the key type", ctlErr)
+	}
+	t.Logf("recorded: stock refuses to COMPILE map<int, string> (%s) while the string-keyed twin compiles",
+		soCollapse(err.Error()))
+
+	// Native declines the same shape, and declines it for the map key rather than
+	// incidentally.
+	b := soBundle(soClassType("SoForeignKey"),
+		[]schema.ClassDef{soClassOf("SoForeignKey", []schema.ClassField{
+			soField("m", soMapOf(intType(), stringType())),
+		})}, nil)
+	if err := checkSupported(b); err == nil {
+		t.Fatal("native ADMITTED a map with a non-string key that BAML will not even compile")
+	} else if !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+		t.Fatalf("native declined the foreign map key with %v, want ErrDeBAMLParseUnsupported", err)
+	}
+	// CONTROL: the string-keyed twin IS admitted, so the decline is about the key.
+	ctl := soBundle(soClassType("SoForeignKeyCtl"),
+		[]schema.ClassDef{soClassOf("SoForeignKeyCtl", []schema.ClassField{
+			soField("m", soMapOf(stringType(), stringType())),
+		})}, nil)
+	if err := checkSupported(ctl); err != nil {
+		t.Fatalf("the string-keyed control was declined (%v); the foreign-key decline is then not "+
+			"key-specific", err)
+	}
+}
+
+// TestServingOracleNoUnionArmIsCoerced asserts the ABSENCE the alignment relies on,
+// with the reason as its evidence.
+//
+// soAlignNativePath carries no union-arm normalisation because production coerce
+// declines every constrained union — at a class field AND at the return type. That
+// is a fact, not an assumption: both union rows are driven here and required to
+// decline with the ErrDeBAMLParseUnsupported sentinel, and NO native site anywhere
+// in the corpus may carry a `|armN` segment.
+//
+// If a future change admits constrained unions, this fails and whoever made the
+// change has to re-derive the alignment with a fixture behind it.
+func TestServingOracleNoUnionArmIsCoerced(t *testing.T) {
+	unions := 0
+	for _, f := range servingOracleFixtures {
+		if f.Family != "union" {
+			continue
+		}
+		unions++
+		native := soRunNative(f)
+		if native.Kind != soNativeCoercionError {
+			t.Errorf("%s: production coerce no longer declines this constrained union (%s); the "+
+				"union-arm path alignment removed from soAlignNativePath has to be restored, with this row "+
+				"as its fixture", f.Name, native.render())
+			continue
+		}
+		if !errors.Is(native.Err, bamlutils.ErrDeBAMLParseUnsupported) {
+			t.Errorf("%s: the union decline is not the unsupported sentinel (%v), so it is a failure rather "+
+				"than a fall back to BAML", f.Name, native.Err)
+		}
+	}
+	if unions == 0 {
+		t.Fatal("no union fixture; the absence claim would be vacuous")
+	}
+	// And nothing anywhere produces an arm segment.
+	for _, f := range servingOracleFixtures {
+		if f.Fatal {
+			continue
+		}
+		for _, s := range soRunNative(f).Sites {
+			if soUnionArmRe.MatchString(s.Path) {
+				t.Errorf("%s: a native site carries the union-arm segment %s, which stock's tree has no step "+
+					"for; soAlignNativePath must normalise it away again", f.Name, s.Path)
+			}
+		}
+	}
+	t.Logf("no union arm is coerced: %d union fixtures, all declined by production coerce", unions)
+}
+
+// TestServingOracleKnownGap_BareStringQuotedText records a PRE-EXISTING divergence
+// this oracle found, in an UNCONSTRAINED shape that production admits and serves.
+//
+// A bare-string return type is admitted (boundary_decline_test.go's "bare string
+// return" control) and served by ParseStaticBundle. Given QUOTED assistant text the
+// two engines produce different values: stock takes the text verbatim, quotes
+// included, while the native static path extracts the JSON string it denotes.
+//
+// Nothing in Slice 7.2a-3 causes this and nothing here fixes it — this slice is
+// test-only and changes no production byte. The test exists so the gap is measured
+// rather than remembered, and it FAILS when the gap closes, with instructions.
+func TestServingOracleKnownGap_BareStringQuotedText(t *testing.T) {
+	f := soFixture(t, "bare_string_quoted_text")
+	if !f.Unconstrained {
+		t.Fatal("the row must be UNCONSTRAINED; a constraint-bearing bundle declines at the gate and would " +
+			"demonstrate nothing about what production serves")
+	}
+	stock := soStockFor(t, f)
+	if stock.Kind != soStockValue {
+		t.Fatalf("stock did not serve a value: %s", stock.render())
+	}
+	if stock.Identity != `string:"\"actual\""` {
+		t.Fatalf("GAP CLOSED or CHANGED — stock now canonicalizes the quoted text as %s. Re-derive this "+
+			"test, or delete it if the two engines now agree.", stock.Identity)
+	}
+
+	// The production serving path, not the collector: this is what a caller receives.
+	if err := checkSupported(f.Bundle); err != nil {
+		t.Fatalf("GAP CLOSED — the bare-string target no longer admits (%v). Delete this test and the "+
+			"bare_string_quoted_text row.", err)
+	}
+	res, err := ParseStaticBundle(context.Background(), f.Bundle, f.Raw)
+	if err != nil {
+		t.Fatalf("GAP CLOSED — ParseStaticBundle now declines the quoted bare-string text (%v). Delete this "+
+			"test and the bare_string_quoted_text row.", err)
+	}
+	if got := string(res.JSON); got != `"actual"` {
+		t.Fatalf("GAP CLOSED or CHANGED — production serving now emits %s. Re-derive this test.", got)
+	}
+	if diff, ok := constraintStateJSONEquivalent(res.JSON, []byte(stock.JSON)); ok {
+		t.Fatalf("GAP CLOSED — production serving and stock now agree on the quoted bare-string text. "+
+			"Delete this test and the bare_string_quoted_text row. (%s)", diff)
+	}
+	t.Logf("KNOWN GAP measured: stock serves %s, production ParseStaticBundle serves %s for the same "+
+		"assistant text %q on an ADMITTED, unconstrained bare-string return. Pre-existing, unrelated to "+
+		"constraints, and out of scope for this TEST-ONLY slice.", stock.JSON, res.JSON, f.Raw)
+}
+
+// TestServingOracleRootCheckFoldIsLossy MEASURES the one place the stock envelope
+// cannot be read raw, using the real baml_go decode rather than a reconstruction.
+//
+// A root Checked's collection reaches Go already folded into a
+// map[string]shared.Check (see soChecked for why there is no hook). This drives a
+// root function declaring TWO @check attributes under one label through the actual
+// CFFI and observes the decoded map keep ONE entry — and drives the SAME two checks
+// one level down, where the raw tree keeps BOTH, in order, with different results.
+//
+// The pair is what makes the loss a measurement: without the nested control, one
+// entry could mean stock evaluated once.
+func TestServingOracleRootCheckFoldIsLossy(t *testing.T) {
+	soEnsureRuntime(t)
+
+	root := soProbe(t, "probe_root_duplicate_label")
+	declared := root.Bundle.Target.Meta.Constraints
+	if len(declared) != 2 || *declared[0].Label != *declared[1].Label {
+		t.Fatalf("the probe must declare TWO checks under ONE label or it measures nothing; got %d",
+			len(declared))
+	}
+	if declared[0].Expression == declared[1].Expression {
+		t.Fatal("the two checks must carry DIFFERENT expressions, or the fold would be undetectable")
+	}
+
+	res, err := soDriveProbe(root)
+	if err != nil {
+		t.Fatalf("drive %s: %v", root.method(), err)
+	}
+	folded, ok := res.(soChecked)
+	if !ok {
+		t.Fatalf("a root-level @check must decode as a Checked; got %T", res)
+	}
+	if len(folded.Checks) != 1 {
+		t.Fatalf("baml_go's ROOT readback now keeps %d entries for two @checks sharing a label. The fold "+
+			"this oracle works around is gone: read the ordered collection directly and delete "+
+			"soFoldedSites' schema-derived ordering.", len(folded.Checks))
+	}
+	kept, present := folded.Checks[*declared[0].Label]
+	if !present {
+		t.Fatalf("the folded map does not carry the declared label %q: %v", *declared[0].Label, folded.Checks)
+	}
+	// The surviving entry is one of the two declared expressions — which one is
+	// baml_go's map-write order and is not a claim this test makes.
+	if kept.Expression != declared[0].Expression && kept.Expression != declared[1].Expression {
+		t.Fatalf("the surviving entry carries %q, which is neither declared expression", kept.Expression)
+	}
+
+	// The NESTED twin: the raw tree keeps both, ordered, with different results.
+	nested := soProbe(t, "probe_nested_duplicate_label")
+	nres, err := soDriveProbe(nested)
+	if err != nil {
+		t.Fatalf("drive %s: %v", nested.method(), err)
+	}
+	var sites []soStockSite
+	if _, _, err := soReadStockResult(nested.Bundle, nres, "$", &sites); err != nil {
+		t.Fatalf("read %s: %v", nested.method(), err)
+	}
+	if len(sites) != 2 {
+		t.Fatalf("the NESTED twin must keep BOTH checks from the raw tree, or the root count of 1 is not a "+
+			"loss; got %d: %s", len(sites), soRenderStockSites(sites))
+	}
+	if sites[0].Label != sites[1].Label {
+		t.Fatalf("the nested pair lost the shared label: %s", soRenderStockSites(sites))
+	}
+	if sites[0].Expression == sites[1].Expression || sites[0].Status == sites[1].Status {
+		t.Fatalf("the nested pair must differ in expression AND result, or the ordering claim is "+
+			"untestable: %s", soRenderStockSites(sites))
+	}
+	if sites[0].Expression != declared[0].Expression || sites[1].Expression != declared[1].Expression {
+		t.Fatalf("the nested pair is not in DECLARATION order:\n  got  %s\n  want %s then %s",
+			soRenderStockSites(sites), declared[0].Expression, declared[1].Expression)
+	}
+	t.Logf("measured: baml_go's root readback keeps %d of %d checks sharing a label; the nested twin keeps "+
+		"both in declaration order", len(folded.Checks), len(declared))
+}
+
+// TestServingOracleRootFoldCompletenessBites proves the guard that stands in for
+// the missing raw root: soFoldedSites fails when the fold LOST an entry.
+//
+// The root duplicate-label probe is exactly that case, so it is fed through the
+// same path a fixture takes and required to be REFUSED rather than silently
+// reported as one check.
+func TestServingOracleRootFoldCompletenessBites(t *testing.T) {
+	soEnsureRuntime(t)
+	root := soProbe(t, "probe_root_duplicate_label")
+	res, err := soDriveProbe(root)
+	if err != nil {
+		t.Fatalf("drive %s: %v", root.method(), err)
+	}
+	var sites []soStockSite
+	if _, _, err := soReadStockResult(root.Bundle, res, "$", &sites); err == nil {
+		t.Fatalf("a LOST folded entry was accepted and reported as %s; the root envelope would be "+
+			"silently incomplete", soRenderStockSites(sites))
+	} else if !strings.Contains(err.Error(), "folds the check collection") {
+		t.Fatalf("the refusal does not name the fold: %v", err)
+	}
+	// UNCONDITIONALITY, in the two states the old map-conditional refusal let
+	// through. A declared duplicate cannot be represented by a map-keyed readback
+	// whatever the map contains, so both of these must refuse.
+	dupBundle := root.Bundle
+	for name, checks := range map[string]map[string]shared.Check{
+		"an EMPTY folded map": {},
+		"a map whose surviving entry is a DIFFERENT label": {
+			"other": {Name: "other", Expression: "this > 1", Status: "succeeded"},
+		},
+	} {
+		if _, err := soFoldedSites(dupBundle, "$", checks); err == nil {
+			t.Errorf("a root node declaring a duplicate label was ACCEPTED with %s; the refusal must be "+
+				"driven by the DECLARATION, not by what survived the fold", name)
+		} else if !strings.Contains(err.Error(), "folds the check collection") {
+			t.Errorf("with %s the refusal does not name the fold: %v", name, err)
+		}
+	}
+
+	// The COUNT half of the guard, witnessed directly: stock reporting a label the
+	// schema does not declare there means the readback and the schema describe
+	// different nodes, and no corpus row can produce it.
+	lossless := soFixture(t, "target_int_check_fail")
+	extra := map[string]shared.Check{
+		"gt":       {Name: "gt", Expression: "this > 100", Status: "failed"},
+		"surprise": {Name: "surprise", Expression: "this > 1", Status: "succeeded"},
+	}
+	if _, err := soFoldedSites(lossless.Bundle, "$", extra); err == nil {
+		t.Error("a folded collection carrying a label the schema does not declare was ACCEPTED; the root " +
+			"envelope would silently describe a different node")
+	}
+	// ...and the same call without the stray entry is accepted, so the count check
+	// is about the mismatch rather than about folded collections in general.
+	delete(extra, "surprise")
+	if got, err := soFoldedSites(lossless.Bundle, "$", extra); err != nil {
+		t.Errorf("the matching control was refused: %v", err)
+	} else if len(got) != 1 || got[0].Path != "$" {
+		t.Errorf("the matching control produced %s", soRenderStockSites(got))
+	}
+
+	// CONTROL: a root fixture whose fold is LOSSLESS is accepted, so the guard is
+	// about the loss rather than about root checks in general.
+	f := soFixture(t, "target_int_check_fail")
+	stock := soStockFor(t, f)
+	if len(stock.Sites) != 1 || stock.Sites[0].Path != "$" {
+		t.Fatalf("the lossless root control must report exactly one site at $; got %s",
+			soRenderStockSites(stock.Sites))
+	}
+}
+
+// soProbe looks a probe up by name.
+func soProbe(t *testing.T, name string) servingOracleProbe {
+	t.Helper()
+	for _, p := range servingOracleProbes {
+		if p.Name == name {
+			return p
+		}
+	}
+	t.Fatalf("no probe named %q", name)
+	return servingOracleProbe{}
+}
+
+// soDriveProbe runs one probe through the stock CFFI and returns the DECODED
+// result, so a test can observe what baml_go itself produced.
+func soDriveProbe(p servingOracleProbe) (any, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"text": p.Raw, "stream": false},
+		Env:    soRuntimeEnv,
+	}
+	encoded, err := args.Encode()
+	if err != nil {
+		return nil, err
+	}
+	return soRuntime.CallFunctionParse(context.Background(), p.method(), encoded)
+}
+
+// TestServingOracleRootEnvelopeCertificationIsUnavailable states, as an assertion
+// rather than as a comment, what this oracle CANNOT certify.
+//
+// baml_go folds a root Checked's collection into a map before any registered type
+// is touched, so at a root position stock's ORDER and MULTIPLICITY are destroyed
+// before the oracle can observe them. The honest response is not to reconstruct
+// them from the schema and present the result as observed — it is to mark those
+// sites uncertified, carry the mark into the pinned envelope, and stop the
+// comparator from claiming an order it never saw.
+//
+// This test pins all three, and pins that the limitation is NARROW: every nested
+// site in the corpus is certified.
+func TestServingOracleRootEnvelopeCertificationIsUnavailable(t *testing.T) {
+	soEnsureRuntime(t)
+	certified, uncertified := 0, 0
+	rowsWithUncertified := []string{}
+	for _, f := range servingOracleFixtures {
+		if f.Fatal {
+			continue
+		}
+		stock := soStockFor(t, f)
+		rowUncertified := 0
+		for _, s := range stock.Sites {
+			if s.Certified {
+				certified++
+				if strings.Contains(s.render(), "~uncertified-order") {
+					t.Errorf("%s: a CERTIFIED site renders the uncertified marker: %s", f.Name, s.render())
+				}
+				continue
+			}
+			uncertified++
+			rowUncertified++
+			// The mark must reach the PINNED envelope, or the corpus would not record
+			// which rows rest on unobservable order.
+			if !strings.Contains(s.render(), "~uncertified-order") {
+				t.Errorf("%s: an uncertified site does not render the marker: %s", f.Name, s.render())
+			}
+			// Only ROOT positions can be uncertified: everything nested is read from
+			// the raw tree.
+			if !soIsRootPath(s.Path) {
+				t.Errorf("%s: the NESTED site %s is uncertified; only a root collection is folded",
+					f.Name, s.render())
+			}
+		}
+		if rowUncertified > 0 {
+			rowsWithUncertified = append(rowsWithUncertified, f.Name)
+			if !strings.Contains(f.Stock, "~uncertified-order") {
+				t.Errorf("%s has uncertified root evidence but its PINNED stock envelope does not say so: %s",
+					f.Name, f.Stock)
+			}
+		}
+	}
+	if uncertified == 0 {
+		t.Fatal("no fixture produced an uncertified root site; the unavailability this test describes would " +
+			"be a claim about nothing")
+	}
+	if certified == 0 {
+		t.Fatal("no fixture produced a certified site; the limitation would look total rather than narrow")
+	}
+	sort.Strings(rowsWithUncertified)
+	t.Logf("root-envelope certification UNAVAILABLE for %d site(s) across %v; %d nested sites are certified "+
+		"from the raw CFFI tree", uncertified, rowsWithUncertified, certified)
+}
+
+// soIsRootPath reports whether a path is one of the three ROOT positions a folded
+// collection can occur at.
+func soIsRootPath(path string) bool {
+	if path == "$" {
+		return true
+	}
+	m := soIndexRe.FindStringSubmatch(path)
+	if m != nil && m[1] == "$" && m[3] == "" {
+		return true
+	}
+	return strings.HasPrefix(path, `$["`) && strings.HasSuffix(path, `"]`)
+}
+
+// TestServingOracleUncertifiedComparisonStillBinds proves the weaker standard is
+// still a standard: order is not claimed, but label, expression, path and result
+// are, in both directions.
+func TestServingOracleUncertifiedComparisonStillBinds(t *testing.T) {
+	site := func(label, expr, status string) soStockSite {
+		return soStockSite{Path: "$", Label: label, Expression: expr, Status: status}
+	}
+	nat := func(label, expr string, o constraintStateOutcome) soNativeSite {
+		return soNativeSite{Path: "$", Level: schema.ConstraintCheck, Labeled: true,
+			Label: label, Expression: expr, Outcome: o}
+	}
+	stock := []soStockSite{site("a", "this > 0", "succeeded"), site("b", "this > 9", "failed")}
+
+	// Order is NOT claimed: the same pair in the opposite order is accepted.
+	swapped := []soNativeSite{nat("b", "this > 9", constraintOutcomeFalse), nat("a", "this > 0", constraintOutcomeTrue)}
+	if got := soCompareUncertifiedSites(stock, swapped); len(got) > 0 {
+		t.Fatalf("a reordered but otherwise identical collection must be accepted, because the order was "+
+			"never observed; got %v", got)
+	}
+	// Everything else still binds.
+	for _, tc := range []struct {
+		name   string
+		native []soNativeSite
+	}{
+		{"a differing result", []soNativeSite{
+			nat("a", "this > 0", constraintOutcomeFalse), nat("b", "this > 9", constraintOutcomeFalse)}},
+		{"a differing expression", []soNativeSite{
+			nat("a", "this > 1", constraintOutcomeTrue), nat("b", "this > 9", constraintOutcomeFalse)}},
+		{"a missing predicate", []soNativeSite{nat("a", "this > 0", constraintOutcomeTrue)}},
+		{"an extra DECIDED predicate", []soNativeSite{
+			nat("a", "this > 0", constraintOutcomeTrue), nat("b", "this > 9", constraintOutcomeFalse),
+			nat("c", "this > 2", constraintOutcomeTrue)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := soCompareUncertifiedSites(stock, tc.native); len(soViolations(got)) == 0 {
+				t.Fatalf("%s was accepted; the uncertified comparison drops ORDER only", tc.name)
+			}
+		})
+	}
+	// An extra DECLINED predicate is not a violation: declining is always allowed.
+	extraDeclined := append(append([]soNativeSite(nil), swapped...), nat("c", "this > 2", constraintOutcomeUnsupported))
+	if got := soCompareUncertifiedSites(stock, extraDeclined); len(soViolations(got)) > 0 {
+		t.Fatalf("an extra DECLINED predicate must be accepted; got %v", got)
+	}
+}
+
+// TestServingOracleStripAndDetectCoverEveryCarrier pins that the constraint
+// DETECTOR and BOTH stripped-twin builders traverse the same schema surface, and
+// that stripping removes constraints without erasing anything else.
+//
+// They had drifted apart in three ways, each of which would have made an
+// attribution claim about a bundle the gate never saw: the untagged stripper
+// skipped Type.Items and rebuilt a bundle without RecursiveClasses or the
+// structural aliases; the integration stripper shallow-copied the aliases, leaving
+// their targets' constraints in the "stripped" twin; and the detector never looked
+// inside an alias target, so a carrier could be classified unconstrained.
+//
+// The witness is synthetic on purpose: no corpus fixture uses these carriers today,
+// which is exactly why the drift was invisible.
+func TestServingOracleStripAndDetectCoverEveryCarrier(t *testing.T) {
+	label := func(s string) *string { return &s }
+	constrained := func(base schema.Type) schema.Type {
+		base.Meta.Constraints = []schema.Constraint{
+			{Level: schema.ConstraintCheck, Expression: "this > 0", Label: label("carrier")},
+		}
+		return base
+	}
+
+	// shapeGate names which production gate owns each carrier's SHAPE rejection, so
+	// the control below asserts the accurate thing rather than a blanket "still
+	// declines". They are different gates and Parse runs both: ValidateOutput rejects
+	// tuple/arrow/top/media before checkSupported ever sees the bundle, while a
+	// structural recursive alias is checkSupported's own blanket decline.
+	const (
+		shapeGateValidateOutput = "ValidateOutput"
+		shapeGateCheckSupported = "checkSupported"
+	)
+	carriers := []struct {
+		name      string
+		shapeGate string
+		// gateSeesConstraint says whether checkSupported's own target walk REACHES a
+		// constraint in this carrier. Measured, not assumed, and it is not uniform:
+		//
+		//   tuple item      YES — checkTypeNoConstraints descends into Type.Items
+		//   arrow param     NO  — it does not descend into Arrow at all
+		//   arrow return    NO  — likewise
+		//   alias target    NO  — the blanket structural-recursive-alias decline fires
+		//                         first, so the walk never reaches the target
+		//
+		// That is not an over-claim anywhere: ValidateOutput rejects tuple/arrow/top
+		// before Parse reaches checkSupported, and the alias declines outright. It does
+		// mean the detector/stripper symmetry is the ONLY thing keeping those carriers
+		// honest, which is exactly why this witness exists.
+		gateSeesConstraint bool
+		bundle             func() *schema.Bundle
+	}{
+		{"a constrained TUPLE item", shapeGateValidateOutput, true, func() *schema.Bundle {
+			return &schema.Bundle{Target: schema.Type{
+				Kind:  schema.TypeTuple,
+				Items: []schema.Type{stringType(), constrained(intType())},
+			}}
+		}},
+		{"a constrained STRUCTURAL-ALIAS target", shapeGateCheckSupported, false, func() *schema.Bundle {
+			return &schema.Bundle{
+				Target: stringType(),
+				StructuralRecursiveAliases: []schema.RecursiveAliasDef{{
+					Name:   "JsonValue",
+					Target: schema.Type{Kind: schema.TypeList, Elem: ptr(constrained(intType()))},
+				}},
+			}
+		}},
+		{"a constrained ARROW return", shapeGateValidateOutput, false, func() *schema.Bundle {
+			return &schema.Bundle{Target: schema.Type{
+				Kind:  schema.TypeArrow,
+				Arrow: &schema.ArrowType{Params: []schema.Type{stringType()}, Return: constrained(intType())},
+			}}
+		}},
+		// Arrow.Params is a SECOND []schema.Type carrier inside the same node, and the
+		// return witness above cannot speak for it: with only that row, deleting the
+		// Params traversal from the detector or from either stripper left every witness
+		// green. The unconstrained sibling parameter and the unconstrained return are
+		// what make the structural-preservation assertions below discriminating — a
+		// "fix" that dropped Params entirely would remove the constraint and destroy
+		// the shape.
+		{"a constrained ARROW parameter", shapeGateValidateOutput, false, func() *schema.Bundle {
+			return &schema.Bundle{Target: schema.Type{
+				Kind: schema.TypeArrow,
+				Arrow: &schema.ArrowType{
+					Params: []schema.Type{stringType(), constrained(intType())},
+					Return: stringType(),
+				},
+			}}
+		}},
+	}
+
+	for _, c := range carriers {
+		t.Run(c.name, func(t *testing.T) {
+			b := c.bundle()
+			// 1. The DETECTOR sees it.
+			if !soBundleHasConstraint(b) {
+				t.Fatalf("soBundleHasConstraint does not look inside %s; a carrier would be misclassified "+
+					"as an unconstrained control and assert the opposite of what it claims", c.name)
+			}
+			// 2. BOTH strippers remove it.
+			for name, stripped := range map[string]*schema.Bundle{
+				"soStripConstraints":     soStripConstraints(b),
+				"servingOracleGateStrip": servingOracleGateStrip(b),
+			} {
+				if soBundleHasConstraint(stripped) {
+					t.Errorf("%s left the constraint in %s; the 'stripped twin is admitted' attribution "+
+						"would be about a bundle that still carries one", name, c.name)
+				}
+			}
+			// 3. The twin still declines, and NOT for a constraint. These shapes
+			// (tuple, arrow, structural alias) are outside the native profile on their
+			// own, so the strip must remove the constraint reason while leaving the
+			// shape reason — claiming a constraint-specific admission here would be
+			// claiming something the gate never grants.
+			// Whether checkSupported REACHES this carrier's constraint is measured and
+			// pinned, in both directions, so the table's claim about each gate stays
+			// true rather than becoming folklore.
+			gateErr := checkSupported(b)
+			sawConstraint := gateErr != nil && strings.Contains(gateErr.Error(), "constraint")
+			if sawConstraint != c.gateSeesConstraint {
+				t.Fatalf("%s: checkSupported reaching this carrier's constraint = %v, want %v (err %v). The "+
+					"table records which gate owns which carrier; a change here means the walk moved.",
+					c.name, sawConstraint, c.gateSeesConstraint, gateErr)
+			}
+			for name, stripped := range map[string]*schema.Bundle{
+				"soStripConstraints":     soStripConstraints(b),
+				"servingOracleGateStrip": servingOracleGateStrip(b),
+			} {
+				// The CONSTRAINT reason must be gone — asserted where checkSupported
+				// reaches the carrier at all, and vacuously true where it does not.
+				if err := checkSupported(stripped); err != nil && strings.Contains(err.Error(), "constraint") {
+					t.Errorf("%s left %s declining for a CONSTRAINT reason (%v); the constraint was supposed "+
+						"to be gone", name, c.name, err)
+				} else if c.gateSeesConstraint && err != nil {
+					t.Errorf("%s left %s declining at checkSupported for %v; the constraint was the only "+
+						"reason that gate had", name, c.name, err)
+				}
+				// …and the SHAPE reason must remain, at whichever gate owns it.
+				switch c.shapeGate {
+				case shapeGateValidateOutput:
+					if err := stripped.ValidateOutput(); err == nil {
+						t.Errorf("%s produced a twin of %s that ValidateOutput now ACCEPTS; the shape fact "+
+							"was erased along with the constraint", name, c.name)
+					}
+				case shapeGateCheckSupported:
+					err := checkSupported(stripped)
+					if err == nil {
+						t.Errorf("%s produced a twin of %s that checkSupported now ADMITS; the shape fact "+
+							"(the structural recursive alias) was erased along with the constraint",
+							name, c.name)
+					}
+				default:
+					t.Fatalf("%s: unknown shape gate %q", c.name, c.shapeGate)
+				}
+			}
+
+			// 4. And nothing ELSE is erased: the strip must be a constraint-free CLONE,
+			// not a different bundle. A recursion fact dropped here would remove an
+			// independently decline-causing property from the twin.
+			for name, stripped := range map[string]*schema.Bundle{
+				"soStripConstraints":     soStripConstraints(b),
+				"servingOracleGateStrip": servingOracleGateStrip(b),
+			} {
+				if len(stripped.StructuralRecursiveAliases) != len(b.StructuralRecursiveAliases) {
+					t.Errorf("%s dropped %d structural recursive alias(es) from %s", name,
+						len(b.StructuralRecursiveAliases)-len(stripped.StructuralRecursiveAliases), c.name)
+				}
+				for i, a := range stripped.StructuralRecursiveAliases {
+					if a.Name != b.StructuralRecursiveAliases[i].Name {
+						t.Errorf("%s renamed a structural alias: %q -> %q", name,
+							b.StructuralRecursiveAliases[i].Name, a.Name)
+					}
+				}
+				if len(stripped.Target.Items) != len(b.Target.Items) {
+					t.Errorf("%s dropped tuple items from %s (%d -> %d)", name, c.name,
+						len(b.Target.Items), len(stripped.Target.Items))
+				}
+				if (stripped.Target.Arrow == nil) != (b.Target.Arrow == nil) {
+					t.Errorf("%s dropped the arrow payload from %s", name, c.name)
+					continue
+				}
+				if b.Target.Arrow != nil {
+					// Removing a parameter's constraint by removing the PARAMETER would
+					// satisfy the detector while destroying the shape, so the arity and
+					// each parameter's kind are pinned, as is the return.
+					if len(stripped.Target.Arrow.Params) != len(b.Target.Arrow.Params) {
+						t.Errorf("%s changed the arrow arity of %s (%d -> %d)", name, c.name,
+							len(b.Target.Arrow.Params), len(stripped.Target.Arrow.Params))
+						continue
+					}
+					for i, p := range stripped.Target.Arrow.Params {
+						if p.Kind != b.Target.Arrow.Params[i].Kind {
+							t.Errorf("%s changed arrow parameter %d of %s from %s to %s", name, i, c.name,
+								b.Target.Arrow.Params[i].Kind, p.Kind)
+						}
+						if len(p.Meta.Constraints) > 0 {
+							t.Errorf("%s left a constraint on arrow parameter %d of %s", name, i, c.name)
+						}
+					}
+					if stripped.Target.Arrow.Return.Kind != b.Target.Arrow.Return.Kind {
+						t.Errorf("%s changed the arrow return of %s from %s to %s", name, c.name,
+							b.Target.Arrow.Return.Kind, stripped.Target.Arrow.Return.Kind)
+					}
+				}
+			}
+		})
+	}
+
+	// RECURSION METADATA, which is the fact whose loss would be most misleading: a
+	// bundle that declines for recursion must still decline after stripping, or the
+	// attribution would credit the constraints for a shape decline.
+	rec := &schema.Bundle{
+		Target:           soClassType("Node"),
+		Classes:          []schema.ClassDef{soClassOf("Node", []schema.ClassField{soField("v", constrained(intType()))})},
+		RecursiveClasses: []string{"Node"},
+	}
+	for name, stripped := range map[string]*schema.Bundle{
+		"soStripConstraints":     soStripConstraints(rec),
+		"servingOracleGateStrip": servingOracleGateStrip(rec),
+	} {
+		if len(stripped.RecursiveClasses) != 1 || stripped.RecursiveClasses[0] != "Node" {
+			t.Errorf("%s erased RecursiveClasses; the stripped twin would be ADMITTED for a bundle whose "+
+				"recursion declines independently of its constraints, and the attribution would be false",
+				name)
+		}
+		if err := checkSupported(stripped); err == nil {
+			t.Errorf("%s produced a twin that is ADMITTED even though the original declines for recursion; "+
+				"the constraint attribution would be crediting the wrong cause", name)
+		}
+	}
+}

--- a/internal/debaml/testdata/serving_oracle/constraint_corpus.json
+++ b/internal/debaml/testdata/serving_oracle/constraint_corpus.json
@@ -1,0 +1,5186 @@
+{
+  "version": 1,
+  "prelude": "\nclass Probe {\n  b int\n  a string\n  c int[]\n}\n\nenum Hue {\n  RED @alias(\"rouge\")\n  GREEN\n}\n\nclass NestInner {\n  name int\n  tags string[]\n}\n\nclass Nest {\n  a NestInner\n  name string\n  rows NestInner[]\n}\n",
+  "groups": [
+    {
+      "name": "const",
+      "baml_type": "int",
+      "input": "{\"v\":1}"
+    },
+    {
+      "name": "int7",
+      "baml_type": "int",
+      "input": "{\"v\":7}"
+    },
+    {
+      "name": "intneg",
+      "baml_type": "int",
+      "input": "{\"v\":-3}"
+    },
+    {
+      "name": "int0",
+      "baml_type": "int",
+      "input": "{\"v\":0}"
+    },
+    {
+      "name": "f25",
+      "baml_type": "float",
+      "input": "{\"v\":2.5}"
+    },
+    {
+      "name": "f20",
+      "baml_type": "float",
+      "input": "{\"v\":2.0}"
+    },
+    {
+      "name": "str",
+      "baml_type": "string",
+      "input": "{\"v\":\"Hello World\"}"
+    },
+    {
+      "name": "stre",
+      "baml_type": "string",
+      "input": "{\"v\":\"\"}"
+    },
+    {
+      "name": "stru",
+      "baml_type": "string",
+      "input": "{\"v\":\"h\\u00e9llo \\u2713 \\u65e5\\u672c\"}"
+    },
+    {
+      "name": "boolt",
+      "baml_type": "bool",
+      "input": "{\"v\":true}"
+    },
+    {
+      "name": "boolf",
+      "baml_type": "bool",
+      "input": "{\"v\":false}"
+    },
+    {
+      "name": "list",
+      "baml_type": "int[]",
+      "input": "{\"v\":[1,2,3]}"
+    },
+    {
+      "name": "liste",
+      "baml_type": "int[]",
+      "input": "{\"v\":[]}"
+    },
+    {
+      "name": "listf",
+      "baml_type": "float[]",
+      "input": "{\"v\":[1,2.5]}"
+    },
+    {
+      "name": "lists",
+      "baml_type": "string[]",
+      "input": "{\"v\":[\"a\",\"b\"]}"
+    },
+    {
+      "name": "map",
+      "baml_type": "map<string, int>",
+      "input": "{\"v\":{\"z\":1,\"a\":2,\"m\":3}}"
+    },
+    {
+      "name": "cls",
+      "baml_type": "Probe",
+      "input": "{\"v\":{\"b\":1,\"a\":\"x\",\"c\":[1,2]}}"
+    },
+    {
+      "name": "enum",
+      "baml_type": "Hue",
+      "input": "{\"v\":\"rouge\"}"
+    },
+    {
+      "name": "null",
+      "baml_type": "int?",
+      "input": "{\"v\":null}"
+    },
+    {
+      "name": "strnum",
+      "baml_type": "string",
+      "input": "{\"v\":\"9007199254740993\"}"
+    },
+    {
+      "name": "strnumsm",
+      "baml_type": "string",
+      "input": "{\"v\":\"42\"}"
+    },
+    {
+      "name": "strexact",
+      "baml_type": "string",
+      "input": "{\"v\":\"9007199254740991\"}"
+    },
+    {
+      "name": "liststr2",
+      "baml_type": "string[]",
+      "input": "{\"v\":[\"9007199254740991\",\"1\"]}"
+    },
+    {
+      "name": "listbig",
+      "baml_type": "int[]",
+      "input": "{\"v\":[4503599627370495,4503599627370496]}"
+    },
+    {
+      "name": "fbig",
+      "baml_type": "float",
+      "input": "{\"v\":9223372036854775808.0}"
+    },
+    {
+      "name": "flistbig",
+      "baml_type": "float[]",
+      "input": "{\"v\":[2.0,3.0,9223372036854775808.0]}"
+    },
+    {
+      "name": "flistsm",
+      "baml_type": "float[]",
+      "input": "{\"v\":[2.0,3.0,4.0]}"
+    },
+    {
+      "name": "nest",
+      "baml_type": "Nest",
+      "input": "{\"v\":{\"a\":{\"name\":5,\"tags\":[\"x\",\"y\"]},\"name\":\"x\",\"rows\":[{\"name\":7,\"tags\":[\"z\"]}]}}"
+    }
+  ],
+  "cases": [
+    {
+      "label": "op_add",
+      "group": "const",
+      "expr": "1 + 1 == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_sub",
+      "group": "const",
+      "expr": "1 - 2 == -1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_mul",
+      "group": "const",
+      "expr": "2 * 3 == 6",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_div",
+      "group": "const",
+      "expr": "7 / 2 == 3.5",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_div_int",
+      "group": "const",
+      "expr": "4 / 2 == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_floordiv",
+      "group": "const",
+      "expr": "7 // 2 == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_rem",
+      "group": "const",
+      "expr": "7 % 3 == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_pow",
+      "group": "const",
+      "expr": "2 ** 10 == 1024",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_neg",
+      "group": "const",
+      "expr": "-3 < 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_not",
+      "group": "const",
+      "expr": "not false",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_and",
+      "group": "const",
+      "expr": "(true and false) == false",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_or",
+      "group": "const",
+      "expr": "true or false",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_lt",
+      "group": "const",
+      "expr": "1 < 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_le",
+      "group": "const",
+      "expr": "2 <= 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_gt",
+      "group": "const",
+      "expr": "3 > 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ge",
+      "group": "const",
+      "expr": "3 >= 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_eq",
+      "group": "const",
+      "expr": "1 == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ne",
+      "group": "const",
+      "expr": "1 != 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_concat",
+      "group": "const",
+      "expr": "\"a\" ~ \"b\" == \"ab\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_concat_num",
+      "group": "const",
+      "expr": "1 ~ 2 == \"12\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_in_list",
+      "group": "const",
+      "expr": "1 in [1,2]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_notin_list",
+      "group": "const",
+      "expr": "4 not in [1,2]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_in_str",
+      "group": "const",
+      "expr": "\"ell\" in \"hello\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_in_maplit",
+      "group": "const",
+      "expr": "\"a\" in {\"a\": 1}",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_eq_list",
+      "group": "const",
+      "expr": "[1,2] == [1,2]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_eq_map",
+      "group": "const",
+      "expr": "{\"a\":1} == {\"a\":1}",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_ternary",
+      "group": "const",
+      "expr": "(1 if true else 2) == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_float_int_eq",
+      "group": "const",
+      "expr": "1.0 == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_str_num_eq",
+      "group": "const",
+      "expr": "\"1\" == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_bool_num_eq",
+      "group": "const",
+      "expr": "true == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_none_eq",
+      "group": "const",
+      "expr": "none == none",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_index",
+      "group": "const",
+      "expr": "[1,2][0] == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_index_neg",
+      "group": "const",
+      "expr": "[1,2,3][-1] == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_slice",
+      "group": "const",
+      "expr": "[1,2,3][1:] == [2,3]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_str_index",
+      "group": "const",
+      "expr": "\"abc\"[0] == \"a\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_mixed_arith",
+      "group": "const",
+      "expr": "1 + 1.5 == 2.5",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_i64max",
+      "group": "const",
+      "expr": "9223372036854775807 - 1 == 9223372036854775806",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_float_assoc",
+      "group": "const",
+      "expr": "0.1 + 0.2 == 0.3",
+      "stock": "false",
+      "native": "false"
+    },
+    {
+      "label": "op_div_zero",
+      "group": "const",
+      "expr": "(1 / 0) > 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_floordiv_zero",
+      "group": "const",
+      "expr": "(1 // 0) > 0",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_rem_zero",
+      "group": "const",
+      "expr": "(1 % 0) > 0",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_str_gt_num",
+      "group": "const",
+      "expr": "\"x\" > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_num_lt_list",
+      "group": "const",
+      "expr": "1 < [1]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_undefined_cmp",
+      "group": "const",
+      "expr": "nosuchvar > 0",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_undefined_attr",
+      "group": "const",
+      "expr": "this.nope > 0",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_str_add_num",
+      "group": "const",
+      "expr": "(\"a\" + 1) == \"a1\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_length_str",
+      "group": "const",
+      "expr": "\"abc\"|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_length_list",
+      "group": "const",
+      "expr": "[1,2,3]|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_length_map",
+      "group": "const",
+      "expr": "{\"a\":1,\"b\":2}|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_count_alias",
+      "group": "const",
+      "expr": "\"abc\"|count == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_lower",
+      "group": "const",
+      "expr": "\"ABC\"|lower == \"abc\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_upper",
+      "group": "const",
+      "expr": "\"abc\"|upper == \"ABC\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_capitalize",
+      "group": "const",
+      "expr": "\"abc\"|capitalize == \"Abc\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_title",
+      "group": "const",
+      "expr": "\"a b\"|title == \"A B\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_trim",
+      "group": "const",
+      "expr": "\"  a \"|trim == \"a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_replace",
+      "group": "const",
+      "expr": "\"aXa\"|replace(\"X\",\"-\") == \"a-a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_format",
+      "group": "const",
+      "expr": "\"%s!\"|format(\"hi\") == \"hi!\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_default_present",
+      "group": "const",
+      "expr": "1|default(2) == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_default_missing",
+      "group": "const",
+      "expr": "nosuchvar|default(2) == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_d_alias",
+      "group": "const",
+      "expr": "\"abc\"|d(\"x\") == \"abc\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_escape",
+      "group": "const",
+      "expr": "\"<b>\"|escape == \"<b>\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_e_alias",
+      "group": "const",
+      "expr": "\"<\"|e == \"<\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_safe",
+      "group": "const",
+      "expr": "\"a\"|safe == \"a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_string",
+      "group": "const",
+      "expr": "1|string == \"1\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_string_float",
+      "group": "const",
+      "expr": "2.0|string == \"2.0\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_bool",
+      "group": "const",
+      "expr": "1|bool == true",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_split",
+      "group": "const",
+      "expr": "\"a,b\"|split(\",\")|length == 2",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_lines",
+      "group": "const",
+      "expr": "\"a\\nb\"|lines|length == 2",
+      "retained": "\"a\\\\nb\"|lines|length == 2",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_first",
+      "group": "const",
+      "expr": "[1,2]|first == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_last",
+      "group": "const",
+      "expr": "[1,2]|last == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_reverse",
+      "group": "const",
+      "expr": "[1,2]|reverse|first == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_sort",
+      "group": "const",
+      "expr": "[2,1]|sort|first == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_join",
+      "group": "const",
+      "expr": "[1,2]|join(\"-\") == \"1-2\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_list_str",
+      "group": "const",
+      "expr": "\"ab\"|list|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_unique",
+      "group": "const",
+      "expr": "[1,1,2]|unique|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_min",
+      "group": "const",
+      "expr": "[1,2]|min == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_max",
+      "group": "const",
+      "expr": "[1,2]|max == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_sum_ints",
+      "group": "const",
+      "expr": "[1,2]|sum == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_sum_mixed",
+      "group": "const",
+      "expr": "[1,2.5]|sum == 3.5",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_sum_intfloat",
+      "group": "const",
+      "expr": "[1,2.0]|sum == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_sum_bool",
+      "group": "const",
+      "expr": "[true,1]|sum == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_sum_str",
+      "group": "const",
+      "expr": "[\"a\"]|sum == 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_sum_empty",
+      "group": "const",
+      "expr": "[]|sum == 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_sum_str_arg",
+      "group": "const",
+      "expr": "\"ab\"|sum == 0",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_sum_map",
+      "group": "const",
+      "expr": "{\"a\":1}|sum == 0",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_sum_attr_kwarg",
+      "group": "const",
+      "expr": "[{\"a\":1}]|sum(attribute=\"a\") == 1",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_batch",
+      "group": "const",
+      "expr": "[1,2,3,4]|batch(2)|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_slice",
+      "group": "const",
+      "expr": "[1,2,3]|slice(2)|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_map_filter",
+      "group": "const",
+      "expr": "[1,2]|map(\"string\")|first == \"1\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_select",
+      "group": "const",
+      "expr": "[1,2,3]|select(\"odd\")|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_reject",
+      "group": "const",
+      "expr": "[1,2,3]|reject(\"odd\")|length == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_selectattr",
+      "group": "const",
+      "expr": "[{\"a\":1}]|selectattr(\"a\")|length == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_rejectattr",
+      "group": "const",
+      "expr": "[{\"a\":1}]|rejectattr(\"a\")|length == 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_groupby",
+      "group": "const",
+      "expr": "[{\"k\":\"a\"},{\"k\":\"a\"},{\"k\":\"b\"}]|groupby(\"k\")|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_chain",
+      "group": "const",
+      "expr": "[1,2]|chain([3])|length == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_zip",
+      "group": "const",
+      "expr": "[1,2]|zip([3,4])|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_abs",
+      "group": "const",
+      "expr": "-1|abs == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_int",
+      "group": "const",
+      "expr": "\"2\"|int == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_float",
+      "group": "const",
+      "expr": "\"2.5\"|float == 2.5",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_round",
+      "group": "const",
+      "expr": "2.4|round == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_round_half",
+      "group": "const",
+      "expr": "2.5|round == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_items",
+      "group": "const",
+      "expr": "{\"a\":1}|items|length == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_items_order",
+      "group": "const",
+      "expr": "({\"z\":1,\"a\":2}|items|first|first) == \"z\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_dictsort",
+      "group": "const",
+      "expr": "({\"b\":2,\"a\":1}|dictsort|first|first) == \"a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_attr",
+      "group": "const",
+      "expr": "{\"a\":1}|attr(\"a\") == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_indent",
+      "group": "const",
+      "expr": "\"a\"|indent(2) == \"a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_pprint",
+      "group": "const",
+      "expr": "[1]|pprint == \"[1]\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_tojson_list",
+      "group": "const",
+      "expr": "[1,2]|tojson == \"[1,2]\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_tojson_map",
+      "group": "const",
+      "expr": "({\"z\":1,\"a\":2}|tojson)[2] == \"z\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_urlencode",
+      "group": "const",
+      "expr": "\"a b\"|urlencode == \"a%20b\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_regex_simple",
+      "group": "const",
+      "expr": "\"abc\"|regex_match(\"^a\")",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_regex_class",
+      "group": "const",
+      "expr": "\"(123)456-7890\"|regex_match(\"\\\\(?\\\\d{3}\\\\)?[-.\\\\s]?\\\\d{3}[-.\\\\s]?\\\\d{4}\")",
+      "retained": "\"(123)456-7890\"|regex_match(\"\\\\\\\\(?\\\\\\\\d{3}\\\\\\\\)?[-.\\\\\\\\s]?\\\\\\\\d{3}[-.\\\\\\\\s]?\\\\\\\\d{4}\")",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_regex_bad",
+      "group": "const",
+      "expr": "\"abc\"|regex_match(\"[\")",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_regex_nonstr",
+      "group": "const",
+      "expr": "1|regex_match(\"1\")",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_regex_word",
+      "group": "const",
+      "expr": "\"a b\"|regex_match(\"\\\\ba\\\\b\")",
+      "retained": "\"a b\"|regex_match(\"\\\\\\\\ba\\\\\\\\b\")",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_regex_unicode",
+      "group": "const",
+      "expr": "\"\\u65e5\"|regex_match(\"\\\\p{Han}\")",
+      "retained": "\"\\\\u65e5\"|regex_match(\"\\\\\\\\p{Han}\")",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_regex_noarg",
+      "group": "const",
+      "expr": "\"a\"|regex_match",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_unknown",
+      "group": "const",
+      "expr": "1|nosuchfilter == 1",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "t_defined",
+      "group": "const",
+      "expr": "1 is defined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_undefined",
+      "group": "const",
+      "expr": "nosuchvar is undefined",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "t_none",
+      "group": "const",
+      "expr": "none is none",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_true",
+      "group": "const",
+      "expr": "true is true",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_false",
+      "group": "const",
+      "expr": "false is false",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_odd",
+      "group": "const",
+      "expr": "1 is odd",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_even",
+      "group": "const",
+      "expr": "2 is even",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_divisibleby",
+      "group": "const",
+      "expr": "4 is divisibleby(2)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_eq",
+      "group": "const",
+      "expr": "1 is eq(1)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_equalto",
+      "group": "const",
+      "expr": "1 is equalto(1)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_ne",
+      "group": "const",
+      "expr": "1 is ne(2)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_lt",
+      "group": "const",
+      "expr": "1 is lt(2)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_lessthan",
+      "group": "const",
+      "expr": "1 is lessthan(2)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_le",
+      "group": "const",
+      "expr": "1 is le(1)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_gt",
+      "group": "const",
+      "expr": "2 is gt(1)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_greaterthan",
+      "group": "const",
+      "expr": "2 is greaterthan(1)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_ge",
+      "group": "const",
+      "expr": "2 is ge(2)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_in",
+      "group": "const",
+      "expr": "1 is in([1,2])",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "t_string",
+      "group": "const",
+      "expr": "\"a\" is string",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_number",
+      "group": "const",
+      "expr": "1 is number",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_integer",
+      "group": "const",
+      "expr": "1 is integer",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_int_alias",
+      "group": "const",
+      "expr": "1 is int",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_float",
+      "group": "const",
+      "expr": "1.5 is float",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_boolean",
+      "group": "const",
+      "expr": "true is boolean",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_sequence",
+      "group": "const",
+      "expr": "[1] is sequence",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_mapping",
+      "group": "const",
+      "expr": "{\"a\":1} is mapping",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "t_iterable",
+      "group": "const",
+      "expr": "[1] is iterable",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "t_startingwith",
+      "group": "const",
+      "expr": "\"abc\" is startingwith(\"a\")",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_endingwith",
+      "group": "const",
+      "expr": "\"abc\" is endingwith(\"c\")",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "t_containing",
+      "group": "const",
+      "expr": "\"abc\" is containing(\"b\")",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "t_safe",
+      "group": "const",
+      "expr": "\"a\" is safe",
+      "stock": "false",
+      "native": "false"
+    },
+    {
+      "label": "t_escaped",
+      "group": "const",
+      "expr": "1 is escaped",
+      "stock": "false",
+      "native": "false"
+    },
+    {
+      "label": "t_sameas",
+      "group": "const",
+      "expr": "1 is sameas(1)",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "t_lower",
+      "group": "const",
+      "expr": "\"a\" is lower",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "t_upper",
+      "group": "const",
+      "expr": "\"A\" is upper",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "t_filter",
+      "group": "const",
+      "expr": "\"upper\" is filter",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "t_test",
+      "group": "const",
+      "expr": "\"odd\" is test",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "t_unknown",
+      "group": "const",
+      "expr": "1 is nosuchtest",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_range",
+      "group": "const",
+      "expr": "range(3)|length == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_range_args",
+      "group": "const",
+      "expr": "range(1,4)|first == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_dict",
+      "group": "const",
+      "expr": "dict(a=1)|length == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_namespace",
+      "group": "const",
+      "expr": "namespace(a=1).a == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_cycler",
+      "group": "const",
+      "expr": "cycler(\"a\",\"b\").next() == \"a\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_joiner",
+      "group": "const",
+      "expr": "joiner(\",\")() == \"\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_unknown",
+      "group": "const",
+      "expr": "nosuchfn() == 1",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_upper",
+      "group": "const",
+      "expr": "\"abc\".upper() == \"ABC\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_lower",
+      "group": "const",
+      "expr": "\"ABC\".lower() == \"abc\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_startswith",
+      "group": "const",
+      "expr": "\"abc\".startswith(\"a\")",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_endswith",
+      "group": "const",
+      "expr": "\"abc\".endswith(\"c\")",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_split",
+      "group": "const",
+      "expr": "\"a-b\".split(\"-\")|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_format",
+      "group": "const",
+      "expr": "\"{}\".format(1) == \"1\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_format_commas",
+      "group": "const",
+      "expr": "\"{:,}\".format(1234567) == \"1,234,567\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_format_float",
+      "group": "const",
+      "expr": "\"{:.2f}\".format(3.14159) == \"3.14\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_find",
+      "group": "const",
+      "expr": "\"abc\".find(\"b\") == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_rfind",
+      "group": "const",
+      "expr": "\"abcb\".rfind(\"b\") == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_count",
+      "group": "const",
+      "expr": "\"aba\".count(\"a\") == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_strip",
+      "group": "const",
+      "expr": "\"  a \".strip() == \"a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_lstrip",
+      "group": "const",
+      "expr": "\" a\".lstrip() == \"a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_rstrip",
+      "group": "const",
+      "expr": "\"a \".rstrip() == \"a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_isalpha",
+      "group": "const",
+      "expr": "\"abc\".isalpha()",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_isdigit",
+      "group": "const",
+      "expr": "\"123\".isdigit()",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_isascii",
+      "group": "const",
+      "expr": "\"abc\".isascii()",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_islower",
+      "group": "const",
+      "expr": "\"abc\".islower()",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_isupper",
+      "group": "const",
+      "expr": "\"ABC\".isupper()",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_isspace",
+      "group": "const",
+      "expr": "\"  \".isspace()",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_isalnum",
+      "group": "const",
+      "expr": "\"a1\".isalnum()",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_isnumeric",
+      "group": "const",
+      "expr": "\"1\".isnumeric()",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_title",
+      "group": "const",
+      "expr": "\"a b\".title() == \"A B\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_capitalize",
+      "group": "const",
+      "expr": "\"abc\".capitalize() == \"Abc\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_replace",
+      "group": "const",
+      "expr": "\"aXa\".replace(\"X\",\"-\") == \"a-a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_splitlines",
+      "group": "const",
+      "expr": "\"a\\nb\".splitlines()|length == 2",
+      "retained": "\"a\\\\nb\".splitlines()|length == 2",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_str_join",
+      "group": "const",
+      "expr": "\",\".join([\"a\",\"b\"]) == \"a,b\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_seq_count",
+      "group": "const",
+      "expr": "[1,1].count(1) == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "py_num_method",
+      "group": "const",
+      "expr": "(1).nosuchmethod() == 1",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_int_gt",
+      "group": "int7",
+      "expr": "this > 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_int_eq",
+      "group": "int7",
+      "expr": "this == 7",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_int_abs",
+      "group": "int7",
+      "expr": "this|abs == 7",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_int_odd",
+      "group": "int7",
+      "expr": "this is odd",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_int_arith",
+      "group": "int7",
+      "expr": "this + 1 == 8",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_int_string",
+      "group": "int7",
+      "expr": "this|string == \"7\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_int_in",
+      "group": "int7",
+      "expr": "this in [7]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_int_bare",
+      "group": "int7",
+      "expr": "this",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_intneg_abs",
+      "group": "intneg",
+      "expr": "this|abs == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_intneg_lt",
+      "group": "intneg",
+      "expr": "this < 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_int0_eq",
+      "group": "int0",
+      "expr": "this == 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_int0_bare",
+      "group": "int0",
+      "expr": "this",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_int0_bool",
+      "group": "int0",
+      "expr": "this|bool == false",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_f25_eq",
+      "group": "f25",
+      "expr": "this == 2.5",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_f25_gt",
+      "group": "f25",
+      "expr": "this > 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_f25_round",
+      "group": "f25",
+      "expr": "this|round == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_f25_int",
+      "group": "f25",
+      "expr": "this|int == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_f25_string",
+      "group": "f25",
+      "expr": "this|string == \"2.5\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_f25_isfloat",
+      "group": "f25",
+      "expr": "this is float",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_f20_eq_int",
+      "group": "f20",
+      "expr": "this == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_f20_string",
+      "group": "f20",
+      "expr": "this|string == \"2.0\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_f20_isint",
+      "group": "f20",
+      "expr": "this is integer",
+      "stock": "false",
+      "native": "false"
+    },
+    {
+      "label": "this_f20_sum",
+      "group": "f20",
+      "expr": "[this]|sum == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_str_length",
+      "group": "str",
+      "expr": "this|length == 11",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_str_lower",
+      "group": "str",
+      "expr": "this|lower == \"hello world\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_str_contains",
+      "group": "str",
+      "expr": "\"World\" in this",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_str_regex",
+      "group": "str",
+      "expr": "this|regex_match(\"^Hello\")",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_str_index",
+      "group": "str",
+      "expr": "this[0] == \"H\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_str_split",
+      "group": "str",
+      "expr": "this|split(\" \")|length == 2",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_str_isstring",
+      "group": "str",
+      "expr": "this is string",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_stre_length",
+      "group": "stre",
+      "expr": "this|length == 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_stre_eq",
+      "group": "stre",
+      "expr": "this == \"\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_stre_nonempty",
+      "group": "stre",
+      "expr": "this|length > 0",
+      "stock": "false",
+      "native": "false"
+    },
+    {
+      "label": "this_stre_bare",
+      "group": "stre",
+      "expr": "this",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_stru_length",
+      "group": "stru",
+      "expr": "this|length == 10",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_stru_upper",
+      "group": "stru",
+      "expr": "this|upper == \"HÉLLO ✓ 日本\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_stru_regex",
+      "group": "stru",
+      "expr": "this|regex_match(\"日\")",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_stru_in",
+      "group": "stru",
+      "expr": "\"✓\" in this",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_stru_index",
+      "group": "stru",
+      "expr": "this[1] == \"é\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_boolt_bare",
+      "group": "boolt",
+      "expr": "this",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_boolt_eq",
+      "group": "boolt",
+      "expr": "this == true",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_boolt_eq_num",
+      "group": "boolt",
+      "expr": "this == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_boolf_not",
+      "group": "boolf",
+      "expr": "not this",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_boolf_bare",
+      "group": "boolf",
+      "expr": "this",
+      "stock": "false",
+      "native": "false"
+    },
+    {
+      "label": "this_list_length",
+      "group": "list",
+      "expr": "this|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_list_sum",
+      "group": "list",
+      "expr": "this|sum == 6",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_list_in",
+      "group": "list",
+      "expr": "1 in this",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_list_index",
+      "group": "list",
+      "expr": "this[0] == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_list_first",
+      "group": "list",
+      "expr": "this|first == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_list_join",
+      "group": "list",
+      "expr": "this|join(\",\") == \"1,2,3\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_list_max",
+      "group": "list",
+      "expr": "this|max == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_list_sortlast",
+      "group": "list",
+      "expr": "this|sort|last == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_list_isseq",
+      "group": "list",
+      "expr": "this is sequence",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_list_eq",
+      "group": "list",
+      "expr": "this == [1,2,3]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_liste_length",
+      "group": "liste",
+      "expr": "this|length == 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_liste_sum",
+      "group": "liste",
+      "expr": "this|sum == 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_liste_first",
+      "group": "liste",
+      "expr": "this|first is undefined",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_listf_sum",
+      "group": "listf",
+      "expr": "this|sum == 3.5",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_lists_join",
+      "group": "lists",
+      "expr": "this|join(\"\") == \"ab\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_lists_in",
+      "group": "lists",
+      "expr": "\"a\" in this",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_length",
+      "group": "map",
+      "expr": "this|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_map_item",
+      "group": "map",
+      "expr": "this[\"z\"] == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_map_attr",
+      "group": "map",
+      "expr": "this.z == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_map_order",
+      "group": "map",
+      "expr": "this|list|join(\",\") == \"z,a,m\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_in",
+      "group": "map",
+      "expr": "\"z\" in this",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_notin",
+      "group": "map",
+      "expr": "\"q\" not in this",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_keys",
+      "group": "map",
+      "expr": "this.keys()|join(\",\") == \"z,a,m\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_values",
+      "group": "map",
+      "expr": "this.values()|sum == 6",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_items",
+      "group": "map",
+      "expr": "this.items()|length == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_get",
+      "group": "map",
+      "expr": "this.get(\"z\") == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_get_missing",
+      "group": "map",
+      "expr": "this.get(\"q\") == none",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_get_default",
+      "group": "map",
+      "expr": "this.get(\"q\", 9) == 9",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_items_filter",
+      "group": "map",
+      "expr": "this|items|length == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_dictsort",
+      "group": "map",
+      "expr": "(this|dictsort|first|first) == \"a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_tojson",
+      "group": "map",
+      "expr": "(this|tojson)[2] == \"z\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_ismapping",
+      "group": "map",
+      "expr": "this is mapping",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_map_first",
+      "group": "map",
+      "expr": "this|first == \"z\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_sum",
+      "group": "map",
+      "expr": "this|sum == 0",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_eq",
+      "group": "map",
+      "expr": "this == {\"z\":1,\"a\":2,\"m\":3}",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_missing_attr",
+      "group": "map",
+      "expr": "this.q is undefined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_cls_attr",
+      "group": "cls",
+      "expr": "this.b == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_cls_attr_str",
+      "group": "cls",
+      "expr": "this.a == \"x\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_cls_nested",
+      "group": "cls",
+      "expr": "this.c|sum == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_cls_order",
+      "group": "cls",
+      "expr": "this|list|join(\",\") == \"b,a,c\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_cls_in",
+      "group": "cls",
+      "expr": "\"a\" in this",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_cls_length",
+      "group": "cls",
+      "expr": "this|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_cls_ismapping",
+      "group": "cls",
+      "expr": "this is mapping",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_cls_item",
+      "group": "cls",
+      "expr": "this[\"b\"] == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_cls_keys",
+      "group": "cls",
+      "expr": "this.keys()|join(\",\") == \"b,a,c\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_enum_eq",
+      "group": "enum",
+      "expr": "this == \"RED\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_enum_alias",
+      "group": "enum",
+      "expr": "this == \"rouge\"",
+      "stock": "false",
+      "native": "false"
+    },
+    {
+      "label": "this_enum_length",
+      "group": "enum",
+      "expr": "this|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_enum_isstring",
+      "group": "enum",
+      "expr": "this is string",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_enum_in",
+      "group": "enum",
+      "expr": "this in [\"RED\",\"GREEN\"]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_null_eq",
+      "group": "null",
+      "expr": "this == none",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_null_isnone",
+      "group": "null",
+      "expr": "this is none",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_null_defined",
+      "group": "null",
+      "expr": "this is defined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_null_string",
+      "group": "null",
+      "expr": "this|string == \"none\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_null_default",
+      "group": "null",
+      "expr": "this|default(1) == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_null_bare",
+      "group": "null",
+      "expr": "this",
+      "stock": "no-checks",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_debug",
+      "group": "const",
+      "expr": "debug()|length > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_lipsum",
+      "group": "const",
+      "expr": "lipsum(1)|length > 0",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_str_lt_str",
+      "group": "const",
+      "expr": "\"a\" < \"b\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_empty_map",
+      "group": "const",
+      "expr": "{}|length == 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_empty_list",
+      "group": "const",
+      "expr": "[]|length == 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_sort_kwarg",
+      "group": "const",
+      "expr": "[1,2]|sort(reverse=true)|first == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_default_boolean",
+      "group": "const",
+      "expr": "\"\"|default(\"b\", true) == \"b\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_length_none",
+      "group": "const",
+      "expr": "none|length == 0",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_string_list",
+      "group": "const",
+      "expr": "([1,2]|string)[0] == \"[\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_string_map",
+      "group": "const",
+      "expr": "({\"z\":1}|string)[0] == \"{\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_string",
+      "group": "map",
+      "expr": "(this|string)[0] == \"{\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_string_len",
+      "group": "map",
+      "expr": "(this|string)|length == 24",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_cls_string_len",
+      "group": "cls",
+      "expr": "(this|string)|length == 33",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_list_string",
+      "group": "list",
+      "expr": "(this|string)[0] == \"[\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_cls_nested_index",
+      "group": "cls",
+      "expr": "this.c[0] == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_map_last",
+      "group": "map",
+      "expr": "this|last == \"m\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_values_join",
+      "group": "map",
+      "expr": "this.values()|join(\",\") == \"1,2,3\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_stru_isascii",
+      "group": "stru",
+      "expr": "this|length > 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "f_maplit_order",
+      "group": "const",
+      "expr": "({\"z\":1,\"a\":2}|list|join(\",\")) == \"z,a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_maplit_first",
+      "group": "const",
+      "expr": "{\"z\":1,\"a\":2}|first == \"z\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_maplit_string",
+      "group": "const",
+      "expr": "({\"z\":1,\"a\":2}|string)[2] == \"z\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_maplit_reverse",
+      "group": "const",
+      "expr": "({\"z\":1,\"a\":2}|reverse|first) == \"a\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_split_first",
+      "group": "const",
+      "expr": "\"a,b\"|split(\",\")|first == \"a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_split_join",
+      "group": "const",
+      "expr": "(\"a,b\"|split(\",\")|join(\"-\")) == \"a-b\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_length_undefined",
+      "group": "const",
+      "expr": "nosuchvar|length == 0",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_length_int",
+      "group": "const",
+      "expr": "1|length == 0",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_map_concat",
+      "group": "map",
+      "expr": "(this ~ \"\")|length == 24",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_cls_concat",
+      "group": "cls",
+      "expr": "(this ~ \"\")|length == 33",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "num_exact_max",
+      "group": "const",
+      "expr": "9007199254740991 == 9007199254740991",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "num_conflate",
+      "group": "const",
+      "expr": "9007199254740993 == 9007199254740992",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "num_at_boundary",
+      "group": "const",
+      "expr": "9007199254740992 == 9007199254740992",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "num_add_inrange",
+      "group": "const",
+      "expr": "9007199254740990 + 1 == 9007199254740991",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "num_i64_min",
+      "group": "const",
+      "expr": "0 - 9223372036854775807 == -9223372036854775807",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "num_mul_escape",
+      "group": "const",
+      "expr": "3037000500 * 3037000500 > 9007199254740992",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "num_small_mul",
+      "group": "const",
+      "expr": "1000 * 1000 == 1000000",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "num_pow_small",
+      "group": "const",
+      "expr": "2 ** 3 == 8",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "num_float_big",
+      "group": "const",
+      "expr": "1.0e300 > 1.0e299",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_int_big_cmp",
+      "group": "int7",
+      "expr": "this * 1000000000 < 9007199254740992",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_int_boundary",
+      "group": "const",
+      "expr": "\"9007199254740993\"|int == \"9007199254740992\"|int",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_int_small",
+      "group": "const",
+      "expr": "\"42\"|int == 42",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_int_map_boundary",
+      "group": "const",
+      "expr": "[\"9007199254740993\"]|map(\"int\")|first > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_int_float_exempt",
+      "group": "const",
+      "expr": "\"9007199254740993\"|float == \"9007199254740992\"|float",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_strnum_int",
+      "group": "strnum",
+      "expr": "this|int > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_strnum_length",
+      "group": "strnum",
+      "expr": "this|length == 16",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_strnumsm_int",
+      "group": "strnumsm",
+      "expr": "this|int == 42",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "num_add_escape",
+      "group": "const",
+      "expr": "9007199254740991 + 1 == 9007199254740992",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "num_pow_escape",
+      "group": "const",
+      "expr": "2 ** 62 > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "num_mul_inrange",
+      "group": "const",
+      "expr": "3000000 * 3000000 == 9000000000000",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_strexact_compose",
+      "group": "strexact",
+      "expr": "this|int + 1 + 1 == this|int + 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_strexact_mul",
+      "group": "strexact",
+      "expr": "this|int * 2 > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_strexact_pow",
+      "group": "strexact",
+      "expr": "this|int ** 2 > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_strexact_int",
+      "group": "strexact",
+      "expr": "this|int == 9007199254740991",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_strexact_length",
+      "group": "strexact",
+      "expr": "this|length == 16",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_liststr_mapsum_compose",
+      "group": "liststr2",
+      "expr": "this|map(\"int\")|sum + 1 + 1 == this|map(\"int\")|sum + 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_liststr_mapsum",
+      "group": "liststr2",
+      "expr": "this|map(\"int\")|sum > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_listbig_sum_arith",
+      "group": "listbig",
+      "expr": "this|sum + 1 == this|sum",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "this_listbig_sum",
+      "group": "listbig",
+      "expr": "this|sum > 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_listbig_max_arith",
+      "group": "listbig",
+      "expr": "this|max + 1 + 1 == this|max + 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_length_arith",
+      "group": "const",
+      "expr": "[1,2]|length + 1 == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "f_abs_arith",
+      "group": "const",
+      "expr": "-1|abs + 1 == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "num_pow_oversized",
+      "group": "const",
+      "expr": "1 ** 9007199254740991 == 1",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "lit_hex",
+      "group": "const",
+      "expr": "0x20000000000001 == 0x20000000000000",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "lit_underscore",
+      "group": "const",
+      "expr": "9_007_199_254_740_993 == 9_007_199_254_740_992",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "lit_binary",
+      "group": "const",
+      "expr": "0b1 + 0b1 == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "lit_octal",
+      "group": "const",
+      "expr": "0o7 + 1 == 8",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "lit_exponent",
+      "group": "const",
+      "expr": "1e5 + 1 == 100001",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "ws_newline_static",
+      "group": "const",
+      "expr": "9007199254740991 \n + 1 \n + 1 == 9007199254740991 \n + 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "ws_newline_small",
+      "group": "const",
+      "expr": "1 \n + 1 == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_strexact_newline",
+      "group": "strexact",
+      "expr": "this|int \n + 1 \n + 1 == this|int \n + 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_range_last_big",
+      "group": "const",
+      "expr": "range(9007199254740990.0, 9007199254740994.0, 2.0)|last == range(9007199254740992.0, 9007199254740994.0, 1.0)|last",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_range_last_small",
+      "group": "const",
+      "expr": "range(3)|last == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "pow_negative_exp",
+      "group": "const",
+      "expr": "2 ** -1 == 0.5",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "pow_float_exp",
+      "group": "const",
+      "expr": "2 ** 0.5 > 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "pow_parenthesised",
+      "group": "const",
+      "expr": "2 ** (10) == 1024",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "pow_double_paren",
+      "group": "const",
+      "expr": "((2)) ** ((10)) == 1024",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "arith_paren_group",
+      "group": "const",
+      "expr": "(1 + 2) * 3 == 9",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "pow_computed_neg_exp",
+      "group": "const",
+      "expr": "2 ** (0 - 1) == 0.5",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "pow_computed_neg_exp2",
+      "group": "const",
+      "expr": "2 ** (1 - 3) == 0.25",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "pow_paren_neg_exp",
+      "group": "const",
+      "expr": "2 ** (-1) == 0.5",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "pow_computed_exp",
+      "group": "const",
+      "expr": "2 ** (1 + 1) == 4",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "pow_floordiv_exp",
+      "group": "const",
+      "expr": "2 ** (4 // 2) == 4",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "pow_nested",
+      "group": "const",
+      "expr": "2 ** 3 ** 2 == 512",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "pow_zero_exp",
+      "group": "const",
+      "expr": "2 ** 0 == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "rem_negative_lhs",
+      "group": "const",
+      "expr": "-1 % 2 == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "rem_negative_rhs",
+      "group": "const",
+      "expr": "7 % -3 == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "rem_computed_neg",
+      "group": "const",
+      "expr": "(0 - 1) % 2 == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "floordiv_negative_rhs",
+      "group": "const",
+      "expr": "1 // -2 == 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "floordiv_negative_lhs",
+      "group": "const",
+      "expr": "-7 // 2 == -4",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "floordiv_computed_neg",
+      "group": "const",
+      "expr": "1 // (0 - 2) == 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "rem_paren_literals",
+      "group": "const",
+      "expr": "(7) % (3) == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "floordiv_paren_literals",
+      "group": "const",
+      "expr": "(7) // (2) == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "div_negative",
+      "group": "const",
+      "expr": "-7 / 2 == -3.5",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "ws_crlf_static",
+      "group": "const",
+      "expr": "9007199254740991 \r\n + 1 \r\n + 1 == 9007199254740991 \r\n + 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "ws_crlf_small",
+      "group": "const",
+      "expr": "1 \r\n + 1 == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "this_strexact_crlf",
+      "group": "strexact",
+      "expr": "this|int \r\n + 1 \r\n + 1 == this|int \r\n + 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "add_sub_neg_chain",
+      "group": "const",
+      "expr": "(1 - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999)) == (2 - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999))",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "add_sub_neg_chain_gt",
+      "group": "const",
+      "expr": "(1 - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999) - (-999999999999999)) > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "add_pos_chain",
+      "group": "const",
+      "expr": "1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 == 2 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "add_two_near_2p52",
+      "group": "const",
+      "expr": "4503599627370496 + 4503599627370496 == 9007199254740992",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "add_sub_neg_small",
+      "group": "const",
+      "expr": "1 - (-2) == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "add_sub_chain_small",
+      "group": "const",
+      "expr": "7 - 2 - 1 == 4",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "add_pos_small",
+      "group": "const",
+      "expr": "1000000 + 1000000 == 2000000",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "add_sub_neg_big_single",
+      "group": "const",
+      "expr": "9007199254740991 - (-1) == 9007199254740992",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "sat_float_handoff_add",
+      "group": "const",
+      "expr": "(1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 - 1 + 0.0) == (1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 0.0)",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "sat_float_handoff_mul",
+      "group": "const",
+      "expr": "(1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 - 1) * 1.0 == (1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999) * 1.0",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "sat_float_handoff_div",
+      "group": "const",
+      "expr": "(1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 - 1) / 1.0 == (1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999) / 1.0",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "sat_float_handoff_sub",
+      "group": "const",
+      "expr": "(1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 - 1) - 0.0 == (1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999) - 0.0",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "sat_float_left",
+      "group": "const",
+      "expr": "0.0 + (1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 - 1) == 0.0 + (1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999)",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "sat_float_base_pow",
+      "group": "const",
+      "expr": "((1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999) * 1.0) ** 1 == ((1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 - 1) * 1.0) ** 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "sat_float_nested",
+      "group": "const",
+      "expr": "(((1 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999 + 999999999999999) + 0.0) - 1.0) * 2.0 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "sat_ctl_float_add",
+      "group": "const",
+      "expr": "(1 + 2 + 0.0) == (3 + 0.0)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "sat_ctl_float_mul",
+      "group": "const",
+      "expr": "(1 + 2) * 1.0 == 3 * 1.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "sat_ctl_float_div",
+      "group": "const",
+      "expr": "(1 + 2) / 1.0 == 3.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "sat_ctl_float_left",
+      "group": "const",
+      "expr": "0.0 + (1 + 2) == 0.0 + 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "sat_ctl_float_base_pow",
+      "group": "const",
+      "expr": "(3 * 1.0) ** 1 == 3.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "sat_ctl_float_nested",
+      "group": "const",
+      "expr": "((1 + 2 + 0.0) - 1.0) * 2.0 > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "fpow_int64_boundary",
+      "group": "const",
+      "expr": "2.0 ** 63 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fpow_at_2p53",
+      "group": "const",
+      "expr": "2.0 ** 53 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fpow_paren_base",
+      "group": "const",
+      "expr": "(2.0) ** 63 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fpow_neg_base",
+      "group": "const",
+      "expr": "(-2.0) ** 63 < 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fpow_big_base",
+      "group": "const",
+      "expr": "999999999999999.0 ** 2 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fpow_computed_base_div",
+      "group": "const",
+      "expr": "(2.0 / 0.0000000000001) ** 2 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fpow_computed_base_add",
+      "group": "const",
+      "expr": "(1.0 + 1.0) ** 63 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fpow_float_exponent",
+      "group": "const",
+      "expr": "2.0 ** 63.0 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fpow_int_base_float_exp",
+      "group": "const",
+      "expr": "2 ** 3.0 == 8",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "frem_float_operand",
+      "group": "const",
+      "expr": "4.0 % 3 == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "frem_past_int64",
+      "group": "const",
+      "expr": "1000000000000000.0 * 1000.0 % 3 == 0",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "ffloordiv_float_operands",
+      "group": "const",
+      "expr": "7.0 // 2.0 == 3.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fpow_ctl_small",
+      "group": "const",
+      "expr": "2.0 ** 3 == 8.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "fpow_ctl_small_vs_int",
+      "group": "const",
+      "expr": "2.0 ** 3 == 8",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "fpow_ctl_below_2p53",
+      "group": "const",
+      "expr": "2.0 ** 52 > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "fpow_ctl_fraction_base",
+      "group": "const",
+      "expr": "0.5 ** 3 == 0.125",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "fpow_ctl_nonintegral_base",
+      "group": "const",
+      "expr": "2.5 ** 2 == 6.25",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "fpow_ctl_ten",
+      "group": "const",
+      "expr": "10.0 ** 3 == 1000.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "fmul_big_integral_floats",
+      "group": "const",
+      "expr": "999999999999999.0 * 999999999999999.0 > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "fadd_big_integral_floats",
+      "group": "const",
+      "expr": "999999999999999.0 + 999999999999999.0 > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "fdiv_floats",
+      "group": "const",
+      "expr": "7.0 / 2.0 == 3.5",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "prom_compose_mul",
+      "group": "const",
+      "expr": "(2.0 ** 52) * (2.0 ** 11) > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_compose_mul_even",
+      "group": "const",
+      "expr": "(2.0 ** 26) * (2.0 ** 27) > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_times_int_literal",
+      "group": "const",
+      "expr": "(2.0 ** 52) * 2 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_int_literal_times",
+      "group": "const",
+      "expr": "2 * (2.0 ** 52) > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_compose_add",
+      "group": "const",
+      "expr": "(2.0 ** 52) + (2.0 ** 52) > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_compose_sub",
+      "group": "const",
+      "expr": "(2.0 ** 52) - (2.0 ** 52) == 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_compose_nested",
+      "group": "const",
+      "expr": "((2.0 ** 26) * (2.0 ** 26)) * 2 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_as_pow_base",
+      "group": "const",
+      "expr": "(2.0 ** 52) ** 2 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_base_four",
+      "group": "const",
+      "expr": "(4.0 ** 26) * (4.0 ** 1) > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_base_ten",
+      "group": "const",
+      "expr": "(10.0 ** 15) * (10.0 ** 3) > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_into_floordiv",
+      "group": "const",
+      "expr": "(2.0 ** 52) // 1 > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_into_rem",
+      "group": "const",
+      "expr": "(2.0 ** 52) % 3 == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_then_compare",
+      "group": "const",
+      "expr": "(2.0 ** 52) * (2.0 ** 11) == 9223372036854775808",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "prom_ctl_compose_mul",
+      "group": "const",
+      "expr": "(2.0 ** 3) * (2.0 ** 4) == 128.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "prom_ctl_compose_add",
+      "group": "const",
+      "expr": "(2.0 ** 3) + (2.0 ** 4) == 24.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "prom_ctl_compose_sub",
+      "group": "const",
+      "expr": "(2.0 ** 3) - 1 == 7",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "prom_ctl_half_bound",
+      "group": "const",
+      "expr": "(2.0 ** 26) * (2.0 ** 26) > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "prom_ctl_float_operand",
+      "group": "const",
+      "expr": "(2.0 ** 52) * 2.0 > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "prom_ctl_float_add",
+      "group": "const",
+      "expr": "(2.0 ** 52) + 1.0 > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "prom_ctl_nonintegral",
+      "group": "const",
+      "expr": "(2.5 ** 2) * (2.5 ** 2) == 39.0625",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "payload_round_mul",
+      "group": "const",
+      "expr": "(562949953421312.000000000000001 ** 1) * 16384 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "payload_round_via_pow",
+      "group": "const",
+      "expr": "(562949953421312.000000000000001 ** 1) * (2.0 ** 14) > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "payload_round_nines",
+      "group": "const",
+      "expr": "(999999999999999.000000000000001 ** 1) * 16 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "payload_round_additive",
+      "group": "const",
+      "expr": "(562949953421312.000000000000001 ** 1) * 8 + (2.0 ** 52) > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "payload_canonical_spelling",
+      "group": "const",
+      "expr": "(562949953421312.0 ** 1) * 16384 > 0.0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "payload_neighbour_half",
+      "group": "const",
+      "expr": "(562949953421312.5 ** 1) * 16384 > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "payload_neighbour_quarter",
+      "group": "const",
+      "expr": "(562949953421312.25 ** 1) * 16384 > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "payload_small_nonintegral",
+      "group": "const",
+      "expr": "(2.000000000000001 ** 52) * (2.0 ** 11) > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "payload_round_direct_mul",
+      "group": "const",
+      "expr": "562949953421312.000000000000001 * 16384 > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "payload_round_small_pow",
+      "group": "const",
+      "expr": "(2.000000000000000 ** 3) == 8.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "payload_round_in_range",
+      "group": "const",
+      "expr": "(562949953421312.000000000000001 ** 1) * 4 > 0.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "asint_float_even",
+      "group": "fbig",
+      "expr": "this is even",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_float_odd",
+      "group": "fbig",
+      "expr": "this is odd",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_float_divisibleby",
+      "group": "fbig",
+      "expr": "this is divisibleby(2)",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_float_integer",
+      "group": "fbig",
+      "expr": "this is integer",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_float_abs",
+      "group": "fbig",
+      "expr": "this|abs > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_float_int",
+      "group": "fbig",
+      "expr": "this|int > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_float_compare",
+      "group": "fbig",
+      "expr": "this > 0",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_float_string",
+      "group": "fbig",
+      "expr": "this|string != \"\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_select_even",
+      "group": "flistbig",
+      "expr": "this|select(\"even\")|list|length == 2",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_reject_odd",
+      "group": "flistbig",
+      "expr": "this|reject(\"odd\")|list|length == 2",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_list_elem_even",
+      "group": "flistbig",
+      "expr": "this[2] is even",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_list_sum",
+      "group": "flistbig",
+      "expr": "this|sum > 0",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_ctl_small_even",
+      "group": "f20",
+      "expr": "this is even",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "asint_ctl_small_odd",
+      "group": "f20",
+      "expr": "this is odd",
+      "stock": "false",
+      "native": "false"
+    },
+    {
+      "label": "asint_ctl_small_divisibleby",
+      "group": "f20",
+      "expr": "this is divisibleby(2)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "asint_ctl_small_abs",
+      "group": "f20",
+      "expr": "this|abs == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "asint_ctl_nonintegral_even",
+      "group": "f25",
+      "expr": "this is even",
+      "stock": "false",
+      "native": "false"
+    },
+    {
+      "label": "asint_ctl_select_even",
+      "group": "flistsm",
+      "expr": "this|select(\"even\")|list|length == 3",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_ctl_reject_odd",
+      "group": "flistsm",
+      "expr": "this|reject(\"odd\")|list|length == 3",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "asint_ctl_list_elem_even",
+      "group": "flistsm",
+      "expr": "this[2] is even",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "asint_ctl_literal_even",
+      "group": "const",
+      "expr": "4 is even",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "slice_start_bigfloat",
+      "group": "const",
+      "expr": "[1,2,3][((\"9223372036854\" ~ \"775808\")|float):]|length == 3",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_stop_bigfloat",
+      "group": "const",
+      "expr": "[1,2,3][:((\"9223372036854\" ~ \"775808\")|float)]|length == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_step_bigfloat",
+      "group": "const",
+      "expr": "[1,2,3][::((\"9223372036854\" ~ \"775808\")|float)]|length == 3",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "index_bigfloat",
+      "group": "const",
+      "expr": "[1,2,3][((\"9223372036854\" ~ \"775808\")|float)] == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "index_this_bigfloat",
+      "group": "list",
+      "expr": "this[((\"9223372036854\" ~ \"775808\")|float)] == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_this_bigfloat",
+      "group": "str",
+      "expr": "this[((\"9223372036854\" ~ \"775808\")|float):] == \"H\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "index_filter_derived",
+      "group": "list",
+      "expr": "this[this|length] == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_filter_derived",
+      "group": "list",
+      "expr": "this[0:this|length]|length == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "index_intcast_derived",
+      "group": "list",
+      "expr": "this[\"9007199254740993\"|int] == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "index_float_literal",
+      "group": "const",
+      "expr": "[1,2,3][1.0] == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "index_nested_brackets",
+      "group": "const",
+      "expr": "[[1],[2]][0][0] == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "index_ctl_literal",
+      "group": "const",
+      "expr": "[1,2,3][0] == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "slice_ctl_from",
+      "group": "const",
+      "expr": "[1,2,3][1:]|length == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "slice_ctl_to",
+      "group": "const",
+      "expr": "[1,2,3][:2]|length == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "slice_ctl_step",
+      "group": "const",
+      "expr": "[1,2,3][::2]|length == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "slice_ctl_all_three",
+      "group": "const",
+      "expr": "[1,2,3][0:3:1]|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "index_ctl_this",
+      "group": "list",
+      "expr": "this[0] == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "slice_ctl_this",
+      "group": "list",
+      "expr": "this[1:]|length == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "index_ctl_string",
+      "group": "str",
+      "expr": "this[0] == \"H\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "slice_ctl_string",
+      "group": "str",
+      "expr": "this[1:3] == \"el\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "index_ctl_mapping",
+      "group": "map",
+      "expr": "this[\"z\"] == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "index_ctl_list_literal",
+      "group": "const",
+      "expr": "\"a\" in [\"a\",\"b\"]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_start_fractional",
+      "group": "const",
+      "expr": "[1,2,3][1.5:]|length == 3",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_stop_fractional",
+      "group": "const",
+      "expr": "[1,2,3][:1.5]|length == 3",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_step_fractional",
+      "group": "const",
+      "expr": "[1,2,3][::1.5]|length == 3",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_start_string",
+      "group": "const",
+      "expr": "[1,2,3][\"x\":]|length == 3",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_stop_string",
+      "group": "const",
+      "expr": "[1,2,3][:\"x\"]|length == 3",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "index_fractional_direct",
+      "group": "const",
+      "expr": "[1,2,3][1.5] == 2",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_this_fractional",
+      "group": "str",
+      "expr": "this[1.5:] == \"H\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_ctl_step_one",
+      "group": "const",
+      "expr": "[1,2,3][::1]|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "slice_ctl_open_both",
+      "group": "const",
+      "expr": "[1,2,3][:]|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "index_ctl_string_key_seq",
+      "group": "const",
+      "expr": "[1,2,3][\"x\"] == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "slice_ctl_negative_start",
+      "group": "const",
+      "expr": "[1,2,3][-1:]|length == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "index_ctl_negative",
+      "group": "const",
+      "expr": "[1,2,3][-1] == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "list_ctl_fractional_elems",
+      "group": "const",
+      "expr": "[1.5,2.5]|sum == 4.0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "arity_divisibleby_float",
+      "group": "const",
+      "expr": "1.5 is divisibleby(0.5)",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_divisibleby_float_subject",
+      "group": "const",
+      "expr": "4.0 is divisibleby(2)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "arity_divisibleby_float_divisor",
+      "group": "const",
+      "expr": "4 is divisibleby(2.0)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "arity_slice_zero",
+      "group": "const",
+      "expr": "[1,2,3]|slice(0)|length == 1",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_slice_fractional",
+      "group": "const",
+      "expr": "[1,2,3]|slice(1.5)|length == 1",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_batch_zero",
+      "group": "const",
+      "expr": "[1,2,3]|batch(0)|length == 1",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_batch_fractional",
+      "group": "const",
+      "expr": "[1,2,3]|batch(1.5)|length == 1",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_replace_extra_arg",
+      "group": "const",
+      "expr": "\"aaa\"|replace(\"a\",\"b\",1) == \"baa\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_tojson_indent_frac",
+      "group": "const",
+      "expr": "[1,2]|tojson(indent=1.5) != \"\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_truncate_zero",
+      "group": "str",
+      "expr": "this|truncate(0) != \"\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_indent_fractional",
+      "group": "str",
+      "expr": "this|indent(1.5) != \"\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_format_extra_arg",
+      "group": "const",
+      "expr": "1|format(\"%d\",\"x\") == \"1\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_ctl_divisibleby_int",
+      "group": "const",
+      "expr": "9 is divisibleby(3)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "arity_ctl_slice_two",
+      "group": "const",
+      "expr": "[1,2,3]|slice(2)|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_ctl_batch_two",
+      "group": "const",
+      "expr": "[1,2,3]|batch(2)|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "arity_ctl_replace_two",
+      "group": "const",
+      "expr": "\"aaa\"|replace(\"a\",\"b\") == \"bbb\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "neg_ctl_slice_start",
+      "group": "const",
+      "expr": "[1,2,3][-1:]|length == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "neg_ctl_slice_start_two",
+      "group": "const",
+      "expr": "[1,2,3][-2:]|length == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "neg_ctl_slice_stop",
+      "group": "const",
+      "expr": "[1,2,3][:-1]|length == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "neg_ctl_index",
+      "group": "const",
+      "expr": "[1,2,3][-1] == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "neg_ctl_step_reverse",
+      "group": "const",
+      "expr": "[1,2,3][::-1]|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "neg_ctl_this_slice",
+      "group": "list",
+      "expr": "this[-1:]|length == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "listarith_binary_sub_chain",
+      "group": "const",
+      "expr": "[900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -3][0] == [900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -900719925474099 - -2][0]",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "listarith_binary_sub_small",
+      "group": "const",
+      "expr": "[1 - -2][0] == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "listarith_binary_plain",
+      "group": "const",
+      "expr": "[1 - 2][0] == -1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "listarith_ctl_unary_elems",
+      "group": "const",
+      "expr": "[-1, 2][0] == -1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "listarith_ctl_plain_list",
+      "group": "const",
+      "expr": "[1, 2, 3][2] == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "listarith_ctl_string_list",
+      "group": "const",
+      "expr": "[\"a\", \"b\"][0] == \"a\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "sig_slice_bool",
+      "group": "const",
+      "expr": "[1,2,3]|slice(false)|length == 1",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_batch_bool",
+      "group": "const",
+      "expr": "[1,2,3]|batch(true)|length == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_replace_int_from",
+      "group": "const",
+      "expr": "\"aaa\"|replace(1,\"b\") == \"bababab\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_replace_int_to",
+      "group": "const",
+      "expr": "\"aaa\"|replace(\"a\",1) == \"111\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_replace_missing_arg",
+      "group": "const",
+      "expr": "\"aaa\"|replace(\"a\") == \"aaa\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_defined_extra_arg",
+      "group": "const",
+      "expr": "1 is defined(0)",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_none_extra_arg",
+      "group": "const",
+      "expr": "1 is none(0)",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_even_extra_arg",
+      "group": "const",
+      "expr": "4 is even(1)",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_upper_extra_arg",
+      "group": "str",
+      "expr": "this|upper(\"x\") != \"\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_join_number_arg",
+      "group": "const",
+      "expr": "[1,2]|join(1) != \"\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_length_extra_arg",
+      "group": "list",
+      "expr": "this|length(1) == 3",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_ctl_replace_two",
+      "group": "str",
+      "expr": "this|replace(\"H\",\"J\")|length == 11",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_ctl_slice_two",
+      "group": "const",
+      "expr": "[1,2,3]|slice(2)|length == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_ctl_defined",
+      "group": "str",
+      "expr": "this is defined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "sig_ctl_even",
+      "group": "const",
+      "expr": "4 is even",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "sig_ctl_join_string",
+      "group": "const",
+      "expr": "[\"a\",\"b\"]|join(\",\") == \"a,b\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_ctl_upper",
+      "group": "str",
+      "expr": "this|upper != \"\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "sig_ctl_startingwith",
+      "group": "str",
+      "expr": "this is startingwith(\"H\")",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "fn_dict_number_arg",
+      "group": "const",
+      "expr": "dict(1)|length == 0",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_dict_kwargs",
+      "group": "const",
+      "expr": "dict(a=1)|length == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "fn_namespace_call",
+      "group": "const",
+      "expr": "namespace(a=1) is defined",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_bool_odd",
+      "group": "const",
+      "expr": "true is odd",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_bool_even",
+      "group": "const",
+      "expr": "false is even",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_string_odd",
+      "group": "const",
+      "expr": "\"3\" is odd",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_number_first",
+      "group": "const",
+      "expr": "(1|first) is undefined",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_number_last",
+      "group": "const",
+      "expr": "(1|last) is undefined",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_bool_list",
+      "group": "const",
+      "expr": "(true|list) is undefined",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_number_min",
+      "group": "const",
+      "expr": "(1|min) is undefined",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_number_max",
+      "group": "const",
+      "expr": "(1|max) is undefined",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_number_reverse",
+      "group": "const",
+      "expr": "(1|reverse) is undefined",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_number_join",
+      "group": "const",
+      "expr": "1|join(\",\") == \"\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_number_sum",
+      "group": "const",
+      "expr": "1|sum == 0",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_string_abs",
+      "group": "str",
+      "expr": "this|abs != \"\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_number_upper",
+      "group": "const",
+      "expr": "1|upper != \"\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_ctl_odd",
+      "group": "const",
+      "expr": "3 is odd",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "subj_ctl_even",
+      "group": "const",
+      "expr": "4 is even",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "subj_ctl_first",
+      "group": "list",
+      "expr": "this|first == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "subj_ctl_last",
+      "group": "list",
+      "expr": "this|last == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "subj_ctl_min",
+      "group": "list",
+      "expr": "this|min == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_ctl_max",
+      "group": "list",
+      "expr": "this|max == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_ctl_list",
+      "group": "list",
+      "expr": "this|list|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "subj_ctl_reverse",
+      "group": "list",
+      "expr": "this|reverse|first == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "subj_ctl_join",
+      "group": "list",
+      "expr": "this|join(\",\") == \"1,2,3\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_ctl_sum",
+      "group": "list",
+      "expr": "this|sum == 6",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "subj_ctl_upper",
+      "group": "str",
+      "expr": "this|upper != \"\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "subj_ctl_abs",
+      "group": "intneg",
+      "expr": "this|abs == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "subj_ctl_length_string",
+      "group": "str",
+      "expr": "this|length == 11",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "subj_ctl_length_map",
+      "group": "map",
+      "expr": "this|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "subj_ctl_defined",
+      "group": "str",
+      "expr": "this is defined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "wd_iterable_none",
+      "group": "null",
+      "expr": "this is iterable",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "wd_iterable_list",
+      "group": "list",
+      "expr": "this is iterable",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "wd_iterable_literal",
+      "group": "const",
+      "expr": "[1,2] is iterable",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "wd_filter_extra_arg",
+      "group": "const",
+      "expr": "\"upper\" is filter(\"x\")",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "wd_test_extra_arg",
+      "group": "const",
+      "expr": "\"odd\" is test(\"x\")",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "wd_filter_number_subject",
+      "group": "const",
+      "expr": "1 is filter(\"upper\")",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "wd_filter_bare",
+      "group": "str",
+      "expr": "this is filter",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "wd_test_bare",
+      "group": "str",
+      "expr": "this is test",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "wd_in_string_container",
+      "group": "const",
+      "expr": "1 is in \"1\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "wd_in_number_container",
+      "group": "const",
+      "expr": "1 is in 2",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "wd_in_list_container",
+      "group": "const",
+      "expr": "1 is in [1,2]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "wd_sameas",
+      "group": "const",
+      "expr": "1 is sameas 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "cmp_eq_list",
+      "group": "const",
+      "expr": "[1,2] is eq([1,2])",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "cmp_eq_this_list",
+      "group": "list",
+      "expr": "this is eq(this)",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "kind_ctl_defined",
+      "group": "str",
+      "expr": "this is defined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "kind_ctl_none",
+      "group": "null",
+      "expr": "this is none",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "kind_ctl_is_string",
+      "group": "str",
+      "expr": "this is string",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "kind_ctl_is_number",
+      "group": "int7",
+      "expr": "this is number",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "kind_ctl_is_seq",
+      "group": "list",
+      "expr": "this is sequence",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "kind_ctl_is_map",
+      "group": "map",
+      "expr": "this is mapping",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "kind_ctl_eq_int",
+      "group": "const",
+      "expr": "1 is eq(1)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "kind_ctl_eq_str",
+      "group": "const",
+      "expr": "\"a\" is eq(\"a\")",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "kind_ctl_lt",
+      "group": "const",
+      "expr": "1 is lt(2)",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "kind_ctl_in_operator",
+      "group": "const",
+      "expr": "\"a\" in [\"a\",\"b\"]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "kind_ctl_odd",
+      "group": "const",
+      "expr": "3 is odd",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "kind_ctl_first",
+      "group": "list",
+      "expr": "this|first == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "kind_ctl_upper",
+      "group": "str",
+      "expr": "this|upper != \"\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "kind_ctl_tojson_seq",
+      "group": "const",
+      "expr": "[1,2]|tojson == \"[1,2]\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "kind_ctl_startingwith",
+      "group": "str",
+      "expr": "this is startingwith(\"H\")",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "content_title_punct",
+      "group": "const",
+      "expr": "\"a!b\"|title == \"A!B\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_trim_nbsp",
+      "group": "const",
+      "expr": "\" a \"|trim == \"a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_title_ascii",
+      "group": "const",
+      "expr": "\"a b\"|title == \"A B\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_upper_sharp_s",
+      "group": "const",
+      "expr": "\"straße\"|upper == \"STRASSE\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_lower_turkish",
+      "group": "const",
+      "expr": "\"İ\"|lower|length == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_capitalize_unicode",
+      "group": "const",
+      "expr": "\"été\"|capitalize|length == 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_replace_empty",
+      "group": "const",
+      "expr": "\"ab\"|replace(\"\",\"-\")|length == 2",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_int_spaces",
+      "group": "const",
+      "expr": "\" 12\"|int == 12",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_join_numbers",
+      "group": "const",
+      "expr": "[1,2]|join(\",\") == \"1,2\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_tojson_escape",
+      "group": "const",
+      "expr": "\"<a>\"|tojson|length == 5",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_string_float",
+      "group": "const",
+      "expr": "2.5|string == \"2.5\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_sort_strings",
+      "group": "const",
+      "expr": "[\"b\",\"A\"]|sort|first == \"A\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_unique_strings",
+      "group": "const",
+      "expr": "[\"a\",\"a\"]|unique|length == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_min_strings",
+      "group": "const",
+      "expr": "[\"b\",\"A\"]|min == \"A\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_is_lower",
+      "group": "str",
+      "expr": "this is lower",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_is_upper",
+      "group": "str",
+      "expr": "this is upper",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_format_pct",
+      "group": "const",
+      "expr": "1|format(\"%d\") == \"1\"",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_indent_tabs",
+      "group": "const",
+      "expr": "\"a\nb\"|indent(2)|length > 3",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "content_truncate",
+      "group": "str",
+      "expr": "this|truncate(3)|length <= 5",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "struct_ctl_length_list",
+      "group": "list",
+      "expr": "this|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_length_string",
+      "group": "str",
+      "expr": "this|length == 11",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_length_map",
+      "group": "map",
+      "expr": "this|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_length_unicode",
+      "group": "stru",
+      "expr": "this|length == 13",
+      "stock": "false",
+      "native": "false"
+    },
+    {
+      "label": "struct_ctl_first",
+      "group": "list",
+      "expr": "this|first == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_last",
+      "group": "list",
+      "expr": "this|last == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_list",
+      "group": "list",
+      "expr": "this|list|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_reverse",
+      "group": "list",
+      "expr": "this|reverse|first == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_sum",
+      "group": "list",
+      "expr": "this|sum == 6",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_abs",
+      "group": "intneg",
+      "expr": "this|abs == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_startingwith_unicode",
+      "group": "stru",
+      "expr": "this is startingwith(\"h\")",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_endingwith",
+      "group": "str",
+      "expr": "this is endingwith(\"d\")",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_eq_unicode",
+      "group": "stru",
+      "expr": "this == \"héllo ✓ 日本\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_is_seq",
+      "group": "list",
+      "expr": "this is sequence",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "struct_ctl_odd",
+      "group": "const",
+      "expr": "3 is odd",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_in_string_needle_r21",
+      "group": "const",
+      "expr": "1 in \"1\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_not_in_string_needle_r21",
+      "group": "const",
+      "expr": "1 not in \"1\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_in_noniterable_r21",
+      "group": "const",
+      "expr": "1 in 2",
+      "stock": "error",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_in_list_literal_r21",
+      "group": "const",
+      "expr": "\"a\" in [\"a\",\"b\"]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_in_this_list_r21",
+      "group": "list",
+      "expr": "1 in this",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_cmp_int_string_r21",
+      "group": "const",
+      "expr": "1 == \"1\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_cmp_int_lt_string_r21",
+      "group": "const",
+      "expr": "1 < \"a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_cmp_none_false_r21",
+      "group": "const",
+      "expr": "none == false",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_cmp_true_one_r21",
+      "group": "const",
+      "expr": "true == 1",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_cmp_this_mixed_r21",
+      "group": "str",
+      "expr": "this == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_cmp_list_literal_r21",
+      "group": "list",
+      "expr": "this == [1,2,3]",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_concat_number_r21",
+      "group": "const",
+      "expr": "1 ~ \"a\" == \"1a\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_and_r21",
+      "group": "const",
+      "expr": "true and false",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_or_r21",
+      "group": "const",
+      "expr": "true or false",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_not_r21",
+      "group": "const",
+      "expr": "not true",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_ternary_r21",
+      "group": "const",
+      "expr": "1 == 1 if true else 2 == 2",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_truthy_none_r21",
+      "group": "null",
+      "expr": "this and true",
+      "stock": "no-checks",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_truthy_empty_list_r21",
+      "group": "liste",
+      "expr": "this or true",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_ctl_int_eq_r21",
+      "group": "const",
+      "expr": "1 == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_string_eq_r21",
+      "group": "const",
+      "expr": "\"a\" == \"a\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_bool_eq_r21",
+      "group": "const",
+      "expr": "true == true",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_this_int_r21",
+      "group": "int7",
+      "expr": "this == 7",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_this_gt_r21",
+      "group": "int7",
+      "expr": "this > 0",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_this_string_r21",
+      "group": "str",
+      "expr": "this == \"Hello World\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_length_cmp_r21",
+      "group": "list",
+      "expr": "this|length == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_length_gt_r21",
+      "group": "list",
+      "expr": "this|length > 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_sum_r21",
+      "group": "list",
+      "expr": "this|sum == 6",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_field_r21",
+      "group": "cls",
+      "expr": "this.b == 1",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_is_test_r21",
+      "group": "str",
+      "expr": "this is defined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_is_not_r21",
+      "group": "str",
+      "expr": "this is not none",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_ctl_arith_r21",
+      "group": "const",
+      "expr": "1 + 2 == 3",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_field_int",
+      "group": "nest",
+      "expr": "this.a.name == 5",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_field_int_false",
+      "group": "nest",
+      "expr": "this.a.name == 6",
+      "stock": "false",
+      "native": "false"
+    },
+    {
+      "label": "nest_outer_field",
+      "group": "nest",
+      "expr": "this.name == \"x\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_subscript_key",
+      "group": "nest",
+      "expr": "this.a[\"name\"] == 5",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_field_index",
+      "group": "nest",
+      "expr": "this.a.tags[0] == \"x\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_field_index_second",
+      "group": "nest",
+      "expr": "this.a.tags[1] == \"y\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_field_neg_index",
+      "group": "nest",
+      "expr": "this.a.tags[-1] == \"y\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_field_first",
+      "group": "nest",
+      "expr": "this.a.tags|first == \"x\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_field_last",
+      "group": "nest",
+      "expr": "this.a.tags|last == \"y\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_field_length",
+      "group": "nest",
+      "expr": "this.a.tags|length == 2",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_field_reverse_first",
+      "group": "nest",
+      "expr": "this.a.tags|reverse|first == \"y\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_index_field",
+      "group": "nest",
+      "expr": "this.rows[0].name == 7",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_index_field_index",
+      "group": "nest",
+      "expr": "this.rows[0].tags[0] == \"z\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_missing_field",
+      "group": "nest",
+      "expr": "this.a.missing is undefined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_index_oob",
+      "group": "nest",
+      "expr": "this.a.tags[9] is undefined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_shadow_field",
+      "group": "nest",
+      "expr": "this.a.name == \"x\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "nest_shadow_key",
+      "group": "nest",
+      "expr": "this.a[\"name\"] == \"x\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "nest_stale_list_elem",
+      "group": "nest",
+      "expr": "[1,2][0] == this.a.tags[0]",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "nest_slice_then_index",
+      "group": "nest",
+      "expr": "this.a.tags[0:1][0] == \"x\"",
+      "stock": "true",
+      "native": "unsupported"
+    },
+    {
+      "label": "str_index_last",
+      "group": "str",
+      "expr": "this[10] == \"d\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "str_index_oob",
+      "group": "str",
+      "expr": "this[11] == \"x\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "str_index_oob_undef",
+      "group": "str",
+      "expr": "this[11] is undefined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "stru_index_last",
+      "group": "stru",
+      "expr": "this[9] == \"本\"",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "stru_index_oob_undef",
+      "group": "stru",
+      "expr": "this[10] is undefined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "stru_index_byte_oob_undef",
+      "group": "stru",
+      "expr": "this[16] is undefined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "nest_string_field_oob",
+      "group": "nest",
+      "expr": "this.name[9] == \"x\"",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_index_oob",
+      "group": "const",
+      "expr": "[1][9] == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_index_oob_undef",
+      "group": "const",
+      "expr": "[1][9] is undefined",
+      "stock": "true",
+      "native": "true"
+    },
+    {
+      "label": "op_index_at_end",
+      "group": "const",
+      "expr": "[1,2][2] == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_index_neg_oob",
+      "group": "const",
+      "expr": "[1,2][-5] == 1",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_index_negzero_list",
+      "group": "list",
+      "expr": "this[-0] is undefined",
+      "stock": "false",
+      "native": "unsupported"
+    },
+    {
+      "label": "op_index_negzero_lit",
+      "group": "const",
+      "expr": "[1,2][-0] == 1",
+      "stock": "true",
+      "native": "unsupported"
+    }
+  ]
+}

--- a/internal/debaml/testdata/serving_oracle/project.baml
+++ b/internal/debaml/testdata/serving_oracle/project.baml
@@ -1,0 +1,503 @@
+// GENERATED at test time from the Slice 7.2a-3 serving-oracle corpus — do not edit.
+//
+// Every declaration below is rendered from the schema.Bundle of one corpus
+// fixture (serving_oracle_corpus_test.go) by soRenderProject, so the .baml the
+// stock BAML v0.223.0 CFFI compiles and the schema.Bundle the native collector
+// coerces against are the same description of the same shape.
+//
+// Regenerate with:
+//   BAML_SERVING_ORACLE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml -run TestServingOracleProjectDrift
+
+client<llm> ServingOracleClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://serving-oracle.invalid/v1"
+  }
+}
+
+class SoIntPass {
+  v int @check(gt, {{ this > 0 }})
+}
+
+class SoIntFail {
+  v int @check(gt, {{ this > 100 }})
+}
+
+class SoIntAssertPass {
+  v int @assert(gt, {{ this > 0 }})
+}
+
+class SoIntAssertFail {
+  v int @assert(gt, {{ this > 100 }})
+}
+
+class SoFloat {
+  v float @check(gt, {{ this > 1.0 }})
+}
+
+class SoBool {
+  v bool @check(istrue, {{ this }})
+}
+
+class SoStrField {
+  v string @check(eq, {{ this == "expected" }})
+}
+
+class SoOptNull {
+  v int? @check(isnull, {{ this == none }})
+}
+
+class SoMulti {
+  v int @check(a, {{ this > 0 }}) @check(b, {{ this > 3 }}) @check(c, {{ this > 100 }})
+}
+
+enum SoSuit {
+  Hearts @alias("hearts_alias")
+  Spades
+}
+
+class SoEnumCanon {
+  v SoSuit @check(spades, {{ this == "Spades" }})
+}
+
+class SoEnumShadow {
+  v SoSuit @check(hearts, {{ this == "Hearts" }})
+}
+
+class SoEnumAlias {
+  v SoSuit @check(canonical, {{ this == "Hearts" }}) @check(alias, {{ this == "hearts_alias" }})
+}
+
+class SoClsLevel {
+  s string
+  n int
+  @@check(hass, {{ this.s|length > 0 }})
+}
+
+class SoClsAssert {
+  s string
+  @@assert(long, {{ this.s|length > 10 }})
+}
+
+class SoOrder {
+  b int @check(bpos, {{ this > 0 }})
+  a string @check(astr, {{ this == "x" }})
+}
+
+class SoAliasCls {
+  amount int @alias("qty")
+  @@check(amount, {{ this.amount == 3 }})
+}
+
+class SoOuter {
+  i SoInner @check(innerb, {{ this.b > 0 }})
+}
+
+class SoInner {
+  b int @check(bpos, {{ this > 1 }})
+  a string
+}
+
+class SoListType {
+  v int[] @check(len, {{ this|length == 3 }})
+}
+
+class SoListElem {
+  v (int @check(pos, {{ this > 0 }}))[]
+}
+
+class SoListDrop {
+  v (int @check(pos, {{ this > 0 }}))[]
+}
+
+class SoNestDrop {
+  v SoNestDropInner[]
+}
+
+class SoNestDropInner {
+  w (int @check(pos, {{ this > 0 }}))[]
+}
+
+class SoListWrap {
+  v (int @check(pos, {{ this > 0 }}))[]
+}
+
+class SoMapVal {
+  v map<string, (int @check(pos, {{ this > 0 }}))>
+}
+
+class SoMapKey {
+  v map<(string @check(k, {{ this|length > 0 }})), int>
+}
+
+class SoUnionInt {
+  v (int @check(pos, {{ this > 0 }})) | string
+}
+
+class SoUnionStr {
+  v (int @check(pos, {{ this > 0 }})) | string
+}
+
+class SoDup {
+  v int @check(dup, {{ this > 0 }}) @check(dup, {{ this > 100 }})
+}
+
+class SoDupSame {
+  v int @check(a, {{ this > 0 }}) @check(b, {{ this > 3 }}) @check(a, {{ this > 0 }})
+}
+
+class SoErrFilter {
+  v int @check(uf, {{ this|nosuchfilter }})
+}
+
+class SoErrNonBool {
+  v int @check(nb, {{ this + 1 }})
+}
+
+class SoErrMethod {
+  v string @check(um, {{ this.nosuchmethod() }})
+}
+
+class SoErrOpt {
+  v int? @check(uf, {{ this|nosuchfilter }})
+}
+
+class SoBigInt {
+  v int @check(gt, {{ this > 9007199254740992 }})
+}
+
+class SoBigFloat {
+  v float @check(gt, {{ this > 1.0 }})
+}
+
+class SoStrNum {
+  v string @check(eq, {{ this == "9007199254740993" }})
+}
+
+class SoArith {
+  v int @check(ar, {{ (this + 1) * 2 == 12 }})
+}
+
+class SoLen {
+  v string @check(len, {{ this|length == 5 }})
+}
+
+class SoPyFmt {
+  v string @check(fmt, {{ "{:,}".format(1234567) == "1,234,567" }})
+}
+
+class SoRegex {
+  v string @check(rx, {{ this|regex_match("abc") }})
+}
+
+class SoDivZero {
+  v int @check(dz, {{ this is divisibleby(0) }})
+}
+
+class SoFenced {
+  v int @check(gt, {{ this > 0 }})
+}
+
+class SoCommented {
+  v int @check(gt, {{ this > 0 }})
+}
+
+class SoCtlCls {
+  b int
+  a string
+}
+
+class SoCtlList {
+  v int[]
+}
+
+class SoCtlMap {
+  v map<string, int>
+}
+
+function SO_scalar_int_check_pass(topic: string) -> SoIntPass {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_scalar_int_check_fail(topic: string) -> SoIntFail {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_scalar_int_assert_pass(topic: string) -> SoIntAssertPass {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_scalar_int_assert_fail(topic: string) -> SoIntAssertFail {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_scalar_float_check(topic: string) -> SoFloat {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_scalar_bool_check(topic: string) -> SoBool {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_scalar_string_check_fail(topic: string) -> SoStrField {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_scalar_optional_null(topic: string) -> SoOptNull {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_scalar_multi_check_order(topic: string) -> SoMulti {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_enum_canonical(topic: string) -> SoEnumCanon {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_enum_alias_shadows_canonical(topic: string) -> SoEnumShadow {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_enum_alias_ingress(topic: string) -> SoEnumAlias {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_class_level_check(topic: string) -> SoClsLevel {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_class_level_assert_fail(topic: string) -> SoClsAssert {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_class_schema_order(topic: string) -> SoOrder {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_class_field_alias(topic: string) -> SoAliasCls {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_class_nested(topic: string) -> SoOuter {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_list_type_check(topic: string) -> SoListType {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_list_elem_check(topic: string) -> SoListElem {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_list_dropped_elem(topic: string) -> SoListDrop {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_list_nested_dropped_elem(topic: string) -> SoNestDrop {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_list_single_to_array(topic: string) -> SoListWrap {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_map_value_check(topic: string) -> SoMapVal {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_map_key_check(topic: string) -> SoMapKey {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_union_constrained_arm_wins(topic: string) -> SoUnionInt {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_union_constrained_arm_loses(topic: string) -> SoUnionStr {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_union_target_level(topic: string) -> (int @check(pos, {{ this > 0 }})) | string {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_target_int_check_fail(topic: string) -> int @check(gt, {{ this > 100 }}) {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_target_int_assert_fail(topic: string) -> int @assert(gt, {{ this > 100 }}) {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_target_string_check_skipped(topic: string) -> string @check(eq, {{ this == "expected" }}) {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_target_string_assert_skipped(topic: string) -> string @assert(eq, {{ this == "expected" }}) {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_target_string_bare_word(topic: string) -> string @check(eq, {{ this == "expected" }}) {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_target_list_elem_check(topic: string) -> (int @check(pos, {{ this > 0 }}))[] {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_duplicate_label(topic: string) -> SoDup {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_duplicate_identical_nonadjacent(topic: string) -> SoDupSame {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_err_unknown_filter(topic: string) -> SoErrFilter {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_err_non_boolean(topic: string) -> SoErrNonBool {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_err_unknown_method(topic: string) -> SoErrMethod {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_err_optional_swallows(topic: string) -> SoErrOpt {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_guard_int_above_2p53(topic: string) -> SoBigInt {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_guard_float_2p63(topic: string) -> SoBigFloat {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_guard_string_number(topic: string) -> SoStrNum {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_guard_arithmetic(topic: string) -> SoArith {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_guard_length_filter(topic: string) -> SoLen {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_decline_pycompat_format(topic: string) -> SoPyFmt {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_decline_regex_match(topic: string) -> SoRegex {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_decline_divisible_by_zero(topic: string) -> SoDivZero {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_serving_markdown_fence(topic: string) -> SoFenced {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_serving_jsonish_comments(topic: string) -> SoCommented {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_control_class_unconstrained(topic: string) -> SoCtlCls {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_control_list_unconstrained(topic: string) -> SoCtlList {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_control_map_unconstrained(topic: string) -> SoCtlMap {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_control_target_string(topic: string) -> string {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_bare_string_quoted_text(topic: string) -> string {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+function SO_probe_root_duplicate_label(topic: string) -> int @check(dup, {{ this > 0 }}) @check(dup, {{ this > 100 }}) {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+class SoProbeNestedDup {
+  v int @check(dup, {{ this > 0 }}) @check(dup, {{ this > 100 }})
+}
+
+function SO_probe_nested_duplicate_label(topic: string) -> SoProbeNestedDup {
+  client ServingOracleClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

**Base:** `origin/master` = `f8036f7c` · **Branch:** `feat/debaml-slice72a3-serving-oracle` · **Do not merge.**

Slice 7.2a-3 builds the **serving-shaped differential oracle** and the **boundary lock**. It is **TEST-ONLY**: production is byte-identical to `f8036f7c`.

## What it does

Per corpus row: render a deterministic **in-memory `.baml` project** (`map[string]string`) from the row's `schema.Bundle`, compile it with the stock BAML v0.223.0 CFFI, drive `BamlRuntime.CallFunctionParse` (the entry point every generated `Parse.<Method>` calls), and compare the recorded stock envelope against the **native #662 coercion-state collector + #649 evaluator**, driven through production's own extraction stage (`stripJSONComments` → `extractCandidateMode` → `coerce`).

**Stock is the authority. Native output is never fed back into the CFFI.** The only bytes handed to the CFFI are a fixture's raw assistant text.

The contract is fail-closed: *native may reproduce stock exactly, or refuse to decide; never a boolean stock did not produce, and never a different one.*

## The envelope — more than JSON equality

| recorded | from each leg, independently |
|---|---|
| identity | one shared vocabulary — class/enum **names**, field/entry **order**, every leaf typed (`class:SoOrder{b=int:2,a=string:"x"}`) |
| document | exact `big.Rat` comparison (`constraintStateValueDiff`), never `float64` |
| sites | every constraint that ran, in traversal-then-declaration order, with path, level, label, **exact expression text** and result |
| kind | value / assertion-failure / evaluator-error / coercion-error / process-fatal — never collapsed |

The stock side is read from the **raw CFFI protobuf**, not from a generated client's decoded structs: `baml_go`'s `decodeCheckedValue` folds `Checked.Checks` into a `map[string]Check`, so two `@check` attributes sharing a label collapse to one and their order is gone. Reading the tree keeps the ordered `[]CFFICheckValue`. Both observations are pinned.

## Boundary lock — UNNARROWED

Nothing is carved out; target-level is included.

- `checkSupported` / `checkSupportedFields` / `checkSupportedType` driven **by name** over every family, in an **untagged** file so it runs in the ordinary `go test ./internal/debaml/...` gate (no CGO required).
- `SupportsNativeFinalBundle` + `ParseStaticBundle` decline every constraint-bearing fixture.
- `BAML_REST_USE_DEBAML` set to `true`/`false`/unset around every gate call — plus a **structural `go/ast` proof** that no production file in `internal/debaml` or `internal/schema` reads the environment at all, so no gate decision *can* be flag-conditioned.
- **Attribution, not just refusal:** every constraint-bearing row's stripped twin must be **admitted**, so the decline is caused by the constraint rather than by the shape. Unconstrained controls are admitted and at least one **serves bytes**.
- `TestNativeDeclines_Constraints` unchanged and green.

## Findings (recorded, not fixed — this slice changes no production byte)

1. **Stock repeats a check** when a value reaches its node twice (single-value→list wrap, or a list re-coerced after `ArrayItemParseError`): the same `(path, label, expression, status)` appears twice.
2. **`@alias` on an enum variant replaces its ingress spelling** rather than adding one — the canonical name no longer matches, and both engines refuse the value.
3. **A `map<int, string>` key does not compile at all** — a fact about the project language, proven with a string-keyed control that does compile.
4. **A #662 collector limitation:** a float whose shortest round-trip decimal differs from its exact value (`2^63`) trips the collector's exact-decimal divergence check, because it compares the two **decimals** rather than the `float64` they both denote.
5. **KNOWN GAP, pre-existing, unrelated to constraints:** for an **unconstrained, admitted** bare-string return given quoted assistant text, stock serves the text verbatim (`"\"actual\""`) while `ParseStaticBundle` serves the string it denotes (`"actual"`). `TestServingOracleKnownGap_BareStringQuotedText` measures it against the real serving path and fails with instructions when it closes.

## Proof integrity

- **Discriminating**: both legs' envelopes are pinned for **equality**; no "no error", non-nil, truthiness or `len>0`.
- **Per-case reports**: every failure names the `.baml` source and method, the raw text, the schema, both envelopes and the mismatch kind (state / event / boundary).
- **No vacuous arms**: every empty-set claim is paired with a non-empty control, and the corpus/gate family lists constrain each other in both directions.
- **No false-green skips**: the subprocess-fatal row needs a **reached-parse marker** before a hang counts; the classifier is pinned over synthetic transcripts including a **real** signal death.
- **Structural (`go/ast`) reachability**: anchors that may only live in `_test.go`, a reserved namespace every oracle identifier must be inside, and a repo-wide no-production-reference scan — with a bite check and a negative control that requires a *production* declaration.
- **Strict**: duplicate map keys and duplicate class fields are refused in the readback (proven directly, since stock cannot produce them); unmodelled CFFI variants are refused rather than rendered.
- **Labelled tallies**: ten agreement buckets, each pinned; every non-agreeing bucket requires a one-sentence `Divergence` note, and an agreeing one forbids it.
- **29/29 mutations bite**, including two applied to **production** `parse.go` (removing the type-constraint decline, and removing #664's target walk) — both reverted.

## Gates

| gate | result |
|---|---|
| `gofmt -l` (new files) | clean |
| `CGO_ENABLED=0 go build ./...` | OK |
| `go vet ./...` / `-tags=integration ./...` | OK |
| `go test ./internal/debaml/...` | ok (13.5s) |
| `go test .` (root guards) | ok |
| serving oracle (integration tag) | **ok** — 53 fixtures, incl. the subprocess-fatal row |
| 719-case constraint differential | **719 cases, 0 failures — unchanged** |
| `boundary_decline_test` + `TestNativeDeclines_Constraints` | PASS |
| #649 seam + #661 harness + #662 collector | PASS |
| `guardledger` / `constraintoracle` / `profileoracle` (integration) | ok |
| production diff vs `f8036f7c` | **EMPTY** (8 `_test.go` + 1 testdata golden) |
| embed | n/a — no non-test `.go` entered the embed set |

CI: the existing `constraint-oracle.yml` gains a serving-oracle step (budget 60 → 75m), and its untagged lane gains `ServingOracle` so the boundary half runs without CGO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded serving-behavior coverage across scalar, collection, union, enum, class, constraint, error, and unsupported scenarios.
  * Added differential validation between standard and native serving results, including output, coercion, validation, and refusal behavior.
  * Added boundary checks confirming constrained inputs are rejected while unconstrained controls remain supported.
  * Added strict coverage for fatal outcomes, duplicate labels, aliases, ordering, and unsupported schema shapes.
  * Added validation for a 719-case corpus, retained expressions, and fail-closed handling of unexpected results.
  * Extended workflow time limits for comprehensive serving checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->