### PR TITLE
feat(debaml): Slice 7.2c-1 — stock-v0.223 CFFI authority + residual characterization for the six direct comparisons (no admission flip)

### DIFF
--- a/.embedignore
+++ b/.embedignore
@@ -136,6 +136,24 @@ internal/debaml/testdata/serving_oracle
 internal/debaml/checkedwire/asymmetries.md
 internal/debaml/checkedwire/testdata
 
+# de-BAML Slice 7.2c-1 PREDICATE-WIRE STOCK AUTHORITY proof material
+# (internal/debaml/predicatewire): the residual ledger the package's //go:build
+# integration tests parse and assert against, and the ISOLATED in-memory .baml fixture
+# projects the stock BAML v0.223.0 CFFI compiles at test time — one per operator, per
+# boundary literal and per residual form, each declaring the two name-pinned classes once
+# so six predicate variants of one class name can be captured without renaming any of
+# them. Both are read FROM DISK by those tests (os.ReadFile), never through the embedded
+# FS, and neither is a customer-build input — they are test-only proof material exactly
+# like checkedwire's two paths above.
+#
+# The package is integration-test-ONLY: it carries no non-_test .go file, so these two
+# paths are its entire contribution to the root manifest. They are named INDIVIDUALLY
+# rather than by excluding the directory, so that a production .go file added here later
+# still surfaces as regen drift and gets a decision instead of being silently swallowed
+# by a directory-wide exclusion — the same reasoning as checkedwire.
+internal/debaml/predicatewire/residuals.md
+internal/debaml/predicatewire/testdata
+
 # de-BAML Phase 4b + 5.1 gated nanollm Prepare validation: a SEPARATE, test-only
 # Go module (github.com/invakid404/baml-rest/internal/nativebody/nanollmprepare)
 # excluded from go.work so the PUBLIC github.com/viktordanov/nanollm-ffi/go

--- a/.github/workflows/constraint-oracle.yml
+++ b/.github/workflows/constraint-oracle.yml
@@ -5,8 +5,9 @@ name: Constraint Evaluator Oracle
 # (internal/debaml/constraintoracle), the guard-removal ledger harness
 # (internal/debaml/guardledger), the bamlprofile oracle
 # (internal/bamlprofile/profileoracle), the serving-shaped oracle (in package
-# internal/debaml) and the Checked[T] wire/assert-error byte authority
-# (internal/debaml/checkedwire).
+# internal/debaml), the Checked[T] wire/assert-error byte authority
+# (internal/debaml/checkedwire) and the six-operator predicate authority
+# (internal/debaml/predicatewire).
 #
 # Why its own workflow. Every one of those packages is integration-tagged and
 # under internal/, so neither of the existing lanes reaches it:
@@ -65,7 +66,7 @@ jobs:
     # round-10 integral-float `2.0 ** 63` promotion are only observable here.
     # A macOS/arm64 developer run is a weaker check, not an equivalent one.
     runs-on: ubuntu-latest
-    # The THREE integration steps below each carry their own 15-minute `go test`
+    # The SIX integration steps below each carry their own 15-minute `go test`
     # timeout, and a Go timeout is worth more than a job cancellation here: it
     # dumps every goroutine, which is the only diagnosis available for the CFFI
     # HANG cases this lane deliberately isolates (`is divisibleby(0)` takes the
@@ -73,15 +74,15 @@ jobs:
     # that dump away.
     #
     # THE BUDGET MUST EXCEED THE SUM OF THE INNER GO TIMEOUTS, so the inner
-    # timeout always fires first and the dump always survives. 5 x 15m = 75m of
+    # timeout always fires first and the dump always survives. 6 x 15m = 90m of
     # inner budget, plus ~15m of headroom for checkout/setup/vet/the unit step
     # and for the dump itself to be written and uploaded. At exactly 75 a hung
     # earlier lane would starve a later one of its own diagnostic timeout —
     # which is how this number went from 45 to 60 when the profileoracle lane was
-    # added, from 60 to 75 when the serving-oracle lane was, and from 75 to 90
-    # when the checked-wire lane was. Any future step with its own `-timeout`
-    # must raise this too.
-    timeout-minutes: 90
+    # added, from 60 to 75 when the serving-oracle lane was, from 75 to 90 when the
+    # checked-wire lane was, and from 90 to 105 when the predicate-wire lane was.
+    # Any future step with its own `-timeout` must raise this too.
+    timeout-minutes: 105
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7.0.0
@@ -190,6 +191,28 @@ jobs:
         env:
           CGO_ENABLED: "1"
         run: go test -tags=integration -count=1 -v -timeout 15m ./internal/debaml/checkedwire/
+
+      - name: Six-operator predicate authority vs stock BAML v0.223.0
+        # Slice 7.2c-1. The byte + error authority for the six DIRECT COMPARISONS on the
+        # two name-pinned static families, captured before any of them is admitted. Unlike
+        # the checked-wire lane above it builds ISOLATED projects — one runtime each —
+        # because a single .baml cannot declare six predicate variants of one class name,
+        # and renaming the class would capture a different family.
+        #
+        # Three load-bearing assertions: TestStockOperatorWireBytes /
+        # TestStockOperatorAssertBytes and their TestStockTopLevelOperator* twins pin raw
+        # sonic bytes and whole unmodified err.Error() strings for all 48 rows — 24 nested
+        # and 24 top-level, which the scope requires separately because a top-level assert
+        # failure carries no required-field wrapper; TestDirectIntBoundaryMatrix drives
+        # the ±2^53 and i64-endpoint matrix through stock and independently re-evaluates
+        # every row with the production evaluator, failing on any boolean stock did not
+        # produce; and TestPredicateWireAdmissionIsUnchanged re-asserts that FIVE of the
+        # six are still refused by the production gates — the no-flip invariant, stated
+        # where the captures are and proven to bite by
+        # TestPredicateWireAdmissionIsProvenToBite.
+        env:
+          CGO_ENABLED: "1"
+        run: go test -tags=integration -count=1 -v -timeout 15m ./internal/debaml/predicatewire/
 
       - name: Constraint evaluator unit lane
         # The CGO-free half of the same claim, so a guard cannot be removed

--- a/internal/debaml/checked_static_test.go
+++ b/internal/debaml/checked_static_test.go
@@ -815,9 +815,80 @@ func staticCheckedSiblings() []staticCheckedSibling {
 			b:    mutate(c.setEmpty),
 		})
 	}
+	// De-BAML Slice 7.2c-1 — the MIXED constraint forms, in BOTH declaration orders.
+	//
+	// internal/debaml/predicatewire captured what stock does with each of these against
+	// the v0.223.0 CFFI and found the two orders INDISTINGUISHABLE in stock's output, in
+	// both outcomes: a passing assert leaves only the check, and a false assert suppresses
+	// a check that would otherwise have been emitted. Neither is a form this mapper models
+	// — it evaluates exactly one constraint and knows one check OR one assert outcome — so
+	// both remain declines here, and their decline is now backed by a measurement rather
+	// than by the one-constraint clause alone.
+	for _, m := range []struct {
+		name  string
+		extra schema.Constraint
+		first schema.Constraint
+	}{{
+		name:  "a @check then a @assert",
+		first: schema.Constraint{Level: schema.ConstraintCheck, Expression: "this < 100", Label: label("c")},
+		extra: schema.Constraint{Level: schema.ConstraintAssert, Expression: "this > 0", Label: label("a")},
+	}, {
+		name:  "a @assert then a @check",
+		first: schema.Constraint{Level: schema.ConstraintAssert, Expression: "this > 0", Label: label("a")},
+		extra: schema.Constraint{Level: schema.ConstraintCheck, Expression: "this < 100", Label: label("c")},
+	}} {
+		m := m
+		siblings = append(siblings, staticCheckedSibling{
+			name: m.name,
+			b: mutate(func(b *schema.Bundle) {
+				b.Classes[0].Fields[1].Type.Meta.Constraints = []schema.Constraint{m.first, m.extra}
+			}),
+		})
+	}
+	// THREE unique checks. Distinct from the existing two-check sibling: stock's map fold
+	// loses declaration order at any count above one, and predicatewire recorded three
+	// DISTINCT sonic byte orderings for this shape — so the byte-parity rule the slice
+	// accepts on has nothing to compare against, whatever the mapper could build.
+	siblings = append(siblings, staticCheckedSibling{
+		name: "three unique checks",
+		b: mutate(func(b *schema.Bundle) {
+			b.Classes[0].Fields[1].Type.Meta.Constraints = []schema.Constraint{
+				{Level: schema.ConstraintCheck, Expression: "this > 0", Label: label("alpha")},
+				{Level: schema.ConstraintCheck, Expression: "this < 100", Label: label("beta")},
+				{Level: schema.ConstraintCheck, Expression: "this != 7", Label: label("gamma")},
+			}
+		}),
+	})
+
+	// De-BAML Slice 7.2c-1 — the five DIRECT COMPARISON operators 7.2c proposes and this
+	// slice does NOT admit.
+	//
+	// Each has a full stock v0.223.0 CFFI capture in internal/debaml/predicatewire — wire
+	// bytes for check true/false and assert true, and the exact err.Error() for a false
+	// assert, on both name-pinned families. Capturing an operator is what a later slice
+	// needs; it is not what admits one, and these rows are what keeps that distinction
+	// enforced. TestStaticCheckedOperatorWideningIsProvenToBite proves the assertion fires
+	// if the fingerprint starts accepting any of them.
+	//
+	// `>` is deliberately absent: it is the ADMITTED predicate, not a sibling.
+	for _, expr := range staticCheckedDeclinedDirectOperators() {
+		siblings = append(siblings, staticCheckedSibling{
+			name: "direct operator " + strconv.Quote(expr),
+			b:    accept(schema.ConstraintCheck, "positive", expr),
+		})
+		siblings = append(siblings, staticCheckedSibling{
+			name: "direct operator " + strconv.Quote(expr) + " (assert)",
+			b:    accept(schema.ConstraintAssert, "positive", expr),
+		})
+	}
+
 	for _, expr := range []string{
-		"this >= 0", "this>0", "this > 0.0", "this > +5", "this > 007",
-		"this > 1_000", "this != 0", "this|length > 0", "this > 9223372036854775808", "this > ",
+		"this>0", "this > 0.0", "this > +5", "this > 007",
+		"this > 1_000", "this|length > 0", "this > 9223372036854775808", "this > ",
+		// The TWO-BYTE operators in their non-canonical spacings. `>=` and `<=` are one
+		// byte longer than `>`, and the canonicaliser counts ASCII spaces rather than
+		// trimming, so each width needs its own rows.
+		"this>=0", "this <=0", "  this >= 0  ", " this <= 0 ", "this >  0", "this ==  0",
 		// PADDING past the admitted one ASCII space each side, and padding that is not
 		// an ASCII space at all. strings.TrimSpace would have accepted every one of
 		// these — including the NO-BREAK SPACE, which unicode.IsSpace reports true for —
@@ -2310,6 +2381,126 @@ func staticCheckedRenamedTwinAdmits(b *schema.Bundle) bool {
 		return false
 	}
 	return staticCheckedFingerprintAdmits(&renamed)
+}
+
+// staticCheckedDeclinedDirectOperators are the five direct comparisons 7.2c proposes and
+// 7.2c-1 does NOT admit, in their canonical spelling.
+//
+// `this > I` is deliberately absent: it is the one admitted predicate. Every expression
+// here has a full stock v0.223.0 CFFI capture in internal/debaml/predicatewire, which is
+// what a later slice needs and is not what admits one.
+func staticCheckedDeclinedDirectOperators() []string {
+	return []string{"this >= 0", "this < 0", "this <= 0", "this == 0", "this != 0"}
+}
+
+// staticCheckedWidenedOperatorTwinAdmits is the 7.2c-3 cutover, arriving early: the
+// production fingerprint with its expression clause replaced by one that accepts all six
+// direct comparisons.
+//
+// It is written as a SHAPE predicate over the same structure the real classifier walks —
+// one class, two ordered fields, one constraint on `confidence` — so the mutant really is
+// "the production fingerprint with a widened operator set" rather than a name match on
+// the corpus rows. Everything else about the fingerprint still has to hold.
+func staticCheckedWidenedOperatorTwinAdmits(b *schema.Bundle) bool {
+	if b == nil || len(b.Classes) != 1 || len(b.Classes[0].Fields) != 2 {
+		return false
+	}
+	cs := b.Classes[0].Fields[1].Type.Meta.Constraints
+	if len(cs) != 1 {
+		return false
+	}
+	canonical, ok := strings.CutPrefix(cs[0].Expression, "this ")
+	if !ok {
+		return false
+	}
+	op, digits, ok := strings.Cut(canonical, " ")
+	if !ok {
+		return false
+	}
+	switch op {
+	case ">", ">=", "<", "<=", "==", "!=":
+	default:
+		return false
+	}
+	n, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil || strconv.FormatInt(n, 10) != digits {
+		return false
+	}
+	// Rewrite the expression to the one predicate the production fingerprint DOES admit
+	// and ask it about the rest of the shape. That way the mutant differs from production
+	// in exactly one clause — the operator — and in nothing else.
+	rewritten := *b
+	rewritten.Classes = []schema.ClassDef{b.Classes[0]}
+	rewritten.Classes[0].Fields = append([]schema.ClassField(nil), b.Classes[0].Fields...)
+	rewritten.Classes[0].Fields[1].Type.Meta.Constraints = []schema.Constraint{{
+		Level: cs[0].Level, Expression: "this > " + digits, Label: cs[0].Label,
+	}}
+	if err := rewritten.RebuildIndexes(); err != nil {
+		return false
+	}
+	return staticCheckedFingerprintAdmits(&rewritten)
+}
+
+// TestStaticCheckedOperatorWideningIsProvenToBite is the 7.2c-1 no-flip mutation proof:
+// the shared gate-agreement comparison, fed a fingerprint widened to the six direct
+// comparisons, must report EVERY declined operator sibling.
+//
+// This is the assertion that makes the new decline rows worth having. Without it, the
+// five operator siblings would be rows that pass because the comparison never fires, and
+// a 7.2c-3 cutover landing early would be invisible here.
+func TestStaticCheckedOperatorWideningIsProvenToBite(t *testing.T) {
+	corpus := staticCheckedAgreementCorpus()
+	gates := staticCheckedSchemaGates()
+
+	// The widened fingerprint must still admit the CURRENT one, or the mutant would be a
+	// different fingerprint rather than a broader one.
+	admitted := staticCheckedBundle(schema.ConstraintCheck, "positive", "this > 0")
+	if !staticCheckedWidenedOperatorTwinAdmits(admitted) {
+		t.Fatal("the widened-operator mutant does not admit the CURRENT fingerprint, so it is not a " +
+			"broadening of it and the disagreements below would prove nothing")
+	}
+	// And it must NOT admit a sibling that differs by something other than the operator,
+	// or "widened by one clause" would be false.
+	renamed := staticCheckedBundle(schema.ConstraintCheck, "positive", "this > 0")
+	renamed.Classes[0].Name.Name = "SomeOtherAnswer"
+	renamed.Target.Name = "SomeOtherAnswer"
+	if err := renamed.RebuildIndexes(); err != nil {
+		t.Fatalf("rebuild indexes: %v", err)
+	}
+	if staticCheckedWidenedOperatorTwinAdmits(renamed) {
+		t.Fatal("the widened-operator mutant admits a RENAMED class, so it drops more than the " +
+			"operator clause and its disagreements would not be attributable to the operator")
+	}
+
+	widened := func(b *schema.Bundle) bool {
+		return staticCheckedFingerprintAdmits(b) || staticCheckedWidenedOperatorTwinAdmits(b)
+	}
+	got := staticCheckedGateDisagreements(widened, gates, corpus)
+	if len(got) == 0 {
+		t.Fatal("a fingerprint widened to all six direct comparisons produced NO disagreement; the " +
+			"agreement assertion cannot detect the 7.2c-3 cutover landing early")
+	}
+	// Every declined operator, in BOTH levels, must be named.
+	for _, expr := range staticCheckedDeclinedDirectOperators() {
+		for _, suffix := range []string{"", " (assert)"} {
+			// The disagreement lines render the row name with %q, so the fragment
+			// searched for has to be quoted the same way — matching the bare name would
+			// silently find nothing and report every row as undriven.
+			row := fmt.Sprintf("%q", "direct operator "+strconv.Quote(expr)+suffix)
+			found := false
+			for _, line := range got {
+				if strings.Contains(line, row) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("widening the operator set produced no disagreement naming %q; that row is "+
+					"not actually being driven through the gates", row)
+			}
+		}
+	}
+	t.Logf("no-flip proof: the six-operator widening is reported %d times across %d gates; all %d "+
+		"declined operator rows are named", len(got), len(gates), len(staticCheckedDeclinedDirectOperators())*2)
 }
 
 func staticCheckedExtraConstraintTwinAdmits(b *schema.Bundle) bool {

--- a/internal/debaml/predicatewire/boundary_test.go
+++ b/internal/debaml/predicatewire/boundary_test.go
@@ -1,0 +1,559 @@
+//go:build integration
+
+package predicatewire
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/internal/debaml"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// The DIRECT-i64 BOUNDARY MATRIX.
+//
+// # What it is for
+//
+// 7.2c-3 would admit a schema whose `confidence` is any i64 the strict extractor can
+// produce. The scope's non-negotiable preclaim rule is that an admitted schema must have
+// a total, byte-proven native outcome for EVERY such value — so the two things that have
+// to be known before 7.2c-2 can be designed are:
+//
+//  1. what stock ANSWERS across the whole i64 range, including around ±2^53 — the
+//     magnitude the native guard refuses from, one step below ±(2^53+1) where float64
+//     actually stops being exact — and at the i64 endpoints; and
+//  2. exactly where native's CURRENT generic evaluator guard REFUSES rather than answers.
+//
+// Both are measured here. The first is a stock capture. The second is an INDEPENDENT
+// native evaluation of the same (expression, value) pair — native's answer is compared
+// against the recorded stock answer in Go, and is never submitted back to the CFFI.
+//
+// # The contract, restated at the boundary
+//
+// internal/debaml.EvaluateConstraint promises either a boolean byte-identical to stock's
+// or an error wrapping ErrConstraintUnsupported. This matrix re-asserts that at the one
+// place it is most likely to break, and a native answer stock did not produce is a
+// FAILURE, never a recorded difference.
+
+// pwBoundaryOutcome is one row of the matrix: what stock said and what native did.
+type pwBoundaryOutcome struct {
+	threshold pwBoundaryThreshold
+	value     int64
+	operator  pwOperator
+	stock     bool
+	// nativeErr is non-nil when the native evaluator refused. The invariant is that it
+	// wraps ErrConstraintUnsupported; anything else is a contract violation.
+	nativeErr error
+	native    bool
+}
+
+// pwStatusBool converts stock's status string to the boolean the evaluator contract is
+// stated in, refusing anything that is neither.
+func pwStatusBool(t *testing.T, what, status string) bool {
+	t.Helper()
+	switch status {
+	case "succeeded":
+		return true
+	case "failed":
+		return false
+	default:
+		t.Fatalf("%s: stock reported status %q, which is neither succeeded nor failed", what, status)
+		return false
+	}
+}
+
+// TestDirectIntBoundaryMatrix drives the whole literal x value x operator matrix through
+// stock, then evaluates the SAME captured expression over the SAME value with the
+// production native evaluator, and reports where the two diverge.
+//
+// Byte-level pinning is deliberately NOT used for these rows. Each boundary function
+// carries SIX checks, so stock's public map has six keys and sonic.Marshal of a Go map
+// has no stable byte order — the very instability [TestTwoCheckWireOrderIsUnstable]
+// records. The assertion is therefore per-check and exact: name, expression and status,
+// compared field by field.
+func TestDirectIntBoundaryMatrix(t *testing.T) {
+	var rows []pwBoundaryOutcome
+	refusedBy := map[string]int{}
+
+	for _, b := range pwBoundaryThresholds() {
+		for _, v := range pwBoundaryValues(b.N) {
+			key := pwDriveKey{Project: b.projectKey(), Func: pwBoundaryFn, Raw: strconv.FormatInt(v, 10)}
+			stock := pwBareChecked(t, key)
+
+			if stock.Value != v {
+				t.Fatalf("%s: stock coerced the value to %d, want %d; the matrix would be measuring "+
+					"a different number", key, stock.Value, v)
+			}
+			if len(stock.Checks) != len(pwOperators()) {
+				t.Fatalf("%s: stock reported %d checks, want %d (one per operator): %v",
+					key, len(stock.Checks), len(pwOperators()), stock.Checks)
+			}
+
+			for _, o := range pwOperators() {
+				expr := fmt.Sprintf("this %s %s", o.Op, b.literal())
+				got, ok := stock.Checks[o.ID]
+				if !ok {
+					t.Fatalf("%s: stock reported no check under %q", key, o.ID)
+				}
+				if got.Name != o.ID || got.Expression != expr {
+					t.Fatalf("%s: stock check %q = {name:%q expression:%q}, want {name:%q expression:%q}",
+						key, o.ID, got.Name, got.Expression, o.ID, expr)
+				}
+				stockAnswer := pwStatusBool(t, key.String()+" "+o.ID, got.Status)
+
+				// The NATIVE leg. It is given the expression stock REPORTED — not the
+				// .baml attribute text — and the same value, and it is evaluated in
+				// this process without any BAML involvement.
+				nativeAnswer, nativeErr := debaml.EvaluateConstraint(debaml.IntValue(v), got.Expression)
+				if nativeErr != nil && !errors.Is(nativeErr, debaml.ErrConstraintUnsupported) {
+					t.Fatalf("%s %s: native returned an error that is NOT ErrConstraintUnsupported, "+
+						"which breaks the fail-closed contract: %v", key, o.ID, nativeErr)
+				}
+				if nativeErr == nil && nativeAnswer != stockAnswer {
+					t.Errorf("%s %s (%q over this=%d): native answered %v where stock answered %v — "+
+						"a boolean stock did not produce",
+						key, o.ID, got.Expression, v, nativeAnswer, stockAnswer)
+				}
+				if nativeErr != nil {
+					refusedBy[pwRefusalReason(b, v)]++
+				}
+				rows = append(rows, pwBoundaryOutcome{
+					threshold: b, value: v, operator: o,
+					stock: stockAnswer, native: nativeAnswer, nativeErr: nativeErr,
+				})
+			}
+		}
+	}
+
+	// The matrix must be the size it CLAIMS to be, against a PINNED number rather than
+	// one recomputed from the same tables that produced the rows. A derived expectation
+	// shrinks in step with a deleted threshold and reports nothing; this one goes red.
+	// [TestDirectIntBoundaryMatrixShapeIsPinned] carries the structural half.
+	if len(rows) != pwBoundaryRowCount {
+		t.Fatalf("the matrix produced %d rows, want the pinned %d; a threshold or a value was dropped "+
+			"(or added) without the pin being updated", len(rows), pwBoundaryRowCount)
+	}
+
+	answered, refused := 0, 0
+	for _, r := range rows {
+		if r.nativeErr != nil {
+			refused++
+			continue
+		}
+		answered++
+	}
+	// A COVERAGE claim, logged so a shrunken matrix cannot read as a full one. The
+	// clamped endpoints are named explicitly: math.MinInt64 and math.MaxInt64 have only
+	// one neighbour inside i64, so their rows are 2 values rather than 3 by arithmetic,
+	// not by omission.
+	t.Logf("direct-i64 boundary matrix: %d thresholds x 6 operators = %d rows "+
+		"(%d stock-answered rows native reproduces, %d native REFUSES). "+
+		"math.MinInt64/math.MaxInt64 contribute 2 values each rather than 3 because one neighbour "+
+		"falls outside i64.", len(pwBoundaryThresholds()), len(rows), answered, refused)
+	for _, reason := range pwSortedKeys(refusedBy) {
+		t.Logf("  native refuses %3d row(s): %s", refusedBy[reason], reason)
+	}
+
+	// Stock ANSWERED every row — asserted inline above, where a status that was neither
+	// `succeeded` nor `failed` is fatal. If stock had refused one, that row would be a
+	// value an admitted direct-int schema could not be total over, and the whole 7.2c
+	// premise would need revisiting.
+	//
+	// The native split is then non-vacuous in BOTH directions. (An `answered + refused ==
+	// len(rows)` check would be arithmetic about a two-way branch, not a claim about the
+	// matrix, so it is deliberately not written.)
+	if refused == 0 {
+		t.Fatal("native refused NOTHING across the whole boundary matrix; the 2^53 guard this slice " +
+			"documents as 7.2c-2's blocker would then not exist, and the exact-int work would be " +
+			"unmotivated — that contradiction must be resolved rather than passed over")
+	}
+	if answered == 0 {
+		t.Fatal("native refused EVERY row; the matrix would prove nothing about where the guard's " +
+			"edge actually is")
+	}
+
+	// THE FRONTIER — reported over NON-NEGATIVE literals only, and with the sign clause
+	// stated separately.
+	//
+	// A single magnitude frontier over all thirteen thresholds would be a MISSTATEMENT,
+	// not just an imprecision: `-1` and `+1` have the same magnitude and opposite
+	// dispositions, because a negative literal is refused by the arithmetic-byte clause
+	// whatever its size. "Answers up to 1 and refuses from 1 upward" is therefore not a
+	// partition of anything. Restricting the frontier to non-negative literals makes the
+	// magnitude claim well-formed; the sign clause is reported beside it as its own fact.
+	var maxAnswered, minRefused uint64
+	var sawAnswered, sawRefused bool
+	negativeAnswered := 0
+	for _, r := range rows {
+		if r.threshold.N < 0 {
+			if r.nativeErr == nil {
+				negativeAnswered++
+			}
+			continue
+		}
+		mag := absInt64(r.threshold.N)
+		if r.nativeErr == nil {
+			if !sawAnswered || mag > maxAnswered {
+				maxAnswered, sawAnswered = mag, true
+			}
+			continue
+		}
+		if !sawRefused || mag < minRefused {
+			minRefused, sawRefused = mag, true
+		}
+	}
+	if !sawAnswered || !sawRefused {
+		t.Fatalf("the non-negative frontier is undefined: answered=%v refused=%v", sawAnswered, sawRefused)
+	}
+	if maxAnswered >= minRefused {
+		t.Fatalf("the non-negative frontier is not ordered: native answers at magnitude %d and refuses "+
+			"at %d, so the two clauses overlap and the log below would misstate the residual",
+			maxAnswered, minRefused)
+	}
+	// The SIGN clause, as its own measured statement rather than folded into the number
+	// above. Every negative threshold is refused at every value, so the magnitude frontier
+	// simply does not apply on that side.
+	if negativeAnswered != 0 {
+		t.Errorf("native answered %d row(s) on a NEGATIVE literal; the recorded sign clause says every "+
+			"negative literal is refused, so either the clause or this count is wrong", negativeAnswered)
+	}
+	t.Logf("  native's frontier over NON-NEGATIVE literals: it answers at threshold magnitudes up to "+
+		"%d and refuses from %d upward. The axis samples no threshold between those two, so the exact "+
+		"crossing is not measured here — the >15-digit clause places it at 10^15, BELOW 2^53.",
+		maxAnswered, minRefused)
+	t.Logf("  the SIGN clause is separate and absolute: all %d negative-literal rows are refused "+
+		"regardless of magnitude, because `-` makes the whole expression arithmetic and `this ...` "+
+		"never parses as the closed numeric sublanguage", pwNegativeLiteralRows(rows))
+}
+
+// pwNegativeLiteralRows counts the matrix rows whose THRESHOLD is negative.
+func pwNegativeLiteralRows(rows []pwBoundaryOutcome) int {
+	n := 0
+	for _, r := range rows {
+		if r.threshold.N < 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// The PINNED shape of the boundary matrix.
+//
+// These are written out rather than derived from pwBoundaryThresholds()/pwBoundaryValues()
+// so that deleting a threshold — or quietly clamping one — fails instead of shrinking the
+// proof in step with its own expectation. The arithmetic is stated once here and checked
+// against the tables by [TestDirectIntBoundaryMatrixShapeIsPinned]:
+//
+//	11 interior thresholds x 3 values (n-1, n, n+1)      = 33
+//	 2 i64 endpoints      x 2 values (one neighbour only) =  4
+//	                                                        37 value-drives
+//	37 value-drives x 6 operators                         = 222 rows
+const (
+	pwBoundaryThresholdCount = 13
+	pwBoundaryValueDrives    = 37
+	pwBoundaryRowCount       = 222
+)
+
+// TestDirectIntBoundaryMatrixShapeIsPinned is the structural half of the size claim: it
+// checks the TABLES against the pinned numbers, independently of the matrix run, and
+// checks the thresholds are the distinct, deliberately chosen set the scope names.
+//
+// Together with the pinned row count in [TestDirectIntBoundaryMatrix], this is what makes
+// "222 rows" a claim rather than a restatement of whatever the tables happened to hold.
+func TestDirectIntBoundaryMatrixShapeIsPinned(t *testing.T) {
+	thresholds := pwBoundaryThresholds()
+	if len(thresholds) != pwBoundaryThresholdCount {
+		t.Fatalf("the threshold axis has %d entries, want the pinned %d", len(thresholds), pwBoundaryThresholdCount)
+	}
+	seenID := map[string]bool{}
+	seenN := map[int64]bool{}
+	drives := 0
+	for _, b := range thresholds {
+		if seenID[b.ID] {
+			t.Errorf("threshold id %q appears twice", b.ID)
+		}
+		seenID[b.ID] = true
+		if seenN[b.N] {
+			t.Errorf("threshold value %d appears twice, so one of its rows is a duplicate rather than "+
+				"a distinct boundary", b.N)
+		}
+		seenN[b.N] = true
+
+		values := pwBoundaryValues(b.N)
+		wantValues := 3
+		if b.N == math.MinInt64 || b.N == math.MaxInt64 {
+			wantValues = 2 // one neighbour falls outside i64
+		}
+		if len(values) != wantValues {
+			t.Errorf("threshold %s (%d) drives %d values, want %d", b.ID, b.N, len(values), wantValues)
+		}
+		// The values really are the neighbourhood of the threshold, not an arbitrary
+		// triple: the threshold itself must be among them.
+		found := false
+		for _, v := range values {
+			if v == b.N {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("threshold %s (%d) is not among the values driven against it", b.ID, b.N)
+		}
+		drives += len(values)
+	}
+	if drives != pwBoundaryValueDrives {
+		t.Fatalf("the threshold axis produces %d value-drives, want the pinned %d", drives, pwBoundaryValueDrives)
+	}
+	if got := drives * len(pwOperators()); got != pwBoundaryRowCount {
+		t.Fatalf("%d value-drives x %d operators = %d, but the pinned row count is %d",
+			drives, len(pwOperators()), got, pwBoundaryRowCount)
+	}
+	// And the drive table — the INDEPENDENT path the CFFI is actually driven through —
+	// must agree with the same number.
+	boundaryDrives := 0
+	for _, k := range pwAllDrives() {
+		if strings.HasPrefix(k.Project, "bound_") {
+			boundaryDrives++
+		}
+	}
+	if boundaryDrives != pwBoundaryValueDrives {
+		t.Fatalf("the drive table performs %d boundary parses but the threshold axis describes %d; the "+
+			"matrix and the rows actually driven have diverged", boundaryDrives, pwBoundaryValueDrives)
+	}
+	// The scope names these specific boundaries; a matrix that dropped one would still be
+	// "13 thresholds" if a filler replaced it.
+	for _, want := range []int64{
+		0, 1, -1,
+		maxExactInt - 1, maxExactInt, maxExactInt + 1,
+		-(maxExactInt - 1), -maxExactInt, -(maxExactInt + 1),
+		math.MaxInt64 - 1, math.MaxInt64, math.MinInt64 + 1, math.MinInt64,
+	} {
+		if !seenN[want] {
+			t.Errorf("the threshold axis omits %d, which the scope names explicitly", want)
+		}
+	}
+}
+
+// TestAdmittedGreaterThanReachesPostClaimUnsupported records a hazard the boundary matrix
+// exposes on the CURRENTLY ADMITTED predicate, not on a proposed one.
+//
+// `staticCheckedThreshold` admits any literal that round-trips through
+// strconv.FormatInt — math.MinInt64 and math.MaxInt64 included — and the strict extractor
+// can produce any i64 value. But the generic evaluator refuses most of that range. So a
+// bundle the production gates admit TODAY can reach ErrConstraintUnsupported AFTER the
+// admission decision, which is exactly the "no postclaim unsupported" rule the scope
+// states and the totality blocker it hands to 7.2c-2.
+//
+// This test CHANGES NOTHING. It records how wide the gap is on the one admitted operator,
+// so 7.2c-2 is sized against a measurement instead of an estimate, and so a later slice
+// that closes the gap has a row to turn green.
+func TestAdmittedGreaterThanReachesPostClaimUnsupported(t *testing.T) {
+	admittedLiterals, reachable, total := 0, 0, 0
+	var examples []string
+	for _, b := range pwBoundaryThresholds() {
+		expr := "this > " + b.literal()
+		bundle := pwBundleFor(schema.ConstraintCheck, pwCheckedLabel, expr)
+		if !pwAdmits(t, expr, bundle) {
+			continue
+		}
+		admittedLiterals++
+		for _, v := range pwBoundaryValues(b.N) {
+			total++
+			if _, err := debaml.EvaluateConstraint(debaml.IntValue(v), expr); err != nil {
+				reachable++
+				if len(examples) < 3 {
+					examples = append(examples, fmt.Sprintf("%q over this=%d", expr, v))
+				}
+			}
+		}
+	}
+	if admittedLiterals == 0 {
+		t.Fatal("the production gates admitted NONE of the boundary literals on `this > I`; the " +
+			"7.2b fingerprint is supposed to accept every canonical i64, so either the gates or this " +
+			"expectation has changed")
+	}
+	t.Logf("RECORDED (7.2c-2 blocker, measured on the ADMITTED predicate): the gates admit "+
+		"`this > I` for %d of %d boundary literals; of the %d (literal, value) pairs that follow, "+
+		"the production evaluator REFUSES %d after the admission decision. Examples: %s",
+		admittedLiterals, len(pwBoundaryThresholds()), total, reachable, strings.Join(examples, "; "))
+	if reachable == 0 {
+		t.Fatal("no admitted row reached an unsupported evaluator result, which would mean the " +
+			"totality blocker the scope hands to 7.2c-2 does not exist; that contradiction must be " +
+			"resolved rather than passed over")
+	}
+	// The hazard is POST-CLAIM by construction: the gate said yes before the evaluator
+	// was ever consulted. Stating it as an assertion keeps the row from being read as a
+	// pre-socket decline.
+	worst := pwBundleFor(schema.ConstraintCheck, pwCheckedLabel, "this > "+strconv.FormatInt(math.MaxInt64, 10))
+	if !pwAdmits(t, "this > math.MaxInt64", worst) {
+		t.Fatal("`this > math.MaxInt64` is no longer admitted; the recorded hazard above is stale")
+	}
+	if _, err := debaml.EvaluateConstraint(debaml.IntValue(math.MaxInt64), "this > "+strconv.FormatInt(math.MaxInt64, 10)); err == nil {
+		t.Fatal("the production evaluator now answers at math.MaxInt64; the recorded hazard above is stale")
+	}
+}
+
+// pwRefusalReason names WHICH clause of the generic numeric profile refuses a row.
+//
+// The two clauses are independent and both reachable here, so a single "native refused"
+// tally would hide which one is doing the work — and 7.2c-2 has to close BOTH for the
+// direct grammar, not just the one that happens to fire most often:
+//
+//   - the VALUE clause: |this| >= 2^53 is refused before evaluation, whatever the
+//     expression (constraint_profile.go's maxAbsInt check); and
+//   - the EXPRESSION clause: a numeric token longer than 15 digits is not provably small,
+//     and any `-` byte makes the whole expression arithmetic that must parse as the closed
+//     numeric sublanguage — which `this ...` never does.
+func pwRefusalReason(b pwBoundaryThreshold, value int64) string {
+	var reasons []string
+	for _, c := range pwRefusalClauses() {
+		if c.applies(b, value) {
+			reasons = append(reasons, c.name)
+		}
+	}
+	if len(reasons) == 0 {
+		return "UNATTRIBUTED — no clause of the documented profile explains this refusal"
+	}
+	return strings.Join(reasons, " + ")
+}
+
+// pwRefusalClause is one named clause of the generic numeric profile, with the ledger row
+// that records it as a residual.
+//
+// The clause set is DATA so that [TestRefusalClausesEachHaveALedgerRow] can enumerate it.
+// The three clauses are independent, and the third is the one it is easiest to leave
+// unrecorded: `9007199254740991` is 2^53-1 — BELOW the exactness bound — yet it is
+// sixteen digits, so it is refused by the literal-length clause alone. Folding it into
+// the 2^53 row would misdescribe the residual and understate what 7.2c-2 has to close.
+type pwRefusalClause struct {
+	// name is the string pwRefusalReason emits.
+	name string
+	// ledgerID is the residuals.md row that records this clause.
+	ledgerID string
+	applies  func(b pwBoundaryThreshold, value int64) bool
+}
+
+func pwRefusalClauses() []pwRefusalClause {
+	return []pwRefusalClause{{
+		name:     "VALUE |this| >= 2^53",
+		ledgerID: "i64_beyond_exact",
+		applies:  func(_ pwBoundaryThreshold, value int64) bool { return absInt64(value) >= uint64(maxExactInt) },
+	}, {
+		name:     "LITERAL has more than 15 digits",
+		ledgerID: "i64_long_literal",
+		applies: func(b pwBoundaryThreshold, _ int64) bool {
+			return len(strings.TrimPrefix(b.literal(), "-")) > 15
+		},
+	}, {
+		name:     "LITERAL is negative, so the expression carries an arithmetic byte",
+		ledgerID: "i64_negative_literal",
+		applies:  func(b pwBoundaryThreshold, _ int64) bool { return strings.HasPrefix(b.literal(), "-") },
+	}}
+}
+
+// absInt64 is |v| as a uint64, which is what the profile's own magnitude test uses:
+// math.MinInt64 has no positive int64 counterpart.
+func absInt64(v int64) uint64 {
+	if v < 0 {
+		return uint64(-(v + 1)) + 1
+	}
+	return uint64(v)
+}
+
+func pwSortedKeys(m map[string]int) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestDirectIntBoundaryRefusalsAreAttributed requires every native refusal in the matrix
+// to be explained by a NAMED clause of the documented profile.
+//
+// An unattributed refusal is the dangerous kind: it means native declines for a reason
+// nobody has written down, and 7.2c-2 would be closing a gap it had not located. This is
+// also the assertion that makes [pwRefusalReason] falsifiable rather than decorative.
+func TestDirectIntBoundaryRefusalsAreAttributed(t *testing.T) {
+	unattributed := 0
+	for _, b := range pwBoundaryThresholds() {
+		for _, v := range pwBoundaryValues(b.N) {
+			for _, o := range pwOperators() {
+				expr := fmt.Sprintf("this %s %s", o.Op, b.literal())
+				_, err := debaml.EvaluateConstraint(debaml.IntValue(v), expr)
+				if err == nil {
+					continue
+				}
+				if reason := pwRefusalReason(b, v); strings.HasPrefix(reason, "UNATTRIBUTED") {
+					unattributed++
+					t.Errorf("native refused %q over this=%d for no documented reason: %v", expr, v, err)
+				}
+			}
+		}
+	}
+	if unattributed != 0 {
+		t.Errorf("%d refusal(s) are outside the documented numeric profile", unattributed)
+	}
+}
+
+// TestDirectIntBoundaryIsProvenToBite is the anti-false-green control for the matrix.
+//
+// The comparison above only bites if a WRONG native answer would actually be reported. A
+// float64-based comparator is the exact wrong implementation the 2^53 guard exists to
+// prevent, so it is used as the mutant: at 2^53+1 it conflates two distinct integers, and
+// the matrix must disagree with it where stock does.
+func TestDirectIntBoundaryIsProvenToBite(t *testing.T) {
+	// (1) The float64 mutant conflates 2^53 and 2^53+1; stock does not. If these agreed,
+	// the whole exactness claim would be untestable at this boundary.
+	const at, above = maxExactInt, maxExactInt + 1
+	if float64(at) != float64(above) {
+		t.Fatal("float64 distinguishes 2^53 from 2^53+1 on this platform, so the mutant below is not " +
+			"the wrong implementation this matrix is meant to exclude")
+	}
+	key := pwDriveKey{Project: "bound_exact_at", Func: pwBoundaryFn, Raw: strconv.FormatInt(above, 10)}
+	stock := pwBareChecked(t, key)
+	eq, ok := stock.Checks["eq"]
+	if !ok {
+		t.Fatalf("%s: stock reported no `eq` check: %v", key, stock.Checks)
+	}
+	// Stock says FALSE where the float64 mutant (checked above to genuinely conflate the
+	// two) would have said TRUE. That gap is the whole content of this row.
+	if got := pwStatusBool(t, "eq at 2^53+1", eq.Status); got {
+		t.Fatalf("stock says %d == %d is TRUE; it is the float64 answer, not the exact one",
+			above, at)
+	}
+
+	// (2) The endpoints must be REACHED, not approximated. A matrix that silently
+	// clamped its thresholds would be green while never touching the range that
+	// motivates the exact-int work.
+	var sawMin, sawMax bool
+	for _, b := range pwBoundaryThresholds() {
+		switch b.N {
+		case math.MinInt64:
+			sawMin = true
+		case math.MaxInt64:
+			sawMax = true
+		}
+	}
+	if !sawMin || !sawMax {
+		t.Fatalf("the threshold axis reaches math.MinInt64=%v and math.MaxInt64=%v; both are required",
+			sawMin, sawMax)
+	}
+	// (3) And stock evaluates EXACTLY at math.MinInt64 — the one literal whose magnitude
+	// has no positive i64, and therefore the likeliest place a parser silently loses a
+	// value.
+	minKey := pwDriveKey{Project: "bound_i64min", Func: pwBoundaryFn, Raw: strconv.FormatInt(math.MinInt64, 10)}
+	minStock := pwBareChecked(t, minKey)
+	if got := minStock.Checks["eq"]; got.Status != "succeeded" {
+		t.Fatalf("stock says math.MinInt64 == math.MinInt64 is %q; the literal did not survive parsing",
+			got.Status)
+	}
+	if got := minStock.Checks["lt"]; got.Status != "failed" {
+		t.Fatalf("stock says math.MinInt64 < math.MinInt64 is %q", got.Status)
+	}
+}

--- a/internal/debaml/predicatewire/drive_test.go
+++ b/internal/debaml/predicatewire/drive_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package predicatewire
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/shared"
+	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+	"github.com/bytedance/sonic"
+)
+
+// Driving the stock CFFI.
+//
+// One parse per (project, function, raw text). Both halves of the result are retained:
+// a drive is either a value capture or an error capture, and which one it is is part of
+// what gets pinned.
+
+// pwDriveKey identifies one drive.
+type pwDriveKey struct {
+	Project string
+	Func    string
+	Raw     string
+}
+
+func (k pwDriveKey) String() string {
+	return fmt.Sprintf("%s/%s(%s)", k.Project, pwFuncPrefix+k.Func, k.Raw)
+}
+
+// pwResult is one stock parse.
+type pwResult struct {
+	value any
+	err   error
+}
+
+// pwCache memoizes one parse per key. No mutex: every subtest here is sequential (the
+// CFFI runtimes are process-global state and this suite deliberately does not
+// parallelise over them).
+var pwCache = map[pwDriveKey]pwResult{}
+
+// pwDrive runs one drive through the stock CFFI.
+//
+// The progress marker goes to STDERR unbuffered before the call, so if a row takes the
+// process down the last marker names the row that did it.
+func pwDrive(t *testing.T, key pwDriveKey) pwResult {
+	t.Helper()
+	if r, ok := pwCache[key]; ok {
+		return r
+	}
+	rt := pwRuntimeOf(t, key.Project)
+	fmt.Fprintf(os.Stderr, "predicate-wire: stock BEGIN %s\n", key)
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"text": key.Raw, "stream": false},
+		Env:    pwEnv,
+	}
+	encoded, err := args.Encode()
+	if err != nil {
+		t.Fatalf("%s: encode arguments: %v", key, err)
+	}
+	value, callErr := rt.CallFunctionParse(context.Background(), pwFuncPrefix+key.Func, encoded)
+	fmt.Fprintf(os.Stderr, "predicate-wire: stock END   %s\n", key)
+	r := pwResult{value: value, err: callErr}
+	pwCache[key] = r
+	return r
+}
+
+// pwValue returns the decoded value for a drive that must SUCCEED.
+func pwValue(t *testing.T, key pwDriveKey) any {
+	t.Helper()
+	r := pwDrive(t, key)
+	if r.err != nil {
+		t.Fatalf("%s: stock parse failed, but this drive is a VALUE capture: %v", key, r.err)
+	}
+	return r.value
+}
+
+// pwError returns the UNMODIFIED error for a drive that must FAIL.
+func pwError(t *testing.T, key pwDriveKey) error {
+	t.Helper()
+	r := pwDrive(t, key)
+	if r.err == nil {
+		t.Fatalf("%s: stock parse SUCCEEDED (%#v), but this drive is an ERROR capture", key, r.value)
+	}
+	if r.value != nil {
+		t.Fatalf("%s: stock produced BOTH an error and a value (%#v); a failed @assert emits no value",
+			key, r.value)
+	}
+	return r.err
+}
+
+// pwCheckedValue pulls a decoded value out of a drive and requires it to be the concrete
+// generated CHECK-family shape.
+//
+// The type assertion is the point: if stock had NOT wrapped `confidence`, or had wrapped
+// it in something else, this fails rather than silently comparing a different shape.
+func pwCheckedValue(t *testing.T, key pwDriveKey) pwCheckedAnswer {
+	t.Helper()
+	v := pwValue(t, key)
+	c, ok := v.(pwCheckedAnswer)
+	if !ok {
+		t.Fatalf("%s: stock decoded a %T, want %s", key, v, pwCheckedClass)
+	}
+	return c
+}
+
+// pwAssertValue is the ASSERT-family twin.
+func pwAssertValue(t *testing.T, key pwDriveKey) pwAssertAnswer {
+	t.Helper()
+	v := pwValue(t, key)
+	a, ok := v.(pwAssertAnswer)
+	if !ok {
+		t.Fatalf("%s: stock decoded a %T, want %s", key, v, pwAssertClass)
+	}
+	return a
+}
+
+// pwBareChecked is the bare-`int`-target twin: a probe whose target carries the
+// constraint directly decodes to the generated carrier itself.
+func pwBareChecked(t *testing.T, key pwDriveKey) shared.Checked[int64] {
+	t.Helper()
+	v := pwValue(t, key)
+	c, ok := v.(shared.Checked[int64])
+	if !ok {
+		t.Fatalf("%s: stock decoded a %T, want shared.Checked[int64]", key, v)
+	}
+	return c
+}
+
+// pwRequireSonicBytes asserts sonic.Marshal(v) is exactly want.
+//
+// sonic is the WIRE AUTHORITY: it is the serializer worker/parse.go and the final stream
+// path use. encoding/json is not interchangeable — it HTML-escapes the output of any
+// json.Marshaler, and every canonical expression here carries a `<`, `>` or both — which
+// checkedwire's TestStockWireEncoderFraming measures on stock's own struct.
+func pwRequireSonicBytes(t *testing.T, what string, v any, want string) {
+	t.Helper()
+	got, err := sonic.Marshal(v)
+	if err != nil {
+		t.Fatalf("%s: sonic.Marshal: %v", what, err)
+	}
+	if string(got) != want {
+		t.Fatalf("%s: sonic bytes:\n got %s\nwant %s", what, got, want)
+	}
+}
+
+// pwAllDrives is EVERY drive this package performs, assembled from the row tables.
+//
+// It exists so whole-table guards ([TestPredicateWireDecodersSawWhatWasDeclared], and the
+// coverage assertion in [TestOperatorManifestIsTheWholeGrammar]) see every row rather
+// than the rows one test happened to reach.
+func pwAllDrives() []pwDriveKey {
+	var out []pwDriveKey
+	for _, o := range pwOperators() {
+		for _, v := range []int64{o.TrueVal, o.FalseVal} {
+			out = append(out,
+				pwDriveKey{Project: o.projectKey(), Func: pwFnChecked, Raw: pwNestedRaw(v)},
+				pwDriveKey{Project: o.projectKey(), Func: pwFnAssert, Raw: pwNestedRaw(v)},
+			)
+		}
+	}
+	// The TOP-LEVEL twins of the operator matrix. A bare target takes the raw integer
+	// text directly rather than the two-field object.
+	for _, o := range pwOperators() {
+		for _, v := range []int64{o.TrueVal, o.FalseVal} {
+			raw := strconv.FormatInt(v, 10)
+			out = append(out,
+				pwDriveKey{Project: pwTopLevelKey, Func: pwTopCheckFn(o), Raw: raw},
+				pwDriveKey{Project: pwTopLevelKey, Func: pwTopAssertFn(o), Raw: raw},
+			)
+		}
+	}
+	for _, probe := range pwPadProbes() {
+		out = append(out, pwDriveKey{Project: pwExprTextKey, Func: "Pad_" + probe.Label, Raw: "5"})
+	}
+	for _, p := range pwLiteralProbes() {
+		// A project stock REFUSES has no function to drive; its capture is the refusal,
+		// asserted by TestStockNonCanonicalLiteralDispositions through pwCompileError.
+		if p.Rejected {
+			continue
+		}
+		out = append(out, pwDriveKey{Project: p.projectKey(), Func: pwFnChecked, Raw: pwNestedRaw(p.Confidence)})
+	}
+	for _, b := range pwBoundaryThresholds() {
+		for _, v := range pwBoundaryValues(b.N) {
+			out = append(out, pwDriveKey{Project: b.projectKey(), Func: pwBoundaryFn, Raw: fmt.Sprint(v)})
+		}
+	}
+	for _, r := range pwResiduals() {
+		for _, v := range r.Drives {
+			out = append(out, pwDriveKey{Project: r.projectKey(), Func: r.fn(), Raw: pwNestedRaw(v)})
+		}
+	}
+	return out
+}
+
+// pwDriveEveryRow drives every row once.
+func pwDriveEveryRow(t *testing.T) {
+	t.Helper()
+	for _, key := range pwAllDrives() {
+		pwDrive(t, key)
+	}
+}

--- a/internal/debaml/predicatewire/exprtext_test.go
+++ b/internal/debaml/predicatewire/exprtext_test.go
@@ -1,0 +1,278 @@
+//go:build integration
+
+package predicatewire
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/shared"
+)
+
+// The EXPRESSION-TEXT half: what stock RETAINS in Check.Expression for each canonical
+// predicate under source padding, and what it does with the non-canonical integer
+// spellings the fingerprint rejects.
+//
+// Both questions are about the string BAML keeps, which is the string a `Check` carries
+// onto the wire and the string an assertion cause quotes. The 7.2c grammar's canonical
+// inner text is only meaningful if stock produces it, and only bounded if the spellings
+// outside it are measured rather than assumed.
+
+// pwPadDriveRaw is the assistant text every padding probe is driven with: a bare int,
+// because these probes sit on a bare `int` target.
+const pwPadDriveRaw = "5"
+
+// pwPadDriveValue is that text as an integer, so the pinned bytes can carry it.
+const pwPadDriveValue = 5
+
+// pwPadStatus is the status stock must report for each operator at `this = 5` against
+// the canonical literal `0`.
+//
+// It is DATA, deliberately, not a Go comparison: computing it would re-derive the answer
+// with the same arithmetic the capture exists to check, and a table that agreed with a
+// wrong engine would be green.
+var pwPadStatus = map[string]string{
+	"gt": "succeeded", // 5 > 0
+	"ge": "succeeded", // 5 >= 0
+	"lt": "failed",    // 5 < 0
+	"le": "failed",    // 5 <= 0
+	"eq": "failed",    // 5 == 0
+	"ne": "succeeded", // 5 != 0
+}
+
+// pwBareWireBytes is the whole wire form of a bare checked int, assembled from the three
+// independent facts a padding probe is about: the label, the expression stock RETAINED,
+// and the status.
+//
+// Building the expectation rather than pinning fourteen near-identical literals is what
+// makes the assertion discriminating: stock is handed the PADDED source and the expected
+// bytes are built from the UNPADDED canonical text, so a stock that kept the padding
+// fails here. [TestStockPaddingIsStrippedForEveryOperator] additionally guards that no
+// expectation it builds carries padding at all.
+func pwBareWireBytes(label, expression, status string) string {
+	return fmt.Sprintf(`{"value":%d,"checks":{%q:{"name":%q,"expression":%q,"status":%q}}}`,
+		pwPadDriveValue, label, label, expression, status)
+}
+
+// TestStockPaddingIsStrippedForEveryOperator measures what stock retains for zero, one
+// and two ASCII spaces of source padding, for all six operators.
+//
+// checkedwire established this for the ONE-byte `>`; the open question 7.2c raises is
+// whether a TWO-byte operator behaves the same, because `>=` is the first admitted
+// expression that is longer than the one the current cause-length ceiling was computed
+// from. The pad-2 row is measured, NOT admitted: the production fingerprint still allows
+// at most one space, which internal/debaml's sibling corpus pins as a decline.
+func TestStockPaddingIsStrippedForEveryOperator(t *testing.T) {
+	pads := map[int]int{}
+	for _, probe := range pwPadProbes() {
+		t.Run(probe.Label, func(t *testing.T) {
+			status, ok := pwPadStatus[probe.Op.ID]
+			if !ok {
+				t.Fatalf("no pinned status for operator %q", probe.Op.ID)
+			}
+			key := pwDriveKey{Project: pwExprTextKey, Func: "Pad_" + probe.Label, Raw: pwPadDriveRaw}
+			stock := pwBareChecked(t, key)
+
+			// (1) Check.Expression DIRECTLY. The wire comparison alone could pass on a
+			// carrier that dropped the field entirely.
+			got, ok := stock.Checks[probe.Label]
+			if !ok {
+				t.Fatalf("stock reported no check under %q: %v", probe.Label, stock.Checks)
+			}
+			want := shared.Check{Name: probe.Label, Expression: probe.canonical(), Status: status}
+			if got != want {
+				t.Fatalf("stock check = %+v, want %+v\n(the source it was given was %q)",
+					got, want, probe.source())
+			}
+
+			// (2) The WIRE, built from the UNPADDED canonical text.
+			pwRequireSonicBytes(t, "stock", stock,
+				pwBareWireBytes(probe.Label, probe.canonical(), status))
+
+			pads[probe.Pad]++
+		})
+	}
+
+	// DISCRIMINATING: a padded source must actually differ from its canonical form, or
+	// "stock strips the padding" would be unfalsifiable for the pad-0 rows.
+	padded := 0
+	for _, probe := range pwPadProbes() {
+		if probe.source() != probe.canonical() {
+			padded++
+			if !strings.HasPrefix(probe.source(), " ") || !strings.HasSuffix(probe.source(), " ") {
+				t.Errorf("%s claims %d spaces of padding but its source is %q",
+					probe.Label, probe.Pad, probe.source())
+			}
+		}
+	}
+	if padded == 0 {
+		t.Fatal("no probe carries padding at all, so this file measures nothing")
+	}
+	// And every expectation this test built must be free of padding, or a stock that
+	// KEPT the padding could still have matched.
+	for _, probe := range pwPadProbes() {
+		w := pwBareWireBytes(probe.Label, probe.canonical(), pwPadStatus[probe.Op.ID])
+		if strings.Contains(w, `"expression":" `) || strings.Contains(w, ` ","status"`) {
+			t.Fatalf("a constructed expectation carries padding in the expression: %s", w)
+		}
+	}
+	// COVERAGE, logged so a shrunken matrix cannot read as a full one. The pad-2 arm is
+	// deliberately narrower than the other two — it exists to answer the two-byte-operator
+	// question, not to propose a third admitted padding.
+	t.Logf("padding measured: pad0 x%d, pad1 x%d, pad2 x%d (pad2 is the TWO-BYTE `>=` probe only, "+
+		"and remains a DECLINE in the production fingerprint)", pads[0], pads[1], pads[2])
+	if pads[0] != len(pwOperators()) || pads[1] != len(pwOperators()) {
+		t.Errorf("pad0/pad1 do not cover all %d operators (%d/%d)", len(pwOperators()), pads[0], pads[1])
+	}
+	if pads[2] == 0 {
+		t.Error("no pad2 probe ran, so the two-byte-operator padding question is unmeasured")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Canonical-literal discriminators.
+// ---------------------------------------------------------------------------
+
+// pwLiteralCapture is what stock did with one non-canonical integer spelling.
+type pwLiteralCapture struct {
+	// rejected is true when BAML's own parser refused the project. Then wire is empty
+	// and the recorded fact is the refusal itself.
+	rejected bool
+	// wire is sonic.Marshal of the decoded nested value when the project compiled.
+	wire string
+	// retained is the string stock put in Check.Expression, quoted here so the
+	// relationship to the .baml source text is visible in review.
+	retained string
+	// status is the outcome stock reached, which says how BAML INTERPRETED the literal.
+	status string
+	// note records what the outcome tells us about the interpretation.
+	note string
+}
+
+// pwCompileRefusedErr is the WHOLE Go-side error baml.CreateRuntime returns when stock's
+// parser refuses a project. The detailed diagnostic goes to the CFFI's own stderr, so
+// this is the entire observable, and it is pinned rather than merely checked non-empty.
+const pwCompileRefusedErr = "failed to create BAML runtime"
+
+// pwLiteralCaptures pins what stock v0.223.0 does with each spelling the 7.2b/7.2c
+// canonical grammar rejects.
+//
+// This is the evidence that the fingerprint's literal rule is a bounded OVER-DECLINE and
+// not a guess. Four of the five spellings COMPILE and evaluate — BAML's Jinja layer reads
+// `007` as 7, `1_000` as 1000 and `5.0` as a float — so nothing upstream would have
+// stopped them; the native rule has to reject them itself. The fifth is refused by BAML's
+// own parser, which is a different and stronger fact, recorded as such.
+var pwLiteralCaptures = map[string]pwLiteralCapture{
+	"plus5": {
+		rejected: true,
+		note: "BAML's Jinja parser REFUSES this spelling outright — the CFFI reports " +
+			"'syntax error: unexpected +' and the project does not compile — so it can never reach " +
+			"a native gate from a real project",
+	},
+	"leading_zeros": {
+		wire:     `{"answer":"sunny","confidence":{"value":9,"checks":{"positive":{"name":"positive","expression":"this > 007","status":"succeeded"}}}}`,
+		retained: "this > 007",
+		status:   "succeeded",
+		note:     "compiles; `007` is read as 7, and 9 > 7 holds. The retained text keeps the leading zeros",
+	},
+	"underscore": {
+		wire:     `{"answer":"sunny","confidence":{"value":9,"checks":{"positive":{"name":"positive","expression":"this > 1_000","status":"failed"}}}}`,
+		retained: "this > 1_000",
+		status:   "failed",
+		note:     "compiles; `1_000` is read as 1000, and 9 > 1000 fails. The retained text keeps the separator",
+	},
+	"float": {
+		wire:     `{"answer":"sunny","confidence":{"value":9,"checks":{"positive":{"name":"positive","expression":"this > 5.0","status":"succeeded"}}}}`,
+		retained: "this > 5.0",
+		status:   "succeeded",
+		note:     "compiles; a float threshold compares against an int `this` without complaint",
+	},
+	"overflow": {
+		wire:     `{"answer":"sunny","confidence":{"value":9,"checks":{"positive":{"name":"positive","expression":"this > 9223372036854775808","status":"failed"}}}}`,
+		retained: "this > 9223372036854775808",
+		status:   "failed",
+		note: "compiles; one past math.MaxInt64 does NOT wrap — 9 > 2^63 fails, so BAML carried the " +
+			"magnitude rather than truncating it to i64",
+	},
+}
+
+// TestStockNonCanonicalLiteralDispositions pins what stock does with every spelling the
+// canonical grammar rejects, so the rejection is measured rather than assumed.
+func TestStockNonCanonicalLiteralDispositions(t *testing.T) {
+	compiled, rejected := 0, 0
+	for _, probe := range pwLiteralProbes() {
+		t.Run(probe.ID, func(t *testing.T) {
+			capture, ok := pwLiteralCaptures[probe.ID]
+			if !ok {
+				t.Fatalf("literal probe %q has no pinned capture", probe.ID)
+			}
+			if capture.note == "" {
+				t.Fatal("a literal capture with no note records an outcome without recording what it means")
+			}
+			if capture.rejected {
+				rejected++
+				// The RECORDED FACT is the refusal. The Go-side text is pinned exactly
+				// even though it is generic: the CFFI writes its detailed diagnostic to
+				// stderr, so this string is the whole of what a caller can observe, and
+				// pinning it is what makes a CHANGE in that observable visible.
+				err := pwCompileError(t, probe.projectKey())
+				if got := err.Error(); got != pwCompileRefusedErr {
+					t.Fatalf("stock's refusal error = %s, want %s",
+						strconv.Quote(got), strconv.Quote(pwCompileRefusedErr))
+				}
+				t.Logf("stock REFUSED %q at parse time: %v", probe.expr(), err)
+				return
+			}
+			compiled++
+			key := pwDriveKey{Project: probe.projectKey(), Func: pwFnChecked, Raw: pwNestedRaw(probe.Confidence)}
+			stock := pwCheckedValue(t, key)
+			want := shared.Check{Name: pwCheckedLabel, Expression: capture.retained, Status: capture.status}
+			if got := stock.Confidence.Checks[pwCheckedLabel]; got != want {
+				t.Fatalf("stock check = %+v, want %+v", got, want)
+			}
+			pwRequireSonicBytes(t, "stock", stock, capture.wire)
+
+			// DISCRIMINATING: the retained text is the SOURCE spelling, not a
+			// canonicalised one. A stock that normalised `007` to `7` would fail here
+			// rather than pass on a string that merely evaluates the same.
+			if capture.retained != probe.expr() {
+				t.Errorf("the pinned retained text %q is not the source spelling %q",
+					capture.retained, probe.expr())
+			}
+			if !strings.Contains(capture.wire, `"expression":`+strconv.Quote(probe.expr())) {
+				t.Errorf("the pinned wire bytes do not carry the source spelling: %s", capture.wire)
+			}
+		})
+	}
+	if compiled == 0 || rejected == 0 {
+		t.Fatalf("the literal matrix landed %d compiled and %d rejected; both dispositions must be "+
+			"witnessed or one of them is an untested branch", compiled, rejected)
+	}
+	t.Logf("non-canonical literals: %d COMPILE and evaluate (so the native fingerprint must reject "+
+		"them itself), %d refused by BAML's own parser", compiled, rejected)
+}
+
+// TestNonCanonicalLiteralsAreNotTheCanonicalOne is the discriminating control: every
+// spelling captured above must actually differ from the canonical `strconv.FormatInt`
+// form of the value it denotes, or the file would be measuring the admitted grammar.
+func TestNonCanonicalLiteralsAreNotTheCanonicalOne(t *testing.T) {
+	canonical := map[string]bool{}
+	for _, o := range pwOperators() {
+		canonical[o.expr()] = true
+	}
+	for _, probe := range pwLiteralProbes() {
+		if canonical[probe.expr()] {
+			t.Errorf("literal probe %q spells a CANONICAL expression (%q); it discriminates nothing",
+				probe.ID, probe.expr())
+		}
+		// The literal's canonical form, where it has one, must be a different string.
+		if n, err := strconv.ParseInt(probe.Literal, 10, 64); err == nil {
+			if strconv.FormatInt(n, 10) == probe.Literal {
+				t.Errorf("literal %q round-trips through FormatInt, so it is CANONICAL and belongs in "+
+					"the admitted grammar rather than in this table", probe.Literal)
+			}
+		}
+	}
+}

--- a/internal/debaml/predicatewire/ledger_test.go
+++ b/internal/debaml/predicatewire/ledger_test.go
@@ -1,0 +1,333 @@
+//go:build integration
+
+package predicatewire
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The RESIDUAL LEDGER guard.
+//
+// residuals.md is proof material, not prose: it is the durable record of what 7.2c
+// defers and on whose authority. A ledger nobody checks is a ledger that goes stale, so
+// this file ties it to the code — every form captured from stock in this package must
+// have a row, every row must be a decline, and every authority naming a test in this
+// package must name one that exists.
+
+const pwLedgerPath = "residuals.md"
+
+// pwLedgerRow is one parsed ledger row.
+type pwLedgerRow struct {
+	id          string
+	form        string
+	disposition string
+	authority   string
+}
+
+// pwParseLedger reads residuals.md and returns its table rows.
+//
+// The parse is strict on purpose: a malformed row is an error rather than a skipped line,
+// because a silently skipped row is exactly how a deferral would stop being covered.
+func pwParseLedger(t *testing.T) []pwLedgerRow {
+	t.Helper()
+	raw, err := os.ReadFile(pwLedgerPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", pwLedgerPath, err)
+	}
+	var out []pwLedgerRow
+	inTable := false
+	for _, line := range strings.Split(string(raw), "\n") {
+		if !strings.HasPrefix(line, "|") {
+			continue
+		}
+		cells := strings.Split(strings.Trim(line, "|"), "|")
+		for i := range cells {
+			cells[i] = strings.TrimSpace(cells[i])
+		}
+		if len(cells) != 4 {
+			t.Fatalf("ledger row has %d cells, want 4: %q", len(cells), line)
+		}
+		if cells[0] == "id" {
+			inTable = true
+			continue
+		}
+		if strings.HasPrefix(cells[0], "---") {
+			continue
+		}
+		if !inTable {
+			t.Fatalf("a table row appears before the header: %q", line)
+		}
+		for i, cell := range cells {
+			if cell == "" {
+				t.Fatalf("ledger row %q has an empty cell at position %d", cells[0], i)
+			}
+		}
+		out = append(out, pwLedgerRow{id: cells[0], form: cells[1], disposition: cells[2], authority: cells[3]})
+	}
+	if len(out) == 0 {
+		t.Fatalf("%s has no table rows; every claim this file makes would be vacuous", pwLedgerPath)
+	}
+	return out
+}
+
+// pwLedgerAdmissionViolations is THE disposition checker: it returns one line per row
+// whose disposition is not exactly `DECLINED`.
+//
+// It is a function rather than an inline loop so the assertion and its mutation proof
+// drive the SAME code. A negative control that re-implements the check — or, worse, that
+// only compares a fabricated field back to the row it was built from — proves that two
+// strings differ, not that the invariant bites.
+func pwLedgerAdmissionViolations(rows []pwLedgerRow) []string {
+	var out []string
+	for _, r := range rows {
+		if r.disposition != "DECLINED" {
+			out = append(out, fmt.Sprintf("row %q has disposition %q; every residual is DECLINED in 7.2c-1",
+				r.id, r.disposition))
+		}
+	}
+	return out
+}
+
+// TestResidualLedgerCoversEveryDeferral is the ledger's own guard.
+func TestResidualLedgerCoversEveryDeferral(t *testing.T) {
+	rows := pwParseLedger(t)
+	byID := map[string]pwLedgerRow{}
+	for _, r := range rows {
+		if _, dup := byID[r.id]; dup {
+			t.Errorf("ledger row %q appears twice", r.id)
+		}
+		byID[r.id] = r
+	}
+	// (1) NOTHING in the ledger may be admitted. This is the whole no-flip invariant,
+	// restated over the document a reviewer reads. It runs through the SAME checker the
+	// bite test drives a mutant through, so the two cannot drift apart.
+	if got := pwLedgerAdmissionViolations(rows); len(got) != 0 {
+		t.Errorf("the ledger records a non-DECLINED disposition:\n  %s", strings.Join(got, "\n  "))
+	}
+
+	// (2) Every form CAPTURED from stock in this package must have a row, or a
+	// measurement would exist with no recorded disposition behind it.
+	for _, res := range pwResiduals() {
+		if _, ok := byID[res.ID]; !ok {
+			t.Errorf("residual %q is captured from stock but has no ledger row", res.ID)
+		}
+	}
+	// (3) And every operator this package captured but did NOT admit must have one too.
+	for _, o := range pwOperators() {
+		if o.Op == ">" {
+			continue // the one admitted predicate; it is not a residual
+		}
+		if _, ok := byID["operator_"+o.ID]; !ok {
+			t.Errorf("operator %q is captured and still declined, but has no ledger row", o.Op)
+		}
+	}
+	if _, ok := byID["operator_gt"]; ok {
+		t.Error("the ledger carries a row for `this > I`, which is the ADMITTED predicate, not a residual")
+	}
+
+	// (4) The scope's own deferral list, written out here independently so the ledger
+	// and the scope can disagree. These are the families §"#583 durable deferrals"
+	// names; a missing one is scope that quietly stopped being tracked.
+	for _, want := range []string{
+		"two_checks", "duplicate_labels", "check_then_assert", "assert_then_check",
+		"compound_predicate", "filters_and_arithmetic",
+		"type_float", "type_string", "type_bool", "type_enum", "type_nullable",
+		"type_list", "type_map", "type_union", "type_nested_class", "type_media",
+		"target_constraint", "class_constraint", "toplevel_constrained",
+		"shape_third_field", "shape_reordered_fields", "shape_constraint_on_answer",
+		"shape_two_constrained_fields", "shape_class_name", "shape_extra_definitions",
+		"meta_alias", "meta_description", "meta_stream_dynamic",
+		"label_non_ascii", "label_empty_present",
+		"route_static_stream", "route_dynamic_final", "route_direct_parse", "route_call_with_raw",
+	} {
+		if _, ok := byID[want]; !ok {
+			t.Errorf("the scope defers %q but the ledger has no row for it", want)
+		}
+	}
+
+	// (4b) Every NUMERIC REFUSAL CLAUSE the boundary matrix can attribute a decline to
+	// must have its own row. The three clauses are independent — a literal can be too
+	// long while its value is well inside 2^53 (`9007199254740991` is 2^53-1 and sixteen
+	// digits) — so one row cannot stand for another without misdescribing the residual
+	// and understating what 7.2c-2 has to close.
+	for _, c := range pwRefusalClauses() {
+		if _, ok := byID[c.ledgerID]; !ok {
+			t.Errorf("the boundary matrix attributes refusals to %q but the ledger has no row %q",
+				c.name, c.ledgerID)
+		}
+	}
+
+	// (5) Every authority naming a test must name one that EXISTS, in the package it
+	// says. A citation to a test that was renamed away is a ledger row with nothing
+	// behind it — and that is the failure mode a ledger has, so it is checked rather
+	// than trusted.
+	measured, cited, scoped := 0, 0, 0
+	for _, r := range rows {
+		pkg, name, ok := strings.Cut(r.authority, ":")
+		if !ok {
+			t.Errorf("ledger row %q has an authority with no package prefix: %q", r.id, r.authority)
+			continue
+		}
+		switch pkg {
+		case "predicatewire":
+			measured++
+		case "scope":
+			scoped++
+			continue
+		default:
+			cited++
+		}
+		dir, ok := pwAuthorityDirs()[pkg]
+		if !ok {
+			t.Errorf("ledger row %q cites unknown authority package %q", r.id, pkg)
+			continue
+		}
+		if !pwAuthorityExists(t, dir, name) {
+			t.Errorf("ledger row %q cites %s, which package %s does not declare", r.id, name, pkg)
+		}
+	}
+	// (6) The BOUND, logged rather than implied. Rows whose authority is `scope:` carry
+	// a decision with no measurement in this PR, and a reader must be able to see how
+	// many there are without counting the table by hand.
+	t.Logf("residual ledger: %d rows — %d MEASURED in this package against stock v0.223.0, "+
+		"%d cited from sibling stock oracles, %d recorded from the scope with NO new measurement "+
+		"in this PR (those are the rows a later slice must measure before moving them)",
+		len(rows), measured, cited, scoped)
+	if measured == 0 {
+		t.Error("no ledger row is backed by a measurement in this package, which is what this PR exists to add")
+	}
+}
+
+// pwAuthorityDirs maps an authority package prefix to the directory its declarations live
+// in, relative to this package.
+func pwAuthorityDirs() map[string]string {
+	return map[string]string{
+		"predicatewire": ".",
+		"checkedwire":   "../checkedwire",
+		"debaml":        "..",
+	}
+}
+
+// pwAuthorityExists reports whether a cited authority is really declared in dir.
+//
+// An authority is either a Go test function or a checked-in proof FILE (checkedwire's
+// asymmetries.md is the one of the latter kind: the non-ASCII truncation boundary is
+// recorded there as an UNMEASURED hazard, which is a disposition without a test).
+func pwAuthorityExists(t *testing.T, dir, name string) bool {
+	t.Helper()
+	if strings.HasSuffix(name, ".md") {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			return false
+		}
+		return true
+	}
+	return strings.Contains(pwPackageSources(t, dir), "func "+name+"(t *testing.T)")
+}
+
+// pwSourceCache memoizes each scanned directory: the sibling debaml package is ~500 KB of
+// _test.go and every cited row would otherwise re-read it.
+var pwSourceCache = map[string]string{}
+
+// pwPackageSources concatenates a package's _test.go sources, so a citation can be checked
+// against the declarations that actually exist.
+func pwPackageSources(t *testing.T, dir string) string {
+	t.Helper()
+	if s, ok := pwSourceCache[dir]; ok {
+		return s
+	}
+	files, err := filepath.Glob(filepath.Join(dir, "*_test.go"))
+	if err != nil {
+		t.Fatalf("glob %s sources: %v", dir, err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("%s declares no _test.go files, so no citation into it can be verified", dir)
+	}
+	var b strings.Builder
+	for _, f := range files {
+		raw, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		b.Write(raw)
+	}
+	pwSourceCache[dir] = b.String()
+	return b.String()
+}
+
+// TestResidualLedgerGuardIsProvenToBite feeds the ledger parser and its checks a
+// deliberately broken row and requires each to be reported.
+//
+// Without it, a parser that silently skipped malformed lines would make every assertion
+// above vacuous — the ledger could be empty and the guard green.
+func TestResidualLedgerGuardIsProvenToBite(t *testing.T) {
+	rows := pwParseLedger(t)
+	// (1) The parse must actually have found the table, not a prefix of it.
+	if len(rows) < 40 {
+		t.Fatalf("the parser found %d rows; the ledger covers substantially more, so it is stopping "+
+			"early and the coverage checks above are only seeing part of the table", len(rows))
+	}
+	// (2) An ADMITTED disposition must be DETECTED BY THE REAL CHECKER. The mutant is
+	// routed through [pwLedgerAdmissionViolations] — the same function
+	// TestResidualLedgerCoversEveryDeferral asserts on — rather than compared against
+	// itself, so this proves the invariant bites instead of proving that "ADMITTED"
+	// differs from "DECLINED".
+	if got := pwLedgerAdmissionViolations(rows); len(got) != 0 {
+		t.Fatalf("the UNMUTATED ledger already reports a violation, so the mutant below would prove "+
+			"nothing:\n  %s", strings.Join(got, "\n  "))
+	}
+	for i := range rows {
+		mutated := append([]pwLedgerRow(nil), rows...)
+		mutated[i].disposition = "ADMITTED"
+		got := pwLedgerAdmissionViolations(mutated)
+		if len(got) != 1 {
+			t.Fatalf("flipping row %q to ADMITTED produced %d violation(s), want exactly 1: %v",
+				rows[i].id, len(got), got)
+		}
+		if !strings.Contains(got[0], rows[i].id) {
+			t.Errorf("flipping row %q to ADMITTED was reported against a different row: %s",
+				rows[i].id, got[0])
+		}
+	}
+	// And a disposition that is neither word — the silent-typo case — must also be
+	// reported, so the check is "is DECLINED" rather than "is not ADMITTED".
+	typo := append([]pwLedgerRow(nil), rows...)
+	typo[0].disposition = "declined"
+	if got := pwLedgerAdmissionViolations(typo); len(got) != 1 {
+		t.Fatalf("a lower-case `declined` produced %d violation(s), want exactly 1; the checker accepts "+
+			"a disposition it never validated: %v", len(got), got)
+	}
+	// (3) The citation check must report a name that is NOT declared. The absent name is
+	// assembled at run time from fragments, so the literal cannot appear in the sources
+	// being scanned and accidentally satisfy its own negative control.
+	absent := "Test" + "AbsentAuthority" + "NegativeControl"
+	for pkg, dir := range pwAuthorityDirs() {
+		if pwAuthorityExists(t, dir, absent) {
+			t.Fatalf("package %s appears to declare %s, so the citation check cannot detect a stale "+
+				"citation", pkg, absent)
+		}
+		if !pwAuthorityExists(t, dir, "TestResidualLedgerCoversEveryDeferral") &&
+			!pwAuthorityExists(t, dir, "TestServingOracleBoundaryLock") &&
+			!pwAuthorityExists(t, dir, "TestStockAssertIsNotACheck") {
+			t.Errorf("the citation check found NO known test in %s, so it would report every row in "+
+				"that package as stale rather than checking them", pkg)
+		}
+	}
+	// And a missing FILE authority must be detectable too, since one row cites one.
+	if pwAuthorityExists(t, "../checkedwire", "definitely-not-a-file.md") {
+		t.Fatal("the file-authority check accepts a file that does not exist")
+	}
+	found := false
+	for _, r := range rows {
+		if strings.HasPrefix(r.authority, "predicatewire:") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("no row cites a test in this package, so the citation check never runs")
+	}
+}

--- a/internal/debaml/predicatewire/operators_test.go
+++ b/internal/debaml/predicatewire/operators_test.go
@@ -1,0 +1,554 @@
+//go:build integration
+
+package predicatewire
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/shared"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/debaml"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// The OPERATOR half: what stock v0.223.0 puts on the wire, and in an assertion error,
+// for each of the six direct comparisons on BOTH name-pinned families.
+//
+// The comparison is on raw []byte from sonic.Marshal and on the WHOLE unmodified
+// err.Error(). Nothing here is normalised, collapsed or matched by substring: a pinned
+// literal is the entire output.
+//
+// These captures are AUTHORITY, not permission. Slice 7.2c-1 admits nothing: five of the
+// six operators below are still declines at every production gate, and
+// [TestPredicateWireAdmissionIsUnchanged] proves it beside the captures rather than
+// leaving it to another package.
+
+// pwOperatorCapture is the four pinned stock outputs for one operator: three wire byte
+// strings and one error byte string.
+type pwOperatorCapture struct {
+	// checkTrue and checkFalse are sonic.Marshal of the decoded CHECK family with the
+	// predicate holding and failing. Both carry the value — a false @check is DATA.
+	checkTrue  string
+	checkFalse string
+	// assertTrue is sonic.Marshal of the decoded ASSERT family with the predicate
+	// holding: an ordinary int, no wrapper, no check entry.
+	assertTrue string
+	// assertFail is the UNMODIFIED err.Error() of the ASSERT family with the predicate
+	// FALSE: no value at all, and stock's required-field wrapper chain. The embedded
+	// `\n` is stock's DEBUG escape (two bytes), never a real newline.
+	assertFail string
+}
+
+// pwOperatorCaptures is the byte authority for the whole six-operator manifest.
+//
+// Every string was produced by driving the raw assistant text of the named isolated
+// project through the stock BAML v0.223.0 CFFI and serializing the decoded value with
+// sonic (or by taking err.Error() unchanged). Nothing here is derived from native output.
+var pwOperatorCaptures = map[string]pwOperatorCapture{
+	"gt": {
+		checkTrue:  `{"answer":"sunny","confidence":{"value":9,"checks":{"positive":{"name":"positive","expression":"this > 0","status":"succeeded"}}}}`,
+		checkFalse: `{"answer":"sunny","confidence":{"value":-1,"checks":{"positive":{"name":"positive","expression":"this > 0","status":"failed"}}}}`,
+		assertTrue: `{"answer":"sunny","confidence":9}`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Failed while parsing required fields: missing=0, unparsed=1", causes: [ParsingError { scope: [], reason: "Failed to parse field confidence: <root>: Assertions failed.\n  - <root>: Failed: positive this > 0", causes: [ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this > 0", causes: [] }] }] }] }`,
+	},
+	"ge": {
+		checkTrue:  `{"answer":"sunny","confidence":{"value":0,"checks":{"positive":{"name":"positive","expression":"this >= 0","status":"succeeded"}}}}`,
+		checkFalse: `{"answer":"sunny","confidence":{"value":-1,"checks":{"positive":{"name":"positive","expression":"this >= 0","status":"failed"}}}}`,
+		assertTrue: `{"answer":"sunny","confidence":0}`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Failed while parsing required fields: missing=0, unparsed=1", causes: [ParsingError { scope: [], reason: "Failed to parse field confidence: <root>: Assertions failed.\n  - <root>: Failed: positive this >= 0", causes: [ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this >= 0", causes: [] }] }] }] }`,
+	},
+	"lt": {
+		checkTrue:  `{"answer":"sunny","confidence":{"value":-1,"checks":{"positive":{"name":"positive","expression":"this < 0","status":"succeeded"}}}}`,
+		checkFalse: `{"answer":"sunny","confidence":{"value":9,"checks":{"positive":{"name":"positive","expression":"this < 0","status":"failed"}}}}`,
+		assertTrue: `{"answer":"sunny","confidence":-1}`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Failed while parsing required fields: missing=0, unparsed=1", causes: [ParsingError { scope: [], reason: "Failed to parse field confidence: <root>: Assertions failed.\n  - <root>: Failed: positive this < 0", causes: [ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this < 0", causes: [] }] }] }] }`,
+	},
+	"le": {
+		checkTrue:  `{"answer":"sunny","confidence":{"value":0,"checks":{"positive":{"name":"positive","expression":"this <= 0","status":"succeeded"}}}}`,
+		checkFalse: `{"answer":"sunny","confidence":{"value":9,"checks":{"positive":{"name":"positive","expression":"this <= 0","status":"failed"}}}}`,
+		assertTrue: `{"answer":"sunny","confidence":0}`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Failed while parsing required fields: missing=0, unparsed=1", causes: [ParsingError { scope: [], reason: "Failed to parse field confidence: <root>: Assertions failed.\n  - <root>: Failed: positive this <= 0", causes: [ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this <= 0", causes: [] }] }] }] }`,
+	},
+	"eq": {
+		checkTrue:  `{"answer":"sunny","confidence":{"value":0,"checks":{"positive":{"name":"positive","expression":"this == 0","status":"succeeded"}}}}`,
+		checkFalse: `{"answer":"sunny","confidence":{"value":9,"checks":{"positive":{"name":"positive","expression":"this == 0","status":"failed"}}}}`,
+		assertTrue: `{"answer":"sunny","confidence":0}`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Failed while parsing required fields: missing=0, unparsed=1", causes: [ParsingError { scope: [], reason: "Failed to parse field confidence: <root>: Assertions failed.\n  - <root>: Failed: positive this == 0", causes: [ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this == 0", causes: [] }] }] }] }`,
+	},
+	"ne": {
+		checkTrue:  `{"answer":"sunny","confidence":{"value":9,"checks":{"positive":{"name":"positive","expression":"this != 0","status":"succeeded"}}}}`,
+		checkFalse: `{"answer":"sunny","confidence":{"value":0,"checks":{"positive":{"name":"positive","expression":"this != 0","status":"failed"}}}}`,
+		assertTrue: `{"answer":"sunny","confidence":9}`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Failed while parsing required fields: missing=0, unparsed=1", causes: [ParsingError { scope: [], reason: "Failed to parse field confidence: <root>: Assertions failed.\n  - <root>: Failed: positive this != 0", causes: [ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this != 0", causes: [] }] }] }] }`,
+	},
+}
+
+// pwCaptureOf returns one operator's pinned capture, failing loudly if an operator was
+// added to the manifest without one.
+func pwCaptureOf(t *testing.T, o pwOperator) pwOperatorCapture {
+	t.Helper()
+	c, ok := pwOperatorCaptures[o.ID]
+	if !ok {
+		t.Fatalf("operator %q (%s) is in the manifest with no pinned stock capture; the widening "+
+			"it proposes would rest on nothing", o.ID, o.Op)
+	}
+	return c
+}
+
+// pwCheckedLabel is the constraint label every operator project uses.
+const pwCheckedLabel = "positive"
+
+// TestOperatorManifestIsTheWholeGrammar pins the manifest itself against the 7.2c scope's
+// operator set, so a quietly dropped operator is a failure rather than a smaller matrix
+// that still passes.
+func TestOperatorManifestIsTheWholeGrammar(t *testing.T) {
+	// The scope's set, written out independently of pwOperators so the two can disagree.
+	want := map[string]bool{">": true, ">=": true, "<": true, "<=": true, "==": true, "!=": true}
+	got := map[string]bool{}
+	for _, o := range pwOperators() {
+		if got[o.Op] {
+			t.Fatalf("operator %q appears twice in the manifest", o.Op)
+		}
+		got[o.Op] = true
+		if o.TrueVal == o.FalseVal {
+			t.Errorf("operator %q drives the same value for both outcomes, so its two captures "+
+				"cannot differ", o.Op)
+		}
+	}
+	for op := range want {
+		if !got[op] {
+			t.Errorf("the manifest omits %q; 7.2c's operator set is exactly {>, >=, <, <=, ==, !=}", op)
+		}
+	}
+	for op := range got {
+		if !want[op] {
+			t.Errorf("the manifest carries %q, which is not in 7.2c's operator set", op)
+		}
+	}
+	// COVERAGE, not a claim about the table. The scope requires NESTED AND TOP-LEVEL
+	// check pass/fail and assert pass/fail for every operator, so both halves are counted
+	// here — a matrix that quietly dropped one of them would otherwise still pass every
+	// byte assertion it did keep.
+	perProject := map[string]int{}
+	perTopFunc := map[string]int{}
+	for _, k := range pwAllDrives() {
+		perProject[k.Project]++
+		if k.Project == pwTopLevelKey {
+			perTopFunc[k.Func]++
+		}
+	}
+	for _, o := range pwOperators() {
+		if n := perProject[o.projectKey()]; n != 4 {
+			t.Errorf("operator %q drives %d NESTED rows, want exactly 4 (check pass/fail, assert "+
+				"pass/fail)", o.Op, n)
+		}
+		for _, fn := range []string{pwTopCheckFn(o), pwTopAssertFn(o)} {
+			if n := perTopFunc[fn]; n != 2 {
+				t.Errorf("operator %q drives %d rows through %s, want exactly 2 (pass and fail)",
+					o.Op, n, fn)
+			}
+		}
+	}
+	if n := perProject[pwTopLevelKey]; n != len(pwOperators())*4 {
+		t.Errorf("the top-level project drives %d rows, want %d (6 operators x 4 outcomes)",
+			n, len(pwOperators())*4)
+	}
+	t.Logf("operator manifest: 6 operators x 4 outcomes x 2 positions = %d captures — %d NESTED on "+
+		"the two pinned families and %d TOP-LEVEL on a bare `int` target",
+		6*4*2, perProject[pwOperators()[0].projectKey()]*6, perProject[pwTopLevelKey])
+}
+
+// pwCarrierFromStock builds the NATIVE carrier from stock's OWN decoded check results.
+//
+// The value and every check field come from stock; the only thing this supplies is the
+// declaration order, which stock's map fold has already destroyed. The label set must
+// match exactly, so a check stock did not report cannot be invented and one it did report
+// cannot be dropped.
+func pwCarrierFromStock(t *testing.T, stock shared.Checked[int64], declared ...string) bamlutils.Checked[int64] {
+	t.Helper()
+	if len(declared) != len(stock.Checks) {
+		t.Fatalf("the fixture declares %d check(s) but stock reported %d: %v", len(declared), len(stock.Checks), stock.Checks)
+	}
+	ordered := make([]bamlutils.Check, 0, len(declared))
+	for _, label := range declared {
+		got, ok := stock.Checks[label]
+		if !ok {
+			t.Fatalf("stock reported no check under the declared label %q: %v", label, stock.Checks)
+		}
+		ordered = append(ordered, bamlutils.Check{Name: got.Name, Expression: got.Expression, Status: got.Status})
+	}
+	carrier, err := bamlutils.NewChecked(stock.Value, ordered)
+	if err != nil {
+		t.Fatalf("NewChecked over stock's own check results: %v", err)
+	}
+	return carrier
+}
+
+// TestStockOperatorWireBytes is the byte oracle for all six direct comparisons on the
+// name-pinned CHECK family, in both outcomes.
+//
+// Three assertions per row, in order of strength: the decoded value field by field (so
+// the bytes cannot pass on a value that merely serializes the same way), the wire bytes
+// themselves, and the native carrier built from stock's own results reproducing them.
+func TestStockOperatorWireBytes(t *testing.T) {
+	for _, o := range pwOperators() {
+		cap := pwCaptureOf(t, o)
+		for _, tc := range []struct {
+			outcome string
+			value   int64
+			status  string
+			want    string
+		}{
+			{"true", o.TrueVal, "succeeded", cap.checkTrue},
+			{"false", o.FalseVal, "failed", cap.checkFalse},
+		} {
+			t.Run(o.ID+"/check_"+tc.outcome, func(t *testing.T) {
+				key := pwDriveKey{Project: o.projectKey(), Func: pwFnChecked, Raw: pwNestedRaw(tc.value)}
+				stock := pwCheckedValue(t, key)
+
+				if stock.Answer != "sunny" {
+					t.Fatalf("stock answer = %q, want %q", stock.Answer, "sunny")
+				}
+				if stock.Confidence.Value != tc.value {
+					t.Fatalf("stock confidence.value = %d, want %d", stock.Confidence.Value, tc.value)
+				}
+				if len(stock.Confidence.Checks) != 1 {
+					t.Fatalf("stock reported %d checks, want exactly 1: %v",
+						len(stock.Confidence.Checks), stock.Confidence.Checks)
+				}
+				want := shared.Check{Name: pwCheckedLabel, Expression: o.expr(), Status: tc.status}
+				if got := stock.Confidence.Checks[pwCheckedLabel]; got != want {
+					t.Fatalf("stock check = %+v, want %+v", got, want)
+				}
+
+				pwRequireSonicBytes(t, "stock", stock, tc.want)
+
+				// The native carrier, built from stock's OWN results, must produce the
+				// SAME bytes. This is the acceptance comparison the scope names.
+				type nativeAnswer struct {
+					Answer     string                   `json:"answer"`
+					Confidence bamlutils.Checked[int64] `json:"confidence"`
+				}
+				native := nativeAnswer{
+					Answer:     stock.Answer,
+					Confidence: pwCarrierFromStock(t, stock.Confidence, pwCheckedLabel),
+				}
+				pwRequireSonicBytes(t, "bamlutils.Checked", native, tc.want)
+			})
+		}
+	}
+}
+
+// TestStockOperatorAssertBytes is the ASSERT twin: a HOLDING assert leaves an ordinary
+// int on the wire, and a FALSE one emits no value at all and its exact wrapper chain.
+//
+// The class differs from the check family in ONE token, so every difference below is
+// attributable to the level and to nothing else.
+func TestStockOperatorAssertBytes(t *testing.T) {
+	for _, o := range pwOperators() {
+		cap := pwCaptureOf(t, o)
+
+		t.Run(o.ID+"/assert_true", func(t *testing.T) {
+			key := pwDriveKey{Project: o.projectKey(), Func: pwFnAssert, Raw: pwNestedRaw(o.TrueVal)}
+			stock := pwAssertValue(t, key)
+			if stock.Answer != "sunny" || stock.Confidence != o.TrueVal {
+				t.Fatalf("stock value = %+v, want answer=sunny confidence=%d", stock, o.TrueVal)
+			}
+			pwRequireSonicBytes(t, "stock", stock, cap.assertTrue)
+			// DISCRIMINATING: the bytes carry no wrapper at all, so an implementation
+			// that wrapped a passing assert would fail here rather than pass on a
+			// superset.
+			if strings.Contains(cap.assertTrue, `"checks"`) || strings.Contains(cap.assertTrue, `"value"`) {
+				t.Fatalf("the passing-assert literal carries wrapper keys: %s", cap.assertTrue)
+			}
+		})
+
+		t.Run(o.ID+"/assert_false", func(t *testing.T) {
+			key := pwDriveKey{Project: o.projectKey(), Func: pwFnAssert, Raw: pwNestedRaw(o.FalseVal)}
+			err := pwError(t, key)
+			if got := err.Error(); got != cap.assertFail {
+				t.Fatalf("stock assertion error bytes:\n got %s\nwant %s",
+					strconv.Quote(got), strconv.Quote(cap.assertFail))
+			}
+			// The wrapper chain is the point of driving this on a CLASS FIELD rather
+			// than a bare target: it names the field, counts the required-field
+			// outcome, and keeps the inner tree beside the flattened display text.
+			cause := "Failed: " + pwCheckedLabel + " " + o.expr()
+			for _, want := range []string{
+				`reason: "Failed while parsing required fields: missing=0, unparsed=1"`,
+				`reason: "Failed to parse field confidence: <root>: Assertions failed.\n  - <root>: ` + cause + `"`,
+				`reason: "Assertions failed."`,
+				`reason: "` + cause + `"`,
+			} {
+				if !strings.Contains(cap.assertFail, want) {
+					t.Errorf("the pinned assertion error does not carry %s", want)
+				}
+			}
+			// The embedded newline is DEBUG-ESCAPED (two bytes), never a real one —
+			// the single most likely way a renderer gets this wrong.
+			if strings.Contains(cap.assertFail, "\n") {
+				t.Fatal("the pinned assertion error carries a REAL newline; stock's `{:?}` rendering escapes it")
+			}
+			if !strings.Contains(cap.assertFail, `\n  - <root>: `) {
+				t.Fatalf("the pinned assertion error does not carry the escaped display separator: %s",
+					cap.assertFail)
+			}
+		})
+	}
+}
+
+// TestStockOperatorCapturesAreProvenToBite is the anti-false-green control for this file.
+//
+// Each mutant is a byte string a WRONG implementation would produce; none may equal a
+// pinned literal, or the corresponding assertion would pass on the wrong bytes. The
+// control at the end rebuilds a real literal from the same pieces, so the inequalities
+// are about the mutations rather than about the formatter.
+func TestStockOperatorCapturesAreProvenToBite(t *testing.T) {
+	// (1) The six operators must be DISTINGUISHABLE from one another. Without this,
+	// a capture harness that silently drove `>` six times would still be green.
+	seen := map[string]string{}
+	for _, o := range pwOperators() {
+		cap := pwCaptureOf(t, o)
+		if prev, dup := seen[cap.checkTrue]; dup {
+			t.Errorf("operators %s and %s pin the SAME check-true bytes; one of them is not being "+
+				"driven with its own predicate", prev, o.Op)
+		}
+		seen[cap.checkTrue] = o.Op
+		if cap.checkTrue == cap.checkFalse {
+			t.Errorf("operator %s pins identical true and false bytes", o.Op)
+		}
+		if !strings.Contains(cap.checkTrue, `"expression":"`+o.expr()+`"`) {
+			t.Errorf("operator %s's check-true literal does not carry its own expression %q: %s",
+				o.Op, o.expr(), cap.checkTrue)
+		}
+		if !strings.Contains(cap.checkTrue, `"status":"succeeded"`) ||
+			!strings.Contains(cap.checkFalse, `"status":"failed"`) {
+			t.Errorf("operator %s's literals do not carry the two distinct statuses", o.Op)
+		}
+		// A FALSE check still carries its value, stated as a byte fact.
+		if !strings.Contains(cap.checkFalse, fmt.Sprintf(`"value":%d`, o.FalseVal)) {
+			t.Errorf("operator %s's failed-check literal drops its value: %s", o.Op, cap.checkFalse)
+		}
+	}
+
+	// (2) The TWO-BYTE operators must not have collapsed to their one-byte prefixes.
+	// `this >= 0` sharing a capture with `this > 0` is the exact failure a substring
+	// assertion would miss, and it is the reason 7.2c has to recompute its cause-length
+	// ceiling rather than inherit it.
+	for _, pair := range []struct{ two, one string }{{"ge", "gt"}, {"le", "lt"}} {
+		twoCap, oneCap := pwOperatorCaptures[pair.two], pwOperatorCaptures[pair.one]
+		for _, oneByte := range []string{`"expression":"this > 0"`, `"expression":"this < 0"`} {
+			if strings.Contains(twoCap.checkTrue, oneByte) {
+				t.Errorf("the %s capture carries the one-byte expression %s", pair.two, oneByte)
+			}
+		}
+		if len(twoCap.assertFail) <= len(oneCap.assertFail) {
+			t.Errorf("the %s assertion error is not longer than the %s one, yet its expression is "+
+				"one byte longer; the cause-length arithmetic 7.2c-3 must redo rests on this",
+				pair.two, pair.one)
+		}
+	}
+
+	// (3) Byte-level mutants of one row, none of which may equal the pinned literal.
+	gt := pwOperatorCaptures["gt"]
+	const (
+		valuePart  = `"value":9`
+		checksPart = `"checks":{"positive":{"name":"positive","expression":"this > 0","status":"succeeded"}}`
+	)
+	inner := "{" + valuePart + "," + checksPart + "}"
+	if want := `{"answer":"sunny","confidence":` + inner + `}`; want != gt.checkTrue {
+		t.Fatalf("the mutation harness cannot rebuild the pinned literal, so its inequalities prove "+
+			"nothing:\n got %s\nwant %s", want, gt.checkTrue)
+	}
+	for name, mutant := range map[string]string{
+		"checks before value":     `{"answer":"sunny","confidence":{` + checksPart + "," + valuePart + `}}`,
+		"check fields permuted":   `{"answer":"sunny","confidence":{"value":9,"checks":{"positive":{"status":"succeeded","name":"positive","expression":"this > 0"}}}}`,
+		"value dropped":           `{"answer":"sunny","confidence":{` + checksPart + `}}`,
+		"answer after confidence": `{"confidence":` + inner + `,"answer":"sunny"}`,
+		"status flipped":          strings.Replace(gt.checkTrue, "succeeded", "failed", 1),
+		// encoding/json rewrites `>` in ANY json.Marshaler's output and sonic does not.
+		// Stock's own canonical expression carries one, so this mutant is the whole
+		// reason sonic — not encoding/json — is the wire authority here.
+		"expression HTML-escaped": strings.Replace(gt.checkTrue, ">", `\u003e`, 1),
+		"operator widened to >=":  strings.Replace(gt.checkTrue, "this > 0", "this >= 0", 1),
+	} {
+		if mutant == gt.checkTrue {
+			t.Errorf("the %q mutant equals the pinned literal, so no assertion distinguishes them", name)
+		}
+	}
+	// (4) And the same for the ERROR bytes: a renderer that unescaped the newline, or
+	// dropped the wrapper, must not produce the pinned string.
+	for name, mutant := range map[string]string{
+		"newline unescaped": strings.ReplaceAll(gt.assertFail, `\n`, "\n"),
+		"wrapper dropped":   `Failed to coerce value: ParsingError { scope: [], reason: "Failed: positive this > 0", causes: [] }`,
+		"label dropped":     strings.ReplaceAll(gt.assertFail, "positive this > 0", "this > 0"),
+	} {
+		if mutant == gt.assertFail {
+			t.Errorf("the %q error mutant equals the pinned literal", name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NO ADMISSION FLIP.
+// ---------------------------------------------------------------------------
+
+// pwBundleFor builds the schema.Bundle that describes exactly what the named isolated
+// project declares for one family, so the native gates are asked about the SAME shape
+// stock was driven with.
+func pwBundleFor(level schema.ConstraintLevel, label, expr string) *schema.Bundle {
+	l := label
+	confidence := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt}
+	confidence.Meta.Constraints = []schema.Constraint{{Level: level, Expression: expr, Label: &l}}
+	name := pwCheckedClass
+	if level == schema.ConstraintAssert {
+		name = pwAssertClass
+	}
+	b := &schema.Bundle{
+		Target: schema.Type{Kind: schema.TypeClass, Name: name, Mode: schema.NonStreaming},
+		Classes: []schema.ClassDef{{
+			Name: schema.Name{Name: name},
+			Mode: schema.NonStreaming,
+			Fields: []schema.ClassField{
+				{Name: schema.Name{Name: "answer"}, Type: schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveString}},
+				{Name: schema.Name{Name: "confidence"}, Type: confidence},
+			},
+		}},
+	}
+	if err := b.RebuildIndexes(); err != nil {
+		panic("predicatewire fixture: " + err.Error())
+	}
+	return b
+}
+
+// pwAdmits reports whether the production entry points ADMIT a bundle, and fails if they
+// disagree with one another.
+//
+// Disagreement is checked rather than assumed because the whole 7.2c discipline is that
+// the shape decision has ONE owner: a package that read only SupportsNativeFinalBundle
+// could not tell an unchanged fingerprint from a nativeserve delegate that had drifted.
+func pwAdmits(t *testing.T, what string, b *schema.Bundle) bool {
+	t.Helper()
+	supportErr := debaml.SupportsNativeFinalBundle(b)
+	switch {
+	case supportErr == nil:
+	case errors.Is(supportErr, bamlutils.ErrDeBAMLParseUnsupported):
+	default:
+		t.Fatalf("%s: SupportsNativeFinalBundle returned a non-sentinel error: %v", what, supportErr)
+	}
+	supported := supportErr == nil
+	delegate := debaml.IsAdmittedStaticCheckedFamily(b)
+	if supported != delegate {
+		t.Fatalf("%s: SupportsNativeFinalBundle says admitted=%v but nativeserve's "+
+			"IsAdmittedStaticCheckedFamily delegate says %v; the gates no longer share one fingerprint",
+			what, supported, delegate)
+	}
+	return supported
+}
+
+// pwAdmissionDisagreements compares an EXPECTATION against the production gates for
+// every operator on both families, and returns one line per disagreement.
+//
+// It is factored out so it can be driven with a DELIBERATELY WRONG expectation and shown
+// to report the mismatch — the mutation proof for a suite whose assertions are all
+// "this still declines".
+func pwAdmissionDisagreements(t *testing.T, admits func(o pwOperator) bool) []string {
+	t.Helper()
+	var out []string
+	for _, o := range pwOperators() {
+		for _, fam := range []struct {
+			what  string
+			level schema.ConstraintLevel
+		}{{"check", schema.ConstraintCheck}, {"assert", schema.ConstraintAssert}} {
+			name := fmt.Sprintf("%s %s", fam.what, o.expr())
+			got := pwAdmits(t, name, pwBundleFor(fam.level, pwCheckedLabel, o.expr()))
+			want := admits(o)
+			if got != want {
+				out = append(out, fmt.Sprintf("%s: gates say admitted=%v, expected %v", name, got, want))
+			}
+		}
+	}
+	return out
+}
+
+// pwOnlyGreaterThan is the CURRENT admitted predicate, and the only one 7.2c-1 leaves
+// admitted: `this > I`.
+func pwOnlyGreaterThan(o pwOperator) bool { return o.Op == ">" }
+
+// TestPredicateWireAdmissionIsUnchanged is the NO-FLIP invariant, stated where the
+// captures are.
+//
+// Slice 7.2c-1 banks authority for six operators and admits ONE. Every other operator —
+// on both families, in both levels — must still be refused by the production gates, and
+// the two gates driven here must agree with each other on every row.
+func TestPredicateWireAdmissionIsUnchanged(t *testing.T) {
+	if got := pwAdmissionDisagreements(t, pwOnlyGreaterThan); len(got) != 0 {
+		t.Fatalf("the admitted predicate is no longer exactly `this > I`:\n  %s", strings.Join(got, "\n  "))
+	}
+	// And the route boundary: even the ADMITTED operator declines on the direct parse
+	// endpoint, which is the scope's /call-only rule. A capture package that let this
+	// slip would be evidence for a route it never measured.
+	for _, o := range pwOperators() {
+		b := pwBundleFor(schema.ConstraintCheck, pwCheckedLabel, o.expr())
+		if _, err := debaml.ParseStaticBundle(context.Background(), b, pwNestedRaw(o.TrueVal)); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			t.Errorf("%s: ParseStaticBundle did not decline the checked family on the direct route: %v",
+				o.expr(), err)
+		}
+	}
+	t.Logf("admission unchanged: 1 admitted predicate (`this > I`), %d captured-but-declined operator "+
+		"rows across both families", (len(pwOperators())-1)*2)
+}
+
+// TestPredicateWireAdmissionIsProvenToBite feeds the SAME comparison two deliberately
+// wrong expectations and requires each to be REPORTED.
+//
+// Without it, [TestPredicateWireAdmissionIsUnchanged] could be green because the
+// comparison never fires — the classic false green for a suite of declines. The mutants
+// are stand-in EXPECTATIONS; the production gates are untouched.
+func TestPredicateWireAdmissionIsProvenToBite(t *testing.T) {
+	// (1) An expectation that every operator is admitted — the 7.2c-3 cutover, arriving
+	// early. It must be reported for the five that are not.
+	all := func(pwOperator) bool { return true }
+	got := pwAdmissionDisagreements(t, all)
+	if len(got) == 0 {
+		t.Error("an expectation that ALL six operators are admitted produced no disagreement; this " +
+			"file cannot detect a widened fingerprint")
+	}
+	if want := (len(pwOperators()) - 1) * 2; len(got) != want {
+		t.Errorf("the widened expectation was reported %d times, want %d (five operators x two "+
+			"families); the comparison is not covering every row", len(got), want)
+	}
+	// (2) An expectation that NOTHING is admitted. It must be reported for `>`, so a
+	// gate that stopped admitting the 7.2b fingerprint is caught too — an under-claim is
+	// a failure in its own right.
+	none := func(pwOperator) bool { return false }
+	if got := pwAdmissionDisagreements(t, none); len(got) != 2 {
+		t.Errorf("an expectation that NOTHING is admitted was reported %d times, want exactly 2 "+
+			"(the `this > I` check and assert families); the admitted row is not being driven", len(got))
+	}
+	// (3) A per-operator mutant: admitting exactly ONE new operator must be reported for
+	// exactly that operator's two families and nothing else. This is the realistic
+	// mistake — a fingerprint widened one token at a time.
+	for _, mutant := range pwOperators() {
+		if mutant.Op == ">" {
+			continue
+		}
+		admits := func(o pwOperator) bool { return o.Op == ">" || o.Op == mutant.Op }
+		got := pwAdmissionDisagreements(t, admits)
+		if len(got) != 2 {
+			t.Errorf("admitting %q alone was reported %d times, want exactly 2:\n  %s",
+				mutant.Op, len(got), strings.Join(got, "\n  "))
+		}
+		for _, line := range got {
+			if !strings.Contains(line, mutant.expr()) {
+				t.Errorf("admitting %q alone was reported against a different row: %s", mutant.Op, line)
+			}
+		}
+	}
+}

--- a/internal/debaml/predicatewire/pins_test.go
+++ b/internal/debaml/predicatewire/pins_test.go
@@ -1,0 +1,47 @@
+//go:build integration
+
+package predicatewire
+
+// pwProjectSHA256 pins the rendered source of every isolated project, beside the
+// checked-in goldens under testdata/projects.
+//
+// It is a SECOND pin on purpose. The golden byte-comparison already fails on any table
+// change, but a regeneration rewrites the golden — so without a hash that has to be
+// updated by hand, a project could be regenerated in the same commit that changed it and
+// the diff would look like an intended edit. [TestPredicateWireProjectDrift] requires
+// this map to cover exactly the project table, so a new project cannot arrive unpinned
+// either.
+var pwProjectSHA256 = map[string]string{
+	"bound_exact_above":     "536c0e82d335db0531cd5f6301e92d10c4ef331ce4187dac01e4a0e43d6d660e",
+	"bound_exact_at":        "c5811ab1ab744509821f10fd3c8310911b490904cfe95448780b3b6f2375ea56",
+	"bound_exact_below":     "f756982dc5a01e25335dd5eec9eafeca391f376ad6dbb15a1cdb8dcdae0887fd",
+	"bound_i64max":          "66a384ba94bb189089ea64216fbffc322abbb8f39f3b9095d358b48b594fd88b",
+	"bound_i64max_below":    "a765de8d60d908eb4ed7fdaf4d533872179b7899822a2088222ea99a063b3fa0",
+	"bound_i64min":          "a020368dee6b383fff01c9702efa8591cf5e849875a9cd39985aff76a0daaa91",
+	"bound_i64min_above":    "37fdf697074df5e889df971ca3bec735b22cac5c13a62820f13c931c548de63b",
+	"bound_neg_exact_above": "b85b81dd2361caddfab7823ac9d4787d8e4639edd691f14e91e4b6be582a7293",
+	"bound_neg_exact_at":    "d100a2e0ea13821c11b0210841bc9ce037e836a82a0cf52efac3a0beeb4831d5",
+	"bound_neg_exact_below": "aa9646a977f027e3e17a74bc17e7a0af32c4d281289dad0562a26294d0ff513d",
+	"bound_neg_one":         "00ada11ff3d4c92752b095f4c64568a13476d1238fbc82eaf9c095a15e5a2ed4",
+	"bound_pos_one":         "d4a5d79af85d142ea3cfbee0f9f081f37f1d6d4f487e0489986fe5a9e07a8ba5",
+	"bound_zero":            "3f34ce0e5fb95573a15f3cb1be7a3a65d544dfd526ca65eb149175d9d8d6d88d",
+	"exprtext":              "38e6c0050e2daf9bd4c62948c518af57628dc3de4d2bc5874439db86ec94e46f",
+	"lit_float":             "bca1b657ccb9673d3293396e530e7b10bc8a55e396e4d5f683fe2569d9894b5a",
+	"lit_leading_zeros":     "8b129ad54ba27eb9d4ff58a62d1a8d6d097d55b87d815637a80392e76bc6af1c",
+	"lit_overflow":          "df4f7cf94843d40c004afdc440f64db2433d5c5cbff6307ff281ca2968ecf212",
+	"lit_plus5":             "1d084ace34d259aef19842d32e404fa17e44a9398840e19fb9697b96da06bcb7",
+	"lit_underscore":        "dcc520997566ab7098a6c5341e3096f349d01fa7990b2bd5cb404bef8802cb48",
+	"op_eq":                 "d6b37014bf55f2950e2e47daa8131cebed83f239aa27f92125c3b6bc21ab058b",
+	"op_ge":                 "d8d1370a2674e13a571cbc446b8348240c0f1a87d72e47e3ec3642586811e789",
+	"op_gt":                 "02d525877e0b3303665e1162ce7bc9ccfdf3158c422fd423328ccbcbea05dff9",
+	"op_le":                 "7d706cf11556b264d18a7739c5170dc78ae00c961f17bf4d23e8d5351c34be24",
+	"op_lt":                 "925cfa1f422d8aeb1a53d488b0c6778664e38a20fbe3d85d1c625fdbfcd6dd8b",
+	"op_ne":                 "3281312944fdaa286d944a6bcb2f0c76df399e482983766daab8e32cfd696982",
+	"res_assert_then_check": "82965dabb57a0ed017ada0a5520fa11bd0095f242e2f22fdd7ec33b00798624c",
+	"res_check_then_assert": "ab6bdc1f6ce0a82e3d1d90e41cd0b8dabdc549dca0f6b0ceec46c356822c67f5",
+	"res_duplicate_labels":  "6ada9682ee0e63e962c50c609ee5eaf52fedaece7f349fa0c9ba6f7ff5c160a5",
+	"res_three_checks":      "a610e27fb88539b83ba83e50fca0c224b953a61c65cd7b8a73157f268d7477ad",
+	"res_two_asserts":       "bed08979ac879a6fe5b8356d16d56c9452703da1d5c4d1789f2c98c7be755a8a",
+	"res_two_checks":        "843c2e259fc860a562229019a7e8a743f798ae00e15758cd6c16ecce4f554353",
+	"toplevel":              "4c12f2c0f4add5b67dbd177fbd0216bc51d1f12a643dfff48fe383cbae98ee5d",
+}

--- a/internal/debaml/predicatewire/projects_test.go
+++ b/internal/debaml/predicatewire/projects_test.go
@@ -1,0 +1,857 @@
+//go:build integration
+
+// Package predicatewire is the de-BAML Slice 7.2c-1 STOCK v0.223.0 CFFI AUTHORITY for
+// the six DIRECT COMPARISON predicates on the two name-pinned static families.
+//
+// # What it establishes, and what it does not
+//
+// Slice 7.2c proposes widening the admitted predicate of `StaticCheckedAnswer` /
+// `StaticAssertAnswer` from `this > I` to the six direct comparisons
+// `this OP I`, OP in {>, >=, <, <=, ==, !=}. That widening is EVIDENCE-GATED: an
+// operator may be admitted (in 7.2c-3) only after fresh stock captures cover it. This
+// package is that evidence, and NOTHING ELSE. It captures each operator in BOTH positions
+// the scope requires — NESTED on the two pinned families (operators_test.go) and
+// TOP-LEVEL on a bare `int` target (toplevel_test.go) — because a top-level check emits
+// an unenclosed carrier and a top-level failing assert carries no required-field wrapper
+// at all, neither of which is derivable from the nested rows.
+//
+// It flips no gate, widens no fingerprint and serves no new shape: the only admitted
+// predicate is still `this > I`, which [TestPredicateWireAdmissionIsUnchanged] and
+// [TestTopLevelOperatorFormsAreDeclined] re-assert through the production entry points
+// for every operator and position captured here.
+//
+// # Why a separate package from checkedwire
+//
+// internal/debaml/checkedwire is the 7.2b byte authority. It builds ONE in-memory
+// project, so its declarations must all coexist — and it namespaces every class with a
+// `CW_` prefix for exactly that reason. The 7.2c question cannot be asked that way: one
+// BAML project cannot declare six predicate variants of the SAME name-pinned class, and
+// renaming the class to make them coexist would answer a question about
+// `StaticGtePredicateAnswer` rather than about the admitted family. So this package
+// builds ISOLATED PROJECTS — one runtime each, each declaring the two pinned names once
+// — and keeps checkedwire's project, its golden and its SHA untouched.
+//
+// The names here are therefore the PRODUCTION names, unprefixed and unpinned-from:
+// `StaticCheckedAnswer` and `StaticAssertAnswer`. That is the point of the isolation.
+// The live `>=` sibling in internal/nativeprompt/testdata/staticserve_fixture is a
+// DIFFERENT class (`StaticGtePredicateAnswer`) and stays a decline; nothing here
+// repurposes it.
+//
+// # Stock is the authority; native output is never fed back in
+//
+// The only bytes handed to the CFFI are a fixture's raw assistant text. What comes back
+// is compared against a pinned literal. The native leg — the evaluator in
+// [TestDirectIntBoundaryMatrix], the gates in [TestPredicateWireAdmissionIsUnchanged] —
+// is driven INDEPENDENTLY over the same captured source and value, and its output is
+// never submitted to BAML as a validation step.
+//
+// # Running
+//
+//	CGO_ENABLED=1 go test -tags integration ./internal/debaml/predicatewire
+//
+// Requires CGO and the stock BAML v0.223.0 CFFI library (auto-located under the user
+// BAML cache dir), exactly like the sibling oracles. .github/workflows/
+// constraint-oracle.yml runs it on every change under internal/debaml/**.
+//
+// # Regenerating the project goldens
+//
+//	PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//	  ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+package predicatewire
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	baml_go "github.com/boundaryml/baml/engine/language_client_go/baml_go"
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/shared"
+	baml "github.com/boundaryml/baml/engine/language_client_go/pkg"
+	"github.com/boundaryml/baml/engine/language_client_go/pkg/cffi"
+	"golang.org/x/mod/modfile"
+)
+
+const (
+	// pwFuncPrefix namespaces every generated function so a probe name cannot collide
+	// with a BAML keyword. CLASS names are deliberately NOT namespaced — see the
+	// package doc.
+	pwFuncPrefix = "PW_"
+	// pwClient is the client every function names. It is never called — this drives
+	// the PARSE entry point, not the LLM — but a BAML function must declare one.
+	pwClient = "PredicateWireClient"
+
+	// pwProjectFile is the single .baml file inside each isolated project, and
+	// pwGoldenDir the directory of checked-in copies the drift test byte-compares
+	// against.
+	pwProjectFile = "predicate_wire.baml"
+	pwGoldenDir   = "testdata/projects"
+
+	// pwWriteEnv rewrites the goldens instead of comparing.
+	pwWriteEnv = "PREDICATE_WIRE_FIXTURE_WRITE"
+
+	// pwBAMLRuntimeVersion is the CFFI version every capture in this package is only
+	// valid against.
+	pwBAMLRuntimeVersion = "0.223.0"
+	// rootGoModPath is the root module's go.mod, from this package's CWD.
+	rootGoModPath         = "../../../go.mod"
+	bamlModulePath        = "github.com/boundaryml/baml"
+	wantBAMLModuleVersion = "v0.223.0"
+)
+
+// The two PINNED class names. They are the production fingerprint's names, written once
+// here so a fixture cannot drift onto a renamed class and quietly answer a different
+// question.
+const (
+	pwCheckedClass = "StaticCheckedAnswer"
+	pwAssertClass  = "StaticAssertAnswer"
+)
+
+// pwPrelude is the fixed head of every isolated project.
+const pwPrelude = `// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> ` + pwClient + ` {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+`
+
+// ---------------------------------------------------------------------------
+// The project model.
+// ---------------------------------------------------------------------------
+
+// pwFunc is one BAML function inside a project.
+type pwFunc struct {
+	// Name is the function suffix; the BAML function is PW_<Name>. It is unique
+	// WITHIN a project, not across the table — two isolated projects deliberately
+	// carry the same function name for the same role under a different predicate.
+	Name string
+	// Doc is rendered into the .baml as a comment, so each checked-in golden explains
+	// what its declarations are for.
+	Doc string
+	// Target is the return-type expression, attributes included.
+	Target string
+}
+
+// pwProject is ONE isolated in-memory BAML project with its OWN stock runtime.
+//
+// Isolation is the mechanism this package exists for: each project may declare the two
+// pinned class names once, so six predicate variants of the same name-pinned class can
+// be captured without ever renaming a class.
+type pwProject struct {
+	// Key names the project and its golden (testdata/projects/<Key>.baml).
+	Key string
+	// Doc is rendered into the golden's head.
+	Doc string
+	// Decls are whole class declarations in source form, emitted in order.
+	Decls []string
+	// Funcs are the functions, emitted in order.
+	Funcs []pwFunc
+	// WantCompile is whether stock's parser must ACCEPT this project.
+	//
+	// It is false for the literal-discriminator projects, whose whole point is that
+	// stock may reject the attribute text outright. A rejection is a RECORDED FACT
+	// with pinned error bytes, not a test failure — and a project that was expected
+	// to be rejected and compiled anyway fails just as loudly as the reverse.
+	WantCompile bool
+}
+
+func (f pwFunc) method() string { return pwFuncPrefix + f.Name }
+
+// pwFuncDeclaration is the exact function declaration the renderer emits. Sharing the
+// formatter lets a guard tie a probe to its own declaration bytes rather than finding a
+// fragment somewhere else in the project.
+func pwFuncDeclaration(f pwFunc) string {
+	return fmt.Sprintf("function %s(topic: string) -> %s {\n  client %s\n  prompt #\"{{ topic }} {{ ctx.output_format }}\"#\n}\n",
+		f.method(), f.Target, pwClient)
+}
+
+// pwRenderProject renders one isolated project. Declarations first in table order, then
+// the functions, so the output is a pure function of the table and the drift test can
+// byte-compare it.
+func pwRenderProject(p pwProject) string {
+	var b strings.Builder
+	b.WriteString(pwPrelude)
+	if p.Doc != "" {
+		b.WriteString("\n")
+		for _, line := range strings.Split(p.Doc, "\n") {
+			fmt.Fprintf(&b, "// %s\n", line)
+		}
+	}
+	for _, d := range p.Decls {
+		b.WriteString("\n")
+		b.WriteString(d)
+	}
+	for _, f := range p.Funcs {
+		b.WriteString("\n")
+		if f.Doc != "" {
+			for _, line := range strings.Split(f.Doc, "\n") {
+				fmt.Fprintf(&b, "// %s\n", line)
+			}
+		}
+		b.WriteString(pwFuncDeclaration(f))
+	}
+	return b.String()
+}
+
+// pwGoldenPath is the checked-in copy of a project's rendered source.
+func pwGoldenPath(key string) string { return filepath.Join(pwGoldenDir, key+".baml") }
+
+// pwProjectHash is the SHA-256 of a rendered project, in hex.
+func pwProjectHash(src string) string {
+	sum := sha256.Sum256([]byte(src))
+	return hex.EncodeToString(sum[:])
+}
+
+// pwProjects is every isolated project in the table, assembled from the per-concern
+// tables in the files beside this one.
+//
+// The order is the order the goldens are reviewed in; nothing depends on it, because
+// each project is rendered and hashed independently.
+func pwProjects() []pwProject {
+	var out []pwProject
+	out = append(out, pwOperatorProjects()...)
+	out = append(out, pwTopLevelProject())
+	out = append(out, pwExprTextProject())
+	out = append(out, pwLiteralProjects()...)
+	out = append(out, pwBoundaryProjects()...)
+	out = append(out, pwResidualProjects()...)
+	return out
+}
+
+// pwProjectNamed looks a project up by key, failing loudly on an unknown one so a
+// renamed project cannot silently stop being driven.
+func pwProjectNamed(t *testing.T, key string) pwProject {
+	t.Helper()
+	for _, p := range pwProjects() {
+		if p.Key == key {
+			return p
+		}
+	}
+	t.Fatalf("no project keyed %q", key)
+	return pwProject{}
+}
+
+// ---------------------------------------------------------------------------
+// The Go side of the generated shapes.
+// ---------------------------------------------------------------------------
+
+// pwUnexpectedFields records class fields the decoders below did not expect.
+//
+// Stock's GENERATED decoders panic on an unexpected field, and a panic on the CFFI
+// callback thread is not recoverable by the caller — it kills the process. These record
+// instead, and [TestPredicateWireDecodersSawWhatWasDeclared] fails on a non-empty
+// record, so the substitution is not a silent weakening.
+var pwUnexpectedFields []string
+
+func pwUnexpected(class, key string) {
+	pwUnexpectedFields = append(pwUnexpectedFields, class+"."+key)
+}
+
+// pwCheckedAnswer mirrors what BAML's Go generator emits for the CHECK family:
+//
+//	class StaticCheckedAnswer { answer string; confidence int @check(...) }
+//
+// The mirror is not taken on trust — internal/debaml/checkedwire's
+// TestGeneratedCarrierShapeMatchesStockCodegen grounds the identical declaration against
+// the checked-in STOCK-GENERATED client under internal/debaml/testdata/constraint_oracle,
+// and [TestPredicateWireMirrorsTheCheckedWireShape] here requires this package's mirror
+// to stay field-for-field identical to that one.
+type pwCheckedAnswer struct {
+	Answer     string                `json:"answer"`
+	Confidence shared.Checked[int64] `json:"confidence"`
+}
+
+func (c *pwCheckedAnswer) Decode(holder *cffi.CFFIValueClass, _ baml.TypeMap) {
+	for _, field := range holder.Fields {
+		switch field.Key {
+		case "answer":
+			c.Answer, _ = baml.Decode(field.Value).Interface().(string)
+		case "confidence":
+			c.Confidence, _ = baml.Decode(field.Value).Interface().(shared.Checked[int64])
+		default:
+			pwUnexpected(pwCheckedClass, field.Key)
+		}
+	}
+}
+
+// pwAssertAnswer mirrors the ASSERT family:
+//
+//	class StaticAssertAnswer { answer string; confidence int @assert(...) }
+//
+// `confidence` is a BARE int64, not a wrapper: `as_check()` excludes an assert from the
+// CFFI check list, so a PASSING assert leaves the generated field its ordinary Go type.
+type pwAssertAnswer struct {
+	Answer     string `json:"answer"`
+	Confidence int64  `json:"confidence"`
+}
+
+func (c *pwAssertAnswer) Decode(holder *cffi.CFFIValueClass, _ baml.TypeMap) {
+	for _, field := range holder.Fields {
+		switch field.Key {
+		case "answer":
+			c.Answer, _ = baml.Decode(field.Value).Interface().(string)
+		case "confidence":
+			c.Confidence, _ = baml.Decode(field.Value).Interface().(int64)
+		default:
+			pwUnexpected(pwAssertClass, field.Key)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The runtimes — one per isolated project.
+// ---------------------------------------------------------------------------
+
+// pwRuntimeEntry is one project's created runtime, or the creation error stock reported.
+//
+// The error is RETAINED rather than fatal because a project's compile disposition is
+// part of what this package pins: the literal-discriminator projects exist to find out
+// whether stock's parser accepts `{{ this > +5 }}` at all.
+type pwRuntimeEntry struct {
+	rt  baml.BamlRuntime
+	err error
+	src string
+}
+
+var (
+	pwOnce      sync.Once
+	pwRuntimes  map[string]*pwRuntimeEntry
+	pwEnv       map[string]string
+	pwSetupErr  error
+	pwTypeMapMu sync.Once
+)
+
+// pwBuildTypeMap registers every name baml_go can ask for while decoding these
+// projects' values.
+//
+// A MISSING key is a panic on the CFFI callback thread — a dead process with no
+// attribution — so the registration is deliberately generous. The names this package
+// depends on are typed precisely, because the captures compare against the concrete
+// shape BAML's generator emits.
+//
+// The type map is PROCESS-GLOBAL while the runtimes are not, and that is exactly why
+// every isolated project declares the two pinned classes with the SAME field types: one
+// entry per class name serves all of them. A project whose `confidence` had a different
+// Go shape could not share the name, which is the structural reason the type/shape
+// residuals in residuals.md are characterised as ledger rows rather than as new CFFI
+// projects here.
+func pwBuildTypeMap() map[string]reflect.Type {
+	anyChecked := reflect.TypeOf(shared.Checked[any]{})
+	tm := map[string]reflect.Type{
+		"CHECKED_TYPES.int":    reflect.TypeOf(shared.Checked[int64]{}),
+		"CHECKED_TYPES.string": reflect.TypeOf(shared.Checked[string]{}),
+	}
+	for _, n := range []string{"float", "bool", "null", "class", "list", "map", "optional", "union", "checked", "stream_state"} {
+		tm["CHECKED_TYPES."+n] = anyChecked
+	}
+	tm["TYPES."+pwCheckedClass] = reflect.TypeOf(pwCheckedAnswer{})
+	tm["TYPES."+pwAssertClass] = reflect.TypeOf(pwAssertAnswer{})
+	tm["CHECKED_TYPES."+pwCheckedClass] = anyChecked
+	tm["CHECKED_TYPES."+pwAssertClass] = anyChecked
+	return tm
+}
+
+// pwEnsureRuntimes renders every project and creates its runtime once per process.
+func pwEnsureRuntimes(t *testing.T) {
+	t.Helper()
+	pwOnce.Do(func() {
+		pwTypeMapMu.Do(func() { baml.SetTypeMap(pwBuildTypeMap()) })
+		pwEnv = pwEnvSnapshot()
+		pwRuntimes = map[string]*pwRuntimeEntry{}
+		seen := map[string]bool{}
+		for _, p := range pwProjects() {
+			if seen[p.Key] {
+				pwSetupErr = fmt.Errorf("two projects share the key %q", p.Key)
+				return
+			}
+			seen[p.Key] = true
+			src := pwRenderProject(p)
+			rt, err := baml.CreateRuntime("./baml_src", map[string]string{pwProjectFile: src}, pwEnv)
+			pwRuntimes[p.Key] = &pwRuntimeEntry{rt: rt, err: err, src: src}
+		}
+	})
+	if pwSetupErr != nil {
+		t.Fatalf("the predicate-wire project table is malformed: %v", pwSetupErr)
+	}
+}
+
+// pwEnvSnapshot mirrors the generated client's getEnvVars. The client is unroutable and
+// no LLM call is ever made; this is passed for parity with the real serving path.
+func pwEnvSnapshot() map[string]string {
+	env := map[string]string{}
+	for _, kv := range os.Environ() {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || v == "" {
+			continue
+		}
+		env[k] = v
+	}
+	return env
+}
+
+// pwRuntimeOf returns the runtime for a project that MUST have compiled.
+func pwRuntimeOf(t *testing.T, key string) baml.BamlRuntime {
+	t.Helper()
+	pwEnsureRuntimes(t)
+	e, ok := pwRuntimes[key]
+	if !ok {
+		t.Fatalf("no project keyed %q", key)
+	}
+	if e.err != nil {
+		t.Fatalf("the stock runtime for project %q could not be created: %v\n"+
+			"the project it renders is not a valid BAML v0.223.0 project:\n%s", key, e.err, e.src)
+	}
+	return e.rt
+}
+
+// pwCompileError returns the creation error for a project that must have been REJECTED.
+func pwCompileError(t *testing.T, key string) error {
+	t.Helper()
+	pwEnsureRuntimes(t)
+	e, ok := pwRuntimes[key]
+	if !ok {
+		t.Fatalf("no project keyed %q", key)
+	}
+	if e.err == nil {
+		t.Fatalf("project %q COMPILED, but it is pinned as a project stock rejects:\n%s", key, e.src)
+	}
+	return e.err
+}
+
+// ---------------------------------------------------------------------------
+// Guards.
+// ---------------------------------------------------------------------------
+
+// pwStockModuleFacts is what the toolchain ACTUALLY resolves the stock BAML module to,
+// as opposed to what any one manifest asks for.
+type pwStockModuleFacts struct {
+	Version string
+	// ReplacedBy is empty when the module is unreplaced, and otherwise names the path
+	// (and version, for a module replacement) it resolves through.
+	ReplacedBy string
+}
+
+// pwResolveStockModule asks the go command what [bamlModulePath] resolves to from this
+// package's directory.
+//
+// It shells out on purpose: reimplementing module resolution would reproduce exactly the
+// blind spot this check exists to close, and the go command is the same one that built
+// this test binary. Adapted from internal/debaml/guardledger's resolveStockModule, which
+// carries the self-test proving a go.work replacement really does surface here.
+func pwResolveStockModule() (pwStockModuleFacts, error) {
+	cmd := exec.Command("go", "list", "-m", "-f",
+		"{{.Version}}\t{{with .Replace}}{{.Path}}@{{.Version}}{{end}}", bamlModulePath)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return pwStockModuleFacts{}, fmt.Errorf("go list -m %s: %w (%s)",
+			bamlModulePath, err, strings.TrimSpace(stderr.String()))
+	}
+	// Trim only the line terminator: an UNREPLACED module leaves the field after the tab
+	// empty, and a general whitespace trim would eat the separator with it.
+	version, replaced, found := strings.Cut(strings.TrimRight(string(out), "\r\n"), "\t")
+	if !found {
+		return pwStockModuleFacts{}, fmt.Errorf("go list -m %s produced an unreadable line %q",
+			bamlModulePath, string(out))
+	}
+	// A DIRECTORY replacement carries no version, so the raw form is `path@`; normalise
+	// that to the bare path rather than reporting a stray separator.
+	return pwStockModuleFacts{Version: version, ReplacedBy: strings.TrimSuffix(replaced, "@")}, nil
+}
+
+// pwActiveWorkspaceFile is the go.work in force for this build, or "" when the build is
+// not in a workspace.
+func pwActiveWorkspaceFile(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("go", "env", "GOWORK").Output()
+	if err != nil {
+		t.Fatalf("go env GOWORK: %v", err)
+	}
+	path := strings.TrimSpace(string(out))
+	if path == "" || path == "off" {
+		return ""
+	}
+	return path
+}
+
+// pwBAMLReplacements reports every replace directive in a manifest that names the stock
+// module on EITHER side.
+//
+// Both positions matter and both are PARSED rather than pattern-matched, so the block
+// form is caught as readily as the single-line one — the substring scan this replaced
+// missed both. The module as the SOURCE (`replace github.com/boundaryml/baml => ...`)
+// swaps the stock runtime out while leaving every version string intact; the module as
+// the TARGET makes some other path resolve to it.
+func pwBAMLReplacements(path string, content []byte, work bool) ([]string, error) {
+	var replaces []*modfile.Replace
+	if work {
+		f, err := modfile.ParseWork(path, content, nil)
+		if err != nil {
+			return nil, err
+		}
+		replaces = f.Replace
+	} else {
+		f, err := modfile.Parse(path, content, nil)
+		if err != nil {
+			return nil, err
+		}
+		replaces = f.Replace
+	}
+	var out []string
+	for _, r := range replaces {
+		if r.Old.Path != bamlModulePath && r.New.Path != bamlModulePath {
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s %s => %s %s", r.Old.Path, r.Old.Version, r.New.Path, r.New.Version))
+	}
+	return out, nil
+}
+
+// pwAssertNoBAMLReplacement fails if the named manifest replaces the stock module.
+func pwAssertNoBAMLReplacement(t *testing.T, path string, work bool) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	found, err := pwBAMLReplacements(path, content, work)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	if len(found) > 0 {
+		t.Fatalf("%s replaces %s (%s); this package must link the STOCK module, and a same-version "+
+			"fork would satisfy the CFFI version string and the require pin while invalidating every "+
+			"capture in this package", path, bamlModulePath, strings.Join(found, "; "))
+	}
+}
+
+// TestPredicateWireBAMLVersionPinned requires the CFFI runtime this binary loaded, AND
+// the module the toolchain actually resolves, to be stock BAML v0.223.0 — so a captured
+// byte string can never be attributed to a different BAML.
+//
+// THE EFFECTIVE RESOLUTION COMES FIRST, because it is the only check that cannot be
+// routed around. A manifest scan answers "what does this file say"; `go list -m` answers
+// "what will the toolchain actually link", after go.mod, the active go.work and any
+// GOFLAGS have all had their say. A workspace replacement is invisible to the former and
+// decisive for the latter — and a SAME-VERSION fork leaves `BamlVersion()` reading
+// "0.223.0" and the root require line reading v0.223.0 while every byte in
+// pwOperatorCaptures came from something else. That hostile configuration is precisely
+// the one an authority package must reject itself rather than inherit from a tidy
+// environment.
+func TestPredicateWireBAMLVersionPinned(t *testing.T) {
+	if got := baml_go.BamlVersion(); got != pwBAMLRuntimeVersion {
+		t.Fatalf("loaded BAML CFFI runtime reports version %q, want exactly %q", got, pwBAMLRuntimeVersion)
+	}
+
+	res, err := pwResolveStockModule()
+	if err != nil {
+		t.Fatalf("resolve the effective %s module: %v\n"+
+			"The pin cannot be verified, so no capture in this package can be attributed to stock BAML.",
+			bamlModulePath, err)
+	}
+	if res.Version != wantBAMLModuleVersion {
+		t.Fatalf("the toolchain resolves %s to %s, want exactly %s",
+			bamlModulePath, res.Version, wantBAMLModuleVersion)
+	}
+	if res.ReplacedBy != "" {
+		t.Fatalf("the toolchain resolves %s through a REPLACEMENT (%s); this package must link the "+
+			"stock module, and a same-version fork would satisfy both the CFFI version string and the "+
+			"manifest checks below while invalidating every captured byte string",
+			bamlModulePath, res.ReplacedBy)
+	}
+
+	// The manifests are then checked directly, so a red run names the FILE that has to
+	// change rather than only the effect. The active go.work is included because it is
+	// the source a root-go.mod scan cannot see.
+	pwAssertNoBAMLReplacement(t, rootGoModPath, false)
+	if work := pwActiveWorkspaceFile(t); work != "" {
+		pwAssertNoBAMLReplacement(t, work, true)
+	}
+
+	raw, err := os.ReadFile(rootGoModPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", rootGoModPath, err)
+	}
+	f, err := modfile.Parse(rootGoModPath, raw, nil)
+	if err != nil {
+		t.Fatalf("parse %s: %v", rootGoModPath, err)
+	}
+	required := false
+	for _, r := range f.Require {
+		if r.Mod.Path != bamlModulePath {
+			continue
+		}
+		required = true
+		if r.Mod.Version != wantBAMLModuleVersion {
+			t.Fatalf("root go.mod requires %s %s, want exactly %s",
+				bamlModulePath, r.Mod.Version, wantBAMLModuleVersion)
+		}
+	}
+	if !required {
+		t.Fatalf("root go.mod does not require %s %s", bamlModulePath, wantBAMLModuleVersion)
+	}
+}
+
+// TestPredicateWireReplacementScanIsProvenToBite is the negative control for the scanner
+// above: a hostile manifest must be REPORTED, in every form and on either side of the
+// arrow.
+//
+// Without it the scan could be a no-op — which is exactly what the substring check it
+// replaced was for the block form. The manifests are synthetic strings; nothing on disk
+// is touched.
+func TestPredicateWireReplacementScanIsProvenToBite(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		work    bool
+		content string
+		want    bool
+	}{{
+		name: "go.mod replaces the stock module", content: "module x\n\ngo 1.21\n\nreplace " + bamlModulePath + " => ./fork\n", want: true,
+	}, {
+		name: "go.mod replaces it at the SAME version", content: "module x\n\ngo 1.21\n\nreplace " + bamlModulePath + " v0.223.0 => ./fork\n", want: true,
+	}, {
+		name: "go.mod block form", content: "module x\n\ngo 1.21\n\nreplace (\n\texample.com/a => ./a\n\t" + bamlModulePath + " => ./fork\n)\n", want: true,
+	}, {
+		name: "go.mod names it as the TARGET", content: "module x\n\ngo 1.21\n\nreplace example.com/other => " + bamlModulePath + " v0.223.0\n", want: true,
+	}, {
+		name: "clean go.mod", content: "module x\n\ngo 1.21\n\nrequire " + bamlModulePath + " v0.223.0\n", want: false,
+	}, {
+		name: "go.work replaces the stock module", work: true,
+		content: "go 1.21\n\nuse .\n\nreplace " + bamlModulePath + " => ./fork\n", want: true,
+	}, {
+		name: "clean go.work", work: true, content: "go 1.21\n\nuse .\n", want: false,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := "go.mod"
+			if tc.work {
+				path = "go.work"
+			}
+			found, err := pwBAMLReplacements(path, []byte(tc.content), tc.work)
+			if err != nil {
+				t.Fatalf("parse the synthetic %s: %v", path, err)
+			}
+			if got := len(found) > 0; got != tc.want {
+				t.Fatalf("replacement detected = %v, want %v (found %v)", got, tc.want, found)
+			}
+		})
+	}
+}
+
+// TestPredicateWireProjectsAreIsolatedAndPinned is the structural invariant this whole
+// package rests on: each project declares the PINNED class names, at most once each, and
+// no project was renamed to make two predicate variants coexist.
+//
+// Without it, a future row could quietly reintroduce the `CW_`-style namespacing (or the
+// live `StaticGtePredicateAnswer` name) and the captures would stop being about the
+// admitted family.
+func TestPredicateWireProjectsAreIsolatedAndPinned(t *testing.T) {
+	projects := pwProjects()
+	if len(projects) < 20 {
+		t.Fatalf("the project table has %d entries; the operator, expression-text, literal, "+
+			"boundary and residual groups together are substantially more", len(projects))
+	}
+	classDecl := 0
+	for _, p := range projects {
+		t.Run(p.Key, func(t *testing.T) {
+			src := pwRenderProject(p)
+			counts := map[string]int{}
+			for _, line := range strings.Split(src, "\n") {
+				rest, ok := strings.CutPrefix(line, "class ")
+				if !ok {
+					continue
+				}
+				name, _, ok := strings.Cut(rest, " ")
+				if !ok || name == "" {
+					t.Fatalf("unparseable class declaration: %q", line)
+				}
+				counts[name]++
+			}
+			for name, n := range counts {
+				classDecl += n
+				if name != pwCheckedClass && name != pwAssertClass {
+					t.Errorf("declares class %q; only the two PINNED names %q and %q may be declared, "+
+						"because a renamed class answers a question about a different family",
+						name, pwCheckedClass, pwAssertClass)
+				}
+				if n != 1 {
+					t.Errorf("declares class %q %d times in one project; a name-pinned class may be "+
+						"declared at most once per isolated project", name, n)
+				}
+			}
+			if len(p.Funcs) == 0 {
+				t.Error("declares no function, so nothing about it can ever be driven")
+			}
+		})
+	}
+	if classDecl == 0 {
+		t.Fatal("no project declares either pinned class; the nested-family captures would be vacuous")
+	}
+	t.Logf("%d isolated projects, %d pinned-class declarations across them", len(projects), classDecl)
+}
+
+// TestPredicateWireProjectDrift byte-compares every rendered project against its
+// checked-in golden and pins its SHA-256, so a table change is visible in review and a
+// golden cannot be regenerated without acknowledging it.
+func TestPredicateWireProjectDrift(t *testing.T) {
+	projects := pwProjects()
+	if os.Getenv(pwWriteEnv) != "" {
+		if err := os.MkdirAll(pwGoldenDir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", pwGoldenDir, err)
+		}
+		keys := map[string]bool{}
+		var lines []string
+		for _, p := range projects {
+			src := pwRenderProject(p)
+			if err := os.WriteFile(pwGoldenPath(p.Key), []byte(src), 0o644); err != nil {
+				t.Fatalf("write %s: %v", pwGoldenPath(p.Key), err)
+			}
+			keys[p.Key] = true
+			lines = append(lines, fmt.Sprintf("\t%q: %q,", p.Key, pwProjectHash(src)))
+		}
+		// A golden whose project was DELETED would otherwise linger and keep being
+		// reviewed as if it were live.
+		stale, err := filepath.Glob(filepath.Join(pwGoldenDir, "*.baml"))
+		if err != nil {
+			t.Fatalf("glob %s: %v", pwGoldenDir, err)
+		}
+		for _, path := range stale {
+			if !keys[strings.TrimSuffix(filepath.Base(path), ".baml")] {
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("remove stale golden %s: %v", path, err)
+				}
+			}
+		}
+		sort.Strings(lines)
+		t.Logf("%s rewritten; update pwProjectSHA256 to:\n%s", pwGoldenDir, strings.Join(lines, "\n"))
+		return
+	}
+
+	if len(pwProjectSHA256) != len(projects) {
+		t.Fatalf("pwProjectSHA256 pins %d projects but the table has %d; every project's golden "+
+			"must be pinned or a new one could arrive unreviewed", len(pwProjectSHA256), len(projects))
+	}
+	for _, p := range projects {
+		t.Run(p.Key, func(t *testing.T) {
+			src := pwRenderProject(p)
+			golden, err := os.ReadFile(pwGoldenPath(p.Key))
+			if err != nil {
+				t.Fatalf("read %s: %v", pwGoldenPath(p.Key), err)
+			}
+			if string(golden) != src {
+				t.Fatalf("%s is stale: it no longer matches the project table. Regenerate with %s=1.",
+					pwGoldenPath(p.Key), pwWriteEnv)
+			}
+			want, ok := pwProjectSHA256[p.Key]
+			if !ok {
+				t.Fatalf("project %q has no pinned SHA-256", p.Key)
+			}
+			if got := pwProjectHash(src); got != want {
+				t.Fatalf("project SHA-256 = %s, want %s; the golden changed without the pin being updated",
+					got, want)
+			}
+		})
+	}
+	// A golden with no project behind it is dead review surface.
+	files, err := filepath.Glob(filepath.Join(pwGoldenDir, "*.baml"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", pwGoldenDir, err)
+	}
+	if len(files) != len(projects) {
+		t.Fatalf("%s holds %d goldens for %d projects; a stale golden is dead review surface. "+
+			"Regenerate with %s=1.", pwGoldenDir, len(files), len(projects), pwWriteEnv)
+	}
+}
+
+// TestPredicateWireProjectsAreTheOnesStockDrives proves the bytes each runtime was
+// created from are the bytes its golden pins, that a project's compile disposition is
+// the pinned one, and that every declared function is present in the compiled source.
+func TestPredicateWireProjectsAreTheOnesStockDrives(t *testing.T) {
+	pwEnsureRuntimes(t)
+	for _, p := range pwProjects() {
+		t.Run(p.Key, func(t *testing.T) {
+			e := pwRuntimes[p.Key]
+			golden, err := os.ReadFile(pwGoldenPath(p.Key))
+			if err != nil {
+				t.Fatalf("read %s: %v", pwGoldenPath(p.Key), err)
+			}
+			if string(golden) != e.src {
+				t.Fatal("the runtime was created from source that differs from the checked-in golden")
+			}
+			switch {
+			case p.WantCompile && e.err != nil:
+				t.Fatalf("stock REJECTED a project pinned as valid: %v", e.err)
+			case !p.WantCompile && e.err == nil:
+				t.Fatal("stock COMPILED a project pinned as one it rejects; the recorded rejection " +
+					"fact is stale")
+			}
+			for _, f := range p.Funcs {
+				if !strings.Contains(e.src, "function "+f.method()+"(") {
+					t.Errorf("declares no function %s in the compiled project", f.method())
+				}
+			}
+		})
+	}
+}
+
+// TestPredicateWireDecodersSawWhatWasDeclared fails if any class decoder met a field it
+// did not expect. Stock's generated decoders panic there; these record instead (a panic
+// on the callback thread kills the process), so the record has to be asserted or the
+// substitution would be a silent weakening.
+func TestPredicateWireDecodersSawWhatWasDeclared(t *testing.T) {
+	pwDriveEveryRow(t)
+	if len(pwUnexpectedFields) != 0 {
+		t.Fatalf("class decoders met unexpected field(s): %v", pwUnexpectedFields)
+	}
+}
+
+// TestPredicateWireMirrorsTheCheckedWireShape requires this package's hand-written
+// generated-shape mirrors to stay field-for-field identical to internal/debaml/
+// checkedwire's, which are themselves grounded against the checked-in STOCK-GENERATED
+// client (checkedwire's TestGeneratedCarrierShapeMatchesStockCodegen).
+//
+// Two copies of a generated shape can drift apart, and a drifted copy would still
+// produce self-consistent bytes here — which is exactly how a capture stops being
+// stock's. Comparing the SOURCE of the sibling declarations makes the grounding
+// transitive instead of assumed.
+func TestPredicateWireMirrorsTheCheckedWireShape(t *testing.T) {
+	raw, err := os.ReadFile("../checkedwire/project_test.go")
+	if err != nil {
+		t.Fatalf("read the checkedwire mirror: %v", err)
+	}
+	src := string(raw)
+	for _, want := range []struct{ what, decl string }{
+		{"checked family", "Answer     string                `json:\"answer\"`\n\tConfidence shared.Checked[int64] `json:\"confidence\"`"},
+		{"assert family", "Answer     string `json:\"answer\"`\n\tConfidence int64  `json:\"confidence\"`"},
+	} {
+		if !strings.Contains(src, want.decl) {
+			t.Errorf("checkedwire no longer declares the %s mirror as this package does; the two "+
+				"generated-shape copies have drifted and only checkedwire's is grounded against the "+
+				"stock-generated client", want.what)
+		}
+	}
+	// DISCRIMINATING: the comparison must be able to fail. A field type this package
+	// does NOT use must be absent from what was matched, or "contains" would be
+	// satisfied by any struct at all.
+	if strings.Contains(src, "Confidence shared.Checked[float64]") {
+		t.Fatal("checkedwire declares a float64 carrier mirror; this package's shape claim no longer " +
+			"identifies a unique declaration")
+	}
+}

--- a/internal/debaml/predicatewire/residual_test.go
+++ b/internal/debaml/predicatewire/residual_test.go
@@ -1,0 +1,670 @@
+//go:build integration
+
+package predicatewire
+
+import (
+	"context"
+	stdjson "encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/shared"
+	"github.com/bytedance/sonic"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/debaml"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// RESIDUAL CHARACTERIZATION — captured, never admitted.
+//
+// Every form in this file is a #583 deferral. Capturing it is what turns "deferred"
+// from an argument into a measurement: the 2+-check ordering question in particular is
+// the single riskiest broadening dimension the scope names, and its answer is not a
+// design preference but an observable property of stock's own output.
+//
+// Nothing here proposes an admission. [TestResidualFormsAreDeclined] proves each form is
+// still refused by the production gates, and [TestResidualDeclinesAreProvenToBite] proves
+// that assertion would fire if one of them started being claimed.
+
+// pwMarshalObservations is how many times a stock value is re-serialized when asking
+// whether its byte order is stable.
+//
+// Go randomises map iteration per range statement, so for a 2-key map the chance that N
+// independent marshals all agree by luck is 2^-(N-1). At 200 that is not a number any
+// test run will meet, which is what lets "only one ordering was observed" be a REPORTABLE
+// event rather than an expected flake.
+const pwMarshalObservations = 200
+
+// pwDistinctMarshals serializes v repeatedly and returns the distinct byte strings
+// observed, sorted so the record is deterministic.
+func pwDistinctMarshals(t *testing.T, v any) []string {
+	t.Helper()
+	seen := map[string]bool{}
+	for i := 0; i < pwMarshalObservations; i++ {
+		b, err := sonic.Marshal(v)
+		if err != nil {
+			t.Fatalf("sonic.Marshal (observation %d): %v", i, err)
+		}
+		seen[string(b)] = true
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestTwoCheckWireOrderIsUnstable is the RECORDED FACT the 7.2c scope calls its highest
+// risk, measured rather than assumed.
+//
+// Stock's CFFI result is an ordered LIST of checks, but the public Go value folds it into
+// a map[string]Check — and sonic.Marshal of a Go map follows Go's map iteration, which is
+// randomised. So for two or more distinct labels there is no single byte string that IS
+// "stock's output", and the slice's acceptance rule ("native's bytes equal stock's bytes")
+// has nothing to compare against.
+//
+// That is WHY 2+ @check stays declined in 7.2c. It is not that the carrier cannot
+// serialize N checks — bamlutils.Checked does so deterministically, in declaration order —
+// but that a deterministic answer cannot be byte-identical to a nondeterministic one.
+func TestTwoCheckWireOrderIsUnstable(t *testing.T) {
+	for _, tc := range []struct {
+		project string
+		labels  []string
+	}{
+		{"res_two_checks", []string{"alpha", "beta"}},
+		{"res_three_checks", []string{"alpha", "beta", "gamma"}},
+	} {
+		t.Run(tc.project, func(t *testing.T) {
+			key := pwDriveKey{Project: tc.project, Func: pwFnChecked, Raw: pwNestedRaw(9)}
+			stock := pwCheckedValue(t, key)
+
+			// The CONTENT is stable and exact — this is not a claim that stock loses
+			// data. Each declared label is present exactly once, with its own
+			// expression and status.
+			if len(stock.Confidence.Checks) != len(tc.labels) {
+				t.Fatalf("stock reported %d checks, want %d: %v",
+					len(stock.Confidence.Checks), len(tc.labels), stock.Confidence.Checks)
+			}
+			for _, label := range tc.labels {
+				got, ok := stock.Confidence.Checks[label]
+				if !ok {
+					t.Fatalf("stock reported no check under the declared label %q: %v",
+						label, stock.Confidence.Checks)
+				}
+				if got.Name != label || got.Status != "succeeded" {
+					t.Fatalf("stock check %q = %+v, want name=%s status=succeeded", label, got, label)
+				}
+			}
+
+			// The ORDER is not. This is the recorded observation.
+			orderings := pwDistinctMarshals(t, stock)
+			t.Logf("RECORDED: %d marshals of stock's %d-check result produced %d DISTINCT byte "+
+				"orderings", pwMarshalObservations, len(tc.labels), len(orderings))
+			for _, o := range orderings {
+				t.Logf("  %s", o)
+			}
+			if len(orderings) < 2 {
+				t.Fatalf("RECORDED: %d marshals of a %d-key stock result produced only ONE byte "+
+					"ordering (%s). That is not evidence of a stable stock ordering — Go's map "+
+					"iteration randomisation makes a single ordering across %d observations a ~2^-%d "+
+					"event — but it does mean this run failed to witness the instability the "+
+					"deferral rests on, and the observation must be re-taken rather than read as "+
+					"stability.",
+					pwMarshalObservations, len(tc.labels), orderings[0],
+					pwMarshalObservations, pwMarshalObservations-1)
+			}
+
+			// And the DECISIVE consequence: the native carrier is deterministic, so its
+			// single answer can match at most one of the orderings stock produces. There
+			// is no byte-exact parity to have.
+			ordered := make([]bamlutils.Check, 0, len(tc.labels))
+			for _, label := range tc.labels {
+				got := stock.Confidence.Checks[label]
+				ordered = append(ordered, bamlutils.Check{Name: got.Name, Expression: got.Expression, Status: got.Status})
+			}
+			carrier, err := bamlutils.NewChecked(stock.Confidence.Value, ordered)
+			if err != nil {
+				t.Fatalf("NewChecked over stock's own check results: %v", err)
+			}
+			// The native value is marshalled inside the SAME two-field struct stock's
+			// was, or the two byte sets would not be comparable at all and a "matches
+			// none" record would be an artifact of the wrapper rather than a fact about
+			// the ordering.
+			type nativeAnswer struct {
+				Answer     string                   `json:"answer"`
+				Confidence bamlutils.Checked[int64] `json:"confidence"`
+			}
+			nativeOrderings := pwDistinctMarshals(t, nativeAnswer{Answer: stock.Answer, Confidence: carrier})
+			if len(nativeOrderings) != 1 {
+				t.Fatalf("the NATIVE carrier produced %d distinct orderings; it is supposed to be "+
+					"deterministic, and a nondeterministic native output would be a defect in its own "+
+					"right: %v", len(nativeOrderings), nativeOrderings)
+			}
+			t.Logf("RECORDED: the native carrier is DETERMINISTIC (1 ordering, declaration order): %s",
+				nativeOrderings[0])
+
+			// COMPARABILITY, established SEMANTICALLY rather than by hoping a particular
+			// permutation was sampled.
+			//
+			// The two sides carry the same value and the same checks; only the key ORDER
+			// differs. That is checked by decoding both through [pwDecodeAnswerStrict] —
+			// which rejects an unknown field and anything after the document — and
+			// comparing the decoded forms, which are order-insensitive by construction.
+			// (An OMITTED field is caught by the comparison rather than the decoder,
+			// since it decodes to a different zero value; [TestDecodedAnswerComparatorIsStrict]
+			// drives both kinds.) Requiring the native bytes to equal one of the SAMPLED
+			// stock orderings would instead be an assumption about Go's map iteration:
+			// with three keys there are six permutations and this run observes three, so
+			// "native is among them" is luck, not a stock wire contract.
+			for i, o := range orderings {
+				pwRequireSameDecodedAnswer(t, fmt.Sprintf("stock ordering %d", i), o, nativeOrderings[0])
+			}
+
+			// THE DECISIVE CONSEQUENCE, stated without needing to know which permutation
+			// native lands on: stock emits at least two distinct byte strings for one
+			// value, and native emits exactly one. So for any deterministic native
+			// output there is at least one stock output it does not equal — byte-exact
+			// parity is unavailable at this key count, whichever ordering native picks.
+			matched := 0
+			for _, o := range orderings {
+				if o == nativeOrderings[0] {
+					matched++
+				}
+			}
+			if matched >= len(orderings) {
+				t.Fatalf("the native ordering matched %d of the %d distinct stock orderings; a single "+
+					"deterministic string cannot equal two different ones, so the observation above is "+
+					"inconsistent", matched, len(orderings))
+			}
+			t.Logf("RECORDED: stock emitted %d distinct byte orderings for one value and native emits "+
+				"exactly 1, so at least %d of stock's own outputs are unreachable for ANY deterministic "+
+				"native ordering. (This run's native bytes matched %d of the %d SAMPLED orderings; that "+
+				"count is an observation about which permutations Go's map iteration happened to "+
+				"produce, NOT a stock contract.) This is the measured reason 2+ @check stays DECLINED "+
+				"in 7.2c.", len(orderings), len(orderings)-1, matched, len(orderings))
+		})
+	}
+}
+
+// pwDecodedAnswer mirrors the two-field wire shape for the ORDER-INSENSITIVE comparison
+// in [TestTwoCheckWireOrderIsUnstable].
+//
+// It is a decode target, not a carrier: `checks` is a map, so two byte strings that
+// differ only in key order decode to equal values, which is exactly the property being
+// used to separate "different order" from "different content".
+type pwDecodedAnswer struct {
+	Answer     string              `json:"answer"`
+	Confidence pwDecodedCheckedInt `json:"confidence"`
+}
+
+type pwDecodedCheckedInt struct {
+	Value  int64                     `json:"value"`
+	Checks map[string]pwDecodedCheck `json:"checks"`
+}
+
+type pwDecodedCheck struct {
+	Name       string `json:"name"`
+	Expression string `json:"expression"`
+	Status     string `json:"status"`
+}
+
+// pwDecodeAnswerStrict decodes ONE wire string into [pwDecodedAnswer], strictly, and
+// requires the input to hold that value and nothing else.
+//
+// Two separate strictnesses, both load-bearing for the claim that a pair of wire strings
+// differs ONLY in key order:
+//
+//   - DisallowUnknownFields. A field either side emitted that this shape does not model
+//     would otherwise be silently dropped, and the comparison would then say "equal"
+//     about two documents that are not. (A field either side OMITTED is caught by the
+//     comparison instead, since it decodes to a different zero value — the decoder has
+//     no say there, and this comment does not claim it does.)
+//   - END OF INPUT. Anything after the value means the string was not the single
+//     document the comparison treats it as.
+//
+// The EOF half is a SECOND Decode that must return io.EOF, not `Decoder.More()`. `More`
+// is documented as reporting "whether there is another element in the current array or
+// object being parsed"; after a complete top-level value there is no such array or
+// object, so using it as an end-of-input test relies on behaviour the API does not
+// promise — and it misses trailing bytes beginning with `}` or `]` outright. Decoding
+// again and demanding io.EOF is what the contract does define.
+func pwDecodeAnswerStrict(in string) (pwDecodedAnswer, error) {
+	var out pwDecodedAnswer
+	dec := stdjson.NewDecoder(strings.NewReader(in))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&out); err != nil {
+		return pwDecodedAnswer{}, fmt.Errorf("strict decode: %w", err)
+	}
+	var tail stdjson.RawMessage
+	switch err := dec.Decode(&tail); {
+	case errors.Is(err, io.EOF):
+		return out, nil
+	case err == nil:
+		return pwDecodedAnswer{}, fmt.Errorf("trailing JSON value after the document: %s", tail)
+	default:
+		return pwDecodedAnswer{}, fmt.Errorf("trailing content after the document: %w", err)
+	}
+}
+
+// pwSameDecodedAnswer reports whether two wire strings decode strictly to the same value.
+//
+// It returns an error rather than taking a *testing.T so the comparator itself can be
+// driven by a negative control ([TestDecodedAnswerComparatorIsStrict]) instead of only
+// ever being exercised on inputs that pass.
+func pwSameDecodedAnswer(left, right string) error {
+	got, err := pwDecodeAnswerStrict(left)
+	if err != nil {
+		return fmt.Errorf("stock: %w\n%s", err, left)
+	}
+	want, err := pwDecodeAnswerStrict(right)
+	if err != nil {
+		return fmt.Errorf("native: %w\n%s", err, right)
+	}
+	if !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("the two wire strings differ in CONTENT, not only in key order:\n"+
+			" stock  %s\n native %s\n decoded stock  %+v\n decoded native %+v",
+			left, right, got, want)
+	}
+	return nil
+}
+
+// pwRequireSameDecodedAnswer is the assertion form.
+func pwRequireSameDecodedAnswer(t *testing.T, what, left, right string) {
+	t.Helper()
+	if err := pwSameDecodedAnswer(left, right); err != nil {
+		t.Fatalf("%s: %v", what, err)
+	}
+}
+
+// TestDecodedAnswerComparatorIsStrict is the negative control for the comparator the
+// 2+-check ordering fact rests on.
+//
+// Without it, "strict and content-preserving" is a claim about code that has only ever
+// been run on inputs that pass. Every row below is a way the comparison could have said
+// "these differ only in key order" about two strings that do not.
+func TestDecodedAnswerComparatorIsStrict(t *testing.T) {
+	const (
+		base     = `{"answer":"sunny","confidence":{"value":9,"checks":{"alpha":{"name":"alpha","expression":"this > 0","status":"succeeded"}}}}`
+		permuted = `{"confidence":{"checks":{"alpha":{"status":"succeeded","expression":"this > 0","name":"alpha"}},"value":9},"answer":"sunny"}`
+	)
+	// The POSITIVE control first: a genuine key-order permutation must compare EQUAL, or
+	// every negative below would pass for the wrong reason.
+	if err := pwSameDecodedAnswer(base, permuted); err != nil {
+		t.Fatalf("two orderings of the SAME document did not compare equal, so this comparator "+
+			"cannot witness the ordering fact at all: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		left  string
+		right string
+	}{
+		{"a trailing second document", base + base, base},
+		// The case Decoder.More() misses: trailing bytes that begin with a closing
+		// delimiter. More() peeks and returns false for `}`, so this slipped through
+		// before the io.EOF check replaced it.
+		{"a trailing close brace", base + "}", base},
+		{"a trailing close bracket", base + "]", base},
+		{"trailing garbage", base + "nonsense", base},
+		{"an unknown field", strings.Replace(base, `"answer":"sunny"`, `"answer":"sunny","extra":1`, 1), base},
+		{"a different value", strings.Replace(base, `"value":9`, `"value":10`, 1), base},
+		{"a different status", strings.Replace(base, "succeeded", "failed", 1), base},
+		{"a different expression", strings.Replace(base, "this > 0", "this >= 0", 1), base},
+		{"a dropped check", `{"answer":"sunny","confidence":{"value":9,"checks":{}}}`, base},
+		{"a renamed label", strings.ReplaceAll(base, "alpha", "beta"), base},
+		{"a missing field", `{"confidence":{"value":9,"checks":{"alpha":{"name":"alpha","expression":"this > 0","status":"succeeded"}}}}`, base},
+		{"an empty input", "", base},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := pwSameDecodedAnswer(tc.left, tc.right); err == nil {
+				t.Fatalf("the comparator accepted %s as differing only in key order:\n%s", tc.name, tc.left)
+			}
+			// And the same defect on the OTHER side must be caught too, so the
+			// comparator is not strict in one direction only.
+			if err := pwSameDecodedAnswer(tc.right, tc.left); err == nil {
+				t.Fatalf("the comparator accepted %s on the RIGHT-hand side:\n%s", tc.name, tc.left)
+			}
+		})
+	}
+}
+
+// TestSingleCheckWireOrderIsStable is the discriminating control for the test above.
+//
+// Without it, "the bytes vary" could be a property of the harness rather than of the key
+// count. A ONE-key result — the admitted family's own shape — must be byte-stable across
+// the same number of observations, which is exactly why 7.2b could pin its literals at all.
+func TestSingleCheckWireOrderIsStable(t *testing.T) {
+	o := pwOperators()[0]
+	key := pwDriveKey{Project: o.projectKey(), Func: pwFnChecked, Raw: pwNestedRaw(o.TrueVal)}
+	stock := pwCheckedValue(t, key)
+	if len(stock.Confidence.Checks) != 1 {
+		t.Fatalf("the control row carries %d checks, want exactly 1", len(stock.Confidence.Checks))
+	}
+	orderings := pwDistinctMarshals(t, stock)
+	if len(orderings) != 1 {
+		t.Fatalf("a ONE-key stock result produced %d distinct byte orderings across %d marshals; the "+
+			"whole 7.2b byte authority rests on this being 1: %v",
+			len(orderings), pwMarshalObservations, orderings)
+	}
+	if orderings[0] != pwOperatorCaptures[o.ID].checkTrue {
+		t.Fatalf("the stable single-key ordering is not the pinned literal:\n got %s\nwant %s",
+			orderings[0], pwOperatorCaptures[o.ID].checkTrue)
+	}
+	t.Logf("RECORDED: a ONE-key result is byte-stable across %d marshals; the instability above is a "+
+		"property of the KEY COUNT, not of this harness", pwMarshalObservations)
+}
+
+// ---------------------------------------------------------------------------
+// Duplicate labels.
+// ---------------------------------------------------------------------------
+
+// pwDuplicateLabelWire is stock's output for two @check attributes sharing ONE label,
+// declared on the pinned family.
+//
+// The map fold is LAST-WRITE-WINS: the surviving entry carries the SECOND expression.
+// checkedwire pins the same fold on a bare target; this row pins it inside the admitted
+// family's own shape, where a mapper would have to reproduce it.
+const pwDuplicateLabelWire = `{"answer":"sunny","confidence":{"value":9,"checks":{"dup":{"name":"dup","expression":"this > 1","status":"succeeded"}}}}`
+
+// TestDuplicateLabelsFoldLastWriteWins pins the fold and the data it destroys.
+func TestDuplicateLabelsFoldLastWriteWins(t *testing.T) {
+	key := pwDriveKey{Project: "res_duplicate_labels", Func: pwFnChecked, Raw: pwNestedRaw(9)}
+	stock := pwCheckedValue(t, key)
+	if len(stock.Confidence.Checks) != 1 {
+		t.Fatalf("stock reported %d checks for two attributes under one label, want 1 after the fold: %v",
+			len(stock.Confidence.Checks), stock.Confidence.Checks)
+	}
+	want := shared.Check{Name: "dup", Expression: "this > 1", Status: "succeeded"}
+	if got := stock.Confidence.Checks["dup"]; got != want {
+		t.Fatalf("stock check = %+v, want %+v (the SECOND declaration wins the fold)", got, want)
+	}
+	pwRequireSonicBytes(t, "stock", stock, pwDuplicateLabelWire)
+
+	// DISCRIMINATING: the FIRST declaration is absent from the bytes. A fold that kept
+	// the first would fail here rather than pass on a superset.
+	if strings.Contains(pwDuplicateLabelWire, "this > 0") {
+		t.Fatalf("the pinned duplicate-label literal carries the FIRST declaration: %s", pwDuplicateLabelWire)
+	}
+	// And the native carrier REFUSES the pair outright rather than reproducing a fold —
+	// a deliberate divergence, which is why the form is declined before it can be served.
+	_, err := bamlutils.NewChecked[int64](9, []bamlutils.Check{
+		{Name: "dup", Expression: "this > 0", Status: "succeeded"},
+		{Name: "dup", Expression: "this > 1", Status: "succeeded"},
+	})
+	if err == nil {
+		t.Fatal("bamlutils.NewChecked accepted a duplicate label; it is supposed to refuse the pair " +
+			"rather than silently pick a winner")
+	}
+	t.Logf("RECORDED: stock folds duplicate labels LAST-WRITE-WINS (%q survives); the native carrier "+
+		"REFUSES the pair (%v). The two cannot agree, so duplicate labels stay DECLINED.",
+		"this > 1", err)
+}
+
+// ---------------------------------------------------------------------------
+// Mixed @check + @assert, in BOTH declaration orders.
+// ---------------------------------------------------------------------------
+
+// The mixed-form captures. Both declaration orders produce the SAME bytes and the SAME
+// error, which is itself the finding: stock's output does not record which attribute was
+// written first.
+const (
+	// A node with one check and a PASSING assert keeps only the check.
+	pwMixedPassWire = `{"answer":"sunny","confidence":{"value":9,"checks":{"c":{"name":"c","expression":"this < 100","status":"succeeded"}}}}`
+	// A FALSE assert emits no value at all — and the PASSING check beside it, which
+	// would otherwise have been emitted, is absent from the error entirely.
+	pwMixedAssertFailErr = `Failed to coerce value: ParsingError { scope: [], reason: "Failed while parsing required fields: missing=0, unparsed=1", causes: [ParsingError { scope: [], reason: "Failed to parse field confidence: <root>: Assertions failed.\n  - <root>: Failed: a this > 0", causes: [ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: a this > 0", causes: [] }] }] }] }`
+)
+
+// TestMixedCheckAndAssertInBothDeclarationOrders captures the mixed form in both orders
+// and in both outcomes, including the false-assert path the scope names as unproved.
+func TestMixedCheckAndAssertInBothDeclarationOrders(t *testing.T) {
+	for _, project := range []string{"res_check_then_assert", "res_assert_then_check"} {
+		t.Run(project, func(t *testing.T) {
+			// (1) BOTH constraints holding: only the CHECK reaches the wire.
+			passKey := pwDriveKey{Project: project, Func: pwFnChecked, Raw: pwNestedRaw(9)}
+			stock := pwCheckedValue(t, passKey)
+			if len(stock.Confidence.Checks) != 1 {
+				t.Fatalf("stock reported %d checks for a check+assert node, want exactly 1: %v",
+					len(stock.Confidence.Checks), stock.Confidence.Checks)
+			}
+			if _, present := stock.Confidence.Checks["a"]; present {
+				t.Fatalf("the passing @assert produced a check entry: %v", stock.Confidence.Checks)
+			}
+			pwRequireSonicBytes(t, "stock", stock, pwMixedPassWire)
+
+			// (2) The assert FALSE while the check still HOLDS. This is the state the
+			// scope calls unproved: a check that would otherwise have been emitted is
+			// suppressed, and the error names only the assert.
+			failKey := pwDriveKey{Project: project, Func: pwFnChecked, Raw: pwNestedRaw(-1)}
+			err := pwError(t, failKey)
+			if got := err.Error(); got != pwMixedAssertFailErr {
+				t.Fatalf("stock mixed-node assertion error bytes:\n got %s\nwant %s",
+					strconv.Quote(got), strconv.Quote(pwMixedAssertFailErr))
+			}
+			// DISCRIMINATING: the surviving check is nowhere in the error. An
+			// implementation that emitted the check beside the failure — or folded the
+			// assert into a failed check — would not produce these bytes.
+			for _, absent := range []string{"this < 100", `"status"`, `"checks"`, "succeeded"} {
+				if strings.Contains(pwMixedAssertFailErr, absent) {
+					t.Errorf("the pinned mixed-node error carries %q; the passing check is supposed to "+
+						"be absent from it entirely", absent)
+				}
+			}
+		})
+	}
+
+	// (3) The two declaration orders are INDISTINGUISHABLE in stock's output. Recorded
+	// as a fact, because it is the reason a mixed admission would need a state machine
+	// rather than an ordering rule: nothing in the output says which came first.
+	a := pwCheckedValue(t, pwDriveKey{Project: "res_check_then_assert", Func: pwFnChecked, Raw: pwNestedRaw(9)})
+	b := pwCheckedValue(t, pwDriveKey{Project: "res_assert_then_check", Func: pwFnChecked, Raw: pwNestedRaw(9)})
+	aBytes, err := sonic.Marshal(a)
+	if err != nil {
+		t.Fatalf("sonic.Marshal: %v", err)
+	}
+	bBytes, err := sonic.Marshal(b)
+	if err != nil {
+		t.Fatalf("sonic.Marshal: %v", err)
+	}
+	if string(aBytes) != string(bBytes) {
+		t.Fatalf("the two declaration orders produced DIFFERENT bytes:\n  check-first: %s\n  assert-first: %s",
+			aBytes, bBytes)
+	}
+	errA := pwError(t, pwDriveKey{Project: "res_check_then_assert", Func: pwFnChecked, Raw: pwNestedRaw(-1)})
+	errB := pwError(t, pwDriveKey{Project: "res_assert_then_check", Func: pwFnChecked, Raw: pwNestedRaw(-1)})
+	if errA.Error() != errB.Error() {
+		t.Fatalf("the two declaration orders produced DIFFERENT errors:\n  check-first: %s\n  assert-first: %s",
+			strconv.Quote(errA.Error()), strconv.Quote(errB.Error()))
+	}
+	t.Log("RECORDED: stock's output is IDENTICAL for both declaration orders, in both outcomes. A " +
+		"mixed admission therefore cannot be derived from declaration order — it needs its own " +
+		"output/error state machine, which is why it stays DECLINED.")
+}
+
+// ---------------------------------------------------------------------------
+// Two failing @assert attributes on the pinned family.
+// ---------------------------------------------------------------------------
+
+// pwTwoAssertsErr is stock's UNMODIFIED err.Error() for TWO failing asserts on the
+// name-pinned assert family.
+//
+// Both causes are present, in DECLARATION order, flattened into the field-level reason
+// and repeated as a sibling pair in the inner tree. The current renderer models exactly
+// ONE failing assert on one required field, so this is a shape it cannot produce — which
+// is the measured reason multi-assert stays declined on this family.
+const pwTwoAssertsErr = `Failed to coerce value: ParsingError { scope: [], reason: "Failed while parsing required fields: missing=0, unparsed=1", causes: [ParsingError { scope: [], reason: "Failed to parse field confidence: <root>: Assertions failed.\n  - <root>: Failed: first this > 100\n  - <root>: Failed: second this > 200", causes: [ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: first this > 100", causes: [] }, ParsingError { scope: [], reason: "Failed: second this > 200", causes: [] }] }] }] }`
+
+// TestTwoAssertsOnThePinnedFamilyRecordCauseOrder pins the multi-assert error on the
+// admitted family's own shape and records the cause ORDER.
+func TestTwoAssertsOnThePinnedFamilyRecordCauseOrder(t *testing.T) {
+	key := pwDriveKey{Project: "res_two_asserts", Func: pwFnAssert, Raw: pwNestedRaw(9)}
+	err := pwError(t, key)
+	if got := err.Error(); got != pwTwoAssertsErr {
+		t.Fatalf("stock two-assert error bytes:\n got %s\nwant %s",
+			strconv.Quote(got), strconv.Quote(pwTwoAssertsErr))
+	}
+	// The ORDER is the recorded fact: `first` before `second`, which is DECLARATION
+	// order, in both the flattened reason and the inner cause list. Asserted by index so
+	// a reordering fails rather than passing on a set-membership check.
+	firstAt := strings.Index(pwTwoAssertsErr, "Failed: first this > 100")
+	secondAt := strings.Index(pwTwoAssertsErr, "Failed: second this > 200")
+	if firstAt < 0 || secondAt < 0 {
+		t.Fatalf("the pinned two-assert error does not carry both causes: %s", pwTwoAssertsErr)
+	}
+	if firstAt >= secondAt {
+		t.Fatalf("the pinned two-assert error carries `second` before `first`; the recorded order is "+
+			"wrong: %s", pwTwoAssertsErr)
+	}
+	// DISCRIMINATING: it is a genuine multi-cause error, not the single-assert shape with
+	// one cause swapped in — the one-assert literal must not be a prefix or equal.
+	if pwTwoAssertsErr == pwOperatorCaptures["gt"].assertFail {
+		t.Fatal("the two-assert error equals the one-assert error")
+	}
+	if strings.Count(pwTwoAssertsErr, "Failed: ") != 4 {
+		t.Fatalf("the pinned two-assert error carries %d `Failed: ` causes, want 4 (each of the two "+
+			"appears in the flattened reason and again in the inner tree): %s",
+			strings.Count(pwTwoAssertsErr, "Failed: "), pwTwoAssertsErr)
+	}
+	t.Logf("RECORDED: two failing asserts on the pinned family produce BOTH causes in DECLARATION " +
+		"order, flattened into the field reason and repeated as a sibling pair in the inner tree. " +
+		"The current renderer models ONE failing assert, so multi-assert stays DECLINED.")
+}
+
+// ---------------------------------------------------------------------------
+// Every residual form still DECLINES.
+// ---------------------------------------------------------------------------
+
+// pwConstraint builds one labelled constraint.
+func pwConstraint(level schema.ConstraintLevel, label, expr string) schema.Constraint {
+	l := label
+	return schema.Constraint{Level: level, Expression: expr, Label: &l}
+}
+
+// pwMultiConstraintBundle builds the pinned CHECK family carrying N constraints on
+// `confidence`, so the residual forms can be asked of the production gates as the same
+// shape stock was driven with.
+func pwMultiConstraintBundle(cs ...schema.Constraint) *schema.Bundle {
+	confidence := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt}
+	confidence.Meta.Constraints = cs
+	b := &schema.Bundle{
+		Target: schema.Type{Kind: schema.TypeClass, Name: pwCheckedClass, Mode: schema.NonStreaming},
+		Classes: []schema.ClassDef{{
+			Name: schema.Name{Name: pwCheckedClass},
+			Mode: schema.NonStreaming,
+			Fields: []schema.ClassField{
+				{Name: schema.Name{Name: "answer"}, Type: schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveString}},
+				{Name: schema.Name{Name: "confidence"}, Type: confidence},
+			},
+		}},
+	}
+	if err := b.RebuildIndexes(); err != nil {
+		panic("predicatewire residual fixture: " + err.Error())
+	}
+	return b
+}
+
+// pwResidualBundles pairs each captured residual FORM with the bundle that describes it.
+func pwResidualBundles() map[string]*schema.Bundle {
+	check, assert := schema.ConstraintCheck, schema.ConstraintAssert
+	return map[string]*schema.Bundle{
+		"two_checks": pwMultiConstraintBundle(
+			pwConstraint(check, "alpha", "this > 0"), pwConstraint(check, "beta", "this < 100")),
+		"three_checks": pwMultiConstraintBundle(
+			pwConstraint(check, "alpha", "this > 0"), pwConstraint(check, "beta", "this < 100"),
+			pwConstraint(check, "gamma", "this != 7")),
+		"duplicate_labels": pwMultiConstraintBundle(
+			pwConstraint(check, "dup", "this > 0"), pwConstraint(check, "dup", "this > 1")),
+		"check_then_assert": pwMultiConstraintBundle(
+			pwConstraint(check, "c", "this < 100"), pwConstraint(assert, "a", "this > 0")),
+		"assert_then_check": pwMultiConstraintBundle(
+			pwConstraint(assert, "a", "this > 0"), pwConstraint(check, "c", "this < 100")),
+		"two_asserts": pwAssertFamilyBundle(
+			pwConstraint(assert, "first", "this > 100"), pwConstraint(assert, "second", "this > 200")),
+	}
+}
+
+// pwAssertFamilyBundle is the pinned ASSERT family carrying N constraints on
+// `confidence`. It is separate from [pwMultiConstraintBundle] because the two families
+// are DIFFERENT pinned class names, and asking the gates about the wrong one would
+// measure the name rather than the form.
+func pwAssertFamilyBundle(cs ...schema.Constraint) *schema.Bundle {
+	b := pwMultiConstraintBundle(cs...)
+	b.Target.Name = pwAssertClass
+	b.Classes[0].Name.Name = pwAssertClass
+	if err := b.RebuildIndexes(); err != nil {
+		panic("predicatewire residual fixture: " + err.Error())
+	}
+	return b
+}
+
+// pwResidualDeclineReport returns one line per residual form the production gates did NOT
+// decline, so the comparison can be driven with a wrong expectation and shown to bite.
+func pwResidualDeclineReport(t *testing.T, declines func(form string) bool) []string {
+	t.Helper()
+	var out []string
+	bundles := pwResidualBundles()
+	for _, form := range pwSortedBundleKeys(bundles) {
+		b := bundles[form]
+		admitted := pwAdmits(t, "residual "+form, b)
+		if admitted == declines(form) {
+			out = append(out, form+": gates admitted="+strconv.FormatBool(admitted)+
+				", expected declined="+strconv.FormatBool(declines(form)))
+		}
+	}
+	return out
+}
+
+func pwSortedBundleKeys(m map[string]*schema.Bundle) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestResidualFormsAreDeclined proves every captured residual form is still refused by
+// the production gates, and on the direct parse route as well.
+func TestResidualFormsAreDeclined(t *testing.T) {
+	always := func(string) bool { return true }
+	if got := pwResidualDeclineReport(t, always); len(got) != 0 {
+		t.Fatalf("a residual form is no longer declined:\n  %s", strings.Join(got, "\n  "))
+	}
+	bundles := pwResidualBundles()
+	for _, form := range pwSortedBundleKeys(bundles) {
+		if _, err := debaml.ParseStaticBundle(context.Background(), bundles[form], pwNestedRaw(9)); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			t.Errorf("%s: ParseStaticBundle did not decline on the direct route: %v", form, err)
+		}
+	}
+	// Every CAPTURED residual project must have a bundle, or a form could be measured
+	// against stock and never checked against the gates.
+	for _, r := range pwResiduals() {
+		if _, ok := bundles[r.ID]; !ok {
+			t.Errorf("residual %q is captured from stock but has no bundle, so its DECLINE is unproven", r.ID)
+		}
+	}
+	t.Logf("%d residual forms captured from stock, all %d still DECLINED at the production gates",
+		len(pwResiduals()), len(bundles))
+}
+
+// TestResidualDeclinesAreProvenToBite feeds the same comparison the opposite expectation
+// and requires every form to be reported.
+//
+// A suite whose every assertion is "this still declines" is exactly the shape that can be
+// green while measuring nothing.
+func TestResidualDeclinesAreProvenToBite(t *testing.T) {
+	never := func(string) bool { return false }
+	got := pwResidualDeclineReport(t, never)
+	if len(got) != len(pwResidualBundles()) {
+		t.Fatalf("an expectation that NO residual form declines was reported %d times, want %d "+
+			"(one per form); the comparison is not covering every form", len(got), len(pwResidualBundles()))
+	}
+}

--- a/internal/debaml/predicatewire/residuals.md
+++ b/internal/debaml/predicatewire/residuals.md
@@ -1,0 +1,125 @@
+# de-BAML Slice 7.2c-1 — residual ledger
+
+Every form the 7.2c scope defers, with its disposition and the authority behind it.
+
+This file is proof material, not documentation: `TestResidualLedgerCoversEveryDeferral`
+in this package parses the table below, requires every residual CAPTURED from stock here
+to have a row, requires every row to be `DECLINED`, and requires every authority that
+names a test — in this package or in a sibling one — to name a test that really exists
+there.
+
+**Nothing in this table is admitted by 7.2c-1.** The only served predicate is still
+`this > I` on the two name-pinned families, which
+`TestPredicateWireAdmissionIsUnchanged` re-asserts through the production gates.
+
+## What "authority" means per row
+
+Three kinds appear, and they are not interchangeable:
+
+- `predicatewire:<Test>` — measured by THIS package against the stock v0.223.0 CFFI, in
+  this PR. The strongest kind: the deferral rests on an observation.
+- `<package>:<Test>` — already measured elsewhere in the repo against the same stock
+  CFFI. Cited rather than duplicated.
+- `scope:<section>` — a decision recorded in `/tmp/shared/slice72c-scope.md` §, with no
+  new measurement in this PR. These are the rows a later slice must measure before it can
+  move them, and they are marked so that is visible rather than implied.
+
+## Why the type/shape candidates are cited and not re-captured here
+
+Every type/shape variant changes the GENERATED GO SHAPE of the pinned class
+(`confidence` becomes `Checked[float64]`, `Checked[string]`, a bare value, or the struct
+gains/reorders a field). `baml_go`'s type map is PROCESS-GLOBAL — one entry per class
+name across every runtime — so a shape variant cannot share `StaticCheckedAnswer` with
+the six operator captures in this package. The only way to capture it here would be to
+rename the class, which is exactly the move the scope forbids: it would confound
+"declined for its shape" with "declined for its name".
+
+Their stock behaviour is already captured under their own names by the 49
+constraint-bearing rows of `internal/debaml`'s serving oracle, which this table cites per
+row. This bound is deliberate, and `TestResidualLedgerCoversEveryDeferral` logs it so a
+partial matrix cannot read as a complete one.
+
+## The ledger
+
+| id | form | disposition | authority |
+| --- | --- | --- | --- |
+| two_checks | two unique `@check` on `confidence` | DECLINED | predicatewire:TestTwoCheckWireOrderIsUnstable |
+| three_checks | three unique `@check` on `confidence` | DECLINED | predicatewire:TestTwoCheckWireOrderIsUnstable |
+| duplicate_labels | two `@check` sharing one label | DECLINED | predicatewire:TestDuplicateLabelsFoldLastWriteWins |
+| check_then_assert | one `@check` then one `@assert` | DECLINED | predicatewire:TestMixedCheckAndAssertInBothDeclarationOrders |
+| assert_then_check | one `@assert` then one `@check` | DECLINED | predicatewire:TestMixedCheckAndAssertInBothDeclarationOrders |
+| two_asserts | two failing `@assert` on the pinned assert family | DECLINED | predicatewire:TestTwoAssertsOnThePinnedFamilyRecordCauseOrder |
+| noncanonical_literal | `+5`, `007`, `1_000`, `5.0`, i64 overflow | DECLINED | predicatewire:TestStockNonCanonicalLiteralDispositions |
+| padding_two_spaces | two ASCII spaces each side of the predicate | DECLINED | predicatewire:TestStockPaddingIsStrippedForEveryOperator |
+| operator_ge | `this >= I` | DECLINED | predicatewire:TestPredicateWireAdmissionIsUnchanged |
+| operator_lt | `this < I` | DECLINED | predicatewire:TestPredicateWireAdmissionIsUnchanged |
+| operator_le | `this <= I` | DECLINED | predicatewire:TestPredicateWireAdmissionIsUnchanged |
+| operator_eq | `this == I` | DECLINED | predicatewire:TestPredicateWireAdmissionIsUnchanged |
+| operator_ne | `this != I` | DECLINED | predicatewire:TestPredicateWireAdmissionIsUnchanged |
+| i64_beyond_exact | an admitted-family VALUE at or past 2^53 | DECLINED | predicatewire:TestDirectIntBoundaryMatrix |
+| i64_long_literal | a canonical literal longer than 15 digits — including `9007199254740991`, which is 2^53-1 and therefore below the guard's own 2^53 threshold | DECLINED | predicatewire:TestDirectIntBoundaryMatrix |
+| i64_negative_literal | a negative canonical literal, which the generic guard reads as arithmetic | DECLINED | predicatewire:TestDirectIntBoundaryMatrix |
+| compound_predicate | `and`, `or`, `not`, `&&`, ternaries, membership, concatenation | DECLINED | scope:Verified broadening decisions 2 |
+| filters_and_arithmetic | filters, arithmetic, parentheses, alternate literal syntax | DECLINED | scope:Verified broadening decisions 2 |
+| type_float | `confidence float` | DECLINED | debaml:TestServingOracleBoundaryLock |
+| type_string | a constrained `string` field | DECLINED | debaml:TestServingOracleBoundaryLock |
+| type_bool | a constrained `bool` field | DECLINED | debaml:TestServingOracleBoundaryLock |
+| type_enum | a constrained enum field | DECLINED | debaml:TestServingOracleBoundaryLock |
+| type_nullable | a constrained nullable field | DECLINED | debaml:TestServingOracleBoundaryLock |
+| type_list | a constrained list, and a constrained list ELEMENT | DECLINED | debaml:TestServingOracleBoundaryLock |
+| type_map | a constrained map key or value | DECLINED | debaml:TestServingOracleBoundaryLock |
+| type_union | a constrained union | DECLINED | debaml:TestServingOracleBoundaryLock |
+| type_nested_class | a constrained field on a nested class | DECLINED | debaml:TestServingOracleBoundaryLock |
+| type_media | a constrained media value | DECLINED | scope:Verified broadening decisions 5 |
+| target_constraint | `@check`/`@assert` on the return type itself | DECLINED | debaml:TestServingOracleBoundaryLock |
+| class_constraint | a `@@check`/`@@assert` class-level constraint | DECLINED | debaml:TestServingOracleBoundaryLock |
+| toplevel_constrained | a bare constrained scalar target (all six operators, both levels) | DECLINED | predicatewire:TestTopLevelOperatorFormsAreDeclined |
+| shape_third_field | a third field beside `answer` and `confidence` | DECLINED | debaml:TestStaticCheckedGatesShareOneFingerprint |
+| shape_reordered_fields | `confidence` before `answer` | DECLINED | debaml:TestStaticCheckedGatesShareOneFingerprint |
+| shape_constraint_on_answer | the constraint on `answer` instead of `confidence` | DECLINED | debaml:TestStaticCheckedGatesShareOneFingerprint |
+| shape_two_constrained_fields | constraints on both fields | DECLINED | debaml:TestStaticCheckedGatesShareOneFingerprint |
+| shape_class_name | either pinned class renamed | DECLINED | debaml:TestStaticCheckedGatesShareOneFingerprint |
+| shape_extra_definitions | a second class, or an enum, in the bundle | DECLINED | debaml:TestStaticCheckedGatesShareOneFingerprint |
+| meta_alias | an `@alias` on a field | DECLINED | checkedwire:TestStockAliasIngressHasCanonicalOutput |
+| meta_description | a `@description` on a field | DECLINED | debaml:TestStaticCheckedGatesShareOneFingerprint |
+| meta_stream_dynamic | stream or dynamic metadata | DECLINED | debaml:TestStaticCheckedGatesShareOneFingerprint |
+| label_non_ascii | a non-ASCII constraint label or expression | DECLINED | checkedwire:asymmetries.md |
+| label_empty_present | a present-but-empty label | DECLINED | debaml:TestStaticCheckedGatesShareOneFingerprint |
+| route_static_stream | the static STREAM lane | DECLINED | debaml:TestStaticCheckedRouteBoundaryKeepsTheDynamicAndStreamLanesClosed |
+| route_dynamic_final | the dynamic final lane | DECLINED | debaml:TestStaticCheckedRouteBoundaryKeepsTheDynamicAndStreamLanesClosed |
+| route_direct_parse | `ParseStaticBundle` without the static-unary claim | DECLINED | predicatewire:TestPredicateWireAdmissionIsUnchanged |
+| route_call_with_raw | `CallWithRaw` | DECLINED | debaml:TestStaticCheckedRouteBoundaryKeepsTheDynamicAndStreamLanesClosed |
+
+## The two findings a later slice must act on
+
+1. **2+ `@check` is blocked by measurement, not by effort.** `sonic.Marshal` of stock's
+   two-key result produced BOTH orderings across 200 observations, and the three-key
+   result produced three. The native carrier is deterministic, so at least N-1 of the
+   distinct strings stock emits are unreachable for ANY single native ordering — byte-exact
+   parity is not available at any key count above one, whichever permutation native picks.
+   (That the two sides agree on CONTENT is proven separately, by strictly decoding both and
+   comparing order-insensitively; which sampled permutation native happens to equal is an
+   observation about Go map iteration, not a stock contract.) Moving this row needs a newly
+   approved stock ordering contract, not mapper work.
+
+2. **The direct-i64 totality gap is much wider than the 2^53 guard.** Of the 222 rows in
+   the boundary matrix, stock answers every one exactly; native's current generic profile
+   answers 36 and refuses 186. The refusals split three INDEPENDENT ways, each with its
+   own ledger row above:
+
+   - `i64_beyond_exact` — a VALUE at or past 2^53. Note this is the GUARD's threshold,
+     not where float64 loses exactness: every integer up to and including 2^53 round-trips
+     exactly, and 2^53+1 is the first that does not, so the guard sits one step early on
+     purpose;
+   - `i64_long_literal` — a LITERAL longer than 15 digits. This one is not a restatement of
+     the first: `9007199254740991` is 2^53-1 — below the guard's own 2^53 threshold, and
+     exactly representable in float64 either way — and is still refused purely for its
+     sixteen digits. Over non-negative literals the measured answering frontier therefore
+     crosses at 10^15, **below** 2^53;
+   - `i64_negative_literal` — **every** negative literal, whatever its magnitude, because
+     `-` is an arithmetic byte and `this ...` never parses as the closed numeric
+     sublanguage. The scope did not call this one out at all.
+
+   7.2c-2 must close all three for the direct grammar, not only the first. The magnitude
+   frontier applies only on the non-negative side; the sign clause is absolute and is
+   reported separately rather than folded into a single number.

--- a/internal/debaml/predicatewire/tables_test.go
+++ b/internal/debaml/predicatewire/tables_test.go
@@ -1,0 +1,553 @@
+//go:build integration
+
+package predicatewire
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// The PROJECT TABLES. Every declaration stock compiles, and every byte stock is given,
+// is here or in the row tables that name these projects.
+//
+// Nothing in these tables is derived from native output. Each drive's raw text is a
+// fixed assistant string; what comes back is compared against a pinned literal.
+
+// ---------------------------------------------------------------------------
+// (A) The six direct operators, on BOTH name-pinned nested families.
+// ---------------------------------------------------------------------------
+
+// pwOperator is one direct comparison, with the values that make its predicate true and
+// false against the SAME canonical literal.
+//
+// One literal across all six is deliberate: it makes every byte difference between two
+// operator captures attributable to the OPERATOR and to nothing else. The literal is `0`
+// — the same one the 7.2b fixtures use — so the six captures are also directly
+// comparable with checkedwire's `this > 0` rows.
+type pwOperator struct {
+	// ID is the project/label suffix; Op is the BAML source operator.
+	ID string
+	Op string
+	// TrueVal and FalseVal are `confidence` values that make `this OP 0` hold and fail.
+	TrueVal  int64
+	FalseVal int64
+}
+
+// pwCanonicalLiteral is the `I` every operator project compares against.
+const pwCanonicalLiteral = 0
+
+// expr is the canonical inner text of this operator's predicate: exactly the string the
+// 7.2c grammar would admit, and exactly what stock reports in Check.Expression.
+func (o pwOperator) expr() string {
+	return fmt.Sprintf("this %s %d", o.Op, pwCanonicalLiteral)
+}
+
+func (o pwOperator) projectKey() string { return "op_" + o.ID }
+
+// pwOperators is the whole six-operator manifest. It is COMPLETE by construction:
+// [TestOperatorManifestIsTheWholeGrammar] checks it against the scope's operator set, so
+// a quietly dropped operator is a failure rather than a smaller matrix.
+func pwOperators() []pwOperator {
+	return []pwOperator{
+		{ID: "gt", Op: ">", TrueVal: 9, FalseVal: -1},
+		{ID: "ge", Op: ">=", TrueVal: 0, FalseVal: -1},
+		{ID: "lt", Op: "<", TrueVal: -1, FalseVal: 9},
+		{ID: "le", Op: "<=", TrueVal: 0, FalseVal: 9},
+		{ID: "eq", Op: "==", TrueVal: 0, FalseVal: 9},
+		{ID: "ne", Op: "!=", TrueVal: 9, FalseVal: 0},
+	}
+}
+
+// pwNestedRaw is the assistant text for one nested-family drive.
+func pwNestedRaw(confidence int64) string {
+	return fmt.Sprintf(`{"answer": "sunny", "confidence": %d}`, confidence)
+}
+
+// pwCheckedClassDecl renders the CHECK family with a given attribute list.
+func pwCheckedClassDecl(attrs string) string {
+	return fmt.Sprintf("class %s {\n  answer string\n  confidence int %s\n}\n", pwCheckedClass, attrs)
+}
+
+// pwAssertClassDecl renders the ASSERT family with a given attribute list.
+func pwAssertClassDecl(attrs string) string {
+	return fmt.Sprintf("class %s {\n  answer string\n  confidence int %s\n}\n", pwAssertClass, attrs)
+}
+
+// The two function names every operator project carries. They are the same in all six
+// projects on purpose: the projects are isolated, so the role is what the name means.
+const (
+	pwFnChecked = "Checked"
+	pwFnAssert  = "Assert"
+)
+
+// pwOperatorProjects is one isolated project per operator, each declaring BOTH pinned
+// classes once with that operator's predicate.
+//
+// This is the shape the whole package exists for. A single project could not hold them:
+// six `class StaticCheckedAnswer` declarations are six definitions of one name, and
+// renaming any of them would capture a different family.
+func pwOperatorProjects() []pwProject {
+	var out []pwProject
+	for _, o := range pwOperators() {
+		out = append(out, pwProject{
+			Key: o.projectKey(),
+			Doc: "Slice 7.2c-1 OPERATOR CAPTURE: the two name-pinned static families carrying\n" +
+				"the direct comparison `" + o.expr() + "`. Isolated in its own project because the\n" +
+				"class names are PINNED — six predicate variants of one name cannot coexist.",
+			Decls: []string{
+				pwCheckedClassDecl(fmt.Sprintf("@check(positive, {{ %s }})", o.expr())),
+				pwAssertClassDecl(fmt.Sprintf("@assert(positive, {{ %s }})", o.expr())),
+			},
+			Funcs: []pwFunc{
+				{Name: pwFnChecked, Doc: "WIRE: the @check family, driven true and false.", Target: pwCheckedClass},
+				{Name: pwFnAssert, Doc: "WIRE + ERROR BYTES: the @assert family, driven true and false.", Target: pwAssertClass},
+			},
+			WantCompile: true,
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// (A2) The same six operators, TOP-LEVEL.
+// ---------------------------------------------------------------------------
+
+// pwTopLevelKey is the single project carrying every top-level operator probe.
+const pwTopLevelKey = "toplevel"
+
+// The two function-name prefixes inside that project.
+const (
+	pwTopCheckPrefix  = "Top_Check_"
+	pwTopAssertPrefix = "Top_Assert_"
+)
+
+// pwTopCheckFn / pwTopAssertFn name one operator's top-level probes.
+func pwTopCheckFn(o pwOperator) string  { return pwTopCheckPrefix + o.ID }
+func pwTopAssertFn(o pwOperator) string { return pwTopAssertPrefix + o.ID }
+
+// pwTopLevelProject carries all twelve top-level probes: a bare `int` target carrying the
+// constraint DIRECTLY, per operator, at both levels.
+//
+// The scope's differential requirements ask for nested AND top-level check pass/fail and
+// assert pass/fail for every direct operator, and the two are genuinely different
+// outcomes rather than one inferable from the other:
+//
+//   - a top-level check emits the carrier as the WHOLE response, with no enclosing
+//     object, so its bytes are not a substring of the nested form; and
+//   - a top-level failing assert has NO required-field wrapper at all — the nested error's
+//     entire `Failed while parsing required fields` / `Failed to parse field confidence`
+//     chain comes from the field position, not from the assert.
+//
+// They all fit ONE project because a bare target declares no class, so there is no
+// name-pinned declaration to collide — the isolation that the nested captures need does
+// not apply here, and twelve extra runtimes would buy nothing.
+func pwTopLevelProject() pwProject {
+	p := pwProject{
+		Key: pwTopLevelKey,
+		Doc: "Slice 7.2c-1 TOP-LEVEL OPERATOR CAPTURE: the six direct comparisons on a BARE `int`\n" +
+			"target, at both levels. The nested twins live in the op_* projects; these are the\n" +
+			"outcomes that cannot be inferred from them — an unenclosed carrier, and an assert\n" +
+			"failure with no required-field wrapper.",
+		WantCompile: true,
+	}
+	for _, o := range pwOperators() {
+		p.Funcs = append(p.Funcs,
+			pwFunc{
+				Name:   pwTopCheckFn(o),
+				Doc:    "WIRE: top-level @check " + strconv.Quote(o.expr()) + ", driven true and false.",
+				Target: fmt.Sprintf("int @check(%s, {{ %s }})", pwCheckedLabel, o.expr()),
+			},
+			pwFunc{
+				Name:   pwTopAssertFn(o),
+				Doc:    "WIRE + ERROR BYTES: top-level @assert " + strconv.Quote(o.expr()) + ", driven true and false.",
+				Target: fmt.Sprintf("int @assert(%s, {{ %s }})", pwCheckedLabel, o.expr()),
+			},
+		)
+	}
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// (B) Expression text: source padding.
+// ---------------------------------------------------------------------------
+
+// pwExprTextKey is the single project that carries every padding probe.
+const pwExprTextKey = "exprtext"
+
+// pwPadProbe is one `{{ PAD expr PAD }}` source-padding probe.
+type pwPadProbe struct {
+	// Label is the @check label AND the probe id.
+	Label string
+	// Pad is the number of ASCII spaces on EACH side inside the `{{ }}`.
+	Pad int
+	// Op is the operator whose canonical expression is padded.
+	Op pwOperator
+}
+
+// canonical is the expression text with no padding — what the 7.2c grammar calls the
+// canonical inner text, and what stock is expected to report.
+func (p pwPadProbe) canonical() string { return p.Op.expr() }
+
+// source is the attribute's inner text as written in the .baml, padding included.
+func (p pwPadProbe) source() string {
+	pad := strings.Repeat(" ", p.Pad)
+	return pad + p.canonical() + pad
+}
+
+// pwPadProbes is zero and one ASCII space each side for ALL SIX operators — the two
+// paddings the 7.2c grammar would admit — plus TWO spaces on the two-byte operator
+// `>=`.
+//
+// The pad-2 probe is not an admission candidate. checkedwire measured 0/1/2 for the
+// ONE-byte `>` and found stock reports the same unpadded string for all three; this row
+// asks the same question of a TWO-byte operator, so the padding rule is measured on both
+// widths rather than generalised from one. The 7.2c fingerprint still admits at most one
+// space, and TestStaticCheckedSiblingsDecline pins `  this >= 0  ` as a decline.
+func pwPadProbes() []pwPadProbe {
+	var out []pwPadProbe
+	for _, o := range pwOperators() {
+		out = append(out,
+			pwPadProbe{Label: "pad0_" + o.ID, Pad: 0, Op: o},
+			pwPadProbe{Label: "pad1_" + o.ID, Pad: 1, Op: o},
+		)
+		if o.ID == pwPadTwoOperator {
+			out = append(out, pwPadProbe{Label: "pad2_" + o.ID, Pad: 2, Op: o})
+		}
+	}
+	return out
+}
+
+// pwPadTwoOperator is the ONE operator the two-space probe runs on: the two-byte `>=`.
+// checkedwire already measured 0/1/2 on the one-byte `>`, so what is open is whether the
+// wider operator behaves the same, not whether a third padding should be admitted.
+const pwPadTwoOperator = "ge"
+
+// pwExprTextProject carries every padding probe on a BARE `int` target.
+//
+// A bare target is correct here and is not a weakening: what a padding probe measures is
+// the string stock retains in Check.Expression, which is a property of the ATTRIBUTE, not
+// of where the constrained node sits. Driving them on a bare target is also what lets all
+// THIRTEEN — six operators at pad 0, the same six at pad 1, and the single two-byte `>=`
+// probe at pad 2 — share ONE project, because a nested probe would need the pinned class
+// and the pinned class may be declared only once per project.
+//
+// [TestStockPaddingIsStrippedForEveryOperator] logs the per-pad counts and fails if
+// pad 0 or pad 1 stops covering all six, so this sentence cannot drift away from the
+// table it describes without a red test.
+func pwExprTextProject() pwProject {
+	p := pwProject{
+		Key: pwExprTextKey,
+		Doc: "Slice 7.2c-1 EXPRESSION TEXT: what stock retains in Check.Expression for each of the\n" +
+			"six canonical predicates under zero, one and two ASCII spaces of source padding.\n" +
+			"Bare `int` targets, so all of them fit one project without touching a pinned class name.",
+		WantCompile: true,
+	}
+	for _, probe := range pwPadProbes() {
+		p.Funcs = append(p.Funcs, pwFunc{
+			Name:   "Pad_" + probe.Label,
+			Doc:    fmt.Sprintf("EXPRESSION TEXT: %d space(s) each side of %q.", probe.Pad, probe.canonical()),
+			Target: fmt.Sprintf("int @check(%s, {{%s}})", probe.Label, probe.source()),
+		})
+	}
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// (C) Canonical-literal discriminators.
+// ---------------------------------------------------------------------------
+
+// pwLiteralProbe is one NON-canonical integer literal spelling, on the PINNED check
+// family.
+//
+// The 7.2c grammar admits exactly `strconv.FormatInt` output, so `+5`, `007`, `1_000`, a
+// float and an i64 overflow are all outside it. What is NOT known without measuring is
+// what STOCK does with them: accept and evaluate, accept and report a different retained
+// expression, or reject the project at compile time. Each gets its own isolated project
+// precisely because a compile rejection would otherwise take its neighbours down.
+type pwLiteralProbe struct {
+	// ID names the project (lit_<ID>).
+	ID string
+	// Literal is the right-hand side as written in the .baml.
+	Literal string
+	// Doc says which rule of the canonical grammar it violates.
+	Doc string
+	// Confidence is the value driven when the project compiles.
+	Confidence int64
+	// Rejected records that BAML's OWN parser refuses this attribute text, so the
+	// project never compiles and there is no wire capture to take. It is a measured
+	// disposition, not a convenience: [TestPredicateWireProjectsAreTheOnesStockDrives]
+	// fails just as loudly if a project pinned as rejected starts compiling.
+	Rejected bool
+}
+
+func (p pwLiteralProbe) projectKey() string { return "lit_" + p.ID }
+func (p pwLiteralProbe) expr() string       { return "this > " + p.Literal }
+
+// pwLiteralProbes are the five non-canonical spellings the 7.2b fingerprint already
+// rejects (internal/debaml.staticCheckedThreshold), captured against stock so the
+// rejection is a measured over-decline rather than an unexamined one.
+func pwLiteralProbes() []pwLiteralProbe {
+	return []pwLiteralProbe{
+		{ID: "plus5", Literal: "+5", Doc: "an explicit `+` sign, which FormatInt never emits", Confidence: 9, Rejected: true},
+		{ID: "leading_zeros", Literal: "007", Doc: "leading zeros, which FormatInt never emits", Confidence: 9},
+		{ID: "underscore", Literal: "1_000", Doc: "a digit separator, which FormatInt never emits", Confidence: 9},
+		{ID: "float", Literal: "5.0", Doc: "a float spelling of an integer threshold", Confidence: 9},
+		{ID: "overflow", Literal: "9223372036854775808", Doc: "one past math.MaxInt64", Confidence: 9},
+	}
+}
+
+// pwLiteralProjects is one isolated project per non-canonical literal, each declaring
+// the PINNED check family so the capture is about the admitted family's own attribute
+// text.
+//
+// The measured split is four/one: BAML's attribute grammar ACCEPTS `007`, `1_000`, `5.0`
+// and the i64 overflow and evaluates all four, which is precisely why the native
+// fingerprint has to reject them ITSELF rather than relying on a parse error upstream. It
+// REFUSES `+5` at parse time. WantCompile carries that measurement per project, so either
+// disposition changing in a future BAML is a visible decision rather than a silent one.
+func pwLiteralProjects() []pwProject {
+	var out []pwProject
+	for _, p := range pwLiteralProbes() {
+		disposition := "Isolated so a compile rejection is attributable to this spelling alone."
+		if p.Rejected {
+			disposition = "RECORDED: stock's own Jinja parser REFUSES this spelling, so the project does not compile."
+		}
+		out = append(out, pwProject{
+			Key: p.projectKey(),
+			Doc: "Slice 7.2c-1 CANONICAL-LITERAL DISCRIMINATOR: `" + p.expr() + "` — " + p.Doc + ".\n" +
+				disposition,
+			Decls:       []string{pwCheckedClassDecl(fmt.Sprintf("@check(positive, {{ %s }})", p.expr()))},
+			Funcs:       []pwFunc{{Name: pwFnChecked, Doc: "WIRE: the non-canonical literal, driven once.", Target: pwCheckedClass}},
+			WantCompile: !p.Rejected,
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// (D) The direct-i64 boundary matrix.
+// ---------------------------------------------------------------------------
+
+// pwBoundaryThreshold is one integer literal the six operators are all measured against.
+type pwBoundaryThreshold struct {
+	// ID names the project (bound_<ID>).
+	ID string
+	// N is the literal, written into the .baml as strconv.FormatInt(N, 10).
+	N int64
+	// Doc says why this threshold is on the boundary.
+	Doc string
+}
+
+func (b pwBoundaryThreshold) projectKey() string { return "bound_" + b.ID }
+func (b pwBoundaryThreshold) literal() string    { return strconv.FormatInt(b.N, 10) }
+
+// maxExactInt is 2^53 — the magnitude at which internal/debaml's generic evaluator
+// profile starts REFUSING (constraint_profile.go's exceedsExactIntegerRange tests
+// `>= 2^53`).
+//
+// It is NOT where float64 stops being exact, and the two must not be conflated. Every
+// integer of magnitude up to and INCLUDING 2^53 round-trips through float64 exactly;
+// 2^53+1 is the first one that does not, because it needs 54 significand bits and
+// collapses onto 2^53. The guard therefore sits one step BEFORE the first inexact
+// integer — a deliberate conservatism, not the representability boundary itself.
+//
+// The boundary axis samples both sides of both facts: `exact_at` is the guard's own
+// threshold and `exact_above` is the first genuinely unrepresentable integer, so a change
+// to either would move a different row.
+const maxExactInt int64 = 1 << 53
+
+// pwBoundaryThresholds is the whole literal axis: zero, both signs, both sides of
+// ±2^53, and both i64 endpoints with their inward neighbours.
+//
+// Every one of these is a value the strict i64 extractor in the production mapper can
+// produce, so every one of them is a value an admitted direct-int schema would have to be
+// TOTAL over. That is what makes this matrix a precondition for 7.2c-2 rather than a
+// curiosity.
+func pwBoundaryThresholds() []pwBoundaryThreshold {
+	return []pwBoundaryThreshold{
+		{ID: "zero", N: 0, Doc: "zero"},
+		{ID: "pos_one", N: 1, Doc: "the smallest positive threshold"},
+		{ID: "neg_one", N: -1, Doc: "the smallest negative threshold"},
+		{ID: "exact_below", N: maxExactInt - 1, Doc: "2^53-1, the largest magnitude the native guard still admits"},
+		{ID: "exact_at", N: maxExactInt, Doc: "2^53, where the native generic guard starts refusing — still EXACT in float64"},
+		{ID: "exact_above", N: maxExactInt + 1, Doc: "2^53+1, the FIRST integer float64 cannot represent (it collapses onto 2^53)"},
+		{ID: "neg_exact_below", N: -(maxExactInt - 1), Doc: "-(2^53-1)"},
+		{ID: "neg_exact_at", N: -maxExactInt, Doc: "-2^53"},
+		{ID: "neg_exact_above", N: -(maxExactInt + 1), Doc: "-(2^53+1)"},
+		{ID: "i64max_below", N: math.MaxInt64 - 1, Doc: "math.MaxInt64-1"},
+		{ID: "i64max", N: math.MaxInt64, Doc: "math.MaxInt64"},
+		{ID: "i64min_above", N: math.MinInt64 + 1, Doc: "math.MinInt64+1"},
+		{ID: "i64min", N: math.MinInt64, Doc: "math.MinInt64 — the one literal whose magnitude has no positive i64"},
+	}
+}
+
+// pwBoundaryFn is the single function each boundary project carries.
+const pwBoundaryFn = "Bound"
+
+// pwBoundaryValues are the `this` values driven against a threshold: the threshold
+// itself and its two neighbours, clamped so an i64 endpoint does not wrap.
+//
+// Three values is exactly what distinguishes all six operators at once — below, at and
+// above — so one parse of a six-check function yields the full truth table for that
+// literal. At an endpoint one neighbour does not exist and is dropped; the matrix test
+// LOGS that so a shorter row cannot read as full coverage.
+func pwBoundaryValues(n int64) []int64 {
+	out := []int64{n}
+	if n > math.MinInt64 {
+		out = append([]int64{n - 1}, out...)
+	}
+	if n < math.MaxInt64 {
+		out = append(out, n+1)
+	}
+	return out
+}
+
+// pwBoundaryProjects is one isolated project per threshold, each carrying ONE bare-int
+// function with SIX checks — one per operator — so a single parse yields all six
+// statuses for that literal.
+//
+// One project per threshold rather than one for all thirteen: `-9223372036854775808` is
+// unary minus applied to a magnitude with no positive i64, and whether BAML's expression
+// parser accepts it at all is one of the things being measured. A shared project would
+// let that one answer erase the other twelve.
+func pwBoundaryProjects() []pwProject {
+	var out []pwProject
+	for _, b := range pwBoundaryThresholds() {
+		var attrs []string
+		for _, o := range pwOperators() {
+			attrs = append(attrs, fmt.Sprintf("@check(%s, {{ this %s %s }})", o.ID, o.Op, b.literal()))
+		}
+		out = append(out, pwProject{
+			Key: b.projectKey(),
+			Doc: "Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against " + b.literal() + " (" + b.Doc + ").\n" +
+				"One function, six checks, so one parse yields the whole truth table for this literal.",
+			Funcs: []pwFunc{{
+				Name:   pwBoundaryFn,
+				Doc:    "BOUNDARY: six direct comparisons against " + b.literal() + ".",
+				Target: "int " + strings.Join(attrs, " "),
+			}},
+			WantCompile: true,
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// (E) Residual characterization — captured, NEVER admitted.
+// ---------------------------------------------------------------------------
+
+// pwResidual is one deferred constraint FORM: a shape 7.2c explicitly does not admit,
+// captured so its deferral rests on measurement instead of on an argument.
+type pwResidual struct {
+	// ID names the project (res_<ID>).
+	ID string
+	// Attrs is the attribute list on `confidence`.
+	Attrs string
+	// Class is the pinned class the form is declared on. A form carrying ANY @check
+	// produces a Checked wrapper, so it must be declared on the CHECK family for the
+	// generated Go shape to match; an assert-only form goes on the ASSERT family.
+	Class string
+	// Drives are the `confidence` values driven, in order.
+	Drives []int64
+	// Doc says what the form is and why it stays declined.
+	Doc string
+}
+
+func (r pwResidual) projectKey() string { return "res_" + r.ID }
+
+// fn is the function name inside this residual's project. It follows the CLASS, because
+// the two families decode to different Go shapes and the name is what says which one a
+// drive expects.
+func (r pwResidual) fn() string {
+	if r.Class == pwAssertClass {
+		return pwFnAssert
+	}
+	return pwFnChecked
+}
+
+// pwResiduals are the deferred CONSTRAINT forms — the ones whose deferral turns on stock
+// behaviour this package can measure.
+//
+// The deferred TYPE/SHAPE candidates (float, string, bool, enum, nullable, list, map,
+// nested, multi-field, reordered/third field, target and list-element constraints) are
+// NOT here, and that bound is deliberate and logged by
+// [TestResidualLedgerCoversEveryDeferral]: each of them changes the GENERATED GO SHAPE of
+// the pinned class, and the baml_go type map is process-global — one entry per class
+// name across every runtime — so a shape variant cannot share the pinned name with the
+// operator captures above. Renaming it to make it fit is the exact move the scope forbids.
+// Their stock behaviour is already captured, under their own names, by the 49
+// constraint-bearing rows of internal/debaml's serving oracle; residuals.md cites that
+// authority per row rather than duplicating it here under a name that would confound
+// "declined for its shape" with "declined for its name".
+func pwResiduals() []pwResidual {
+	return []pwResidual{{
+		ID:    "two_checks",
+		Class: pwCheckedClass,
+		Attrs: "@check(alpha, {{ this > 0 }}) @check(beta, {{ this < 100 }})",
+		Doc: "TWO UNIQUE @check attributes. The carrier can serialize N checks in declaration\n" +
+			"order; stock's public map[string]Check cannot, and sonic.Marshal of a Go map has no\n" +
+			"stable byte order. TestTwoCheckWireOrderIsUnstable records what stock actually does.",
+		Drives: []int64{9},
+	}, {
+		ID:    "three_checks",
+		Class: pwCheckedClass,
+		Attrs: "@check(alpha, {{ this > 0 }}) @check(beta, {{ this < 100 }}) @check(gamma, {{ this != 7 }})",
+		Doc: "THREE UNIQUE @check attributes — the same instability with more keys, so the\n" +
+			"observation is not a two-element coincidence.",
+		Drives: []int64{9},
+	}, {
+		ID:    "duplicate_labels",
+		Class: pwCheckedClass,
+		Attrs: "@check(dup, {{ this > 0 }}) @check(dup, {{ this > 1 }})",
+		Doc: "DUPLICATE LABELS on the pinned family. The raw CFFI list keeps both; baml_go's map\n" +
+			"fold keeps one. checkedwire pins the same fold on a bare target; this row pins it\n" +
+			"inside the admitted family's own shape.",
+		Drives: []int64{9},
+	}, {
+		ID:    "check_then_assert",
+		Class: pwCheckedClass,
+		Attrs: "@check(c, {{ this < 100 }}) @assert(a, {{ this > 0 }})",
+		Doc: "MIXED, @check FIRST. Driven with the assert HOLDING (check also holds) and with the\n" +
+			"assert FALSE while the check would otherwise have been emitted — the state the\n" +
+			"one-constraint mapper and one-assert renderer have no model for.",
+		Drives: []int64{9, -1},
+	}, {
+		ID:    "assert_then_check",
+		Class: pwCheckedClass,
+		Attrs: "@assert(a, {{ this > 0 }}) @check(c, {{ this < 100 }})",
+		Doc: "MIXED, @assert FIRST — the SAME two constraints in the other declaration order, so\n" +
+			"any ordering effect in stock's evaluation or error is attributable to the order.",
+		Drives: []int64{9, -1},
+	}, {
+		ID:    "two_asserts",
+		Class: pwAssertClass,
+		Attrs: "@assert(first, {{ this > 100 }}) @assert(second, {{ this > 200 }})",
+		Doc: "TWO @assert attributes, both FAILING, on the ASSERT family. checkedwire measured\n" +
+			"stock's MAX_CAUSES=5 and cause ORDER on a bare target; this row asks the same of the\n" +
+			"name-pinned family, whose renderer models exactly ONE failing assert on one required\n" +
+			"field. The cause order recorded here is what a multi-assert admission would have to\n" +
+			"reproduce.",
+		Drives: []int64{9},
+	}}
+}
+
+// pwResidualProjects is one isolated project per residual form.
+func pwResidualProjects() []pwProject {
+	var out []pwProject
+	for _, r := range pwResiduals() {
+		decl := pwCheckedClassDecl(r.Attrs)
+		if r.Class == pwAssertClass {
+			decl = pwAssertClassDecl(r.Attrs)
+		}
+		out = append(out, pwProject{
+			Key:         r.projectKey(),
+			Doc:         "Slice 7.2c-1 RESIDUAL (captured, NEVER admitted):\n" + r.Doc,
+			Decls:       []string{decl},
+			Funcs:       []pwFunc{{Name: r.fn(), Doc: "RESIDUAL: driven for characterization only.", Target: r.Class}},
+			WantCompile: true,
+		})
+	}
+	return out
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_exact_above.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_exact_above.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against 9007199254740993 (2^53+1, the FIRST integer float64 cannot represent (it collapses onto 2^53)).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against 9007199254740993.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > 9007199254740993 }}) @check(ge, {{ this >= 9007199254740993 }}) @check(lt, {{ this < 9007199254740993 }}) @check(le, {{ this <= 9007199254740993 }}) @check(eq, {{ this == 9007199254740993 }}) @check(ne, {{ this != 9007199254740993 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_exact_at.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_exact_at.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against 9007199254740992 (2^53, where the native generic guard starts refusing — still EXACT in float64).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against 9007199254740992.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > 9007199254740992 }}) @check(ge, {{ this >= 9007199254740992 }}) @check(lt, {{ this < 9007199254740992 }}) @check(le, {{ this <= 9007199254740992 }}) @check(eq, {{ this == 9007199254740992 }}) @check(ne, {{ this != 9007199254740992 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_exact_below.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_exact_below.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against 9007199254740991 (2^53-1, the largest magnitude the native guard still admits).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against 9007199254740991.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > 9007199254740991 }}) @check(ge, {{ this >= 9007199254740991 }}) @check(lt, {{ this < 9007199254740991 }}) @check(le, {{ this <= 9007199254740991 }}) @check(eq, {{ this == 9007199254740991 }}) @check(ne, {{ this != 9007199254740991 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_i64max.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_i64max.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against 9223372036854775807 (math.MaxInt64).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against 9223372036854775807.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > 9223372036854775807 }}) @check(ge, {{ this >= 9223372036854775807 }}) @check(lt, {{ this < 9223372036854775807 }}) @check(le, {{ this <= 9223372036854775807 }}) @check(eq, {{ this == 9223372036854775807 }}) @check(ne, {{ this != 9223372036854775807 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_i64max_below.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_i64max_below.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against 9223372036854775806 (math.MaxInt64-1).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against 9223372036854775806.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > 9223372036854775806 }}) @check(ge, {{ this >= 9223372036854775806 }}) @check(lt, {{ this < 9223372036854775806 }}) @check(le, {{ this <= 9223372036854775806 }}) @check(eq, {{ this == 9223372036854775806 }}) @check(ne, {{ this != 9223372036854775806 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_i64min.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_i64min.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against -9223372036854775808 (math.MinInt64 — the one literal whose magnitude has no positive i64).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against -9223372036854775808.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > -9223372036854775808 }}) @check(ge, {{ this >= -9223372036854775808 }}) @check(lt, {{ this < -9223372036854775808 }}) @check(le, {{ this <= -9223372036854775808 }}) @check(eq, {{ this == -9223372036854775808 }}) @check(ne, {{ this != -9223372036854775808 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_i64min_above.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_i64min_above.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against -9223372036854775807 (math.MinInt64+1).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against -9223372036854775807.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > -9223372036854775807 }}) @check(ge, {{ this >= -9223372036854775807 }}) @check(lt, {{ this < -9223372036854775807 }}) @check(le, {{ this <= -9223372036854775807 }}) @check(eq, {{ this == -9223372036854775807 }}) @check(ne, {{ this != -9223372036854775807 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_neg_exact_above.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_neg_exact_above.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against -9007199254740993 (-(2^53+1)).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against -9007199254740993.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > -9007199254740993 }}) @check(ge, {{ this >= -9007199254740993 }}) @check(lt, {{ this < -9007199254740993 }}) @check(le, {{ this <= -9007199254740993 }}) @check(eq, {{ this == -9007199254740993 }}) @check(ne, {{ this != -9007199254740993 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_neg_exact_at.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_neg_exact_at.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against -9007199254740992 (-2^53).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against -9007199254740992.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > -9007199254740992 }}) @check(ge, {{ this >= -9007199254740992 }}) @check(lt, {{ this < -9007199254740992 }}) @check(le, {{ this <= -9007199254740992 }}) @check(eq, {{ this == -9007199254740992 }}) @check(ne, {{ this != -9007199254740992 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_neg_exact_below.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_neg_exact_below.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against -9007199254740991 (-(2^53-1)).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against -9007199254740991.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > -9007199254740991 }}) @check(ge, {{ this >= -9007199254740991 }}) @check(lt, {{ this < -9007199254740991 }}) @check(le, {{ this <= -9007199254740991 }}) @check(eq, {{ this == -9007199254740991 }}) @check(ne, {{ this != -9007199254740991 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_neg_one.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_neg_one.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against -1 (the smallest negative threshold).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against -1.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > -1 }}) @check(ge, {{ this >= -1 }}) @check(lt, {{ this < -1 }}) @check(le, {{ this <= -1 }}) @check(eq, {{ this == -1 }}) @check(ne, {{ this != -1 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_pos_one.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_pos_one.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against 1 (the smallest positive threshold).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against 1.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > 1 }}) @check(ge, {{ this >= 1 }}) @check(lt, {{ this < 1 }}) @check(le, {{ this <= 1 }}) @check(eq, {{ this == 1 }}) @check(ne, {{ this != 1 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/bound_zero.baml
+++ b/internal/debaml/predicatewire/testdata/projects/bound_zero.baml
@@ -1,0 +1,24 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 DIRECT-i64 BOUNDARY: all six operators against 0 (zero).
+// One function, six checks, so one parse yields the whole truth table for this literal.
+
+// BOUNDARY: six direct comparisons against 0.
+function PW_Bound(topic: string) -> int @check(gt, {{ this > 0 }}) @check(ge, {{ this >= 0 }}) @check(lt, {{ this < 0 }}) @check(le, {{ this <= 0 }}) @check(eq, {{ this == 0 }}) @check(ne, {{ this != 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/exprtext.baml
+++ b/internal/debaml/predicatewire/testdata/projects/exprtext.baml
@@ -1,0 +1,97 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 EXPRESSION TEXT: what stock retains in Check.Expression for each of the
+// six canonical predicates under zero, one and two ASCII spaces of source padding.
+// Bare `int` targets, so all of them fit one project without touching a pinned class name.
+
+// EXPRESSION TEXT: 0 space(s) each side of "this > 0".
+function PW_Pad_pad0_gt(topic: string) -> int @check(pad0_gt, {{this > 0}}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 1 space(s) each side of "this > 0".
+function PW_Pad_pad1_gt(topic: string) -> int @check(pad1_gt, {{ this > 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 0 space(s) each side of "this >= 0".
+function PW_Pad_pad0_ge(topic: string) -> int @check(pad0_ge, {{this >= 0}}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 1 space(s) each side of "this >= 0".
+function PW_Pad_pad1_ge(topic: string) -> int @check(pad1_ge, {{ this >= 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 2 space(s) each side of "this >= 0".
+function PW_Pad_pad2_ge(topic: string) -> int @check(pad2_ge, {{  this >= 0  }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 0 space(s) each side of "this < 0".
+function PW_Pad_pad0_lt(topic: string) -> int @check(pad0_lt, {{this < 0}}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 1 space(s) each side of "this < 0".
+function PW_Pad_pad1_lt(topic: string) -> int @check(pad1_lt, {{ this < 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 0 space(s) each side of "this <= 0".
+function PW_Pad_pad0_le(topic: string) -> int @check(pad0_le, {{this <= 0}}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 1 space(s) each side of "this <= 0".
+function PW_Pad_pad1_le(topic: string) -> int @check(pad1_le, {{ this <= 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 0 space(s) each side of "this == 0".
+function PW_Pad_pad0_eq(topic: string) -> int @check(pad0_eq, {{this == 0}}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 1 space(s) each side of "this == 0".
+function PW_Pad_pad1_eq(topic: string) -> int @check(pad1_eq, {{ this == 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 0 space(s) each side of "this != 0".
+function PW_Pad_pad0_ne(topic: string) -> int @check(pad0_ne, {{this != 0}}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// EXPRESSION TEXT: 1 space(s) each side of "this != 0".
+function PW_Pad_pad1_ne(topic: string) -> int @check(pad1_ne, {{ this != 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/lit_float.baml
+++ b/internal/debaml/predicatewire/testdata/projects/lit_float.baml
@@ -1,0 +1,29 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 CANONICAL-LITERAL DISCRIMINATOR: `this > 5.0` — a float spelling of an integer threshold.
+// Isolated so a compile rejection is attributable to this spelling alone.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(positive, {{ this > 5.0 }})
+}
+
+// WIRE: the non-canonical literal, driven once.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/lit_leading_zeros.baml
+++ b/internal/debaml/predicatewire/testdata/projects/lit_leading_zeros.baml
@@ -1,0 +1,29 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 CANONICAL-LITERAL DISCRIMINATOR: `this > 007` — leading zeros, which FormatInt never emits.
+// Isolated so a compile rejection is attributable to this spelling alone.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(positive, {{ this > 007 }})
+}
+
+// WIRE: the non-canonical literal, driven once.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/lit_overflow.baml
+++ b/internal/debaml/predicatewire/testdata/projects/lit_overflow.baml
@@ -1,0 +1,29 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 CANONICAL-LITERAL DISCRIMINATOR: `this > 9223372036854775808` — one past math.MaxInt64.
+// Isolated so a compile rejection is attributable to this spelling alone.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(positive, {{ this > 9223372036854775808 }})
+}
+
+// WIRE: the non-canonical literal, driven once.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/lit_plus5.baml
+++ b/internal/debaml/predicatewire/testdata/projects/lit_plus5.baml
@@ -1,0 +1,29 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 CANONICAL-LITERAL DISCRIMINATOR: `this > +5` — an explicit `+` sign, which FormatInt never emits.
+// RECORDED: stock's own Jinja parser REFUSES this spelling, so the project does not compile.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(positive, {{ this > +5 }})
+}
+
+// WIRE: the non-canonical literal, driven once.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/lit_underscore.baml
+++ b/internal/debaml/predicatewire/testdata/projects/lit_underscore.baml
@@ -1,0 +1,29 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 CANONICAL-LITERAL DISCRIMINATOR: `this > 1_000` — a digit separator, which FormatInt never emits.
+// Isolated so a compile rejection is attributable to this spelling alone.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(positive, {{ this > 1_000 }})
+}
+
+// WIRE: the non-canonical literal, driven once.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/op_eq.baml
+++ b/internal/debaml/predicatewire/testdata/projects/op_eq.baml
@@ -1,0 +1,41 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 OPERATOR CAPTURE: the two name-pinned static families carrying
+// the direct comparison `this == 0`. Isolated in its own project because the
+// class names are PINNED — six predicate variants of one name cannot coexist.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(positive, {{ this == 0 }})
+}
+
+class StaticAssertAnswer {
+  answer string
+  confidence int @assert(positive, {{ this == 0 }})
+}
+
+// WIRE: the @check family, driven true and false.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: the @assert family, driven true and false.
+function PW_Assert(topic: string) -> StaticAssertAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/op_ge.baml
+++ b/internal/debaml/predicatewire/testdata/projects/op_ge.baml
@@ -1,0 +1,41 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 OPERATOR CAPTURE: the two name-pinned static families carrying
+// the direct comparison `this >= 0`. Isolated in its own project because the
+// class names are PINNED — six predicate variants of one name cannot coexist.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(positive, {{ this >= 0 }})
+}
+
+class StaticAssertAnswer {
+  answer string
+  confidence int @assert(positive, {{ this >= 0 }})
+}
+
+// WIRE: the @check family, driven true and false.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: the @assert family, driven true and false.
+function PW_Assert(topic: string) -> StaticAssertAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/op_gt.baml
+++ b/internal/debaml/predicatewire/testdata/projects/op_gt.baml
@@ -1,0 +1,41 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 OPERATOR CAPTURE: the two name-pinned static families carrying
+// the direct comparison `this > 0`. Isolated in its own project because the
+// class names are PINNED — six predicate variants of one name cannot coexist.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(positive, {{ this > 0 }})
+}
+
+class StaticAssertAnswer {
+  answer string
+  confidence int @assert(positive, {{ this > 0 }})
+}
+
+// WIRE: the @check family, driven true and false.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: the @assert family, driven true and false.
+function PW_Assert(topic: string) -> StaticAssertAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/op_le.baml
+++ b/internal/debaml/predicatewire/testdata/projects/op_le.baml
@@ -1,0 +1,41 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 OPERATOR CAPTURE: the two name-pinned static families carrying
+// the direct comparison `this <= 0`. Isolated in its own project because the
+// class names are PINNED — six predicate variants of one name cannot coexist.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(positive, {{ this <= 0 }})
+}
+
+class StaticAssertAnswer {
+  answer string
+  confidence int @assert(positive, {{ this <= 0 }})
+}
+
+// WIRE: the @check family, driven true and false.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: the @assert family, driven true and false.
+function PW_Assert(topic: string) -> StaticAssertAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/op_lt.baml
+++ b/internal/debaml/predicatewire/testdata/projects/op_lt.baml
@@ -1,0 +1,41 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 OPERATOR CAPTURE: the two name-pinned static families carrying
+// the direct comparison `this < 0`. Isolated in its own project because the
+// class names are PINNED — six predicate variants of one name cannot coexist.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(positive, {{ this < 0 }})
+}
+
+class StaticAssertAnswer {
+  answer string
+  confidence int @assert(positive, {{ this < 0 }})
+}
+
+// WIRE: the @check family, driven true and false.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: the @assert family, driven true and false.
+function PW_Assert(topic: string) -> StaticAssertAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/op_ne.baml
+++ b/internal/debaml/predicatewire/testdata/projects/op_ne.baml
@@ -1,0 +1,41 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 OPERATOR CAPTURE: the two name-pinned static families carrying
+// the direct comparison `this != 0`. Isolated in its own project because the
+// class names are PINNED — six predicate variants of one name cannot coexist.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(positive, {{ this != 0 }})
+}
+
+class StaticAssertAnswer {
+  answer string
+  confidence int @assert(positive, {{ this != 0 }})
+}
+
+// WIRE: the @check family, driven true and false.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: the @assert family, driven true and false.
+function PW_Assert(topic: string) -> StaticAssertAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/res_assert_then_check.baml
+++ b/internal/debaml/predicatewire/testdata/projects/res_assert_then_check.baml
@@ -1,0 +1,30 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 RESIDUAL (captured, NEVER admitted):
+// MIXED, @assert FIRST — the SAME two constraints in the other declaration order, so
+// any ordering effect in stock's evaluation or error is attributable to the order.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @assert(a, {{ this > 0 }}) @check(c, {{ this < 100 }})
+}
+
+// RESIDUAL: driven for characterization only.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/res_check_then_assert.baml
+++ b/internal/debaml/predicatewire/testdata/projects/res_check_then_assert.baml
@@ -1,0 +1,31 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 RESIDUAL (captured, NEVER admitted):
+// MIXED, @check FIRST. Driven with the assert HOLDING (check also holds) and with the
+// assert FALSE while the check would otherwise have been emitted — the state the
+// one-constraint mapper and one-assert renderer have no model for.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(c, {{ this < 100 }}) @assert(a, {{ this > 0 }})
+}
+
+// RESIDUAL: driven for characterization only.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/res_duplicate_labels.baml
+++ b/internal/debaml/predicatewire/testdata/projects/res_duplicate_labels.baml
@@ -1,0 +1,31 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 RESIDUAL (captured, NEVER admitted):
+// DUPLICATE LABELS on the pinned family. The raw CFFI list keeps both; baml_go's map
+// fold keeps one. checkedwire pins the same fold on a bare target; this row pins it
+// inside the admitted family's own shape.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(dup, {{ this > 0 }}) @check(dup, {{ this > 1 }})
+}
+
+// RESIDUAL: driven for characterization only.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/res_three_checks.baml
+++ b/internal/debaml/predicatewire/testdata/projects/res_three_checks.baml
@@ -1,0 +1,30 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 RESIDUAL (captured, NEVER admitted):
+// THREE UNIQUE @check attributes — the same instability with more keys, so the
+// observation is not a two-element coincidence.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(alpha, {{ this > 0 }}) @check(beta, {{ this < 100 }}) @check(gamma, {{ this != 7 }})
+}
+
+// RESIDUAL: driven for characterization only.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/res_two_asserts.baml
+++ b/internal/debaml/predicatewire/testdata/projects/res_two_asserts.baml
@@ -1,0 +1,33 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 RESIDUAL (captured, NEVER admitted):
+// TWO @assert attributes, both FAILING, on the ASSERT family. checkedwire measured
+// stock's MAX_CAUSES=5 and cause ORDER on a bare target; this row asks the same of the
+// name-pinned family, whose renderer models exactly ONE failing assert on one required
+// field. The cause order recorded here is what a multi-assert admission would have to
+// reproduce.
+
+class StaticAssertAnswer {
+  answer string
+  confidence int @assert(first, {{ this > 100 }}) @assert(second, {{ this > 200 }})
+}
+
+// RESIDUAL: driven for characterization only.
+function PW_Assert(topic: string) -> StaticAssertAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/res_two_checks.baml
+++ b/internal/debaml/predicatewire/testdata/projects/res_two_checks.baml
@@ -1,0 +1,31 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 RESIDUAL (captured, NEVER admitted):
+// TWO UNIQUE @check attributes. The carrier can serialize N checks in declaration
+// order; stock's public map[string]Check cannot, and sonic.Marshal of a Go map has no
+// stable byte order. TestTwoCheckWireOrderIsUnstable records what stock actually does.
+
+class StaticCheckedAnswer {
+  answer string
+  confidence int @check(alpha, {{ this > 0 }}) @check(beta, {{ this < 100 }})
+}
+
+// RESIDUAL: driven for characterization only.
+function PW_Checked(topic: string) -> StaticCheckedAnswer {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/testdata/projects/toplevel.baml
+++ b/internal/debaml/predicatewire/testdata/projects/toplevel.baml
@@ -1,0 +1,92 @@
+// GENERATED at test time from the Slice 7.2c-1 predicate-wire project table
+// (projects_test.go) — do not edit.
+//
+// Regenerate with:
+//   PREDICATE_WIRE_FIXTURE_WRITE=1 CGO_ENABLED=1 go test -tags integration \
+//     ./internal/debaml/predicatewire -run TestPredicateWireProjectDrift
+
+client<llm> PredicateWireClient {
+  provider openai
+  options {
+    model "fake"
+    api_key "fake"
+    base_url "https://predicate-wire.invalid/v1"
+  }
+}
+
+// Slice 7.2c-1 TOP-LEVEL OPERATOR CAPTURE: the six direct comparisons on a BARE `int`
+// target, at both levels. The nested twins live in the op_* projects; these are the
+// outcomes that cannot be inferred from them — an unenclosed carrier, and an assert
+// failure with no required-field wrapper.
+
+// WIRE: top-level @check "this > 0", driven true and false.
+function PW_Top_Check_gt(topic: string) -> int @check(positive, {{ this > 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: top-level @assert "this > 0", driven true and false.
+function PW_Top_Assert_gt(topic: string) -> int @assert(positive, {{ this > 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE: top-level @check "this >= 0", driven true and false.
+function PW_Top_Check_ge(topic: string) -> int @check(positive, {{ this >= 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: top-level @assert "this >= 0", driven true and false.
+function PW_Top_Assert_ge(topic: string) -> int @assert(positive, {{ this >= 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE: top-level @check "this < 0", driven true and false.
+function PW_Top_Check_lt(topic: string) -> int @check(positive, {{ this < 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: top-level @assert "this < 0", driven true and false.
+function PW_Top_Assert_lt(topic: string) -> int @assert(positive, {{ this < 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE: top-level @check "this <= 0", driven true and false.
+function PW_Top_Check_le(topic: string) -> int @check(positive, {{ this <= 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: top-level @assert "this <= 0", driven true and false.
+function PW_Top_Assert_le(topic: string) -> int @assert(positive, {{ this <= 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE: top-level @check "this == 0", driven true and false.
+function PW_Top_Check_eq(topic: string) -> int @check(positive, {{ this == 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: top-level @assert "this == 0", driven true and false.
+function PW_Top_Assert_eq(topic: string) -> int @assert(positive, {{ this == 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE: top-level @check "this != 0", driven true and false.
+function PW_Top_Check_ne(topic: string) -> int @check(positive, {{ this != 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}
+
+// WIRE + ERROR BYTES: top-level @assert "this != 0", driven true and false.
+function PW_Top_Assert_ne(topic: string) -> int @assert(positive, {{ this != 0 }}) {
+  client PredicateWireClient
+  prompt #"{{ topic }} {{ ctx.output_format }}"#
+}

--- a/internal/debaml/predicatewire/toplevel_test.go
+++ b/internal/debaml/predicatewire/toplevel_test.go
@@ -1,0 +1,301 @@
+//go:build integration
+
+package predicatewire
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/boundaryml/baml/engine/language_client_go/baml_go/shared"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/internal/debaml"
+	"github.com/invakid404/baml-rest/internal/schema"
+)
+
+// The TOP-LEVEL half of the operator matrix: what stock puts on the wire, and in an
+// assertion error, when the constraint sits on the RETURN TYPE itself rather than on a
+// class field.
+//
+// # Why this is a separate capture and not an inference from the nested one
+//
+// The scope requires nested AND top-level check pass/fail and assert pass/fail for every
+// direct operator, and the two are different outcomes:
+//
+//   - a top-level check emits the carrier as the WHOLE response. Its bytes are not the
+//     nested object minus a wrapper; there is no enclosing object at all, so a mapper
+//     that produced the nested form here would be wrong in a way the nested fixtures
+//     cannot see.
+//   - a top-level FAILING assert carries NO required-field wrapper. The nested error's
+//     entire `Failed while parsing required fields: missing=0, unparsed=1` /
+//     `Failed to parse field confidence: ...` chain comes from the FIELD POSITION. Strip
+//     it and what remains is a two-level `Assertions failed.` / `Failed: <label> <expr>`
+//     tree — which is what these rows pin, and which no amount of reasoning about the
+//     nested capture would have established.
+//
+// Everything here is still a DECLINE: the admitted fingerprint requires the two-field
+// name-pinned class, so a bare constrained target is refused before any socket.
+// [TestTopLevelOperatorFormsAreDeclined] proves it and is proven to bite.
+
+// pwTopLevelCaptures is the byte authority for the six operators at TOP LEVEL.
+//
+// Same provenance as pwOperatorCaptures: each string is stock v0.223.0's own output for
+// the named drive, through sonic (values) or unchanged (errors).
+var pwTopLevelCaptures = map[string]pwOperatorCapture{
+	"gt": {
+		checkTrue:  `{"value":9,"checks":{"positive":{"name":"positive","expression":"this > 0","status":"succeeded"}}}`,
+		checkFalse: `{"value":-1,"checks":{"positive":{"name":"positive","expression":"this > 0","status":"failed"}}}`,
+		assertTrue: `9`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this > 0", causes: [] }] }`,
+	},
+	"ge": {
+		checkTrue:  `{"value":0,"checks":{"positive":{"name":"positive","expression":"this >= 0","status":"succeeded"}}}`,
+		checkFalse: `{"value":-1,"checks":{"positive":{"name":"positive","expression":"this >= 0","status":"failed"}}}`,
+		assertTrue: `0`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this >= 0", causes: [] }] }`,
+	},
+	"lt": {
+		checkTrue:  `{"value":-1,"checks":{"positive":{"name":"positive","expression":"this < 0","status":"succeeded"}}}`,
+		checkFalse: `{"value":9,"checks":{"positive":{"name":"positive","expression":"this < 0","status":"failed"}}}`,
+		assertTrue: `-1`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this < 0", causes: [] }] }`,
+	},
+	"le": {
+		checkTrue:  `{"value":0,"checks":{"positive":{"name":"positive","expression":"this <= 0","status":"succeeded"}}}`,
+		checkFalse: `{"value":9,"checks":{"positive":{"name":"positive","expression":"this <= 0","status":"failed"}}}`,
+		assertTrue: `0`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this <= 0", causes: [] }] }`,
+	},
+	"eq": {
+		checkTrue:  `{"value":0,"checks":{"positive":{"name":"positive","expression":"this == 0","status":"succeeded"}}}`,
+		checkFalse: `{"value":9,"checks":{"positive":{"name":"positive","expression":"this == 0","status":"failed"}}}`,
+		assertTrue: `0`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this == 0", causes: [] }] }`,
+	},
+	"ne": {
+		checkTrue:  `{"value":9,"checks":{"positive":{"name":"positive","expression":"this != 0","status":"succeeded"}}}`,
+		checkFalse: `{"value":0,"checks":{"positive":{"name":"positive","expression":"this != 0","status":"failed"}}}`,
+		assertTrue: `9`,
+		assertFail: `Failed to coerce value: ParsingError { scope: [], reason: "Assertions failed.", causes: [ParsingError { scope: [], reason: "Failed: positive this != 0", causes: [] }] }`,
+	},
+}
+
+// pwTopCaptureOf returns one operator's pinned TOP-LEVEL capture.
+func pwTopCaptureOf(t *testing.T, o pwOperator) pwOperatorCapture {
+	t.Helper()
+	c, ok := pwTopLevelCaptures[o.ID]
+	if !ok {
+		t.Fatalf("operator %q (%s) has no pinned TOP-LEVEL capture; the scope requires nested AND "+
+			"top-level rows for every direct operator", o.ID, o.Op)
+	}
+	return c
+}
+
+// TestStockTopLevelOperatorWireBytes is the byte oracle for the six comparisons on a bare
+// `int` target, in both check outcomes, with the native carrier reproducing them.
+func TestStockTopLevelOperatorWireBytes(t *testing.T) {
+	for _, o := range pwOperators() {
+		capture := pwTopCaptureOf(t, o)
+		for _, tc := range []struct {
+			outcome string
+			value   int64
+			status  string
+			want    string
+		}{
+			{"true", o.TrueVal, "succeeded", capture.checkTrue},
+			{"false", o.FalseVal, "failed", capture.checkFalse},
+		} {
+			t.Run(o.ID+"/check_"+tc.outcome, func(t *testing.T) {
+				key := pwDriveKey{Project: pwTopLevelKey, Func: pwTopCheckFn(o), Raw: strconv.FormatInt(tc.value, 10)}
+				stock := pwBareChecked(t, key)
+
+				if stock.Value != tc.value {
+					t.Fatalf("stock value = %d, want %d", stock.Value, tc.value)
+				}
+				if len(stock.Checks) != 1 {
+					t.Fatalf("stock reported %d checks, want exactly 1: %v", len(stock.Checks), stock.Checks)
+				}
+				want := shared.Check{Name: pwCheckedLabel, Expression: o.expr(), Status: tc.status}
+				if got := stock.Checks[pwCheckedLabel]; got != want {
+					t.Fatalf("stock check = %+v, want %+v", got, want)
+				}
+				pwRequireSonicBytes(t, "stock", stock, tc.want)
+
+				// The native carrier, built from stock's OWN results, must produce the
+				// SAME bytes — here UNENCLOSED, which is the whole point of the row.
+				pwRequireSonicBytes(t, "bamlutils.Checked",
+					pwCarrierFromStock(t, stock, pwCheckedLabel), tc.want)
+			})
+		}
+	}
+}
+
+// TestStockTopLevelOperatorAssertBytes pins the ASSERT twin at top level: a holding
+// assert leaves a BARE int with no wrapper at all, and a failing one produces the
+// unwrapped two-level assertion tree.
+func TestStockTopLevelOperatorAssertBytes(t *testing.T) {
+	for _, o := range pwOperators() {
+		capture := pwTopCaptureOf(t, o)
+
+		t.Run(o.ID+"/assert_true", func(t *testing.T) {
+			key := pwDriveKey{Project: pwTopLevelKey, Func: pwTopAssertFn(o), Raw: strconv.FormatInt(o.TrueVal, 10)}
+			v := pwValue(t, key)
+			// A passing assert creates no check entry, so no wrapper exists at all: the
+			// decoded value is a bare int64, not a Checked. Asserted as a TYPE fact
+			// first, so the bytes below cannot pass on a wrapper that happens to
+			// serialize to a number.
+			if _, wrapped := v.(shared.Checked[int64]); wrapped {
+				t.Fatalf("a passing top-level @assert produced a Checked wrapper: %#v", v)
+			}
+			n, ok := v.(int64)
+			if !ok {
+				t.Fatalf("stock decoded a %T, want a bare int64", v)
+			}
+			if n != o.TrueVal {
+				t.Fatalf("stock value = %d, want %d", n, o.TrueVal)
+			}
+			pwRequireSonicBytes(t, "stock", v, capture.assertTrue)
+			if strings.Contains(capture.assertTrue, `"checks"`) || strings.Contains(capture.assertTrue, `"value"`) {
+				t.Fatalf("the passing top-level assert literal carries wrapper keys: %s", capture.assertTrue)
+			}
+		})
+
+		t.Run(o.ID+"/assert_false", func(t *testing.T) {
+			key := pwDriveKey{Project: pwTopLevelKey, Func: pwTopAssertFn(o), Raw: strconv.FormatInt(o.FalseVal, 10)}
+			err := pwError(t, key)
+			if got := err.Error(); got != capture.assertFail {
+				t.Fatalf("stock top-level assertion error bytes:\n got %s\nwant %s",
+					strconv.Quote(got), strconv.Quote(capture.assertFail))
+			}
+			cause := "Failed: " + pwCheckedLabel + " " + o.expr()
+			for _, want := range []string{`reason: "Assertions failed."`, `reason: "` + cause + `"`} {
+				if !strings.Contains(capture.assertFail, want) {
+					t.Errorf("the pinned top-level assertion error does not carry %s", want)
+				}
+			}
+			// THE DISCRIMINATING HALF: the required-field wrapper the NESTED error carries
+			// is ABSENT here. That is the fact this row exists to establish, and it is
+			// what makes the top-level capture irreducible to the nested one.
+			for _, absent := range []string{
+				"Failed while parsing required fields",
+				"Failed to parse field confidence",
+				`\n  - <root>: `,
+			} {
+				if strings.Contains(capture.assertFail, absent) {
+					t.Errorf("the pinned top-level assertion error carries the NESTED wrapper fragment "+
+						"%q; a bare target has no field position for it to come from", absent)
+				}
+			}
+			// And it carries a REAL newline nowhere — the nested form's escaped separator
+			// is absent because the whole display line is absent, not because it was
+			// unescaped.
+			if strings.Contains(capture.assertFail, "\n") {
+				t.Fatal("the pinned top-level assertion error carries a REAL newline")
+			}
+		})
+	}
+}
+
+// TestTopLevelCapturesAreIrreducibleToTheNestedOnes is the control that makes the whole
+// file non-redundant: every top-level row must DIFFER from its nested twin, or the scope's
+// "nested and top-level" requirement would be satisfied by one capture written twice.
+func TestTopLevelCapturesAreIrreducibleToTheNestedOnes(t *testing.T) {
+	for _, o := range pwOperators() {
+		top, nested := pwTopCaptureOf(t, o), pwCaptureOf(t, o)
+		for _, tc := range []struct{ what, top, nested string }{
+			{"check-true", top.checkTrue, nested.checkTrue},
+			{"check-false", top.checkFalse, nested.checkFalse},
+			{"assert-true", top.assertTrue, nested.assertTrue},
+			{"assert-false", top.assertFail, nested.assertFail},
+		} {
+			if tc.top == tc.nested {
+				t.Errorf("%s %s: the top-level and nested literals are IDENTICAL, so one of them is "+
+					"not being driven from its own fixture", o.Op, tc.what)
+			}
+		}
+		// The nested check literal ENCLOSES the top-level one; the top-level one is not a
+		// standalone slice of the nested bytes plus an object, which is the shape a
+		// careless implementation would assume.
+		if !strings.Contains(nested.checkTrue, top.checkTrue) {
+			t.Errorf("%s: the nested check literal does not contain the top-level carrier bytes; the "+
+				"two captures disagree about the carrier itself, which is a real divergence rather "+
+				"than a nesting difference:\n  nested: %s\n  top:    %s",
+				o.Op, nested.checkTrue, top.checkTrue)
+		}
+		// The nested ASSERT error, by contrast, is NOT an extension of the top-level one:
+		// stock re-renders the inner tree rather than nesting the outer error's text. This
+		// is recorded because it is the assumption a renderer is most likely to make.
+		if strings.Contains(nested.assertFail, top.assertFail) {
+			t.Errorf("%s: the nested assertion error CONTAINS the top-level one verbatim; the recorded "+
+				"relationship between the two error shapes is wrong", o.Op)
+		}
+	}
+	t.Logf("top-level captures: 6 operators x 4 outcomes = %d rows, every one distinct from its "+
+		"nested twin", len(pwOperators())*4)
+}
+
+// pwTopLevelBundle builds the bare constrained-target bundle: the return type IS the
+// constrained `int`, with no class anywhere.
+func pwTopLevelBundle(level schema.ConstraintLevel, label, expr string) *schema.Bundle {
+	l := label
+	target := schema.Type{Kind: schema.TypePrimitive, Primitive: schema.PrimitiveInt}
+	target.Meta.Constraints = []schema.Constraint{{Level: level, Expression: expr, Label: &l}}
+	b := &schema.Bundle{Target: target}
+	if err := b.RebuildIndexes(); err != nil {
+		panic("predicatewire top-level fixture: " + err.Error())
+	}
+	return b
+}
+
+// pwTopLevelDeclineReport returns one line per top-level form whose gate disposition
+// disagrees with the expectation, so the comparison can be driven with a wrong one.
+func pwTopLevelDeclineReport(t *testing.T, declines func(o pwOperator) bool) []string {
+	t.Helper()
+	var out []string
+	for _, o := range pwOperators() {
+		for _, fam := range []struct {
+			what  string
+			level schema.ConstraintLevel
+		}{{"check", schema.ConstraintCheck}, {"assert", schema.ConstraintAssert}} {
+			name := "top-level " + fam.what + " " + o.expr()
+			admitted := pwAdmits(t, name, pwTopLevelBundle(fam.level, pwCheckedLabel, o.expr()))
+			if admitted == declines(o) {
+				out = append(out, name+": gates admitted="+strconv.FormatBool(admitted)+
+					", expected declined="+strconv.FormatBool(declines(o)))
+			}
+		}
+	}
+	return out
+}
+
+// TestTopLevelOperatorFormsAreDeclined proves the newly captured top-level forms are ALL
+// still refused — including `this > I`, which is admitted in its nested two-field form
+// and must not become claimable just because its bytes are now pinned.
+func TestTopLevelOperatorFormsAreDeclined(t *testing.T) {
+	always := func(pwOperator) bool { return true }
+	if got := pwTopLevelDeclineReport(t, always); len(got) != 0 {
+		t.Fatalf("a top-level constrained target is no longer declined:\n  %s", strings.Join(got, "\n  "))
+	}
+	for _, o := range pwOperators() {
+		b := pwTopLevelBundle(schema.ConstraintCheck, pwCheckedLabel, o.expr())
+		if _, err := debaml.ParseStaticBundle(context.Background(), b, strconv.FormatInt(o.TrueVal, 10)); !errors.Is(err, bamlutils.ErrDeBAMLParseUnsupported) {
+			t.Errorf("%s: ParseStaticBundle did not decline the bare constrained target: %v", o.expr(), err)
+		}
+	}
+	t.Logf("all %d top-level operator forms (6 operators x 2 levels) DECLINE at the production "+
+		"gates, `this > I` included", len(pwOperators())*2)
+}
+
+// TestTopLevelDeclinesAreProvenToBite feeds the same comparison the opposite expectation
+// and requires every row to be reported.
+func TestTopLevelDeclinesAreProvenToBite(t *testing.T) {
+	never := func(pwOperator) bool { return false }
+	got := pwTopLevelDeclineReport(t, never)
+	if want := len(pwOperators()) * 2; len(got) != want {
+		t.Fatalf("an expectation that NO top-level form declines was reported %d times, want %d "+
+			"(six operators x two levels); the comparison is not covering every row", len(got), want)
+	}
+}


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

Slice 7.2c-1 of the predicate-only widening arc. It is the **authority-capture and characterization** PR: it banks the stock BAML v0.223.0 CFFI oracle that 7.2c-2 and 7.2c-3 will be gated on, and pins the current dispositions.

**It flips nothing.** The only served predicate is still `this > I`, the serving-oracle boundary lock is unchanged at **4 served / 49 declined**, and `cmd/build/nativeworker_module.tar` plus every first-party pin are byte-untouched.

## Isolated same-name fixture projects

One BAML project cannot declare six predicate variants of the same name-pinned class, and renaming the class would answer a question about a different family. So `internal/debaml/predicatewire` builds **isolated in-memory projects — one stock runtime each** — and each declares the two production names `StaticCheckedAnswer` / `StaticAssertAnswer` exactly once. `TestPredicateWireProjectsAreIsolatedAndPinned` fails if any project declares any other class name, or declares a pinned one twice.

The live `StaticGtePredicateAnswer` `>=` sibling in `internal/nativeprompt/testdata/staticserve_fixture` is untouched and stays a decline; nothing here repurposes it.

## What was captured

| capture | rows | authority |
| --- | --- | --- |
| six operators x check t/f + assert t/f, **nested** on both pinned families | 24 | raw `sonic.Marshal` bytes; whole unmodified `err.Error()` for the false asserts |
| the same matrix **top-level**, on a bare `int` target | 24 | same, and irreducible to the nested rows (see below) |
| source padding 0/1 on all six, plus 2 on the two-byte `>=` | 13 | `Check.Expression` directly **and** through the wire bytes |
| non-canonical literal spellings | 5 | wire bytes, or the pinned compile refusal |
| direct-i64 boundary matrix (13 thresholds x 6 operators) | 222 | per-check name/expression/status, plus an independent native evaluation |
| deferred forms (2 and 3 checks, duplicate labels, mixed in both orders, two failing asserts) | 6 projects | wire bytes, error bytes, and a repeated-marshal ordering observation |

**Nested and top-level are both captured**, as the scope's differential requirements demand, and the top-level rows are not inferable from the nested ones: a top-level check emits an *unenclosed* carrier, and a top-level failing assert carries **no required-field wrapper at all** — the nested error's entire `Failed while parsing required fields` / `Failed to parse field confidence` chain comes from the field position, not from the assert. `TestTopLevelCapturesAreIrreducibleToTheNestedOnes` asserts every one of the 24 top-level literals differs from its nested twin. All twelve top-level forms decline at the gates, `this > I` included, and that is proven to bite.

Notable measured facts: stock strips source padding identically for one- and two-byte operators; `007` is read as 7, `1_000` as 1000, `5.0` as a float, and one past `MaxInt64` does **not** wrap — all four compile, so the native fingerprint has to reject them itself — while `+5` is refused by BAML's own Jinja parser.

## Two findings the next slices need

**1. 2+ `@check` is blocked by measurement, not by effort.** 200 `sonic.Marshal` observations of stock's two-key result produced **both** orderings; the three-key result produced **three**. The native carrier is deterministic, so its single answer matches at most one of them — byte-exact parity is unavailable at any key count above one. A one-key result is byte-stable across the same 200 marshals, which is the control proving this is a property of the key count and not of the harness.

**2. The direct-i64 totality gap is wider than the 2^53 guard.** Stock answers all 222 boundary rows exactly. The current generic profile answers **36** and refuses **186**, across three clauses — a value at or past 2^53, a literal longer than 15 digits, and (not called out in the scope) **every negative literal**, because `-` is an arithmetic byte and `this ...` never parses as the closed numeric sublanguage. Worse, on the **already-admitted** `this > I`: the gates admit all 13 boundary literals, and **31 of the 37** resulting (literal, value) pairs reach `ErrConstraintUnsupported` *after* the admission decision. 7.2c-2 must close all three clauses, not only the first.

Also captured: duplicate labels fold **last-write-wins** in stock while the native carrier refuses the pair outright; mixed `@check`+`@assert` produces **identical** bytes and identical errors in *both* declaration orders, with a passing check suppressed entirely from a false-assert error; and two failing asserts on the pinned assert family emit both causes in **declaration order**, a shape the one-assert renderer cannot produce. All stay declined.

## No admission flip, proven to bite

- `TestPredicateWireAdmissionIsUnchanged` drives `SupportsNativeFinalBundle` and nativeserve's `IsAdmittedStaticCheckedFamily` over every operator on both families and requires them to agree with each other and to admit exactly `this > I`.
- `TestPredicateWireAdmissionIsProvenToBite` feeds the same comparison three wrong expectations — all-admitted, none-admitted, and one-new-operator-at-a-time — and requires the exact expected number of reports.
- `TestStaticCheckedOperatorWideningIsProvenToBite` feeds the shared five-gate agreement corpus a fingerprint widened to all six comparisons; it is reported **50 times across 5 gates** and names all 10 declined operator rows.
- `TestResidualDeclinesAreProvenToBite` does the same for the deferred forms.

Every gate function, both parser entry points and the codegen path are unchanged; no codegen admission gate was added.

## Tally honesty

No rows were added to the serving-oracle corpus, so its **4 served / 49 declined** tally is unchanged and still accurate. The new declined rows went to the shared five-gate agreement corpus in `checked_static_test.go`, whose admitted count stays 4.

## Bounded coverage, logged not implied

The deferred **type/shape** candidates are ledger rows citing the serving oracle's existing 49 captures rather than new CFFI projects here. Every such variant changes the generated Go shape of the pinned class, and `baml_go`'s type map is process-global — one entry per class name across all runtimes — so a shape variant cannot share the pinned name without the rename the scope forbids. `TestResidualLedgerCoversEveryDeferral` logs the split (measured here / cited / scope-only) so a partial matrix cannot read as a complete one.

## Gates

- `gofmt` clean on changed files; `CGO_ENABLED=0 go build ./...`; `go vet ./...` and `go vet -tags=integration ./...`.
- `go test ./...` green; `internal/debaml` + `bamlutils` green; the 719-case differential stays **719/0**; boundary lock and `TestNativeDeclines_Constraints` green with every new row declining.
- **`cmd/regenerate-dynclient` fresh-tree idempotence run locally: empty diff.** `embed.go` is byte-identical. Removing the two new `.embedignore` entries was verified to *change* `embed.go` and add a `predicatewire` reference, so the entries are load-bearing rather than decorative.
- **Tar-neutral, verified not assumed:** `cmd/build/nativeworker_module.tar` byte-unchanged (`0045434661…`), `TestNativeWorkerModuleTarIsFresh` green under `GOWORK=off`, no `nativeserve` / `nanollmprepare` / pin file touched, and both out-of-`go.work` modules still build clean under `GOWORK=off`. `nativeserve-goget` runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded predicate coverage across operators, assertions, expression formatting, literals, and numeric boundaries.
  * Added integration checks for serialization, parsing, admission behavior, error handling, and top-level constraints.
  * Added safeguards against behavior drift using pinned fixtures, mutation checks, manifest validation, and residual tracking.

* **Documentation**
  * Added a residual ledger documenting deferred predicate scenarios and supporting coverage.
  * Updated workflow guidance and verification steps for the expanded integration suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->