### PR TITLE
docs(debaml): S0 — reconcile stream_serve residual-doc drift (five triggers → two residuals)

### DIFF
--- a/internal/debaml/stream_serve.go
+++ b/internal/debaml/stream_serve.go
@@ -135,19 +135,24 @@ func SupportsNativeStreamBundle(bundle *schema.Bundle) error {
 // an extra key, exactly as jsonish coerce_class does. A field @description, class/enum
 // @alias/@description, and non-ASCII names/values are ADMITTED too — no key-matching divergence.)
 //
-// NOTE (§5.9 owed debt, ledger #583): for these admitted schemas, five NON-conforming /
-// BAML-jsonish greedy-recovery INPUT classes — a bare unquoted scalar in a string field, an
-// embedded quote in a string, an invalid enum member, a transient extra non-schema field,
-// and a lone incomplete comment marker `/` — still make BAML emit transient greedy-recovery
-// partials that native under-emits/skips (final-consistent, never an over-claim). This is an
-// EXPLICITLY DEFERRED must-close teardown-blocker, NOT a lowered contract: §5.9's exact
-// per-boundary partial parity stays the target.
+// NOTE (§5.9 owed debt, ledger #583): for these admitted schemas, the canonical inventory of
+// residual greedy-recovery INPUT classes is the STRICT/DEFERRED split in
+// integration/stream_typespace_differential_test.go — that executable test is the authority;
+// keep this comment pointed there rather than re-enumerating a count that drifts. §5.9.1
+// collapsed most of the old over-decline leg into STRICT: an invalid enum member, a transient
+// extra non-schema field, a lone incomplete comment marker, and a bare unquoted scalar in a
+// list<string> ELEMENT are now reproduced BYTE-EXACT. TWO genuine residuals remain, each a PURE
+// UNDER-approximation (native SKIPS rather than emit a byte-different value): (1) a bare unquoted
+// scalar in a DIRECT string field — specifically the nested-brace cascade (20 pinned prefixes);
+// (2) the embedded-quote close (measured ~12587 skips). Both are EXPLICITLY DEFERRED must-close
+// teardown-blockers, NOT a lowered contract: §5.9's exact per-boundary partial parity stays the
+// target.
 //
 // After this returns nil, the FINAL for the admitted schema is reproduced byte-exact, and
-// every BAML-success partial boundary is reproduced EXCEPT the five #583 owed-debt triggers
+// every BAML-success partial boundary is reproduced EXCEPT the two #583 owed-debt residuals
 // above (for which native purely UNDER-emits / skips — never a divergent or over-claim emit;
 // proven by the rigorous type-space differential's strict + deferred-byte-check legs and the
-// corpus acceptance probe). The five-trigger exception is deferred debt, NOT a lowered §5.9
+// corpus acceptance probe). The two-residual exception is deferred debt, NOT a lowered §5.9
 // bar — exact per-boundary parity for them stays the target (ledger #583).
 // checkStreamRootSupported applies the root-class stream cut-line. prof is nil for
 // the stream lane and every non-recursive final bundle — the blanket cycle/union


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

**S0 of the de-BAML serving/front-end cutover arc** — comment-only doc-drift fix (the cheap fix the teardown-readiness assessment caught).

`internal/debaml/stream_serve.go`'s §5.9 owed-debt comment still named **five** residual greedy-recovery INPUT triggers. §5.9.1 has since promoted four of those classes to **STRICT** (byte-exact): the invalid enum member, the transient extra non-schema field, the lone incomplete comment marker, and the bare unquoted scalar in a `list<string>` element. Only **two** genuine residuals remain, each a pure under-approximation (native skips rather than emit a byte-different value):

1. a bare unquoted scalar in a **direct** string field — the nested-brace cascade (20 pinned prefixes);
2. the embedded-quote close (~12587 measured skips).

This points the comment at the **executable** strict/deferred split in `integration/stream_typespace_differential_test.go` as the canonical inventory, rather than a hand-maintained count that drifts.

- Comment-only; **no behavior change** (14 insertions / 9 deletions, all `//` lines).
- The `stream_typespace_differential` test remains the executable authority and is unchanged.
- Tar-neutral (root `internal/debaml` only; no out-of-`go.work` module touched).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated owed-debt documentation to clarify recovery behavior for malformed inputs.
  * Reduced the listed greedy-recovery cases to direct string-field scalars and embedded-quote closures.
  * Documented byte-exact reproduction for invalid enum values, transient extra fields, incomplete comment markers, and unquoted string-list elements.
  * Clarified deferred under-emission handling while retaining final and partial parity requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->