### PR TITLE
fix(buildrequest): stream raw partials independent of structured parse + opt-in soft final

### DIFF
--- a/adapters/common/codegen/codegen_adapter.go
+++ b/adapters/common/codegen/codegen_adapter.go
@@ -138,6 +138,13 @@ func emitFrameworkAdapter(out *jen.File, opts Options) {
 		jen.Comment("text passed to Parse/ParseStream."),
 		jen.Id("includeReasoning").Bool(),
 		jen.Line(),
+		jen.Comment("softFinalParse is the per-handler opt-in (dynclient.WithSoftFinalParse)"),
+		jen.Comment("that softens a final structured-parse miss on a raw-wanted STREAM into a"),
+		jen.Comment("successful raw-only final instead of a hard error. Default false keeps the"),
+		jen.Comment("strict final parse. Consumed by the stream router as"),
+		jen.Comment("StreamConfig.SoftFinalParse (streaming + raw only)."),
+		jen.Id("softFinalParse").Bool(),
+		jen.Line(),
 		jen.Comment("clientRegistryProvider is the provider of the primary client from"),
 		jen.Comment("the runtime ClientRegistry override. Empty if no override."),
 		jen.Id("clientRegistryProvider").String(),
@@ -266,6 +273,7 @@ func emitFrameworkAdapter(out *jen.File, opts Options) {
 
 	emitFrameworkAdapterRetryConfig(out, bamlutilsPkg)
 	emitFrameworkAdapterIncludeReasoning(out)
+	emitFrameworkAdapterSoftFinalParse(out)
 	emitFrameworkAdapterSetClientRegistry(out, opts, bamlPkg, bamlutilsPkg)
 	emitFrameworkAdapterClientRegistryProvider(out)
 	emitFrameworkAdapterOriginalClientRegistry(out, bamlutilsPkg)
@@ -308,6 +316,20 @@ func emitFrameworkAdapterIncludeReasoning(out *jen.File) {
 		Id("IncludeReasoning").Params().Bool().
 		Block(
 			jen.Return(jen.Id("b").Dot("includeReasoning")),
+		)
+}
+
+func emitFrameworkAdapterSoftFinalParse(out *jen.File) {
+	out.Func().Params(jen.Id("b").Op("*").Id("BamlAdapter")).
+		Id("SetSoftFinalParse").Params(jen.Id("softFinalParse").Bool()).
+		Block(
+			jen.Id("b").Dot("softFinalParse").Op("=").Id("softFinalParse"),
+		)
+
+	out.Func().Params(jen.Id("b").Op("*").Id("BamlAdapter")).
+		Id("SoftFinalParse").Params().Bool().
+		Block(
+			jen.Return(jen.Id("b").Dot("softFinalParse")),
 		)
 }
 

--- a/adapters/common/codegen/codegen_buildrequest.go
+++ b/adapters/common/codegen/codegen_buildrequest.go
@@ -751,11 +751,16 @@ func (me *methodEmitter) emitBuildRequest() {
 		// the WithClient target so a centrally-unwrapped RR child
 		// routes to the selected leaf rather than the RR wrapper name.
 		jen.Id("streamConfig").Op(":=").Op("&").Qual(g.pkgs.BuildRequestPkg, "StreamConfig").Values(jen.Dict{
-			jen.Id("Provider"):           jen.Id("provider"),
-			jen.Id("RetryPolicy"):        jen.Id("retryPolicy"),
-			jen.Id("NeedsPartials"):      jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsPartials").Call(),
-			jen.Id("NeedsRaw"):           jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsRaw").Call(),
-			jen.Id("IncludeReasoning"):   jen.Id("adapter").Dot("IncludeReasoning").Call(),
+			jen.Id("Provider"):         jen.Id("provider"),
+			jen.Id("RetryPolicy"):      jen.Id("retryPolicy"),
+			jen.Id("NeedsPartials"):    jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsPartials").Call(),
+			jen.Id("NeedsRaw"):         jen.Id("adapter").Dot("StreamMode").Call().Dot("NeedsRaw").Call(),
+			jen.Id("IncludeReasoning"): jen.Id("adapter").Dot("IncludeReasoning").Call(),
+			// SoftFinalParse is the per-handler opt-in (dynclient.WithSoftFinalParse)
+			// that softens a final structured-parse miss on a raw-wanted STREAM. The
+			// orchestrator gates it on NeedsPartials && NeedsRaw, so it never affects
+			// the non-streaming CallWithRaw bridge.
+			jen.Id("SoftFinalParse"):     jen.Id("adapter").Dot("SoftFinalParse").Call(),
 			jen.Id("FallbackChain"):      jen.Id("fallbackChain"),
 			jen.Id("ClientOverride"):     jen.Id("clientOverride"),
 			jen.Id("ClientProviders"):    jen.Id("clientProviders"),

--- a/adapters/common/codegen/codegen_pool_lifecycle_test.go
+++ b/adapters/common/codegen/codegen_pool_lifecycle_test.go
@@ -731,6 +731,8 @@ func (a *fakeAdapter) SetRetryConfig(*bamlutils.RetryConfig)                {}
 func (a *fakeAdapter) RetryConfig() *bamlutils.RetryConfig                  { return nil }
 func (a *fakeAdapter) SetIncludeReasoning(bool)                             {}
 func (a *fakeAdapter) IncludeReasoning() bool                               { return false }
+func (a *fakeAdapter) SetSoftFinalParse(bool)                               {}
+func (a *fakeAdapter) SoftFinalParse() bool                                 { return false }
 func (a *fakeAdapter) ClientRegistryProvider() string                       { return "" }
 func (a *fakeAdapter) OriginalClientRegistry() *bamlutils.ClientRegistry    { return nil }
 func (a *fakeAdapter) HTTPClient() *llmhttp.Client                          { return nil }

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -156,6 +156,19 @@ type StreamConfig struct {
 	// Zero means parse on every SSE event (no throttling).
 	ParseThrottleInterval time.Duration
 
+	// SoftFinalParse is the per-request opt-in that softens a final
+	// structured-parse miss on a raw-wanted STREAM. When true AND the
+	// stream needs both partials and raw (NeedsPartials && NeedsRaw —
+	// i.e. StreamModeStreamWithRaw), a parseFinal error that is not a
+	// cancellation/deadline completes the call successfully with the
+	// accumulated raw text (nil structured final) instead of hard-failing
+	// with newRawError. Default false keeps the strict final-parse
+	// behaviour. It never applies to the non-streaming CallWithRaw bridge
+	// (NeedsPartials=false), to non-raw streams, or to the native lane
+	// (whose final parse is terminal by design). See the final-parse arms
+	// in tryOneStreamChild / tryOneBedrockStreamChild.
+	SoftFinalParse bool
+
 	// FallbackChain is the ordered list of child client names for fallback
 	// strategies. When non-empty, each retry attempt walks the entire chain
 	// in order; if any child succeeds, the attempt returns immediately.

--- a/bamlutils/buildrequest/orchestrator.go
+++ b/bamlutils/buildrequest/orchestrator.go
@@ -614,23 +614,41 @@ func RunStreamOrchestration(
 		// the output buffer is full so the LLM stream keeps draining (matches the
 		// legacy path which intentionally drops non-reset partials rather than
 		// coupling upstream reads to downstream consumer backpressure).
-		if config.NeedsPartials && parseStreamFn != nil {
-			shouldParse := config.ParseThrottleInterval == 0 ||
-				time.Since(acc.lastParseTime) >= config.ParseThrottleInterval
-			if shouldParse {
-				// Update throttle timestamp regardless of parse success/failure so
-				// repeated failures don't bypass the throttle interval.
-				acc.lastParseTime = time.Now()
-				parsed, parseErr := parseStreamFn(ctx, acc.parseable.String())
-				if parseErr == nil && parsed != nil {
-					rawForResult := ""
-					reasoningForResult := ""
-					if config.NeedsRaw {
-						rawForResult = rawDelta
-						reasoningForResult = reasoningDelta
+		if config.NeedsPartials {
+			// Attempt a throttled structured parse, but DELIVER RAW REGARDLESS of
+			// whether the parse succeeds, errors, returns nil, OR the tick is
+			// throttle-skipped: for a NeedsRaw stream, raw partials must not depend
+			// on structured-parse success or cadence (the customer's core
+			// complaint — prose streamed against a class schema fails ParseStream
+			// for every prefix, which previously hid every live partial).
+			var parsed any
+			if parseStreamFn != nil {
+				shouldParse := config.ParseThrottleInterval == 0 ||
+					time.Since(acc.lastParseTime) >= config.ParseThrottleInterval
+				if shouldParse {
+					// Update throttle timestamp regardless of parse success/failure so
+					// repeated failures don't bypass the throttle interval.
+					acc.lastParseTime = time.Now()
+					if candidate, parseErr := parseStreamFn(ctx, acc.parseable.String()); parseErr == nil && candidate != nil {
+						parsed = candidate
 					}
-					return trySendPartialShared(parsed, rawForResult, reasoningForResult)
 				}
+			}
+			if parsed != nil {
+				rawForResult := ""
+				reasoningForResult := ""
+				if config.NeedsRaw {
+					rawForResult = rawDelta
+					reasoningForResult = reasoningDelta
+				}
+				return trySendPartialShared(parsed, rawForResult, reasoningForResult)
+			}
+			if config.NeedsRaw {
+				// No structured partial this tick (parse error, nil result, OR a
+				// throttle-skipped tick). Emit the raw/reasoning delta on its own so
+				// live raw survives a parse miss and a throttle skip alike. Non-raw
+				// streams never enter this branch, preserving their strict cadence.
+				return trySendPartialShared(nil, rawDelta, reasoningDelta)
 			}
 		}
 		return nil
@@ -749,22 +767,39 @@ func RunStreamOrchestration(
 				continue
 			}
 
-			if config.NeedsPartials && parseStream != nil {
-				shouldParse := config.ParseThrottleInterval == 0 ||
-					time.Since(lastParseTime) >= config.ParseThrottleInterval
-				if shouldParse {
-					lastParseTime = time.Now()
-					parsed, parseErr := parseStream(ctx, parseableAccumulated.String())
-					if parseErr == nil && parsed != nil {
-						rawForResult := ""
-						reasoningForResult := ""
-						if config.NeedsRaw {
-							rawForResult = delta.Raw
-							reasoningForResult = delta.Reasoning
+			if config.NeedsPartials {
+				// Same raw-decouple as the shared processDelta cadence: attempt a
+				// throttled structured parse, but deliver raw for a NeedsRaw stream
+				// regardless of parse success, a nil parse, OR a throttle-skipped
+				// tick. Structurally parallel to processDelta; the bedrock child
+				// keeps its own local accumulators/clock (delta, lastParseTime,
+				// parseableAccumulated) so it does not route through processDelta.
+				var parsed any
+				if parseStream != nil {
+					shouldParse := config.ParseThrottleInterval == 0 ||
+						time.Since(lastParseTime) >= config.ParseThrottleInterval
+					if shouldParse {
+						lastParseTime = time.Now()
+						if candidate, parseErr := parseStream(ctx, parseableAccumulated.String()); parseErr == nil && candidate != nil {
+							parsed = candidate
 						}
-						if err := trySendPartialShared(parsed, rawForResult, reasoningForResult); err != nil {
-							return nil, "", "", err
-						}
+					}
+				}
+				if parsed != nil {
+					rawForResult := ""
+					reasoningForResult := ""
+					if config.NeedsRaw {
+						rawForResult = delta.Raw
+						reasoningForResult = delta.Reasoning
+					}
+					if err := trySendPartialShared(parsed, rawForResult, reasoningForResult); err != nil {
+						return nil, "", "", err
+					}
+				} else if config.NeedsRaw {
+					// Parse error, nil result, or throttle-skip: emit raw/reasoning
+					// alone so live raw survives on the bedrock transport too.
+					if err := trySendPartialShared(nil, delta.Raw, delta.Reasoning); err != nil {
+						return nil, "", "", err
 					}
 				}
 			}
@@ -775,6 +810,19 @@ func RunStreamOrchestration(
 
 		finalResult, parseErr := parseFinal(ctx, parseableAccumulated.String())
 		if parseErr != nil {
+			// Opt-in soft-final (default OFF): a raw-first STREAMING caller that
+			// enabled SoftFinalParse completes successfully carrying the
+			// accumulated raw text (nil structured final) instead of hard-failing
+			// on a final structured-parse miss. Scoped to STREAMING — NeedsPartials
+			// excludes the non-streaming CallWithRaw bridge (StreamModeCallWithRaw,
+			// NeedsPartials=false) — requires NeedsRaw, and NEVER swallows a
+			// cancellation/deadline (those fall through to the strict path).
+			if config.NeedsPartials && config.NeedsRaw && config.SoftFinalParse &&
+				ctx.Err() == nil &&
+				!errors.Is(parseErr, context.Canceled) &&
+				!errors.Is(parseErr, context.DeadlineExceeded) {
+				return nil, fullRaw, fullReasoning, nil
+			}
 			// Carry accumulated raw across the retry/fallback boundary
 			// so the outer error emission can forward it as
 			// details.raw (per #256). The wrap is no-op when fullRaw
@@ -1009,6 +1057,16 @@ func RunStreamOrchestration(
 
 		finalResult, parseErr := parseFinal(ctx, acc.parseable.String())
 		if parseErr != nil {
+			// Opt-in soft-final (default OFF), identical scope/guards to the
+			// bedrock final arm: STREAMING (NeedsPartials) + NeedsRaw +
+			// SoftFinalParse, and never a cancellation/deadline. Completes with the
+			// accumulated raw as a successful raw-only final (nil structured final).
+			if config.NeedsPartials && config.NeedsRaw && config.SoftFinalParse &&
+				ctx.Err() == nil &&
+				!errors.Is(parseErr, context.Canceled) &&
+				!errors.Is(parseErr, context.DeadlineExceeded) {
+				return nil, fullRaw, fullReasoning, nil
+			}
 			// Same raw-carrying wrap as the bedrock final-parse site
 			// — the outer emission extracts via rawFromError.
 			return nil, "", "", newRawError(

--- a/bamlutils/buildrequest/orchestrator_rawstream_canary_test.go
+++ b/bamlutils/buildrequest/orchestrator_rawstream_canary_test.go
@@ -1,0 +1,430 @@
+package buildrequest
+
+// Canary forward-port of the Codex-approved 0.0.48 raw-stream hotfix
+// (hotfix/raw-stream-partials). These locks are written FAILING-FIRST against
+// clean master (the de-BAML codebase) and prove two independent defects + their
+// scope guards, driving the REAL RunStreamOrchestration against REAL httptest
+// SSE / AWS-event-stream servers streaming the exact customer prose deltas. Only
+// parseStream / parseFinal are injected — they stand in for the pinned BAML
+// runtime's root-coercion verdict on a `{value: string}` class schema fed plain
+// prose (runtime-originated, not the orchestrator under repair).
+//
+// Defect (1) raw-decouple: live raw partials must flow for a NeedsRaw stream
+// regardless of whether ParseStream succeeds, errors, returns nil, OR the tick
+// is throttle-skipped. On clean master the ordinary-text arm emits raw ONLY
+// inside `if parseErr == nil && parsed != nil`, so a prose-before-a-class-object
+// stream hides every live partial.
+//
+// Defect (2) soft-final (opt-in, default OFF): with SoftFinalParse enabled on a
+// streaming raw-wanted call, a final structured-parse miss completes
+// successfully carrying the accumulated raw text instead of hard-failing —
+// scoped to STREAMING (NeedsPartials && NeedsRaw), cancellation-safe, and never
+// applied to the non-streaming CallWithRaw bridge.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/bamlutils"
+	"github.com/invakid404/baml-rest/bamlutils/llmhttp"
+)
+
+// customerProseDeltas are the three SSE content deltas from the customer bundle
+// (ISSUE.md): plain prose streamed against a `{value: string}` class schema, so
+// BAML's ParseStream returns a root-coercion error for every prefix.
+var customerProseDeltas = []string{"Here is ", "plain prose, ", "not structured JSON."}
+
+// customerCoerceError mirrors the stable BAML root-coercion verdict the pinned
+// runtime returns for prose against a class schema. parseStream / parseFinal
+// return it so these hermetic locks exercise the same failure the real E2E
+// exercises, without linking the CFFI.
+func customerCoerceError() error {
+	return errors.New("Failed to coerce value: [InferedObject(String(\"Here is plain prose, not structured JSON.\", Complete))]")
+}
+
+// rawStreamCounts categorises a drained orchestration output channel.
+type rawStreamCounts struct {
+	heartbeats int
+	partials   int // StreamResultKindStream, non-reset
+	rawDeltas  []string
+	finals     int
+	finalRaw   string
+	errors     int
+	lastErr    error
+}
+
+func drainRawStream(out <-chan bamlutils.StreamResult) rawStreamCounts {
+	var c rawStreamCounts
+	for r := range out {
+		switch r.Kind() {
+		case bamlutils.StreamResultKindHeartbeat:
+			c.heartbeats++
+		case bamlutils.StreamResultKindStream:
+			if r.Reset() {
+				continue
+			}
+			c.partials++
+			c.rawDeltas = append(c.rawDeltas, r.Raw())
+		case bamlutils.StreamResultKindFinal:
+			c.finals++
+			c.finalRaw = r.Raw()
+		case bamlutils.StreamResultKindError:
+			c.errors++
+			c.lastErr = r.Error()
+		}
+	}
+	return c
+}
+
+func proseBuildRequestFn(url string) BuildRequestFunc {
+	return func(_ context.Context, _ string) (*llmhttp.Request, error) {
+		return &llmhttp.Request{URL: url, Method: "POST", Body: `{}`}, nil
+	}
+}
+
+// --- Defect (1): raw partials survive ParseStream failure (SSE) --------------
+
+// TestRunStreamOrchestration_RawPartialsSurviveParseFailure_SSE FAILS on clean
+// master: a NeedsRaw stream whose ParseStream errors for every prefix emits 0
+// live partials (expected 3, one per prose delta).
+func TestRunStreamOrchestration_RawPartialsSurviveParseFailure_SSE(t *testing.T) {
+	server := makeOpenAIServer(customerProseDeltas)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &StreamConfig{Provider: "openai", NeedsPartials: true, NeedsRaw: true}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		proseBuildRequestFn(server.URL),
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		newTestResult,
+	)
+	if err != nil {
+		t.Fatalf("RunStreamOrchestration returned err: %v", err)
+	}
+	close(out)
+
+	c := drainRawStream(out)
+	if c.partials != len(customerProseDeltas) {
+		t.Fatalf("expected %d live raw partials (one per prose delta), got %d: %v",
+			len(customerProseDeltas), c.partials, c.rawDeltas)
+	}
+	for i, want := range customerProseDeltas {
+		if c.rawDeltas[i] != want {
+			t.Errorf("raw partial[%d] = %q, want %q", i, c.rawDeltas[i], want)
+		}
+	}
+}
+
+// TestRunStreamOrchestration_RawPartialsSurviveParseFailure_Bedrock is the
+// AWS-event-stream twin: the bedrock child shares the same raw-gating defect.
+func TestRunStreamOrchestration_RawPartialsSurviveParseFailure_Bedrock(t *testing.T) {
+	pinnedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+
+	var frames bytes.Buffer
+	frames.Write(bedrockStreamFrame(t, "messageStart", []byte(`{"role":"assistant"}`)))
+	for _, d := range customerProseDeltas {
+		frames.Write(bedrockStreamFrame(t, "contentBlockDelta", []byte(`{"delta":{"text":`+jsonQuote(d)+`}}`)))
+	}
+	frames.Write(bedrockStreamFrame(t, "messageStop", []byte(`{"stopReason":"end_turn"}`)))
+
+	server := newMockBedrockStreamServer(t, frames.Bytes(), nil, nil, nil)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &StreamConfig{
+		Provider:                  "aws-bedrock",
+		NeedsPartials:             true,
+		NeedsRaw:                  true,
+		BuildBedrockStreamRequest: makeBedrockStreamRequestFn(server.URL, pinnedTime),
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		func(context.Context, string) (*llmhttp.Request, error) {
+			return nil, errors.New("buildRequest must not be called for aws-bedrock")
+		},
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		newTestResult,
+	)
+	if err != nil {
+		t.Fatalf("RunStreamOrchestration returned err: %v", err)
+	}
+	close(out)
+
+	c := drainRawStream(out)
+	if c.partials != len(customerProseDeltas) {
+		t.Fatalf("expected %d live raw partials (one per prose delta), got %d: %v",
+			len(customerProseDeltas), c.partials, c.rawDeltas)
+	}
+}
+
+// TestRunStreamOrchestration_RawPartialsSurviveThrottle_SSE FAILS on clean
+// master: with ParseThrottleInterval large enough that only the first tick
+// parses, the throttle-skipped ticks drop their raw entirely (raw-only emit
+// lives inside the throttle gate). Raw must survive a throttle-skip.
+func TestRunStreamOrchestration_RawPartialsSurviveThrottle_SSE(t *testing.T) {
+	server := makeOpenAIServer(customerProseDeltas)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &StreamConfig{
+		Provider:              "openai",
+		NeedsPartials:         true,
+		NeedsRaw:              true,
+		ParseThrottleInterval: time.Hour,
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		proseBuildRequestFn(server.URL),
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		newTestResult,
+	)
+	if err != nil {
+		t.Fatalf("RunStreamOrchestration returned err: %v", err)
+	}
+	close(out)
+
+	c := drainRawStream(out)
+	if c.partials != len(customerProseDeltas) {
+		t.Fatalf("throttle: expected %d raw partials (raw independent of parse cadence), got %d: %v",
+			len(customerProseDeltas), c.partials, c.rawDeltas)
+	}
+}
+
+// TestRunStreamOrchestration_NonRawStrictOnParseFailure_SSE is a scope guard:
+// a non-raw stream (StreamModeStream) still emits 0 partials while ParseStream
+// fails, and still hard-fails at the final parse. PASSES before AND after —
+// the raw-decouple must not leak into non-raw streams.
+func TestRunStreamOrchestration_NonRawStrictOnParseFailure_SSE(t *testing.T) {
+	server := makeOpenAIServer(customerProseDeltas)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &StreamConfig{Provider: "openai", NeedsPartials: true, NeedsRaw: false}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		proseBuildRequestFn(server.URL),
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		newTestResult,
+	)
+	if err != nil {
+		t.Fatalf("RunStreamOrchestration returned err: %v", err)
+	}
+	close(out)
+
+	c := drainRawStream(out)
+	if c.partials != 0 {
+		t.Errorf("non-raw stream should emit 0 partials on parse failure, got %d", c.partials)
+	}
+	if c.errors != 1 {
+		t.Errorf("non-raw stream should hard-fail at final parse (1 error), got %d", c.errors)
+	}
+	if c.finals != 0 {
+		t.Errorf("non-raw stream should emit 0 finals on parse failure, got %d", c.finals)
+	}
+}
+
+// --- Defect (2): opt-in soft-final ------------------------------------------
+
+// TestRunStreamOrchestration_SoftFinalParse_OptIn_ReturnsRawSuccess_SSE FAILS
+// on clean master: with SoftFinalParse enabled, a final-parse miss on a
+// streaming raw-wanted call must complete SUCCESSFULLY carrying the accumulated
+// raw (0 errors, 1 final). Clean master still hard-fails (1 error, 0 finals).
+func TestRunStreamOrchestration_SoftFinalParse_OptIn_ReturnsRawSuccess_SSE(t *testing.T) {
+	server := makeOpenAIServer(customerProseDeltas)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &StreamConfig{
+		Provider:       "openai",
+		NeedsPartials:  true,
+		NeedsRaw:       true,
+		SoftFinalParse: true,
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		proseBuildRequestFn(server.URL),
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		newTestResult,
+	)
+	if err != nil {
+		t.Fatalf("RunStreamOrchestration returned err: %v", err)
+	}
+	close(out)
+
+	c := drainRawStream(out)
+	if c.errors != 0 {
+		t.Errorf("SoftFinalParse ON: expected 0 error results, got %d (%v)", c.errors, c.lastErr)
+	}
+	if c.finals != 1 {
+		t.Fatalf("SoftFinalParse ON: expected 1 successful final, got %d", c.finals)
+	}
+	if want := strings.Join(customerProseDeltas, ""); c.finalRaw != want {
+		t.Errorf("SoftFinalParse ON: final raw = %q, want %q", c.finalRaw, want)
+	}
+}
+
+// TestRunStreamOrchestration_SoftFinalParse_DefaultStrict_Errors_SSE is the
+// default guard: with SoftFinalParse OFF (default), a final-parse miss still
+// hard-fails. PASSES before AND after.
+func TestRunStreamOrchestration_SoftFinalParse_DefaultStrict_Errors_SSE(t *testing.T) {
+	server := makeOpenAIServer(customerProseDeltas)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &StreamConfig{
+		Provider:       "openai",
+		NeedsPartials:  true,
+		NeedsRaw:       true,
+		SoftFinalParse: false,
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		proseBuildRequestFn(server.URL),
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		newTestResult,
+	)
+	if err != nil {
+		t.Fatalf("RunStreamOrchestration returned err: %v", err)
+	}
+	close(out)
+
+	c := drainRawStream(out)
+	if c.errors != 1 {
+		t.Errorf("SoftFinalParse OFF: expected 1 error result, got %d", c.errors)
+	}
+	if c.finals != 0 {
+		t.Errorf("SoftFinalParse OFF: expected 0 finals, got %d", c.finals)
+	}
+}
+
+// TestRunStreamOrchestration_SoftFinalParse_ScopedToStreaming_SSE guards that
+// the opt-in never leaks into the non-streaming CallWithRaw bridge
+// (NeedsPartials=false, NeedsRaw=true). Even with SoftFinalParse ON, a
+// final-parse miss stays strict. PASSES before AND after.
+func TestRunStreamOrchestration_SoftFinalParse_ScopedToStreaming_SSE(t *testing.T) {
+	server := makeOpenAIServer(customerProseDeltas)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	// StreamModeCallWithRaw shape: NeedsRaw=true, NeedsPartials=false.
+	config := &StreamConfig{
+		Provider:       "openai",
+		NeedsPartials:  false,
+		NeedsRaw:       true,
+		SoftFinalParse: true,
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		proseBuildRequestFn(server.URL),
+		nil, // call-with-raw does not parse partials
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		newTestResult,
+	)
+	if err != nil {
+		t.Fatalf("RunStreamOrchestration returned err: %v", err)
+	}
+	close(out)
+
+	c := drainRawStream(out)
+	if c.errors != 1 {
+		t.Errorf("SoftFinalParse scoped-to-streaming: CallWithRaw must stay strict (1 error), got %d", c.errors)
+	}
+	if c.finals != 0 {
+		t.Errorf("SoftFinalParse scoped-to-streaming: expected 0 finals, got %d", c.finals)
+	}
+}
+
+// TestRunStreamOrchestration_SoftFinalParse_HonorsCancellation_SSE guards that
+// the opt-in never turns a cancellation/deadline into a successful raw final:
+// parseFinal returning context.Canceled must fall through to the strict path.
+// PASSES before AND after; catches a soft-final that swallows cancellation.
+func TestRunStreamOrchestration_SoftFinalParse_HonorsCancellation_SSE(t *testing.T) {
+	server := makeOpenAIServer(customerProseDeltas)
+	defer server.Close()
+
+	client := llmhttp.NewClient(server.Client())
+	out := make(chan bamlutils.StreamResult, 100)
+
+	config := &StreamConfig{
+		Provider:       "openai",
+		NeedsPartials:  true,
+		NeedsRaw:       true,
+		SoftFinalParse: true,
+	}
+
+	err := RunStreamOrchestration(
+		context.Background(), out, config, client,
+		proseBuildRequestFn(server.URL),
+		func(context.Context, string) (any, error) { return nil, customerCoerceError() },
+		// parseFinal reports a cancellation, but the request context is still
+		// live (ctx.Err()==nil) — the soft branch must reject it on the
+		// errors.Is(parseErr, context.Canceled) clause, not on ctx.Err().
+		func(context.Context, string) (any, error) { return nil, context.Canceled },
+		newTestResult,
+	)
+	if err != nil {
+		t.Fatalf("RunStreamOrchestration returned err: %v", err)
+	}
+	close(out)
+
+	c := drainRawStream(out)
+	if c.finals != 0 {
+		t.Errorf("cancellation must NOT become a raw-success final; got %d finals (raw=%q)", c.finals, c.finalRaw)
+	}
+	if c.errors != 1 {
+		t.Errorf("cancellation should surface a strict error result, got %d", c.errors)
+	}
+}
+
+// jsonQuote returns the JSON string literal for s (including surrounding
+// quotes), used to embed a prose delta into a Bedrock contentBlockDelta
+// fixture payload.
+func jsonQuote(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/bamlutils/buildrequest/resolve_test.go
+++ b/bamlutils/buildrequest/resolve_test.go
@@ -36,6 +36,8 @@ func (m *mockAdapter) SetRetryConfig(rc *bamlutils.RetryConfig) { m.retryConfig 
 func (m *mockAdapter) RetryConfig() *bamlutils.RetryConfig      { return m.retryConfig }
 func (m *mockAdapter) SetIncludeReasoning(v bool)               { m.includeReasoning = v }
 func (m *mockAdapter) IncludeReasoning() bool                   { return m.includeReasoning }
+func (m *mockAdapter) SetSoftFinalParse(bool)                   {}
+func (m *mockAdapter) SoftFinalParse() bool                     { return false }
 func (m *mockAdapter) ClientRegistryProvider() string           { return m.clientRegistryProvider }
 func (m *mockAdapter) HTTPClient() *llmhttp.Client              { return m.httpClient }
 func (m *mockAdapter) SetHTTPClient(c *llmhttp.Client)          { m.httpClient = c }

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -1209,17 +1209,17 @@ type Adapter interface {
 	// IncludeReasoning returns the per-request opt-in flag. Defaults to
 	// false when no override has been applied.
 	IncludeReasoning() bool
-	// SetSoftFinalParse installs the per-handler opt-in
-	// (dynclient.WithSoftFinalParse) that softens a final structured-parse
-	// miss on a raw-wanted STREAM (StreamModeStreamWithRaw) into a
-	// successful raw-only final instead of a hard error. Default false keeps
-	// the strict final parse. The stream router forwards it verbatim into
+	// SoftFinalParse returns the per-handler soft-final opt-in
+	// (dynclient.WithSoftFinalParse): whether a final structured-parse miss
+	// on a raw-wanted STREAM (StreamModeStreamWithRaw) completes as a
+	// successful raw-only final instead of a hard error. Defaults to false
+	// (strict final parse). The stream router forwards it into
 	// StreamConfig.SoftFinalParse, where the orchestrator gates it on
 	// NeedsPartials && NeedsRaw (streaming only) and never applies it to a
-	// cancellation/deadline.
-	SetSoftFinalParse(softFinalParse bool)
-	// SoftFinalParse returns the per-handler soft-final opt-in flag.
-	// Defaults to false when no override has been applied.
+	// cancellation/deadline. Read-only here — the value is INSTALLED via the
+	// narrow, off-interface softFinalParseSetter (worker.configureAdapter),
+	// mirroring SetDeBAMLRenderer/SetDeBAMLParser, so minimal adapter doubles
+	// that never stream need not implement a setter they would panic on.
 	SoftFinalParse() bool
 	// ClientRegistryProvider returns the provider string of the primary client
 	// from the runtime ClientRegistry override, or empty string if no override.

--- a/bamlutils/interfaces.go
+++ b/bamlutils/interfaces.go
@@ -1209,6 +1209,18 @@ type Adapter interface {
 	// IncludeReasoning returns the per-request opt-in flag. Defaults to
 	// false when no override has been applied.
 	IncludeReasoning() bool
+	// SetSoftFinalParse installs the per-handler opt-in
+	// (dynclient.WithSoftFinalParse) that softens a final structured-parse
+	// miss on a raw-wanted STREAM (StreamModeStreamWithRaw) into a
+	// successful raw-only final instead of a hard error. Default false keeps
+	// the strict final parse. The stream router forwards it verbatim into
+	// StreamConfig.SoftFinalParse, where the orchestrator gates it on
+	// NeedsPartials && NeedsRaw (streaming only) and never applies it to a
+	// cancellation/deadline.
+	SetSoftFinalParse(softFinalParse bool)
+	// SoftFinalParse returns the per-handler soft-final opt-in flag.
+	// Defaults to false when no override has been applied.
+	SoftFinalParse() bool
 	// ClientRegistryProvider returns the provider string of the primary client
 	// from the runtime ClientRegistry override, or empty string if no override.
 	// Used by the BuildRequest router to select the correct SSE delta extractor.

--- a/dynclient/client.go
+++ b/dynclient/client.go
@@ -133,6 +133,7 @@ func newWithRuntime(rt worker.Runtime, init func(), opts ...Option) (*Client, er
 		NativeStreamServeComparator: cfg.nativeStreamServe,
 		BaseURLRewrites:             cfg.baseURLRewrites,
 		HTTPClient:                  httpClient,
+		SoftFinalParse:              cfg.softFinalParse,
 	}
 	if cfg.sharedState != nil {
 		workerCfg.SharedState = worker.NewStoreSharedStateHook(cfg.sharedState)

--- a/dynclient/client_test.go
+++ b/dynclient/client_test.go
@@ -29,6 +29,7 @@ type fakeAdapter struct {
 	logger                 bamlutils.Logger
 	retryConfig            *bamlutils.RetryConfig
 	includeReasoning       bool
+	softFinalParse         bool
 	originalRegistry       *bamlutils.ClientRegistry
 	clientRegistryProvider string
 	roundRobinAdvancer     bamlutils.RoundRobinAdvancer
@@ -62,6 +63,8 @@ func (a *fakeAdapter) SetRetryConfig(c *bamlutils.RetryConfig) { a.retryConfig =
 func (a *fakeAdapter) RetryConfig() *bamlutils.RetryConfig     { return a.retryConfig }
 func (a *fakeAdapter) SetIncludeReasoning(v bool)              { a.includeReasoning = v }
 func (a *fakeAdapter) IncludeReasoning() bool                  { return a.includeReasoning }
+func (a *fakeAdapter) SetSoftFinalParse(v bool)                { a.softFinalParse = v }
+func (a *fakeAdapter) SoftFinalParse() bool                    { return a.softFinalParse }
 func (a *fakeAdapter) ClientRegistryProvider() string          { return a.clientRegistryProvider }
 func (a *fakeAdapter) OriginalClientRegistry() *bamlutils.ClientRegistry {
 	return a.originalRegistry
@@ -277,6 +280,46 @@ func TestNewAppliesOptions(t *testing.T) {
 	if gotURL != "http://proxy.local:8080/v1" {
 		t.Errorf("base_url after rewrite = %q, want http://proxy.local:8080/v1", gotURL)
 	}
+}
+
+// TestWithSoftFinalParseThreadsToAdapter locks the dynclient -> worker ->
+// adapter threading for the soft-final opt-in: WithSoftFinalParse() must reach
+// the per-request adapter (which the generated stream router copies into
+// StreamConfig.SoftFinalParse), and the default must stay OFF. The orchestrator
+// behaviour driven by the flag is locked separately in
+// bamlutils/buildrequest/orchestrator_rawstream_canary_test.go.
+func TestWithSoftFinalParseThreadsToAdapter(t *testing.T) {
+	run := func(t *testing.T, opts ...Option) *fakeAdapter {
+		t.Helper()
+		rt := &fakeRuntime{}
+		c := newClient(t, rt, opts...)
+		rt.streamingImpl = func(adapter bamlutils.Adapter, _ any) (<-chan bamlutils.StreamResult, error) {
+			ch := make(chan bamlutils.StreamResult, 1)
+			ch <- &fakeStreamResult{kind: bamlutils.StreamResultKindFinal, final: map[string]any{"DynamicProperties": map[string]any{"answer": "ok"}}}
+			close(ch)
+			return ch, nil
+		}
+		if _, err := c.DynamicCall(context.Background(), validRequest()); err != nil {
+			t.Fatalf("DynamicCall: %v", err)
+		}
+		captured := rt.capturedAdapter.Load()
+		if captured == nil {
+			t.Fatal("expected adapter to be captured")
+		}
+		return captured
+	}
+
+	t.Run("opt_in", func(t *testing.T) {
+		if got := run(t, WithSoftFinalParse()).SoftFinalParse(); !got {
+			t.Errorf("SoftFinalParse() = %v, want true (WithSoftFinalParse wiring)", got)
+		}
+	})
+
+	t.Run("default_off", func(t *testing.T) {
+		if got := run(t).SoftFinalParse(); got {
+			t.Errorf("SoftFinalParse() = %v, want false by default", got)
+		}
+	})
 }
 
 func TestNewDoesNotReadEnv(t *testing.T) {

--- a/dynclient/internal/generated/adapter.go
+++ b/dynclient/internal/generated/adapter.go
@@ -809,8 +809,9 @@ func bamlRestDynamicBuildRequest(adapter bamlutils.Adapter, rawInput any, out ch
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newBamlRestDynamicOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {

--- a/dynclient/internal/generated/adapter/adapter.go
+++ b/dynclient/internal/generated/adapter/adapter.go
@@ -48,6 +48,13 @@ type BamlAdapter struct {
 	// text passed to Parse/ParseStream.
 	includeReasoning bool
 
+	// softFinalParse is the per-handler opt-in (dynclient.WithSoftFinalParse)
+	// that softens a final structured-parse miss on a raw-wanted STREAM into a
+	// successful raw-only final instead of a hard error. Default false keeps the
+	// strict final parse. Consumed by the stream router as
+	// StreamConfig.SoftFinalParse (streaming + raw only).
+	softFinalParse bool
+
 	// clientRegistryProvider is the provider of the primary client from
 	// the runtime ClientRegistry override. Empty if no override.
 	clientRegistryProvider string
@@ -175,6 +182,12 @@ func (b *BamlAdapter) SetIncludeReasoning(includeReasoning bool) {
 }
 func (b *BamlAdapter) IncludeReasoning() bool {
 	return b.includeReasoning
+}
+func (b *BamlAdapter) SetSoftFinalParse(softFinalParse bool) {
+	b.softFinalParse = softFinalParse
+}
+func (b *BamlAdapter) SoftFinalParse() bool {
+	return b.softFinalParse
 }
 func (b *BamlAdapter) SetClientRegistry(clientRegistry *bamlutils.ClientRegistry) error {
 	if clientRegistry == nil {

--- a/dynclient/options.go
+++ b/dynclient/options.go
@@ -46,6 +46,11 @@ type config struct {
 	trustedClients       *trustedclients.Set
 	sharedState          *workerplugin.SharedStateStore
 
+	// softFinalParse is the client-wide WithSoftFinalParse opt-in. It is
+	// forwarded to worker.Config.SoftFinalParse and installed on every
+	// adapter, reaching the orchestrator as StreamConfig.SoftFinalParse.
+	softFinalParse bool
+
 	clientMode    llmhttp.ClientMode
 	clientModeSet bool
 
@@ -103,6 +108,27 @@ func WithDeBAMLRenderer(render bamlutils.DeBAMLRenderFunc) Option {
 func WithDeBAMLParser(parse bamlutils.DeBAMLParseFunc) Option {
 	return func(c *config) error {
 		c.deBAMLParse = parse
+		return nil
+	}
+}
+
+// WithSoftFinalParse enables the soft-final opt-in for this client. On a
+// /stream-with-raw dynamic streaming call (DynamicStreamRaw), a final
+// structured-parse miss — e.g. plain prose streamed against a class schema,
+// which BAML's Parse rejects with a root-coercion error — completes
+// SUCCESSFULLY carrying the accumulated raw text (a final frame with a null
+// structured payload) instead of returning a terminal parse error. Default
+// OFF: the strict final parse is unchanged.
+//
+// Scope: STREAMING raw calls only. The orchestrator gates the softening on
+// NeedsPartials && NeedsRaw, so the non-streaming DynamicCallRaw bridge stays
+// strict even with this enabled, and a cancellation/deadline is never turned
+// into a success. Live raw partials are ALWAYS decoupled from the structured
+// parse (they flow even without this option); enable this only to also receive
+// a successful final when the final parse misses.
+func WithSoftFinalParse() Option {
+	return func(c *config) error {
+		c.softFinalParse = true
 		return nil
 	}
 }

--- a/integration/dynclient_rawstream_softfinal_test.go
+++ b/integration/dynclient_rawstream_softfinal_test.go
@@ -1,0 +1,186 @@
+//go:build integration
+
+package integration
+
+// Real-BAML forward-port E2E for the raw-stream fix + WithSoftFinalParse opt-in
+// (canary of the Codex-approved 0.0.48 hotfix). Unlike the hermetic
+// orchestrator locks in bamlutils/buildrequest (which inject the parse verdict),
+// these exercise the REAL BAML runtime, the REAL generated dynclient adapter,
+// and the mock upstream streaming plain prose against a `{answer: string}` class
+// schema — so BAML's ParseStream/Parse return the authentic root-coercion
+// verdict for every prefix, exactly the customer's reported failure.
+//
+// Gated //go:build integration (needs the mock-LLM TestEnv), so it never runs in
+// the hermetic de-BAML unit-test suite.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/invakid404/baml-rest/dynclient"
+)
+
+// proseContent is plain prose streamed against a `{answer: string}` class
+// schema. BAML's Parse/ParseStream cannot coerce a bare string into the object,
+// so the final parse misses with the stable customer error.
+const proseContent = "Here is plain prose, not structured JSON."
+
+// TestDynclientRawStreamProsePartials_RealRuntime is the faithful E2E: live raw
+// partials must flow while the structured parse fails for every prefix, and the
+// WithSoftFinalParse opt-in must convert the terminal final-parse miss into a
+// successful raw-only final.
+func TestDynclientRawStreamProsePartials_RealRuntime(t *testing.T) {
+	dynclientCallGate(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	opts := setupScenario(t, "test-dynclient-rawstream-prose", proseContent)
+	_, libSchema := simpleAnswerSchema()
+	hello := "Give me the answer."
+
+	newReq := func() dynclient.Request {
+		return dynclient.Request{
+			Messages:       []dynclient.Message{{Role: "user", TextContent: &hello}},
+			ClientRegistry: dynRegistry(opts.ClientRegistry),
+			OutputSchema:   libSchema,
+		}
+	}
+
+	t.Run("live_raw_partials_even_when_final_parse_fails", func(t *testing.T) {
+		client := newDynclient(t) // default: strict final parse
+		stream, err := client.DynamicStreamRaw(ctx, newReq())
+		if err != nil {
+			t.Fatalf("DynamicStreamRaw open: %v", err)
+		}
+		defer stream.Close()
+
+		var (
+			rawSeen  []string
+			finals   int
+			finalRaw string
+			termErr  error
+		)
+		for {
+			ev, err := stream.Next()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				termErr = err
+				break
+			}
+			switch ev.Kind {
+			case dynclient.EventPartial:
+				if ev.Raw != "" {
+					rawSeen = append(rawSeen, ev.Raw)
+				}
+			case dynclient.EventFinal:
+				finals++
+				finalRaw = ev.Raw
+			}
+		}
+
+		// Fix (1): live raw partials flow even though every prefix fails to parse.
+		if len(rawSeen) == 0 {
+			t.Errorf("expected live raw partials as the prose streams, got none " +
+				"(regression: raw suppressed by structured-parse gating)")
+		}
+		// Default strict: no successful final, and the terminal error is the
+		// stable customer coerce error (assert the stable wrapper + payload, not
+		// an over-specific string).
+		if finals != 0 {
+			t.Errorf("default strict: expected no final frame, got %d (raw=%q)", finals, finalRaw)
+		}
+		if termErr == nil {
+			t.Fatalf("default strict: expected a terminal final-parse error, got clean EOF")
+		}
+		msg := termErr.Error()
+		if !strings.Contains(msg, "failed to parse final result") {
+			t.Errorf("terminal error missing stable wrapper %q: %v", "failed to parse final result", msg)
+		}
+		if !strings.Contains(msg, "Failed to coerce value") {
+			t.Errorf("terminal error missing root-coercion payload %q: %v", "Failed to coerce value", msg)
+		}
+	})
+
+	t.Run("WithSoftFinalParse_yields_successful_raw_final", func(t *testing.T) {
+		client := newDynclient(t, dynclient.WithSoftFinalParse())
+		stream, err := client.DynamicStreamRaw(ctx, newReq())
+		if err != nil {
+			t.Fatalf("DynamicStreamRaw open: %v", err)
+		}
+		defer stream.Close()
+
+		var (
+			rawSeen  []string
+			finals   int
+			finalRaw string
+			termErr  error
+		)
+		for {
+			ev, err := stream.Next()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				termErr = err
+				break
+			}
+			switch ev.Kind {
+			case dynclient.EventPartial:
+				if ev.Raw != "" {
+					rawSeen = append(rawSeen, ev.Raw)
+				}
+			case dynclient.EventFinal:
+				finals++
+				finalRaw = ev.Raw
+			}
+		}
+
+		if len(rawSeen) == 0 {
+			t.Errorf("expected live raw partials with the opt-in on, got none")
+		}
+		if termErr != nil {
+			t.Fatalf("WithSoftFinalParse: expected clean completion, got terminal error: %v", termErr)
+		}
+		if finals != 1 {
+			t.Fatalf("WithSoftFinalParse: expected exactly 1 successful final, got %d", finals)
+		}
+		if finalRaw != proseContent {
+			t.Errorf("WithSoftFinalParse: final raw = %q, want the full accumulated prose %q", finalRaw, proseContent)
+		}
+	})
+}
+
+// TestDynclientCallRaw_SoftFinalParse_ScopeGuard_RealRuntime pins that the
+// opt-in never leaks into the non-streaming DynamicCallRaw bridge
+// (NeedsPartials=false): even with WithSoftFinalParse enabled, a prose response
+// against a class schema returns the strict terminal parse error.
+func TestDynclientCallRaw_SoftFinalParse_ScopeGuard_RealRuntime(t *testing.T) {
+	dynclientCallGate(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	opts := setupScenario(t, "test-dynclient-callraw-prose-scope", proseContent)
+	_, libSchema := simpleAnswerSchema()
+	hello := "Give me the answer."
+
+	client := newDynclient(t, dynclient.WithSoftFinalParse())
+	_, err := client.DynamicCallRaw(ctx, dynclient.Request{
+		Messages:       []dynclient.Message{{Role: "user", TextContent: &hello}},
+		ClientRegistry: dynRegistry(opts.ClientRegistry),
+		OutputSchema:   libSchema,
+	})
+	if err == nil {
+		t.Fatalf("DynamicCallRaw with WithSoftFinalParse must stay strict on a prose/class mismatch, got success")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "Failed to coerce value") {
+		t.Errorf("DynamicCallRaw scope guard: expected the strict root-coercion error, got: %v", msg)
+	}
+}

--- a/internal/nativeprompt/testdata/staticserve_fixture/generated/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_fixture/generated/adapter.go
@@ -559,8 +559,9 @@ func staticAssertConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any,
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticAssertConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -1452,8 +1453,9 @@ func staticCheckedAliasedFieldBuildRequest(adapter bamlutils.Adapter, rawInput a
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedAliasedFieldOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -2345,8 +2347,9 @@ func staticCheckedConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -3238,8 +3241,9 @@ func staticCheckedFloatBuildRequest(adapter bamlutils.Adapter, rawInput any, out
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedFloatOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -4131,8 +4135,9 @@ func staticCheckedGtePredicateBuildRequest(adapter bamlutils.Adapter, rawInput a
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedGtePredicateOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -5024,8 +5029,9 @@ func staticCheckedListBuildRequest(adapter bamlutils.Adapter, rawInput any, out 
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedListOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -5917,8 +5923,9 @@ func staticCheckedNonAsciiLabelBuildRequest(adapter bamlutils.Adapter, rawInput 
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedNonAsciiLabelOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -6810,8 +6817,9 @@ func staticCheckedOptionalBuildRequest(adapter bamlutils.Adapter, rawInput any, 
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedOptionalOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -7703,8 +7711,9 @@ func staticCheckedRenamedClassBuildRequest(adapter bamlutils.Adapter, rawInput a
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedRenamedClassOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -8596,8 +8605,9 @@ func staticCheckedReorderedBuildRequest(adapter bamlutils.Adapter, rawInput any,
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedReorderedOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -9489,8 +9499,9 @@ func staticCheckedTwoChecksBuildRequest(adapter bamlutils.Adapter, rawInput any,
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedTwoChecksOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -10382,8 +10393,9 @@ func staticCheckedUnionBuildRequest(adapter bamlutils.Adapter, rawInput any, out
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedUnionOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -11275,8 +11287,9 @@ func staticCompletionBuildRequest(adapter bamlutils.Adapter, rawInput any, out c
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCompletionOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -12168,8 +12181,9 @@ func staticCompletionOutputFormatBuildRequest(adapter bamlutils.Adapter, rawInpu
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCompletionOutputFormatOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -13061,8 +13075,9 @@ func staticEnumArgCanonicalEqBuildRequest(adapter bamlutils.Adapter, rawInput an
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticEnumArgCanonicalEqOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -13954,8 +13969,9 @@ func staticEnumArgMemberEqBuildRequest(adapter bamlutils.Adapter, rawInput any, 
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticEnumArgMemberEqOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -14847,8 +14863,9 @@ func staticEnumCanonicalArgEqBuildRequest(adapter bamlutils.Adapter, rawInput an
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticEnumCanonicalArgEqOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -15726,8 +15743,9 @@ func staticEnumCanonicalEqBuildRequest(adapter bamlutils.Adapter, rawInput any, 
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticEnumCanonicalEqOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -16601,8 +16619,9 @@ func staticEnumCanonicalInMemberListBuildRequest(adapter bamlutils.Adapter, rawI
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticEnumCanonicalInMemberListOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -17476,8 +17495,9 @@ func staticEnumDifferentMemberEqBuildRequest(adapter bamlutils.Adapter, rawInput
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticEnumDifferentMemberEqOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -18351,8 +18371,9 @@ func staticEnumDisplayAliasEqBuildRequest(adapter bamlutils.Adapter, rawInput an
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticEnumDisplayAliasEqOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -19240,8 +19261,9 @@ func staticEnumMemberArgEqBuildRequest(adapter bamlutils.Adapter, rawInput any, 
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticEnumMemberArgEqOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -20119,8 +20141,9 @@ func staticEnumMemberInCanonicalListBuildRequest(adapter bamlutils.Adapter, rawI
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticEnumMemberInCanonicalListOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -20994,8 +21017,9 @@ func staticEnumReverseCanonicalEqBuildRequest(adapter bamlutils.Adapter, rawInpu
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticEnumReverseCanonicalEqOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -21869,8 +21893,9 @@ func staticEnumSameMemberEqBuildRequest(adapter bamlutils.Adapter, rawInput any,
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticEnumSameMemberEqOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -22773,8 +22798,9 @@ func staticMediaImageBuildRequest(adapter bamlutils.Adapter, rawInput any, out c
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticMediaImageOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -23695,8 +23721,9 @@ func staticMediaImageListBuildRequest(adapter bamlutils.Adapter, rawInput any, o
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticMediaImageListOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -24626,8 +24653,9 @@ func staticMediaInClassBuildRequest(adapter bamlutils.Adapter, rawInput any, out
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticMediaInClassOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -25523,8 +25551,9 @@ func staticOutputFormatBuildRequest(adapter bamlutils.Adapter, rawInput any, out
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticOutputFormatOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -26419,8 +26448,9 @@ func staticPrimitiveArgsBuildRequest(adapter bamlutils.Adapter, rawInput any, ou
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticPrimitiveArgsOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -27327,8 +27357,9 @@ func staticRecursiveABuildRequest(adapter bamlutils.Adapter, rawInput any, out c
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRecursiveAOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -28220,8 +28251,9 @@ func staticRecursiveAliasJsonBuildRequest(adapter bamlutils.Adapter, rawInput an
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRecursiveAliasJsonOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -29113,8 +29145,9 @@ func staticRecursiveAliasJsonValueBuildRequest(adapter bamlutils.Adapter, rawInp
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRecursiveAliasJsonValueOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -30006,8 +30039,9 @@ func staticRecursiveAliasJsonValueReorderedBuildRequest(adapter bamlutils.Adapte
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRecursiveAliasJsonValueReorderedOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -30899,8 +30933,9 @@ func staticRecursiveBBuildRequest(adapter bamlutils.Adapter, rawInput any, out c
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRecursiveBOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -31792,8 +31827,9 @@ func staticRecursiveLoopBuildRequest(adapter bamlutils.Adapter, rawInput any, ou
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRecursiveLoopOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -32685,8 +32721,9 @@ func staticRecursiveNodeBuildRequest(adapter bamlutils.Adapter, rawInput any, ou
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRecursiveNodeOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -33578,8 +33615,9 @@ func staticRecursiveNodeAnnBuildRequest(adapter bamlutils.Adapter, rawInput any,
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRecursiveNodeAnnOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -34471,8 +34509,9 @@ func staticRenderEnumBuildRequest(adapter bamlutils.Adapter, rawInput any, out c
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRenderEnumOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -35364,8 +35403,9 @@ func staticRenderListBuildRequest(adapter bamlutils.Adapter, rawInput any, out c
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRenderListOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -36257,8 +36297,9 @@ func staticRenderPaletteBuildRequest(adapter bamlutils.Adapter, rawInput any, ou
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRenderPaletteOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -37150,8 +37191,9 @@ func staticRenderPalettesBuildRequest(adapter bamlutils.Adapter, rawInput any, o
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRenderPalettesOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -38043,8 +38085,9 @@ func staticRenderStringsBuildRequest(adapter bamlutils.Adapter, rawInput any, ou
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRenderStringsOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -38937,8 +38980,9 @@ func staticRoleChatBuildRequest(adapter bamlutils.Adapter, rawInput any, out cha
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticRoleChatOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -39839,8 +39883,9 @@ func staticStreamAliasEqBuildRequest(adapter bamlutils.Adapter, rawInput any, ou
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticStreamAliasEqOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -40732,8 +40777,9 @@ func staticStreamRenderEnumBuildRequest(adapter bamlutils.Adapter, rawInput any,
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticStreamRenderEnumOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {

--- a/internal/nativeprompt/testdata/staticserve_fixture/generated/adapter/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_fixture/generated/adapter/adapter.go
@@ -48,6 +48,13 @@ type BamlAdapter struct {
 	// text passed to Parse/ParseStream.
 	includeReasoning bool
 
+	// softFinalParse is the per-handler opt-in (dynclient.WithSoftFinalParse)
+	// that softens a final structured-parse miss on a raw-wanted STREAM into a
+	// successful raw-only final instead of a hard error. Default false keeps the
+	// strict final parse. Consumed by the stream router as
+	// StreamConfig.SoftFinalParse (streaming + raw only).
+	softFinalParse bool
+
 	// clientRegistryProvider is the provider of the primary client from
 	// the runtime ClientRegistry override. Empty if no override.
 	clientRegistryProvider string
@@ -175,6 +182,12 @@ func (b *BamlAdapter) SetIncludeReasoning(includeReasoning bool) {
 }
 func (b *BamlAdapter) IncludeReasoning() bool {
 	return b.includeReasoning
+}
+func (b *BamlAdapter) SetSoftFinalParse(softFinalParse bool) {
+	b.softFinalParse = softFinalParse
+}
+func (b *BamlAdapter) SoftFinalParse() bool {
+	return b.softFinalParse
 }
 func (b *BamlAdapter) SetClientRegistry(clientRegistry *bamlutils.ClientRegistry) error {
 	if clientRegistry == nil {

--- a/internal/nativeprompt/testdata/staticserve_op_fixtures/eq/generated/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_op_fixtures/eq/generated/adapter.go
@@ -559,8 +559,9 @@ func staticAssertConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any,
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticAssertConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -1452,8 +1453,9 @@ func staticCheckedConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {

--- a/internal/nativeprompt/testdata/staticserve_op_fixtures/eq/generated/adapter/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_op_fixtures/eq/generated/adapter/adapter.go
@@ -48,6 +48,13 @@ type BamlAdapter struct {
 	// text passed to Parse/ParseStream.
 	includeReasoning bool
 
+	// softFinalParse is the per-handler opt-in (dynclient.WithSoftFinalParse)
+	// that softens a final structured-parse miss on a raw-wanted STREAM into a
+	// successful raw-only final instead of a hard error. Default false keeps the
+	// strict final parse. Consumed by the stream router as
+	// StreamConfig.SoftFinalParse (streaming + raw only).
+	softFinalParse bool
+
 	// clientRegistryProvider is the provider of the primary client from
 	// the runtime ClientRegistry override. Empty if no override.
 	clientRegistryProvider string
@@ -175,6 +182,12 @@ func (b *BamlAdapter) SetIncludeReasoning(includeReasoning bool) {
 }
 func (b *BamlAdapter) IncludeReasoning() bool {
 	return b.includeReasoning
+}
+func (b *BamlAdapter) SetSoftFinalParse(softFinalParse bool) {
+	b.softFinalParse = softFinalParse
+}
+func (b *BamlAdapter) SoftFinalParse() bool {
+	return b.softFinalParse
 }
 func (b *BamlAdapter) SetClientRegistry(clientRegistry *bamlutils.ClientRegistry) error {
 	if clientRegistry == nil {

--- a/internal/nativeprompt/testdata/staticserve_op_fixtures/ge/generated/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_op_fixtures/ge/generated/adapter.go
@@ -559,8 +559,9 @@ func staticAssertConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any,
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticAssertConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -1452,8 +1453,9 @@ func staticCheckedConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {

--- a/internal/nativeprompt/testdata/staticserve_op_fixtures/ge/generated/adapter/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_op_fixtures/ge/generated/adapter/adapter.go
@@ -48,6 +48,13 @@ type BamlAdapter struct {
 	// text passed to Parse/ParseStream.
 	includeReasoning bool
 
+	// softFinalParse is the per-handler opt-in (dynclient.WithSoftFinalParse)
+	// that softens a final structured-parse miss on a raw-wanted STREAM into a
+	// successful raw-only final instead of a hard error. Default false keeps the
+	// strict final parse. Consumed by the stream router as
+	// StreamConfig.SoftFinalParse (streaming + raw only).
+	softFinalParse bool
+
 	// clientRegistryProvider is the provider of the primary client from
 	// the runtime ClientRegistry override. Empty if no override.
 	clientRegistryProvider string
@@ -175,6 +182,12 @@ func (b *BamlAdapter) SetIncludeReasoning(includeReasoning bool) {
 }
 func (b *BamlAdapter) IncludeReasoning() bool {
 	return b.includeReasoning
+}
+func (b *BamlAdapter) SetSoftFinalParse(softFinalParse bool) {
+	b.softFinalParse = softFinalParse
+}
+func (b *BamlAdapter) SoftFinalParse() bool {
+	return b.softFinalParse
 }
 func (b *BamlAdapter) SetClientRegistry(clientRegistry *bamlutils.ClientRegistry) error {
 	if clientRegistry == nil {

--- a/internal/nativeprompt/testdata/staticserve_op_fixtures/le/generated/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_op_fixtures/le/generated/adapter.go
@@ -559,8 +559,9 @@ func staticAssertConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any,
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticAssertConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -1452,8 +1453,9 @@ func staticCheckedConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {

--- a/internal/nativeprompt/testdata/staticserve_op_fixtures/le/generated/adapter/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_op_fixtures/le/generated/adapter/adapter.go
@@ -48,6 +48,13 @@ type BamlAdapter struct {
 	// text passed to Parse/ParseStream.
 	includeReasoning bool
 
+	// softFinalParse is the per-handler opt-in (dynclient.WithSoftFinalParse)
+	// that softens a final structured-parse miss on a raw-wanted STREAM into a
+	// successful raw-only final instead of a hard error. Default false keeps the
+	// strict final parse. Consumed by the stream router as
+	// StreamConfig.SoftFinalParse (streaming + raw only).
+	softFinalParse bool
+
 	// clientRegistryProvider is the provider of the primary client from
 	// the runtime ClientRegistry override. Empty if no override.
 	clientRegistryProvider string
@@ -175,6 +182,12 @@ func (b *BamlAdapter) SetIncludeReasoning(includeReasoning bool) {
 }
 func (b *BamlAdapter) IncludeReasoning() bool {
 	return b.includeReasoning
+}
+func (b *BamlAdapter) SetSoftFinalParse(softFinalParse bool) {
+	b.softFinalParse = softFinalParse
+}
+func (b *BamlAdapter) SoftFinalParse() bool {
+	return b.softFinalParse
 }
 func (b *BamlAdapter) SetClientRegistry(clientRegistry *bamlutils.ClientRegistry) error {
 	if clientRegistry == nil {

--- a/internal/nativeprompt/testdata/staticserve_op_fixtures/lt/generated/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_op_fixtures/lt/generated/adapter.go
@@ -559,8 +559,9 @@ func staticAssertConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any,
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticAssertConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -1452,8 +1453,9 @@ func staticCheckedConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {

--- a/internal/nativeprompt/testdata/staticserve_op_fixtures/lt/generated/adapter/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_op_fixtures/lt/generated/adapter/adapter.go
@@ -48,6 +48,13 @@ type BamlAdapter struct {
 	// text passed to Parse/ParseStream.
 	includeReasoning bool
 
+	// softFinalParse is the per-handler opt-in (dynclient.WithSoftFinalParse)
+	// that softens a final structured-parse miss on a raw-wanted STREAM into a
+	// successful raw-only final instead of a hard error. Default false keeps the
+	// strict final parse. Consumed by the stream router as
+	// StreamConfig.SoftFinalParse (streaming + raw only).
+	softFinalParse bool
+
 	// clientRegistryProvider is the provider of the primary client from
 	// the runtime ClientRegistry override. Empty if no override.
 	clientRegistryProvider string
@@ -175,6 +182,12 @@ func (b *BamlAdapter) SetIncludeReasoning(includeReasoning bool) {
 }
 func (b *BamlAdapter) IncludeReasoning() bool {
 	return b.includeReasoning
+}
+func (b *BamlAdapter) SetSoftFinalParse(softFinalParse bool) {
+	b.softFinalParse = softFinalParse
+}
+func (b *BamlAdapter) SoftFinalParse() bool {
+	return b.softFinalParse
 }
 func (b *BamlAdapter) SetClientRegistry(clientRegistry *bamlutils.ClientRegistry) error {
 	if clientRegistry == nil {

--- a/internal/nativeprompt/testdata/staticserve_op_fixtures/ne/generated/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_op_fixtures/ne/generated/adapter.go
@@ -559,8 +559,9 @@ func staticAssertConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any,
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticAssertConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {
@@ -1452,8 +1453,9 @@ func staticCheckedConfidenceBuildRequest(adapter bamlutils.Adapter, rawInput any
 		NewMetadataResult: func(md *bamlutils.Metadata) bamlutils.StreamResult {
 			return newStaticCheckedConfidenceOutputMetadata(md)
 		},
-		Provider:    provider,
-		RetryPolicy: retryPolicy,
+		Provider:       provider,
+		RetryPolicy:    retryPolicy,
+		SoftFinalParse: adapter.SoftFinalParse(),
 	}
 	__httpClient := llmhttp.DefaultClient
 	if __c := adapter.HTTPClient(); __c != nil {

--- a/internal/nativeprompt/testdata/staticserve_op_fixtures/ne/generated/adapter/adapter.go
+++ b/internal/nativeprompt/testdata/staticserve_op_fixtures/ne/generated/adapter/adapter.go
@@ -48,6 +48,13 @@ type BamlAdapter struct {
 	// text passed to Parse/ParseStream.
 	includeReasoning bool
 
+	// softFinalParse is the per-handler opt-in (dynclient.WithSoftFinalParse)
+	// that softens a final structured-parse miss on a raw-wanted STREAM into a
+	// successful raw-only final instead of a hard error. Default false keeps the
+	// strict final parse. Consumed by the stream router as
+	// StreamConfig.SoftFinalParse (streaming + raw only).
+	softFinalParse bool
+
 	// clientRegistryProvider is the provider of the primary client from
 	// the runtime ClientRegistry override. Empty if no override.
 	clientRegistryProvider string
@@ -175,6 +182,12 @@ func (b *BamlAdapter) SetIncludeReasoning(includeReasoning bool) {
 }
 func (b *BamlAdapter) IncludeReasoning() bool {
 	return b.includeReasoning
+}
+func (b *BamlAdapter) SetSoftFinalParse(softFinalParse bool) {
+	b.softFinalParse = softFinalParse
+}
+func (b *BamlAdapter) SoftFinalParse() bool {
+	return b.softFinalParse
 }
 func (b *BamlAdapter) SetClientRegistry(clientRegistry *bamlutils.ClientRegistry) error {
 	if clientRegistry == nil {

--- a/internal/nativespinefixture/adapter.go
+++ b/internal/nativespinefixture/adapter.go
@@ -51,6 +51,8 @@ func (a *fixtureAdapter) SetRetryConfig(c *bamlutils.RetryConfig) { a.retryConfi
 func (a *fixtureAdapter) RetryConfig() *bamlutils.RetryConfig     { return a.retryConfig }
 func (a *fixtureAdapter) SetIncludeReasoning(v bool)              { a.includeReasoning = v }
 func (a *fixtureAdapter) IncludeReasoning() bool                  { return a.includeReasoning }
+func (a *fixtureAdapter) SetSoftFinalParse(bool)                  {}
+func (a *fixtureAdapter) SoftFinalParse() bool                    { return false }
 func (a *fixtureAdapter) ClientRegistryProvider() string          { return "" }
 func (a *fixtureAdapter) OriginalClientRegistry() *bamlutils.ClientRegistry {
 	return a.originalRegistry

--- a/worker/handler.go
+++ b/worker/handler.go
@@ -219,6 +219,19 @@ type deBAMLParserSetter interface {
 	SetDeBAMLParser(bamlutils.DeBAMLParseFunc)
 }
 
+// softFinalParseSetter is the narrow optional interface the adapter
+// implements to receive the per-handler soft-final opt-in
+// (dynclient.WithSoftFinalParse). Kept OFF bamlutils.Adapter — only the
+// getter SoftFinalParse() is on the interface (the generated stream router
+// reads it) — so minimal adapter doubles that only exercise non-streaming
+// routes (e.g. the direct-parse route double, which embeds bamlutils.Adapter
+// and implements only the setters it uses) need not implement a setter
+// configureAdapter would otherwise dispatch on their nil embed. The generated
+// dynclient/static adapters implement it.
+type softFinalParseSetter interface {
+	SetSoftFinalParse(bool)
+}
+
 // nativeShadowSetter is the narrow optional interface the adapter implements to
 // receive the native one-send SHADOW comparator (de-BAML cutover Slice 4). Kept
 // off the bamlutils.Adapter interface like the renderer/parser setters so test
@@ -476,7 +489,12 @@ func (h *Handler) NativeCapability() NativeCapability {
 func (h *Handler) configureAdapter(adapter bamlutils.Adapter) {
 	adapter.SetHTTPClient(h.httpClient)
 	adapter.SetDeBAMLConfig(h.deBAML)
-	adapter.SetSoftFinalParse(h.softFinalParse)
+	// Installed via the optional interface (not an unconditional call) so
+	// minimal non-streaming adapter doubles that embed a nil bamlutils.Adapter
+	// are skipped rather than dispatching SetSoftFinalParse on the nil embed.
+	if setter, ok := adapter.(softFinalParseSetter); ok {
+		setter.SetSoftFinalParse(h.softFinalParse)
+	}
 	if setter, ok := adapter.(deBAMLRendererSetter); ok {
 		setter.SetDeBAMLRenderer(h.deBAMLRender)
 	}

--- a/worker/handler.go
+++ b/worker/handler.go
@@ -62,6 +62,16 @@ type Config struct {
 	BaseURLRewrites []urlrewrite.Rule
 	HTTPClient      *llmhttp.Client
 
+	// SoftFinalParse is the per-handler opt-in (dynclient.WithSoftFinalParse)
+	// that softens a final structured-parse miss on a raw-wanted STREAM
+	// (/stream-with-raw, StreamModeStreamWithRaw) into a successful raw-only
+	// final instead of a hard error. Zero value (false) keeps the strict
+	// final parse. configureAdapter installs it on every adapter; the
+	// orchestrator gates it on NeedsPartials && NeedsRaw (streaming only) and
+	// never applies it to a cancellation/deadline. dynclient supplies it
+	// explicitly; server/worker entrypoints leave it false today.
+	SoftFinalParse bool
+
 	// DeBAML mirrors BAML_REST_USE_DEBAML — the umbrella switch for
 	// native de-BAML behaviour (the native ctx.output_format renderer on
 	// the dynamic BuildRequest route today). Zero value (disabled) keeps
@@ -307,6 +317,10 @@ type Handler struct {
 	deBAMLRender    bamlutils.DeBAMLRenderFunc
 	deBAMLParse     bamlutils.DeBAMLParseFunc
 
+	// softFinalParse mirrors Config.SoftFinalParse — the per-handler
+	// soft-final opt-in installed on every adapter in configureAdapter.
+	softFinalParse bool
+
 	// nativeCapability is the neutral native-send capability linked into this
 	// worker binary, or nil for the BAML-only worker. Stored at construction
 	// and read back via NativeCapability; never wired to the orchestrator in
@@ -411,6 +425,7 @@ func New(cfg Config) (*Handler, error) {
 		deBAML:                  cfg.DeBAML,
 		deBAMLRender:            cfg.DeBAMLRender,
 		deBAMLParse:             cfg.DeBAMLParse,
+		softFinalParse:          cfg.SoftFinalParse,
 		nativeCapability:        cfg.NativeCapability,
 		nativeShadow:            cfg.NativeShadowComparator,
 		nativeServe:             cfg.NativeServeComparator,
@@ -461,6 +476,7 @@ func (h *Handler) NativeCapability() NativeCapability {
 func (h *Handler) configureAdapter(adapter bamlutils.Adapter) {
 	adapter.SetHTTPClient(h.httpClient)
 	adapter.SetDeBAMLConfig(h.deBAML)
+	adapter.SetSoftFinalParse(h.softFinalParse)
 	if setter, ok := adapter.(deBAMLRendererSetter); ok {
 		setter.SetDeBAMLRenderer(h.deBAMLRender)
 	}

--- a/worker/runtime_testhelpers_test.go
+++ b/worker/runtime_testhelpers_test.go
@@ -88,6 +88,8 @@ func (a *fakeAdapter) SetRetryConfig(c *bamlutils.RetryConfig) { a.retryConfig =
 func (a *fakeAdapter) RetryConfig() *bamlutils.RetryConfig     { return a.retryConfig }
 func (a *fakeAdapter) SetIncludeReasoning(v bool)              { a.includeReasoning = v }
 func (a *fakeAdapter) IncludeReasoning() bool                  { return a.includeReasoning }
+func (a *fakeAdapter) SetSoftFinalParse(bool)                  {}
+func (a *fakeAdapter) SoftFinalParse() bool                    { return false }
 func (a *fakeAdapter) ClientRegistryProvider() string          { return a.clientRegistryProvider }
 func (a *fakeAdapter) OriginalClientRegistry() *bamlutils.ClientRegistry {
 	return a.originalRegistry


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->

Forward-port of the Codex-approved 0.0.48 hotfix (`hotfix/raw-stream-partials`, tip `648f3c566`) to **master (the de-BAML codebase)**. The same raw-stream gating bug is live on canary today; this adapts the approved design to master's restructured orchestrator (an adaptation, not a cherry-pick) and preserves the `WithSoftFinalParse` opt-in so it survives de-BAML.

## The bug (confirmed live on master)
`bamlutils/buildrequest/orchestrator.go` emitted the raw delta for an ordinary-text tick **only inside `if parseErr == nil && parsed != nil`**. Plain prose streamed against a `{value: string}` class schema fails BAML's `ParseStream` for every prefix, so **no live raw partials** reached the caller, and `parseFinal` then hard-failed the whole call.

## The fix (mirrors the approved design + all 5 hardening fixes)
**(1) Raw-decouple, always-on for `NeedsRaw`** — in **both** cadence sites:
- the shared `processDelta` closure (drives the SSE lane *and* the de-BAML native `EmitDelta` lane), and
- the structurally-parallel inline copy in `tryOneBedrockStreamChild`.

Raw is delivered whenever the parse errors, returns nil, **or the tick is throttle-skipped**. Non-raw streams keep their strict cadence.

**(2) Opt-in soft-final (default OFF)** — both BAML/hybrid final arms (SSE + bedrock), before the strict `newRawError`:
```
NeedsPartials && NeedsRaw && SoftFinalParse &&
  ctx.Err()==nil && !errors.Is(parseErr, context.Canceled) &&
  !errors.Is(parseErr, context.DeadlineExceeded)
```
→ completes with the accumulated raw (nil structured final). Streaming-scoped (excludes the `DynamicCallRaw` bridge, `NeedsPartials=false`), cancellation-safe. The de-BAML **native** lane's final parse stays terminal by design (untouched).

## The option (`dynclient.WithSoftFinalParse()`)
Threaded via master's **per-handler config idiom** (the `DeBAMLConfig` template) — **not** `BamlOptions` — so the `codegenspine` `options_envelope` guard is not touched:
```
WithSoftFinalParse() → config.softFinalParse → worker.Config.SoftFinalParse
  → Handler.softFinalParse → configureAdapter: adapter.SetSoftFinalParse()
  → bamlutils.Adapter.{Set,}SoftFinalParse() → StreamConfig.SoftFinalParse → orchestrator
```
Codegen emitters (`codegen_adapter.go`, `codegen_buildrequest.go`) updated in lockstep; `dynclient/internal/generated` regenerated **exactly** via `go run ./dynclient/cmd/genadapter` (byte-identical to the fresh-tree CI gate, verified idempotent).

## Tests (locked failing-first)
- 8 hermetic orchestrator locks (SSE + Bedrock raw-decouple, throttle guard, soft-final opt-in, default-strict, streaming-scope guard, cancellation guard) — proven to FAIL on clean master, then green.
- dynclient threading lock (`WithSoftFinalParse` → adapter, opt-in vs default-off).
- Real-BAML E2E (`//go:build integration`) asserting the stable `failed to parse final result` + `Failed to coerce value` customer error and the soft-final success.

## de-BAML machinery reconciliation
- **codegenspine guard**: not tripped — Template B avoids `BamlOptions`; no guarded tree (`internal/debaml`, `nativeserve`, `internal/nativebody/nanollmprepare`), pin, or tar touched.
- **embed**: no new file lands in the embed tree; `go run ./cmd/embed` is a no-op.
- **staticserve fixtures** regenerated via `gen-staticserve-fixture` (offline, idempotent) so the gated de-BAML static-serve suites compile.

**Full suites green, zero regressions** across root, `bamlutils`, `worker`, `dynclient`, `pool`, `workerplugin`, `introspected`, and `adapters/common/codegen` (`GOWORK=off`); `go vet` clean; `nativeserve` builds against the modified `bamlutils`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nPsK9dpAZCJsbXaD7Vfgh


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional soft final-parse mode for streaming raw responses.
  * Raw partial results remain available when final structured parsing fails or is skipped.
  * Added a client option to enable soft final parsing for applicable streaming calls.

* **Bug Fixes**
  * Preserved strict parsing for non-streaming calls, non-raw streams, and cancellation or deadline errors.

* **Tests**
  * Added coverage for SSE, AWS event streams, dynamic clients, and integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->