### PR TITLE
feat(debaml): M3b native output carriers — unions, literals, canonical aliases

### DIFF
--- a/adapters/common/codegen/nativespine.go
+++ b/adapters/common/codegen/nativespine.go
@@ -13,13 +13,23 @@ package codegen
 //
 // Two faithfulness properties the M1 review required:
 //
-//   - Output carriers serialize the EXACT BAML wire key of every field via a
-//     pure-Go custom JSON codec (nativeSpineMarshalObject/UnmarshalObject), so
-//     arbitrary aliases — "-", "", names with commas, unicode — round-trip
-//     losslessly instead of being mangled by an encoding/json struct tag.
+//   - Output carriers serialize each field under its CANONICAL BAML key via a
+//     pure-Go custom JSON codec (nativeSpineMarshalObject/UnmarshalObject).
+//     BAML serves — and a generated Go struct tags — the canonical field name
+//     and canonical enum value, never an @alias (empirically confirmed, M3b
+//     scope §2); the alias is ingress-only metadata and is never an output
+//     token. The custom codec is retained over a struct tag because a canonical
+//     name can still be a string a struct tag cannot express ("-", "", a comma),
+//     and to keep HTML escaping off to match the serving path.
 //   - Emitted output type names are namespaced with an "Output" prefix so they
 //     can never collide with the fixed generated declarations (Executor,
 //     MethodName, BuildMethod, ErrUnsupportedStreamMode, <Method>Input).
+//
+// M3b extends the carrier vocabulary with multi-arm unions (a discriminated
+// value carrier per union — see nativespine_union.go), string/int/bool literals
+// (a standalone literal lowers to its plain Go base; a literal union arm carries
+// its identity via a no-argument constructor), and @alias metadata (admitted and
+// ignored for output token selection).
 //
 // It is separate from the reflection-driven adapter codegen in this package: it
 // learns the method from the descriptor artifact, never from a reflected
@@ -101,12 +111,12 @@ func CheckNativeNameCollision(methodName string, argNames []string, ret schemade
 		// output class, and Go forbids a field and method with the same name — so
 		// reserve those identifiers in the per-class set alongside the fields.
 		fields := map[string]string{"MarshalJSON": "generated codec method", "UnmarshalJSON": "generated codec method"}
-		// The codec keys its map[string]any / marshals each field by its exact WIRE
-		// key (wireName: alias when present, else canonical name), which is a
-		// different space than the normalized Go field. Two fields can share a wire
-		// key (e.g. a field aliased onto another's name, or two empty aliases) while
-		// having distinct Go fields; that emits a duplicate map-literal key (a Go
-		// compile error) and a doubled JSON key. Reject it here, fail-closed.
+		// The codec keys its map[string]any / marshals each field by its CANONICAL
+		// name (field.Name.Name), never an @alias (aliases are ignored on output).
+		// BAML forbids two fields of a class sharing a canonical name, but the
+		// direct emitter accepts synthetic bundles, so reject a duplicate canonical
+		// key fail-closed (it would emit a duplicate map-literal key — a Go compile
+		// error — and a doubled JSON key).
 		keys := map[string]bool{}
 		for _, f := range c.Fields {
 			fg := strcase.UpperCamelCase(f.Name.Name)
@@ -114,9 +124,9 @@ func CheckNativeNameCollision(methodName string, argNames []string, ret schemade
 				return fmt.Errorf("field %q of class %q normalizes to Go identifier %q, colliding with %s", f.Name.Name, c.Name.Name, fg, what)
 			}
 			fields[fg] = "field " + f.Name.Name
-			k := wireName(f.Name)
+			k := f.Name.Name
 			if keys[k] {
-				return fmt.Errorf("fields of class %q share the wire key %q", c.Name.Name, k)
+				return fmt.Errorf("fields of class %q share the canonical key %q", c.Name.Name, k)
 			}
 			keys[k] = true
 		}
@@ -129,6 +139,25 @@ func CheckNativeNameCollision(methodName string, argNames []string, ret schemade
 		for _, v := range e.Values {
 			if err := claim(enumType+strcase.UpperCamelCase(v.Name.Name), "enum constant of "+e.Name.Name); err != nil {
 				return err
+			}
+		}
+	}
+	// Planned multi-arm union carriers add package-level identifiers: the carrier
+	// type (OutputUnionN) and its per-arm constructors (OutputUnionNNewVariantK).
+	// Claiming them here keeps admission and emission on ONE plan, so a class
+	// named e.g. "Union1" (→ OutputUnion1) is declined as a collision rather than
+	// emitted as a duplicate declaration. A malformed union (unplannable) is left
+	// to classifyOutputSchema / the emitter's own buildCarrierPlan to reject with
+	// its shape code, so a plan-build error here is not turned into a collision.
+	if plan, perr := buildCarrierPlan(ret); perr == nil {
+		for _, u := range plan.unions {
+			if err := claim(u.name, "output union carrier"); err != nil {
+				return err
+			}
+			for i := range u.variants {
+				if err := claim(fmt.Sprintf("%sNewVariant%d", u.name, i), "union constructor of "+u.name); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -176,30 +205,40 @@ func EmitNativeStaticUnary(m projectdescriptor.Method, opts NativeSpineOptions) 
 		return nil, fmt.Errorf("codegen: method %q: %w", m.Name, err)
 	}
 
+	// Plan the reachable multi-arm unions before writing any declaration; a
+	// malformed union (zero-arm) fails closed here even if the classifier
+	// preflight was bypassed (M3b open risk 4).
+	plan, err := buildCarrierPlan(m.Return)
+	if err != nil {
+		return nil, fmt.Errorf("codegen: method %q: %w", m.Name, err)
+	}
+
 	inputStruct := strcase.UpperCamelCase(m.Name + "Input")
 
-	outputBase, err := schemaGoType(m.Return.Target)
+	outputBase, err := schemaGoType(m.Return.Target, plan)
 	if err != nil {
 		return nil, fmt.Errorf("codegen: method %q: output %w", m.Name, err)
 	}
 
 	hasClasses := len(m.Return.Classes) > 0
 	hasEnums := len(m.Return.Enums) > 0
+	hasUnions := len(plan.unions) > 0
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "// Code generated by adapters/common/codegen EmitNativeStaticUnary; DO NOT EDIT.\n\n")
 	fmt.Fprintf(&b, "package %s\n\n", opts.PackageName)
 
 	// Imports: fmt + bamlutils always. bytes when an output class is emitted (its
-	// codec assembles bytes by hand). encoding/json when a class OR an enum is
-	// emitted: the class codec encodes each field with it (HTML escaping off, to
-	// match the serving serializer), and the validating enum codec marshals/
-	// unmarshals its string value with it.
+	// codec assembles bytes by hand). encoding/json when a class, an enum, OR a
+	// union carrier is emitted: the class codec encodes each field with it (HTML
+	// escaping off, to match the serving serializer), the validating enum codec
+	// marshals/unmarshals its string value with it, and the union carrier codec
+	// marshals/unmarshals the selected arm with it (BAML generated-carrier parity).
 	b.WriteString("import (\n")
 	if hasClasses {
 		fmt.Fprintf(&b, "\t%q\n", "bytes")
 	}
-	if hasClasses || hasEnums {
+	if hasClasses || hasEnums || hasUnions {
 		fmt.Fprintf(&b, "\t%q\n", "encoding/json")
 	}
 	fmt.Fprintf(&b, "\t%q\n\n\t%q\n)\n\n", "fmt", bamlutilsPkg)
@@ -228,7 +267,10 @@ func EmitNativeStaticUnary(m projectdescriptor.Method, opts NativeSpineOptions) 
 		if len(e.Values) > 0 {
 			fmt.Fprintf(&b, "const (\n")
 			for _, v := range e.Values {
-				fmt.Fprintf(&b, "\t%s%s %s = %q\n", name, strcase.UpperCamelCase(v.Name.Name), name, wireName(v.Name))
+				// CANONICAL enum value (v.Name.Name), never the alias: BAML serves
+				// canonical enum members and a generated enum validates against them
+				// (empirically confirmed, scope §2). An @alias is metadata only.
+				fmt.Fprintf(&b, "\t%s%s %s = %q\n", name, strcase.UpperCamelCase(v.Name.Name), name, v.Name.Name)
 			}
 			fmt.Fprintf(&b, ")\n\n")
 		}
@@ -240,17 +282,26 @@ func EmitNativeStaticUnary(m projectdescriptor.Method, opts NativeSpineOptions) 
 		fmt.Fprintf(&b, "type %s struct {\n", name)
 		fields := make([]string, 0, len(c.Fields))
 		for _, f := range c.Fields {
-			gt, err := schemaGoType(f.Type)
+			gt, err := schemaGoType(f.Type, plan)
 			if err != nil {
 				return nil, fmt.Errorf("codegen: method %q: class %s field %q %w", m.Name, c.Name.Name, f.Name.Name, err)
 			}
 			goField := strcase.UpperCamelCase(f.Name.Name)
 			fields = append(fields, goField)
-			// No json struct tag: the custom codec below emits the exact wire key.
+			// No json struct tag: the custom codec below emits the canonical key.
 			fmt.Fprintf(&b, "\t%s %s\n", goField, gt)
 		}
 		fmt.Fprintf(&b, "}\n\n")
 		emitClassCodec(&b, name, c.Fields, fields)
+	}
+
+	// Output union carriers, in first-reach plan order (OutputUnion1, ...). A
+	// class field / list element / map value / nested-union arm above binds to
+	// these by name; Go resolves the forward reference at package level.
+	for _, u := range plan.unions {
+		if err := emitUnionCarrier(&b, u, plan); err != nil {
+			return nil, fmt.Errorf("codegen: method %q: %w", m.Name, err)
+		}
 	}
 
 	// Neutral executor seam + boilerplate + registration (+ object-codec helpers
@@ -265,21 +316,26 @@ func EmitNativeStaticUnary(m projectdescriptor.Method, opts NativeSpineOptions) 
 }
 
 // emitClassCodec emits MarshalJSON/UnmarshalJSON for one output class that map
-// each Go field to the EXACT BAML wire key, so arbitrary aliases round-trip.
+// each Go field to its CANONICAL BAML key (field.Name.Name). BAML serves — and a
+// generated Go struct tags — the canonical field name, never an @alias
+// (empirically confirmed, scope §2); the alias is ingress-only metadata and is
+// never an output token. The custom codec is retained (over a struct tag)
+// because a canonical name can still be a string a struct tag cannot express
+// ("-", "", a comma), and to keep HTML escaping off to match the serving path.
 func emitClassCodec(b *strings.Builder, typeName string, schemaFields []schemadescriptor.ClassField, goFields []string) {
-	fmt.Fprintf(b, "// MarshalJSON emits %s with each field under its exact BAML wire key.\n", typeName)
+	fmt.Fprintf(b, "// MarshalJSON emits %s with each field under its canonical BAML key.\n", typeName)
 	fmt.Fprintf(b, "func (v %s) MarshalJSON() ([]byte, error) {\n", typeName)
 	fmt.Fprintf(b, "\treturn nativeSpineMarshalObject([]nativeSpineField{\n")
 	for i, f := range schemaFields {
-		fmt.Fprintf(b, "\t\t{%q, v.%s},\n", wireName(f.Name), goFields[i])
+		fmt.Fprintf(b, "\t\t{%q, v.%s},\n", f.Name.Name, goFields[i])
 	}
 	fmt.Fprintf(b, "\t})\n}\n\n")
 
-	fmt.Fprintf(b, "// UnmarshalJSON reads %s from each field's exact BAML wire key.\n", typeName)
+	fmt.Fprintf(b, "// UnmarshalJSON reads %s from each field's canonical BAML key.\n", typeName)
 	fmt.Fprintf(b, "func (v *%s) UnmarshalJSON(data []byte) error {\n", typeName)
 	fmt.Fprintf(b, "\treturn nativeSpineUnmarshalObject(data, map[string]any{\n")
 	for i, f := range schemaFields {
-		fmt.Fprintf(b, "\t\t%q: &v.%s,\n", wireName(f.Name), goFields[i])
+		fmt.Fprintf(b, "\t\t%q: &v.%s,\n", f.Name.Name, goFields[i])
 	}
 	fmt.Fprintf(b, "\t})\n}\n\n")
 }
@@ -493,22 +549,18 @@ func BuildMethod(exec Executor) (bamlutils.StreamingMethod, bamlutils.ParseMetho
 ` + codec
 }
 
-// wireName returns the JSON wire name for a schemadescriptor.Name: its alias when
-// present (even when empty), else its canonical name.
-func wireName(n schemadescriptor.Name) string {
-	if n.Alias != nil {
-		return *n.Alias
-	}
-	return n.Name
-}
-
 // schemaGoType maps a schemadescriptor output type to a Go type expression,
-// within the M3a final-carrier profile (primitive/enum/class/list/optional/
-// string-keyed map). Class/enum references use the namespaced output type name.
-// Anything else — union (other than the optional T? form), tuple, literal,
-// recursion, media, dynamic — is a fail-closed error; those stay declined by the
-// classifier until their own sub-slice lands.
-func schemaGoType(t schemadescriptor.Type) (string, error) {
+// within the M3a+M3b final-carrier profile (primitive/enum/class/list/optional/
+// string-keyed map/literal/multi-arm union). Class/enum references use the
+// namespaced output type name; a multi-arm union resolves to its planned carrier
+// name (see [carrierPlan]). Anything else — tuple, recursion, media, dynamic — is
+// a fail-closed error; those stay declined by the classifier until their own
+// sub-slice lands.
+//
+// plan supplies the native names for reachable multi-arm unions and MUST be the
+// plan built for this bundle; a nil plan makes any multi-arm union a fail-closed
+// error (the M3a optional `T?` and literal paths do not need it).
+func schemaGoType(t schemadescriptor.Type, plan *carrierPlan) (string, error) {
 	switch t.Kind {
 	case schemadescriptor.TypePrimitive:
 		switch t.Primitive {
@@ -523,13 +575,18 @@ func schemaGoType(t schemadescriptor.Type) (string, error) {
 		default:
 			return "", fmt.Errorf("primitive %q is outside the carrier profile", t.Primitive)
 		}
+	case schemadescriptor.TypeLiteral:
+		// A standalone/arm literal lowers to its ordinary Go base, exactly like
+		// BAML v0.223 generated fields (e.g. both `true` and `false` fields are
+		// plain `bool`). Literal identity is carried only by union construction.
+		return literalGoBase(t.Literal)
 	case schemadescriptor.TypeEnum, schemadescriptor.TypeClass:
 		return outputTypeName(t.Name), nil
 	case schemadescriptor.TypeList:
 		if t.Elem == nil {
 			return "", fmt.Errorf("list has no element type")
 		}
-		elem, err := schemaGoType(*t.Elem)
+		elem, err := schemaGoType(*t.Elem, plan)
 		if err != nil {
 			return "", err
 		}
@@ -544,20 +601,35 @@ func schemaGoType(t schemadescriptor.Type) (string, error) {
 		if t.Key.Kind != schemadescriptor.TypePrimitive || t.Key.Primitive != schemadescriptor.PrimitiveString {
 			return "", fmt.Errorf("only string-keyed maps are in the carrier profile")
 		}
-		val, err := schemaGoType(*t.Value)
+		val, err := schemaGoType(*t.Value, plan)
 		if err != nil {
 			return "", err
 		}
 		return "map[string]" + val, nil
 	case schemadescriptor.TypeUnion:
-		if t.Union != nil && t.Union.Nullable && len(t.Union.Variants) == 1 {
-			inner, err := schemaGoType(t.Union.Variants[0])
+		if t.Union == nil {
+			return "", fmt.Errorf("union has no payload")
+		}
+		// Optional-of-one (`T?`) stays M3a's `*T`.
+		if t.Union.Nullable && len(t.Union.Variants) == 1 {
+			inner, err := schemaGoType(t.Union.Variants[0], plan)
 			if err != nil {
 				return "", err
 			}
 			return "*" + inner, nil
 		}
-		return "", fmt.Errorf("only optional (single nullable variant) unions are in the carrier profile")
+		// Multi-arm union → its planned carrier; nullable multi-arm → *carrier.
+		if len(t.Union.Variants) >= 2 {
+			name, ok := plan.unionName(t.Union.Variants)
+			if !ok {
+				return "", fmt.Errorf("multi-arm union was not planned (admission outran emission)")
+			}
+			if t.Union.Nullable {
+				return "*" + name, nil
+			}
+			return name, nil
+		}
+		return "", fmt.Errorf("union with %d variant(s) is outside the carrier profile", len(t.Union.Variants))
 	default:
 		return "", fmt.Errorf("type kind %q is outside the carrier profile", t.Kind)
 	}

--- a/adapters/common/codegen/nativespine_test.go
+++ b/adapters/common/codegen/nativespine_test.go
@@ -300,6 +300,9 @@ func TestEmitNativeStaticUnaryRejectsUnionNameCollisions(t *testing.T) {
 	if _, err := EmitNativeStaticUnary(cc, NativeSpineOptions{PackageName: "p"}); err == nil {
 		t.Error("want error for class Union1NewVariant0 colliding with planned constructor, got nil")
 	}
+	if err := CheckNativeNameCollision(cc.Name, nil, cc.Return); err == nil {
+		t.Error("classifier preflight must also reject the union constructor-name collision")
+	}
 }
 
 // TestEmitNativeStaticUnaryRejectsMalformedUnion is the emitter backstop for a

--- a/adapters/common/codegen/nativespine_test.go
+++ b/adapters/common/codegen/nativespine_test.go
@@ -105,30 +105,28 @@ func aliasMethod(alias string) projectdescriptor.Method {
 	return m
 }
 
-// TestEmitNativeStaticUnaryAliasCodec proves output fields serialize under their
-// EXACT BAML wire key via the custom codec — even keys a Go struct tag cannot
-// express ("-" would drop the field; "" would fall back to the Go name) (P1-4).
-func TestEmitNativeStaticUnaryAliasCodec(t *testing.T) {
-	dash, err := EmitNativeStaticUnary(aliasMethod("-"), NativeSpineOptions{PackageName: "p"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	got := string(dash)
-	if strings.Contains(got, "`json:\"-\"`") {
-		t.Error("emitted a json:\"-\" struct tag on an output field — encoding/json would drop it")
-	}
-	// Marshal side carries the exact key; unmarshal side keys on it too (gofmt may
-	// pad the map value, so match the key alone).
-	if !strings.Contains(got, `{"-", v.Text}`) || !strings.Contains(got, `"-":`) {
-		t.Errorf("codec does not carry the exact wire key %q:\n%s", "-", got)
-	}
-
-	empty, err := EmitNativeStaticUnary(aliasMethod(""), NativeSpineOptions{PackageName: "p"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(empty), `{"", v.Text}`) {
-		t.Error("codec does not carry an empty wire key")
+// TestEmitNativeStaticUnaryAliasIgnoredCanonicalOutput proves M3b's canonical
+// output-key policy (scope §2): an @alias on an output field is IGNORED — the
+// codec keys the field by its CANONICAL name (field.Name.Name), never the alias.
+// This holds for exotic aliases a struct tag could not even express ("-", "", a
+// comma, unicode), which must NOT become output tokens.
+func TestEmitNativeStaticUnaryAliasIgnoredCanonicalOutput(t *testing.T) {
+	for _, alias := range []string{"-", "", "a,b", "naïve", "score"} {
+		src, err := EmitNativeStaticUnary(aliasMethod(alias), NativeSpineOptions{PackageName: "p"})
+		if err != nil {
+			t.Fatalf("alias %q: emit: %v", alias, err)
+		}
+		got := string(src)
+		// The canonical field name "text" is the marshal AND unmarshal key.
+		if !strings.Contains(got, `{"text", v.Text}`) || !strings.Contains(got, `"text":`) {
+			t.Errorf("alias %q: codec does not key on the canonical name %q:\n%s", alias, "text", got)
+		}
+		// The alias string is never emitted as a codec key (skip "" which would
+		// match spuriously, and skip "score" which contains no chars that would
+		// only appear as a key — assert the codec key line specifically).
+		if alias != "" && strings.Contains(got, `{"`+alias+`", v.Text}`) {
+			t.Errorf("alias %q leaked into the output codec as a wire key:\n%s", alias, got)
+		}
 	}
 }
 
@@ -251,12 +249,94 @@ func TestEmitNativeStaticUnaryRejectsCodecMethodCollision(t *testing.T) {
 	}
 }
 
-// TestEmitNativeStaticUnaryRejectsDuplicateWireKey proves the emitter backstop
-// rejects two fields of one output class that share a WIRE key (alias or canonical
-// name). Their Go fields differ, so the field-normalization guard passes, but the
-// codec would emit a duplicate map-literal key (a Go compile error) and a doubled
-// JSON key. Here `body @alias("text")` collides with the canonical `text`.
-func TestEmitNativeStaticUnaryRejectsDuplicateWireKey(t *testing.T) {
+// unionField returns a class field of a bare 2-arm union type, used to force a
+// planned OutputUnion1 in the synthetic collision tests.
+func unionField(name string, arms ...sd.Type) sd.ClassField {
+	return sd.ClassField{Name: sd.Name{Name: name}, Type: sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Variants: arms}}}
+}
+
+// TestEmitNativeStaticUnaryRejectsUnionNameCollisions is the emitter backstop for
+// the M3b plan (open risk 4): a planned union carrier's type name or constructor
+// name colliding with a declared output type must fail closed, so the classifier
+// (which delegates to CheckNativeNameCollision) declines EXACTLY what the emitter
+// cannot emit. A synthetic descriptor is used because the BAML parser cannot
+// produce these collisions directly.
+func TestEmitNativeStaticUnaryRejectsUnionNameCollisions(t *testing.T) {
+	prim := func(p sd.PrimitiveKind) sd.Type { return sd.Type{Kind: sd.TypePrimitive, Primitive: p} }
+
+	// Union TYPE-name collision: class "Union1" -> OutputUnion1, colliding with the
+	// planned OutputUnion1 for the string|int field.
+	tc := sampleMethod()
+	tc.Name = "UnionTypeCollide"
+	tc.Args = nil
+	tc.Return.Target = sd.Type{Kind: sd.TypeClass, Name: "Wrap"}
+	tc.Return.Classes = []sd.ClassDef{
+		{Name: sd.Name{Name: "Union1"}, Fields: []sd.ClassField{strField("x", "\x00")}},
+		{Name: sd.Name{Name: "Wrap"}, Fields: []sd.ClassField{
+			unionField("u", prim(sd.PrimitiveString), prim(sd.PrimitiveInt)),
+			{Name: sd.Name{Name: "w"}, Type: sd.Type{Kind: sd.TypeClass, Name: "Union1"}},
+		}},
+	}
+	if _, err := EmitNativeStaticUnary(tc, NativeSpineOptions{PackageName: "p"}); err == nil {
+		t.Error("want error for class Union1 colliding with planned OutputUnion1, got nil")
+	}
+	if err := CheckNativeNameCollision(tc.Name, nil, tc.Return); err == nil {
+		t.Error("classifier preflight must also reject the union type-name collision")
+	}
+
+	// Union CONSTRUCTOR-name collision: class "Union1NewVariant0" ->
+	// OutputUnion1NewVariant0, colliding with the generated constructor.
+	cc := sampleMethod()
+	cc.Name = "UnionCtorCollide"
+	cc.Args = nil
+	cc.Return.Target = sd.Type{Kind: sd.TypeClass, Name: "Wrap"}
+	cc.Return.Classes = []sd.ClassDef{
+		{Name: sd.Name{Name: "Union1NewVariant0"}, Fields: []sd.ClassField{strField("x", "\x00")}},
+		{Name: sd.Name{Name: "Wrap"}, Fields: []sd.ClassField{
+			unionField("u", prim(sd.PrimitiveString), prim(sd.PrimitiveInt)),
+			{Name: sd.Name{Name: "w"}, Type: sd.Type{Kind: sd.TypeClass, Name: "Union1NewVariant0"}},
+		}},
+	}
+	if _, err := EmitNativeStaticUnary(cc, NativeSpineOptions{PackageName: "p"}); err == nil {
+		t.Error("want error for class Union1NewVariant0 colliding with planned constructor, got nil")
+	}
+}
+
+// TestEmitNativeStaticUnaryRejectsMalformedUnion is the emitter backstop for a
+// union shape the classifier declines and the BAML parser cannot produce: a
+// zero-arm union and a nil-payload literal arm must fail closed at emit time even
+// when the classifier preflight is bypassed (direct emitter call).
+func TestEmitNativeStaticUnaryRejectsMalformedUnion(t *testing.T) {
+	// Zero-arm (non-nullable) union target.
+	z := sampleMethod()
+	z.Name = "ZeroArm"
+	z.Args = nil
+	z.Return.Target = sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Variants: nil}}
+	z.Return.Classes = nil
+	if _, err := EmitNativeStaticUnary(z, NativeSpineOptions{PackageName: "p"}); err == nil {
+		t.Error("want error for a zero-arm union target, got nil")
+	}
+
+	// A multi-arm union with a nil-payload literal arm.
+	n := sampleMethod()
+	n.Name = "NilLit"
+	n.Args = nil
+	n.Return.Target = sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Variants: []sd.Type{
+		{Kind: sd.TypePrimitive, Primitive: sd.PrimitiveString},
+		{Kind: sd.TypeLiteral, Literal: nil},
+	}}}
+	n.Return.Classes = nil
+	if _, err := EmitNativeStaticUnary(n, NativeSpineOptions{PackageName: "p"}); err == nil {
+		t.Error("want error for a nil-payload literal union arm, got nil")
+	}
+}
+
+// TestEmitNativeStaticUnaryAliasOntoAnotherCanonicalAdmitted proves the M3b
+// output policy resolves the former M3a "duplicate wire key" case: `body
+// @alias("text")` alongside a canonical `text` field no longer collides, because
+// the alias is IGNORED — the two output keys are the distinct canonical names
+// `body` and `text`. The emit succeeds and emits both canonical keys once.
+func TestEmitNativeStaticUnaryAliasOntoAnotherCanonicalAdmitted(t *testing.T) {
 	m := sampleMethod()
 	m.Name = "WireDup"
 	m.Args = nil
@@ -268,8 +348,18 @@ func TestEmitNativeStaticUnaryRejectsDuplicateWireKey(t *testing.T) {
 			{Name: sd.Name{Name: "text"}, Type: sd.Type{Kind: sd.TypePrimitive, Primitive: sd.PrimitiveString}},
 		},
 	}}
-	if _, err := EmitNativeStaticUnary(m, NativeSpineOptions{PackageName: "p"}); err == nil {
-		t.Error("want error for duplicate wire key across two fields, got nil")
+	src, err := EmitNativeStaticUnary(m, NativeSpineOptions{PackageName: "p"})
+	if err != nil {
+		t.Fatalf("alias-onto-another-canonical must be admitted under M3b canonical output, got: %v", err)
+	}
+	got := string(src)
+	if !strings.Contains(got, `{"body", v.Body}`) || !strings.Contains(got, `{"text", v.Text}`) {
+		t.Errorf("expected distinct canonical keys body+text, got:\n%s", got)
+	}
+	// The alias "text" must NOT double the "text" key: exactly one marshal entry
+	// keyed "text" (v.Text), and none keyed "text" for v.Body.
+	if strings.Contains(got, `{"text", v.Body}`) {
+		t.Errorf("alias leaked: body field emitted under alias key \"text\":\n%s", got)
 	}
 }
 
@@ -301,12 +391,13 @@ func TestEmitNativeStaticUnaryRejectsUndeclaredRef(t *testing.T) {
 	}
 }
 
-// TestEmitNativeStaticUnaryAliasRoundTrip is the required BEHAVIORAL proof (P1-4,
-// fix #2): it COMPILES and EXECUTES the emitted MarshalJSON/UnmarshalJSON and
-// asserts exact wire bytes both directions for a canonical (nil-alias) key, a
-// present-empty-alias key, a "-" key, and a comma key — guarding against a
-// marshal/unmarshal key mismatch that would still compile.
-func TestEmitNativeStaticUnaryAliasRoundTrip(t *testing.T) {
+// TestEmitNativeStaticUnaryAliasCanonicalRoundTrip is the required BEHAVIORAL
+// proof of the M3b canonical output-key policy (scope §2): it COMPILES and
+// EXECUTES the emitted MarshalJSON/UnmarshalJSON and asserts the wire bytes use
+// the CANONICAL field names in both directions, even when the fields carry
+// exotic aliases ("", "-", a comma) that a struct tag could not express — the
+// aliases are ignored and never appear in the bytes.
+func TestEmitNativeStaticUnaryAliasCanonicalRoundTrip(t *testing.T) {
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("go not on PATH; skipping behavioral round-trip")
 	}
@@ -317,9 +408,9 @@ func TestEmitNativeStaticUnaryAliasRoundTrip(t *testing.T) {
 		Name: sd.Name{Name: "Reply"},
 		Fields: []sd.ClassField{
 			strField("canon", "\x00"), // nil alias -> canonical "canon"
-			strField("empty", ""),     // present empty alias -> ""
-			strField("dash", "-"),     // "-" (a json:"-" tag would drop the field)
-			strField("comma", "a,b"),  // comma (a struct tag would read it as options)
+			strField("empty", ""),     // present empty alias -> IGNORED, canonical "empty"
+			strField("dash", "-"),     // "-" alias -> IGNORED, canonical "dash"
+			strField("comma", "a,b"),  // comma alias -> IGNORED, canonical "comma"
 		},
 	}}
 	src, err := EmitNativeStaticUnary(m, NativeSpineOptions{PackageName: "rtpkg"})
@@ -327,13 +418,16 @@ func TestEmitNativeStaticUnaryAliasRoundTrip(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 	rt := "package rtpkg\n\n" +
-		"import (\n\t\"encoding/json\"\n\t\"reflect\"\n\t\"testing\"\n)\n\n" +
+		"import (\n\t\"encoding/json\"\n\t\"reflect\"\n\t\"strings\"\n\t\"testing\"\n)\n\n" +
 		"func TestRoundTrip(t *testing.T) {\n" +
 		"\tv := OutputReply{Canon: \"c\", Empty: \"e\", Dash: \"d\", Comma: \"m\"}\n" +
 		"\tgot, err := json.Marshal(v)\n" +
 		"\tif err != nil { t.Fatal(err) }\n" +
-		"\tconst want = `{\"canon\":\"c\",\"\":\"e\",\"-\":\"d\",\"a,b\":\"m\"}`\n" +
+		"\tconst want = `{\"canon\":\"c\",\"empty\":\"e\",\"dash\":\"d\",\"comma\":\"m\"}`\n" +
 		"\tif string(got) != want { t.Fatalf(\"marshal = %s, want %s\", got, want) }\n" +
+		"\tfor _, alias := range []string{`\"-\"`, `\"a,b\"`} {\n" +
+		"\t\tif strings.Contains(string(got), alias) { t.Fatalf(\"alias %s leaked into output bytes %s\", alias, got) }\n" +
+		"\t}\n" +
 		"\tvar back OutputReply\n" +
 		"\tif err := json.Unmarshal([]byte(want), &back); err != nil { t.Fatal(err) }\n" +
 		"\tif !reflect.DeepEqual(v, back) { t.Fatalf(\"round-trip mismatch: %+v != %+v\", back, v) }\n" +

--- a/adapters/common/codegen/nativespine_test.go
+++ b/adapters/common/codegen/nativespine_test.go
@@ -307,6 +307,16 @@ func TestEmitNativeStaticUnaryRejectsUnionNameCollisions(t *testing.T) {
 // zero-arm union and a nil-payload literal arm must fail closed at emit time even
 // when the classifier preflight is bypassed (direct emitter call).
 func TestEmitNativeStaticUnaryRejectsMalformedUnion(t *testing.T) {
+	// Nil union payload (distinct from a non-nil empty Variants slice).
+	np := sampleMethod()
+	np.Name = "NilPayload"
+	np.Args = nil
+	np.Return.Target = sd.Type{Kind: sd.TypeUnion, Union: nil}
+	np.Return.Classes = nil
+	if _, err := EmitNativeStaticUnary(np, NativeSpineOptions{PackageName: "p"}); err == nil {
+		t.Error("want error for a nil-payload union target, got nil")
+	}
+
 	// Zero-arm (non-nullable) union target.
 	z := sampleMethod()
 	z.Name = "ZeroArm"

--- a/adapters/common/codegen/nativespine_union.go
+++ b/adapters/common/codegen/nativespine_union.go
@@ -1,0 +1,339 @@
+package codegen
+
+// nativespine_union.go is the M3b union-planning and union-carrier emission
+// layer (codegen-spine slice M3b). It extends the merged M3a output-carrier core
+// (nativespine.go) with the native discriminated value carrier for a
+// multi-arm TypeUnion, plus the literal-arm lowering that rides on it.
+//
+// The carrier reproduces BAML v0.223's generated types/unions.go JSON behavior
+// (the authoritative reference is in the module cache under
+// engine/generators/languages/go/.../types/unions.go), MINUS the CFFI
+// Decode/Encode/BamlTypeName methods and imports. Two properties are PINNED, not
+// improved:
+//
+//   - MarshalJSON switches on the discriminator and marshals ONLY the selected
+//     arm pointer via encoding/json; an unset/unknown discriminator errors.
+//   - UnmarshalJSON tries arms SEQUENTIALLY in descriptor order, clearing a
+//     failed arm and selecting the FIRST successful standard JSON decode. This
+//     is intentionally not a semantic BAML parser: it reproduces the generated
+//     Go carrier, including same-base literal ambiguity (for `true | false`,
+//     generic JSON `false` decodes into the first bool arm; for `"a" | "b"`, any
+//     JSON string decodes into the first string arm). No value checks are added
+//     — that would make native stricter than BAML's generated carrier. Literal
+//     correctness is established upstream by BAML parsing/materialization and by
+//     the no-argument literal constructors.
+//
+// Native Go identifier spelling (OutputUnionN / VariantN) is not a public
+// compatibility surface (docs/codegen-spine/05 D8: JSON projection is
+// authoritative, source text is not); this layer does NOT reimplement BAML's
+// private union-name mangling. It only preserves DESCRIPTOR ARM ORDER, which
+// controls the first-success selection above.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/invakid404/baml-rest/bamlutils/schemadescriptor"
+)
+
+// carrierPlan holds the deterministic native names assigned to every distinct
+// multi-arm union reachable from a method's return graph. It is the single
+// source of truth shared by name-collision preflight, schemaGoType, and
+// emission, so admission can never outrun what emission can name (M3b open risk
+// 4). Building the plan is the mandatory step before any Go declaration is
+// written.
+type carrierPlan struct {
+	// byFingerprint maps a union's structural fingerprint (over its arms, NOT
+	// its nullability) to the native name assigned to that carrier, so identical
+	// union occurrences deduplicate to one declaration and `A|B` shares its
+	// carrier with the nullable `(A|B)?` (which is emitted as `*OutputUnionN`).
+	byFingerprint map[string]string
+	// unions is the ordered list of distinct union carriers in first-reach order
+	// of the deterministic return-graph walk (target, then class fields in
+	// descriptor order, descending into lists/maps/nested unions).
+	unions []plannedUnion
+}
+
+// plannedUnion is one emitted union carrier: its native name and the arms in
+// descriptor order (the arms are re-resolved to Go types at emit time so a
+// nested union arm can reference a later-planned carrier).
+type plannedUnion struct {
+	name     string
+	variants []schemadescriptor.Type
+}
+
+// buildCarrierPlan walks the return graph in deterministic order and assigns a
+// native name to every distinct multi-arm union. It returns a fail-closed error
+// for a union shape it cannot lower to a carrier (a non-nullable/zero-arm union
+// with fewer than two arms) so a direct emitter call rejects it even when the
+// classifier preflight is bypassed. Structurally identical unions dedupe by
+// fingerprint; the single-nullable-variant `T?` case is NOT a union carrier
+// (M3a emits it as `*T`) and is walked through, not registered.
+func buildCarrierPlan(ret schemadescriptor.Bundle) (*carrierPlan, error) {
+	p := &carrierPlan{byFingerprint: map[string]string{}}
+
+	var walk func(t *schemadescriptor.Type) error
+	walk = func(t *schemadescriptor.Type) error {
+		if t == nil {
+			return nil
+		}
+		switch t.Kind {
+		case schemadescriptor.TypeList:
+			return walk(t.Elem)
+		case schemadescriptor.TypeMap:
+			if err := walk(t.Key); err != nil {
+				return err
+			}
+			return walk(t.Value)
+		case schemadescriptor.TypeUnion:
+			if t.Union == nil {
+				return nil
+			}
+			// M3a optional-of-one (`T?`) stays `*T`; it is not a union carrier.
+			if t.Union.Nullable && len(t.Union.Variants) == 1 {
+				return walk(&t.Union.Variants[0])
+			}
+			if len(t.Union.Variants) < 2 {
+				return fmt.Errorf("union with %d variant(s) cannot be lowered to a carrier", len(t.Union.Variants))
+			}
+			fp := unionFingerprint(t.Union.Variants)
+			if _, ok := p.byFingerprint[fp]; !ok {
+				name := fmt.Sprintf("%sUnion%d", outputTypeNamePrefix, len(p.unions)+1)
+				p.byFingerprint[fp] = name
+				p.unions = append(p.unions, plannedUnion{name: name, variants: t.Union.Variants})
+			}
+			// Descend into arms to discover nested acyclic unions (assigned later
+			// ordinals; recursive edges are declined by the classifier, so this
+			// terminates).
+			for i := range t.Union.Variants {
+				if err := walk(&t.Union.Variants[i]); err != nil {
+					return err
+				}
+			}
+			return nil
+		default:
+			// primitive, literal, enum, class: leaves for planning purposes (a
+			// class/enum reference is a name; its definition is walked at the
+			// bundle level).
+			return nil
+		}
+	}
+
+	if err := walk(&ret.Target); err != nil {
+		return nil, err
+	}
+	for ci := range ret.Classes {
+		for fi := range ret.Classes[ci].Fields {
+			if err := walk(&ret.Classes[ci].Fields[fi].Type); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return p, nil
+}
+
+// unionName resolves a multi-arm union's arms to its planned native name. A nil
+// plan (or an unplanned union) reports not-found so callers fail closed.
+func (p *carrierPlan) unionName(variants []schemadescriptor.Type) (string, bool) {
+	if p == nil {
+		return "", false
+	}
+	name, ok := p.byFingerprint[unionFingerprint(variants)]
+	return name, ok
+}
+
+// unionFingerprint is a canonical structural key over a union's arms. The M3b
+// vocabulary carries no maps inside a Type node and D1 declines any
+// attribute-bearing union, so encoding/json is deterministic here and equals
+// structural equality of the arm trees. Nullability is deliberately excluded so
+// `A|B` and `(A|B)?` share one carrier.
+func unionFingerprint(variants []schemadescriptor.Type) string {
+	b, err := json.Marshal(variants)
+	if err != nil {
+		// A Type tree cannot fail to marshal; fall back to a spelling that still
+		// distinguishes arm counts if the impossible ever happens.
+		return fmt.Sprintf("!fpfail:%d", len(variants))
+	}
+	return string(b)
+}
+
+// literalGoBase maps a literal's kind to the ordinary Go base BAML v0.223
+// generates for it (string/int64/bool). A nil payload, a float literal, or an
+// unknown kind is a fail-closed error (unsupported_output_shape upstream); BAML
+// v0.223 has no float literal and the descriptor model no float literal kind.
+func literalGoBase(l *schemadescriptor.LiteralValue) (string, error) {
+	if l == nil {
+		return "", fmt.Errorf("literal has no value")
+	}
+	switch l.Kind {
+	case schemadescriptor.LiteralString:
+		return "string", nil
+	case schemadescriptor.LiteralInt:
+		return "int64", nil
+	case schemadescriptor.LiteralBool:
+		return "bool", nil
+	default:
+		return "", fmt.Errorf("literal kind %q is outside the carrier profile", l.Kind)
+	}
+}
+
+// literalGoConst renders the Go constant expression for a literal arm's
+// no-argument constructor/setter (the reference carrier installs the constant
+// with `var v <base> = <const>`).
+func literalGoConst(l *schemadescriptor.LiteralValue) (string, error) {
+	if l == nil {
+		return "", fmt.Errorf("literal has no value")
+	}
+	switch l.Kind {
+	case schemadescriptor.LiteralString:
+		return fmt.Sprintf("%q", l.String), nil
+	case schemadescriptor.LiteralInt:
+		return fmt.Sprintf("%d", l.Int), nil
+	case schemadescriptor.LiteralBool:
+		if l.Bool {
+			return "true", nil
+		}
+		return "false", nil
+	default:
+		return "", fmt.Errorf("literal kind %q is outside the carrier profile", l.Kind)
+	}
+}
+
+// unionArm is one resolved arm of a planned union: its discriminator string, the
+// ordinal method suffix, its Go value type, and — for a literal arm — the
+// constant its no-argument constructor/setter installs.
+type unionArm struct {
+	field  string // struct field name: variant0, variant1, ...
+	disc   string // discriminator value stored in `variant`: v0, v1, ...
+	suffix string // method suffix: Variant0, Variant1, ...
+	goType string // arm value Go type (int64, OutputInner, []string, *string, OutputUnion2, ...)
+	isLit  bool
+	litVal string // Go constant expression when isLit
+}
+
+// resolveUnionArms resolves every arm of a planned union to its Go type and
+// literal metadata via schemaGoType (so a nested-union arm binds to its own
+// planned carrier). It fails closed on any arm outside the carrier vocabulary.
+func resolveUnionArms(u plannedUnion, plan *carrierPlan) ([]unionArm, error) {
+	arms := make([]unionArm, 0, len(u.variants))
+	for i := range u.variants {
+		v := u.variants[i]
+		gt, err := schemaGoType(v, plan)
+		if err != nil {
+			return nil, fmt.Errorf("union %s arm %d: %w", u.name, i, err)
+		}
+		a := unionArm{
+			field:  fmt.Sprintf("variant%d", i),
+			disc:   fmt.Sprintf("v%d", i),
+			suffix: fmt.Sprintf("Variant%d", i),
+			goType: gt,
+		}
+		if v.Kind == schemadescriptor.TypeLiteral {
+			lit, err := literalGoConst(v.Literal)
+			if err != nil {
+				return nil, fmt.Errorf("union %s arm %d: %w", u.name, i, err)
+			}
+			a.isLit = true
+			a.litVal = lit
+		}
+		arms = append(arms, a)
+	}
+	return arms, nil
+}
+
+// emitUnionCarrier writes the pure-Go discriminated value carrier for one
+// planned union: the struct, MarshalJSON/UnmarshalJSON, and per-arm
+// constructor/setter/predicate/accessor. It mirrors BAML v0.223's generated
+// carrier JSON behavior without any CFFI method/import. It returns an error for
+// an arm it cannot resolve (fail-closed backstop for a direct emitter call).
+func emitUnionCarrier(b *strings.Builder, u plannedUnion, plan *carrierPlan) error {
+	arms, err := resolveUnionArms(u, plan)
+	if err != nil {
+		return err
+	}
+
+	// Struct: a discriminator string plus one pointer per arm.
+	fmt.Fprintf(b, "// %s is a generated output union carrier: a discriminated value\n", u.name)
+	fmt.Fprintf(b, "// holding exactly one arm, reproducing BAML v0.223 generated-carrier JSON behavior.\n")
+	fmt.Fprintf(b, "type %s struct {\n", u.name)
+	fmt.Fprintf(b, "\tvariant string\n")
+	for _, a := range arms {
+		fmt.Fprintf(b, "\t%s *%s\n", a.field, a.goType)
+	}
+	fmt.Fprintf(b, "}\n\n")
+
+	// MarshalJSON: switch on the discriminator, marshal only the selected arm
+	// pointer; unset/unknown errors (BAML parity: an unset union does not
+	// serialize).
+	fmt.Fprintf(b, "// MarshalJSON emits the selected arm; an unset/unknown discriminator errors.\n")
+	fmt.Fprintf(b, "func (u %s) MarshalJSON() ([]byte, error) {\n", u.name)
+	fmt.Fprintf(b, "\tswitch u.variant {\n")
+	for _, a := range arms {
+		fmt.Fprintf(b, "\tcase %q:\n\t\treturn json.Marshal(u.%s)\n", a.disc, a.field)
+	}
+	fmt.Fprintf(b, "\t}\n")
+	fmt.Fprintf(b, "\treturn nil, fmt.Errorf(%q, u.variant)\n", "nativespine: "+u.name+": invalid union variant %q")
+	fmt.Fprintf(b, "}\n\n")
+
+	// UnmarshalJSON: try arms sequentially in descriptor order, clearing a failed
+	// arm, first-success wins. No value checks (BAML parity, incl. same-base
+	// literal ambiguity).
+	fmt.Fprintf(b, "// UnmarshalJSON tries arms sequentially in descriptor order, first-success\n")
+	fmt.Fprintf(b, "// (BAML v0.223 generated-carrier parity: no value checks; same-base arms are ambiguous).\n")
+	fmt.Fprintf(b, "func (u *%s) UnmarshalJSON(data []byte) error {\n", u.name)
+	for _, a := range arms {
+		fmt.Fprintf(b, "\tif err := json.Unmarshal(data, &u.%s); err == nil {\n", a.field)
+		fmt.Fprintf(b, "\t\tu.variant = %q\n\t\treturn nil\n\t}\n", a.disc)
+		fmt.Fprintf(b, "\tu.%s = nil\n", a.field)
+	}
+	fmt.Fprintf(b, "\treturn fmt.Errorf(%q, string(data))\n", "nativespine: "+u.name+": no union variant matched: %s")
+	fmt.Fprintf(b, "}\n\n")
+
+	// Per-arm constructor / setter / predicate / accessor. Every setter clears
+	// all OTHER arm pointers.
+	for i, a := range arms {
+		if a.isLit {
+			// Literal arm: no-argument constructor/setter install the constant.
+			fmt.Fprintf(b, "// %s%s constructs %s holding literal arm %d.\n", u.name, "New"+a.suffix, u.name, i)
+			fmt.Fprintf(b, "func %sNew%s() %s {\n", u.name, a.suffix, u.name)
+			fmt.Fprintf(b, "\tv := %s(%s)\n", a.goType, a.litVal)
+			fmt.Fprintf(b, "\treturn %s{variant: %q, %s: &v}\n}\n\n", u.name, a.disc, a.field)
+
+			fmt.Fprintf(b, "// Set%s selects literal arm %d, clearing the others.\n", a.suffix, i)
+			fmt.Fprintf(b, "func (u *%s) Set%s() {\n", u.name, a.suffix)
+			fmt.Fprintf(b, "\tv := %s(%s)\n", a.goType, a.litVal)
+			fmt.Fprintf(b, "\tu.variant = %q\n\tu.%s = &v\n", a.disc, a.field)
+			emitClearOtherArms(b, arms, i)
+			fmt.Fprintf(b, "}\n\n")
+		} else {
+			fmt.Fprintf(b, "// %sNew%s constructs %s holding arm %d.\n", u.name, a.suffix, u.name, i)
+			fmt.Fprintf(b, "func %sNew%s(v %s) %s {\n", u.name, a.suffix, a.goType, u.name)
+			fmt.Fprintf(b, "\treturn %s{variant: %q, %s: &v}\n}\n\n", u.name, a.disc, a.field)
+
+			fmt.Fprintf(b, "// Set%s selects arm %d, clearing the others.\n", a.suffix, i)
+			fmt.Fprintf(b, "func (u *%s) Set%s(v %s) {\n", u.name, a.suffix, a.goType)
+			fmt.Fprintf(b, "\tu.variant = %q\n\tu.%s = &v\n", a.disc, a.field)
+			emitClearOtherArms(b, arms, i)
+			fmt.Fprintf(b, "}\n\n")
+		}
+
+		fmt.Fprintf(b, "// Is%s reports whether arm %d is selected.\n", a.suffix, i)
+		fmt.Fprintf(b, "func (u *%s) Is%s() bool { return u.variant == %q }\n\n", u.name, a.suffix, a.disc)
+
+		fmt.Fprintf(b, "// As%s returns the arm-%d pointer, or nil when another arm is selected.\n", a.suffix, i)
+		fmt.Fprintf(b, "func (u *%s) As%s() *%s {\n", u.name, a.suffix, a.goType)
+		fmt.Fprintf(b, "\tif u.variant != %q {\n\t\treturn nil\n\t}\n\treturn u.%s\n}\n\n", a.disc, a.field)
+	}
+	return nil
+}
+
+// emitClearOtherArms writes `u.variantK = nil` for every arm K != selected.
+func emitClearOtherArms(b *strings.Builder, arms []unionArm, selected int) {
+	for k, a := range arms {
+		if k == selected {
+			continue
+		}
+		fmt.Fprintf(b, "\tu.%s = nil\n", a.field)
+	}
+}

--- a/adapters/common/codegen/nativespine_union.go
+++ b/adapters/common/codegen/nativespine_union.go
@@ -88,7 +88,10 @@ func buildCarrierPlan(ret schemadescriptor.Bundle) (*carrierPlan, error) {
 			return walk(t.Value)
 		case schemadescriptor.TypeUnion:
 			if t.Union == nil {
-				return nil
+				// A nil union payload is malformed — fail closed here rather than
+				// silently skip it and defer to schemaGoType (keeps the emitter's plan
+				// and type resolution symmetric, and admission == emission).
+				return fmt.Errorf("union node has a nil payload")
 			}
 			// M3a optional-of-one (`T?`) stays `*T`; it is not a union carrier.
 			if t.Union.Nullable && len(t.Union.Variants) == 1 {

--- a/adapters/common/codegen/nativespine_union_differential_test.go
+++ b/adapters/common/codegen/nativespine_union_differential_test.go
@@ -1,0 +1,457 @@
+package codegen
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/invakid404/baml-rest/adapters/common/codegen/internal/testharness"
+	"github.com/invakid404/baml-rest/bamlutils/projectdescriptor"
+	sd "github.com/invakid404/baml-rest/bamlutils/schemadescriptor"
+)
+
+// unionLiteralMethod is an admitted static-unary method whose RETURN class
+// exercises the M3b carrier additions in one shape:
+//
+//   - cross: a CROSS-KIND union `string | int`  -> OutputUnion1
+//   - choice: a SAME-BASE string-literal union `"a" | "b"` -> OutputUnion2 (both *string)
+//   - flag: a SAME-BASE bool-literal union `true | false` -> OutputUnion3 (both *bool)
+//   - maybe: a NULLABLE multi-arm union `(string | int)?` -> *OutputUnion1 (DEDUPES to OutputUnion1)
+//   - status: a STANDALONE string literal `"active"` -> plain string
+//   - code: a STANDALONE int literal `200` -> plain int64
+//   - items: a LIST of the `string | int` union -> []OutputUnion1 (dedupe again)
+//
+// Every field uses its canonical name (M3b aliases are covered separately). This
+// is the descriptor the emitter lowers to the differential carriers.
+func unionLiteralMethod() projectdescriptor.Method {
+	prim := func(p sd.PrimitiveKind) sd.Type { return sd.Type{Kind: sd.TypePrimitive, Primitive: p} }
+	litStr := func(s string) sd.Type {
+		return sd.Type{Kind: sd.TypeLiteral, Literal: &sd.LiteralValue{Kind: sd.LiteralString, String: s}}
+	}
+	litBool := func(v bool) sd.Type {
+		return sd.Type{Kind: sd.TypeLiteral, Literal: &sd.LiteralValue{Kind: sd.LiteralBool, Bool: v}}
+	}
+	litInt := func(v int64) sd.Type {
+		return sd.Type{Kind: sd.TypeLiteral, Literal: &sd.LiteralValue{Kind: sd.LiteralInt, Int: v}}
+	}
+	union := func(nullable bool, arms ...sd.Type) sd.Type {
+		return sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Nullable: nullable, Variants: arms}}
+	}
+	list := func(elem sd.Type) sd.Type { e := elem; return sd.Type{Kind: sd.TypeList, Elem: &e} }
+
+	stringOrInt := []sd.Type{prim(sd.PrimitiveString), prim(sd.PrimitiveInt)}
+
+	return projectdescriptor.Method{
+		Name:  "UnionLit",
+		Class: projectdescriptor.ClassStaticUnary,
+		Return: sd.Bundle{
+			Version: sd.Version,
+			Method:  "UnionLit",
+			Target:  sd.Type{Kind: sd.TypeClass, Name: "UL"},
+			Classes: []sd.ClassDef{{
+				Name: sd.Name{Name: "UL"},
+				Fields: []sd.ClassField{
+					{Name: sd.Name{Name: "cross"}, Type: union(false, stringOrInt...)},
+					{Name: sd.Name{Name: "choice"}, Type: union(false, litStr("a"), litStr("b"))},
+					{Name: sd.Name{Name: "flag"}, Type: union(false, litBool(true), litBool(false))},
+					{Name: sd.Name{Name: "maybe"}, Type: union(true, stringOrInt...)},
+					{Name: sd.Name{Name: "status"}, Type: litStr("active")},
+					{Name: sd.Name{Name: "code"}, Type: litInt(200)},
+					{Name: sd.Name{Name: "items"}, Type: list(union(false, stringOrInt...))},
+				},
+			}},
+		},
+	}
+}
+
+// unionLiteralTestSource is the hermetic differential harness. It compares the
+// emitted M3b carrier against a FROZEN, CFFI-free reference that mirrors BAML
+// v0.223's generated types/unions.go JSON methods (module cache:
+// engine/generators/languages/go/.../types/unions.go), MINUS CFFI. It asserts:
+//
+//   - native bytes == frozen golden == reference-carrier bytes (non-map rows);
+//   - unmarshal -> remarshal byte-identity for each golden;
+//   - constructors select/clear the right arm; an unset union marshal errors;
+//   - sequential UnmarshalJSON arm precedence matches BAML, INCLUDING the
+//     counterintuitive same-base literal controls (generic JSON `false` decodes
+//     into the first bool arm; any JSON string into the first string arm; no
+//     value checks);
+//   - a standalone literal field is a plain base with NO extra rejection.
+const unionLiteralTestSource = `package ulpkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/bytedance/sonic"
+)
+
+// --- Frozen reference carriers: BAML v0.223 generated types/unions.go JSON
+// --- methods, verbatim except for the stripped CFFI Decode/Encode/BamlTypeName.
+
+// refUnion1 mirrors a generated Union2StringOrInt (arms in descriptor order:
+// string, then int).
+type refUnion1 struct {
+	variant string
+
+	variant_String *string
+	variant_Int    *int64
+}
+
+func refUnion1NewString(v string) refUnion1 { return refUnion1{variant: "String", variant_String: &v} }
+func refUnion1NewInt(v int64) refUnion1     { return refUnion1{variant: "Int", variant_Int: &v} }
+
+func (u refUnion1) MarshalJSON() ([]byte, error) {
+	switch u.variant {
+	case "String":
+		return json.Marshal(u.variant_String)
+	case "Int":
+		return json.Marshal(u.variant_Int)
+	}
+	return nil, fmt.Errorf("invalid union variant: %s", u.variant)
+}
+func (u *refUnion1) UnmarshalJSON(data []byte) error {
+	var err error
+	err = json.Unmarshal(data, &u.variant_String)
+	if err == nil {
+		u.variant = "String"
+		return nil
+	} else {
+		u.variant_String = nil
+	}
+	err = json.Unmarshal(data, &u.variant_Int)
+	if err == nil {
+		u.variant = "Int"
+		return nil
+	} else {
+		u.variant_Int = nil
+	}
+	return fmt.Errorf("invalid union variant: %s", string(data))
+}
+
+// refUnion2 mirrors a generated Union2 of string literals "a" | "b" (both *string,
+// arm order a, b).
+type refUnion2 struct {
+	variant string
+
+	variant_A *string
+	variant_B *string
+}
+
+func refUnion2NewA() refUnion2 { v := "a"; return refUnion2{variant: "A", variant_A: &v} }
+func refUnion2NewB() refUnion2 { v := "b"; return refUnion2{variant: "B", variant_B: &v} }
+
+func (u refUnion2) MarshalJSON() ([]byte, error) {
+	switch u.variant {
+	case "A":
+		return json.Marshal(u.variant_A)
+	case "B":
+		return json.Marshal(u.variant_B)
+	}
+	return nil, fmt.Errorf("invalid union variant: %s", u.variant)
+}
+func (u *refUnion2) UnmarshalJSON(data []byte) error {
+	var err error
+	err = json.Unmarshal(data, &u.variant_A)
+	if err == nil {
+		u.variant = "A"
+		return nil
+	} else {
+		u.variant_A = nil
+	}
+	err = json.Unmarshal(data, &u.variant_B)
+	if err == nil {
+		u.variant = "B"
+		return nil
+	} else {
+		u.variant_B = nil
+	}
+	return fmt.Errorf("invalid union variant: %s", string(data))
+}
+
+// refUnion3 mirrors a generated Union2 of bool literals true | false (both *bool,
+// arm order true, false — matching the source declaration order).
+type refUnion3 struct {
+	variant string
+
+	variant_True  *bool
+	variant_False *bool
+}
+
+func refUnion3NewTrue() refUnion3  { v := true; return refUnion3{variant: "True", variant_True: &v} }
+func refUnion3NewFalse() refUnion3 { v := false; return refUnion3{variant: "False", variant_False: &v} }
+
+func (u refUnion3) MarshalJSON() ([]byte, error) {
+	switch u.variant {
+	case "True":
+		return json.Marshal(u.variant_True)
+	case "False":
+		return json.Marshal(u.variant_False)
+	}
+	return nil, fmt.Errorf("invalid union variant: %s", u.variant)
+}
+func (u *refUnion3) UnmarshalJSON(data []byte) error {
+	var err error
+	err = json.Unmarshal(data, &u.variant_True)
+	if err == nil {
+		u.variant = "True"
+		return nil
+	} else {
+		u.variant_True = nil
+	}
+	err = json.Unmarshal(data, &u.variant_False)
+	if err == nil {
+		u.variant = "False"
+		return nil
+	} else {
+		u.variant_False = nil
+	}
+	return fmt.Errorf("invalid union variant: %s", string(data))
+}
+
+// refUL mirrors the shape a BAML-generated Go class has: a plain struct with json
+// tags in declaration order; the union fields are the reference carriers above.
+type refUL struct {
+	Cross  refUnion1   ` + "`json:\"cross\"`" + `
+	Choice refUnion2   ` + "`json:\"choice\"`" + `
+	Flag   refUnion3   ` + "`json:\"flag\"`" + `
+	Maybe  *refUnion1  ` + "`json:\"maybe\"`" + `
+	Status string      ` + "`json:\"status\"`" + `
+	Code   int64       ` + "`json:\"code\"`" + `
+	Items  []refUnion1 ` + "`json:\"items\"`" + `
+}
+
+func nativeValue(maybe *OutputUnion1) OutputUl {
+	return OutputUl{
+		Cross:  OutputUnion1NewVariant0("hi"),
+		Choice: OutputUnion2NewVariant0(),
+		Flag:   OutputUnion3NewVariant1(),
+		Maybe:  maybe,
+		Status: "active",
+		Code:   200,
+		Items:  []OutputUnion1{OutputUnion1NewVariant1(7), OutputUnion1NewVariant0("x")},
+	}
+}
+func refValue(maybe *refUnion1) refUL {
+	return refUL{
+		Cross:  refUnion1NewString("hi"),
+		Choice: refUnion2NewA(),
+		Flag:   refUnion3NewFalse(),
+		Maybe:  maybe,
+		Status: "active",
+		Code:   200,
+		Items:  []refUnion1{refUnion1NewInt(7), refUnion1NewString("x")},
+	}
+}
+
+const goldenNilMaybe = ` + "`{\"cross\":\"hi\",\"choice\":\"a\",\"flag\":false,\"maybe\":null,\"status\":\"active\",\"code\":200,\"items\":[7,\"x\"]}`" + `
+const goldenPresentMaybe = ` + "`{\"cross\":\"hi\",\"choice\":\"a\",\"flag\":false,\"maybe\":42,\"status\":\"active\",\"code\":200,\"items\":[7,\"x\"]}`" + `
+
+// TestUnionDifferential marshals both carriers with the SERVING serializer (sonic
+// ConfigDefault) and asserts native == golden == reference, then round-trips.
+func TestUnionDifferential(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		nativeMaybe  *OutputUnion1
+		refMaybe     *refUnion1
+		golden       string
+	}{
+		{"nil maybe", nil, nil, goldenNilMaybe},
+		{"present maybe", func() *OutputUnion1 { u := OutputUnion1NewVariant1(42); return &u }(),
+			func() *refUnion1 { u := refUnion1NewInt(42); return &u }(), goldenPresentMaybe},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			native, err := sonic.Marshal(nativeValue(tc.nativeMaybe))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(native) != tc.golden {
+				t.Fatalf("native carrier JSON != golden\n native: %s\n golden: %s", native, tc.golden)
+			}
+			ref, err := sonic.Marshal(refValue(tc.refMaybe))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(ref) != string(native) {
+				t.Fatalf("native carrier JSON != reference carrier JSON\n native: %s\n ref:    %s", native, ref)
+			}
+			// Round-trip: golden -> native carrier -> re-marshal -> byte-identical.
+			var back OutputUl
+			if err := json.Unmarshal([]byte(tc.golden), &back); err != nil {
+				t.Fatal(err)
+			}
+			again, err := sonic.Marshal(back)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(again) != tc.golden {
+				t.Fatalf("round-trip not byte-identical\n got:    %s\n golden: %s", again, tc.golden)
+			}
+		})
+	}
+}
+
+// TestUnionConstructorsSelectClear proves a constructor selects exactly its arm
+// and a setter clears the others (accessors return nil for the non-selected arm).
+func TestUnionConstructorsSelectClear(t *testing.T) {
+	u := OutputUnion1NewVariant0("hi")
+	if !u.IsVariant0() || u.IsVariant1() {
+		t.Fatalf("NewVariant0: discriminator wrong")
+	}
+	if got := u.AsVariant0(); got == nil || *got != "hi" {
+		t.Fatalf("AsVariant0 = %v", got)
+	}
+	if u.AsVariant1() != nil {
+		t.Fatalf("AsVariant1 should be nil for a variant0 value")
+	}
+	u.SetVariant1(9)
+	if !u.IsVariant1() || u.IsVariant0() {
+		t.Fatalf("SetVariant1: discriminator wrong")
+	}
+	if u.AsVariant0() != nil {
+		t.Fatalf("SetVariant1 must clear the variant0 pointer")
+	}
+	if got := u.AsVariant1(); got == nil || *got != 9 {
+		t.Fatalf("AsVariant1 = %v", got)
+	}
+}
+
+// TestUnsetUnionMarshalErrors proves an unset union errors on marshal, both bare
+// and as a class field (BAML parity: an unset union does not serialize).
+func TestUnsetUnionMarshalErrors(t *testing.T) {
+	var bare OutputUnion1
+	if _, err := json.Marshal(bare); err == nil {
+		t.Fatal("bare unset union marshaled without error")
+	}
+	if _, err := sonic.Marshal(OutputUl{}); err == nil {
+		t.Fatal("class with an unset union field marshaled without error")
+	}
+}
+
+// TestUnionCrossKindPrecedence proves cross-kind arm selection: a JSON number
+// falls through the string arm to the int arm; a JSON string binds the string arm.
+func TestUnionCrossKindPrecedence(t *testing.T) {
+	var n OutputUnion1
+	if err := json.Unmarshal([]byte("7"), &n); err != nil {
+		t.Fatal(err)
+	}
+	if !n.IsVariant1() || n.AsVariant1() == nil || *n.AsVariant1() != 7 {
+		t.Fatalf("JSON 7 should bind the int arm; got variant0=%v variant1=%v", n.AsVariant0(), n.AsVariant1())
+	}
+	var s OutputUnion1
+	if err := json.Unmarshal([]byte(` + "`\"z\"`" + `), &s); err != nil {
+		t.Fatal(err)
+	}
+	if !s.IsVariant0() || s.AsVariant0() == nil || *s.AsVariant0() != "z" {
+		t.Fatalf("JSON \"z\" should bind the string arm; got %v", s)
+	}
+	// Reference agrees.
+	var r refUnion1
+	if err := json.Unmarshal([]byte("7"), &r); err != nil || r.variant != "Int" {
+		t.Fatalf("reference JSON 7 -> variant %q, err %v", r.variant, err)
+	}
+}
+
+// TestSameBaseLiteralAmbiguity PINS the counterintuitive first-success selection
+// for same-base literal arms (do NOT "improve" this): any JSON string decodes into
+// the FIRST string arm regardless of value, and generic JSON false decodes into the
+// FIRST bool arm. No value checks. Native and the BAML-equivalent reference agree.
+func TestSameBaseLiteralAmbiguity(t *testing.T) {
+	// "a" | "b": JSON "b" (and even a non-literal "zzz") lands in the FIRST arm.
+	for _, in := range []string{` + "`\"b\"`" + `, ` + "`\"zzz\"`" + `} {
+		var u OutputUnion2
+		if err := json.Unmarshal([]byte(in), &u); err != nil {
+			t.Fatal(err)
+		}
+		if !u.IsVariant0() || u.IsVariant1() {
+			t.Fatalf("string %s should bind the FIRST string arm (v0), got v0=%v v1=%v", in, u.AsVariant0(), u.AsVariant1())
+		}
+	}
+	var r2 refUnion2
+	if err := json.Unmarshal([]byte(` + "`\"b\"`" + `), &r2); err != nil || r2.variant != "A" {
+		t.Fatalf("reference \"b\" -> variant %q (want first arm A), err %v", r2.variant, err)
+	}
+
+	// true | false: JSON false decodes into the FIRST (true-declared) bool arm.
+	var b OutputUnion3
+	if err := json.Unmarshal([]byte("false"), &b); err != nil {
+		t.Fatal(err)
+	}
+	if !b.IsVariant0() || b.AsVariant0() == nil || *b.AsVariant0() != false {
+		t.Fatalf("JSON false should bind the FIRST bool arm (v0) holding false, got %v", b)
+	}
+	var r3 refUnion3
+	if err := json.Unmarshal([]byte("false"), &r3); err != nil || r3.variant != "True" {
+		t.Fatalf("reference false -> variant %q (want first arm True), err %v", r3.variant, err)
+	}
+}
+
+// TestStandaloneLiteralNoValidation proves a standalone literal field is a plain
+// Go base with NO value validation (BAML v0.223 generated classes do not enforce
+// literal values in ordinary json.Unmarshal).
+func TestStandaloneLiteralNoValidation(t *testing.T) {
+	const in = ` + "`{\"cross\":\"hi\",\"choice\":\"a\",\"flag\":true,\"maybe\":null,\"status\":\"anything\",\"code\":999,\"items\":[]}`" + `
+	var v OutputUl
+	if err := json.Unmarshal([]byte(in), &v); err != nil {
+		t.Fatalf("standalone literal field rejected an out-of-literal value: %v", err)
+	}
+	if v.Status != "anything" || v.Code != 999 {
+		t.Fatalf("standalone literals not plain bases: status=%q code=%d", v.Status, v.Code)
+	}
+}
+`
+
+// TestNativeUnionLiteralDifferential is the M3b JSON-roundtrip differential: the
+// emitted union/literal carrier serializes byte-identically to BAML v0.223's
+// generated-carrier behavior, compiles in a hermetic module with NO
+// baml_client/CFFI import, and is deterministic.
+func TestNativeUnionLiteralDifferential(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not on PATH; skipping union/literal differential")
+	}
+	m := unionLiteralMethod()
+	src, err := EmitNativeStaticUnary(m, NativeSpineOptions{PackageName: "ulpkg"})
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	// Determinism: a second emit is byte-identical.
+	src2, err := EmitNativeStaticUnary(m, NativeSpineOptions{PackageName: "ulpkg"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(src) != string(src2) {
+		t.Fatal("emitter is not deterministic for the union/literal carrier")
+	}
+	// The emitted carrier must carry the planned union types and the standalone
+	// literal bases (dedupe: exactly OutputUnion1/2/3, no OutputUnion4).
+	// Alignment-insensitive checks (gofmt pads struct fields): assert standalone
+	// type expressions and constructor signatures rather than field-name/type pairs.
+	for _, want := range []string{
+		"type OutputUnion1 struct",
+		"type OutputUnion2 struct",
+		"type OutputUnion3 struct",
+		"*OutputUnion1",                               // nullable multi-arm union -> pointer to the DEDUPED carrier
+		"[]OutputUnion1",                              // list of the deduped carrier
+		"func OutputUnion2NewVariant0() OutputUnion2", // literal-arm constructor takes NO value
+		`v := string("a")`,                            // and installs the literal constant
+		`v := bool(false)`,                            // bool literal arm constant
+	} {
+		if !strings.Contains(string(src), want) {
+			t.Errorf("emitted carrier missing %q", want)
+		}
+	}
+	if strings.Contains(string(src), "type OutputUnion4 struct") {
+		t.Error("union dedupe failed: a 4th carrier was emitted for a repeated union shape")
+	}
+
+	tmp := t.TempDir()
+	testharness.WriteTempModule(t, tmp, string(src), map[string]string{"union_differential_test.go": unionLiteralTestSource})
+
+	// No-CFFI proof on the emitted carrier's non-test dependency graph.
+	assertNoCFFI(t, tmp)
+
+	if out, err := testharness.RunGoTest(t, tmp, "TestUnionDifferential|TestUnionConstructorsSelectClear|TestUnsetUnionMarshalErrors|TestUnionCrossKindPrecedence|TestSameBaseLiteralAmbiguity|TestStandaloneLiteralNoValidation"); err != nil {
+		t.Fatalf("union/literal differential failed: %v\n%s", err, out)
+	}
+}

--- a/adapters/common/embed.go
+++ b/adapters/common/embed.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed adapterversions codegen/codegen.go codegen/codegen_adapter.go codegen/codegen_buildrequest.go codegen/codegen_debaml.go codegen/codegen_debaml_static.go codegen/codegen_dynamic_types.go codegen/codegen_legacy_stream.go codegen/codegen_methods.go codegen/codegen_options.go codegen/codegen_reflect.go codegen/codegen_router.go codegen/codegen_slice_pool.go codegen/codegen_stream_helpers.go codegen/nativespine.go embed.go go.mod go.sum helpers.go testdriver testhelpers/snapshot.go utils/dynamic.go
+//go:embed adapterversions codegen/codegen.go codegen/codegen_adapter.go codegen/codegen_buildrequest.go codegen/codegen_debaml.go codegen/codegen_debaml_static.go codegen/codegen_dynamic_types.go codegen/codegen_legacy_stream.go codegen/codegen_methods.go codegen/codegen_options.go codegen/codegen_reflect.go codegen/codegen_router.go codegen/codegen_slice_pool.go codegen/codegen_stream_helpers.go codegen/nativespine.go codegen/nativespine_union.go embed.go go.mod go.sum helpers.go testdriver testhelpers/snapshot.go utils/dynamic.go
 var source embed.FS
 
 var Sources = make(map[string]embed.FS)

--- a/cmd/introspect/native_spine_test.go
+++ b/cmd/introspect/native_spine_test.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/invakid404/baml-rest/adapters/common/codegen"
 	"github.com/invakid404/baml-rest/bamlutils/projectdescriptor"
 	"github.com/invakid404/baml-rest/internal/nativespine"
 )
@@ -736,5 +739,462 @@ func TestNativeSpineStrictMissingDir(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "strict source diagnostics") {
 		t.Errorf("error = %q, want a strict source-diagnostics failure", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// M3b: real introspect -> classifier -> codegen pipeline coverage (scope §5A).
+// These drive the REAL parseBamlSourceDir pipeline (not source-grep / not a
+// hand-built descriptor), assert the exact admission/decline map for the M3b
+// vocabulary (multi-arm unions, string/int/bool literals, @alias metadata), and
+// then EMIT the admitted method, compile it in a temp module, and EXECUTE
+// behavioral JSON tests. Descriptor presence alone is not admission.
+// ---------------------------------------------------------------------------
+
+// pipelineProject runs the REAL introspect pipeline and returns the whole
+// Project (so a test can pull an admitted method and emit it).
+func pipelineProject(t *testing.T, sources map[string]string) projectdescriptor.Project {
+	t.Helper()
+	dir := t.TempDir()
+	for name, src := range sources {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(src), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	bc := parseBamlSourceDir(dir)
+	proj := nativespine.BuildProjectDescriptor(bc.nativeSourceFacts())
+	if err := proj.Validate(); err != nil {
+		t.Fatalf("descriptor invalid: %v", err)
+	}
+	return proj
+}
+
+// admittedMethodByName returns the admitted method of the given name, failing if
+// it was not admitted.
+func admittedMethodByName(t *testing.T, proj projectdescriptor.Project, name string) projectdescriptor.Method {
+	t.Helper()
+	for i := range proj.Methods {
+		if proj.Methods[i].Name == name {
+			return proj.Methods[i]
+		}
+	}
+	t.Fatalf("method %q was not admitted (methods: %v)", name, methodNames(proj))
+	return projectdescriptor.Method{}
+}
+
+func methodNames(proj projectdescriptor.Project) []string {
+	out := make([]string, 0, len(proj.Methods))
+	for _, m := range proj.Methods {
+		out = append(out, m.Name)
+	}
+	return out
+}
+
+// compileAndRunEmittedCarrier writes the emitted carrier + a behavioral test into
+// a throwaway module (bamlutils resolved via a local replace, repo go.sum reused,
+// fully offline) and runs `go test`. Mirrors the proven cmd/introspect Gate-A
+// temp-module recipe; it respects module boundaries (no adapters/common internal
+// testharness import from the root module).
+func compileAndRunEmittedCarrier(t *testing.T, packageName, emitted, behavioralTest string) {
+	t.Helper()
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not on PATH; skipping emitted-carrier compile+execute")
+	}
+	repoRoot := gateARepoRoot(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "carrier.go"), []byte(emitted), 0o644); err != nil {
+		t.Fatalf("write carrier.go: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "carrier_test.go"), []byte(behavioralTest), 0o644); err != nil {
+		t.Fatalf("write carrier_test.go: %v", err)
+	}
+	const bamlutilsPkg = "github.com/invakid404/baml-rest/bamlutils"
+	bamlutilsAbs := filepath.Join(repoRoot, "bamlutils")
+	goMod := fmt.Sprintf("module m3bcarrier\n\ngo %s\n\nrequire %s v0.0.0\n\nreplace %s => %s\n",
+		gateAGoVersion(t, repoRoot), bamlutilsPkg, bamlutilsPkg, filepath.ToSlash(bamlutilsAbs))
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if sum, err := os.ReadFile(filepath.Join(repoRoot, "go.sum")); err == nil {
+		if err := os.WriteFile(filepath.Join(dir, "go.sum"), sum, 0o644); err != nil {
+			t.Fatalf("write go.sum: %v", err)
+		}
+	}
+	// Import-graph gate on the emitted carrier: no baml_client / BAML / CFFI.
+	assertEmittedCarrierNoCFFI(t, dir)
+
+	cmd := exec.Command("go", "test", "-count=1", ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"CGO_ENABLED=0",
+		"GOWORK=off",
+		"GOFLAGS=-mod=mod",
+		"GOPROXY=off",
+		"GOSUMDB=off",
+		"GOTOOLCHAIN=local",
+	)
+	if outBytes, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("emitted carrier behavioral test failed: %v\n%s", err, outBytes)
+	}
+}
+
+// assertEmittedCarrierNoCFFI runs `go list -deps` on the carrier package (NON-test
+// graph) and rejects any baml_client / BAML runtime / CFFI / patched-client path
+// (scope §5C).
+func assertEmittedCarrierNoCFFI(t *testing.T, dir string) {
+	t.Helper()
+	forbidden := []string{"baml_client", "github.com/boundaryml/baml", "dynclient/baml-patched", "language_client_go", "cffi"}
+	cmd := exec.Command("go", "list", "-deps", ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"CGO_ENABLED=0", "GOWORK=off", "GOFLAGS=-mod=mod", "GOPROXY=off", "GOSUMDB=off", "GOTOOLCHAIN=local",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list -deps on emitted carrier: %v\n%s", err, out)
+	}
+	for _, dep := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		for _, bad := range forbidden {
+			if strings.Contains(dep, bad) {
+				t.Errorf("emitted carrier depends on %q (matches forbidden %q)", dep, bad)
+			}
+		}
+	}
+}
+
+// TestNativeSpineM3bAdmissionAndDeclines drives the real pipeline and asserts the
+// exact M3b admission/decline map: multi-arm unions (cross-kind, class/enum arms,
+// nested list/map arms, repeated shapes, nullable), string/int/bool literals and
+// same-base literal unions, and aliased fields/enum members (incl. exotic
+// aliases) are ADMITTED; recursion, media-under-union, tuple, null-only, dynamic,
+// non-string-key map, and unsupported input union/map are DECLINED. One clean
+// M3a method proves no global poisoning.
+func TestNativeSpineM3bAdmissionAndDeclines(t *testing.T) {
+	sources := map[string]string{
+		"clients.baml": goodClient,
+		"types.baml": `
+enum Suit { Hearts @alias("hearts_alias")
+  Spades
+}
+class Aliased { qty int @alias("amount")
+  empt string @alias("")
+  comma string @alias("a,b")
+  uni string @alias("naïve")
+  suit Suit
+}
+class Holder { pick string | int
+  items (string | int)[]
+  lut map<string, string | int>
+}
+class RecA { child RecB }
+class RecB { back RecA }
+class DynClass { f string
+  @@dynamic
+}
+`,
+		"functions.baml": `
+function CrossUnion() -> string | int { client GPT4 prompt #"x"# }
+function StrLitUnion() -> "a" | "b" { client GPT4 prompt #"x"# }
+function IntLitUnion() -> 1 | 2 { client GPT4 prompt #"x"# }
+function BoolLitUnion() -> true | false { client GPT4 prompt #"x"# }
+function StandaloneStr() -> "active" { client GPT4 prompt #"x"# }
+function StandaloneInt() -> 200 { client GPT4 prompt #"x"# }
+function NullableUnion() -> (string | int)? { client GPT4 prompt #"x"# }
+function EnumClassUnion() -> Suit | Aliased { client GPT4 prompt #"x"# }
+function RepeatedUnions() -> Holder { client GPT4 prompt #"x"# }
+function AliasProbe() -> Aliased { client GPT4 prompt #"x"# }
+function CleanM3a() -> string { client GPT4 prompt #"x"# }
+
+function RecReturn() -> RecA { client GPT4 prompt #"x"# }
+function UnionMedia() -> string | image { client GPT4 prompt #"x"# }
+function NullReturn() -> null { client GPT4 prompt #"x"# }
+function TupleReturn() -> (string, int) { client GPT4 prompt #"x"# }
+function DynReturn() -> DynClass { client GPT4 prompt #"x"# }
+function IntKeyMap() -> map<int, string> { client GPT4 prompt #"x"# }
+function UnionInput(x: string | int) -> string { client GPT4 prompt #"{{ x }}"# }
+function MapInput(m: map<string, string>) -> string { client GPT4 prompt #"x"# }
+`,
+	}
+	admitted, declines := pipelineDeclines(t, sources)
+
+	wantAdmitted := []string{
+		"CrossUnion", "StrLitUnion", "IntLitUnion", "BoolLitUnion",
+		"StandaloneStr", "StandaloneInt", "NullableUnion", "EnumClassUnion",
+		"RepeatedUnions", "AliasProbe", "CleanM3a",
+	}
+	for _, name := range wantAdmitted {
+		if !admitted[name] {
+			t.Errorf("%s should be admitted (M3b vocabulary); decline=%q", name, declines[name])
+		}
+	}
+
+	wantDeclines := map[string]string{
+		"RecReturn":   "unsupported_output_shape", // recursive class graph
+		"UnionMedia":  "unsupported_output_shape", // media child under a union (pre-decline context)
+		"NullReturn":  "unsupported_output_shape", // null-only
+		"TupleReturn": "unsupported_output_shape", // tuple
+		// A @@dynamic RETURN class pre-declines in the static-schema builder, named
+		// by reliable OUTPUT context (precise schema_dynamic_class is stamped only
+		// where the winning producer knows it — input class / unused enum / macro
+		// arg; see TestNativeSpinePreDeclineStructural). Either way, dynamic is declined.
+		"DynReturn": "unsupported_output_shape",
+		"IntKeyMap": "unsupported_output_shape", // non-string-key map
+		"UnionInput":  "unsupported_input_shape",  // union INPUT stays declined (output-only slice)
+		"MapInput":    "unsupported_input_shape",  // map input stays declined
+	}
+	for name, code := range wantDeclines {
+		if declines[name] != code {
+			t.Errorf("%s decline = %q, want %q", name, declines[name], code)
+		}
+	}
+}
+
+// TestNativeSpineM3bAliasCanonicalPipeline is the scope §2 real-pipeline
+// deliverable: a `.baml` class with an aliased int field + an enum with an
+// aliased member is admitted, EMITTED, compiled, and executed to prove the
+// carrier serves CANONICAL keys/values, an alias is never an output token, an
+// alias key does not populate the field on direct unmarshal, and an alias enum
+// value is REJECTED on direct unmarshal.
+func TestNativeSpineM3bAliasCanonicalPipeline(t *testing.T) {
+	sources := map[string]string{
+		"clients.baml": goodClient,
+		"types.baml": `
+enum Suit { Hearts @alias("hearts_alias")
+  Spades
+}
+class Aliased { qty int @alias("amount")
+  empt string @alias("")
+  comma string @alias("a,b")
+  uni string @alias("naïve")
+  suit Suit
+}
+`,
+		"functions.baml": `function AliasProbe() -> Aliased { client GPT4 prompt #"x"# }`,
+	}
+	proj := pipelineProject(t, sources)
+	m := admittedMethodByName(t, proj, "AliasProbe")
+
+	src, err := codegen.EmitNativeStaticUnary(m, codegen.NativeSpineOptions{PackageName: "carrier"})
+	if err != nil {
+		t.Fatalf("emit AliasProbe: %v", err)
+	}
+	got := string(src)
+	// Emitted codec keys canonically; no alias string is a codec wire key.
+	for _, want := range []string{`{"qty", v.Qty}`, `OutputSuitHearts OutputSuit = "Hearts"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("emitted carrier missing canonical token %q:\n%s", want, got)
+		}
+	}
+	for _, bad := range []string{`"amount"`, `"hearts_alias"`, `"naïve"`, `"a,b"`} {
+		if strings.Contains(got, bad) {
+			t.Errorf("alias %s leaked into emitted carrier source", bad)
+		}
+	}
+
+	compileAndRunEmittedCarrier(t, "carrier", got, aliasBehavioralTest)
+}
+
+const aliasBehavioralTest = `package carrier
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAliasCanonicalBehavior(t *testing.T) {
+	v := OutputAliased{Qty: 7, Empt: "E", Comma: "C", Uni: "U", Suit: OutputSuitHearts}
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{` + "`\"qty\":7`" + `, ` + "`\"suit\":\"Hearts\"`" + `} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("canonical token %s missing from %s", want, s)
+		}
+	}
+	for _, bad := range []string{"amount", "hearts_alias"} {
+		if strings.Contains(s, bad) {
+			t.Fatalf("alias %q leaked into output bytes %s", bad, s)
+		}
+	}
+	// Canonical direct unmarshal populates the fields.
+	var back OutputAliased
+	if err := json.Unmarshal([]byte(` + "`{\"qty\":9,\"empt\":\"z\",\"comma\":\"c\",\"uni\":\"u\",\"suit\":\"Hearts\"}`" + `), &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.Qty != 9 || back.Suit != OutputSuitHearts {
+		t.Fatalf("canonical unmarshal = %+v", back)
+	}
+	// A class alias key does NOT populate the field (generated struct tags canonical).
+	var viaAlias OutputAliased
+	if err := json.Unmarshal([]byte(` + "`{\"amount\":9}`" + `), &viaAlias); err != nil {
+		t.Fatal(err)
+	}
+	if viaAlias.Qty != 0 {
+		t.Fatalf("alias key \"amount\" populated the canonical field: qty=%d", viaAlias.Qty)
+	}
+	// An enum ALIAS value is rejected on direct unmarshal; canonical is accepted.
+	var suit OutputSuit
+	if err := json.Unmarshal([]byte(` + "`\"hearts_alias\"`" + `), &suit); err == nil {
+		t.Fatal("enum accepted the alias value \"hearts_alias\"")
+	}
+	if err := json.Unmarshal([]byte(` + "`\"Spades\"`" + `), &suit); err != nil {
+		t.Fatalf("enum rejected canonical \"Spades\": %v", err)
+	}
+}
+`
+
+// TestNativeSpineM3bUnionLiteralPipeline emits a real-pipeline class carrying
+// multi-arm unions + standalone literals, compiles it, and executes behavioral
+// arm-selection / same-base-ambiguity / no-literal-validation proofs.
+func TestNativeSpineM3bUnionLiteralPipeline(t *testing.T) {
+	sources := map[string]string{
+		"clients.baml": goodClient,
+		"types.baml": `class UBox { cross string | int
+  choice "a" | "b"
+  flag true | false
+  status "active"
+  code 200
+}
+`,
+		"functions.baml": `function UnionBox() -> UBox { client GPT4 prompt #"x"# }`,
+	}
+	proj := pipelineProject(t, sources)
+	m := admittedMethodByName(t, proj, "UnionBox")
+
+	src, err := codegen.EmitNativeStaticUnary(m, codegen.NativeSpineOptions{PackageName: "carrier"})
+	if err != nil {
+		t.Fatalf("emit UnionBox: %v", err)
+	}
+	got := string(src)
+	for _, want := range []string{"type OutputUnion1 struct", "type OutputUnion2 struct", "type OutputUnion3 struct"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("emitted carrier missing %q", want)
+		}
+	}
+
+	compileAndRunEmittedCarrier(t, "carrier", got, unionLiteralBehavioralTest)
+}
+
+const unionLiteralBehavioralTest = `package carrier
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUnionLiteralBehavior(t *testing.T) {
+	// Cross-kind arm selection (cross = string | int -> OutputUnion1).
+	var cross OutputUnion1
+	if err := json.Unmarshal([]byte("7"), &cross); err != nil {
+		t.Fatal(err)
+	}
+	if !cross.IsVariant1() {
+		t.Fatalf("JSON 7 should bind the int arm (v1)")
+	}
+	if err := json.Unmarshal([]byte(` + "`\"hi\"`" + `), &cross); err != nil {
+		t.Fatal(err)
+	}
+	if !cross.IsVariant0() || cross.AsVariant0() == nil || *cross.AsVariant0() != "hi" {
+		t.Fatalf("JSON \"hi\" should bind the string arm (v0)")
+	}
+
+	// Same-base string-literal ambiguity (choice = "a" | "b" -> OutputUnion2):
+	// any string binds the FIRST arm, no value check.
+	var choice OutputUnion2
+	if err := json.Unmarshal([]byte(` + "`\"b\"`" + `), &choice); err != nil {
+		t.Fatal(err)
+	}
+	if !choice.IsVariant0() {
+		t.Fatalf("string \"b\" should bind the FIRST literal arm (v0)")
+	}
+
+	// Same-base bool-literal ambiguity (flag = true | false -> OutputUnion3):
+	// JSON false binds the FIRST (true-declared) arm.
+	var flag OutputUnion3
+	if err := json.Unmarshal([]byte("false"), &flag); err != nil {
+		t.Fatal(err)
+	}
+	if !flag.IsVariant0() || flag.AsVariant0() == nil || *flag.AsVariant0() != false {
+		t.Fatalf("JSON false should bind the FIRST bool arm (v0) holding false")
+	}
+
+	// Unset union marshal errors; a constructed arm marshals to its bare value.
+	var unset OutputUnion1
+	if _, err := json.Marshal(unset); err == nil {
+		t.Fatal("unset union marshaled without error")
+	}
+	if b, err := json.Marshal(OutputUnion1NewVariant0("z")); err != nil || string(b) != ` + "`\"z\"`" + ` {
+		t.Fatalf("constructor marshal = %s, %v", b, err)
+	}
+
+	// Standalone literals are plain bases with NO value validation.
+	var box OutputUBox
+	if err := json.Unmarshal([]byte(` + "`{\"cross\":1,\"choice\":\"a\",\"flag\":true,\"status\":\"anything\",\"code\":999}`" + `), &box); err != nil {
+		t.Fatalf("standalone literal rejected an out-of-literal value: %v", err)
+	}
+	if box.Status != "anything" || box.Code != 999 {
+		t.Fatalf("standalone literals not plain bases: status=%q code=%d", box.Status, box.Code)
+	}
+}
+`
+
+// TestNativeSpineM3bEmitsAdmittedUnionShapes emits (no compile) the admitted
+// union shapes that the behavioral tests do not exercise directly — an enum|class
+// union arm, and a union reachable via a class field, a list element, AND a map
+// value that all DEDUPE to one carrier — proving the plan resolves every reach
+// site and emission succeeds for the full admitted vocabulary.
+func TestNativeSpineM3bEmitsAdmittedUnionShapes(t *testing.T) {
+	sources := map[string]string{
+		"clients.baml": goodClient,
+		"types.baml": `
+enum Suit { Hearts
+  Spades
+}
+class Aliased { qty int @alias("amount")
+  suit Suit
+}
+class Holder { pick string | int
+  items (string | int)[]
+  lut map<string, string | int>
+}
+`,
+		"functions.baml": `
+function EnumClassUnion() -> Suit | Aliased { client GPT4 prompt #"x"# }
+function RepeatedUnions() -> Holder { client GPT4 prompt #"x"# }
+`,
+	}
+	proj := pipelineProject(t, sources)
+
+	// enum|class union at the target: emits OutputUnion1 with enum + class arms.
+	ec := admittedMethodByName(t, proj, "EnumClassUnion")
+	ecSrc, err := codegen.EmitNativeStaticUnary(ec, codegen.NativeSpineOptions{PackageName: "carrier"})
+	if err != nil {
+		t.Fatalf("emit EnumClassUnion: %v", err)
+	}
+	for _, want := range []string{"type OutputUnion1 struct", "type OutputSuit string", "type OutputAliased struct"} {
+		if !strings.Contains(string(ecSrc), want) {
+			t.Errorf("EnumClassUnion carrier missing %q", want)
+		}
+	}
+
+	// One union shape reached via a class field, a list element, and a map value —
+	// all must DEDUPE to a single OutputUnion1 (no OutputUnion2).
+	ru := admittedMethodByName(t, proj, "RepeatedUnions")
+	ruSrc, err := codegen.EmitNativeStaticUnary(ru, codegen.NativeSpineOptions{PackageName: "carrier"})
+	if err != nil {
+		t.Fatalf("emit RepeatedUnions: %v", err)
+	}
+	s := string(ruSrc)
+	if !strings.Contains(s, "type OutputUnion1 struct") {
+		t.Error("RepeatedUnions carrier missing OutputUnion1")
+	}
+	if strings.Contains(s, "type OutputUnion2 struct") {
+		t.Error("union dedupe failed: field/list/map reaches of one shape emitted more than one carrier")
+	}
+	if !strings.Contains(s, "[]OutputUnion1") || !strings.Contains(s, "map[string]OutputUnion1") {
+		t.Errorf("RepeatedUnions carrier missing list/map union bindings:\n%s", s)
 	}
 }

--- a/internal/nativespine/build.go
+++ b/internal/nativespine/build.go
@@ -601,7 +601,11 @@ func walkType(t *schemadescriptor.Type, seen map[*schemadescriptor.Type]bool) (p
 		return walkType(t.Value, seen)
 	case schemadescriptor.TypeUnion:
 		if t.Union == nil {
-			return "", ""
+			// A union node with a NIL payload (distinct from a non-nil empty
+			// Variants slice below) is malformed — decline rather than admit a shape
+			// the emitter's schemaGoType/buildCarrierPlan reject (keeps admission ==
+			// emission). Not constructible via the descriptor builder.
+			return DeclineUnsupportedOutputShape, "return schema contains a union with no payload"
 		}
 		// M3b admits a multi-arm union whose EVERY arm is otherwise in the M3a+M3b
 		// vocabulary (a union does not launder an unsupported child into

--- a/internal/nativespine/build.go
+++ b/internal/nativespine/build.go
@@ -522,14 +522,11 @@ func classifyOutputSchema(b schemadescriptor.Bundle) (projectdescriptor.Capabili
 			return code, detail
 		}
 		for j := range c.Fields {
-			// An aliased output field serves under its ALIAS in the native codec,
-			// but a baml_client-generated carrier serves it under its CANONICAL
-			// json tag (e.g. `confidence @alias("score")` -> `json:"confidence"`),
-			// so the two byte streams diverge. Decline until M3b pins the
-			// output-key policy and differentially proves it.
-			if c.Fields[j].Name.Alias != nil {
-				return DeclineUnsupportedOutputShape, "return schema field " + c.Name.Name + "." + c.Fields[j].Name.Name + " is aliased (native output-key policy deferred to M3b)"
-			}
+			// M3b: an @alias on an output field is admitted and IGNORED — BAML
+			// serves the CANONICAL field key and a generated Go struct tags it
+			// canonical (empirically confirmed, scope §2). The emitter keys the
+			// codec by field.Name.Name, so there is no divergence to decline. All
+			// surrounding shape gates still apply via walkType below.
 			if code, detail := walkType(&c.Fields[j].Type, seen); code != "" {
 				return code, detail
 			}
@@ -539,13 +536,9 @@ func classifyOutputSchema(b schemadescriptor.Bundle) (projectdescriptor.Capabili
 		if code, detail := constraintCode(b.Enums[i].Constraints); code != "" {
 			return code, detail
 		}
-		for j := range b.Enums[i].Values {
-			// Same divergence for an aliased enum member (native emits the alias as
-			// the string value; the generated enum emits the canonical member).
-			if b.Enums[i].Values[j].Name.Alias != nil {
-				return DeclineUnsupportedOutputShape, "return schema enum " + b.Enums[i].Name.Name + " member " + b.Enums[i].Values[j].Name.Name + " is aliased (native output-key policy deferred to M3b)"
-			}
-		}
+		// M3b: an @alias on an enum member is admitted and IGNORED — BAML serves
+		// the CANONICAL enum value and a generated enum validates against it
+		// (empirically confirmed, scope §2). The emitter emits canonical constants.
 	}
 	return "", ""
 }
@@ -577,6 +570,19 @@ func walkType(t *schemadescriptor.Type, seen map[*schemadescriptor.Type]bool) (p
 		}
 	case schemadescriptor.TypeEnum, schemadescriptor.TypeClass:
 		return "", "" // named ref; the def is walked at the Bundle level
+	case schemadescriptor.TypeLiteral:
+		// M3b admits a string/int/bool literal (it lowers to its plain Go base;
+		// BAML has no float literal). A nil payload or unknown kind is malformed —
+		// decline rather than admit-then-fail in the emitter.
+		if t.Literal == nil {
+			return DeclineUnsupportedOutputShape, "return schema contains a literal with no value"
+		}
+		switch t.Literal.Kind {
+		case schemadescriptor.LiteralString, schemadescriptor.LiteralInt, schemadescriptor.LiteralBool:
+			return "", ""
+		default:
+			return DeclineUnsupportedOutputShape, "return schema contains an unsupported literal kind " + string(t.Literal.Kind)
+		}
 	case schemadescriptor.TypeList:
 		return walkType(t.Elem, seen)
 	case schemadescriptor.TypeMap:
@@ -597,8 +603,18 @@ func walkType(t *schemadescriptor.Type, seen map[*schemadescriptor.Type]bool) (p
 		if t.Union == nil {
 			return "", ""
 		}
-		if len(t.Union.Variants) > 1 {
-			return DeclineUnsupportedOutputShape, "return schema contains a multi-variant union"
+		// M3b admits a multi-arm union whose EVERY arm is otherwise in the M3a+M3b
+		// vocabulary (a union does not launder an unsupported child into
+		// admission). A carrier requires either the optional-of-one `T?` form
+		// (Nullable + exactly one arm, which stays M3a's *T) or a multi-arm union
+		// (>=2 arms). A zero-arm union OR a NON-nullable single-arm union is
+		// malformed for a carrier — decline rather than admit a shape the emitter's
+		// plan cannot name (keeps admission == emission; the emitter's
+		// buildCarrierPlan errors on the same shapes). Neither is constructible
+		// through the descriptor builder's union normalization, but the classifier
+		// must still fail closed rather than admit-then-fail.
+		if len(t.Union.Variants) == 0 || (len(t.Union.Variants) == 1 && !t.Union.Nullable) {
+			return DeclineUnsupportedOutputShape, "return schema contains a malformed union (needs an optional-of-one or a multi-arm union)"
 		}
 		for i := range t.Union.Variants {
 			if code, detail := walkType(&t.Union.Variants[i], seen); code != "" {
@@ -607,7 +623,7 @@ func walkType(t *schemadescriptor.Type, seen map[*schemadescriptor.Type]bool) (p
 		}
 		return "", ""
 	default:
-		// top, literal, tuple, arrow, recursive_alias: outside the M3a class.
+		// top, tuple, arrow, recursive_alias: outside the M3a+M3b class.
 		return DeclineUnsupportedOutputShape, "return schema contains an unsupported type kind " + string(t.Kind)
 	}
 }

--- a/internal/nativespine/build_test.go
+++ b/internal/nativespine/build_test.go
@@ -128,7 +128,32 @@ func TestClassifyOutputSchema(t *testing.T) {
 			Classes: []sd.ClassDef{{Name: sd.Name{Name: "C"}, Constraints: []sd.Constraint{{Level: sd.ConstraintCheck, Expression: "x"}}}},
 		}, DeclineChecks},
 		{"assert constraint on target meta", sd.Bundle{Target: sd.Type{Kind: sd.TypePrimitive, Primitive: sd.PrimitiveString, Meta: sd.TypeMeta{Constraints: []sd.Constraint{{Level: sd.ConstraintAssert, Expression: "x"}}}}}, DeclineAsserts},
-		{"multi-variant union", sd.Bundle{Target: sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Variants: []sd.Type{prim(sd.PrimitiveString), prim(sd.PrimitiveInt)}}}}, DeclineUnsupportedOutputShape},
+		// M3b: a multi-arm union of supported arms is now ADMITTED (it lowers to a
+		// discriminated carrier). A single-nullable-variant union stays M3a's *T.
+		{"multi-variant union of supported arms", sd.Bundle{Target: sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Variants: []sd.Type{prim(sd.PrimitiveString), prim(sd.PrimitiveInt)}}}}, ""},
+		{"multi-variant nullable union", sd.Bundle{Target: sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Nullable: true, Variants: []sd.Type{prim(sd.PrimitiveString), prim(sd.PrimitiveInt)}}}}, ""},
+		// M3b: string/int/bool literals admit (standalone and as union arms).
+		{"standalone string literal", sd.Bundle{Target: sd.Type{Kind: sd.TypeLiteral, Literal: &sd.LiteralValue{Kind: sd.LiteralString, String: "active"}}}, ""},
+		{"standalone int literal", sd.Bundle{Target: sd.Type{Kind: sd.TypeLiteral, Literal: &sd.LiteralValue{Kind: sd.LiteralInt, Int: 7}}}, ""},
+		{"standalone bool literal", sd.Bundle{Target: sd.Type{Kind: sd.TypeLiteral, Literal: &sd.LiteralValue{Kind: sd.LiteralBool, Bool: true}}}, ""},
+		{"same-base literal union", sd.Bundle{Target: sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Variants: []sd.Type{
+			{Kind: sd.TypeLiteral, Literal: &sd.LiteralValue{Kind: sd.LiteralString, String: "a"}},
+			{Kind: sd.TypeLiteral, Literal: &sd.LiteralValue{Kind: sd.LiteralString, String: "b"}},
+		}}}}, ""},
+		// A literal with no value is malformed — decline, never admit-then-fail.
+		{"nil-payload literal", sd.Bundle{Target: sd.Type{Kind: sd.TypeLiteral, Literal: nil}}, DeclineUnsupportedOutputShape},
+		// A union does NOT launder an unsupported arm (media) into admission.
+		{"union with media arm", sd.Bundle{Target: sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Variants: []sd.Type{
+			prim(sd.PrimitiveString),
+			{Kind: sd.TypePrimitive, Primitive: sd.PrimitiveMedia, Media: sd.MediaImage},
+		}}}}, DeclineMediaImage},
+		// A zero-arm union is malformed — decline rather than emit an arm-less carrier.
+		{"zero-arm union", sd.Bundle{Target: sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Variants: nil}}}, DeclineUnsupportedOutputShape},
+		// A NON-nullable single-arm union is malformed for a carrier (not an
+		// optional-of-one, not multi-arm) — decline, keeping admission == emission
+		// (the emitter's buildCarrierPlan errors on len<2). Not constructible via the
+		// descriptor builder, but the classifier must still fail closed.
+		{"non-nullable single-arm union", sd.Bundle{Target: sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Nullable: false, Variants: []sd.Type{prim(sd.PrimitiveString)}}}}, DeclineUnsupportedOutputShape},
 		// M3a admits a STRING-keyed map (value within the carrier profile); a
 		// non-string-keyed map or a value outside the profile still declines.
 		{"string-keyed map", sd.Bundle{Target: sd.Type{Kind: sd.TypeMap, Key: ptr(prim(sd.PrimitiveString)), Value: ptr(prim(sd.PrimitiveString))}}, ""},
@@ -139,21 +164,27 @@ func TestClassifyOutputSchema(t *testing.T) {
 		{"string-keyed map, nil value type", sd.Bundle{Target: sd.Type{Kind: sd.TypeMap, Key: ptr(prim(sd.PrimitiveString)), Value: nil}}, DeclineUnsupportedOutputShape},
 		{"string-keyed map of media value", sd.Bundle{Target: sd.Type{Kind: sd.TypeMap, Key: ptr(prim(sd.PrimitiveString)), Value: ptr(sd.Type{Kind: sd.TypePrimitive, Primitive: sd.PrimitiveMedia, Media: sd.MediaImage})}}, DeclineMediaImage},
 		{"recursive classes", sd.Bundle{Target: sd.Type{Kind: sd.TypeClass, Name: "C"}, RecursiveClasses: []string{"C"}}, DeclineUnsupportedOutputShape},
-		// An aliased output field/enum member is DECLINED: the native codec would
-		// serve it under the ALIAS, but a baml_client-generated carrier serves it
-		// under the CANONICAL json tag, so the bytes diverge. (Policy deferred to M3b.)
+		// M3b: an aliased output field/enum member is now ADMITTED — the alias is
+		// ingress-only metadata and is IGNORED; the emitter serves the CANONICAL
+		// key/value (empirically confirmed, scope §2). Even an exotic alias admits.
 		{"aliased class field", sd.Bundle{
 			Target: sd.Type{Kind: sd.TypeClass, Name: "C"},
 			Classes: []sd.ClassDef{{Name: sd.Name{Name: "C"}, Fields: []sd.ClassField{
 				{Name: sd.Name{Name: "confidence", Alias: strptr("score")}, Type: prim(sd.PrimitiveFloat)},
 			}}},
-		}, DeclineUnsupportedOutputShape},
+		}, ""},
+		{"exotic aliased class field", sd.Bundle{
+			Target: sd.Type{Kind: sd.TypeClass, Name: "C"},
+			Classes: []sd.ClassDef{{Name: sd.Name{Name: "C"}, Fields: []sd.ClassField{
+				{Name: sd.Name{Name: "confidence", Alias: strptr("")}, Type: prim(sd.PrimitiveFloat)},
+			}}},
+		}, ""},
 		{"aliased enum member", sd.Bundle{
 			Target: sd.Type{Kind: sd.TypeEnum, Name: "E"},
 			Enums: []sd.EnumDef{{Name: sd.Name{Name: "E"}, Values: []sd.EnumValue{
 				{Name: sd.Name{Name: "RED", Alias: strptr("rouge")}},
 			}}},
-		}, DeclineUnsupportedOutputShape},
+		}, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/nativespine/build_test.go
+++ b/internal/nativespine/build_test.go
@@ -147,7 +147,12 @@ func TestClassifyOutputSchema(t *testing.T) {
 			prim(sd.PrimitiveString),
 			{Kind: sd.TypePrimitive, Primitive: sd.PrimitiveMedia, Media: sd.MediaImage},
 		}}}}, DeclineMediaImage},
-		// A zero-arm union is malformed — decline rather than emit an arm-less carrier.
+		// A union node with a NIL payload (distinct from the non-nil empty-Variants
+		// zero-arm case below) is malformed — decline rather than admit a shape the
+		// emitter rejects.
+		{"nil-payload union", sd.Bundle{Target: sd.Type{Kind: sd.TypeUnion, Union: nil}}, DeclineUnsupportedOutputShape},
+		// A zero-arm union (non-nil payload, empty Variants) is malformed — decline
+		// rather than emit an arm-less carrier.
 		{"zero-arm union", sd.Bundle{Target: sd.Type{Kind: sd.TypeUnion, Union: &sd.UnionType{Variants: nil}}}, DeclineUnsupportedOutputShape},
 		// A NON-nullable single-arm union is malformed for a carrier (not an
 		// optional-of-one, not multi-arm) — decline, keeping admission == emission

--- a/internal/nativespinefixture/generated_greeting.go
+++ b/internal/nativespinefixture/generated_greeting.go
@@ -25,7 +25,7 @@ type OutputGreeting struct {
 	Formal bool
 }
 
-// MarshalJSON emits OutputGreeting with each field under its exact BAML wire key.
+// MarshalJSON emits OutputGreeting with each field under its canonical BAML key.
 func (v OutputGreeting) MarshalJSON() ([]byte, error) {
 	return nativeSpineMarshalObject([]nativeSpineField{
 		{"text", v.Text},
@@ -33,7 +33,7 @@ func (v OutputGreeting) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// UnmarshalJSON reads OutputGreeting from each field's exact BAML wire key.
+// UnmarshalJSON reads OutputGreeting from each field's canonical BAML key.
 func (v *OutputGreeting) UnmarshalJSON(data []byte) error {
 	return nativeSpineUnmarshalObject(data, map[string]any{
 		"text":   &v.Text,


### PR DESCRIPTION
<!-- webtty-bridge session=s-yqyd29e14n -->
## Codegen-spine M3b — native output carriers (unions / literals / canonical aliases)

Extends the merged M3a output-carrier core to reproduce BAML v0.223's generated Go **output carrier** for multi-arm unions, string/int/bool literals, and `@alias` metadata — failing closed on anything it cannot emit byte-faithfully. Output-only, read-only slice; does not widen inputs, streaming, recursion, checks, media, or dynamic overlays.

### What landed
- **Multi-arm unions** — new `adapters/common/codegen/nativespine_union.go`: a deterministic `carrierPlan` (first-reach walk, dedup by arm-fingerprint so `A|B` and `(A|B)?` share one `OutputUnionN`) and a discriminated value carrier equivalent to v0.223's `types/unions.go` **minus CFFI**. `MarshalJSON` switches on the discriminator; `UnmarshalJSON` tries arms **sequentially in descriptor order, first-success, with no value checks** — the same-base literal ambiguity (`"b"`→first string arm; JSON `false`→first bool arm) is **pinned, not "improved"**. Per-arm `New`/`Set`/`Is`/`As`; literal arms use no-argument constructors.
- **Literals** — a standalone `string`/`int`/`bool` literal lowers to its plain Go base; a literal union arm installs the constant via a no-arg constructor. nil/float/unknown → fail closed.
- **Aliases → canonical output** (empirically proven, scope §2) — `emitClassCodec` keys by `field.Name.Name`, enum constants emit `value.Name.Name`, `wireName` removed from the output path (and deleted). The classifier's class-field and enum-member alias declines are lifted; an `@alias` is admitted and **ignored**, never an output token.
- **Classifier** (`internal/nativespine`) — admits literals and multi-arm unions whose every arm is in the vocabulary; declines a malformed union (zero-arm, or non-nullable single-arm) and a nil/unknown literal, keeping **admission == emission**. `CheckNativeNameCollision` claims the planned union type + constructor identifiers.

### Verification
- **Deliverable-1:** both CFFI alias oracle probes (`TestStockAliasIngressHasCanonicalOutput`, `TestServingOracleAliasCanonicalization`) pass **before and after** — the canonical-output oracle did not move.
- Compiled hermetic JSON differential vs **frozen CFFI-free v0.223 reference carriers**: native == golden == reference; same-base controls; unset-union marshal error; emit-twice byte-identical.
- Real `introspect → classifier → codegen` pipeline: exact admission/decline map + **emit → compile-in-temp-module → execute** for the alias and union/literal carriers; `go list -deps` on the emitted carrier rejects `baml_client`/`github.com/boundaryml/baml`/`language_client_go`/`cffi`/`dynclient/baml-patched`.
- Synthetic emitter backstops: union type-name/constructor collisions and malformed-union/nil-literal fail-closed.

### Pin / tar / guard — NEUTRAL
Changes are under `adapters/common/codegen` + `internal/nativespine` (+ `cmd/introspect` tests + a codec-only golden regen: 2 comment lines). No pins, `nativeworker_module.tar`, `internal/codegenspine/guard.json`, `internal/debaml`, `nativeserve`, `nanollmprepare`, or any `go.mod`/`go.sum` touched. `go test ./internal/codegenspine -run TestSourceGuard` stays green.

### Review status
An independent code review of the production diff found no high-confidence correctness bugs; one sub-threshold admit-then-fail asymmetry (a non-nullable single-arm union) was **fixed before push** so admission == emission on that edge.

> Do **not** merge — a Codex cold review + owner sign-off gate the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nuHzXYPnp4WwabXJrbXt5


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/invakid404/baml-rest/pull/705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multi-option unions, nullable unions, and literal values in generated native output types.
  * Preserved canonical field and enum names during serialization, including aliased definitions.
  * Added JSON encoding and decoding for union values, with constructors and accessors for each option.

* **Bug Fixes**
  * Improved validation for malformed, unsupported, or ambiguous union and literal definitions.
  * Prevented naming collisions in generated union types.

* **Tests**
  * Added end-to-end coverage for unions, aliases, literals, canonical JSON output, determinism, and round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->