### PR TITLE
feat(debaml): native-first dynamic /parse (final mode) with same-input BAML transition oracle

### DIFF
--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -1276,12 +1276,15 @@ type BamlOptions struct {
 	IncludeReasoning bool `json:"include_reasoning,omitempty"`
 
 	// OutputSchema carries the original dynamic output schema to the
-	// worker so the native ctx.output_format renderer can run at the
-	// dynamic BuildRequest seam under BAML_REST_USE_DEBAML. The worker
-	// installs it on the adapter via SetDeBAMLOutputSchema. Only the
-	// dynamic call/stream path sets it (DynamicInput.ToWorkerInput);
-	// it is harmlessly absent everywhere else, and unused entirely when
-	// the de-BAML flag is off.
+	// worker. It feeds two native de-BAML seams under BAML_REST_USE_DEBAML:
+	// the ctx.output_format renderer on the dynamic BuildRequest path, and
+	// the native-first DYNAMIC direct parse in worker.Parse (which coerces
+	// the raw text against it and holds the result against BAML's). The
+	// worker also installs it on the adapter via SetDeBAMLOutputSchema.
+	// Both DynamicInput.ToWorkerInput (call/stream) and
+	// DynamicParseInput.ToWorkerInput (direct parse) set it; it is
+	// harmlessly absent everywhere else, and unused entirely when the
+	// de-BAML flag is off.
 	OutputSchema *DynamicOutputSchema `json:"output_schema,omitempty"`
 }
 

--- a/bamlutils/native_direct_parse.go
+++ b/bamlutils/native_direct_parse.go
@@ -23,12 +23,18 @@ import "context"
 // # What it is NOT
 //
 // It is NOT a native parse path, and it cannot become one by accident. The observer
-// returns nothing the parse route acts on: `Parse` calls it and then runs BAML
-// exactly as before, whatever the observer does. It cannot claim, cannot decline,
+// returns nothing the parse route acts on: `Parse` calls it and then parses exactly
+// as it would have, whatever the observer does. It cannot claim, cannot decline,
 // cannot substitute a result, and cannot fail the request — a panic inside it is
-// contained by the caller. Introducing an actual native direct-parse claim is a
-// later slice's work (the scope's S9), which is precisely why this seam observes
-// instead of dispatching.
+// contained by the caller.
+//
+// A native direct-parse CLAIM does now exist, but not here and not through this
+// seam: worker/parse.go carries a native-first bridge for the DYNAMIC final parse
+// that runs the injected DeBAMLParseFunc and then serves its bytes only when a
+// same-input BAML parse produced the identical bytes. That bridge has its own
+// gate, its own counter and its own transition oracle; this observer neither feeds
+// it nor learns anything from it, and remains a pure telemetry sink for the
+// surface as a whole.
 //
 // With BAML_REST_USE_DEBAML off, a worker installs no observer at all, so the parse
 // route calls nothing and the surface reports nothing — the same zero-native-observation

--- a/integration/debaml_direct_parse_route_test.go
+++ b/integration/debaml_direct_parse_route_test.go
@@ -1,0 +1,410 @@
+//go:build integration
+
+package integration
+
+// De-BAML native-first DYNAMIC direct parse — the DEPLOYED-ROUTE differential.
+//
+// # Why this test exists and what it proves that the unit tests cannot
+//
+// worker's own tests prove the transition oracle's LOGIC with fake legs, and
+// TestBamlfuzzParseRecovery proves the native PARSER reproduces BAML over the same
+// 186-case corpus by calling internal/debaml.Parse in process. Neither of them
+// touches `/parse/_dynamic`. That gap is exactly where a native-first parse would
+// go wrong in production: the schema has to survive the wire and the worker input
+// encoding, the native parser has to be injected in the shipped binary, the
+// umbrella flag has to actually reach the worker, and the payload native produces
+// has to survive the host's flatten / absent-optional / ordering passes.
+//
+// So this test drives the real HTTP route on a real container, twice:
+//
+//   - a container with BAML_REST_USE_DEBAML pinned ON — the native-first path;
+//   - a container with it pinned OFF — stock BAML, the reference.
+//
+// For every final-parse corpus case it asserts the two responses are BYTE-IDENTICAL
+// (status, body, error message and error code), which is the "native never
+// out-claims BAML" invariant stated in the only terms a caller can observe. Then it
+// reads the ON container's own disposition counter to establish WHICH engine served
+// the request, and holds that against the corpus's pinned native cut-line. The OFF
+// container is checked for zero native dispositions at the end: flag-off is 100%
+// BAML, not "BAML most of the time".
+//
+// Both legs pin the flag explicitly rather than inheriting the shared TestEnv,
+// which is default-ON and could not serve as the OFF control.
+
+import (
+	"context"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/bamlfuzz"
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/integration/testutil"
+)
+
+// directParseDispositionMetric is the counter the worker records one disposition
+// into per native-first direct parse, as it appears in the server's combined
+// exposition (the host prefixes every worker family with `bamlrest_`).
+const directParseDispositionMetric = "bamlrest_debaml_direct_parse_total"
+
+// directParseDisposition is one (engine, reason) pair from that counter. The
+// `surface` label is constant for this series and is asserted rather than keyed on.
+type directParseDisposition struct {
+	engine string
+	reason string
+}
+
+// directParseRouteTimeout bounds a single route call. A parse is local CPU work
+// with no provider contact, so this is generous by an order of magnitude and only
+// exists so a wedged container fails a case instead of the whole suite.
+const directParseRouteTimeout = 30 * time.Second
+
+// dedicatedDeBAMLEnv spins a baml-rest container with the umbrella flag pinned to
+// flagValue and tears it down with the test. Both legs of this differential need a
+// KNOWN flag value, which the shared TestEnv cannot provide.
+func dedicatedDeBAMLEnv(t *testing.T, flagValue string) *testutil.TestEnvironment {
+	t.Helper()
+
+	opts := matrixSetupOptions()
+	opts.RuntimeEnv = map[string]string{bamlutils.EnvUseDeBAML: flagValue}
+
+	setupCtx, cancel := context.WithTimeout(context.Background(), testutil.SetupBudget(opts))
+	defer cancel()
+
+	env, err := testutil.Setup(setupCtx, opts)
+	if err != nil {
+		t.Fatalf("setup dedicated %s=%s env: %v", bamlutils.EnvUseDeBAML, flagValue, err)
+	}
+	t.Cleanup(func() {
+		termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer termCancel()
+		if err := env.Terminate(termCtx); err != nil {
+			t.Logf("dedicated env (%s=%s) Terminate: %v", bamlutils.EnvUseDeBAML, flagValue, err)
+		}
+	})
+	return env
+}
+
+// readDirectParseDispositions scrapes the server and returns the direct-parse
+// counter summed per (engine, reason) across every worker in the pool. A request
+// may land on any worker, so the per-worker series are aggregated exactly the way
+// a dashboard would.
+//
+// The exposition is parsed here rather than through expfmt: that parser reads a
+// mutable package-global name-validation scheme in prometheus/common and panics
+// when it is unset, which is exactly the state a test binary that never configured
+// it is in. This series' shape is fixed and simple (one counter, four label pairs,
+// no escapes), so a direct reader is both sufficient and free of that coupling.
+func readDirectParseDispositions(t *testing.T, client *testutil.BAMLRestClient) map[directParseDisposition]float64 {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), directParseRouteTimeout)
+	defer cancel()
+	body, err := client.Metrics(ctx)
+	if err != nil {
+		t.Fatalf("scrape /metrics: %v", err)
+	}
+
+	out := map[directParseDisposition]float64{}
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, directParseDispositionMetric+"{") {
+			continue
+		}
+		labels, value, ok := parseCounterSample(t, line)
+		if !ok {
+			continue
+		}
+		if got := labels["surface"]; got != "direct_parse" {
+			t.Errorf("%s carries surface=%q, want the constant %q", directParseDispositionMetric, got, "direct_parse")
+		}
+		out[directParseDisposition{engine: labels["engine"], reason: labels["reason"]}] += value
+	}
+	return out
+}
+
+// parseCounterSample splits one Prometheus text-format counter sample into its
+// label set and value. It reports ok=false for a line it cannot read rather than
+// guessing, and fails the test rather than silently returning a zero that would
+// read as "the counter did not move".
+func parseCounterSample(t *testing.T, line string) (map[string]string, float64, bool) {
+	t.Helper()
+
+	open := strings.Index(line, "{")
+	closeIdx := strings.LastIndex(line, "}")
+	if open < 0 || closeIdx < open {
+		t.Errorf("unreadable counter sample (no label set): %q", line)
+		return nil, 0, false
+	}
+	labels := map[string]string{}
+	for _, pair := range strings.Split(line[open+1:closeIdx], ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		name, value, found := strings.Cut(pair, "=")
+		if !found {
+			t.Errorf("unreadable label pair %q in %q", pair, line)
+			return nil, 0, false
+		}
+		labels[strings.TrimSpace(name)] = strings.Trim(strings.TrimSpace(value), `"`)
+	}
+	value, err := strconv.ParseFloat(strings.TrimSpace(line[closeIdx+1:]), 64)
+	if err != nil {
+		t.Errorf("unreadable counter value in %q: %v", line, err)
+		return nil, 0, false
+	}
+	return labels, value, true
+}
+
+// dispositionDelta subtracts a previous scrape from a later one, yielding what the
+// request between them recorded. Requests are issued one at a time, so the delta is
+// attributable to exactly one parse.
+func dispositionDelta(before, after map[directParseDisposition]float64) map[directParseDisposition]float64 {
+	delta := map[directParseDisposition]float64{}
+	for k, v := range after {
+		if d := v - before[k]; d != 0 {
+			delta[k] = d
+		}
+	}
+	return delta
+}
+
+// parseRouteBody builds the `/parse/_dynamic` request body for one corpus case
+// through the bamlutils types the endpoint decodes into, so the schema's
+// declaration order survives to the server (the map-backed testutil schema cannot
+// carry it) and preserve_schema_order is pinned explicitly rather than inherited
+// from a server default.
+func parseRouteBody(t *testing.T, c bamlfuzz.ParseRecoveryCase) []byte {
+	t.Helper()
+
+	lowered, err := bamlfuzz.LowerToDynamicSchema(c.Schema)
+	if err != nil {
+		t.Fatalf("lower case schema onto the dynamic path: %v", err)
+	}
+	preserve := c.PreserveSchemaOrder
+	body, err := sonic.Marshal(bamlutils.DynamicParseInput{
+		Raw:                 c.Raw,
+		OutputSchema:        &lowered,
+		PreserveSchemaOrder: &preserve,
+	})
+	if err != nil {
+		t.Fatalf("marshal parse request body: %v", err)
+	}
+	return body
+}
+
+// TestDeBAMLDirectParseRouteNativeFirst is the deployed-route differential
+// described at the top of this file.
+func TestDeBAMLDirectParseRouteNativeFirst(t *testing.T) {
+	if !bamlutils.IsVersionAtLeast(BAMLVersion, "0.215.0") {
+		t.Skip("Skipping: dynamic endpoints require BAML >= 0.215.0")
+	}
+
+	corpus, err := bamlfuzz.LoadParseRecoveryCorpus(parseRecoveryCorpusDir)
+	if err != nil {
+		t.Fatalf("load parse recovery corpus from %s: %v", parseRecoveryCorpusDir, err)
+	}
+	if len(corpus) == 0 {
+		t.Fatalf("parse recovery corpus at %s is empty", parseRecoveryCorpusDir)
+	}
+
+	onEnv := dedicatedDeBAMLEnv(t, "true")
+	offEnv := dedicatedDeBAMLEnv(t, "false")
+	on := testutil.NewBAMLRestClient(onEnv.BAMLRestURL)
+	off := testutil.NewBAMLRestClient(offEnv.BAMLRestURL)
+
+	var served, declined int
+	declines := map[string]int{}
+	// nativeServed records which cases the route served natively, so the named
+	// fallback guard below reads the same evidence the per-case assertions did.
+	nativeServed := map[string]bool{}
+	// observed records every case the run actually routed. Without it the named
+	// fallback guard would pass VACUOUSLY for a case that was renamed or removed
+	// from the corpus: the nativeServed lookup would return false and the guard
+	// would silently stop guarding.
+	observed := map[string]bool{}
+
+	prev := readDirectParseDispositions(t, on)
+	for _, c := range corpus {
+		if !c.HasFinal() {
+			continue // streaming-only fixture: no final leg to route.
+		}
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			observed[c.Name] = true
+			body := parseRouteBody(t, c)
+
+			ctx, cancel := context.WithTimeout(context.Background(), directParseRouteTimeout)
+			defer cancel()
+			onResp, err := on.DynamicParseJSON(ctx, body)
+			if err != nil {
+				t.Fatalf("flag-ON /parse/_dynamic: %v", err)
+			}
+			offResp, err := off.DynamicParseJSON(ctx, body)
+			if err != nil {
+				t.Fatalf("flag-OFF /parse/_dynamic: %v", err)
+			}
+
+			// THE invariant, in the only terms a caller can observe: turning the
+			// umbrella flag on changed nothing about the response.
+			if onResp.StatusCode != offResp.StatusCode {
+				t.Errorf("status drift: flag-ON %d, flag-OFF %d", onResp.StatusCode, offResp.StatusCode)
+			}
+			if string(onResp.Data) != string(offResp.Data) {
+				t.Errorf("body drift on %q:\n flag-ON : %s\n flag-OFF: %s", c.Raw, string(onResp.Data), string(offResp.Data))
+			}
+			if onResp.ErrorCode != offResp.ErrorCode {
+				t.Errorf("error-code drift: flag-ON %q, flag-OFF %q", onResp.ErrorCode, offResp.ErrorCode)
+			}
+			if onResp.Error != offResp.Error {
+				// BAML's own error TEXT is not stable across processes: its
+				// match-ambiguity message enumerates the candidate values in hash
+				// order, and the two containers are two processes with two hash
+				// seeds. Re-running either leg reproduces that leg's own ordering,
+				// so no cross-container comparison of this text can be exact.
+				//
+				// Rather than drop the check, compare the messages as CHARACTER
+				// MULTISETS: a pure reordering of the same content passes (and is
+				// logged), while any actual content change — a different value, a
+				// different reason, a different scope — still fails. The bridge
+				// never substitutes native's error anyway: an errored parse returns
+				// BAML's own error object untouched, which the engine assertion
+				// below independently confirms.
+				if sortedRunes(onResp.Error) != sortedRunes(offResp.Error) {
+					t.Errorf("error drift: flag-ON %q, flag-OFF %q", onResp.Error, offResp.Error)
+				} else {
+					t.Logf("BAML's error text differs only by ordering (its own per-process enumeration order):\n flag-ON : %s\n flag-OFF: %s", onResp.Error, offResp.Error)
+				}
+			}
+
+			// Which engine served it, straight from the deployed worker's counter.
+			cur := readDirectParseDispositions(t, on)
+			delta := dispositionDelta(prev, cur)
+			prev = cur
+
+			total := 0.0
+			for _, v := range delta {
+				total += v
+			}
+			if total != 1 {
+				t.Fatalf("the route recorded %v direct-parse dispositions for one request, want exactly 1 (delta=%v)", total, delta)
+			}
+			var d directParseDisposition
+			for k := range delta {
+				d = k
+			}
+
+			// An errored parse must never be served by native: the bridge returns
+			// BAML's own error object, so the disposition has to say so.
+			if onResp.StatusCode >= 400 && d.engine != "baml" {
+				t.Errorf("an errored parse was attributed to engine %q; an error is always BAML's", d.engine)
+			}
+
+			switch d.engine {
+			case "native":
+				served++
+				nativeServed[c.Name] = true
+				if d.reason != "agreement" {
+					t.Errorf("a natively-served parse carries reason %q, want %q — native may only win on proven agreement", d.reason, "agreement")
+				}
+				t.Logf("route served %q NATIVELY (%s)", c.Name, d.reason)
+			case "baml":
+				declined++
+				declines[d.reason]++
+				t.Logf("route declined %q to BAML (%s)", c.Name, d.reason)
+			default:
+				t.Fatalf("unknown engine label %q", d.engine)
+			}
+		})
+	}
+
+	t.Logf("deployed /parse/_dynamic dispositions: %d served natively, %d declined to BAML", served, declined)
+	for reason, n := range declines {
+		t.Logf("  decline reason %-24s %d", reason, n)
+	}
+
+	// The scoreboard, pinned as a FLOOR. Without it every assertion above would
+	// still pass if native declined the entire corpus — the parity checks would be
+	// trivially satisfied and the named-fallback guard only forbids over-claiming.
+	// A floor (rather than an exact count) fails on regression while leaving room
+	// for the burn-down this counter exists to drive.
+	if served < routeNativeServeFloor {
+		t.Errorf("the deployed route served %d cases natively, below the pinned floor of %d — native coverage regressed", served, routeNativeServeFloor)
+	}
+
+	// The corpus's named fallback families must still decline at the route. They are
+	// the burn-down list: each one is a shape native is known not to reproduce, and
+	// a case quietly flipping to native-served would mean the cut-line moved without
+	// anyone deciding it should.
+	for _, name := range parseRouteNamedFallbacks {
+		if !observed[name] {
+			t.Errorf("named fallback %q is not a final-parse case in the corpus; the guard for it is stale and guards nothing", name)
+			continue
+		}
+		if nativeServed[name] {
+			t.Errorf("named fallback %q was served NATIVELY at the route; it must decline to BAML", name)
+		}
+	}
+
+	// Flag-off is zero native, not mostly-BAML: the OFF container must never have
+	// recorded a single direct-parse disposition, because the bridge does not run
+	// there at all.
+	if offDispositions := readDirectParseDispositions(t, off); len(offDispositions) != 0 {
+		t.Errorf("the flag-OFF container recorded direct-parse dispositions: %v", offDispositions)
+	}
+}
+
+// routeNativeServeFloor is how many of the corpus's final-parse cases the deployed
+// `/parse/_dynamic` route serves NATIVELY today: 151 of 186. The remaining 35
+// decline — 26 outside the native parser's cut-line, 5 where native's payload
+// differs from BAML's before the host's normalization passes (an absent optional
+// BAML spells as null, and nested-object field order), 3 where BAML recovered a
+// non-finite float that cannot be serialized at all, and 1 where both parsers
+// errored and BAML's error text is the one served.
+//
+// Asserted as a floor, not an equality: raising it is the point of the burn-down,
+// and a corpus that grows should not have to move this number to stay green.
+const routeNativeServeFloor = 151
+
+// parseRouteNamedFallbacks are the corpus families the native parser is known not
+// to reproduce and that must therefore keep declining at the deployed route. It is
+// a SUBSET of the corpus's full fallback set (parseRecoveryNativeClaim pins every
+// case); these are the ones named as this slice's guarded burn-down list.
+//
+// This test deliberately does NOT key off parseRecoveryNativeClaim itself, because
+// the two pin DIFFERENT facts. That map pins the native PARSER's cut-line — whether
+// internal/debaml.Parse claims a case at all. This test observes the ROUTE's
+// disposition — whether the transition oracle then found native's payload equal to
+// BAML's. A case can be claimed by the parser and still decline at the route (five
+// do today), so reusing the map would assert a fact this surface does not have.
+// What DOES transfer is the one-directional guarantee: a case the parser declines
+// can never be served natively, which is what this list checks.
+var parseRouteNamedFallbacks = []string{
+	"truncated_final_error",
+	"trailing_commas_nested_object_array",
+	"map_bad_enum_key",
+	"map_partial_incomplete",
+	"class_union_all_default_stays_fallback",
+	"scalar_union_no_match_fallback",
+	"list_scalar_union_stays_fallback",
+	"literal_int_numeric_string_mismatch",
+	"literal_int_hex_spelling_stays_fallback",
+	"map_enum_key_nonmember_live_probe",
+	"primitive_int_array_empty_stays_fallback",
+	"list_string_int_union_stays_fallback",
+	"baml_error_native_fallback_guard",
+}
+
+// sortedRunes returns s's characters in sorted order, so two strings that differ
+// only by ordering compare equal. Used to separate BAML's own per-process
+// enumeration order from a real change in an error message's content.
+func sortedRunes(s string) string {
+	runes := []rune(s)
+	slices.Sort(runes)
+	return string(runes)
+}

--- a/integration/testutil/client.go
+++ b/integration/testutil/client.go
@@ -1595,6 +1595,30 @@ func (c *BAMLRestClient) dynamicStreamRequestBodyNDJSON(ctx context.Context, url
 	return events, errs
 }
 
+// DynamicParseJSON executes a /parse/_dynamic request with a caller-provided
+// JSON body — the parse twin of DynamicCallJSON. Used by tests that build the
+// request through bamlutils-ordered types so the output schema's declaration
+// order survives end to end (DynamicParseRequest's schema is map-backed and
+// cannot carry it), and by tests that need to set fields
+// DynamicParseRequest does not expose, such as preserve_schema_order.
+func (c *BAMLRestClient) DynamicParseJSON(ctx context.Context, body []byte) (*DynamicParseResponse, error) {
+	url := fmt.Sprintf("%s/parse/_dynamic", c.baseURL)
+	resp, respBody, err := c.doWithRetry(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &DynamicParseResponse{
+		StatusCode: resp.StatusCode,
+	}
+	if resp.StatusCode >= 400 {
+		result.Error, result.ErrorCode = extractErrorMessageAndCode(respBody)
+	} else {
+		result.Data = respBody
+	}
+	return result, nil
+}
+
 // DynamicParse executes a /parse/_dynamic request.
 func (c *BAMLRestClient) DynamicParse(ctx context.Context, req DynamicParseRequest) (*DynamicParseResponse, error) {
 	body, err := sonic.Marshal(req)
@@ -1619,6 +1643,22 @@ func (c *BAMLRestClient) DynamicParse(ctx context.Context, req DynamicParseReque
 	}
 
 	return result, nil
+}
+
+// Metrics fetches the server's Prometheus exposition from /metrics. The payload
+// is the COMBINED gather — main-process series plus every healthy worker's, so a
+// worker-registered counter is visible here exactly as an operator would scrape
+// it. Returned as raw text for the caller to parse.
+func (c *BAMLRestClient) Metrics(ctx context.Context) ([]byte, error) {
+	url := fmt.Sprintf("%s/metrics", c.baseURL)
+	resp, body, err := c.doWithRetry(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from /metrics: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
 }
 
 // OpenAPISchema represents the parsed OpenAPI schema with commonly accessed fields.

--- a/worker/direct_parse_metrics.go
+++ b/worker/direct_parse_metrics.go
@@ -1,0 +1,145 @@
+package worker
+
+import (
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// De-BAML native-first direct parse — the burn-down scoreboard.
+//
+// The native-first dynamic final parse (direct_parse_native.go) decides, per
+// request, whether the NATIVE parser's answer was byte-identical to BAML's and
+// therefore served, or whether BAML's answer stood. That decision is the only
+// interesting fact about the surface, and it needs to be countable: "how much of
+// direct parse does native reproduce today" is the number this slice exists to
+// move, and the structural reasons behind a decline are the burn-down list.
+//
+// The series is deliberately small and secret-free. It carries the SURFACE (a
+// constant — this counter serves one endpoint class), the ENGINE that produced the
+// served answer, and a STABLE STRUCTURAL REASON drawn from a closed set of
+// constants below. It carries NO method name, NO cohort/fingerprint/seal/approval
+// label, NO schema identity and nothing derived from the raw input or the parsed
+// output — so its cardinality is bounded by construction (2 engines × the fixed
+// reason list) and there is nothing in it to redact.
+
+// directParseSurface is the constant `surface` label value. The counter is scoped
+// to `/parse/{method}` and never used for another endpoint class, so the label is
+// a fixed string rather than a parameter — it exists so the series joins the
+// cutover's other surface-labelled series on a dashboard.
+const directParseSurface = "direct_parse"
+
+// The `engine` label: which parser's answer the request was served with.
+const (
+	// directParseEngineNative — the native parser's result was served. It is
+	// recorded ONLY after the transition oracle proved the native bytes equal to
+	// BAML's bytes for this same input, so it can never mean "native answered
+	// differently and won".
+	directParseEngineNative = "native"
+	// directParseEngineBAML — BAML's result (or BAML's error) was served. Every
+	// decline lands here, tagged with the structural reason it declined for.
+	directParseEngineBAML = "baml"
+)
+
+// The `reason` label: a stable, structural account of the disposition. These are
+// the burn-down categories — each names a distinct shape of native/BAML
+// disagreement (or a distinct shape of native abstention), so a dashboard split by
+// reason says which family of work would move the number next.
+const (
+	// directParseReasonAgreement — native and BAML produced byte-identical results
+	// and native's bytes were served. The only reason recorded under
+	// engine="native".
+	directParseReasonAgreement = "agreement"
+
+	// directParseReasonNativeUnsupported — the native parser returned
+	// bamlutils.ErrDeBAMLParseUnsupported: the schema shape or the raw syntax is
+	// outside its cut-line. This is the ordinary, expected decline and the biggest
+	// burn-down bucket.
+	directParseReasonNativeUnsupported = "native_unsupported"
+
+	// directParseReasonNativeErrorBAMLOK — native CLAIMED a parse failure on input
+	// BAML parsed successfully. BAML's success is served. This is a prevented
+	// out-claim: without the oracle the request would have failed.
+	directParseReasonNativeErrorBAMLOK = "native_error_baml_ok"
+
+	// directParseReasonNativeOKBAMLError — native CLAIMED a result on input BAML
+	// rejected. BAML's error is served. This is the most dangerous prevented
+	// out-claim shape: without the oracle the request would have returned data
+	// where stock BAML returns an error.
+	directParseReasonNativeOKBAMLError = "native_ok_baml_error"
+
+	// directParseReasonBothError — both parsers rejected the input. BAML's error is
+	// served, because the error BYTES a client sees are BAML's and native's message
+	// is not proven to match them. Error-class parity holds; message parity is not
+	// claimed, so native does not win here.
+	directParseReasonBothError = "both_error"
+
+	// directParseReasonResultDrift — both parsers succeeded and their serialized
+	// results differ. BAML's result is served. This is the shape the oracle exists
+	// for. It covers two populations that the comparison cannot tell apart and
+	// deliberately treats alike: real semantic drift, and a difference the HOST's
+	// downstream normalization (absent-optional injection, reorder/sort) would have
+	// erased before the wire. Both decline, because the worker compares what it
+	// actually produces and does not model the host's pipeline.
+	directParseReasonResultDrift = "result_drift"
+
+	// directParseReasonBAMLResultUnusable — BAML parsed the input but its result
+	// could not be serialized at all (a non-finite float has no JSON form, so a
+	// recovered NaN/Inf fails the marshal). The request fails exactly as it always
+	// did; there is simply no BAML payload to compare against, so native cannot
+	// win. Counted so the surface's accounting stays complete: every request that
+	// enters the bridge records exactly one disposition.
+	directParseReasonBAMLResultUnusable = "baml_result_unusable"
+
+	// directParseReasonNativeResultUnusable — native reported success but its JSON
+	// could not be re-encoded into the dynamic-output envelope the surface returns
+	// (not a JSON object, or undecodable). BAML's result is served. A parser bug
+	// rather than a semantic disagreement, kept distinct so it cannot hide inside
+	// the drift bucket.
+	directParseReasonNativeResultUnusable = "native_result_unusable"
+)
+
+// directParseMetrics is the handler-scoped counter set for the native-first
+// direct-parse bridge. One CounterVec; nothing else about the surface is metered
+// here, because nothing else about it is a rollout fact.
+type directParseMetrics struct {
+	dispositions *prometheus.CounterVec
+}
+
+// newDirectParseMetrics registers (or re-uses) the direct-parse disposition
+// counter on reg.
+//
+// Re-use rather than failure on AlreadyRegisteredError is deliberate: Config.Metrics
+// is public and an in-process host may hand the SAME registry to more than one
+// Handler. Two handlers sharing a registry must share the counter and keep
+// counting, not fail construction or silently drop one handler's observations.
+func newDirectParseMetrics(reg prometheus.Registerer) (*directParseMetrics, error) {
+	c := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "debaml_direct_parse_total",
+		Help: "De-BAML native-first direct parse dispositions by served engine and structural reason.",
+	}, []string{"surface", "engine", "reason"})
+	if reg == nil {
+		return &directParseMetrics{dispositions: c}, nil
+	}
+	if err := reg.Register(c); err != nil {
+		var already prometheus.AlreadyRegisteredError
+		if errors.As(err, &already) {
+			existing, ok := already.ExistingCollector.(*prometheus.CounterVec)
+			if !ok {
+				return nil, err
+			}
+			return &directParseMetrics{dispositions: existing}, nil
+		}
+		return nil, err
+	}
+	return &directParseMetrics{dispositions: c}, nil
+}
+
+// record counts one direct-parse disposition. A nil receiver is a no-op so a
+// handler constructed without metrics still serves.
+func (m *directParseMetrics) record(engine, reason string) {
+	if m == nil || m.dispositions == nil {
+		return
+	}
+	m.dispositions.WithLabelValues(directParseSurface, engine, reason).Inc()
+}

--- a/worker/direct_parse_native.go
+++ b/worker/direct_parse_native.go
@@ -1,0 +1,286 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/bytedance/sonic"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// De-BAML: native-first DYNAMIC direct parse (final mode) with a same-input BAML
+// TRANSITION ORACLE.
+//
+// # What this is
+//
+// `/parse/{method}` was the one serving surface with no native claim of any kind:
+// the dynamic method's generated parse entry point could reach the native parser,
+// but nothing held that native answer against BAML's, so a native result was
+// served on trust. This bridge moves the decision into the worker and makes it
+// EARNED per request:
+//
+//  1. run the injected native parser (bamlutils.DeBAMLParseFunc — internal/debaml.Parse
+//     in every real build) against the carried dynamic OutputSchema and the exact
+//     raw string;
+//  2. run BAML's parse on the SAME raw input, with the de-BAML flag turned OFF for
+//     that call so it is a genuine BAML parse and not a second trip through the
+//     native seam;
+//  3. serve native's bytes ONLY when they are byte-identical to BAML's. On ANY
+//     disagreement — drift, a claimed native error, an unsupported shape, an
+//     unusable native result — BAML's answer is what the caller gets.
+//
+// # Why the comparison is on raw bytes
+//
+// The comparison is `bytes.Equal` over the WORKER-BOUNDARY payload: the exact
+// `ParseResult.Data` each leg would return. Nothing downstream (the flatten,
+// absent-optional injection and order/sort passes in the host and dynclient)
+// re-canonicalizes string escaping or number spelling, so two payloads that are
+// merely "semantically equal" can still reach the wire as different bytes. Holding
+// native to the bytes BAML produced is therefore the only comparison that supports
+// the claim this bridge makes: a native win changes NOTHING a client can observe.
+// The native leg is re-encoded through the same order-preserving decode + sonic
+// encode the BAML envelope goes through so the two are compared in one encoding
+// space; a native result that survives that and still differs is a real
+// disagreement and declines.
+//
+// # What stays on BAML, unconditionally
+//
+// Static `/parse` methods, parse-STREAM (`Stream=true`), a request carrying no
+// dynamic output schema, a build with no native parser injected, and every
+// flag-off build: none of them enter this bridge at all, so they run the exact
+// BAML path they ran before. The native parser's own cut-line (constraints, media,
+// recursive shapes, general unions, un-lowerable schemas) is enforced inside it and
+// surfaces here as bamlutils.ErrDeBAMLParseUnsupported — an ordinary decline.
+//
+// # Never out-claim
+//
+// That is the invariant this file exists to hold, and it is structural rather than
+// aspirational: the ONLY path that returns native bytes requires those bytes to
+// equal BAML's, which the same request just computed. Weakening the native parser
+// to claim more would not help it here — a wrong answer simply fails the byte
+// comparison and BAML serves.
+
+// nativeDirectParse is one request's native leg, computed BEFORE the BAML oracle
+// leg runs. It holds everything needed to settle the disposition once BAML's answer
+// is known, and nothing else; it is created per request and never shared.
+type nativeDirectParse struct {
+	h *Handler
+
+	// data is the worker-boundary payload native would return: its flattened parse
+	// output re-encoded and wrapped in the dynamic-output envelope. Non-nil only
+	// when the native parser reported success AND that output could be re-encoded.
+	data []byte
+
+	// err is the native parser's error, or nil on success.
+	// bamlutils.ErrDeBAMLParseUnsupported means "outside the native cut-line";
+	// anything else is a CLAIMED native parse failure.
+	err error
+
+	// unusable records that native reported success but its JSON could not be
+	// re-encoded into the envelope this surface returns. Distinct from err (native
+	// did not claim a failure) and from a drift (nothing comparable was produced).
+	unusable bool
+
+	// unusableErr is why the re-encode failed, kept so the disposition is
+	// diagnosable: the counter says a native result was unusable, this says whether
+	// it was undecodable or simply not a JSON object. Set iff unusable.
+	unusableErr error
+}
+
+// beginNativeDirectParse runs the native leg for an eligible dynamic final parse,
+// or returns nil when the request is not eligible — in which case Parse behaves
+// exactly as it did before this bridge existed.
+//
+// Eligibility is the whole gate, and every clause is load-bearing:
+//
+//   - the umbrella flag must be on (a flag-off build does zero native parse work);
+//   - a native parser must be injected (the BAML-only worker injects none);
+//   - the method must be the DYNAMIC one — static parse methods have no dynamic
+//     output schema and the native parser cannot service them;
+//   - Stream must be false — parse-STREAM keeps BAML's partial semantics, which
+//     this final-mode bridge does not model;
+//   - the request must carry the dynamic output schema, which is what the native
+//     parser coerces against.
+//
+// The native call happens HERE, before BAML runs, so "native-first" is literal:
+// BAML is the oracle the native answer is checked against, not the path native is
+// bolted onto. It is a local CPU operation with no I/O, no provider contact and no
+// mutation of the adapter, so running it first costs the request nothing but the
+// parse itself.
+func (h *Handler) beginNativeDirectParse(ctx context.Context, methodName string, input *workerParseInput) *nativeDirectParse {
+	if !h.deBAML.Enabled || h.deBAMLParse == nil {
+		return nil
+	}
+	if input.Stream || methodName != bamlutils.DynamicMethodName {
+		return nil
+	}
+	if input.Options == nil || input.Options.OutputSchema == nil {
+		return nil
+	}
+
+	n := &nativeDirectParse{h: h}
+	// A panic inside the native parser is deliberately NOT contained. The generated
+	// dynamic parse seam already drove this same parser over this same untrusted raw
+	// input before this bridge existed, so containment here would change no exposure
+	// — it would only convert a native bug into a silent BAML fallback, which is the
+	// one failure mode the seam contract (bamlutils.DeBAMLParseFunc) refuses.
+	res, err := h.deBAMLParse(ctx, bamlutils.DeBAMLParseRequest{
+		Raw:          input.Raw,
+		OutputSchema: input.Options.OutputSchema,
+	})
+	if err != nil {
+		n.err = err
+		return n
+	}
+	data, encErr := encodeNativeDynamicParseResult(res.JSON)
+	if encErr != nil {
+		n.unusable = true
+		n.unusableErr = encErr
+		return n
+	}
+	n.data = data
+	return n
+}
+
+// settle decides the disposition once BAML's own payload is known, records it, and
+// reports whether the native payload should be served.
+//
+// It returns (nativeBytes, true) ONLY when those bytes equal bamlData exactly. In
+// every other case it returns (nil, false) and the caller serves BAML's payload —
+// which is what the caller already holds, so a decline costs nothing and changes
+// nothing.
+func (n *nativeDirectParse) settle(bamlData []byte) ([]byte, bool) {
+	switch {
+	case n.err != nil:
+		if errors.Is(n.err, bamlutils.ErrDeBAMLParseUnsupported) {
+			n.record(directParseEngineBAML, directParseReasonNativeUnsupported)
+			return nil, false
+		}
+		// Native CLAIMED a parse failure where BAML succeeded — an out-claim the
+		// oracle just prevented. Logged, not just counted: a claimed failure against
+		// a BAML success is the shape most worth a human noticing.
+		n.record(directParseEngineBAML, directParseReasonNativeErrorBAMLOK)
+		n.warn("de-BAML native direct parse claimed a failure BAML did not; serving BAML", n.err)
+		return nil, false
+	case n.unusable:
+		// Native reported success and produced something this surface cannot
+		// return. That is a parser bug, not a disagreement, and it is worth the
+		// same bounded line the out-claim shapes get — otherwise the counter
+		// records the disposition with no way to tell WHICH failure it was.
+		n.record(directParseEngineBAML, directParseReasonNativeResultUnusable)
+		n.warn("de-BAML native direct parse produced an unusable result; serving BAML", n.unusableErr)
+		return nil, false
+	case bytes.Equal(n.data, bamlData):
+		n.record(directParseEngineNative, directParseReasonAgreement)
+		return n.data, true
+	default:
+		n.record(directParseEngineBAML, directParseReasonResultDrift)
+		return nil, false
+	}
+}
+
+// settleBAMLResultUnusable records the disposition for a request BAML parsed but
+// whose result could not be serialized. There is no BAML payload to hold native
+// against, so native cannot win and the request fails as it always did; the
+// disposition is recorded so every request that enters the bridge accounts for
+// itself.
+func (n *nativeDirectParse) settleBAMLResultUnusable() {
+	n.record(directParseEngineBAML, directParseReasonBAMLResultUnusable)
+}
+
+// settleBAMLError records the disposition for a request BAML itself rejected. BAML's
+// error is always what the caller gets: the bytes a client sees for a failed parse
+// are BAML's message and classification, and native's message is not proven to
+// match them, so native never wins an error.
+func (n *nativeDirectParse) settleBAMLError() {
+	// Same three-arm shape, in the same order, as settle: the native leg's own
+	// failure modes are classified FIRST, and only a native leg that actually
+	// produced a servable payload reaches the out-claim bucket.
+	switch {
+	case n.err != nil:
+		if errors.Is(n.err, bamlutils.ErrDeBAMLParseUnsupported) {
+			n.record(directParseEngineBAML, directParseReasonNativeUnsupported)
+			return
+		}
+		n.record(directParseEngineBAML, directParseReasonBothError)
+	case n.unusable:
+		// Native reported success but produced nothing this surface could return,
+		// so there was no out-claim to prevent — only a parser bug, which the
+		// unusable bucket names. Classifying it as native_ok_baml_error would put a
+		// non-out-claim in the bucket that exists to count out-claims, and warn
+		// that native "claimed a result" it could never have served.
+		n.record(directParseEngineBAML, directParseReasonNativeResultUnusable)
+		n.warn("de-BAML native direct parse produced an unusable result; serving BAML's error", n.unusableErr)
+	default:
+		// Native produced a servable RESULT for input BAML rejected. This is the
+		// most dangerous out-claim shape — data where stock BAML errors — so it is
+		// both counted and logged.
+		n.record(directParseEngineBAML, directParseReasonNativeOKBAMLError)
+		n.warn("de-BAML native direct parse claimed a result BAML rejected; serving BAML's error", nil)
+	}
+}
+
+// record forwards one disposition to the handler's counter.
+func (n *nativeDirectParse) record(engine, reason string) {
+	n.h.directParseMetrics.record(engine, reason)
+}
+
+// warn emits a bounded, secret-free line for the two prevented-out-claim shapes.
+// It names neither the raw input nor the parsed output — only which side claimed
+// what, plus the native error text when there is one (native error strings are
+// schema/shape descriptions, not caller data). Best-effort: no logger, no line.
+func (n *nativeDirectParse) warn(msg string, err error) {
+	if n.h.logger == nil {
+		return
+	}
+	if err != nil {
+		n.h.logger.Warn(msg, "surface", directParseSurface, "err", err.Error())
+		return
+	}
+	n.h.logger.Warn(msg, "surface", directParseSurface)
+}
+
+// dynamicOutputEnvelopePrefix opens the generated dynamic-output envelope
+// (`Baml_Rest_DynamicOutput`, whose sole field is DynamicProperties). BAML's leg
+// reaches the worker boundary as this envelope marshalled by sonic; the native leg
+// is wrapped in the identical shape so the two are compared — and served — as the
+// same kind of payload. The worker module cannot import the generated types (they
+// live in the built adapter), so the envelope is assembled from bytes; the byte
+// comparison against BAML's own payload is what proves the shape agrees.
+const dynamicOutputEnvelopePrefix = `{"DynamicProperties":`
+
+// encodeNativeDynamicParseResult re-encodes the native parser's flattened output
+// and wraps it in the dynamic-output envelope, producing the exact bytes native
+// would return from the worker.
+//
+// The re-encode is the NORMALIZATION half of the oracle. The native parser and
+// BAML's Go value take different routes to JSON, so comparing their raw texts would
+// reject on formatting incidentals rather than on meaning. Decoding through
+// bamlutils.DecodeOrderedAny and re-marshalling with sonic puts native's output in
+// the same encoding space as the BAML envelope while preserving the two things that
+// ARE semantic here: object key ORDER (DecodeOrderedAny yields order-preserving
+// carriers, so a map's observable key order survives) and NUMBER SPELLING
+// (DecodeOrderedAny keeps the exact numeric token, so 1 and 1.0 stay distinct).
+//
+// A native result that is not a JSON object cannot be a dynamic output and is
+// rejected here rather than wrapped into a malformed envelope.
+func encodeNativeDynamicParseResult(flat []byte) ([]byte, error) {
+	decoded, err := bamlutils.DecodeOrderedAny(flat)
+	if err != nil {
+		return nil, fmt.Errorf("decode native de-BAML parse result: %w", err)
+	}
+	if _, ok := decoded.(bamlutils.OrderedMap[any]); !ok {
+		return nil, fmt.Errorf("native de-BAML parse result is not a JSON object")
+	}
+	body, err := sonic.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-encode native de-BAML parse result: %w", err)
+	}
+	out := make([]byte, 0, len(dynamicOutputEnvelopePrefix)+len(body)+1)
+	out = append(out, dynamicOutputEnvelopePrefix...)
+	out = append(out, body...)
+	return append(out, '}'), nil
+}

--- a/worker/direct_parse_native_test.go
+++ b/worker/direct_parse_native_test.go
@@ -1,0 +1,690 @@
+package worker
+
+// De-BAML native-first DYNAMIC direct parse + the same-input BAML transition
+// oracle, from the worker side.
+//
+// The bridge's whole claim is "native never out-claims BAML", and these tests hold
+// it from both directions: native's bytes are served when — and only when — they
+// equal BAML's, and every way native can disagree ends with BAML's answer on the
+// wire and a named structural reason in the counter.
+//
+// The BITING test is TestNativeDirectParseNeverOutClaimsOnDrift and its order-only
+// sibling: they mutate the native parser into producing a DIFFERENT answer than
+// BAML for the same input, which is exactly the failure the oracle exists to catch.
+// If the bridge ever served native's answer unchecked, those two would fail.
+
+import (
+	"context"
+	stdjson "encoding/json"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+)
+
+// rawDynamicOutput stands in for the generated Baml_Rest_DynamicOutput envelope:
+// one field, marshalled by the same sonic call worker.Parse uses on BAML's result.
+// Holding the payload as a RawMessage lets a test state BAML's exact bytes.
+type rawDynamicOutput struct {
+	DynamicProperties stdjson.RawMessage `json:"DynamicProperties"`
+}
+
+// oracleLeg records what BAML's parse implementation saw, so a test can prove the
+// oracle leg ran, ran on the same raw input, and ran with the de-BAML flag off (a
+// genuine BAML parse rather than a second trip through the generated native seam).
+type oracleLeg struct {
+	calls    int
+	raw      string
+	deBAMLOn bool
+}
+
+// dynamicParseRuntime builds a runtime whose Baml_Rest_Dynamic parse method stands
+// in for BAML: it returns payload (or bamlErr) and records the call on leg.
+func dynamicParseRuntime(leg *oracleLeg, payload string, bamlErr error) *fakeRuntime {
+	method := bamlutils.ParseMethod{
+		MakeOutput: func() any { return &rawDynamicOutput{} },
+		Impl: func(a bamlutils.Adapter, raw string) (any, error) {
+			leg.calls++
+			leg.raw = raw
+			leg.deBAMLOn = a.DeBAMLConfig().Enabled
+			if bamlErr != nil {
+				return nil, bamlErr
+			}
+			return rawDynamicOutput{DynamicProperties: stdjson.RawMessage(payload)}, nil
+		},
+	}
+	return &fakeRuntime{parseMethods: map[string]bamlutils.ParseMethod{
+		bamlutils.DynamicMethodName: method,
+	}}
+}
+
+// nativeLeg records the native parser's invocations.
+type nativeLeg struct {
+	calls int
+	raw   string
+}
+
+// nativeParser returns a DeBAMLParseFunc that answers with payload (or err) and
+// records the call on leg.
+func nativeParser(leg *nativeLeg, payload string, err error) bamlutils.DeBAMLParseFunc {
+	return func(_ context.Context, req bamlutils.DeBAMLParseRequest) (bamlutils.DeBAMLParseResult, error) {
+		leg.calls++
+		leg.raw = req.Raw
+		if err != nil {
+			return bamlutils.DeBAMLParseResult{}, err
+		}
+		return bamlutils.DeBAMLParseResult{JSON: stdjson.RawMessage(payload)}, nil
+	}
+}
+
+// dynamicParseInput marshals a worker parse input carrying a dynamic output schema,
+// which is what makes a request eligible for the native-first bridge.
+func dynamicParseInput(t *testing.T, raw string, stream bool) []byte {
+	t.Helper()
+	in, err := sonic.Marshal(workerParseInput{
+		Raw:    raw,
+		Stream: stream,
+		Options: &bamlutils.BamlOptions{
+			OutputSchema: &bamlutils.DynamicOutputSchema{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal parse input: %v", err)
+	}
+	return in
+}
+
+// deBAMLOnConfig is the flag-on umbrella config every bridge test uses.
+func deBAMLOnConfig() bamlutils.DeBAMLConfig {
+	return bamlutils.DeBAMLConfig{Enabled: true}
+}
+
+// directParseCount reads one disposition counter off the handler's own registry —
+// the same registry the worker exports through GetMetrics, so what a test asserts
+// is what an operator would scrape.
+func directParseCount(t *testing.T, h *Handler, engine, reason string) float64 {
+	t.Helper()
+	families, err := h.metricsReg.Gather()
+	if err != nil {
+		t.Fatalf("gather worker metrics: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != "debaml_direct_parse_total" {
+			continue
+		}
+		for _, m := range mf.Metric {
+			if labelValue(m, "engine") == engine && labelValue(m, "reason") == reason &&
+				labelValue(m, "surface") == directParseSurface {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func labelValue(m *dto.Metric, name string) string {
+	for _, l := range m.Label {
+		if l.GetName() == name {
+			return l.GetValue()
+		}
+	}
+	return ""
+}
+
+// directParseTotal sums every disposition the handler recorded. Zero is the
+// flag-off / ineligible property: the bridge did not run at all.
+func directParseTotal(t *testing.T, h *Handler) float64 {
+	t.Helper()
+	families, err := h.metricsReg.Gather()
+	if err != nil {
+		t.Fatalf("gather worker metrics: %v", err)
+	}
+	var total float64
+	for _, mf := range families {
+		if mf.GetName() != "debaml_direct_parse_total" {
+			continue
+		}
+		for _, m := range mf.Metric {
+			total += m.GetCounter().GetValue()
+		}
+	}
+	return total
+}
+
+const (
+	// agreedPayload is what both legs produce when they agree.
+	agreedPayload = `{"name":"Ada","age":41}`
+	// agreedEnvelope is the worker-boundary payload that agreement produces.
+	agreedEnvelope = `{"DynamicProperties":{"name":"Ada","age":41}}`
+)
+
+// TestNativeDirectParseServesNativeOnAgreement is the positive case: native and
+// BAML produce identical bytes for the same raw input, so native's payload is
+// served — and it is byte-identical to what BAML alone would have returned.
+func TestNativeDirectParseServesNativeOnAgreement(t *testing.T) {
+	t.Parallel()
+
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime:     dynamicParseRuntime(baml, agreedPayload, nil),
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, agreedPayload, nil),
+	})
+
+	res, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", false))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := string(res.Data); got != agreedEnvelope {
+		t.Fatalf("served payload = %s, want %s", got, agreedEnvelope)
+	}
+	if native.calls != 1 {
+		t.Errorf("native parser called %d times, want exactly 1", native.calls)
+	}
+	if native.raw != "{...}" {
+		t.Errorf("native parsed %q, want the exact raw input", native.raw)
+	}
+	// The oracle is not optional: BAML must have parsed the SAME input even on the
+	// path where native wins. Without this, "agreement" would be unverified.
+	if baml.calls != 1 {
+		t.Errorf("BAML oracle leg called %d times, want exactly 1", baml.calls)
+	}
+	if baml.raw != "{...}" {
+		t.Errorf("BAML oracle parsed %q, want the same raw input native saw", baml.raw)
+	}
+	if baml.deBAMLOn {
+		t.Error("the BAML oracle leg ran with de-BAML still enabled; it would re-enter the native seam instead of being an independent parse")
+	}
+	if got := directParseCount(t, h, directParseEngineNative, directParseReasonAgreement); got != 1 {
+		t.Errorf("native/agreement counter = %v, want 1", got)
+	}
+}
+
+// TestNativeDirectParseNeverOutClaimsOnDrift is the BITING test. The native parser
+// is mutated to answer differently from BAML for the same input — the exact shape
+// of an out-claim. The bridge must serve BAML's bytes and record drift; a bridge
+// that trusted native would fail here.
+func TestNativeDirectParseNeverOutClaimsOnDrift(t *testing.T) {
+	t.Parallel()
+
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime: dynamicParseRuntime(baml, agreedPayload, nil),
+		DeBAML:  deBAMLOnConfig(),
+		// One field differs. BAML says age 41; native says 42.
+		DeBAMLParse: nativeParser(native, `{"name":"Ada","age":42}`, nil),
+	})
+
+	res, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", false))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := string(res.Data); got != agreedEnvelope {
+		t.Fatalf("native out-claimed BAML: served %s, want BAML's %s", got, agreedEnvelope)
+	}
+	if got := directParseCount(t, h, directParseEngineBAML, directParseReasonResultDrift); got != 1 {
+		t.Errorf("baml/result_drift counter = %v, want 1", got)
+	}
+	if got := directParseCount(t, h, directParseEngineNative, directParseReasonAgreement); got != 0 {
+		t.Errorf("a drifting parse was recorded as agreement (%v)", got)
+	}
+}
+
+// TestNativeDirectParseNeverOutClaimsOnKeyOrder is the second biting case, and the
+// reason the oracle compares BYTES rather than semantics: these two payloads carry
+// the same fields with the same values in a different ORDER. Key order is
+// observable on the wire (nothing downstream re-canonicalizes it), so a native
+// answer that reorders BAML's output is a real difference and must not be served.
+func TestNativeDirectParseNeverOutClaimsOnKeyOrder(t *testing.T) {
+	t.Parallel()
+
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime:     dynamicParseRuntime(baml, agreedPayload, nil),
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, `{"age":41,"name":"Ada"}`, nil),
+	})
+
+	res, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", false))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := string(res.Data); got != agreedEnvelope {
+		t.Fatalf("native out-claimed BAML on key order: served %s, want BAML's %s", got, agreedEnvelope)
+	}
+	if got := directParseCount(t, h, directParseEngineBAML, directParseReasonResultDrift); got != 1 {
+		t.Errorf("baml/result_drift counter = %v, want 1", got)
+	}
+}
+
+// TestNativeDirectParseNormalizesEncodingBeforeComparing is the counterpart to the
+// key-order test: whitespace and escaping are NOT observable differences, so a
+// native answer that differs from BAML only in encoding still agrees. Without the
+// re-encode the bridge would decline every one of these and claim nothing.
+func TestNativeDirectParseNormalizesEncodingBeforeComparing(t *testing.T) {
+	t.Parallel()
+
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime: dynamicParseRuntime(baml, agreedPayload, nil),
+		DeBAML:  deBAMLOnConfig(),
+		// Same fields, same order, same numbers — pretty-printed.
+		DeBAMLParse: nativeParser(native, "{\n  \"name\": \"Ada\",\n  \"age\": 41\n}", nil),
+	})
+
+	res, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", false))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := string(res.Data); got != agreedEnvelope {
+		t.Fatalf("served payload = %s, want %s", got, agreedEnvelope)
+	}
+	if got := directParseCount(t, h, directParseEngineNative, directParseReasonAgreement); got != 1 {
+		t.Errorf("native/agreement counter = %v, want 1", got)
+	}
+}
+
+// TestNativeDirectParseKeepsNumberSpelling pins the other half of normalization: a
+// number's SPELLING is observable (41 and 41.0 reach the wire differently), so the
+// re-encode must preserve it and the comparison must reject the difference.
+func TestNativeDirectParseKeepsNumberSpelling(t *testing.T) {
+	t.Parallel()
+
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime:     dynamicParseRuntime(baml, agreedPayload, nil),
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, `{"name":"Ada","age":41.0}`, nil),
+	})
+
+	res, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", false))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := string(res.Data); got != agreedEnvelope {
+		t.Fatalf("41.0 was served for BAML's 41: %s", got)
+	}
+	if got := directParseCount(t, h, directParseEngineBAML, directParseReasonResultDrift); got != 1 {
+		t.Errorf("baml/result_drift counter = %v, want 1", got)
+	}
+}
+
+// TestNativeDirectParseDeclinesUnsupported is the ordinary decline: the raw text or
+// the schema is outside the native cut-line, so BAML parses and the reason names
+// the cut-line rather than a disagreement.
+func TestNativeDirectParseDeclinesUnsupported(t *testing.T) {
+	t.Parallel()
+
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime:     dynamicParseRuntime(baml, agreedPayload, nil),
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, "", bamlutils.ErrDeBAMLParseUnsupported),
+	})
+
+	res, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", false))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := string(res.Data); got != agreedEnvelope {
+		t.Fatalf("served payload = %s, want BAML's %s", got, agreedEnvelope)
+	}
+	if baml.calls != 1 {
+		t.Errorf("BAML parsed %d times, want exactly 1", baml.calls)
+	}
+	if got := directParseCount(t, h, directParseEngineBAML, directParseReasonNativeUnsupported); got != 1 {
+		t.Errorf("baml/native_unsupported counter = %v, want 1", got)
+	}
+}
+
+// TestNativeDirectParseClaimedErrorDoesNotFailARequestBAMLParses is the third
+// out-claim shape: native CLAIMED a parse failure on input BAML parses fine. The
+// caller must still get BAML's successful result — a native bug cannot turn a
+// working parse into a failure.
+func TestNativeDirectParseClaimedErrorDoesNotFailARequestBAMLParses(t *testing.T) {
+	t.Parallel()
+
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime:     dynamicParseRuntime(baml, agreedPayload, nil),
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, "", errors.New("native: cannot coerce field age")),
+	})
+
+	res, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", false))
+	if err != nil {
+		t.Fatalf("a claimed native failure failed a parse BAML succeeded at: %v", err)
+	}
+	if got := string(res.Data); got != agreedEnvelope {
+		t.Fatalf("served payload = %s, want BAML's %s", got, agreedEnvelope)
+	}
+	if got := directParseCount(t, h, directParseEngineBAML, directParseReasonNativeErrorBAMLOK); got != 1 {
+		t.Errorf("baml/native_error_baml_ok counter = %v, want 1", got)
+	}
+}
+
+// TestNativeDirectParseBAMLErrorWins is the most dangerous out-claim shape
+// inverted: native produced a RESULT for input BAML rejects. The caller must get
+// BAML's error, not native's data.
+func TestNativeDirectParseBAMLErrorWins(t *testing.T) {
+	t.Parallel()
+
+	bamlErr := errors.New("baml: unterminated object")
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime:     dynamicParseRuntime(baml, "", bamlErr),
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, agreedPayload, nil),
+	})
+
+	res, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...", false))
+	if err == nil {
+		t.Fatalf("native's result was served where BAML errored: %s", string(res.Data))
+	}
+	if !errors.Is(err, bamlErr) {
+		t.Errorf("Parse error = %v, want BAML's own error", err)
+	}
+	if got := directParseCount(t, h, directParseEngineBAML, directParseReasonNativeOKBAMLError); got != 1 {
+		t.Errorf("baml/native_ok_baml_error counter = %v, want 1", got)
+	}
+}
+
+// TestNativeDirectParseUnusableResultWithBAMLErrorIsNotAnOutClaim pins the one
+// combination the two settle paths could disagree about: native reported success,
+// its result could not be encoded, and BAML then errored.
+//
+// Native produced nothing servable, so there was no out-claim to prevent. Counting
+// it as native_ok_baml_error would put a parser bug in the bucket that exists to
+// count the most dangerous out-claim shape — and warn that native "claimed a
+// result" it could never have served.
+func TestNativeDirectParseUnusableResultWithBAMLErrorIsNotAnOutClaim(t *testing.T) {
+	t.Parallel()
+
+	bamlErr := errors.New("baml: unterminated object")
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime:     dynamicParseRuntime(baml, "", bamlErr),
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, `["not","an","object"]`, nil),
+	})
+
+	_, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...", false))
+	if !errors.Is(err, bamlErr) {
+		t.Fatalf("Parse error = %v, want BAML's own error", err)
+	}
+	if got := directParseCount(t, h, directParseEngineBAML, directParseReasonNativeResultUnusable); got != 1 {
+		t.Errorf("baml/native_result_unusable counter = %v, want 1", got)
+	}
+	if got := directParseCount(t, h, directParseEngineBAML, directParseReasonNativeOKBAMLError); got != 0 {
+		t.Errorf("an unusable native result was counted as a prevented out-claim (%v)", got)
+	}
+}
+
+// TestNativeDirectParseBothErrorServesBAMLsError pins that error PARITY is not
+// enough to win: the bytes a client sees for a failed parse are BAML's message, and
+// native's message is not proven to match, so BAML's error is served.
+func TestNativeDirectParseBothErrorServesBAMLsError(t *testing.T) {
+	t.Parallel()
+
+	bamlErr := errors.New("baml: unterminated object")
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime:     dynamicParseRuntime(baml, "", bamlErr),
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, "", errors.New("native: unterminated object")),
+	})
+
+	_, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...", false))
+	if !errors.Is(err, bamlErr) {
+		t.Fatalf("Parse error = %v, want BAML's own error", err)
+	}
+	if got := directParseCount(t, h, directParseEngineBAML, directParseReasonBothError); got != 1 {
+		t.Errorf("baml/both_error counter = %v, want 1", got)
+	}
+}
+
+// TestNativeDirectParseRejectsUnusableNativeResult covers a native parser that
+// reports success but hands back something that is not a dynamic output object.
+// It is a parser bug, not a semantic disagreement, and it must not reach the wire.
+func TestNativeDirectParseRejectsUnusableNativeResult(t *testing.T) {
+	t.Parallel()
+
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime:     dynamicParseRuntime(baml, agreedPayload, nil),
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, `["not","an","object"]`, nil),
+	})
+
+	res, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", false))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := string(res.Data); got != agreedEnvelope {
+		t.Fatalf("served payload = %s, want BAML's %s", got, agreedEnvelope)
+	}
+	if got := directParseCount(t, h, directParseEngineBAML, directParseReasonNativeResultUnusable); got != 1 {
+		t.Errorf("baml/native_result_unusable counter = %v, want 1", got)
+	}
+}
+
+// TestNativeDirectParseRecordsAnUnserializableBAMLResult covers the one path where
+// there is no BAML payload to compare against: BAML recovered a value with no JSON
+// form (a non-finite float), so the marshal fails and the request errors exactly as
+// it always did. The disposition is still recorded, so every request the bridge
+// handled accounts for itself.
+func TestNativeDirectParseRecordsAnUnserializableBAMLResult(t *testing.T) {
+	t.Parallel()
+
+	native := &nativeLeg{}
+	method := bamlutils.ParseMethod{
+		MakeOutput: func() any { return &nonFiniteDynamicOutput{} },
+		Impl: func(bamlutils.Adapter, string) (any, error) {
+			return nonFiniteDynamicOutput{DynamicProperties: map[string]any{"ratio": math.Inf(1)}}, nil
+		},
+	}
+	h := newTestHandler(t, Config{
+		Runtime: &fakeRuntime{parseMethods: map[string]bamlutils.ParseMethod{
+			bamlutils.DynamicMethodName: method,
+		}},
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, agreedPayload, nil),
+	})
+
+	if _, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", false)); err == nil {
+		t.Fatal("an unserializable BAML result did not fail the parse")
+	}
+	if got := directParseCount(t, h, directParseEngineBAML, directParseReasonBAMLResultUnusable); got != 1 {
+		t.Errorf("baml/baml_result_unusable counter = %v, want 1", got)
+	}
+	if got := directParseTotal(t, h); got != 1 {
+		t.Errorf("the request recorded %v dispositions, want exactly 1", got)
+	}
+}
+
+// nonFiniteDynamicOutput is a dynamic-output envelope whose payload cannot be
+// marshalled: JSON has no representation for ±Inf or NaN.
+type nonFiniteDynamicOutput struct {
+	DynamicProperties map[string]any `json:"DynamicProperties"`
+}
+
+// TestNativeDirectParseIsOffWithTheFlagOff is the flag-off control: zero native
+// parse work, zero counters, and the adapter keeps the de-BAML config the handler
+// gave it.
+func TestNativeDirectParseIsOffWithTheFlagOff(t *testing.T) {
+	t.Parallel()
+
+	baml := &oracleLeg{}
+	native := &nativeLeg{}
+	h := newTestHandler(t, Config{
+		Runtime:     dynamicParseRuntime(baml, agreedPayload, nil),
+		DeBAML:      bamlutils.DeBAMLConfig{},
+		DeBAMLParse: nativeParser(native, agreedPayload, nil),
+	})
+
+	res, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", false))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := string(res.Data); got != agreedEnvelope {
+		t.Fatalf("served payload = %s, want BAML's %s", got, agreedEnvelope)
+	}
+	if native.calls != 0 {
+		t.Errorf("the native parser ran %d times with the umbrella flag off", native.calls)
+	}
+	if got := directParseTotal(t, h); got != 0 {
+		t.Errorf("the flag-off build recorded %v direct-parse dispositions, want 0", got)
+	}
+}
+
+// TestNativeDirectParseIsOffWithoutAParser is the BAML-only worker control: the
+// flag is on but no native parser is injected, so nothing native happens.
+func TestNativeDirectParseIsOffWithoutAParser(t *testing.T) {
+	t.Parallel()
+
+	baml := &oracleLeg{}
+	h := newTestHandler(t, Config{
+		Runtime: dynamicParseRuntime(baml, agreedPayload, nil),
+		DeBAML:  deBAMLOnConfig(),
+	})
+
+	if _, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", false)); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !baml.deBAMLOn {
+		t.Error("the parse ran with de-BAML disabled on the adapter; with no bridge active the adapter must keep the handler's config")
+	}
+	if got := directParseTotal(t, h); got != 0 {
+		t.Errorf("a parser-less worker recorded %v direct-parse dispositions, want 0", got)
+	}
+}
+
+// TestNativeDirectParseSkipsParseStream keeps parse-STREAM on BAML: the bridge
+// models final-parse semantics only, so a Stream request must not reach native and
+// must leave the generated seam's own config untouched.
+func TestNativeDirectParseSkipsParseStream(t *testing.T) {
+	t.Parallel()
+
+	native := &nativeLeg{}
+	var streamRan bool
+	var streamDeBAMLOn bool
+	method := bamlutils.ParseMethod{
+		MakeOutput: func() any { return &rawDynamicOutput{} },
+		Impl:       func(bamlutils.Adapter, string) (any, error) { return rawDynamicOutput{}, nil },
+		StreamImpl: func(a bamlutils.Adapter, _ string) (any, error) {
+			streamRan = true
+			streamDeBAMLOn = a.DeBAMLConfig().Enabled
+			return rawDynamicOutput{DynamicProperties: stdjson.RawMessage(`{"partial":true}`)}, nil
+		},
+	}
+	h := newTestHandler(t, Config{
+		Runtime: &fakeRuntime{parseMethods: map[string]bamlutils.ParseMethod{
+			bamlutils.DynamicMethodName: method,
+		}},
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, agreedPayload, nil),
+	})
+
+	if _, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, dynamicParseInput(t, "{...}", true)); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !streamRan {
+		t.Fatal("the parse-stream implementation did not run")
+	}
+	if native.calls != 0 {
+		t.Errorf("the final-mode native bridge ran on a parse-stream request (%d calls)", native.calls)
+	}
+	if !streamDeBAMLOn {
+		t.Error("the parse-stream leg lost its de-BAML config; the bridge must not touch a request it does not handle")
+	}
+}
+
+// TestNativeDirectParseSkipsStaticMethods keeps static `/parse/{method}` on BAML.
+// The native parser coerces against a dynamic output schema a static method does
+// not have, so the bridge must not fire — and must leave the static path's own
+// de-BAML config alone.
+func TestNativeDirectParseSkipsStaticMethods(t *testing.T) {
+	t.Parallel()
+
+	native := &nativeLeg{}
+	baml := &oracleLeg{}
+	rt := dynamicParseRuntime(baml, agreedPayload, nil)
+	rt.parseMethods["ParseTree"] = rt.parseMethods[bamlutils.DynamicMethodName]
+	h := newTestHandler(t, Config{
+		Runtime:     rt,
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, agreedPayload, nil),
+	})
+
+	if _, err := h.Parse(context.Background(), "ParseTree", dynamicParseInput(t, "{...}", false)); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if native.calls != 0 {
+		t.Errorf("the dynamic bridge ran for a static parse method (%d calls)", native.calls)
+	}
+	if !baml.deBAMLOn {
+		t.Error("a static parse lost its de-BAML config; the bridge must not touch a request it does not handle")
+	}
+	if got := directParseTotal(t, h); got != 0 {
+		t.Errorf("a static parse recorded %v direct-parse dispositions, want 0", got)
+	}
+}
+
+// TestNativeDirectParseSkipsSchemalessRequests covers a dynamic parse that carries
+// no output schema: there is nothing for the native parser to coerce against, so
+// BAML owns it.
+func TestNativeDirectParseSkipsSchemalessRequests(t *testing.T) {
+	t.Parallel()
+
+	native := &nativeLeg{}
+	baml := &oracleLeg{}
+	h := newTestHandler(t, Config{
+		Runtime:     dynamicParseRuntime(baml, agreedPayload, nil),
+		DeBAML:      deBAMLOnConfig(),
+		DeBAMLParse: nativeParser(native, agreedPayload, nil),
+	})
+
+	if _, err := h.Parse(context.Background(), bamlutils.DynamicMethodName, []byte(`{"raw":"{...}"}`)); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if native.calls != 0 {
+		t.Errorf("the bridge ran without a carried output schema (%d calls)", native.calls)
+	}
+	if got := directParseTotal(t, h); got != 0 {
+		t.Errorf("a schema-less parse recorded %v direct-parse dispositions, want 0", got)
+	}
+}
+
+// TestDirectParseMetricsReuseASharedRegistry pins the construction contract: an
+// in-process host may build several handlers on one registry, and that must keep
+// counting rather than fail.
+func TestDirectParseMetricsReuseASharedRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	first := newTestHandler(t, Config{Runtime: &fakeRuntime{}, Metrics: reg})
+	second := newTestHandler(t, Config{Runtime: &fakeRuntime{}, Metrics: reg})
+
+	first.directParseMetrics.record(directParseEngineNative, directParseReasonAgreement)
+	second.directParseMetrics.record(directParseEngineNative, directParseReasonAgreement)
+
+	if got := directParseCount(t, first, directParseEngineNative, directParseReasonAgreement); got != 2 {
+		t.Fatalf("shared-registry counter = %v, want 2 (both handlers counting into one series)", got)
+	}
+}

--- a/worker/embed.go
+++ b/worker/embed.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed admin.go defaults.go embed.go errors.go go.mod go.sum handler.go metrics.go native_capability.go options.go parse.go runtime_iface.go sharedstate.go stream.go stream_recover_inprocess.go stream_recover_subprocess.go trustedclients.go
+//go:embed admin.go defaults.go direct_parse_metrics.go direct_parse_native.go embed.go errors.go go.mod go.sum handler.go metrics.go native_capability.go options.go parse.go runtime_iface.go sharedstate.go stream.go stream_recover_inprocess.go stream_recover_subprocess.go trustedclients.go
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/invakid404/baml-rest/bamlutils v0.0.48
 	github.com/invakid404/baml-rest/workerplugin v0.0.48
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )
 
@@ -45,7 +46,6 @@ require (
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.69.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/worker/handler.go
+++ b/worker/handler.go
@@ -368,6 +368,12 @@ type Handler struct {
 	// never change what BAML parses. See bamlutils.NativeDirectParseObserveFunc.
 	nativeDirectParseObserver bamlutils.NativeDirectParseObserveFunc
 
+	// directParseMetrics is the native-first direct-parse burn-down counter,
+	// registered on metricsReg at construction. It is recorded ONLY from inside the
+	// native-first bridge, so a flag-off / BAML-only worker never touches it and the
+	// series stays absent there. See direct_parse_metrics.go.
+	directParseMetrics *directParseMetrics
+
 	sharedStateHook hookStorage
 
 	noSharedStateWarnOnce    sync.Once
@@ -416,6 +422,16 @@ func New(cfg Config) (*Handler, error) {
 
 		nativeDirectParseObserver: cfg.NativeDirectParseObserver,
 	}
+	// Register the direct-parse disposition counter up front. A registry that
+	// rejects it is a real misconfiguration (a colliding metric of a different
+	// type), so it fails construction here rather than at first parse; a registry
+	// that already carries it — an in-process host sharing one registry across
+	// handlers — re-uses it. See newDirectParseMetrics.
+	dpm, err := newDirectParseMetrics(metricsReg)
+	if err != nil {
+		return nil, fmt.Errorf("worker: registering direct-parse metrics: %w", err)
+	}
+	h.directParseMetrics = dpm
 	if cfg.SharedState != nil {
 		h.SetSharedStateHook(cfg.SharedState)
 	}

--- a/worker/parse.go
+++ b/worker/parse.go
@@ -78,9 +78,31 @@ func (h *Handler) Parse(ctx context.Context, methodName string, inputJSON []byte
 		impl = method.StreamImpl
 	}
 
+	// De-BAML native-first DYNAMIC direct parse (final mode). Runs the injected
+	// native parser against the carried output schema and this exact raw string
+	// BEFORE BAML, and returns nil for everything outside that narrow lane —
+	// static methods, parse-stream, a schema-less request, a build with no native
+	// parser, and every flag-off build — leaving the path below byte-identical to
+	// what it has always been. See direct_parse_native.go.
+	native := h.beginNativeDirectParse(ctx, methodName, &input)
+	if native != nil {
+		// The oracle leg must be a GENUINE BAML parse of the same input, so turn
+		// the de-BAML flag OFF on this adapter for the call below. The generated
+		// dynamic parse entry point consults it first, so without this the "BAML"
+		// leg would take the generated native seam and the comparison would be
+		// native against itself. The adapter is per-request and is not used after
+		// this parse, so nothing else observes the change.
+		adapter.SetDeBAMLConfig(bamlutils.DeBAMLConfig{})
+	}
+
 	// Call the selected parse implementation.
 	result, err := impl(adapter, input.Raw)
 	if err != nil {
+		// The transition oracle: BAML rejected this input, so BAML's error is what
+		// the caller gets. Record what native had claimed for it.
+		if native != nil {
+			native.settleBAMLError()
+		}
 		// Wrap with any typed classification so the gRPC layer's
 		// errors.As against GetCode()/GetDetails() picks it up
 		// (workerplugin/grpc.go:220+). The /parse host endpoint also
@@ -98,7 +120,24 @@ func (h *Handler) Parse(ctx context.Context, methodName string, inputJSON []byte
 	// Marshal the result to JSON
 	data, err := sonic.Marshal(result)
 	if err != nil {
+		// BAML recovered a value with no JSON form (a non-finite float). There is
+		// no BAML payload for the oracle to hold native against, so the request
+		// fails exactly as it always did — but the disposition is still recorded,
+		// so every request the bridge handled accounts for itself.
+		if native != nil {
+			native.settleBAMLResultUnusable()
+		}
 		return nil, fmt.Errorf("failed to marshal parse result: %w", err)
+	}
+
+	// The transition oracle: native's payload is served ONLY when it is
+	// byte-identical to the BAML payload just produced for the same input. Any
+	// disagreement — drift, a claimed native error, an unsupported shape — falls
+	// through to `data` below, so BAML's answer stands.
+	if native != nil {
+		if nativeData, ok := native.settle(data); ok {
+			return &workerplugin.ParseResult{Data: nativeData}, nil
+		}
 	}
 
 	return &workerplugin.ParseResult{Data: data}, nil


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

First slice of the delete-BAML critical path: make dynamic direct-parse native-first, with a same-input BAML transition oracle that guarantees native can never out-claim BAML.

## The premise this slice was written against was stale

`/parse/_dynamic` was **not** a categorical BAML dependency at master `ba998e1dc04a`. The whole native chain was already wired — `DynamicParseInput.ToWorkerInput` carries the output schema, `configureAdapter` installs `internal/debaml.Parse`, and codegen emits a **native-first** parse-only seam for the dynamic method (`parseBamlRestDynamic` → `maybeParseDeBAMLFinal(adapter, adapter, raw, "parse_only")`). What it did not have was **anything holding that native answer against BAML's**: under `BAML_REST_USE_DEBAML` (default-on), a native claim was returned on trust and BAML never ran.

So the deliverable is not "turn native on" — it is **"stop native from winning unverified"**.

(The other stale number: the parse-recovery differential pins **186** final-leg cases at **157 claimed / 29 fallback**, not 50 at 37/13. All 13 named fallback families are inside the 29 and are guarded by name.)

## What this does

For `Baml_Rest_Dynamic` + `Stream=false` only, under the umbrella flag, `worker.Parse`:

1. runs the injected `DeBAMLParseFunc` against the carried `OutputSchema` and the exact raw string, **before** BAML;
2. runs BAML's parse on the **same** raw input with the de-BAML flag turned **off** on that adapter — without which the "BAML" leg would take the generated native seam and the comparison would be native against itself;
3. serves native's payload **only** when it is byte-identical to BAML's.

The comparison is `bytes.Equal` over the worker-boundary payload, not a semantic diff: nothing downstream re-canonicalizes string escaping or number spelling, so "semantically equal" payloads can still reach the wire as different bytes. Native's output is re-encoded through `DecodeOrderedAny` + `sonic.Marshal` — normalizing whitespace/escaping while preserving key **order** and exact numeric **tokens** — then wrapped in the dynamic-output envelope and compared against BAML's own marshal. A native win is therefore indistinguishable from BAML by construction. Errors are never native's: an errored parse returns BAML's own error object.

Everything else never enters the bridge: static `/parse`, parse-stream, schema-less requests, parser-less builds, every flag-off build. Constraints/media/recursive shapes decline through the native parser's own cut-line as `native_unsupported`.

Scoreboard: `debaml_direct_parse_total{surface,engine,reason}`, recorded only inside the bridge, bounded by construction (2 engines × 8 fixed reasons), no method name, no cohort/seal label, nothing derived from input or output.

## Proof over the deployed route

`integration/debaml_direct_parse_route_test.go` — two containers with the flag pinned ON and OFF, all 186 final-parse corpus cases POSTed to both:

```
deployed /parse/_dynamic dispositions: 151 served natively, 35 declined to BAML
  native_unsupported    26
  result_drift           5
  baml_result_unusable   3
  both_error             1
```

- 151/186 served natively, **byte-exact** against the flag-OFF container (status, body bytes, error code);
- all 13 named fallbacks decline, asserted by name;
- the flag-OFF container recorded **zero** dispositions;
- every request records exactly one disposition, so the accounting is complete;
- `routeNativeServeFloor = 151` is pinned as a floor — without it the test would pass vacuously if native declined everything.

**The 5 drifts are characterized and none is semantic**: one absent optional BAML spells as `null` and native omits (`class_missing_optional_null`), four are nested-object field ORDER. All five are erased by the host's own `InjectAbsentOptionals`/`SortDynamicOutput` before the wire. I did not close them by replicating host normalization inside the worker — `worker.Parse` is a published module's public API and that would be hidden coupling. The burn-down belongs on the native side (emit what BAML emits), and would move 151 → 156 with no change to the oracle.

**Biting**: `TestNativeDirectParseNeverOutClaimsOnDrift` and `…OnKeyOrder` mutate the native parser into answering differently — by value, and by order only — and require BAML's bytes to be served.

**Incidental finding, pre-existing**: BAML's match-ambiguity error text enumerates candidates in per-process hash order, so the same input yields `Got: DOG …, CAT …` from one process and `Got: CAT …, DOG …` from another. No cross-process comparison of that text can be exact; the test compares status and code strictly and the message as a character multiset.

## Pin/tar: TAR-NEUTRAL, verified

- `worker/` is not packaged — the tar carries only `internal/nativebody/nanollmprepare/**` and `nativeserve/**`;
- `go run ./cmd/build/gen-nativeworker-src` reproduces the committed tar **byte-for-byte** (md5 unchanged);
- `nativeserve` and `nanollmprepare` are untouched and both build standalone under `CGO_ENABLED=1 GOWORK=off` against the **unchanged** pins — no `updates to go.mod needed`;
- `go test ./cmd/build/...` green, incl. tar freshness + `TestFirstPartyPinFollowupIsTracked` + `TestPackagedManifestsMatchTheTrackedPins`.

So the five pseudo-version selections stay put, both `// PIN-STATUS` markers stay `RESOLVED`, `pin_followup.md` is untouched, and **no post-squash re-pin is owed by this change**.

One follow-up deliberately not taken: `nativeserve/admission/direct_parse.go`'s decline message ("direct /parse has no native implementation; BAML owns this surface") is now imprecise — still true of the cohort-admission seam it describes, which this bridge does not go through, but false of the surface as a whole. Correcting it would put a packaged file in the tar diff and cost the byte-identical-tar proof for a comment. `bamlutils/native_direct_parse.go` (not packaged) **was** corrected instead.

## Gates

`gofmt` clean on every touched file · `CGO_ENABLED=0 go build ./...` · `go vet ./...` across all modules · root `go test ./...` (24 pkgs) · bamlutils/dynclient/introspected/pool/workerplugin · worker incl. `GOWORK=off` · `go test ./cmd/build/...` · `cmd/regenerate-dynclient` idempotent (tree unchanged) · `cmd/embed` regenerated · **full integration suite green, 412s, 0 failures**.

`scripts/sync.sh` cannot run in the jj workspace this was authored in (it fingerprints via `git ls-files`; that workspace has no `.git`). Its functional steps were run directly — `go work sync`, `GOWORK=off go mod tidy` across all 7 published modules and all 3 `adapter_v*`, `cmd/verify-adapter-pins` (4/4 match). Only result: `worker/go.mod` promotes `prometheus/client_model` indirect → direct. A second pass changed nothing.

Full report: `/tmp/shared/sparse-impl.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FP4VWTHxd7i2snwzmGAQJR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native-first parsing for eligible dynamic, non-streaming requests.
  - Native results are returned only when they match established parser results.
  - Added structured metrics for native parsing outcomes and fallback behavior.

- **Bug Fixes**
  - Prevents incorrect native results when outputs differ, parsing fails, results are unusable, or requests are unsupported.
  - Preserves established error handling and fallback behavior.

- **Documentation**
  - Clarified output schema behavior and parsing telemetry documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->